### PR TITLE
Fix: GUI downloads fail on Linux with Python encodings error

### DIFF
--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -558,7 +558,7 @@ mod tests {
 
         // Create a command with a "dirty" environment simulating a conda/virtualenv shell
         let mut cmd = Command::new(python);
-        
+
         // Simulate polluted environment by setting variables on the Command
         cmd.env("PYTHONHOME", "/fake/python/home")
             .env("PYTHONPATH", "/fake/python/path")

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -374,7 +374,11 @@ async fn run_python_command(python: &Path, args: &[&str]) -> Result<(), EnvSetup
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let mut details = format!("{} {args:?} exited with {}", python.display(), output.status);
+        let mut details = format!(
+            "{} {args:?} exited with {}",
+            python.display(),
+            output.status
+        );
         if !stdout.is_empty() {
             details.push_str(&format!("\nstdout: {stdout}"));
         }

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -336,7 +336,7 @@ async fn find_bootstrap_python_validated() -> Result<PathBuf, EnvSetupError> {
     let mut last_error: Option<String> = None;
 
     for candidate in PYTHON_CANDIDATES {
-        tried.push(candidate.to_string());
+        tried.push((*candidate).to_string());
         let Ok(path) = which::which(candidate) else {
             continue;
         };
@@ -345,7 +345,6 @@ async fn find_bootstrap_python_validated() -> Result<PathBuf, EnvSetupError> {
             Ok(_) => return Ok(path),
             Err(e) => {
                 last_error = Some(e.to_string());
-                continue;
             }
         }
     }
@@ -380,10 +379,12 @@ async fn run_python_command(python: &Path, args: &[&str]) -> Result<(), EnvSetup
             output.status
         );
         if !stdout.is_empty() {
-            details.push_str(&format!("\nstdout: {stdout}"));
+            use std::fmt::Write;
+            let _ = write!(details, "\nstdout: {stdout}");
         }
         if !stderr.is_empty() {
-            details.push_str(&format!("\nstderr: {stderr}"));
+            use std::fmt::Write;
+            let _ = write!(details, "\nstderr: {stderr}");
         }
         return Err(EnvSetupError::RequirementsFailed(details));
     }
@@ -441,10 +442,12 @@ async fn validate_python_interpreter(python: &Path) -> Result<String, EnvSetupEr
 
         let mut reason = format!("exited with {}", output.status);
         if !stdout.is_empty() {
-            reason.push_str(&format!("\nstdout: {stdout}"));
+            use std::fmt::Write;
+            let _ = write!(reason, "\nstdout: {stdout}");
         }
         if !stderr.is_empty() {
-            reason.push_str(&format!("\nstderr: {stderr}"));
+            use std::fmt::Write;
+            let _ = write!(reason, "\nstderr: {stderr}");
         }
 
         return Err(EnvSetupError::PythonInvalid {

--- a/crates/gglib-download/src/cli_exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/mod.rs
@@ -39,5 +39,6 @@ pub use types::*;
 
 // Re-export Python bridge for use by the async manager
 pub use exec::python_bridge::{
-    FastDownloadRequest, PythonBridgeError, ensure_fast_helper_ready, run_fast_download,
+    FastDownloadRequest, PythonBridgeError, ensure_fast_helper_ready, preflight_fast_helper,
+    run_fast_download,
 };

--- a/crates/gglib-runtime/src/llama/config.rs
+++ b/crates/gglib-runtime/src/llama/config.rs
@@ -58,10 +58,13 @@ impl BuildConfig {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "cli")]
     use super::*;
+    #[cfg(feature = "cli")]
     use tempfile::tempdir;
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_build_config_roundtrip() {
         let dir = tempdir().unwrap();
         let config_path = dir.path().join("test-config.json");

--- a/crates/gglib-runtime/src/llama/deps.rs
+++ b/crates/gglib-runtime/src/llama/deps.rs
@@ -153,9 +153,11 @@ pub fn check_disk_space(_required_mb: u64) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "cli")]
     use super::*;
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_check_disk_space() {
         // Should not panic
         let result = check_disk_space(800);

--- a/crates/gglib-runtime/src/llama/download/mod.rs
+++ b/crates/gglib-runtime/src/llama/download/mod.rs
@@ -775,9 +775,11 @@ fn save_prebuilt_config(gglib_dir: &Path, version: &str, platform: &str) -> Resu
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "prebuilt")]
     use super::*;
 
     #[test]
+    #[cfg(feature = "prebuilt")]
     fn test_check_prebuilt_availability() {
         let availability = check_prebuilt_availability();
         // Just verify it doesn't panic and returns a valid variant

--- a/crates/gglib-runtime/src/system/mod.rs
+++ b/crates/gglib-runtime/src/system/mod.rs
@@ -238,10 +238,10 @@ mod tests {
     #[test]
     fn test_gpu_detection() {
         let probe = DefaultSystemProbe::new();
-        let gpu = probe.detect_gpu_info();
+        let _gpu = probe.detect_gpu_info();
         // On macOS, should have Metal
         #[cfg(target_os = "macos")]
-        assert!(gpu.has_metal);
+        assert!(_gpu.has_metal);
     }
 
     #[test]

--- a/crates/gglib-tauri/src/events.rs
+++ b/crates/gglib-tauri/src/events.rs
@@ -15,6 +15,10 @@ pub mod names {
     // Download events
     pub const DOWNLOAD_PROGRESS: &str = "download-progress";
 
+    // Download system initialization events (fast Python helper availability)
+    pub const DOWNLOAD_SYSTEM_READY: &str = "download-system:ready";
+    pub const DOWNLOAD_SYSTEM_ERROR: &str = "download-system:error";
+
     // Server log event stream (separate from AppEvent::* server lifecycle events)
     pub const SERVER_LOG: &str = "server-log";
 
@@ -37,6 +41,12 @@ pub mod names {
     pub const MENU_INSTALL_LLAMA: &str = "menu:install-llama";
     pub const MENU_CHECK_LLAMA_STATUS: &str = "menu:check-llama-status";
     pub const MENU_OPEN_SETTINGS: &str = "menu:open-settings";
+}
+
+/// Payload emitted when the download subsystem fails to initialize.
+#[derive(Clone, Debug, Serialize)]
+pub struct DownloadSystemErrorPayload {
+    pub message: String,
 }
 
 /// Emit an event to the frontend, logging any errors.

--- a/src/components/ModelLibraryPanel/AddDownloadContent.tsx
+++ b/src/components/ModelLibraryPanel/AddDownloadContent.tsx
@@ -10,6 +10,8 @@ interface AddDownloadContentProps {
   onModelAdded: (filePath: string) => Promise<void>;
   activeSubTab?: AddDownloadSubTab;
   onSubTabChange?: (subtab: AddDownloadSubTab) => void;
+  /** Optional error message if the backend download system failed to initialize */
+  downloadSystemError?: string | null;
   /** Callback when an HF model is selected for preview */
   onSelectHfModel?: (model: HfModelSummary | null) => void;
   /** Currently selected HF model ID */
@@ -20,6 +22,7 @@ const AddDownloadContent: FC<AddDownloadContentProps> = ({
   onModelAdded,
   activeSubTab: externalActiveSubTab,
   onSubTabChange,
+  downloadSystemError,
   onSelectHfModel,
   selectedHfModelId,
 }) => {
@@ -40,6 +43,12 @@ const AddDownloadContent: FC<AddDownloadContentProps> = ({
 
   return (
     <div className="add-download-content">
+      {downloadSystemError && (
+        <div style={{ padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', marginBottom: 10 }}>
+          <strong>Downloads unavailable.</strong>
+          <div style={{ marginTop: 4, whiteSpace: 'pre-wrap' }}>{downloadSystemError}</div>
+        </div>
+      )}
       <div className="add-download-subtabs">
         <button
           className={`add-download-subtab ${activeSubTab === 'browse' ? 'active' : ''}`}

--- a/src/components/ModelLibraryPanel/ModelLibraryPanel.tsx
+++ b/src/components/ModelLibraryPanel/ModelLibraryPanel.tsx
@@ -33,6 +33,8 @@ interface ModelLibraryPanelProps {
   onModelAdded: (filePath: string) => Promise<void>;
   activeSubTab?: AddDownloadSubTab;
   onSubTabChange?: (subtab: AddDownloadSubTab) => void;
+  /** Optional error message if the backend download system failed to initialize */
+  downloadSystemError?: string | null;
   
   // HuggingFace model selection (for preview in inspector)
   onSelectHfModel?: (model: HfModelSummary | null) => void;
@@ -66,6 +68,7 @@ const ModelLibraryPanel: FC<ModelLibraryPanelProps> = ({
   onModelAdded,
   activeSubTab,
   onSubTabChange,
+  downloadSystemError,
   onSelectHfModel,
   selectedHfModelId,
   activeTab: externalActiveTab,
@@ -208,6 +211,7 @@ const ModelLibraryPanel: FC<ModelLibraryPanelProps> = ({
             onModelAdded={onModelAdded}
             activeSubTab={activeSubTab}
             onSubTabChange={onSubTabChange}
+            downloadSystemError={downloadSystemError}
             onSelectHfModel={onSelectHfModel}
             selectedHfModelId={selectedHfModelId}
           />

--- a/src/hooks/useDownloadSystemStatus.ts
+++ b/src/hooks/useDownloadSystemStatus.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { isDesktop } from '../services/platform';
+
+export type DownloadSystemStatus =
+  | { status: 'initializing' }
+  | { status: 'ready' }
+  | { status: 'error'; message: string };
+
+const DOWNLOAD_SYSTEM_READY_EVENT = 'download-system:ready';
+const DOWNLOAD_SYSTEM_ERROR_EVENT = 'download-system:error';
+
+type DownloadSystemErrorPayload = {
+  message: string;
+};
+
+/**
+ * Tracks whether the backend download subsystem (Python fast helper) is usable.
+ *
+ * On desktop (Tauri), the backend emits explicit init events on app startup.
+ * On web, this is always ready (fast helper not applicable).
+ */
+export function useDownloadSystemStatus(): DownloadSystemStatus {
+  const [state, setState] = useState<DownloadSystemStatus>({
+    status: isDesktop() ? 'initializing' : 'ready',
+  });
+
+  useEffect(() => {
+    if (!isDesktop()) {
+      return;
+    }
+
+    let cancelled = false;
+    let unlistenReady: null | (() => void) = null;
+    let unlistenError: null | (() => void) = null;
+
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+
+        unlistenReady = await listen<boolean>(DOWNLOAD_SYSTEM_READY_EVENT, () => {
+          if (cancelled) return;
+          setState({ status: 'ready' });
+        });
+
+        unlistenError = await listen<DownloadSystemErrorPayload>(DOWNLOAD_SYSTEM_ERROR_EVENT, (event) => {
+          if (cancelled) return;
+          const message = event.payload?.message || 'Download system initialization failed';
+          setState({ status: 'error', message });
+        });
+      } catch (e) {
+        if (cancelled) return;
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ status: 'error', message: `Failed to subscribe to download init events: ${message}` });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      try {
+        unlistenReady?.();
+      } catch {
+        // ignore
+      }
+      try {
+        unlistenError?.();
+      } catch {
+        // ignore
+      }
+    };
+  }, []);
+
+  return state;
+}

--- a/src/pages/ModelControlCenterPage.tsx
+++ b/src/pages/ModelControlCenterPage.tsx
@@ -5,6 +5,7 @@ import { useDownloadManager } from '../hooks/useDownloadManager';
 import { useDownloadCompletionEffects } from '../hooks/useDownloadCompletionEffects';
 import { useModelFilterOptions } from '../hooks/useModelFilterOptions';
 import { useToastContext } from '../contexts/ToastContext';
+import { useDownloadSystemStatus } from '../hooks/useDownloadSystemStatus';
 import ModelLibraryPanel from '../components/ModelLibraryPanel/ModelLibraryPanel';
 import { ModelInspectorPanel } from '../components/ModelInspectorPanel';
 import { GlobalDownloadStatus } from '../components/GlobalDownloadStatus';
@@ -74,6 +75,10 @@ export default function ModelControlCenterPage({
   } = useDownloadManager({
     onCompleted,
   });
+
+  // Backend download system initialization (Python fast helper)
+  const downloadSystem = useDownloadSystemStatus();
+  const downloadSystemError = downloadSystem.status === 'error' ? downloadSystem.message : null;
   
   // Track whether user dismissed completion banner
   const [downloadDismissed] = useState(false);
@@ -250,6 +255,7 @@ export default function ModelControlCenterPage({
             onModelAdded={handleModelAdded}
             activeSubTab={activeSubTab}
             onSubTabChange={handleSubTabChange}
+            downloadSystemError={downloadSystemError}
             onSelectHfModel={handleSelectHfModel}
             selectedHfModelId={selectedHfModel?.id}
             activeTab={sidebarTab}


### PR DESCRIPTION
## Summary

Fixes #52 - Resolves GUI download failures on Linux caused by Python subprocess inheriting polluted shell environment variables.

## Problem

On Linux, the GUI download functionality would crash immediately with:
```
Fatal Python error: Failed to import encodings module
ModuleNotFoundError: No module named 'encodings'
```

This occurred when Python inherited `PYTHONHOME`, `PYTHONPATH`, or Conda-related environment variables from the parent shell, breaking stdlib resolution.

## Solution

### 1. Strict Environment Isolation (`python_env.rs`, `python_bridge.rs`)
- Apply denylist-based environment scrubbing to all Python subprocesses
- Remove `PYTHONHOME`, `PYTHONPATH`, `VIRTUAL_ENV`, `CONDA_*` variables
- Set `PYTHONNOUSERSITE=1` to prevent user-site interference
- Add `GGLIB_PYTHON` environment variable for explicit interpreter override

### 2. Dynamic Interpreter Discovery & Validation
- Prefer `python3` over `python` on non-Windows platforms
- Validate interpreter with preflight check: `import encodings; import sys`
- Provide clear error messages when Python is unavailable

### 3. Frontend Resilience (`useDownloadSystemStatus.ts`)
- Add startup init event emission (download-system:ready/error)
- Display persistent inline error banner in Add Models panel
- Show actionable error messages with Python installation instructions

## Testing

- ✅ Rust tests pass (`cargo test -p gglib-download`)
- ✅ Tauri app typechecks (`cargo check`)
- ✅ Frontend builds successfully (`npm run build`)

## User Impact

**Before**: Download box never appears on Linux, silent failure  
**After**: Clear error message with installation instructions, or downloads work correctly