### PR TITLE
fix: Deep Research mode question tracking and deduplication

### DIFF
--- a/src/hooks/useDeepResearch/buildTurnMessages.ts
+++ b/src/hooks/useDeepResearch/buildTurnMessages.ts
@@ -102,18 +102,18 @@ Do NOT use tools in planning phase. Output ONLY the JSON.`,
 You are searching for information to answer the research questions.
 
 INSTRUCTIONS:
-1. Look at the Research Plan - find the highest-priority PENDING question
-2. Use the search tool to find relevant information
-3. If you have enough information to answer a question, report it
+1. Check the "🎯 Current Focus" section to see which question you are working on
+2. Use the search tool to find relevant information for that question
+3. When you have enough information, provide an AnswerResponse
 
 IF YOU NEED TO SEARCH:
 Call the appropriate search tool (e.g., tavily_search) with a well-crafted query.
 
-IF YOU CAN ANSWER A QUESTION:
+IF YOU CAN ANSWER THE CURRENT FOCUS QUESTION:
 Respond with JSON:
 {
   "type": "answer",
-  "questionId": "id-of-question-answered",
+  "questionIndex": 1,
   "answer": "Brief answer summary (max 500 chars)",
   "facts": [
     {
@@ -127,7 +127,10 @@ Respond with JSON:
   "newGaps": ["Newly discovered unknowns..."]
 }
 
-Choose ONE action: either call a tool OR output JSON. Not both.`,
+IMPORTANT:
+- "questionIndex" is the Q number from the Research Plan (Q1, Q2, etc.)
+- Check the "🎯 Current Focus" section for the exact questionIndex to use
+- Choose ONE action: either call a tool OR output JSON. Not both.`,
 
   synthesizing: `## Current Task: SYNTHESIZING
 

--- a/src/hooks/useDeepResearch/runResearchLoop.ts
+++ b/src/hooks/useDeepResearch/runResearchLoop.ts
@@ -671,7 +671,7 @@ export async function runResearchLoop(
             ),
             knowledgeGaps: [
               ...state.knowledgeGaps,
-              `Unable to find definitive data for Q${questionIndex}: "${timedOutQuestion.text}" after ${QUESTION_FOCUS_TIMEOUT_STEPS} attempts`,
+              `Unable to find definitive data for Q${questionIndex}: "${timedOutQuestion.question}" after ${QUESTION_FOCUS_TIMEOUT_STEPS} attempts`,
             ],
           };
         }

--- a/src/hooks/useDeepResearch/runResearchLoop.ts
+++ b/src/hooks/useDeepResearch/runResearchLoop.ts
@@ -57,6 +57,9 @@ export const TOOL_TIMEOUT_MS = 30000;
 /** Maximum retries for transient errors */
 export const MAX_TOOL_RETRIES = 2;
 
+/** Maximum steps a question can be in-progress before being marked blocked */
+export const QUESTION_FOCUS_TIMEOUT_STEPS = 5;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -182,10 +185,14 @@ interface PlanResponse {
 
 /**
  * Gathering phase response (when answering, not tool calling).
+ * Now supports questionIndex (preferred) or questionId (legacy).
  */
 interface AnswerResponse {
   type: 'answer';
-  questionId: string;
+  /** Preferred: 1-based index matching Q1, Q2, etc. from Research Plan */
+  questionIndex?: number;
+  /** Legacy: UUID of question (kept for backwards compatibility) */
+  questionId?: string;
   answer: string;
   facts: Array<{
     claim: string;
@@ -420,6 +427,39 @@ async function handleGatheringPhase(
   const parsed = tryParseStructuredResponse(llmResponse.content);
   
   if (parsed && parsed.type === 'answer') {
+    // Resolve the question being answered using multiple fallback strategies
+    let targetQuestion: ResearchQuestion | undefined;
+    
+    // Strategy 1: Use questionIndex (preferred, 1-based)
+    if (parsed.questionIndex !== undefined && parsed.questionIndex > 0) {
+      targetQuestion = newState.researchPlan[parsed.questionIndex - 1];
+    }
+    
+    // Strategy 2: Fall back to questionId (legacy UUID)
+    if (!targetQuestion && parsed.questionId) {
+      targetQuestion = newState.researchPlan.find(q => q.id === parsed.questionId);
+    }
+    
+    // Strategy 3: Fall back to current in-progress question
+    if (!targetQuestion) {
+      targetQuestion = newState.researchPlan.find(q => q.status === 'in-progress');
+      if (targetQuestion) {
+        console.log(
+          `[handleGatheringPhase] Using in-progress question fallback: Q${newState.researchPlan.indexOf(targetQuestion) + 1}`
+        );
+      }
+    }
+    
+    // If still no match, log warning but continue (facts still get extracted)
+    if (!targetQuestion) {
+      console.warn(
+        '[handleGatheringPhase] Could not resolve target question for answer. ' +
+        `questionIndex=${parsed.questionIndex}, questionId=${parsed.questionId}`
+      );
+    }
+    
+    const targetQuestionId = targetQuestion?.id ?? 'unknown';
+    
     // Extract facts
     const newFacts: GatheredFact[] = parsed.facts.map((f) =>
       createFact(
@@ -428,19 +468,21 @@ async function handleGatheringPhase(
         f.sourceTitle,
         f.confidence,
         state.currentStep,
-        [parsed.questionId]
+        [targetQuestionId]
       )
     );
     
     // Add facts with pruning
     newState = addFacts(newState, newFacts);
     
-    // Update question status
-    newState = updateQuestion(newState, parsed.questionId, {
-      status: 'answered',
-      answerSummary: parsed.answer.slice(0, 500),
-      supportingFactIds: newFacts.map((f) => f.id),
-    });
+    // Update question status if we found a target
+    if (targetQuestion) {
+      newState = updateQuestion(newState, targetQuestion.id, {
+        status: 'answered',
+        answerSummary: parsed.answer.slice(0, 500),
+        supportingFactIds: newFacts.map((f) => f.id),
+      });
+    }
     
     // Update hypothesis if provided
     if (parsed.updatedHypothesis) {
@@ -601,6 +643,68 @@ export async function runResearchLoop(
           `Maximum steps (${state.maxSteps}) reached without completing research.`
         );
         break;
+      }
+
+      // === FOCUS TIMEOUT CHECK ===
+      // Check if any question has been in-progress too long and should be marked blocked
+      if (state.phase === 'gathering') {
+        const timedOutQuestion = state.researchPlan.find(
+          (q) =>
+            q.status === 'in-progress' &&
+            q.inProgressSince !== undefined &&
+            state.currentStep - q.inProgressSince >= QUESTION_FOCUS_TIMEOUT_STEPS
+        );
+
+        if (timedOutQuestion) {
+          const questionIndex = state.researchPlan.indexOf(timedOutQuestion) + 1;
+          console.log(
+            `[runResearchLoop] Question Q${questionIndex} timed out after ${QUESTION_FOCUS_TIMEOUT_STEPS} steps, marking as blocked`
+          );
+
+          // Mark as blocked and record knowledge gap
+          state = {
+            ...state,
+            researchPlan: state.researchPlan.map((q) =>
+              q.id === timedOutQuestion.id
+                ? { ...q, status: 'blocked' as const }
+                : q
+            ),
+            knowledgeGaps: [
+              ...state.knowledgeGaps,
+              `Unable to find definitive data for Q${questionIndex}: "${timedOutQuestion.text}" after ${QUESTION_FOCUS_TIMEOUT_STEPS} attempts`,
+            ],
+          };
+        }
+      }
+
+      // === ENSURE IN-PROGRESS QUESTION ===
+      // If in gathering phase and no question is in-progress, mark the next pending one
+      if (state.phase === 'gathering') {
+        const hasInProgress = state.researchPlan.some(
+          (q) => q.status === 'in-progress'
+        );
+
+        if (!hasInProgress) {
+          const nextPending = state.researchPlan.find(
+            (q) => q.status === 'pending'
+          );
+
+          if (nextPending) {
+            const questionIndex = state.researchPlan.indexOf(nextPending) + 1;
+            console.log(
+              `[runResearchLoop] Setting Q${questionIndex} as current focus`
+            );
+
+            state = {
+              ...state,
+              researchPlan: state.researchPlan.map((q) =>
+                q.id === nextPending.id
+                  ? { ...q, status: 'in-progress' as const, inProgressSince: state.currentStep }
+                  : q
+              ),
+            };
+          }
+        }
       }
 
       // === SOFT LANDING GUARDRAIL ===

--- a/src/hooks/useDeepResearch/types.ts
+++ b/src/hooks/useDeepResearch/types.ts
@@ -665,18 +665,174 @@ export function renderContextForSystemPrompt(
 }
 
 // =============================================================================
+// Deduplication Helpers
+// =============================================================================
+
+/** Similarity threshold for deduplication (0-1, higher = stricter) */
+const DEDUP_SIMILARITY_THRESHOLD = 0.55;
+
+/**
+ * Normalize text for comparison.
+ */
+function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Tokenize text into words/ngrams for comparison.
+ */
+function tokenize(text: string): Set<string> {
+  const normalized = normalizeText(text);
+  const words = normalized.split(' ').filter((w) => w.length > 2);
+  
+  const tokens = new Set(words);
+  for (let i = 0; i < words.length - 1; i++) {
+    tokens.add(`${words[i]} ${words[i + 1]}`);
+  }
+  
+  return tokens;
+}
+
+/**
+ * Calculate Jaccard similarity between two token sets.
+ */
+function jaccardSimilarity(setA: Set<string>, setB: Set<string>): number {
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+  
+  let intersection = 0;
+  for (const token of setA) {
+    if (setB.has(token)) intersection++;
+  }
+  
+  const union = setA.size + setB.size - intersection;
+  return intersection / union;
+}
+
+/**
+ * Extract numeric values from text for comparison.
+ */
+function extractNumbers(text: string): string[] {
+  const numbers: string[] = [];
+  
+  // Match percentages (including formatted like "1,153%")
+  const percentRegex = /([0-9,]+(?:\.[0-9]+)?)\s*%/g;
+  let match;
+  while ((match = percentRegex.exec(text)) !== null) {
+    numbers.push(match[1].replace(/,/g, ''));
+  }
+  
+  // Match money values with multipliers
+  const moneyRegex = /\$\s*([0-9,]+(?:\.[0-9]+)?)\s*(billion|million|thousand)?/gi;
+  while ((match = moneyRegex.exec(text)) !== null) {
+    let num = parseFloat(match[1].replace(/,/g, ''));
+    const multiplier = (match[2] || '').toLowerCase();
+    if (multiplier === 'billion') num *= 1e9;
+    else if (multiplier === 'million') num *= 1e6;
+    else if (multiplier === 'thousand') num *= 1e3;
+    numbers.push(num.toString());
+  }
+  
+  // Match multipliers (3.5x, 2x)
+  const multiplierRegex = /([0-9]+(?:\.[0-9]+)?)\s*x\b/gi;
+  while ((match = multiplierRegex.exec(text)) !== null) {
+    numbers.push(match[1]);
+  }
+  
+  return numbers;
+}
+
+/**
+ * Check if two texts have conflicting numeric values.
+ */
+function hasNumericDivergence(textA: string, textB: string): boolean {
+  const numsA = extractNumbers(textA);
+  const numsB = extractNumbers(textB);
+  
+  if (numsA.length === 0 || numsB.length === 0) return false;
+  
+  const numericMatch = numsA.some(a => {
+    const parsedA = parseFloat(a);
+    return numsB.some(b => {
+      const parsedB = parseFloat(b);
+      const ratio = Math.abs(parsedA - parsedB) / Math.max(parsedA, parsedB, 1);
+      return ratio < 0.1;
+    });
+  });
+  
+  return !numericMatch;
+}
+
+/**
+ * Check if a fact claim is similar to an existing claim.
+ */
+function isSimilarClaim(claimA: string, claimB: string): boolean {
+  const tokensA = tokenize(claimA);
+  const tokensB = tokenize(claimB);
+  const similarity = jaccardSimilarity(tokensA, tokensB);
+  
+  if (similarity >= DEDUP_SIMILARITY_THRESHOLD) {
+    // Check for numeric divergence before marking as duplicate
+    return !hasNumericDivergence(claimA, claimB);
+  }
+  return false;
+}
+
+// =============================================================================
 // State Mutation Helpers
 // =============================================================================
 
 /**
- * Add facts to state with automatic pruning.
+ * Add facts to state with automatic deduplication and pruning.
+ * 
+ * Deduplication uses Jaccard similarity (threshold 0.55) with numeric-aware
+ * comparison to prevent merging facts with different numbers (e.g., "40%" vs "1,153%").
  */
 export function addFacts(
   state: ResearchState,
   newFacts: GatheredFact[],
   maxFacts: number = 50
 ): ResearchState {
-  const combined = [...state.gatheredFacts, ...newFacts];
+  // Deduplicate new facts against existing facts
+  const dedupedNewFacts: GatheredFact[] = [];
+  let duplicateCount = 0;
+  
+  for (const newFact of newFacts) {
+    const isDuplicate = state.gatheredFacts.some(
+      (existing) => isSimilarClaim(newFact.claim, existing.claim)
+    );
+    
+    if (isDuplicate) {
+      console.log(
+        `[addFacts] Discarding duplicate: "${newFact.claim.slice(0, 50)}..."`
+      );
+      duplicateCount++;
+    } else {
+      // Also check against facts we're adding in this batch
+      const isBatchDuplicate = dedupedNewFacts.some(
+        (added) => isSimilarClaim(newFact.claim, added.claim)
+      );
+      
+      if (isBatchDuplicate) {
+        console.log(
+          `[addFacts] Discarding batch duplicate: "${newFact.claim.slice(0, 50)}..."`
+        );
+        duplicateCount++;
+      } else {
+        dedupedNewFacts.push(newFact);
+      }
+    }
+  }
+  
+  if (duplicateCount > 0) {
+    console.log(`[addFacts] Deduplication removed ${duplicateCount} duplicate facts`);
+  }
+  
+  const combined = [...state.gatheredFacts, ...dedupedNewFacts];
 
   if (combined.length <= maxFacts) {
     return { ...state, gatheredFacts: combined };


### PR DESCRIPTION
## Summary

This PR fixes three interconnected bugs in Deep Research mode that caused questions to never be marked as answered and progress to get stuck at 10%.

## Issues Fixed

- Fixes #117 - Duplicate facts not being deduplicated
- Fixes #118 - Questions never marked as answered
- Fixes #119 - Progress stuck at 10%
- Fixes #120 - Focus timeout as circuit breaker

## Root Causes Identified

1. **LLM couldn't identify questions**: UUIDs not visible in context, preventing valid `questionId` responses
2. **In-progress status never set**: No code path assigned `status: 'in-progress'`
3. **Jaccard similarity too strict**: Threshold 0.8 missed synonyms ("increased"/"rose")
4. **No timeout mechanism**: Stuck questions blocked forever

## Changes

### Question Tracking ([types.ts](src/hooks/useDeepResearch/types.ts))
- Add `inProgressSince` field to `ResearchQuestion` for timeout detection
- Add `currentFocus` to `ResearchContextInjection` for LLM context
- Update `renderQuestion()` to show `Q{N}` prefix
- Add "🎯 Current Focus" section in `renderContextForSystemPrompt()`

### LLM Instructions ([buildTurnMessages.ts](src/hooks/useDeepResearch/buildTurnMessages.ts))
- Update `PHASE_INSTRUCTIONS.gathering` to use `questionIndex` (1-based) instead of UUID
- LLM now sees: "When answering Q1, use `questionIndex: 1`"

### In-Progress Logic ([runResearchLoop.ts](src/hooks/useDeepResearch/runResearchLoop.ts))
- Add `QUESTION_FOCUS_TIMEOUT_STEPS = 5` constant
- Add timeout check in main loop (marks as 'blocked' after 5 steps)
- Add automatic in-progress assignment for next pending question
- Update `handleGatheringPhase` with 3-strategy question resolution:
  1. Try `questionIndex` (LLM-provided, 1-based)
  2. Fallback to `questionId` (UUID for backwards compat)
  3. Final fallback to current in-progress question

### Deduplication ([types.ts](src/hooks/useDeepResearch/types.ts), [factExtractor.ts](src/hooks/useDeepResearch/factExtractor.ts))
- Lower Jaccard similarity threshold from 0.8 to 0.55
- Add numeric extraction (percentages, money, multipliers)
- Add `hasNumericDivergence()` to prevent merging facts with different numbers
- Facts like "40%" vs "1,153%" are now preserved as distinct

### Progress Formula ([ResearchArtifact.tsx](src/components/DeepResearch/ResearchArtifact.tsx))
- Replace linear progress with exponential saturation:
  - `factProgress = 0.4 * (1 - e^(-facts/15))`
- Cap at 50% from facts alone until questions answered
- Questions contribute remaining 50%: `0.5 * (answered/total)`

## Testing

- [x] TypeScript compiles without errors
- [ ] Manual testing with Deep Research mode (pending)
- [ ] Verify facts are properly deduplicated
- [ ] Verify questions transition to in-progress/answered
- [ ] Verify progress bar moves smoothly