### PR TITLE
feat(cli): add question command with piped stdin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gglib provides a simple interface to catalog, organize, and serve GGUF models lo
 - **Remove models**: Clean removal of models from your database
 - **Serve models**: Start llama-server with automatic context size detection
 - **Chat via CLI**: Launch llama-cli directly for quick terminal chat sessions
+- **Question command**: Ask one-shot questions with optional piped context (`cat file | gglib question "summarize"`)
 - **OpenAI-compatible Proxy**: Automatic model swapping with OpenAI API compatibility
 - **HuggingFace Hub Integration**: Download models directly from HuggingFace Hub
 - **Fast-path Downloads**: Managed Python helper (hf_xet) via Miniconda for multi-gigabyte transfers

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -114,23 +114,29 @@ See the [Architecture Overview](../../README.md#architecture-overview) for the c
 
 ### Question Command
 
-The `question` command supports piped input for context-aware queries:
+The `question` command (alias: `q`) supports piped input or file context:
 
 ```bash
 # Simple question (uses default model)
-gglib question "What is the capital of France?"
+gglib q "What is the capital of France?"
 
-# With explicit model
-gglib question --model 1 "Explain quantum computing"
+# Read context from a file
+gglib q --file README.md "Summarize this project"
 
 # Pipe context into the question
-cat README.md | gglib question "Summarize this file"
+cat README.md | gglib q "Summarize this file"
 
 # Use {} placeholder for inline substitution
-echo "Paris, London, Tokyo" | gglib question "List these cities: {}"
+echo "Paris, London, Tokyo" | gglib q "List these cities: {}"
 
 # Pipe command output
-git diff | gglib question "Explain these changes"
+git diff | gglib q "Explain these changes"
+
+# Debug: see the constructed prompt
+gglib q --verbose --file CODE.rs "Explain this"
+
+# Cleaner output for scripting (no prompt echo, no timings)
+gglib q -Q "What is 2+2?"
 ```
 
 **Set a default model** to avoid using `--model` every time:

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -111,7 +111,6 @@ See the [Architecture Overview](../../README.md#architecture-overview) for the c
 | `search <query>` | Search HuggingFace Hub for models |
 | `config settings show` | Show current configuration |
 | `config default <id>` | Set/show/clear the default model |
-| `config settings set-default-model <id>` | Set the default model (alias) |
 
 ### Question Command
 

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -110,8 +110,8 @@ See the [Architecture Overview](../../README.md#architecture-overview) for the c
 | `download <repo>` | Download a model from HuggingFace |
 | `search <query>` | Search HuggingFace Hub for models |
 | `config settings show` | Show current configuration |
-| `config settings set-default-model <id>` | Set the default model for commands |
-| `config settings get-default-model` | Show the current default model |
+| `config default <id>` | Set/show/clear the default model |
+| `config settings set-default-model <id>` | Set the default model (alias) |
 
 ### Question Command
 
@@ -137,7 +137,7 @@ git diff | gglib question "Explain these changes"
 **Set a default model** to avoid using `--model` every time:
 
 ```bash
-gglib config settings set-default-model 1
+gglib config default 1
 ```
 
 ## Usage

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -105,12 +105,40 @@ See the [Architecture Overview](../../README.md#architecture-overview) for the c
 | `remove <id>` | Remove a model from the library |
 | `serve <id>` | Start llama-server for a model |
 | `chat <id>` | Start interactive llama-cli chat |
+| `question <text>` | Ask a question (with optional piped context) |
 | `proxy` | Start the OpenAI-compatible proxy |
-| `hf search <query>` | Search HuggingFace Hub for models |
-| `hf download <repo>` | Download a model from HuggingFace |
-| `mcp list` | List configured MCP servers |
-| `mcp start <id>` | Start an MCP server |
-| `config show` | Show current configuration |
+| `download <repo>` | Download a model from HuggingFace |
+| `search <query>` | Search HuggingFace Hub for models |
+| `config settings show` | Show current configuration |
+| `config settings set-default-model <id>` | Set the default model for commands |
+| `config settings get-default-model` | Show the current default model |
+
+### Question Command
+
+The `question` command supports piped input for context-aware queries:
+
+```bash
+# Simple question (uses default model)
+gglib question "What is the capital of France?"
+
+# With explicit model
+gglib question --model 1 "Explain quantum computing"
+
+# Pipe context into the question
+cat README.md | gglib question "Summarize this file"
+
+# Use {} placeholder for inline substitution
+echo "Paris, London, Tokyo" | gglib question "List these cities: {}"
+
+# Pipe command output
+git diff | gglib question "Explain these changes"
+```
+
+**Set a default model** to avoid using `--model` every time:
+
+```bash
+gglib config settings set-default-model 1
+```
 
 ## Usage
 

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -190,6 +190,26 @@ pub enum Commands {
         simple_io: bool,
     },
 
+    /// Ask a question (with optional piped context)
+    ///
+    /// Usage: 
+    ///   gglib question "What is Rust?"
+    ///   cat file.txt | gglib question "Summarize this"
+    ///   git --help | gglib question "How do I rebase?"
+    Question {
+        /// Question to ask (use {} as placeholder for piped input)
+        question: String,
+        /// Model ID or name (uses default model if not specified)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Context size (use 'max' to auto-detect from model metadata)
+        #[arg(short, long)]
+        ctx_size: Option<String>,
+        /// Enable memory lock
+        #[arg(long)]
+        mlock: bool,
+    },
+
     /// Launch the Tauri desktop GUI
     Gui {
         /// Run in development mode with hot-reload (requires Node.js and npm)

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -190,24 +190,32 @@ pub enum Commands {
         simple_io: bool,
     },
 
-    /// Ask a question (with optional piped context)
-    ///
-    /// Usage:
-    ///   gglib question "What is Rust?"
-    ///   cat file.txt | gglib question "Summarize this"
-    ///   git --help | gglib question "How do I rebase?"
+    /// Ask a question with optional context from stdin or file
+    #[command(
+        alias = "q",
+        after_help = "EXAMPLES:\n    gglib q \"What is Rust?\"\n    cat file.txt | gglib q \"Summarize this\"\n    gglib q --file README.md \"Explain this project\"\n    echo \"Paris, Tokyo\" | gglib q \"List these cities: {}\""
+    )]
     Question {
-        /// Question to ask (use {} as placeholder for piped input)
+        /// Question to ask (use {} as placeholder for piped/file input)
         question: String,
         /// Model ID or name (uses default model if not specified)
         #[arg(short, long)]
         model: Option<String>,
+        /// Read context from file instead of stdin
+        #[arg(short, long)]
+        file: Option<String>,
         /// Context size (use 'max' to auto-detect from model metadata)
         #[arg(short, long)]
         ctx_size: Option<String>,
         /// Enable memory lock
         #[arg(long)]
         mlock: bool,
+        /// Show the constructed prompt before sending
+        #[arg(long)]
+        verbose: bool,
+        /// Cleaner output for scripting (no prompt echo, no timings)
+        #[arg(long, short = 'Q')]
+        quiet: bool,
     },
 
     /// Launch the Tauri desktop GUI

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -192,7 +192,7 @@ pub enum Commands {
 
     /// Ask a question (with optional piped context)
     ///
-    /// Usage: 
+    /// Usage:
     ///   gglib question "What is Rust?"
     ///   cat file.txt | gglib question "Summarize this"
     ///   git --help | gglib question "How do I rebase?"

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -8,6 +8,14 @@ use clap::Subcommand;
 /// Configuration management commands.
 #[derive(Subcommand)]
 pub enum ConfigCommand {
+    /// View or set the default model (shorthand for settings get/set-default-model)
+    Default {
+        /// Model ID or name to set as default (omit to show current)
+        identifier: Option<String>,
+        /// Clear the current default model
+        #[arg(long)]
+        clear: bool,
+    },
     /// View or change the models directory preference
     ModelsDir {
         #[command(subcommand)]

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -66,4 +66,11 @@ pub enum SettingsCommand {
         #[arg(short, long)]
         force: bool,
     },
+    /// Set the default model for commands that support it
+    SetDefaultModel {
+        /// Model ID or name to set as default
+        identifier: String,
+    },
+    /// Show the current default model
+    GetDefaultModel,
 }

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -74,11 +74,4 @@ pub enum SettingsCommand {
         #[arg(short, long)]
         force: bool,
     },
-    /// Set the default model for commands that support it
-    SetDefaultModel {
-        /// Model ID or name to set as default
-        identifier: String,
-    },
-    /// Show the current default model
-    GetDefaultModel,
 }

--- a/crates/gglib-cli/src/handlers/config.rs
+++ b/crates/gglib-cli/src/handlers/config.rs
@@ -95,19 +95,17 @@ async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<(
                 "  max_download_queue_size: {:?}",
                 settings.max_download_queue_size
             );
-            
+
             // Show default model with name if available
             match settings.default_model_id {
-                Some(model_id) => {
-                    match ctx.app().models().get_by_id(model_id).await? {
-                        Some(model) => {
-                            println!("  default_model_id:        {} ({})", model_id, model.name);
-                        }
-                        None => {
-                            println!("  default_model_id:        {} (not found)", model_id);
-                        }
+                Some(model_id) => match ctx.app().models().get_by_id(model_id).await? {
+                    Some(model) => {
+                        println!("  default_model_id:        {} ({})", model_id, model.name);
                     }
-                }
+                    None => {
+                        println!("  default_model_id:        {} (not found)", model_id);
+                    }
+                },
                 None => {
                     println!("  default_model_id:        None");
                 }
@@ -216,11 +214,7 @@ async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<(
         }
         SettingsCommand::SetDefaultModel { identifier } => {
             // Resolve the model first to ensure it exists
-            let model = ctx
-                .app()
-                .models()
-                .find_by_identifier(&identifier)
-                .await?;
+            let model = ctx.app().models().find_by_identifier(&identifier).await?;
 
             // Update settings with the model ID
             let update = SettingsUpdate {
@@ -229,10 +223,7 @@ async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<(
             };
 
             ctx.app().settings().update(update).await?;
-            println!(
-                "✓ Default model set to: {} (ID: {})",
-                model.name, model.id
-            );
+            println!("✓ Default model set to: {} (ID: {})", model.name, model.id);
             Ok(())
         }
         SettingsCommand::GetDefaultModel => {
@@ -245,16 +236,15 @@ async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<(
                             println!("Default model: {} (ID: {})", model.name, model.id);
                         }
                         None => {
-                            println!(
-                                "Default model ID: {} (warning: model not found)",
-                                model_id
-                            );
+                            println!("Default model ID: {} (warning: model not found)", model_id);
                         }
                     }
                 }
                 None => {
                     println!("No default model set.");
-                    println!("Use 'gglib config settings set-default-model <id-or-name>' to set one.");
+                    println!(
+                        "Use 'gglib config settings set-default-model <id-or-name>' to set one."
+                    );
                 }
             }
             Ok(())

--- a/crates/gglib-cli/src/handlers/config.rs
+++ b/crates/gglib-cli/src/handlers/config.rs
@@ -71,16 +71,14 @@ async fn handle_default_model(
             // Show current default
             let settings = ctx.app().settings().get().await?;
             match settings.default_model_id {
-                Some(model_id) => {
-                    match ctx.app().models().get_by_id(model_id).await? {
-                        Some(model) => {
-                            println!("Default model: {} (ID: {})", model.name, model.id);
-                        }
-                        None => {
-                            println!("Default model ID: {} (warning: model not found)", model_id);
-                        }
+                Some(model_id) => match ctx.app().models().get_by_id(model_id).await? {
+                    Some(model) => {
+                        println!("Default model: {} (ID: {})", model.name, model.id);
                     }
-                }
+                    None => {
+                        println!("Default model ID: {} (warning: model not found)", model_id);
+                    }
+                },
                 None => {
                     println!("No default model set.");
                     println!("Use 'gglib config default <id-or-name>' to set one.");

--- a/crates/gglib-cli/src/handlers/config.rs
+++ b/crates/gglib-cli/src/handlers/config.rs
@@ -271,41 +271,6 @@ async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<(
             println!("✓ All settings have been reset to defaults.");
             Ok(())
         }
-        SettingsCommand::SetDefaultModel { identifier } => {
-            // Resolve the model first to ensure it exists
-            let model = ctx.app().models().find_by_identifier(&identifier).await?;
-
-            // Update settings with the model ID
-            let update = SettingsUpdate {
-                default_model_id: Some(Some(model.id)),
-                ..Default::default()
-            };
-
-            ctx.app().settings().update(update).await?;
-            println!("✓ Default model set to: {} (ID: {})", model.name, model.id);
-            Ok(())
-        }
-        SettingsCommand::GetDefaultModel => {
-            let settings = ctx.app().settings().get().await?;
-            match settings.default_model_id {
-                Some(model_id) => {
-                    // Try to fetch the model to show its name
-                    match ctx.app().models().get_by_id(model_id).await? {
-                        Some(model) => {
-                            println!("Default model: {} (ID: {})", model.name, model.id);
-                        }
-                        None => {
-                            println!("Default model ID: {} (warning: model not found)", model_id);
-                        }
-                    }
-                }
-                None => {
-                    println!("No default model set.");
-                    println!("Use 'gglib config default <id-or-name>' to set one.");
-                }
-            }
-            Ok(())
-        }
     }
 }
 

--- a/crates/gglib-cli/src/handlers/mod.rs
+++ b/crates/gglib-cli/src/handlers/mod.rs
@@ -23,6 +23,7 @@ pub mod config;
 pub mod download;
 pub mod list;
 pub mod paths;
+pub mod question;
 pub mod remove;
 pub mod serve;
 pub mod update;

--- a/crates/gglib-cli/src/handlers/question.rs
+++ b/crates/gglib-cli/src/handlers/question.rs
@@ -1,0 +1,252 @@
+//! Question command handler.
+//!
+//! Handles asking a question with optional piped stdin context.
+
+use anyhow::{Context, Result, anyhow};
+use std::io::{self, Read, IsTerminal};
+use std::process::Stdio;
+
+use crate::bootstrap::CliContext;
+use gglib_core::paths::llama_cli_path;
+use gglib_runtime::llama::{ContextResolution, LlamaCommandBuilder, resolve_context_size};
+
+/// Execute the question command.
+///
+/// This command allows asking a question with or without piped context.
+/// If stdin is piped, it will be used as context. The `{}` placeholder
+/// in the question will be replaced with the piped input, or if no
+/// placeholder exists, the input will be prepended to the question.
+///
+/// # Arguments
+///
+/// * `ctx` - The CLI context providing access to AppCore
+/// * `question` - The question to ask
+/// * `model` - Optional model identifier (ID or name)
+/// * `ctx_size` - Optional context size override
+/// * `mlock` - Whether to enable memory lock
+///
+/// # Returns
+///
+/// Returns `Result<()>` indicating success or failure.
+pub async fn execute(
+    ctx: &CliContext,
+    question: String,
+    model: Option<String>,
+    ctx_size: Option<String>,
+    mlock: bool,
+) -> Result<()> {
+    // Check if stdin is piped
+    let stdin = io::stdin();
+    let is_piped = !stdin.is_terminal();
+
+    // Read piped input if available
+    let piped_input = if is_piped {
+        let mut buffer = String::new();
+        stdin.lock().read_to_string(&mut buffer)
+            .context("Failed to read from stdin")?;
+        Some(buffer)
+    } else {
+        None
+    };
+
+    // Resolve the model: --model flag -> settings default -> error
+    let model = resolve_model(ctx, model.as_deref()).await?;
+
+    // Build the prompt based on whether we have piped input
+    let prompt = build_prompt(&question, piped_input.as_deref())?;
+
+    // Calculate intelligent context size
+    let context_resolution = calculate_context_size(
+        &prompt,
+        ctx_size.as_deref(),
+        model.context_length,
+    )?;
+
+    // Get llama-cli path
+    let llama_cli_path = llama_cli_path()
+        .context("Failed to resolve llama-cli path")?;
+
+    // Build and execute the command
+    // Use simple -p flag which works with chat-tuned models
+    let mut cmd = LlamaCommandBuilder::new(&llama_cli_path, &model.file_path)
+        .context_resolution(context_resolution)
+        .mlock(mlock)
+        .build();
+
+    // Add prompt with single-turn mode (exit after response)
+    cmd.arg("-p").arg(&prompt)
+        .arg("--single-turn"); // exit after one response
+
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let status = cmd.status()
+        .context("Failed to execute llama-cli")?;
+
+    if !status.success() {
+        return Err(anyhow!("llama-cli exited with error"));
+    }
+
+    Ok(())
+}
+
+/// Resolve the model to use for the question.
+///
+/// Resolution order:
+/// 1. Explicit --model flag
+/// 2. Default model from settings
+/// 3. Error with helpful message
+async fn resolve_model(
+    ctx: &CliContext,
+    model_identifier: Option<&str>,
+) -> Result<gglib_core::Model> {
+    if let Some(identifier) = model_identifier {
+        // User specified a model explicitly
+        ctx.app()
+            .models()
+            .find_by_identifier(identifier)
+            .await
+            .context(format!("Failed to find model: {}", identifier))
+    } else {
+        // Try to use default model from settings
+        let settings = ctx.app().settings().get().await
+            .context("Failed to load settings")?;
+
+        match settings.default_model_id {
+            Some(model_id) => {
+                ctx.app()
+                    .models()
+                    .get_by_id(model_id)
+                    .await
+                    .context("Failed to load default model")?
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Default model (ID: {}) not found. \
+                             Update default with: gglib config settings set-default-model <id-or-name>",
+                            model_id
+                        )
+                    })
+            }
+            None => {
+                Err(anyhow!(
+                    "No model specified and no default model set.\n\
+                     Use --model <id-or-name> or set a default:\n  \
+                     gglib config settings set-default-model <id-or-name>"
+                ))
+            }
+        }
+    }
+}
+
+/// Build the prompt based on the question and optional piped input.
+///
+/// If piped input is provided:
+/// - If question contains `{}`, replace it with the piped input
+/// - Otherwise, prepend the piped input before the question
+///
+/// If no piped input, just use the question as-is.
+fn build_prompt(question: &str, piped_input: Option<&str>) -> Result<String> {
+    match piped_input {
+        Some(input) if !input.is_empty() => {
+            if question.contains("{}") {
+                // Replace {} placeholder with piped input
+                Ok(question.replace("{}", input))
+            } else {
+                // Prepend input as context
+                Ok(format!(
+                    "Context:\n{}\n\nQuestion: {}\n\nAnswer:",
+                    input.trim(),
+                    question
+                ))
+            }
+        }
+        _ => {
+            // No piped input, use question directly
+            Ok(question.to_string())
+        }
+    }
+}
+
+/// Calculate intelligent context size based on input length and model capabilities.
+///
+/// Estimates token count using chars/4 heuristic and validates against model max.
+fn calculate_context_size(
+    prompt: &str,
+    ctx_size_arg: Option<&str>,
+    model_max_context: Option<u64>,
+) -> Result<ContextResolution> {
+    // If user explicitly provided context size, use resolve_context_size
+    if ctx_size_arg.is_some() || model_max_context.is_some() {
+        return resolve_context_size(ctx_size_arg.map(String::from), model_max_context);
+    }
+
+    // Estimate token count (chars / 4 is a standard approximation)
+    let estimated_prompt_tokens = (prompt.len() / 4) as u64;
+    // Add buffer for the response (2048 tokens for generation)
+    let total_needed = estimated_prompt_tokens + 2048;
+
+    // Use estimated or 4096 minimum
+    let context_size = total_needed.max(4096);
+
+    resolve_context_size(Some(context_size.to_string()), model_max_context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_prompt_with_placeholder() {
+        let question = "Summarize this: {}";
+        let input = "Hello world";
+        let prompt = build_prompt(question, Some(input)).unwrap();
+        assert_eq!(prompt, "Summarize this: Hello world");
+    }
+
+    #[test]
+    fn test_build_prompt_without_placeholder() {
+        let question = "What does this mean?";
+        let input = "Hello world";
+        let prompt = build_prompt(question, Some(input)).unwrap();
+        assert!(prompt.contains("Context:"));
+        assert!(prompt.contains("Hello world"));
+        assert!(prompt.contains("What does this mean?"));
+    }
+
+    #[test]
+    fn test_build_prompt_no_input() {
+        let question = "What is Rust?";
+        let prompt = build_prompt(question, None).unwrap();
+        assert_eq!(prompt, "What is Rust?");
+    }
+
+    #[test]
+    fn test_build_prompt_empty_input() {
+        let question = "What is Rust?";
+        let prompt = build_prompt(question, Some("")).unwrap();
+        assert_eq!(prompt, "What is Rust?");
+    }
+
+    #[test]
+    fn test_calculate_context_size_explicit() {
+        let result = calculate_context_size("test", Some("8192"), Some(16384)).unwrap();
+        assert_eq!(result.value, Some(8192));
+    }
+
+    #[test]
+    fn test_calculate_context_size_auto() {
+        // Small prompt should use minimum 4096
+        let result = calculate_context_size("test", None, Some(16384)).unwrap();
+        assert_eq!(result.value, Some(4096));
+    }
+
+    #[test]
+    fn test_calculate_context_size_large_prompt() {
+        // Create a large prompt (10000 chars ~= 2500 tokens + 2048 response = 4548 tokens needed)
+        let large_prompt = "x".repeat(10000);
+        let result = calculate_context_size(&large_prompt, None, Some(16384)).unwrap();
+        // Should use estimated size (2500 + 2048 = 4548, rounded up to meet minimum)
+        assert!(result.value.unwrap() >= 4548);
+    }
+}

--- a/crates/gglib-cli/src/handlers/question.rs
+++ b/crates/gglib-cli/src/handlers/question.rs
@@ -114,27 +114,24 @@ async fn resolve_model(
             .context("Failed to load settings")?;
 
         match settings.default_model_id {
-            Some(model_id) => {
-                ctx.app()
-                    .models()
-                    .get_by_id(model_id)
-                    .await
-                    .context("Failed to load default model")?
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "Default model (ID: {}) not found. \
+            Some(model_id) => ctx
+                .app()
+                .models()
+                .get_by_id(model_id)
+                .await
+                .context("Failed to load default model")?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Default model (ID: {}) not found. \
                              Update default with: gglib config default <id-or-name>",
-                            model_id
-                        )
-                    })
-            }
-            None => {
-                Err(anyhow!(
-                    "No model specified and no default model set.\n\
+                        model_id
+                    )
+                }),
+            None => Err(anyhow!(
+                "No model specified and no default model set.\n\
                      Use --model <id-or-name> or set a default:\n  \
                      gglib config default <id-or-name>"
-                ))
-            }
+            )),
         }
     }
 }

--- a/crates/gglib-cli/src/handlers/question.rs
+++ b/crates/gglib-cli/src/handlers/question.rs
@@ -123,7 +123,7 @@ async fn resolve_model(
                     .ok_or_else(|| {
                         anyhow!(
                             "Default model (ID: {}) not found. \
-                             Update default with: gglib config settings set-default-model <id-or-name>",
+                             Update default with: gglib config default <id-or-name>",
                             model_id
                         )
                     })
@@ -132,7 +132,7 @@ async fn resolve_model(
                 Err(anyhow!(
                     "No model specified and no default model set.\n\
                      Use --model <id-or-name> or set a default:\n  \
-                     gglib config settings set-default-model <id-or-name>"
+                     gglib config default <id-or-name>"
                 ))
             }
         }

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -225,6 +225,15 @@ async fn main() -> anyhow::Result<()> {
             };
             handlers::chat::execute(&ctx, args).await?;
         }
+        Commands::Question {
+            question,
+            model,
+            ctx_size,
+            mlock,
+        } => {
+            // NEW: Ask a question with optional piped context
+            handlers::question::execute(&ctx, question, model, ctx_size, mlock).await?;
+        }
         Commands::Download {
             model_id,
             quantization,

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -228,11 +228,14 @@ async fn main() -> anyhow::Result<()> {
         Commands::Question {
             question,
             model,
+            file,
             ctx_size,
             mlock,
+            verbose,
+            quiet,
         } => {
-            // NEW: Ask a question with optional piped context
-            handlers::question::execute(&ctx, question, model, ctx_size, mlock).await?;
+            // Ask a question with optional piped/file context
+            handlers::question::execute(&ctx, question, model, file, ctx_size, mlock, verbose, quiet).await?;
         }
         Commands::Download {
             model_id,

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -235,7 +235,10 @@ async fn main() -> anyhow::Result<()> {
             quiet,
         } => {
             // Ask a question with optional piped/file context
-            handlers::question::execute(&ctx, question, model, file, ctx_size, mlock, verbose, quiet).await?;
+            handlers::question::execute(
+                &ctx, question, model, file, ctx_size, mlock, verbose, quiet,
+            )
+            .await?;
         }
         Commands::Download {
             model_id,

--- a/crates/gglib-core/src/settings.rs
+++ b/crates/gglib-core/src/settings.rs
@@ -41,6 +41,9 @@ pub struct Settings {
 
     /// Maximum stagnation steps before stopping agent loop.
     pub max_stagnation_steps: Option<u32>,
+
+    /// Default model ID for commands that support a default model.
+    pub default_model_id: Option<i64>,
 }
 
 impl Settings {
@@ -56,6 +59,7 @@ impl Settings {
             show_memory_fit_indicators: Some(true),
             max_tool_iterations: Some(25),
             max_stagnation_steps: Some(5),
+            default_model_id: None,
         }
     }
 
@@ -103,6 +107,9 @@ impl Settings {
         if let Some(ref steps) = other.max_stagnation_steps {
             self.max_stagnation_steps = *steps;
         }
+        if let Some(ref model_id) = other.default_model_id {
+            self.default_model_id = *model_id;
+        }
     }
 }
 
@@ -122,6 +129,7 @@ pub struct SettingsUpdate {
     pub show_memory_fit_indicators: Option<Option<bool>>,
     pub max_tool_iterations: Option<Option<u32>>,
     pub max_stagnation_steps: Option<Option<u32>>,
+    pub default_model_id: Option<Option<i64>>,
 }
 
 /// Settings validation error.

--- a/crates/gglib-gui/src/settings.rs
+++ b/crates/gglib-gui/src/settings.rs
@@ -101,6 +101,7 @@ impl<'a> SettingsOps<'a> {
             show_memory_fit_indicators: settings.show_memory_fit_indicators,
             max_tool_iterations: settings.max_tool_iterations,
             max_stagnation_steps: settings.max_stagnation_steps,
+            default_model_id: settings.default_model_id,
         })
     }
 
@@ -115,7 +116,7 @@ impl<'a> SettingsOps<'a> {
             show_memory_fit_indicators: request.show_memory_fit_indicators,
             max_tool_iterations: request.max_tool_iterations,
             max_stagnation_steps: request.max_stagnation_steps,
-            default_model_id: None, // Not exposed in GUI settings yet
+            default_model_id: request.default_model_id,
         };
 
         let settings = self
@@ -138,6 +139,7 @@ impl<'a> SettingsOps<'a> {
             show_memory_fit_indicators: settings.show_memory_fit_indicators,
             max_tool_iterations: settings.max_tool_iterations,
             max_stagnation_steps: settings.max_stagnation_steps,
+            default_model_id: settings.default_model_id,
         })
     }
 

--- a/crates/gglib-gui/src/settings.rs
+++ b/crates/gglib-gui/src/settings.rs
@@ -115,6 +115,7 @@ impl<'a> SettingsOps<'a> {
             show_memory_fit_indicators: request.show_memory_fit_indicators,
             max_tool_iterations: request.max_tool_iterations,
             max_stagnation_steps: request.max_stagnation_steps,
+            default_model_id: None, // Not exposed in GUI settings yet
         };
 
         let settings = self

--- a/crates/gglib-gui/src/types.rs
+++ b/crates/gglib-gui/src/types.rs
@@ -273,6 +273,8 @@ pub struct AppSettings {
     pub show_memory_fit_indicators: Option<bool>,
     pub max_tool_iterations: Option<u32>,
     pub max_stagnation_steps: Option<u32>,
+    /// Default model ID for quick commands (e.g., `gglib question`).
+    pub default_model_id: Option<i64>,
 }
 
 /// Request body for updating application settings.
@@ -286,6 +288,8 @@ pub struct UpdateSettingsRequest {
     pub show_memory_fit_indicators: Option<Option<bool>>,
     pub max_tool_iterations: Option<Option<u32>>,
     pub max_stagnation_steps: Option<Option<u32>>,
+    /// Default model ID for quick commands (e.g., `gglib question`).
+    pub default_model_id: Option<Option<i64>>,
 }
 
 // ============================================================================

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { FC, FormEvent, useCallback, useEffect, useMemo, useState } from "react"
 import { useModelsDirectory } from "../hooks/useModelsDirectory";
 import { useSettings } from "../hooks/useSettings";
 import { useMcpServers } from "../hooks/useMcpServers";
+import { useModels } from "../hooks/useModels";
 import { UpdateSettingsRequest } from "../types";
 import type { McpServerInfo } from "../services/clients/mcp";
 import { McpServersPanel } from "./McpServersPanel";
@@ -26,6 +27,7 @@ const sourceLabels: Record<string, string> = {
 export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const { info, loading: loadingDir, saving: savingDir, error: dirError, refresh: refreshDir, save: saveDir } = useModelsDirectory();
   const { settings, loading: loadingSettings, saving: savingSettings, error: settingsError, refresh: refreshSettings, save: saveSettings } = useSettings();
+  const { models, loading: loadingModels } = useModels();
   
   const [pathInput, setPathInput] = useState("");
   const [contextSizeInput, setContextSizeInput] = useState("");
@@ -36,6 +38,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const [maxToolIterationsInput, setMaxToolIterationsInput] = useState("");
   const [maxStagnationStepsInput, setMaxStagnationStepsInput] = useState("");
   const [showFitIndicators, setShowFitIndicators] = useState(true);
+  const [defaultModelInput, setDefaultModelInput] = useState("");
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<SettingsTab>("general");
@@ -65,6 +68,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       setMaxToolIterationsInput(settings.max_tool_iterations?.toString() || "");
       setMaxStagnationStepsInput(settings.max_stagnation_steps?.toString() || "");
       setShowFitIndicators(settings.show_memory_fit_indicators !== false);
+      setDefaultModelInput(settings.default_model_id?.toString() || "");
     }
   }, [settings]);
 
@@ -96,6 +100,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           max_tool_iterations: parseNumericInput(maxToolIterationsInput),
           max_stagnation_steps: parseNumericInput(maxStagnationStepsInput),
           show_memory_fit_indicators: showFitIndicators,
+          default_model_id: parseNumericInput(defaultModelInput),
         };
 
         // Check if any updates were made
@@ -107,7 +112,8 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           updates.title_generation_prompt !== undefined ||
           updates.max_tool_iterations !== undefined ||
           updates.max_stagnation_steps !== undefined ||
-          updates.show_memory_fit_indicators !== undefined;
+          updates.show_memory_fit_indicators !== undefined ||
+          updates.default_model_id !== undefined;
 
         if (hasUpdates) {
           await saveSettings(updates);
@@ -128,6 +134,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       maxToolIterationsInput,
       maxStagnationStepsInput,
       showFitIndicators,
+      defaultModelInput,
       info,
       saveDir,
       saveSettings,
@@ -205,6 +212,10 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
             setMaxQueueSizeInput={setMaxQueueSizeInput}
             showFitIndicators={showFitIndicators}
             setShowFitIndicators={setShowFitIndicators}
+            defaultModelInput={defaultModelInput}
+            setDefaultModelInput={setDefaultModelInput}
+            models={models}
+            loadingModels={loadingModels}
             isAdvancedOpen={isAdvancedOpen}
             setIsAdvancedOpen={setIsAdvancedOpen}
             maxToolIterationsInput={maxToolIterationsInput}

--- a/src/components/SettingsModal/GeneralSettings.tsx
+++ b/src/components/SettingsModal/GeneralSettings.tsx
@@ -2,8 +2,9 @@ import { FC, FormEvent } from "react";
 import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { Textarea } from "../ui/Textarea";
+import { Select } from "../ui/Select";
 import { DEFAULT_TITLE_GENERATION_PROMPT } from "../../services/clients/chat";
-import type { ModelsDirectoryInfo } from "../../types";
+import type { ModelsDirectoryInfo, GgufModel } from "../../types";
 import styles from "../SettingsModal.module.css";
 
 interface GeneralSettingsProps {
@@ -24,6 +25,12 @@ interface GeneralSettingsProps {
   setMaxQueueSizeInput: (value: string) => void;
   showFitIndicators: boolean;
   setShowFitIndicators: (value: boolean) => void;
+  
+  // Default model state
+  defaultModelInput: string;
+  setDefaultModelInput: (value: string) => void;
+  models: GgufModel[];
+  loadingModels: boolean;
   
   // Advanced settings
   isAdvancedOpen: boolean;
@@ -63,6 +70,10 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
   setMaxQueueSizeInput,
   showFitIndicators,
   setShowFitIndicators,
+  defaultModelInput,
+  setDefaultModelInput,
+  models,
+  loadingModels,
   isAdvancedOpen,
   setIsAdvancedOpen,
   maxToolIterationsInput,
@@ -144,6 +155,26 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
       />
       <div className={styles.helperText}>
         <span>Default context size for models (e.g., 4096, 8192, 16384)</span>
+      </div>
+
+      <label className={styles.label} htmlFor="default-model-select">
+        Default Model
+      </label>
+      <Select
+        id="default-model-select"
+        value={defaultModelInput}
+        onChange={(event) => setDefaultModelInput(event.target.value)}
+        disabled={saving || loadingModels}
+      >
+        <option value="">No default model</option>
+        {models.map((model) => (
+          <option key={model.id} value={model.id?.toString() ?? ""}>
+            {model.name}{model.quantization ? ` (${model.quantization})` : ""}
+          </option>
+        ))}
+      </Select>
+      <div className={styles.helperText}>
+        <span>Model to use for quick commands like <code>gglib question</code></span>
       </div>
 
       <label className={styles.label} htmlFor="proxy-port-input">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,8 @@ export interface AppSettings {
   max_tool_iterations?: number | null;
   /** Maximum stagnation steps before stopping agent loop (default: 5) */
   max_stagnation_steps?: number | null;
+  /** Default model ID for quick commands (e.g., `gglib question`) */
+  default_model_id?: number | null;
 }
 
 export interface UpdateSettingsRequest {
@@ -68,6 +70,8 @@ export interface UpdateSettingsRequest {
   max_tool_iterations?: number | null | undefined;
   /** Maximum stagnation steps before stopping agent loop (default: 5) */
   max_stagnation_steps?: number | null | undefined;
+  /** Default model ID for quick commands (e.g., `gglib question`) */
+  default_model_id?: number | null | undefined;
 }
 
 // ============================================================================

--- a/tests/integration_question_command.rs
+++ b/tests/integration_question_command.rs
@@ -1,0 +1,276 @@
+//! Integration tests for the question command functionality.
+//!
+//! This module tests the question command workflow including:
+//! - Default model configuration via settings
+//! - Model resolution fallback chain
+//! - Settings persistence
+
+mod common;
+
+use common::database::setup_test_pool;
+use std::sync::Arc;
+
+use gglib_core::{
+    ModelRepository, NewModel, Settings, SettingsUpdate,
+    services::SettingsService,
+};
+use gglib_db::{SqliteModelRepository, SqliteSettingsRepository};
+use chrono::Utc;
+use tempfile::tempdir;
+use std::fs;
+
+/// Create a test GGUF file with minimal valid header
+fn create_test_gguf_file(temp_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let file_path = temp_dir.join(format!("{name}.gguf"));
+    // Create a minimal GGUF file with correct header
+    let gguf_header = [
+        0x47, 0x47, 0x55, 0x46, // Magic "GGUF"
+        0x03, 0x00, 0x00, 0x00, // Version 3
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Tensor count (1)
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Metadata count (1)
+    ];
+    fs::write(&file_path, gguf_header).unwrap();
+    file_path
+}
+
+// =============================================================================
+// Settings: default_model_id persistence tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_settings_default_model_id_initially_none() {
+    let pool = setup_test_pool().await.unwrap();
+    let repo = SqliteSettingsRepository::new(pool);
+    let service = SettingsService::new(Arc::new(repo));
+
+    let settings = service.get().await.unwrap();
+    assert_eq!(
+        settings.default_model_id, None,
+        "default_model_id should be None initially"
+    );
+}
+
+#[tokio::test]
+async fn test_settings_set_and_get_default_model_id() {
+    let pool = setup_test_pool().await.unwrap();
+    let repo = SqliteSettingsRepository::new(pool);
+    let service = SettingsService::new(Arc::new(repo));
+
+    // Set default model ID
+    let update = SettingsUpdate {
+        default_model_id: Some(Some(42)),
+        ..Default::default()
+    };
+    service.update(update).await.unwrap();
+
+    // Retrieve and verify
+    let settings = service.get().await.unwrap();
+    assert_eq!(
+        settings.default_model_id,
+        Some(42),
+        "default_model_id should be 42 after update"
+    );
+}
+
+#[tokio::test]
+async fn test_settings_clear_default_model_id() {
+    let pool = setup_test_pool().await.unwrap();
+    let repo = SqliteSettingsRepository::new(pool);
+    let service = SettingsService::new(Arc::new(repo));
+
+    // First set a value
+    let update = SettingsUpdate {
+        default_model_id: Some(Some(42)),
+        ..Default::default()
+    };
+    service.update(update).await.unwrap();
+
+    // Verify it's set
+    let settings = service.get().await.unwrap();
+    assert_eq!(settings.default_model_id, Some(42));
+
+    // Now clear it
+    let clear_update = SettingsUpdate {
+        default_model_id: Some(None),
+        ..Default::default()
+    };
+    service.update(clear_update).await.unwrap();
+
+    // Verify it's cleared
+    let settings = service.get().await.unwrap();
+    assert_eq!(
+        settings.default_model_id, None,
+        "default_model_id should be None after clearing"
+    );
+}
+
+#[tokio::test]
+async fn test_settings_default_model_id_survives_other_updates() {
+    let pool = setup_test_pool().await.unwrap();
+    let repo = SqliteSettingsRepository::new(pool);
+    let service = SettingsService::new(Arc::new(repo));
+
+    // Set default model ID
+    let update = SettingsUpdate {
+        default_model_id: Some(Some(42)),
+        ..Default::default()
+    };
+    service.update(update).await.unwrap();
+
+    // Update a different setting
+    let other_update = SettingsUpdate {
+        proxy_port: Some(Some(9999)),
+        ..Default::default()
+    };
+    service.update(other_update).await.unwrap();
+
+    // Verify default_model_id is preserved
+    let settings = service.get().await.unwrap();
+    assert_eq!(
+        settings.default_model_id,
+        Some(42),
+        "default_model_id should survive other updates"
+    );
+    assert_eq!(
+        settings.proxy_port,
+        Some(9999),
+        "proxy_port should be updated"
+    );
+}
+
+// =============================================================================
+// Model resolution tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_find_model_by_id() {
+    let pool = setup_test_pool().await.unwrap();
+    let model_repo = SqliteModelRepository::new(pool);
+    let temp_dir = tempdir().unwrap();
+    let file_path = create_test_gguf_file(temp_dir.path(), "test_model");
+
+    // Add a model
+    let new_model = NewModel::new(
+        "Test Model".to_string(),
+        file_path.clone(),
+        7.0,
+        Utc::now(),
+    );
+    let inserted = model_repo.insert(&new_model).await.unwrap();
+    let id = inserted.id;
+
+    // Find by ID - returns Result<Model>
+    let found = model_repo.get_by_id(id).await;
+    assert!(found.is_ok(), "Model should be found by ID");
+    let model = found.unwrap();
+    assert_eq!(model.id, id);
+    assert_eq!(model.name, "Test Model");
+}
+
+#[tokio::test]
+async fn test_find_model_by_name() {
+    let pool = setup_test_pool().await.unwrap();
+    let model_repo = SqliteModelRepository::new(pool);
+    let temp_dir = tempdir().unwrap();
+    let file_path = create_test_gguf_file(temp_dir.path(), "named_model");
+
+    // Add a model
+    let new_model = NewModel::new(
+        "Named Model".to_string(),
+        file_path.clone(),
+        7.0,
+        Utc::now(),
+    );
+    model_repo.insert(&new_model).await.unwrap();
+
+    // Find by name using get_by_name
+    let found = model_repo.get_by_name("Named Model").await;
+    assert!(found.is_ok(), "Model should be found by name");
+    let model = found.unwrap();
+    assert_eq!(model.name, "Named Model");
+}
+
+#[tokio::test]
+async fn test_find_model_not_found() {
+    let pool = setup_test_pool().await.unwrap();
+    let model_repo = SqliteModelRepository::new(pool);
+
+    // Try to find a model that doesn't exist
+    let found = model_repo.get_by_name("nonexistent model").await;
+    assert!(found.is_err(), "Should error when model not found");
+}
+
+#[tokio::test]
+async fn test_find_model_by_id_not_found() {
+    let pool = setup_test_pool().await.unwrap();
+    let model_repo = SqliteModelRepository::new(pool);
+
+    // Try to find a model by ID that doesn't exist
+    let found = model_repo.get_by_id(99999).await;
+    assert!(found.is_err(), "Should error when model ID not found");
+}
+
+// =============================================================================
+// Settings merge behavior tests
+// =============================================================================
+
+#[test]
+fn test_settings_merge_preserves_unset_fields() {
+    let mut settings = Settings::with_defaults();
+    settings.default_model_id = Some(42);
+
+    let update = SettingsUpdate {
+        proxy_port: Some(Some(9999)),
+        ..Default::default()
+    };
+
+    settings.merge(&update);
+
+    assert_eq!(
+        settings.default_model_id,
+        Some(42),
+        "Merge should preserve default_model_id when not in update"
+    );
+    assert_eq!(
+        settings.proxy_port,
+        Some(9999),
+        "Merge should apply proxy_port from update"
+    );
+}
+
+#[test]
+fn test_settings_merge_updates_default_model_id() {
+    let mut settings = Settings::with_defaults();
+    settings.default_model_id = Some(42);
+
+    let update = SettingsUpdate {
+        default_model_id: Some(Some(99)),
+        ..Default::default()
+    };
+
+    settings.merge(&update);
+
+    assert_eq!(
+        settings.default_model_id,
+        Some(99),
+        "Merge should update default_model_id"
+    );
+}
+
+#[test]
+fn test_settings_merge_clears_default_model_id() {
+    let mut settings = Settings::with_defaults();
+    settings.default_model_id = Some(42);
+
+    let update = SettingsUpdate {
+        default_model_id: Some(None),
+        ..Default::default()
+    };
+
+    settings.merge(&update);
+
+    assert_eq!(
+        settings.default_model_id, None,
+        "Merge should clear default_model_id when set to None"
+    );
+}

--- a/tests/integration_question_command.rs
+++ b/tests/integration_question_command.rs
@@ -10,14 +10,11 @@ mod common;
 use common::database::setup_test_pool;
 use std::sync::Arc;
 
-use gglib_core::{
-    ModelRepository, NewModel, Settings, SettingsUpdate,
-    services::SettingsService,
-};
-use gglib_db::{SqliteModelRepository, SqliteSettingsRepository};
 use chrono::Utc;
-use tempfile::tempdir;
+use gglib_core::{ModelRepository, NewModel, Settings, SettingsUpdate, services::SettingsService};
+use gglib_db::{SqliteModelRepository, SqliteSettingsRepository};
 use std::fs;
+use tempfile::tempdir;
 
 /// Create a test GGUF file with minimal valid header
 fn create_test_gguf_file(temp_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
@@ -150,12 +147,7 @@ async fn test_find_model_by_id() {
     let file_path = create_test_gguf_file(temp_dir.path(), "test_model");
 
     // Add a model
-    let new_model = NewModel::new(
-        "Test Model".to_string(),
-        file_path.clone(),
-        7.0,
-        Utc::now(),
-    );
+    let new_model = NewModel::new("Test Model".to_string(), file_path.clone(), 7.0, Utc::now());
     let inserted = model_repo.insert(&new_model).await.unwrap();
     let id = inserted.id;
 


### PR DESCRIPTION
## Summary
Implements a `gglib question` command for quick LLM queries with optional piped input, similar to the qllama workflow.

Closes #76

## Features

### Default Model Configuration
- Added `default_model_id` field to Settings
- New CLI commands: `config set-default-model` and `config get-default-model`
- Model resolution priority: `--model` flag → default model → error

### Question Command
```bash
# Simple question
gglib question "What is Rust?"

# Piped context
cat src/main.rs | gglib question "Explain this code"

# Placeholder substitution
echo "fn main() {}" | gglib question "What does {} do?"

# Override model for specific query
gglib question -m 5 "Summarize this"
```

### Stdin Detection
- Uses `std::io::IsTerminal` to detect piped vs interactive input
- Hybrid UX: reads stdin only when piped, skips when typing directly

### Context Handling
- `{}` placeholder: replaced with stdin content inline
- No placeholder: prepends as "Context:\n...\nQuestion:"
- Context size validation against model's max context

### Implementation Details
- Uses `LlamaCommandBuilder` for consistent llama-cli invocation
- `--single-turn` flag for automatic exit after response
- Streams output directly to terminal

## Commits
- `feat(core): add default_model_id field to Settings`
- `fix(gui): add default_model_id to SettingsUpdate in GUI`
- `feat(cli): add set-default-model and get-default-model commands`
- `feat(cli): implement default model management in config handler`
- `feat(cli): add Question command variant`
- `feat(cli): implement question command handler`
- `feat(cli): wire up Question command in main`
- `docs: add question command documentation`