### PR TITLE
fix(tauri): restore platform-default bundle targets for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,12 +266,14 @@ build-tauri:
 	@if ! command -v npm >/dev/null 2>&1; then echo "Error: npm not found"; exit 1; fi
 	@rm -f src-tauri/target/release/bundle/dmg/*.dmg 2>/dev/null || true
 	npm install
-	# linuxdeploy's embedded strip can fail on some distros (e.g. Arch) due to RELR relocations.
+	# On Linux: use --bundles deb,rpm to avoid AppImage issues on Arch.
+	# linuxdeploy's embedded strip fails on Arch due to RELR relocations (linuxdeploy#272).
 	# NO_STRIP=1 is a linuxdeploy-supported knob that avoids the failure by skipping stripping.
+	# On macOS: use defaults to produce .app bundle.
 	# Source Rust environment for npm subshell (needed for tauri to find cargo)
 	@if [ "$(UNAME_S)" = "Linux" ]; then \
 		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
-		NO_STRIP=1 npm run tauri:build; \
+		NO_STRIP=1 npm run tauri:build -- --bundles deb,rpm; \
 	else \
 		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
 		npm run tauri:build; \

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,10 +38,6 @@
       "icons/icon.png"
     ],
     "resources": [],
-    "shortDescription": "",
-    "targets": [
-      "deb",
-      "rpm"
-    ]
+    "shortDescription": ""
   }
 }


### PR DESCRIPTION
## Summary

Fix macOS GUI launch regression where `gglib gui` fails because the `.app` bundle is not being built.

## Problem

Commit [`61e7554`](https://github.com/mmogr/gglib/commit/61e7554) in PR #72 changed `tauri.conf.json` to use explicit Linux-only bundle targets (`["deb", "rpm"]`) to work around an Arch Linux issue with linuxdeploy ([linuxdeploy/linuxdeploy#272](https://github.com/linuxdeploy/linuxdeploy/issues/272)). This inadvertently broke macOS builds since those targets don't produce `.app` bundles.

## Solution

1. **Remove `targets` from `tauri.conf.json`** — Let Tauri use platform-appropriate defaults
2. **Add `--bundles deb,rpm` to Makefile for Linux only** — Move the Arch workaround to where platform detection already exists

This ensures:
- ✅ macOS builds produce proper `.app` bundles
- ✅ Linux/Arch builds still avoid the linuxdeploy RELR issue  
- ✅ CI workflow continues working (already passes explicit `--bundles` per platform)

## Changes

| File | Change |
|------|--------|
| `src-tauri/tauri.conf.json` | Remove `"targets": ["deb", "rpm"]` |
| `Makefile` | Add `--bundles deb,rpm` flag only when `UNAME_S = Linux` |

## Testing

- [ ] `make build-tauri` on macOS produces `src-tauri/target/release/bundle/macos/GGLib GUI.app`
- [ ] `gglib gui` launches successfully on macOS
- [ ] `make build-tauri` on Linux produces `.deb` and `.rpm` packages

## Related

- Fixes #96
- Reverts tauri.conf.json change from commit [`61e7554`](https://github.com/mmogr/gglib/commit/61e7554) (PR #72)
- Original Arch issue: [linuxdeploy/linuxdeploy#272](https://github.com/linuxdeploy/linuxdeploy/issues/272)