### PR TITLE
Fix right-column border/padding; improve dev tasks; upgrade Vite

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -473,7 +473,7 @@
 			}
 		},
 		{
-			"label": "🎨 Start Frontend Dev Server",
+			"label": "🎨 Run Frontend Dev",
 			"type": "shell",
 			"command": "npm",
 			"args": [
@@ -500,6 +500,98 @@
 					"endsPattern": "Local:.*http"
 				}
 			},
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": false,
+				"clear": true
+			}
+		},
+		{
+			"label": "🧠 Run Backend Dev (API-only)",
+			"type": "shell",
+			"command": "cargo",
+			"args": [
+				"run",
+				"--package",
+				"gglib-cli",
+				"--",
+				"web",
+				"--api-only",
+				"--port",
+				"9887",
+				"--base-port",
+				"9000"
+			],
+			"isBackground": true,
+			"group": "none",
+			"problemMatcher": {
+				"pattern": {
+					"regexp": "^(.*)$",
+					"message": 1
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": ".",
+					"endsPattern": "API:"
+				}
+			},
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": false,
+				"clear": true
+			}
+		},
+		{
+			"label": "🌐 Cargo Web",
+			"type": "shell",
+			"command": "cargo",
+			"args": [
+				"run",
+				"--package",
+				"gglib-cli",
+				"--",
+				"web",
+				"--port",
+				"9887",
+				"--base-port",
+				"9000",
+				"--static-dir",
+				"./web_ui"
+			],
+			"isBackground": true,
+			"group": "none",
+			"dependsOn": [
+				"🎨 Build Frontend"
+			],
+			"problemMatcher": {
+				"pattern": {
+					"regexp": "^(.*)$",
+					"message": 1
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": ".",
+					"endsPattern": "Serving UI from:"
+				}
+			},
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": false,
+				"clear": true
+			}
+		},
+		{
+			"label": "🚀 Run Dev (Frontend + Backend)",
+			"dependsOn": [
+				"🎨 Run Frontend Dev",
+				"🧠 Run Backend Dev (API-only)"
+			],
+			"dependsOrder": "parallel",
+			"group": "none",
+			"problemMatcher": [],
 			"presentation": {
 				"reveal": "always",
 				"panel": "shared",

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -205,6 +205,13 @@ pub enum Commands {
         /// Base port for llama-server instances (Note: Port 5000 conflicts with macOS AirPlay)
         #[arg(long, default_value = "9000")]
         base_port: u16,
+        /// Serve API endpoints only (do not serve static UI assets)
+        ///
+        /// By default, `gglib web` will auto-detect a built frontend (e.g. `./web_ui`) and
+        /// serve it with SPA fallback. Use this flag when running the React dev server (Vite)
+        /// separately.
+        #[arg(long)]
+        api_only: bool,
         /// Path to the directory containing built frontend assets (e.g., ./web_ui/dist)
         #[arg(long)]
         static_dir: Option<std::path::PathBuf>,

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -239,6 +239,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Web {
             port,
             base_port,
+            api_only,
             static_dir,
         } => {
             use gglib_axum::{ServerConfig, start_server};
@@ -254,17 +255,19 @@ async fn main() -> anyhow::Result<()> {
                 cors: gglib_axum::CorsConfig::AllowAll,
             };
 
-            // Resolve static directory: explicit flag > default location > API-only
-            if let Some(dir) = static_dir {
-                config.static_dir = Some(dir);
-            } else {
-                // Try default locations (order matters - prefer built assets first)
-                let candidates = ["./web_ui/dist", "./dist", "./web_ui/assets", "./web_ui"];
-                for candidate in &candidates {
-                    let path = std::path::Path::new(candidate);
-                    if path.join("index.html").exists() {
-                        config.static_dir = Some(path.to_path_buf());
-                        break;
+            // Resolve static directory: api-only flag > explicit flag > default location > API-only
+            if !api_only {
+                if let Some(dir) = static_dir {
+                    config.static_dir = Some(dir);
+                } else {
+                    // Try default locations (order matters - prefer built assets first)
+                    let candidates = ["./web_ui/dist", "./dist", "./web_ui/assets", "./web_ui"];
+                    for candidate in &candidates {
+                        let path = std::path::Path::new(candidate);
+                        if path.join("index.html").exists() {
+                            config.static_dir = Some(path.to_path_buf());
+                            break;
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^4.0.3",
-    "@vitest/coverage-v8": "^2.1.8",
+    "@vitejs/plugin-react": "^5.1.2",
+    "@vitest/coverage-v8": "^4.0.16",
     "eslint": "^9.17.0",
     "jsdom": "^25.0.1",
     "typescript": "^5.0.2",
     "typescript-eslint": "^8.18.1",
-    "vite": "^4.4.4",
-    "vitest": "^2.1.8"
+    "vite": "^7.3.0",
+    "vitest": "^4.0.16"
   }
 }

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -242,11 +242,15 @@ Start the web-based GUI server.
 **Options:**
 - `--port <PORT>`: Port to serve the web GUI on (default: 9887)
 - `--base-port <PORT>`: Base port for llama-server instances (default: 9000)
+- `--api-only`: Serve API endpoints only (do not serve static UI assets)
 
 **Example:**
 ```bash
 # Start web server (accessible from LAN by default)
 gglib web --port 9887
+
+# API-only mode (useful when running the React dev server separately)
+gglib web --api-only --port 9887
 
 # Use different base port for model servers
 gglib web --port 9887 --base-port 9000

--- a/src/components/GlobalDownloadStatus/GlobalDownloadStatus.module.css
+++ b/src/components/GlobalDownloadStatus/GlobalDownloadStatus.module.css
@@ -1,11 +1,11 @@
 /* GlobalDownloadStatus - Uses app design system variables */
 
 .container {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  background: var(--color-background);
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
   padding: var(--spacing-base);
-  margin-bottom: var(--spacing-base);
+  margin-bottom: 0;
 }
 
 /* Progress Section (Active Download) */

--- a/src/pages/ModelControlCenterPage.css
+++ b/src/pages/ModelControlCenterPage.css
@@ -117,7 +117,6 @@
 
 /* Right panel container - allows GlobalDownloadStatus + inspector to stack */
 .right-panel-container {
-  padding: var(--spacing-base);
   gap: 0;
 }
 


### PR DESCRIPTION
### Summary
- Fix main page right-column padding that caused an odd inset/border look.
- Improve VS Code dev tasks to run frontend + backend cleanly.
- Add `gglib web --api-only` to run the backend in API-only mode when Vite is used for the UI.
- Upgrade Vite/Vitest tooling to eliminate Node 24 `DEP0060` (`util._extend`) warning during dev.

### How to test
- VS Code tasks:
  - Run Backend Dev (API-only)
  - Run Frontend Dev
  - Run Dev (Frontend + Backend)
  - Cargo Web
- Frontend build: `npm run build`

### Notes
- Vite dev continues to proxy `/api` to `http://localhost:9887`.
