### PR TITLE
Fix Stop Serving in GUI + enforce canonical server events

### DIFF
--- a/crates/gglib-tauri/src/events.rs
+++ b/crates/gglib-tauri/src/events.rs
@@ -15,11 +15,7 @@ pub mod names {
     // Download events
     pub const DOWNLOAD_PROGRESS: &str = "download-progress";
 
-    // Server lifecycle events
-    pub const SERVER_RUNNING: &str = "server:running";
-    pub const SERVER_STOPPING: &str = "server:stopping";
-    pub const SERVER_STOPPED: &str = "server:stopped";
-    pub const SERVER_SNAPSHOT: &str = "server:snapshot";
+    // Server log event stream (separate from AppEvent::* server lifecycle events)
     pub const SERVER_LOG: &str = "server-log";
 
     // Llama installation events

--- a/crates/gglib-tauri/src/server_events.rs
+++ b/crates/gglib-tauri/src/server_events.rs
@@ -3,11 +3,10 @@
 //! This module implements the `ServerEvents` port by converting `ServerSummary`
 //! to Tauri's `ServerEvent` types and emitting via the Tauri event system.
 
-use gglib_core::events::{ServerEvents, ServerSummary};
-use gglib_runtime::process::{ServerEvent, ServerStateInfo, ServerStatus};
+use gglib_core::events::{AppEvent, ServerEvents, ServerSummary};
 use tauri::AppHandle;
 
-use crate::events::{emit_or_log, names};
+use crate::events::emit_or_log;
 
 /// Tauri adapter for server lifecycle events.
 ///
@@ -24,65 +23,57 @@ impl TauriServerEvents {
     pub fn new(app: AppHandle) -> Self {
         Self { app }
     }
-
-    /// Parse model_id with logging on failure.
-    fn parse_model_id(server: &ServerSummary) -> u32 {
-        server.parsed_model_id().unwrap_or_else(|| {
-            tracing::warn!(
-                model_id = %server.model_id,
-                "Failed to parse ServerSummary.model_id; defaulting to 0"
-            );
-            0
-        })
-    }
 }
 
 // NOTE: This adapter mirrors the Axum ServerEvents implementation (gglib-axum/src/sse.rs).
 // All server lifecycle events for Tauri MUST flow through this port implementation.
 impl ServerEvents for TauriServerEvents {
     fn started(&self, server: &ServerSummary) {
-        let model_id = Self::parse_model_id(server);
-        let event = ServerEvent::running(model_id, server.port);
-        emit_or_log(&self.app, names::SERVER_RUNNING, &event);
+        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
+        let event = AppEvent::server_started(model_id, &server.model_name, server.port);
+        emit_or_log(&self.app, event.event_name(), &event);
     }
 
     fn stopping(&self, server: &ServerSummary) {
-        let model_id = Self::parse_model_id(server);
-        let state = ServerStateInfo::new(model_id, ServerStatus::Stopping, Some(server.port));
-        let event = ServerEvent::Stopping(state);
-        emit_or_log(&self.app, names::SERVER_STOPPING, &event);
+        // No canonical AppEvent variant for "stopping".
+        tracing::debug!(
+            model_id = %server.model_id,
+            model_name = %server.model_name,
+            "Server stopping"
+        );
     }
 
     fn stopped(&self, server: &ServerSummary) {
-        let model_id = Self::parse_model_id(server);
-        let state = ServerStateInfo::new(model_id, ServerStatus::Stopped, Some(server.port));
-        let event = ServerEvent::Stopped(state);
-        emit_or_log(&self.app, names::SERVER_STOPPED, &event);
+        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
+        let event = AppEvent::server_stopped(model_id, &server.model_name);
+        emit_or_log(&self.app, event.event_name(), &event);
     }
 
     fn snapshot(&self, servers: &[ServerSummary]) {
-        let states: Vec<ServerStateInfo> = servers
+        let started_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let entries: Vec<gglib_core::events::ServerSnapshotEntry> = servers
             .iter()
-            .map(|s| {
-                let model_id = Self::parse_model_id(s);
-                ServerStateInfo::new(model_id, ServerStatus::Running, Some(s.port))
+            .map(|s| gglib_core::events::ServerSnapshotEntry {
+                model_id: s.model_id.parse::<i64>().unwrap_or(0),
+                model_name: s.model_name.clone(),
+                port: s.port,
+                started_at,
+                healthy: s.healthy.unwrap_or(false),
             })
             .collect();
 
-        let event = ServerEvent::snapshot(states);
-        emit_or_log(&self.app, names::SERVER_SNAPSHOT, &event);
+        let event = AppEvent::server_snapshot(entries);
+        emit_or_log(&self.app, event.event_name(), &event);
     }
 
     fn error(&self, server: &ServerSummary, error: &str) {
-        // NOTE: Tauri did not previously emit SERVER_ERROR events.
-        // Keep as logging-only to maintain behavior-neutral refactor.
-        // If we introduce SERVER_ERROR events, do it in a separate issue.
-        tracing::error!(
-            model_id = %server.model_id,
-            model_name = %server.model_name,
-            error = %error,
-            "Server error"
-        );
+        let model_id = server.model_id.parse::<i64>().ok();
+        let event = AppEvent::server_error(model_id, &server.model_name, error);
+        emit_or_log(&self.app, event.event_name(), &event);
     }
 }
 
@@ -114,78 +105,31 @@ mod tests {
     }
 
     #[test]
-    fn test_server_event_running_serialization() {
-        // Verify that ServerEvent::running serializes to expected JSON shape
-        let event = ServerEvent::running(42, 8080);
+    fn test_app_event_server_started_serialization() {
+        let s = summary("42", 8080);
+        let model_id = s.model_id.parse::<i64>().unwrap();
+        let event = AppEvent::server_started(model_id, &s.model_name, s.port);
+
+        assert_eq!(event.event_name(), "server:started");
+
         let json = serde_json::to_value(&event).expect("serialization should succeed");
-
-        assert_eq!(json["type"], "running");
-        assert_eq!(json["modelId"], "42"); // model_id is serialized as string
-        assert_eq!(json["status"], "running");
-        assert_eq!(json["port"], 8080);
-        assert!(json["updatedAt"].is_number());
-    }
-
-    #[test]
-    fn test_server_event_stopping_serialization() {
-        let state = ServerStateInfo::new(42, ServerStatus::Stopping, Some(8080));
-        let event = ServerEvent::Stopping(state);
-        let json = serde_json::to_value(&event).expect("serialization should succeed");
-
-        assert_eq!(json["type"], "stopping");
-        assert_eq!(json["modelId"], "42");
-        assert_eq!(json["status"], "stopping");
+        assert_eq!(json["type"], "server_started");
+        assert_eq!(json["modelId"], 42);
+        assert_eq!(json["modelName"], "TestModel");
         assert_eq!(json["port"], 8080);
     }
 
     #[test]
-    fn test_server_event_stopped_serialization() {
-        let state = ServerStateInfo::new(42, ServerStatus::Stopped, Some(8080));
-        let event = ServerEvent::Stopped(state);
+    fn test_app_event_server_stopped_serialization() {
+        let s = summary("42", 8080);
+        let model_id = s.model_id.parse::<i64>().unwrap();
+        let event = AppEvent::server_stopped(model_id, &s.model_name);
+
+        assert_eq!(event.event_name(), "server:stopped");
+
         let json = serde_json::to_value(&event).expect("serialization should succeed");
-
-        assert_eq!(json["type"], "stopped");
-        assert_eq!(json["modelId"], "42");
-        assert_eq!(json["status"], "stopped");
-        assert_eq!(json["port"], 8080);
-    }
-
-    #[test]
-    fn test_snapshot_event_serialization() {
-        let states = vec![
-            ServerStateInfo::new(1, ServerStatus::Running, Some(8080)),
-            ServerStateInfo::new(2, ServerStatus::Running, Some(8081)),
-        ];
-        let event = ServerEvent::snapshot(states);
-        let json = serde_json::to_value(&event).expect("serialization should succeed");
-
-        assert_eq!(json["type"], "snapshot");
-        assert!(json["servers"].is_array());
-        let servers_array = json["servers"].as_array().unwrap();
-        assert_eq!(servers_array.len(), 2);
-
-        // Verify first server in snapshot
-        assert_eq!(servers_array[0]["modelId"], "1");
-        assert_eq!(servers_array[0]["status"], "running");
-        assert_eq!(servers_array[0]["port"], 8080);
-    }
-
-    #[test]
-    fn test_snapshot_with_empty_servers() {
-        let event = ServerEvent::snapshot(vec![]);
-        let json = serde_json::to_value(&event).expect("serialization should succeed");
-
-        assert_eq!(json["type"], "snapshot");
-        assert_eq!(json["servers"].as_array().unwrap().len(), 0);
-    }
-
-    #[test]
-    fn test_parse_model_id_helper() {
-        let s1 = summary("123", 8080);
-        assert_eq!(TauriServerEvents::parse_model_id(&s1), 123);
-
-        let s2 = summary("invalid", 8080);
-        // Should default to 0 (with warning logged)
-        assert_eq!(TauriServerEvents::parse_model_id(&s2), 0);
+        assert_eq!(json["type"], "server_stopped");
+        assert_eq!(json["modelId"], 42);
+        assert_eq!(json["modelName"], "TestModel");
     }
 }

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -90,6 +90,24 @@ GGLib runs in **both Tauri (desktop) and Axum WebUI (browser)**. Ensure your UI 
 - Platform-specific behavior goes in **adapter layers** (e.g., `src/services/transport/`)
 - Test in both modes: `npm run tauri:dev` and `npm run dev`
 
+## Canonical Event Names
+
+GGLib uses **canonical event names** (emitted by the Rust backend and listened to by the frontend) to keep desktop (Tauri) and web (SSE) behavior aligned.
+
+### Server Lifecycle Events
+
+**Strict contract (no legacy aliases):**
+
+| Event Name | Meaning |
+|-----------|---------|
+| `server:snapshot` | Snapshot of currently running servers |
+| `server:started` | A server started and is ready |
+| `server:stopped` | A server stopped cleanly |
+| `server:error` | A server encountered an error |
+| `server:health_changed` | A running server's health status changed |
+
+If you need to add/change event names, update **both** the Rust source of truth (`AppEvent::event_name()`) and the frontend subscription constants.
+
 ## File Structure Conventions
 
 ### Component Organization

--- a/src-tauri/src/app/README.md
+++ b/src-tauri/src/app/README.md
@@ -58,8 +58,9 @@ Backend Operation (server start, download progress, etc.)
     │                     │
     │  Events:            │
     │  • download-progress│
-    │  • server:running   │
+    │  • server:started   │
     │  • server:stopped   │
+    │  • server:error     │
     │  • server:snapshot  │
     │  • menu:*           │
     └──────────┬──────────┘
@@ -76,7 +77,7 @@ Backend Operation (server start, download progress, etc.)
 | Category | Events |
 |----------|--------|
 | Downloads | `DOWNLOAD_PROGRESS` |
-| Server Lifecycle | `SERVER_RUNNING`, `SERVER_STOPPING`, `SERVER_STOPPED`, `SERVER_CRASHED`, `SERVER_SNAPSHOT` |
+| Server Lifecycle | `server:started`, `server:stopped`, `server:error`, `server:snapshot`, `server:health_changed` |
 | Menu Actions | `MENU_ADD_MODEL`, `MENU_REMOVE_MODEL`, `MENU_BROWSE_HUGGINGFACE`, `MENU_START_SERVER`, `MENU_STOP_SERVER`, `MENU_OPEN_CHAT`, `MENU_INSTALL_LLAMA` |
 
 <!-- module-docs:end -->

--- a/src-tauri/src/menu/README.md
+++ b/src-tauri/src/menu/README.md
@@ -74,7 +74,7 @@ Menu items are enabled/disabled based on application state. This keeps the nativ
                     │    proxy_running,     │
                     │    proxy_url,         │
                     │    model_selected,    │
-                    │    server_running,    │
+                    │    server_active,     │
                     │  }                    │
                     └───────────┬───────────┘
                                 │
@@ -91,8 +91,8 @@ Menu items are enabled/disabled based on application state. This keeps the nativ
 | Item | Enabled When | Checked When |
 |------|--------------|--------------|
 | Start Server | Model selected + llama installed + server not running | — |
-| Stop Server | Server running for selected model | — |
-| Restart Server | Server running for selected model | — |
+| Stop Server | Server active for selected model | — |
+| Restart Server | Server active for selected model | — |
 | Install llama.cpp | llama NOT installed | — |
 | Proxy Toggle | Always | Proxy running |
 | Copy Proxy URL | Proxy running | — |

--- a/src-tauri/src/menu/mod.rs
+++ b/src-tauri/src/menu/mod.rs
@@ -48,7 +48,7 @@ pub struct MenuState {
     pub llama_installed: bool,
     pub proxy_running: bool,
     pub model_selected: bool,
-    pub selected_model_server_running: bool,
+    pub selected_model_server_active: bool,
 }
 
 impl AppMenu {
@@ -63,11 +63,11 @@ impl AppMenu {
         // Model menu items
         // Start Server: enabled if model selected AND not already running
         self.start_server
-            .set_enabled(state.model_selected && !state.selected_model_server_running)?;
+            .set_enabled(state.model_selected && !state.selected_model_server_active)?;
 
         // Stop Server: enabled if model selected AND currently running
         self.stop_server
-            .set_enabled(state.model_selected && state.selected_model_server_running)?;
+            .set_enabled(state.model_selected && state.selected_model_server_active)?;
 
         // Remove Model: enabled if model selected
         self.remove_model.set_enabled(state.model_selected)?;

--- a/src-tauri/src/menu/state_sync.rs
+++ b/src-tauri/src/menu/state_sync.rs
@@ -37,7 +37,7 @@ pub async fn sync_menu_state_internal(
     let model_selected = selected_id.is_some();
 
     // Check if selected model has a running server
-    let selected_model_server_running = if let Some(id) = selected_id {
+    let selected_model_server_active = if let Some(id) = selected_id {
         let servers = state.gui.list_servers().await;
         servers.iter().any(|s| s.model_id == id)
     } else {
@@ -48,7 +48,7 @@ pub async fn sync_menu_state_internal(
         llama_installed,
         proxy_running,
         model_selected,
-        selected_model_server_running,
+        selected_model_server_active,
     };
 
     // Update menu items

--- a/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
+++ b/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
@@ -66,7 +66,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
   const uptimeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Get server state from registry - undefined means not running
-  // Polling resumes automatically when status changes to 'running' via server:running event
+  // Polling resumes automatically when status changes to 'running' via server:started event
   const serverState = useServerState(modelId);
   const isRunning = serverState?.status === 'running';
 
@@ -102,7 +102,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
   // Poll server metrics using setTimeout recursion + AbortController
   // Only polls when server status is 'running'
   // On fetch failure: stops local loop, clears metrics, does not affect global state
-  // Polling resumes automatically when status changes to 'running' via server:running event
+  // Polling resumes automatically when status changes to 'running' via server:started event
   useEffect(() => {
     // Don't poll if server is not running
     if (!isRunning) {

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -68,7 +68,7 @@ When a model is served, the view transitions to a Chat layout with tab switching
 
 ### Console View
 When a model is served, users can switch between Chat and Console views:
-- **`ConsoleInfoPanel/`**: Left panel showing server info (port, uptime, context usage), live metrics from `/metrics` endpoint, and stop button. Uses `useServerState` hook to subscribe to backend lifecycle events - polling automatically stops when server stops and resumes when a new `server:running` event is received.
+- **`ConsoleInfoPanel/`**: Left panel showing server info (port, uptime, context usage), live metrics from `/metrics` endpoint, and stop button. Uses `useServerState` hook to subscribe to backend lifecycle events - polling automatically stops when server stops and resumes when a new `server:started` event is received.
 
 ### Server Management
 - **`ServerStatus.tsx`**: Display server health and status

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -78,10 +78,10 @@ Events are the source of truth for server state. All events flow from the Rust b
 | Event | Description |
 |-------|-------------|
 | `server:snapshot` | Initial state of all running servers (emitted on app init) |
-| `server:running` | Server started and ready |
-| `server:stopping` | Server stop initiated |
+| `server:started` | Server started and ready |
 | `server:stopped` | Server stopped cleanly |
-| `server:crashed` | Server exited unexpectedly |
+| `server:error` | Server encountered an error |
+| `server:health_changed` | Server health status changed |
 
 ## Platform Utilities
 

--- a/src/services/serverEvents.normalize.ts
+++ b/src/services/serverEvents.normalize.ts
@@ -80,7 +80,7 @@ function normalizeHealthChanged(data: Record<string, unknown>): ServerEvent | nu
 
   const updatedAt =
     typeof data.timestamp === 'number'
-      ? (coerceUnixTimeToMs(data.timestamp) ?? data.timestamp)
+      ? (coerceUnixTimeToMs(data.timestamp) ?? Date.now())
       : typeof data.updatedAt === 'number'
         ? data.updatedAt
         : typeof data.updated_at === 'number'
@@ -101,7 +101,7 @@ function normalizeLifecycle(
   data: Record<string, unknown>
 ): ServerEvent | null {
   const modelId = String(data.modelId ?? data.model_id ?? '');
-  if (!modelId) return kind === 'crashed' ? null : null;
+  if (!modelId) return null;
 
   const port = typeof data.port === 'number' ? data.port : undefined;
 
@@ -116,7 +116,7 @@ function normalizeLifecycle(
   if (kind === 'stopped') return { type: 'stopped', modelId, port, updatedAt };
 
   // server:error may omit modelId on the Rust side; ignore in that case.
-  return modelId ? { type: 'crashed', modelId, port, updatedAt } : null;
+  return { type: 'crashed', modelId, port, updatedAt };
 }
 
 /**

--- a/src/services/serverEvents.normalize.ts
+++ b/src/services/serverEvents.normalize.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared server lifecycle event normalization.
+ *
+ * Keeps Tauri and Web(SSE) behavior identical by translating backend event payloads
+ * into the `serverRegistry` event union.
+ */
+
+import type { ServerEvent } from './serverRegistry';
+
+export type CanonicalServerEventName =
+  | 'server:snapshot'
+  | 'server:started'
+  | 'server:stopped'
+  | 'server:error'
+  | 'server:health_changed';
+
+function toRecord(payload: unknown): Record<string, unknown> | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  return payload as Record<string, unknown>;
+}
+
+function coerceUnixTimeToMs(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+
+  // Heuristics:
+  // - seconds: ~1e9 .. 1e10
+  // - milliseconds: ~1e12 .. 1e13
+  // - nanoseconds: ~1e18
+  if (value >= 1e17) return Math.floor(value / 1e6); // ns -> ms
+  if (value >= 1e11) return Math.floor(value); // already ms
+  return Math.floor(value * 1000); // seconds -> ms
+}
+
+function normalizeSnapshot(data: Record<string, unknown>): ServerEvent | null {
+  const servers = data.servers;
+  if (!Array.isArray(servers)) return null;
+
+  return {
+    type: 'snapshot',
+    servers: servers
+      .map((s) => {
+        if (typeof s !== 'object' || s === null) return null;
+        const entry = s as Record<string, unknown>;
+
+        const modelId = String(entry.modelId ?? entry.model_id ?? '');
+        if (!modelId) return null;
+
+        const port = typeof entry.port === 'number' ? entry.port : undefined;
+
+        const startedAtRaw =
+          typeof entry.startedAt === 'number'
+            ? entry.startedAt
+            : typeof entry.started_at === 'number'
+              ? entry.started_at
+              : undefined;
+
+        const updatedAt =
+          coerceUnixTimeToMs(startedAtRaw) ??
+          (typeof entry.updatedAt === 'number'
+            ? entry.updatedAt
+            : typeof entry.updated_at === 'number'
+              ? entry.updated_at
+              : Date.now());
+
+        // Snapshot only lists running servers.
+        return { modelId, status: 'running' as const, port, updatedAt };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null),
+  };
+}
+
+function normalizeHealthChanged(data: Record<string, unknown>): ServerEvent | null {
+  const modelId = String(data.modelId ?? data.model_id ?? '');
+  if (!modelId) return null;
+
+  const status = data.status as Record<string, unknown> | undefined;
+  if (!status || typeof status.status !== 'string') return null;
+
+  const detail = typeof data.detail === 'string' ? data.detail : undefined;
+
+  const updatedAt =
+    typeof data.timestamp === 'number'
+      ? (coerceUnixTimeToMs(data.timestamp) ?? data.timestamp)
+      : typeof data.updatedAt === 'number'
+        ? data.updatedAt
+        : typeof data.updated_at === 'number'
+          ? data.updated_at
+          : Date.now();
+
+  return {
+    type: 'server_health_changed',
+    modelId,
+    status: status as import('../types').ServerHealthStatus,
+    detail,
+    updatedAt,
+  };
+}
+
+function normalizeLifecycle(
+  kind: 'running' | 'stopped' | 'crashed',
+  data: Record<string, unknown>
+): ServerEvent | null {
+  const modelId = String(data.modelId ?? data.model_id ?? '');
+  if (!modelId) return kind === 'crashed' ? null : null;
+
+  const port = typeof data.port === 'number' ? data.port : undefined;
+
+  const updatedAt =
+    typeof data.updatedAt === 'number'
+      ? data.updatedAt
+      : typeof data.updated_at === 'number'
+        ? data.updated_at
+        : Date.now();
+
+  if (kind === 'running') return { type: 'running', modelId, port, updatedAt };
+  if (kind === 'stopped') return { type: 'stopped', modelId, port, updatedAt };
+
+  // server:error may omit modelId on the Rust side; ignore in that case.
+  return modelId ? { type: 'crashed', modelId, port, updatedAt } : null;
+}
+
+/**
+ * Normalize a named canonical server:* event (Tauri uses event names).
+ */
+export function normalizeServerEventFromNamedEvent(
+  eventName: CanonicalServerEventName,
+  payload: unknown
+): ServerEvent | null {
+  const data = toRecord(payload);
+  if (!data) return null;
+
+  switch (eventName) {
+    case 'server:snapshot':
+      return normalizeSnapshot(data);
+    case 'server:started':
+      return normalizeLifecycle('running', data);
+    case 'server:stopped':
+      return normalizeLifecycle('stopped', data);
+    case 'server:error':
+      return normalizeLifecycle('crashed', data);
+    case 'server:health_changed':
+      return normalizeHealthChanged(data);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Normalize a backend AppEvent payload coming from SSE.
+ *
+ * SSE payloads are AppEvent objects tagged with snake_case `type`, e.g.:
+ * - { type: 'server_started', modelId: 1, port: 8080 }
+ */
+export function normalizeServerEventFromAppEvent(payload: unknown): ServerEvent | null {
+  const data = toRecord(payload);
+  if (!data) return null;
+
+  const t = data.type;
+  if (typeof t !== 'string') return null;
+
+  switch (t) {
+    case 'server_snapshot':
+      return normalizeSnapshot(data);
+    case 'server_started':
+      return normalizeLifecycle('running', data);
+    case 'server_stopped':
+      return normalizeLifecycle('stopped', data);
+    case 'server_error':
+      return normalizeLifecycle('crashed', data);
+    case 'server_health_changed':
+      return normalizeHealthChanged(data);
+    default:
+      return null;
+  }
+}

--- a/src/services/serverRegistry.ts
+++ b/src/services/serverRegistry.ts
@@ -191,7 +191,7 @@ export function isServerRunning(modelId: string | number): boolean {
  * Returns undefined for unknown models (UI should treat as not running).
  * Automatically re-renders when the server's state changes.
  * Polling resumes automatically when status changes to 'running' via a new
- * server:running event.
+ * server:started event.
  */
 export function useServerState(modelId: string | number): ServerState | undefined {
   const modelIdStr = String(modelId);

--- a/src/services/transport/events/sse.ts
+++ b/src/services/transport/events/sse.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Unsubscribe, EventHandler } from '../types/common';
-import type { AppEventType, AppEventMap, ServerEvent, DownloadEvent, LogEvent } from '../types/events';
+import type { AppEventType, AppEventMap } from '../types/events';
 import { decodeDownloadEvent } from '../../decoders/downloadEvent';
 import { createSSEStream, type SSEMessage } from '../../../utils/sse';
 import { getApiBaseUrl, getAuthHeaders, getClient } from '../api/client';
@@ -331,24 +331,6 @@ export function subscribeSseEvent<K extends AppEventType>(
 /**
  * Parse server event from SSE payload.
  */
-export function parseServerEvent(payload: unknown): ServerEvent {
-  return payload as ServerEvent;
-}
-
-/**
- * Parse download event from SSE payload.
- */
-export function parseDownloadEvent(payload: unknown): DownloadEvent {
-  return payload as DownloadEvent;
-}
-
-/**
- * Parse log event from SSE payload.
- */
-export function parseLogEvent(payload: unknown): LogEvent {
-  return payload as LogEvent;
-}
-
 /**
  * Create SSE-based event system.
  * Returns object with subscribe method matching EventsTransport interface.

--- a/src/services/transport/events/tauri.ts
+++ b/src/services/transport/events/tauri.ts
@@ -5,7 +5,7 @@
 
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import type { Unsubscribe, EventHandler } from '../types/common';
-import type { AppEventType, AppEventMap, ServerEvent, DownloadEvent, LogEvent } from '../types/events';
+import type { AppEventType, AppEventMap } from '../types/events';
 import {
   DOWNLOAD_EVENT_NAMES,
   SERVER_EVENT_NAMES,
@@ -91,26 +91,4 @@ export function createTauriEvents() {
   }
   
   return { subscribe };
-}
-
-/**
- * Parse server event from Tauri payload.
- */
-export function parseServerEvent(payload: unknown): ServerEvent {
-  // Tauri sends events directly as the correct shape
-  return payload as ServerEvent;
-}
-
-/**
- * Parse download event from Tauri payload.
- */
-export function parseDownloadEvent(payload: unknown): DownloadEvent {
-  return payload as DownloadEvent;
-}
-
-/**
- * Parse log event from Tauri payload.
- */
-export function parseLogEvent(payload: unknown): LogEvent {
-  return payload as LogEvent;
 }

--- a/tests/ts/services/server/safeActions.test.ts
+++ b/tests/ts/services/server/safeActions.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression guard: safeStopServer must not consult local serverRegistry state.
+// If a future change reintroduces `isServerRunning()` gating, this mock will
+// throw and the test will fail.
+vi.mock('../../../../src/services/serverRegistry', () => ({
+  isServerRunning: () => {
+    throw new Error('safeStopServer must not consult isServerRunning()');
+  },
+}));
+
+vi.mock('../../../../src/services/clients/servers', () => ({
+  stopServer: vi.fn(),
+}));
+
+import { safeStopServer } from '../../../../src/services/server/safeActions';
+import { stopServer } from '../../../../src/services/clients/servers';
+import { TransportError } from '../../../../src/services/transport/errors';
+
+describe('safeStopServer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('always calls stopServer (no client-side gating)', async () => {
+    vi.mocked(stopServer).mockResolvedValue(undefined);
+
+    await expect(safeStopServer(123)).resolves.toBeUndefined();
+
+    expect(stopServer).toHaveBeenCalledTimes(1);
+    expect(stopServer).toHaveBeenCalledWith(123);
+  });
+
+  it('treats NOT_FOUND as idempotent success', async () => {
+    vi.mocked(stopServer).mockRejectedValue(new TransportError('NOT_FOUND', 'not found'));
+
+    await expect(safeStopServer(123)).resolves.toBeUndefined();
+  });
+
+  it('treats CONFLICT as idempotent success', async () => {
+    vi.mocked(stopServer).mockRejectedValue(new TransportError('CONFLICT', 'already stopped'));
+
+    await expect(safeStopServer(123)).resolves.toBeUndefined();
+  });
+
+  it('rethrows unexpected errors', async () => {
+    vi.mocked(stopServer).mockRejectedValue(new TransportError('INTERNAL', 'boom'));
+
+    await expect(safeStopServer(123)).rejects.toMatchObject({
+      name: 'TransportError',
+      code: 'INTERNAL',
+    });
+  });
+});

--- a/tests/ts/services/server/serverEvents.normalize.test.ts
+++ b/tests/ts/services/server/serverEvents.normalize.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  normalizeServerEventFromAppEvent,
+  normalizeServerEventFromNamedEvent,
+} from '../../../../src/services/serverEvents.normalize';
+
+describe('serverEvents.normalize', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('normalizes server_snapshot with started_at seconds -> updatedAt ms', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_snapshot',
+      servers: [
+        {
+          modelId: 1,
+          modelName: 'M',
+          port: 8080,
+          started_at: 1_700_000_000,
+          healthy: true,
+        },
+      ],
+    });
+
+    expect(evt).toEqual({
+      type: 'snapshot',
+      servers: [
+        {
+          modelId: '1',
+          status: 'running',
+          port: 8080,
+          updatedAt: 1_700_000_000_000,
+        },
+      ],
+    });
+  });
+
+  it('normalizes server_started into running with deterministic updatedAt', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_started',
+      modelId: 123,
+      modelName: 'TestModel',
+      port: 9000,
+    });
+
+    expect(evt).toMatchObject({
+      type: 'running',
+      modelId: '123',
+      port: 9000,
+      updatedAt: Date.now(),
+    });
+  });
+
+  it('normalizes server_stopped into stopped', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_stopped',
+      modelId: 123,
+      modelName: 'TestModel',
+    });
+
+    expect(evt).toMatchObject({
+      type: 'stopped',
+      modelId: '123',
+      updatedAt: Date.now(),
+    });
+  });
+
+  it('ignores server_error when modelId is missing', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_error',
+      modelId: null,
+      modelName: 'TestModel',
+      error: 'boom',
+    });
+
+    expect(evt).toBeNull();
+  });
+
+  it('normalizes server_health_changed using timestamp (ms)', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_health_changed',
+      serverId: 99,
+      modelId: 7,
+      status: { status: 'healthy' },
+      detail: 'ok',
+      timestamp: 1_700_000_000_123,
+    });
+
+    expect(evt).toEqual({
+      type: 'server_health_changed',
+      modelId: '7',
+      status: { status: 'healthy' },
+      detail: 'ok',
+      updatedAt: 1_700_000_000_123,
+    });
+  });
+
+  it('named-event path matches app-event path for snapshot', () => {
+    const payload = {
+      type: 'server_snapshot',
+      servers: [{ modelId: 1, port: 8080, started_at: 1_700_000_000 }],
+    };
+
+    const a = normalizeServerEventFromAppEvent(payload);
+    const b = normalizeServerEventFromNamedEvent('server:snapshot', payload);
+
+    expect(b).toEqual(a);
+  });
+});


### PR DESCRIPTION
Closes #40.

## What changed
- Stop actions are backend-authoritative and idempotent (no client-side gating).
- Desktop (Tauri) server lifecycle events use the canonical `server:*` names and AppEvent payloads.
- Strict cleanup: legacy server event aliases removed; docs updated to record canonical event list.
- Regression test added to prevent reintroducing stop gating.

## Verification
- `npm run build`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `cargo test -p gglib-tauri`