### PR TITLE
fix(tauri): update tauri-plugin-dialog to v2.6 to match NPM package

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6399,9 +6399,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05416b57601eca8666b5ec4186f5b1dc826ed35263b4797ad6641e58da6bc6c3"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
 dependencies = [
  "log",
  "raw-window-handle",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "2.4.1", features = [] }
 
 [dependencies]
 tauri = { version = "2.8.5", features = ["devtools"] }
-tauri-plugin-dialog = "2.5"
+tauri-plugin-dialog = "2.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"


### PR DESCRIPTION
## Summary

Fixes version mismatch between Rust crate (`tauri-plugin-dialog` v2.5) and NPM package (`@tauri-apps/plugin-dialog` v2.6) that was causing `make setup` to fail during the Tauri build phase.

## Problem

Running `make setup` fails with:
```
Found version mismatched Tauri packages. Make sure the NPM package and Rust crate versions are on the same major/minor releases:
tauri-plugin-dialog (v2.5.0) : @tauri-apps/plugin-dialog (v2.6.0)
```

## Root Cause

This is a regression from PR #70 (commit 21279be) which aligned the versions at 2.5. The NPM package has since been updated to 2.6 via semver range resolution (`^2.0.0` in `package.json`).

## Solution

Update `tauri-plugin-dialog` from `2.5` to `2.6` in `src-tauri/Cargo.toml`.

## Related

- Issue #93: Fix Tauri plugin-dialog version mismatch in make setup
- PR #70: Original version alignment fix
- Commit 21279be: fix: update tauri-plugin-dialog to v2.5 to match NPM package

## Testing

- [ ] `make setup` completes without errors
- [ ] Tauri desktop app builds successfully

Closes #93