### PR TITLE
fix: add cfg(test) Duration import for gc_expired method

### DIFF
--- a/crates/gglib-download/src/manager/shard_group_tracker.rs
+++ b/crates/gglib-download/src/manager/shard_group_tracker.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
+#[cfg(test)]
+use std::time::Duration;
+
 use gglib_core::download::Quantization;
 
 use crate::queue::ShardGroupId;
@@ -199,7 +202,6 @@ impl ShardGroupTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     fn test_metadata() -> GroupMetadata {
         GroupMetadata {


### PR DESCRIPTION
## Summary

Fixes #113 - Resolves Coverage workflow failure caused by missing `Duration` import.

## Problem

PR #110 (commit 4dacc54) moved the `Duration` import into the test module, but `gc_expired()` is a `#[cfg(test)]` method defined in the main impl block. This caused compilation to fail during coverage tests because the method couldn't access the `Duration` type.

## Root Cause

When a method is marked with `#[cfg(test)]` but is defined **outside** the `mod tests` block (in the main impl), it still needs access to module-level imports. The `Duration` import was incorrectly placed inside `mod tests`, making it inaccessible to `gc_expired()`.

Regular CI tests passed because they don't compile `#[cfg(test)]` code, but coverage tests failed because they instrument all code including test-only items.

## Solution

- ✅ Add `#[cfg(test)] use std::time::Duration;` at module level
- ✅ Remove duplicate import from `mod tests`
- ✅ Keeps import conditional to test builds only
- ✅ Allows `gc_expired()` to access `Duration` type

## Testing

```bash
cargo test --package gglib-download --lib -- manager::shard_group_tracker::tests
```

All 8 tests pass ✅

## References

- Closes #113
- Introduced by: PR #110, commit 4dacc54
- Failed workflow: https://github.com/mmogr/gglib/actions/runs/21333580788