### PR TITLE
Fix Arch/Manjaro Tauri AppImage bundling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,13 @@ build-tauri:
 	@if ! command -v npm >/dev/null 2>&1; then echo "Error: npm not found"; exit 1; fi
 	@rm -f src-tauri/target/release/bundle/dmg/*.dmg 2>/dev/null || true
 	npm install
-	npm run tauri:build
+	# linuxdeploy's embedded strip can fail on some distros (e.g. Arch) due to RELR relocations.
+	# NO_STRIP=1 is a linuxdeploy-supported knob that avoids the failure by skipping stripping.
+	@if [ "$(UNAME_S)" = "Linux" ]; then \
+		NO_STRIP=1 npm run tauri:build; \
+	else \
+		npm run tauri:build; \
+	fi
 	@echo "✓ Tauri app built to src-tauri/target/release/gglib-gui"
 
 # Full setup from scratch

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -19,6 +19,131 @@ use gglib_runtime::llama::{
     handle_update,
 };
 
+fn find_linux_gui_artifact(repo_root: &std::path::Path) -> std::path::PathBuf {
+    let appimage_dir = repo_root.join("src-tauri/target/release/bundle/appimage");
+    if let Ok(read_dir) = std::fs::read_dir(&appimage_dir) {
+        let mut candidates: Vec<std::path::PathBuf> = read_dir
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_file()
+                    && path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|name| name.ends_with(".AppImage"))
+            })
+            .collect();
+
+        candidates.sort();
+        if let Some(path) = candidates.into_iter().next() {
+            return path;
+        }
+    }
+
+    repo_root.join("src-tauri/target/release/gglib-app")
+}
+
+fn launch_gui_command(repo_root: &std::path::Path) -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let app_bundle = repo_root.join("src-tauri/target/release/bundle/macos/GGLib GUI.app");
+        if app_bundle.exists() {
+            println!("Launching GGLib GUI...");
+            let status = std::process::Command::new("open").arg(&app_bundle).status();
+            match status {
+                Ok(s) if s.success() => Ok(()),
+                Ok(s) => anyhow::bail!("Failed to launch GUI (exit code: {:?})", s.code()),
+                Err(e) => Err(e.into()),
+            }
+        } else {
+            println!("Desktop GUI not found at: {}", app_bundle.display());
+            println!();
+            println!("To build the GUI, run: make build-tauri");
+            println!("Or: npm run tauri:build");
+            Ok(())
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let artifact = find_linux_gui_artifact(repo_root);
+        if artifact.exists() {
+            println!("Launching GGLib GUI...");
+            let spawned = std::process::Command::new(&artifact).spawn();
+            match spawned {
+                Ok(_child) => Ok(()),
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::PermissionDenied {
+                        anyhow::bail!(
+                            "Failed to launch GUI: {} (is it executable? try: chmod +x \"{}\")",
+                            e,
+                            artifact.display()
+                        );
+                    }
+                    Err(e.into())
+                }
+            }
+        } else {
+            let appimage_dir = repo_root.join("src-tauri/target/release/bundle/appimage");
+            println!(
+                "Desktop GUI not found at: {} (or any *.AppImage in {})",
+                repo_root.join("src-tauri/target/release/gglib-app").display(),
+                appimage_dir.display()
+            );
+            println!();
+            println!("To build the GUI, run: make build-tauri");
+            println!("Or: npm run tauri:build");
+            Ok(())
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = repo_root;
+        anyhow::bail!("gglib gui is not supported on this OS yet")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_temp_dir(prefix: &str) -> std::path::PathBuf {
+        let mut base = std::env::temp_dir();
+        base.push(format!(
+            "{}_{}_{}",
+            prefix,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    #[test]
+    fn linux_gui_artifact_prefers_any_appimage() {
+        let root = make_temp_dir("gglib_cli_gui");
+        let appimage_dir = root.join("src-tauri/target/release/bundle/appimage");
+        std::fs::create_dir_all(&appimage_dir).unwrap();
+
+        let appimage = appimage_dir.join("GGLib GUI_0.2.4_amd64.AppImage");
+        std::fs::write(&appimage, b"stub").unwrap();
+
+        let chosen = find_linux_gui_artifact(&root);
+        assert_eq!(chosen, appimage);
+    }
+
+    #[test]
+    fn linux_gui_artifact_falls_back_to_binary_when_no_appimage() {
+        let root = make_temp_dir("gglib_cli_gui");
+        let chosen = find_linux_gui_artifact(&root);
+        assert_eq!(chosen, root.join("src-tauri/target/release/gglib-app"));
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Initialize logging
@@ -210,29 +335,9 @@ async fn main() -> anyhow::Result<()> {
             if dev {
                 println!("Development mode requires running 'cargo tauri dev' directly");
             } else {
-                // Try to find and launch the built GUI app
                 let repo_root = std::path::PathBuf::from(env!("GGLIB_REPO_ROOT"));
-                let app_bundle =
-                    repo_root.join("src-tauri/target/release/bundle/macos/GGLib GUI.app");
-
-                if app_bundle.exists() {
-                    println!("Launching GGLib GUI...");
-                    let status = std::process::Command::new("open").arg(&app_bundle).status();
-
-                    match status {
-                        Ok(s) if s.success() => {}
-                        Ok(s) => {
-                            eprintln!("Failed to launch GUI (exit code: {:?})", s.code());
-                        }
-                        Err(e) => {
-                            eprintln!("Failed to launch GUI: {}", e);
-                        }
-                    }
-                } else {
-                    println!("Desktop GUI not found at: {}", app_bundle.display());
-                    println!();
-                    println!("To build the GUI, run: make build-tauri");
-                    println!("Or: npm run tauri:build");
+                if let Err(e) = launch_gui_command(&repo_root) {
+                    eprintln!("{}", e);
                 }
             }
         }

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -87,7 +87,9 @@ fn launch_gui_command(repo_root: &std::path::Path) -> anyhow::Result<()> {
             let appimage_dir = repo_root.join("src-tauri/target/release/bundle/appimage");
             println!(
                 "Desktop GUI not found at: {} (or any *.AppImage in {})",
-                repo_root.join("src-tauri/target/release/gglib-app").display(),
+                repo_root
+                    .join("src-tauri/target/release/gglib-app")
+                    .display(),
                 appimage_dir.display()
             );
             println!();

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -537,7 +537,14 @@ main() {
         # Check curl development headers (required for llama.cpp on Linux)
         check_lib "libcurl-dev" "Required for llama.cpp HTTP/HTTPS support" "true" "libcurl"
         
-        check_dep "patchelf" "Required for Tauri AppImage bundling" "true" "patchelf"
+        check_dep "patchelf" "Required for Tauri AppImage bundling (linuxdeploy)" "true" "patchelf"
+
+        # On some rolling distros (notably Arch), linuxdeploy's bundled binutils can be too old
+        # to strip modern system libraries that use RELR relocations, causing AppImage bundling to fail.
+        # Workaround: build with NO_STRIP=1 (Makefile sets this automatically for Linux builds).
+        if [ "$(detect_linux_distro)" = "arch" ] && [ -z "${NO_STRIP:-}" ]; then
+            echo -e "${YELLOW}NOTE:${RESET} If AppImage bundling fails with 'unknown type [0x13] section .relr.dyn', run builds with ${BOLD}NO_STRIP=1${RESET}."
+        fi
         # Try webkit2gtk-4.1 first (Ubuntu 24.04+), fallback to 4.0
         if ! pkg-config --exists webkit2gtk-4.1 2>/dev/null && pkg-config --exists webkit2gtk-4.0 2>/dev/null; then
             check_lib "webkit2gtk-4.1" "Required for Tauri desktop app (WebView)" "true" "webkit2gtk-4.0"


### PR DESCRIPTION
Fixes #45.

### Summary
On Arch/Manjaro (and potentially other rolling distros), `make setup` could fail during the Tauri AppImage bundling step with a generic error like “failed to run linuxdeploy”.

### Root Cause
The `linuxdeploy` AppImage used by Tauri includes an embedded `strip` binary. On Arch, some system libraries are built with newer ELF relocation formats (RELR, `.relr.dyn`). The embedded `strip` in linuxdeploy is too old to understand these relocations and fails while linuxdeploy is stripping deployed libraries, which aborts AppImage bundling.

### Fix
- For Linux builds invoked via `make build-tauri`, set `NO_STRIP=1` when running `tauri build`.
- `linuxdeploy` recognizes `NO_STRIP=1` and skips stripping, avoiding the incompatible embedded `strip`.
- This change is Linux-only; macOS/Windows behavior is unchanged.

### Trade-offs
- AppImage size may be slightly larger because libraries aren’t stripped. This is acceptable for dev and unblocks Arch/Manjaro users.

### Verification
- Confirmed `make build-tauri` produces `.deb`, `.rpm`, and `.AppImage` successfully on Arch/Manjaro.
