### PR TITLE
Upgrade react-markdown to v10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lucide-react": "^0.469.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.0",
     "remark-gfm": "^4.0.0"
   },

--- a/src/components/ChatMessagesPanel/ThinkingBlock.tsx
+++ b/src/components/ChatMessagesPanel/ThinkingBlock.tsx
@@ -133,14 +133,15 @@ const ThinkingBlock: React.FC<ThinkingBlockProps> = ({
       
       <div className={cx('thinking-content', isExpanded && 'thinking-content-expanded')}>
         <div className="thinking-content-inner">
-          <ReactMarkdown
-            className="thinking-markdown"
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeHighlight]}
-            components={components}
-          >
-            {thinking || ''}
-          </ReactMarkdown>
+          <div className="thinking-markdown">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeHighlight]}
+              components={components}
+            >
+              {thinking || ''}
+            </ReactMarkdown>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ChatMessagesPanel/components/MarkdownMessageContent.tsx
+++ b/src/components/ChatMessagesPanel/components/MarkdownMessageContent.tsx
@@ -52,14 +52,15 @@ const MarkdownMessageContent: React.FC<MarkdownMessageContentProps> = ({ text: p
   };
 
   return (
-    <ReactMarkdown
-      className="chat-markdown-body"
-      remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeHighlight]}
-      components={components}
-    >
-      {text || ''}
-    </ReactMarkdown>
+    <div className="chat-markdown-body">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={components}
+      >
+        {text || ''}
+      </ReactMarkdown>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
Upgrades `react-markdown` from 9.1.0 to 10.1.0.

## Changes
- **package.json**: Updated `react-markdown` dependency to `^10.1.0`
- **MarkdownMessageContent.tsx**: Wrapped `<ReactMarkdown>` in `<div className="chat-markdown-body">` (breaking change: className prop removed in v10)
- **ThinkingBlock.tsx**: Wrapped `<ReactMarkdown>` in `<div className="thinking-markdown">`

## Breaking Changes Addressed
React-markdown v10 removed the `className` prop from the component. The migration strategy wraps each ReactMarkdown component in a container div with the className instead.

## Compatibility Verified
- ✅ remark-gfm 4.0.1 - compatible with v10
- ✅ rehype-highlight 7.0.2 - compatible with v10
- ✅ All CSS descendant selectors continue working with wrapper divs
- ✅ TypeScript compilation successful
- ✅ Build completed without errors

## Testing Checklist
- [ ] Chat messages render correctly with markdown
- [ ] Code blocks display with syntax highlighting
- [ ] Tables render properly
- [ ] Lists (ordered and unordered) display correctly
- [ ] Inline code formatting works
- [ ] Thinking blocks render correctly with markdown

Closes #92