### PR TITLE
fix: Add missing server log endpoints for console view

### DIFF
--- a/crates/gglib-axum/src/handlers/servers.rs
+++ b/crates/gglib-axum/src/handlers/servers.rs
@@ -101,7 +101,7 @@ pub async fn stream_logs(
     Path(port): Path<u16>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static> {
     let receiver = state.gui.subscribe_server_logs();
-    
+
     let stream = BroadcastStream::new(receiver).filter_map(move |result| {
         match result {
             Ok(entry) => {
@@ -109,7 +109,7 @@ pub async fn stream_logs(
                 if entry.port != port {
                     return None;
                 }
-                
+
                 // Serialize log entry to JSON
                 match serde_json::to_string(&entry) {
                     Ok(json) => Some(Ok(Event::default().data(json))),
@@ -134,10 +134,7 @@ pub async fn stream_logs(
 }
 
 /// Clear logs for a specific server port (DELETE endpoint).
-pub async fn clear_logs(
-    State(state): State<AppState>,
-    Path(port): Path<u16>,
-) -> Json<String> {
+pub async fn clear_logs(State(state): State<AppState>, Path(port): Path<u16>) -> Json<String> {
     state.gui.clear_server_logs(port);
     Json(format!("Logs cleared for port {}", port))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -86,8 +86,14 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/servers/stop", post(handlers::servers::stop_body))
         .route("/servers/:id/start", post(handlers::servers::start))
         .route("/servers/:id/stop", post(handlers::servers::stop))
-        .route("/servers/:port/logs", get(handlers::servers::get_logs).delete(handlers::servers::clear_logs))
-        .route("/servers/:port/logs/stream", get(handlers::servers::stream_logs))
+        .route(
+            "/servers/:port/logs",
+            get(handlers::servers::get_logs).delete(handlers::servers::clear_logs),
+        )
+        .route(
+            "/servers/:port/logs/stream",
+            get(handlers::servers::stream_logs),
+        )
         // Downloads API
         .route("/downloads", get(handlers::downloads::list))
         .route(

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -86,6 +86,8 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/servers/stop", post(handlers::servers::stop_body))
         .route("/servers/:id/start", post(handlers::servers::start))
         .route("/servers/:id/stop", post(handlers::servers::stop))
+        .route("/servers/:port/logs", get(handlers::servers::get_logs).delete(handlers::servers::clear_logs))
+        .route("/servers/:port/logs/stream", get(handlers::servers::stream_logs))
         // Downloads API
         .route("/downloads", get(handlers::downloads::list))
         .route(

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -166,6 +166,22 @@ impl GuiBackend {
         self.server_ops().list_servers().await
     }
 
+    /// Get logs for a specific server port.
+    pub fn get_server_logs(&self, port: u16) -> Vec<ServerLogEntry> {
+        self.server_ops().get_logs(port)
+    }
+
+    /// Subscribe to real-time server log events.
+    /// Returns a broadcast receiver that emits ServerLogEntry for all servers.
+    pub fn subscribe_server_logs(&self) -> tokio::sync::broadcast::Receiver<ServerLogEntry> {
+        self.server_ops().subscribe_logs()
+    }
+
+    /// Clear logs for a specific server port.
+    pub fn clear_server_logs(&self, port: u16) {
+        self.server_ops().clear_logs(port);
+    }
+
     /// Build a server snapshot for event emission.
     ///
     /// Queries all running servers and converts them to `ServerSummary` instances.

--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -455,6 +455,22 @@ impl<'a> ServerOps<'a> {
             Err(_) => Vec::new(),
         }
     }
+
+    /// Get logs for a specific server port.
+    pub fn get_logs(&self, port: u16) -> Vec<crate::types::ServerLogEntry> {
+        gglib_runtime::get_log_manager().get_logs(port)
+    }
+
+    /// Subscribe to real-time log events.
+    /// Returns a broadcast receiver for ServerLogEntry events.
+    pub fn subscribe_logs(&self) -> tokio::sync::broadcast::Receiver<crate::types::ServerLogEntry> {
+        gglib_runtime::get_log_manager().subscribe()
+    }
+
+    /// Clear logs for a specific server port.
+    pub fn clear_logs(&self, port: u16) {
+        gglib_runtime::get_log_manager().clear_logs(port);
+    }
 }
 
 #[cfg(test)]

--- a/crates/gglib-gui/src/types.rs
+++ b/crates/gglib-gui/src/types.rs
@@ -413,3 +413,10 @@ pub struct McpToolCallResponse {
     pub data: Option<serde_json::Value>,
     pub error: Option<String>,
 }
+
+// ============================================================================
+// Server Log Types
+// ============================================================================
+
+// Re-export from gglib-runtime for cross-adapter use
+pub use gglib_runtime::ServerLogEntry;

--- a/crates/gglib-runtime/src/process/logs.rs
+++ b/crates/gglib-runtime/src/process/logs.rs
@@ -136,3 +136,23 @@ impl Default for ServerLogManager {
         Self::new()
     }
 }
+
+// ============================================================================
+// Log Sink Adapter
+// ============================================================================
+
+use gglib_core::ports::ServerLogSinkPort;
+
+/// Log sink that forwards process output to the global ServerLogManager.
+///
+/// This adapter bridges the process output capture (via spawn_log_readers)
+/// to the log broadcasting system. It's a zero-sized type since it just
+/// delegates to the global log manager singleton.
+#[derive(Debug, Clone, Default)]
+pub struct LogManagerSink;
+
+impl ServerLogSinkPort for LogManagerSink {
+    fn append(&self, port: u16, _stream_type: &str, line: String) {
+        get_log_manager().add_log(port, &line);
+    }
+}

--- a/crates/gglib-runtime/src/process/mod.rs
+++ b/crates/gglib-runtime/src/process/mod.rs
@@ -32,7 +32,7 @@ pub use broadcaster::{ServerEventBroadcaster, get_event_broadcaster};
 pub use core::GuiProcessCore;
 pub use events::{ServerEvent, ServerStateInfo, ServerStatus};
 pub use health::{check_process_health, update_health_batch, wait_for_http_health};
-pub use logs::{ServerLogEntry, ServerLogManager, get_log_manager};
+pub use logs::{LogManagerSink, ServerLogEntry, ServerLogManager, get_log_manager};
 pub use manager::{CurrentModelState, ProcessManager, ProcessStrategy};
 pub use shutdown::{kill_pid, shutdown_child};
 pub use types::{RunningProcess, ServerInfo};

--- a/crates/gglib-runtime/src/process_core.rs
+++ b/crates/gglib-runtime/src/process_core.rs
@@ -68,7 +68,9 @@ impl ProcessCore {
             // Non-fatal - continue anyway
         }
 
-        command::spawn_log_readers(&mut child, port, None);
+        // Wire log capture to the log manager for GUI streaming
+        use crate::process::LogManagerSink;
+        command::spawn_log_readers(&mut child, port, Some(std::sync::Arc::new(LogManagerSink)));
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Summary

Fixes #30 - Console view not displaying server logs

The console view was showing "Waiting for server output..." indefinitely because the HTTP API endpoints for log streaming were never implemented. This PR adds the missing log endpoints following the centralized `GuiBackend` pattern to maintain DRY code.

## Changes

### Core Infrastructure (gglib-gui)
- **types.rs**: Re-export `ServerLogEntry` from `gglib-runtime` for cross-adapter use
- **servers.rs**: Add log methods to `ServerOps`:
  - `get_logs(port)` - retrieve buffered logs
  - `subscribe_logs()` - subscribe to log broadcast channel
  - `clear_logs(port)` - clear log buffer
- **backend.rs**: Add facade methods to `GuiBackend`:
  - `get_server_logs(port)`
  - `subscribe_server_logs()`
  - `clear_server_logs(port)`

### HTTP API (gglib-axum)
- **handlers/servers.rs**: Add three log handlers:
  - `get_logs` - REST endpoint for initial logs
  - `stream_logs` - SSE endpoint with port filtering
  - `clear_logs` - DELETE endpoint
- **routes.rs**: Register log endpoints:
  - `GET /api/servers/:port/logs`
  - `GET /api/servers/:port/logs/stream`
  - `DELETE /api/servers/:port/logs`

## Architecture

- Follows the established centralized pattern where both Tauri and Axum use shared `GuiBackend` facade
- Log management handled by `gglib-runtime` (5000 lines per port buffer)
- SSE stream includes 30-second keep-alive pings
- Client-side port filtering in SSE handler

## Testing

- [x] Code compiles successfully
- [ ] Manual test: Start server and verify logs in console view (Tauri)
- [ ] Manual test: Start server and verify logs in console view (web)
- [ ] Manual test: Verify auto-scroll, copy, and clear buttons work
- [ ] Manual test: Logs persist when switching between chat/console tabs

## Commits

Each change is in a separate, descriptive commit:
1. Re-export ServerLogEntry type
2. Add log methods to ServerOps
3. Add log facade methods to GuiBackend
4. Add Axum HTTP handlers
5. Register routes