### PR TITLE
fix(deps): update jsdom 25→27.4.0 to resolve whatwg-encoding deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/mmogr/gglib.git"
   },
   "type": "module",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -27,13 +30,13 @@
     "@ai-sdk/openai": "^1.0.14",
     "@assistant-ui/react": "^0.11.48",
     "@assistant-ui/react-ai-sdk": "^1.1.17",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "ai": "^4.1.10",
     "anser": "^2.3.3",
-    "@radix-ui/react-dialog": "^1.1.2",
-    "lucide-react": "^0.469.0",
     "highlight.js": "^11.11.1",
+    "lucide-react": "^0.469.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-markdown": "^9.0.1",
@@ -42,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@tailwindcss/vite": "^4.0.0",
     "@tauri-apps/cli": "^2.9.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
@@ -50,9 +54,8 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.16",
-    "@tailwindcss/vite": "^4.0.0",
     "eslint": "^9.17.0",
-    "jsdom": "^25.0.1",
+    "jsdom": "^27.4.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.0.2",
     "typescript-eslint": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=24.0.0"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@assistant-ui/react": "^0.11.48",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "anser": "^2.3.3",


### PR DESCRIPTION
## Summary

Updates `jsdom` from v25.0.1 to v27.4.0 to resolve the deprecated `whatwg-encoding` transitive dependency warning.

Closes #64

## Changes

- **jsdom**: `^25.0.1` → `^27.4.0` (devDependency)
- **engines**: Added `"node": ">=24.0.0"` to document Node.js requirement

## Why jsdom 27.4.0?

jsdom 27.4.0 (released 2025-12-26) is the first version that replaces `whatwg-encoding` with `@exodus/bytes`. Earlier 27.x versions still used the deprecated package.

## Compatibility

| Requirement | Status |
|-------------|--------|
| **Node.js** | ✅ Requires `^20.19.0 \| ^22.12.0 \| >=24.0.0` — project uses v25.2.1 |
| **Vitest** | ✅ vitest@4.0.16 has `jsdom: '*'` peer dependency |

## Testing

- `npm ls whatwg-encoding` returns empty (deprecated package removed)
- Test suite passes with same results as before (35 pre-existing failures unrelated to this change)