### PR TITLE
fix: source Rust environment for Tauri build in npm subshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ run-gui:
 # Run web server
 run-web:
 	@echo "Starting web server..."
-	cargo run -p gglib-cli -- web $(if $(PORT),--port $(PORT),)
+	$(CARGO) run -p gglib-cli -- web $(if $(PORT),--port $(PORT),)
 
 # Build Tauri desktop app (production)
 build-tauri:
@@ -268,9 +268,12 @@ build-tauri:
 	npm install
 	# linuxdeploy's embedded strip can fail on some distros (e.g. Arch) due to RELR relocations.
 	# NO_STRIP=1 is a linuxdeploy-supported knob that avoids the failure by skipping stripping.
+	# Source Rust environment for npm subshell (needed for tauri to find cargo)
 	@if [ "$(UNAME_S)" = "Linux" ]; then \
+		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
 		NO_STRIP=1 npm run tauri:build; \
 	else \
+		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
 		npm run tauri:build; \
 	fi
 	@echo "✓ Tauri app built to src-tauri/target/release/gglib-gui"

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -77,6 +77,11 @@ detect_user_shell() {
 # Detect the user's shell
 detect_user_shell
 
+# Source Rust environment if it exists (needed for non-interactive shells like VS Code tasks)
+if [ -f "$HOME/.cargo/env" ]; then
+    source "$HOME/.cargo/env"
+fi
+
 # Track results
 MISSING_REQUIRED=()
 PRESENT_REQUIRED=()


### PR DESCRIPTION
## Description
Fixes cargo not being found when Tauri build is invoked through npm scripts from make targets.

## Changes
- Source `~/.cargo/env` before running `npm run tauri:build` in both Linux and non-Linux paths
- Fixed `run-web` target to use `$(CARGO)` variable for consistency

## Problem
When make runs npm scripts, npm spawns a new subshell that doesn't inherit the Makefile's CARGO variable or environment. This causes Tauri CLI to fail when trying to run `cargo metadata`.

## Solution
Explicitly source the Rust environment within the same shell command that runs npm, ensuring cargo is available to the Tauri build process.

## Testing
Tested on Arch Linux with Rust installed via rustup, running `make setup` from VS Code task. Tauri now successfully finds cargo and progresses to dependency version checks.

Fixes #67