### PR TITLE
fix(ci): allow workflow_run events in create-release job condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: check-version
-    if: github.event_name == 'push' && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
+    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
     outputs:
       version: ${{ needs.check-version.outputs.new-version }}
     steps:


### PR DESCRIPTION
## Summary

Fixes #74

Resolves the issue where releases are not created after version bumps, even though the release workflow runs successfully.

## Root Cause

PR #63 changed the release workflow trigger from `push` to `workflow_run` to avoid redundant workflow overlap. However, the `create-release` job condition was not updated:

```yaml
# Old condition (always false with workflow_run trigger)
if: github.event_name == 'push' && needs.check-version.outputs.version-changed == 'true' ...
```

## Changes

Updated the condition to accept both trigger types:

```yaml
# New condition (supports both push and workflow_run)
if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true' ...
```

## Testing Evidence

- v0.2.6 (Dec 30): Successfully released with `push` event
- v0.2.7 (Jan 10): Workflow ran but skipped release creation due to event type mismatch

## Impact

This fix will allow the pending v0.2.7 release to be created once merged.