### PR TITLE
chore: remove unused AI SDK dependencies

### DIFF
--- a/crates/gglib-runtime/src/assistant_ui/mod.rs
+++ b/crates/gglib-runtime/src/assistant_ui/mod.rs
@@ -53,9 +53,6 @@ pub fn handle_update() -> Result<(), String> {
     let update_result = Command::new("npm")
         .arg("update")
         .arg("@assistant-ui/react")
-        .arg("@assistant-ui/react-ai-sdk")
-        .arg("ai")
-        .arg("@ai-sdk/openai")
         .arg("react-markdown")
         .arg("remark-gfm")
         .arg("rehype-highlight")
@@ -105,9 +102,6 @@ pub fn handle_status() -> Result<(), String> {
     // Check each required package
     let packages = vec![
         "@assistant-ui/react",
-        "@assistant-ui/react-ai-sdk",
-        "ai",
-        "@ai-sdk/openai",
         "react-markdown",
         "remark-gfm",
         "rehype-highlight",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,9 @@
     "lint:boundaries": "eslint src/ --rule 'no-restricted-imports: error'"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^1.0.14",
     "@assistant-ui/react": "^0.11.48",
-    "@assistant-ui/react-ai-sdk": "^1.1.17",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
-    "ai": "^4.1.10",
     "anser": "^2.3.3",
     "@radix-ui/react-dialog": "^1.1.2",
     "lucide-react": "^0.469.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,9 +20,6 @@ export default defineConfig(async () => ({
         manualChunks: {
           'chat-runtime': [
             '@assistant-ui/react',
-            '@assistant-ui/react-ai-sdk',
-            '@ai-sdk/openai',
-            'ai',
           ],
           markdown: [
             'react-markdown',


### PR DESCRIPTION
## Summary

Remove `ai`, `@ai-sdk/openai`, and `@assistant-ui/react-ai-sdk` packages that were never imported in the codebase.

## Background

Investigation for Issue #81 revealed these packages were vestigial dependencies—chat functionality runs entirely on:
- `@assistant-ui/react` core primitives
- Custom `useGglibRuntime` hook
- Custom `parseSSEStream` SSE parser
- Rust backend passing through raw SSE from llama-server

## Changes

- **package.json**: Remove 3 unused dependencies
- **vite.config.ts**: Simplify `manualChunks['chat-runtime']` 
- **assistant_ui/mod.rs**: Remove packages from `handle_update()` and `handle_status()`

## Results

- 32 packages pruned from node_modules
- Build successful, no import errors
- Dev server verified working

Closes #81