### PR TITLE
fix(ci): update all release jobs to accept workflow_run events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
     name: Deploy Documentation
     runs-on: ubuntu-latest
     needs: [check-version, create-release]
-    if: github.event_name == 'push' && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && needs.check-version.outputs.is-prerelease != 'true' && inputs.test_run != true
+    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && needs.check-version.outputs.is-prerelease != 'true' && inputs.test_run != true
     # Allow one concurrent deployment
     concurrency:
       group: "pages"
@@ -252,7 +252,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     needs: [check-version]
-    if: github.event_name == 'push' && needs.check-version.outputs.version-changed == 'true'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -369,7 +369,7 @@ jobs:
     name: Build GUI ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     needs: [check-version]
-    if: github.event_name == 'push' && needs.check-version.outputs.version-changed == 'true'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #102 - Release workflow jobs skipped due to incomplete workflow_run migration. PR #63 changed the trigger to workflow_run but only updated check-version. PR #75 fixed create-release but missed deploy-docs, build, and build-gui. Updated all to accept both push and workflow_run events.