### PR TITLE
macOS-only menubar (hide menu on Linux/Windows)

### DIFF
--- a/src-tauri/src/menu/mod.rs
+++ b/src-tauri/src/menu/mod.rs
@@ -11,11 +11,17 @@
 //! - `handlers` - Menu event handling
 //! - `state_sync` - Menu state synchronization with app state
 
+#[cfg(target_os = "macos")]
 mod build;
+
+#[cfg(target_os = "macos")]
 pub mod handlers;
+
+#[cfg(target_os = "macos")]
 pub mod ids;
 pub mod state_sync;
 
+#[cfg(target_os = "macos")]
 pub use build::build_app_menu;
 
 use tauri::{

--- a/src-tauri/src/menu/state_sync.rs
+++ b/src-tauri/src/menu/state_sync.rs
@@ -7,6 +7,7 @@ use crate::app::AppState;
 use crate::menu::MenuState;
 use gglib_runtime::llama::check_llama_installed;
 use tauri::AppHandle;
+#[cfg(target_os = "macos")]
 use tracing::warn;
 
 /// Sync menu state based on current application state.
@@ -61,6 +62,7 @@ pub async fn sync_menu_state_internal(
 /// Sync menu state, logging any errors.
 ///
 /// Convenience wrapper for fire-and-forget sync from async contexts.
+#[cfg(target_os = "macos")]
 pub async fn sync_menu_state_logged(app: &AppHandle, state: &tauri::State<'_, AppState>) {
     if let Err(e) = sync_menu_state_internal(app, state).await {
         warn!("Failed to sync menu state: {}", e);
@@ -68,6 +70,7 @@ pub async fn sync_menu_state_logged(app: &AppHandle, state: &tauri::State<'_, Ap
 }
 
 /// Alias for sync_menu_state_logged (backward compatibility).
+#[cfg(target_os = "macos")]
 pub async fn sync_menu_state_or_log(app: &AppHandle, state: &tauri::State<'_, AppState>) {
     sync_menu_state_logged(app, state).await;
 }


### PR DESCRIPTION
Fixes #47

## Problem
The Tauri app was unconditionally building and attaching a native application menu on all platforms. On Linux, desktop environments that support app menubars (GNOME, KDE, etc.) would render this menu at the top of the window, even though the menubar feature was designed exclusively for macOS.

## Solution
Implemented compile-time platform gating using `#[cfg(target_os = "macos")]` to ensure the native menu is only active on macOS:

### Changes
1. **Menu initialization** ([src-tauri/src/main.rs](src-tauri/src/main.rs))
   - macOS: builds full menu hierarchy, registers event handlers, stores menu state for dynamic updates
   - Non-macOS: explicitly attaches an empty `Menu` to prevent Tauri/platform defaults (File/Edit/Window menus)

2. **Event handling** ([src-tauri/src/main.rs](src-tauri/src/main.rs))
   - Gated `.on_menu_event(...)` registration to macOS-only
   - Non-macOS builds don't include menu event dispatch code

3. **Module compilation** ([src-tauri/src/menu/mod.rs](src-tauri/src/menu/mod.rs), [src-tauri/src/menu/state_sync.rs](src-tauri/src/menu/state_sync.rs))
   - Menu builder, handlers, and IDs are only compiled on macOS
   - Menu sync commands remain registered on all platforms (return Ok/no-op when menu is None)
   - Prevents "command not found" errors from frontend

### Design Decisions
- ✅ `AppState` is always managed (avoids panic from missing state)
- ✅ Menu sync commands always registered cross-platform (frontend can safely invoke)
- ✅ Empty menu explicitly attached on non-macOS (blocks platform default menus)
- ✅ Compile-time gating (zero runtime overhead on Linux/Windows)

### Testing
- `cargo check` passes cleanly on Linux with no warnings
- Commands remain registered and callable (no frontend breakage)