### PR TITLE
Chat: tools disabled by default

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -9,7 +9,7 @@ import { GenericToolUI, TimeToolUI } from '../components/ToolUI';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
 import { Textarea } from '../components/ui/Textarea';
-import { useGglibRuntime, TOOL_ENABLED_SYSTEM_PROMPT } from '../hooks/useGglibRuntime';
+import { useGglibRuntime, DEFAULT_SYSTEM_PROMPT as RUNTIME_DEFAULT_SYSTEM_PROMPT } from '../hooks/useGglibRuntime';
 import { useChatPersistence } from '../hooks/useChatPersistence';
 import { useSettings } from '../hooks/useSettings';
 import { useToastContext } from '../contexts/ToastContext';
@@ -26,8 +26,9 @@ import type { ConversationSummary } from '../services/clients/chat';
 import './ChatPage.css';
 
 const DEFAULT_CONVERSATION_TITLE = 'New Chat';
-// Use tool-enabled prompt by default (most common for served models with jinja/agent tag)
-const DEFAULT_SYSTEM_PROMPT = TOOL_ENABLED_SYSTEM_PROMPT;
+// Base prompt stored on the conversation by default.
+// Tool availability is handled dynamically at request-time.
+const DEFAULT_SYSTEM_PROMPT = RUNTIME_DEFAULT_SYSTEM_PROMPT;
 
 interface ChatPageProps {
   serverPort: number;

--- a/tests/ts/services/tools/registry.test.ts
+++ b/tests/ts/services/tools/registry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { ToolRegistry } from '../../../../src/services/tools/registry';
+
+describe('ToolRegistry (secure-by-default enablement)', () => {
+  it('defaults newly registered tools to disabled', () => {
+    const registry = new ToolRegistry();
+
+    registry.registerFunction(
+      'test_tool',
+      'A test tool',
+      undefined,
+      () => ({ success: true, data: 'ok' })
+    );
+
+    expect(registry.isEnabled('test_tool')).toBe(false);
+    expect(registry.getEnabledDefinitions()).toHaveLength(0);
+  });
+
+  it('enable()/disable() toggles state as expected', () => {
+    const registry = new ToolRegistry();
+
+    registry.registerFunction(
+      'test_tool',
+      'A test tool',
+      undefined,
+      () => ({ success: true, data: 'ok' })
+    );
+
+    registry.enable('test_tool');
+    expect(registry.isEnabled('test_tool')).toBe(true);
+    expect(registry.getEnabledDefinitions().map((d) => d.function.name)).toEqual(['test_tool']);
+
+    registry.disable('test_tool');
+    expect(registry.isEnabled('test_tool')).toBe(false);
+    expect(registry.getEnabledDefinitions()).toHaveLength(0);
+  });
+
+  it('unregister + re-register preserves previously enabled state (MCP resync simulation)', () => {
+    const registry = new ToolRegistry();
+
+    registry.registerFunction(
+      'mcp_tool',
+      'An MCP-provided tool',
+      undefined,
+      () => ({ success: true, data: 'ok' }),
+      'mcp:server-1'
+    );
+
+    // User enables it
+    registry.enable('mcp_tool');
+    expect(registry.isEnabled('mcp_tool')).toBe(true);
+
+    // Tool disappears during a resync (unregister), then comes back (register)
+    expect(registry.unregister('mcp_tool')).toBe(true);
+
+    registry.registerFunction(
+      'mcp_tool',
+      'An MCP-provided tool (re-registered)',
+      undefined,
+      () => ({ success: true, data: 'ok' }),
+      'mcp:server-1'
+    );
+
+    // Should still be enabled after re-register
+    expect(registry.isEnabled('mcp_tool')).toBe(true);
+  });
+
+  it('unregister + re-register keeps disabled tools disabled if never enabled', () => {
+    const registry = new ToolRegistry();
+
+    registry.registerFunction(
+      'mcp_tool',
+      'An MCP-provided tool',
+      undefined,
+      () => ({ success: true, data: 'ok' }),
+      'mcp:server-1'
+    );
+
+    expect(registry.isEnabled('mcp_tool')).toBe(false);
+
+    expect(registry.unregister('mcp_tool')).toBe(true);
+
+    registry.registerFunction(
+      'mcp_tool',
+      'An MCP-provided tool (re-registered)',
+      undefined,
+      () => ({ success: true, data: 'ok' }),
+      'mcp:server-1'
+    );
+
+    expect(registry.isEnabled('mcp_tool')).toBe(false);
+  });
+});


### PR DESCRIPTION
### Summary
This PR makes the chat GUI **secure-by-default**: no tools are active unless the user explicitly enables them.

- Tools register as **disabled by default** (prevents MCP resync from accidentally re-enabling tools).
- The LLM system prompt is **hot-swapped at request time** *only* when:
  - the stored prompt is exactly the default prompt, and
  - at least one tool is currently enabled.
  This preserves user-edited prompts while still enabling tool-priming when needed.
- Adds focused unit tests for `ToolRegistry` default-off, enable/disable toggling, and unregister+re-register state preservation.

### Behavior Changes
- New tools: `isEnabled(name) === false` until explicitly enabled.
- Enabling tools mid-chat works: the request uses the tool-enabled prompt **for that request only** when safe.

### Files
- `src/services/tools/registry.ts`
- `src/hooks/useGglibRuntime/streamModelResponse.ts`
- `src/pages/ChatPage.tsx`
- `tests/ts/services/tools/registry.test.ts`

### Testing
- `npm run build`
- `npx vitest run tests/ts/services/tools/registry.test.ts`

### Notes
- The full test suite currently has existing unrelated failures, so this PR includes a focused regression test for the new behavior.
