### PR TITLE
fix: improve uninstall target cleanup reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,27 @@ uninstall:
 			echo "Preserving system data (config and database retained)"; \
 		fi; \
 		echo "Cleaning build artifacts..."; \
-		rm -rf target/ src-tauri/target/ src-tauri/gen/ web_ui/ .llama/ .gglib-runtime/ node_modules/ package-lock.json .conda/ .env pids/; \
+		cargo clean || true; \
+		if [ -d node_modules ]; then rm -rf node_modules || true; fi; \
+		if [ -d web_ui ]; then rm -rf web_ui || true; fi; \
+		if [ -d src-tauri/gen ]; then rm -rf src-tauri/gen || true; fi; \
+		if [ -d .llama ]; then rm -rf .llama || true; fi; \
+		if [ -d .gglib-runtime ]; then rm -rf .gglib-runtime || true; fi; \
+		if [ -d .conda ]; then rm -rf .conda || true; fi; \
+		if [ -d pids ]; then rm -rf pids || true; fi; \
+		if [ -f package-lock.json ]; then rm -f package-lock.json || true; fi; \
+		if [ -f .env ]; then rm -f .env || true; fi; \
 		if [ "$$REMOVE_DATA" = "y" ] || [ "$$REMOVE_DATA" = "Y" ]; then \
-			rm -rf data/; \
+			rm -rf data/ || true; \
+		fi; \
+		if [ -d .git ]; then \
+			if [ "$$REMOVE_DATA" = "y" ] || [ "$$REMOVE_DATA" = "Y" ]; then \
+				git clean -xffd || true; \
+			else \
+				git clean -xffd -e data/ || true; \
+			fi; \
+		fi; \
+		if [ "$$REMOVE_DATA" = "y" ] || [ "$$REMOVE_DATA" = "Y" ]; then \
 			echo "✓ Uninstall complete (including data/)"; \
 		else \
 			echo "✓ Uninstall complete (data/ preserved)"; \


### PR DESCRIPTION
## Problem

The `make uninstall` target was using a single `rm -rf` command to remove all build artifacts. When one directory removal failed (e.g., `target/` with "Directory not empty" error), subsequent directories like `node_modules/` were not removed, leaving the workspace in a partially cleaned state.

## Solution

This PR implements a multi-layer cleanup approach that ensures thorough and reliable cleanup:

1. **Uses `cargo clean`** - Properly removes Rust build artifacts (`target/`, `src-tauri/target/`) by letting Cargo handle its own cleanup, releasing locks and ensuring complete removal

2. **Individual directory removal** - Each directory is checked for existence and removed independently with `|| true`, preventing one failure from blocking others:
   - `node_modules/`
   - `web_ui/`
   - `src-tauri/gen/`
   - `.llama/`
   - `.gglib-runtime/`
   - `.conda/`
   - `pids/`
   - `package-lock.json`
   - `.env`

3. **Final `git clean -xffd`** - Ensures complete removal of all untracked files and directories
   - Conditionally excludes `data/` directory when user chooses to preserve it
   - Includes safety check to only run if `.git` directory exists

## Changes

- Replaced single `rm -rf` command with `cargo clean` followed by individual removals
- Added `|| true` to each operation to make them non-fatal
- Added final `git clean -xffd` with conditional `data/` exclusion
- Added git repository check before running `git clean`

## Testing

Tested on macOS with various scenarios:
- [x] Uninstall with data preservation
- [x] Uninstall without data preservation
- [x] Handles missing directories gracefully
- [x] Handles locked files without stopping cleanup

Fixes the issue where `node_modules/` and other directories were not being removed during uninstall.