### PR TITLE
feat: Human-in-the-Loop controls for Deep Research mode

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -30,6 +30,7 @@ import type { MessageActionsContextValue } from './components';
 import { useChatPersistence, useTitleGeneration } from './hooks';
 import { useSharedTicker } from './hooks/useSharedTicker';
 import { ThinkingTimingProvider } from './context/ThinkingTimingContext';
+import { DeepResearchProvider } from './context/DeepResearchContext';
 import type { ReasoningTimingTracker } from '../../hooks/useGglibRuntime/reasoningTiming';
 import { DeepResearchToggle } from '../DeepResearch';
 import { useDeepResearch } from '../../hooks/useDeepResearch';
@@ -648,6 +649,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
             <div className="chat-empty-state">Loading messages…</div>
           ) : (
             <MessageActionsContext.Provider value={messageActionsValue}>
+              <DeepResearchProvider isRunning={deepResearch.isRunning} skipQuestion={deepResearch.skipQuestion}>
               <ThinkingTimingProvider value={{ timingTracker, currentStreamingAssistantMessageId, tick }}>
                 <ThreadPrimitive.Root
                   key={activeConversationId ?? 'thread-root'}
@@ -687,6 +689,8 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                         onToggle={toggleDeepResearch}
                         isRunning={deepResearch.isRunning}
                         onStop={stopDeepResearch}
+                        onWrapUp={deepResearch.requestWrapUp}
+                        researchPhase={deepResearch.state?.phase}
                         disabled={!isServerConnected || isThreadRunning}
                         disabledReason={
                           !isServerConnected
@@ -738,6 +742,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                 </div>
               </ThreadPrimitive.Root>
               </ThinkingTimingProvider>
+              </DeepResearchProvider>
             </MessageActionsContext.Provider>
           )}
         </div>

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -256,6 +256,10 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
       pendingObservations: [],
       finalReport: null,
       citations: [],
+      // Verbose tracking fields
+      activityLog: [],
+      activeToolCalls: [],
+      isLLMGenerating: false,
     };
 
     const assistantMessage: ThreadMessageLike = {

--- a/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
+++ b/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
@@ -15,6 +15,7 @@ import { threadMessageToTranscriptMarkdown } from '../../../utils/messages';
 import { MessageActionsContext } from './MessageActionsContext';
 import { useThinkingTiming } from '../context/ThinkingTimingContext';
 import { ToolUsageBadge } from '../../ToolUsageBadge';
+import { useDeepResearchContext } from '../context/DeepResearchContext';
 import { ResearchArtifact } from '../../DeepResearch';
 import type { GglibMessageCustom } from '../../../types/messages';
 import type { ResearchState } from '../../../hooks/useDeepResearch/types';
@@ -46,6 +47,7 @@ function isDeepResearchMessage(message: ReturnType<typeof useMessage>): boolean 
 export const AssistantMessageBubble: React.FC = () => {
   const message = useMessage();
   const timing = useThinkingTiming();
+  const deepResearchCtx = useDeepResearchContext();
   const timestamp = new Intl.DateTimeFormat(undefined, {
     hour: '2-digit',
     minute: '2-digit',
@@ -86,6 +88,7 @@ export const AssistantMessageBubble: React.FC = () => {
           <ResearchArtifact
             state={researchState}
             isRunning={isResearchRunning}
+            onSkipQuestion={deepResearchCtx?.skipQuestion}
             defaultExpanded={true}
           />
         </div>

--- a/src/components/ChatMessagesPanel/context/DeepResearchContext.tsx
+++ b/src/components/ChatMessagesPanel/context/DeepResearchContext.tsx
@@ -1,0 +1,47 @@
+/**
+ * Deep Research Context
+ *
+ * Provides intervention callbacks for deep research components in the message tree.
+ *
+ * @module components/ChatMessagesPanel/context/DeepResearchContext
+ */
+
+import React, { createContext, useContext } from 'react';
+
+export interface DeepResearchContextValue {
+  /** Whether research is currently running */
+  isRunning: boolean;
+  /** Skip a specific question (mark as blocked) */
+  skipQuestion?: (questionId: string) => void;
+}
+
+const DeepResearchContext = createContext<DeepResearchContextValue | null>(null);
+
+export interface DeepResearchProviderProps {
+  children: React.ReactNode;
+  isRunning: boolean;
+  skipQuestion?: (questionId: string) => void;
+}
+
+/**
+ * Provider component for deep research context.
+ */
+export const DeepResearchProvider: React.FC<DeepResearchProviderProps> = ({
+  children,
+  isRunning,
+  skipQuestion,
+}) => {
+  return (
+    <DeepResearchContext.Provider value={{ isRunning, skipQuestion }}>
+      {children}
+    </DeepResearchContext.Provider>
+  );
+};
+
+/**
+ * Hook to access deep research context.
+ * Returns null if not within a DeepResearchProvider.
+ */
+export const useDeepResearchContext = (): DeepResearchContextValue | null => {
+  return useContext(DeepResearchContext);
+};

--- a/src/components/DeepResearch/DeepResearchToggle.module.css
+++ b/src/components/DeepResearch/DeepResearchToggle.module.css
@@ -114,6 +114,33 @@
   justify-content: center;
 }
 
+/* Wrap up button */
+.wrapUpButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  border-radius: 6px;
+  color: #4ade80;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.wrapUpButton:hover {
+  background: rgba(34, 197, 94, 0.25);
+  border-color: rgba(34, 197, 94, 0.6);
+}
+
+.wrapUpIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Running indicator */
 .runningIndicator {
   display: flex;

--- a/src/components/DeepResearch/DeepResearchToggle.tsx
+++ b/src/components/DeepResearch/DeepResearchToggle.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { Loader2, Search, Square, Sparkles } from 'lucide-react';
+import { FastForward, Loader2, Search, Square, Sparkles } from 'lucide-react';
 import { Icon } from '../ui/Icon';
 import styles from './DeepResearchToggle.module.css';
 
@@ -21,12 +21,16 @@ export interface DeepResearchToggleProps {
   isRunning?: boolean;
   /** Stop the current research */
   onStop?: () => void;
+  /** Request early wrap-up (synthesize with current facts) */
+  onWrapUp?: () => void;
   /** Whether the toggle is disabled */
   disabled?: boolean;
   /** Tooltip text when disabled */
   disabledReason?: string;
   /** Optional className */
   className?: string;
+  /** Current research phase (for showing wrap-up button only in gathering) */
+  researchPhase?: string;
 }
 
 /**
@@ -42,18 +46,36 @@ export const DeepResearchToggle: React.FC<DeepResearchToggleProps> = ({
   onToggle,
   isRunning = false,
   onStop,
+  onWrapUp,
   disabled = false,
   disabledReason,
   className,
+  researchPhase,
 }) => {
   // If research is running, show stop button
   if (isRunning) {
+    // Only show wrap-up during gathering phase
+    const canWrapUp = researchPhase === 'gathering' && onWrapUp;
+    
     return (
       <div className={`${styles.toggleContainer} ${className || ''}`}>
         <div className={styles.runningIndicator}>
           <Icon icon={Loader2} size={12} className={styles.runningSpinner} />
           <span>Researching...</span>
         </div>
+        {canWrapUp && (
+          <button
+            className={styles.wrapUpButton}
+            onClick={onWrapUp}
+            title="Wrap up research early (synthesize now)"
+            type="button"
+          >
+            <span className={styles.wrapUpIcon}>
+              <Icon icon={FastForward} size={12} />
+            </span>
+            <span>Wrap Up</span>
+          </button>
+        )}
         {onStop && (
           <button
             className={styles.stopButton}

--- a/src/components/DeepResearch/ResearchArtifact.module.css
+++ b/src/components/DeepResearch/ResearchArtifact.module.css
@@ -163,6 +163,32 @@
   color: var(--text-muted, #666);
 }
 
+/* === Activity Log (Velocity Stream) === */
+.activityLog {
+  padding: 8px 14px;
+  background: var(--bg-tertiary, #252525);
+  border-top: 1px solid var(--border-color, #333);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.activityEntry {
+  font-size: 11px;
+  color: var(--text-secondary, #a0a0a0);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: opacity 0.2s ease;
+}
+
+.activityEntry::before {
+  content: '›';
+  margin-right: 6px;
+  color: var(--text-muted, #666);
+}
+
 /* === Expanded Content === */
 .expandedContent {
   border-top: 1px solid var(--border-color, #333);
@@ -288,6 +314,17 @@
   font-size: 13px;
   color: var(--text-primary, #e0e0e0);
   line-height: 1.4;
+}
+
+/* Blocked questions are visually deprioritized */
+.questionBlocked {
+  opacity: 0.5;
+  background: transparent;
+}
+
+.questionBlocked .questionText {
+  text-decoration: line-through;
+  color: var(--text-muted, #666);
 }
 
 .questionAnswer {

--- a/src/components/DeepResearch/ResearchArtifact.module.css
+++ b/src/components/DeepResearch/ResearchArtifact.module.css
@@ -297,6 +297,47 @@
   line-height: 1.4;
 }
 
+/* Skip button for research questions */
+.skipButton {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted, #666);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.questionItem:hover .skipButton {
+  opacity: 1;
+}
+
+.skipButton:hover {
+  background: rgba(251, 146, 60, 0.15);
+  color: #fb923c;
+}
+
+.skipButton:active {
+  background: rgba(251, 146, 60, 0.25);
+}
+
+.skipButton.skipPending {
+  opacity: 1;
+  cursor: default;
+  background: transparent;
+  color: #fb923c;
+}
+
+.skipSpinner {
+  animation: spin 1s linear infinite;
+}
+
 /* === Gathered Facts === */
 .factList {
   display: flex;

--- a/src/hooks/useDeepResearch/buildTurnMessages.ts
+++ b/src/hooks/useDeepResearch/buildTurnMessages.ts
@@ -288,9 +288,21 @@ export function buildTurnMessages(options: BuildTurnMessagesOptions): TurnMessag
     : contextString;
 
   // 5. Get phase instruction (use override or default)
-  const instruction = phaseInstruction ?? PHASE_INSTRUCTIONS[state.phase];
+  let instruction = phaseInstruction ?? PHASE_INSTRUCTIONS[state.phase];
+  
+  // 6. Append manual termination note if user requested early wrap-up
+  if (state.isManualTermination && state.phase === 'synthesizing') {
+    instruction += `
 
-  // 6. Build complete system prompt
+📋 USER EARLY TERMINATION REQUEST
+The user has requested early termination of this research session.
+Synthesize the facts gathered so far into a coherent report.
+Do NOT apologize for incomplete research or make excuses.
+Focus on what WAS found and present it confidently.
+Note any unanswered questions briefly as "Areas for further research" at the end.`;
+  }
+
+  // 7. Build complete system prompt
   const systemContent = buildSystemPrompt(
     baseSystemPrompt,
     fullContext,

--- a/src/hooks/useDeepResearch/index.ts
+++ b/src/hooks/useDeepResearch/index.ts
@@ -25,6 +25,9 @@ export type {
   // Core state
   ResearchPhase,
   ResearchState,
+  // Human-in-the-loop
+  ResearchIntervention,
+  InterventionRef,
   // Serialization
   ResearchContextInjection,
   SerializedResearchState,

--- a/src/hooks/useDeepResearch/runResearchLoop.ts
+++ b/src/hooks/useDeepResearch/runResearchLoop.ts
@@ -970,7 +970,6 @@ export async function runResearchLoop(
           }))
         );
       }
-      }
 
       // === PROCESS RESPONSE BY PHASE ===
       switch (state.phase) {

--- a/src/hooks/useDeepResearch/types.ts
+++ b/src/hooks/useDeepResearch/types.ts
@@ -229,6 +229,23 @@ export type ResearchPhase =
   | 'error';
 
 // =============================================================================
+// Human-in-the-Loop Intervention
+// =============================================================================
+
+/**
+ * Intervention signal for human-in-the-loop control.
+ * Written to a MutableRefObject by UI, read by research loop.
+ */
+export type ResearchIntervention =
+  | { type: 'wrap-up' }
+  | { type: 'skip-question'; questionId: string };
+
+/**
+ * Type for the intervention ref passed to the research loop.
+ */
+export type InterventionRef = React.MutableRefObject<ResearchIntervention | null>;
+
+// =============================================================================
 // Core Research State (The Scratchpad)
 // =============================================================================
 
@@ -302,6 +319,10 @@ export interface ResearchState {
     factId: string;
     footnoteNumber: number;
   }>;
+
+  // === Human-in-the-Loop Flags ===
+  /** True if user manually triggered early termination via "Wrap Up" */
+  isManualTermination?: boolean;
 
   // === Error Handling ===
   /** Error message if phase='error' */

--- a/src/hooks/useDeepResearch/types.ts
+++ b/src/hooks/useDeepResearch/types.ts
@@ -246,6 +246,30 @@ export type ResearchIntervention =
 export type InterventionRef = React.MutableRefObject<ResearchIntervention | null>;
 
 // =============================================================================
+// Verbose Execution Tracking (Activity Visibility)
+// =============================================================================
+
+/**
+ * An active tool call being executed.
+ * Used to show the user what searches/tools are running.
+ */
+export interface ActiveToolCall {
+  /** Tool name (e.g., 'tavily_search', 'web_extract') */
+  toolName: string;
+  /** Tool call ID from the LLM response */
+  toolCallId: string;
+  /** Extracted search query if this is a search tool */
+  searchQuery?: string;
+  /** When this tool call started (Unix timestamp ms) */
+  startedAt: number;
+}
+
+/**
+ * Maximum number of entries in the activity log.
+ */
+export const MAX_ACTIVITY_LOG_ENTRIES = 5;
+
+// =============================================================================
 // Core Research State (The Scratchpad)
 // =============================================================================
 
@@ -324,6 +348,14 @@ export interface ResearchState {
   /** True if user manually triggered early termination via "Wrap Up" */
   isManualTermination?: boolean;
 
+  // === Verbose Execution Tracking ===
+  /** Activity log showing recent events (max 5, FIFO) */
+  activityLog: string[];
+  /** Currently executing tool calls with details */
+  activeToolCalls: ActiveToolCall[];
+  /** Whether LLM is currently generating (for "Thinking..." indicator) */
+  isLLMGenerating: boolean;
+
   // === Error Handling ===
   /** Error message if phase='error' */
   errorMessage?: string;
@@ -370,6 +402,11 @@ export function createInitialState(
     // Output
     finalReport: null,
     citations: [],
+
+    // Verbose tracking
+    activityLog: [],
+    activeToolCalls: [],
+    isLLMGenerating: false,
   };
 }
 
@@ -967,6 +1004,75 @@ export function completeResearch(
     finalReport: report,
     citations,
   };
+}
+
+// =============================================================================
+// Activity Log Helpers
+// =============================================================================
+
+/**
+ * Push an entry to the activity log (FIFO, max 5 entries).
+ * Returns new state with updated log.
+ */
+export function pushActivityLog(
+  state: ResearchState,
+  message: string
+): ResearchState {
+  const newLog = [...state.activityLog, message];
+  // Keep only the last N entries
+  while (newLog.length > MAX_ACTIVITY_LOG_ENTRIES) {
+    newLog.shift();
+  }
+  return { ...state, activityLog: newLog };
+}
+
+/**
+ * Set active tool calls and optionally log the start.
+ */
+export function setActiveToolCalls(
+  state: ResearchState,
+  activeToolCalls: ActiveToolCall[],
+  logSearchQueries: boolean = true
+): ResearchState {
+  let newState = { ...state, activeToolCalls };
+  
+  // Log search queries for visibility
+  if (logSearchQueries) {
+    for (const tc of activeToolCalls) {
+      if (tc.searchQuery) {
+        const truncated = tc.searchQuery.length > 50
+          ? tc.searchQuery.slice(0, 47) + '...'
+          : tc.searchQuery;
+        newState = pushActivityLog(newState, `Searching: "${truncated}"`);
+      } else {
+        newState = pushActivityLog(newState, `Running ${tc.toolName}...`);
+      }
+    }
+  }
+  
+  return newState;
+}
+
+/**
+ * Clear active tool calls (after completion).
+ */
+export function clearActiveToolCalls(state: ResearchState): ResearchState {
+  return { ...state, activeToolCalls: [] };
+}
+
+/**
+ * Set LLM generating state.
+ */
+export function setLLMGenerating(
+  state: ResearchState,
+  isGenerating: boolean,
+  logMessage?: string
+): ResearchState {
+  let newState = { ...state, isLLMGenerating: isGenerating };
+  if (logMessage) {
+    newState = pushActivityLog(newState, logMessage);
+  }
+  return newState;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Adds Human-in-the-Loop controls and verbose activity tracking for Deep Research mode, allowing users to manually intervene and see exactly what the research is doing in real-time.

## Features

### 🎯 Wrap Up Early
- **"Wrap Up" button** appears during the gathering phase (green fast-forward icon)
- Triggers immediate synthesis with currently gathered facts
- LLM receives context note: "Do NOT apologize for incomplete research"

### ⏭️ Skip Stuck Questions
- **"Skip" button** appears on hover for pending/in-progress questions
- Marks question as blocked and adds knowledge gap to facts
- Optimistic UI with loading spinner while processing
- **Fixed**: Skip now works correctly (was zombie-researching before)

### 📊 Verbose Activity Stream
- **Activity log** shows last 5 events with trailing opacity (FIFO)
- Real-time status: `Thinking...`, `Searching: "query" (5s)`, etc.
- Logs fact extraction, question completion, phase transitions
- User interventions logged immediately for instant feedback

### 🎨 Visual Improvements
- Blocked questions moved to bottom of list
- Blocked questions dimmed with strikethrough
- Enhanced progress display with elapsed time on tool calls

## Technical Implementation

### State Changes (types.ts)
```typescript
interface ResearchState {
  // New verbose tracking fields
  activityLog: string[];           // Last 5 events (FIFO)
  activeToolCalls: ActiveToolCall[]; // Currently running tools
  isLLMGenerating: boolean;        // For 'Thinking...' indicator
}

interface ActiveToolCall {
  toolName: string;
  searchQuery?: string;  // Extracted from tool args
  startedAt: number;     // For elapsed time display
}
```

### Bug Fix (runResearchLoop.ts)
**Root cause**: After handling an intervention, the loop continued with the current iteration instead of re-evaluating.

**Fix**: Added `continue` after `handleIntervention()` to immediately restart the loop with new state.

### Activity Events Logged
- `User intervention: Wrapping up/Skipping...` (immediate feedback)
- `Thinking...` (before LLM call)
- `Searching: "query"` (with extracted search terms)
- `Found N new facts`
- `Answered Q1: "..."`
- `Moving to Q2: "..."`
- `Q1 timed out, moving on...`
- `Created plan with N questions`
- `All questions answered, synthesizing...`

## Files Changed

**types.ts**: Added `ActiveToolCall`, `activityLog`, `isLLMGenerating`, helper functions

**runResearchLoop.ts**: Fixed intervention bug, added activity logging throughout

**ResearchArtifact.tsx**: Activity log UI, enhanced status display, blocked question sorting

**ResearchArtifact.module.css**: Activity log styles, blocked question dimming

## Testing

1. Start a deep research query
2. Watch the activity log stream events in real-time
3. Click "Wrap Up" during gathering → should synthesize immediately with log entry
4. Click "Skip" on a question → should show "User intervention: Skipping..." and move to next
5. Blocked questions should appear at bottom, dimmed with strikethrough