### PR TITLE
Fix: Stop button leaves UI in 'Thinking/Responding' state

### DIFF
--- a/src/hooks/useGglibRuntime/parseSSEStream.ts
+++ b/src/hooks/useGglibRuntime/parseSSEStream.ts
@@ -93,7 +93,7 @@ export async function* parseSSEStream(
   try {
     while (true) {
       if (abortSignal?.aborted) {
-        break;
+        throw new DOMException('Aborted', 'AbortError');
       }
 
       const { done, value } = await reader.read();

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -234,6 +234,9 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
                       text: '\n\n[Stopped]',
                     },
                   ] as GglibContent,
+                  // Explicit status tells assistant-ui the message is complete (not running)
+                  // This is critical: assistant-ui derives isRunning from last message's status
+                  status: { type: 'complete', reason: 'stop' },
                 }
               : m
           )

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -153,6 +153,11 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
   // AGENTIC LOOP - one iteration = one assistant message
   while (iteration < maxToolIterations) {
+    // Explicit abort check at iteration start (crucial for immediate loop termination)
+    if (abortSignal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
     iteration++;
     agentState.iter = iteration;
 
@@ -184,8 +189,10 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     // Mark this message as currently streaming (for live timer)
     setCurrentStreamingAssistantMessageId?.(assistantMessageId);
 
-    // Stream LLM response INTO this specific message
-    const streamResult = await streamModelResponse({
+    let streamResult;
+    try {
+      // Stream LLM response INTO this specific message
+      streamResult = await streamModelResponse({
       serverPort: selectedServerPort,
       messages: apiMessages,
       toolDefinitions,
@@ -207,8 +214,35 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
       timingTracker,
     });
 
-    // Clear streaming state (stream completed for this message)
-    setCurrentStreamingAssistantMessageId?.(null);
+      // Clear streaming state (stream completed for this message)
+      setCurrentStreamingAssistantMessageId?.(null);
+    } catch (error) {
+      // Clear streaming state on error
+      setCurrentStreamingAssistantMessageId?.(null);
+
+      // If AbortError, mark message as [Stopped] and rethrow to exit loop
+      if (error instanceof Error && error.name === 'AbortError') {
+        setMessages(prev =>
+          prev.map(m =>
+            m.id === assistantMessageId
+              ? {
+                  ...m,
+                  content: [
+                    ...(Array.isArray(m.content) ? m.content : []),
+                    {
+                      type: 'text',
+                      text: '\n\n[Stopped]',
+                    },
+                  ] as GglibContent,
+                }
+              : m
+          )
+        );
+        throw error; // Re-throw to exit loop immediately
+      }
+      // Other errors: re-throw
+      throw error;
+    }
 
     // Mark timing as finalized to trigger final persist with durations
     // This ensures the transcript is regenerated with duration attributes
@@ -350,6 +384,11 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
         success: false as const,
         error: String((e as { message?: string })?.message ?? e ?? 'Unknown error'),
       }));
+
+      // Explicit abort check after tool execution (tools don't natively support abort)
+      if (abortSignal?.aborted) {
+        throw new DOMException('Aborted', 'AbortError');
+      }
 
       console.log(`   ${toolCall.function.name}:`, result);
 

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -183,6 +183,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
         abortControllerRef.current = null;
       }
       setIsRunning(false);
+      setCurrentStreamingAssistantMessageId(null);
     },
   });
 

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -221,6 +221,9 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
             return {
               ...m,
               content: updatedContent as GglibContent,
+              // Explicit status tells assistant-ui the message is complete (not running)
+              // This is critical: assistant-ui derives isRunning from last message's status
+              status: { type: 'complete', reason: 'stop' },
             };
           })
         );

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -66,6 +66,13 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
   
   // Track which assistant message is currently streaming (for live timer)
   const [currentStreamingAssistantMessageId, setCurrentStreamingAssistantMessageId] = useState<string | null>(null);
+  // Ref to access current streaming message ID without stale closure in onCancel
+  const currentStreamingAssistantMessageIdRef = useRef<string | null>(null);
+  
+  // Sync ref with state
+  useEffect(() => {
+    currentStreamingAssistantMessageIdRef.current = currentStreamingAssistantMessageId;
+  }, [currentStreamingAssistantMessageId]);
 
   // Timing tracker for reasoning duration (persists across renders)
   const timingTrackerRef = useRef(new ReasoningTimingTracker(performanceClock));
@@ -150,9 +157,13 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
           onError?.(error as Error);
         }
       } finally {
-        setIsRunning(false);
-        setCurrentStreamingAssistantMessageId(null);
-        abortControllerRef.current = null;
+        // Only clear state if we weren't explicitly cancelled via onCancel
+        // (onCancel sets abortControllerRef.current to null first)
+        if (abortControllerRef.current !== null) {
+          setIsRunning(false);
+          setCurrentStreamingAssistantMessageId(null);
+          abortControllerRef.current = null;
+        }
       }
     },
 
@@ -182,6 +193,39 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
         abortControllerRef.current.abort();
         abortControllerRef.current = null;
       }
+      
+      // Get current streaming message ID from ref (avoids stale closure)
+      const streamingId = currentStreamingAssistantMessageIdRef.current;
+      
+      // Atomic state update: mark message as stopped, clear streaming ID, set not running
+      // This ensures assistant-ui derives the correct status from the message
+      if (streamingId) {
+        setMessages(prev => 
+          prev.map(m => {
+            if (m.id !== streamingId) return m;
+            
+            // Mark this message as [Stopped]
+            const updatedContent = Array.isArray(m.content) 
+              ? [
+                  ...m.content,
+                  {
+                    type: 'text' as const,
+                    text: '\n\n[Stopped]',
+                  },
+                ]
+              : [{
+                  type: 'text' as const,
+                  text: '[Stopped]',
+                }];
+            
+            return {
+              ...m,
+              content: updatedContent as GglibContent,
+            };
+          })
+        );
+      }
+      
       setIsRunning(false);
       setCurrentStreamingAssistantMessageId(null);
     },


### PR DESCRIPTION
## Summary

Fixes #60 - When user presses Stop during message generation, the backend cancellation works but the UI indicators ('Assistant is thinking...' / 'Responding') remain stuck, creating confusion.

## Root Cause Analysis

The issue had two layers:

### Layer 1: Backend Cancellation (Initially Fixed)
- The agentic loop wasn't checking abort signals at iteration boundaries
- Stream parser used quiet `break` instead of throwing AbortError
- AbortError wasn't caught and handled distinctly

### Layer 2: Frontend State Synchronization (Core Issue)
**The UI's `isRunning` is NOT directly reading our local statepush*

assistant-ui's `ThreadState.isRunning` is derived from the **last message's status**:
```typescript
isRunning: lastMessage?.status.type === "running"
```

The message status is computed from our `isRunning` state + whether it's the last message. When Stop fires:

1. ✅ onCancel sets `isRunning = false`
2. ⏳ React schedules re-render (state updates are async)
3. ⏳ Meanwhile, finally block also sets `isRunning = false`  
4. ⏳ React batches updates and re-renders
5. ❌ **The message array hasn't been marked [Stopped] yet**
6. ⏳ assistant-ui computes status from the **unchanged message**
7. ❌ UI still shows 'Thinking/Responding' because message appears incomplete

## Solution

This PR implements a comprehensive fix with two phases:

### Phase 1: Explicit Abort Propagation (Commits 1-3)
1. **Synchronous UI Cleanup**: Stop handler immediately clears streaming state
2. **Loop Termination Checks**: Explicit abort checks at iteration boundaries and after tool execution
3. **Stream Error Propagation**: Changed stream abort from quiet break to throwing AbortError

### Phase 2: State Synchronization Fix (Commit 4)
1. **Ref Pattern**: Added `currentStreamingAssistantMessageIdRef` synced with state via useEffect, allowing onCancel to access current streaming message ID without stale closure
2. **Atomic State Update**: onCancel now updates ALL state in one React cycle:
   - Marks the streaming message as [Stopped] using functional update (`setMessages(prev => ...)`)
   - Clears `currentStreamingAssistantMessageId`
   - Sets `isRunning = false`
3. **Finally Block Guard**: Prevents finally from overwriting [Stopped] state by checking if `abortControllerRef` is still valid (onCancel nullifies it first)

This ensures assistant-ui sees a complete, consistent state where the last message is explicitly marked complete, immediately clearing the 'Thinking/Responding' banners.

## Changes

### 1. Synchronous UI Cleanup (useGglibRuntime.ts)
- Stop handler immediately clears `currentStreamingAssistantMessageId`
- Sets `abortControllerRef.current = null` to prevent ghost updates

### 2. Explicit Abort Checks in Agentic Loop (runAgenticLoop.ts)
- Added abort signal check at loop iteration entry
- Added abort signal check after tool execution
- Added try/catch to mark message as [Stopped] on AbortError

### 3. Stream Abort Handling (parseSSEStream.ts)
- Changed from quiet `break` to throwing AbortError
- Ensures stream rejection propagates as error, not success

### 4. Ref Pattern + Atomic Updates (useGglibRuntime.ts)
- Added `currentStreamingAssistantMessageIdRef` to avoid stale closures
- onCancel uses functional state update to mark message [Stopped]
- Finally block guarded to prevent overwriting stopped state

## Visual Feedback

When Stop is pressed, the incomplete assistant message is marked with [Stopped] suffix, providing clear visual indication of termination.

## Testing

Tested with:
- Basic generation stop → UI clears immediately
- Stop during tool execution → terminates before next iteration
- Stop during reasoning phase → properly handled with visual feedback
- Rapid stop/restart → no ghost updates from previous run
- Verify [Stopped] marker appears in message content