### PR TITLE
chore(deps): upgrade lucide-react 0.469.0 → 0.562.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "anser": "^2.3.3",
     "highlight.js": "^11.11.1",
-    "lucide-react": "^0.469.0",
+    "lucide-react": "^0.562.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-markdown": "^9.0.1",


### PR DESCRIPTION
## Summary

Upgrade lucide-react from `^0.469.0` to `^0.562.0` (~90 releases).

Closes #91

## Verification

| Check | Status | Details |
|-------|--------|---------|
| **Type Compatibility** | ✅ Pass | `LucideIcon` type unchanged; `Icon.tsx` wrapper works |
| **React 19 Support** | ✅ Pass | Both versions support React 19 |
| **Peer Dependencies** | ✅ Pass | No conflicts |
| **Icon Names** | ✅ Pass | All 53 icons in use unchanged |
| **Bundle Size** | ✅ Pass | +458 bytes (+0.05%) |
| **TypeScript Check** | ✅ Pass | `tsc --noEmit` clean |
| **Icons Render** | ✅ Pass | 69 icons rendered in test output |

## Bundle Size Comparison

| Metric | Before (0.469.0) | After (0.562.0) | Delta |
|--------|------------------|-----------------|-------|
| Total JS | 891.4 KB | 891.8 KB | +458 bytes (+0.05%) |

## Breaking Changes Review

The only documented breaking change between these versions is:
- `Fingerprint` icon renamed to `FingerprintPattern` in v0.554.0

**Impact: None** - This icon is not used in this project.

## Test Notes

Pre-existing test failures (35) are unrelated to this upgrade:
- ModelList emoji+text matching issues
- Download manager hook tests
- Thinking content handler tests
- MCP client tests
- Event names contract tests

All icon rendering works correctly.