### PR TITLE
fix: use direct API fetch for 'View Model' action

### DIFF
--- a/crates/gglib-axum/src/handlers/hf.rs
+++ b/crates/gglib-axum/src/handlers/hf.rs
@@ -6,7 +6,8 @@ use axum::extract::{Path, State};
 use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_gui::types::{
-    HfQuantizationsResponse, HfSearchRequest, HfSearchResponse, HfToolSupportResponse,
+    HfModelSummary, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse,
+    HfToolSupportResponse,
 };
 
 /// Search HuggingFace for GGUF models.
@@ -31,4 +32,14 @@ pub async fn tool_support(
     Path(model_id): Path<String>,
 ) -> Result<Json<HfToolSupportResponse>, HttpError> {
     Ok(Json(state.gui.get_hf_tool_support(&model_id).await?))
+}
+
+/// Get model summary by exact repo ID (direct API lookup).
+///
+/// Uses wildcard path to capture the full `owner/repo` format including slashes.
+pub async fn model_summary(
+    State(state): State<AppState>,
+    Path(model_id): Path<String>,
+) -> Result<Json<HfModelSummary>, HttpError> {
+    Ok(Json(state.gui.get_model_summary(&model_id).await?))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -138,7 +138,7 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/proxy/stop", post(handlers::proxy::stop))
         // Hugging Face API (strip /api prefix since we're nested under /api)
         .route("/hf/search", post(handlers::hf::search))
-        .route("/hf/model/*model_id", get(handlers::hf::model_summary))
+        .route("/hf/model/{*model_id}", get(handlers::hf::model_summary))
         .route(
             "/hf/quantizations/{model_id}",
             get(handlers::hf::quantizations),

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -138,6 +138,7 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/proxy/stop", post(handlers::proxy::stop))
         // Hugging Face API (strip /api prefix since we're nested under /api)
         .route("/hf/search", post(handlers::hf::search))
+        .route("/hf/model/*model_id", get(handlers::hf::model_summary))
         .route(
             "/hf/quantizations/{model_id}",
             get(handlers::hf::quantizations),

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -316,6 +316,11 @@ impl GuiBackend {
         self.download_ops().get_model_quantizations(model_id).await
     }
 
+    /// Get model summary by exact repo ID (direct API lookup).
+    pub async fn get_model_summary(&self, model_id: &str) -> Result<HfModelSummary, GuiError> {
+        self.download_ops().get_model_summary(model_id).await
+    }
+
     /// Check if a model supports tool calling.
     pub async fn get_hf_tool_support(
         &self,

--- a/crates/gglib-gui/src/downloads.rs
+++ b/crates/gglib-gui/src/downloads.rs
@@ -242,4 +242,48 @@ impl<'a> DownloadOps<'a> {
 
         Ok(HfToolSupportResponse::from(detection))
     }
+
+    /// Get model summary by exact repo ID (direct API lookup).
+    ///
+    /// Unlike search, this fetches model info directly from the HuggingFace API
+    /// using the exact repo ID (e.g., `unsloth/medgemma-4b-it-GGUF`).
+    ///
+    /// Returns an error if the model doesn't exist or has no GGUF files.
+    pub async fn get_model_summary(&self, model_id: &str) -> Result<HfModelSummary, GuiError> {
+        // Fetch model info directly by ID
+        let info = self
+            .hf_client
+            .get_model_info(model_id)
+            .await
+            .map_err(|e| GuiError::NotFound {
+                entity: "model",
+                id: format!("{model_id}: {e}"),
+            })?;
+
+        // Check if the model has GGUF files by checking quantizations
+        let quants = self
+            .hf_client
+            .list_quantizations(model_id)
+            .await
+            .map_err(|e| GuiError::Internal(format!("Failed to check quantizations: {e}")))?;
+
+        if quants.is_empty() {
+            return Err(GuiError::ValidationFailed(format!(
+                "Model '{model_id}' exists but contains no GGUF files"
+            )));
+        }
+
+        // Map HfRepoInfo to HfModelSummary
+        Ok(HfModelSummary {
+            id: info.model_id,
+            name: info.name,
+            author: info.author,
+            downloads: info.downloads,
+            likes: info.likes,
+            last_modified: info.last_modified,
+            parameters_b: info.parameters_b,
+            description: info.description,
+            tags: info.tags,
+        })
+    }
 }

--- a/crates/gglib-gui/src/downloads.rs
+++ b/crates/gglib-gui/src/downloads.rs
@@ -251,14 +251,14 @@ impl<'a> DownloadOps<'a> {
     /// Returns an error if the model doesn't exist or has no GGUF files.
     pub async fn get_model_summary(&self, model_id: &str) -> Result<HfModelSummary, GuiError> {
         // Fetch model info directly by ID
-        let info = self
-            .hf_client
-            .get_model_info(model_id)
-            .await
-            .map_err(|e| GuiError::NotFound {
-                entity: "model",
-                id: format!("{model_id}: {e}"),
-            })?;
+        let info =
+            self.hf_client
+                .get_model_info(model_id)
+                .await
+                .map_err(|e| GuiError::NotFound {
+                    entity: "model",
+                    id: format!("{model_id}: {e}"),
+                })?;
 
         // Check if the model has GGUF files by checking quantizations
         let quants = self

--- a/src/services/api/routes.ts
+++ b/src/services/api/routes.ts
@@ -8,5 +8,6 @@
 
 // Hugging Face routes
 export const HF_SEARCH_PATH = '/api/hf/search';
+export const HF_MODEL_PATH = '/api/hf/model';
 export const HF_QUANTIZATIONS_PATH = '/api/hf/quantizations';
 export const HF_TOOL_SUPPORT_PATH = '/api/hf/tool-support';

--- a/src/services/clients/huggingface.ts
+++ b/src/services/clients/huggingface.ts
@@ -10,6 +10,7 @@
 import { getTransport } from '../transport';
 import type { HfModelId } from '../transport/types/ids';
 import type {
+  HfModelSummary,
   HfSearchRequest,
   HfSearchResponse,
   HfQuantizationsResponse,
@@ -21,6 +22,16 @@ import type {
  */
 export async function browseHfModels(params: HfSearchRequest): Promise<HfSearchResponse> {
   return getTransport().browseHfModels(params);
+}
+
+/**
+ * Get model summary by exact repo ID (direct API lookup).
+ *
+ * Unlike browseHfModels (search), this fetches model info directly
+ * using the exact repo ID (e.g., "unsloth/medgemma-4b-it-GGUF").
+ */
+export async function getHfModelSummary(modelId: HfModelId): Promise<HfModelSummary> {
+  return getTransport().getHfModelSummary(modelId);
 }
 
 /**

--- a/src/services/transport/api/models/hf.ts
+++ b/src/services/transport/api/models/hf.ts
@@ -4,7 +4,7 @@
  */
 
 import { get, post } from '../client';
-import { HF_SEARCH_PATH, HF_QUANTIZATIONS_PATH, HF_TOOL_SUPPORT_PATH } from '../../../api/routes';
+import { HF_SEARCH_PATH, HF_MODEL_PATH, HF_QUANTIZATIONS_PATH, HF_TOOL_SUPPORT_PATH } from '../../../api/routes';
 import type { HfModelId } from '../../types/ids';
 import type {
   HfSearchRequest,
@@ -12,12 +12,28 @@ import type {
   HfQuantizationsResponse,
   HfToolSupportResponse,
 } from '../../types/models';
+import type { HfModelSummary } from '../../../../types';
 
 /**
  * Browse HuggingFace models with search and filtering.
  */
 export async function browseHfModels(params: HfSearchRequest): Promise<HfSearchResponse> {
   return post<HfSearchResponse>(HF_SEARCH_PATH, params);
+}
+
+/**
+ * Get model summary by exact repo ID (direct API lookup).
+ * 
+ * Unlike browseHfModels (search), this fetches model info directly
+ * using the exact repo ID (e.g., "unsloth/medgemma-4b-it-GGUF").
+ * 
+ * The model ID is NOT URL-encoded here because the backend uses a 
+ * wildcard route (/hf/model/*model_id) that captures the full path
+ * including the slash.
+ */
+export async function getHfModelSummary(modelId: HfModelId): Promise<HfModelSummary> {
+  // Don't encode the modelId - the wildcard route expects the raw path
+  return get<HfModelSummary>(`${HF_MODEL_PATH}/${modelId}`);
 }
 
 /**

--- a/src/services/transport/types/models.ts
+++ b/src/services/transport/types/models.ts
@@ -83,6 +83,7 @@ export interface ModelsTransport {
 
   // HuggingFace browsing
   browseHfModels(params: HfSearchRequest): Promise<HfSearchResponse>;
+  getHfModelSummary(modelId: HfModelId): Promise<HfModelSummary>;
   getHfQuantizations(modelId: HfModelId): Promise<HfQuantizationsResponse>;
   getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse>;
 


### PR DESCRIPTION
## Summary

Fixes #108 - View Model fails for exact repo names like `unsloth/medgemma-4b-it-GGUF`

## Problem

When typing an exact HuggingFace repo ID (e.g., `unsloth/medgemma-4b-it-GGUF`) and clicking **View Model**, the app would incorrectly report "Model not found" even though the model exists.

This happened because the previous implementation used the **search API** and looked for an exact match in the top 10 results. The HuggingFace search API is fuzzy text search, not exact ID lookup, so valid models could be missed.

## Solution

Use the HuggingFace direct model info API instead:
```
GET https://huggingface.co/api/models/{owner}/{repo}
```

### Changes

**Backend (gglib-axum, gglib-gui):**
- Add `/api/hf/model/*model_id` route with wildcard path to handle slashes in repo IDs
- Add `get_model_summary` method that calls the direct HuggingFace API
- Validate the model has GGUF files before returning (returns clear error if not)

**Frontend:**
- Add `getHfModelSummary(modelId)` transport function
- Update `handleViewRepo` to use direct fetch instead of search+find
- Improved error messages for different failure cases:
  - Model not found (404)
  - Model exists but has no GGUF files
  - General fetch errors

## Testing

1. Type `unsloth/medgemma-4b-it-GGUF` in the HuggingFace browser
2. Click "View Model"
3. Model should load and display in the preview panel

## Edge Cases Handled

- **URL routing with slashes**: Uses wildcard route (`*model_id`) so `owner/repo` is captured correctly
- **GGUF validation**: Returns clear error if model exists but has no GGUF files
