### PR TITLE
Fix gglib chat failing due to unsupported llama-cli interactive flags

### DIFF
--- a/crates/gglib-cli/src/handlers/chat.rs
+++ b/crates/gglib-cli/src/handlers/chat.rs
@@ -69,7 +69,6 @@ pub async fn execute(ctx: &CliContext, args: ChatArgs) -> Result<()> {
     let mut cmd = LlamaCommandBuilder::new(&llama_cli_path, &model.file_path)
         .context_resolution(context_resolution)
         .mlock(mlock)
-        .flag("-i")
         .build();
 
     // Add chat-specific flags

--- a/crates/gglib-cli/src/handlers/chat.rs
+++ b/crates/gglib-cli/src/handlers/chat.rs
@@ -69,7 +69,7 @@ pub async fn execute(ctx: &CliContext, args: ChatArgs) -> Result<()> {
     let mut cmd = LlamaCommandBuilder::new(&llama_cli_path, &model.file_path)
         .context_resolution(context_resolution)
         .mlock(mlock)
-        .flag("--interactive-first")
+        .flag("-i")
         .build();
 
     // Add chat-specific flags


### PR DESCRIPTION
Fixes #5\n\n currently passes an interactive flag to  that may be unsupported depending on the installed llama.cpp build, causing the chat command to fail immediately. This change stops passing explicit interactive flags so chat can run across different  builds.