### PR TITLE
feat: Collapsible research details after completion

### DIFF
--- a/src/components/DeepResearch/ResearchArtifact.module.css
+++ b/src/components/DeepResearch/ResearchArtifact.module.css
@@ -738,3 +738,77 @@
 .hoverCardLink:hover {
   text-decoration: underline;
 }
+
+/* === Research Details (Collapsible Post-Completion) === */
+.researchDetailsContainer {
+  border-top: 1px solid var(--border-color, #333);
+  background: var(--bg-tertiary, #252525);
+}
+
+.researchDetailsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s ease;
+}
+
+.researchDetailsHeader:hover {
+  background: var(--bg-hover, #2a2a2a);
+}
+
+.researchDetailsTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #a0a0a0);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.researchDetailsToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted, #666);
+  transition: transform 0.2s ease;
+}
+
+.researchDetailsContent {
+  background: var(--bg-secondary, #1e1e1e);
+}
+
+/* Activity Log Snapshot (for completed research) */
+.activityLogSnapshot {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary, #a0a0a0);
+}
+
+.activityItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 6px 8px;
+  background: var(--bg-tertiary, #252525);
+  border-radius: 4px;
+  line-height: 1.4;
+}
+
+/* Skip button styling when disabled (post-completion) */
+.skipButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: transparent;
+}
+
+.skipButton:disabled:hover {
+  background: transparent;
+  color: var(--text-muted, #666);
+}

--- a/src/hooks/useDeepResearch/types.ts
+++ b/src/hooks/useDeepResearch/types.ts
@@ -356,6 +356,14 @@ export interface ResearchState {
   /** Whether LLM is currently generating (for "Thinking..." indicator) */
   isLLMGenerating: boolean;
 
+  // === Completion Snapshot (Post-Research) ===
+  /** Snapshot of activity log and metrics when research completed (for UI display) */
+  completionSnapshot?: {
+    activityLog: string[];
+    stepsTaken: number;
+    elapsedTime?: number;
+  };
+
   // === Error Handling ===
   /** Error message if phase='error' */
   errorMessage?: string;
@@ -997,12 +1005,20 @@ export function completeResearch(
   report: string,
   citations: ResearchState['citations']
 ): ResearchState {
+  const completedAt = Date.now();
+  const elapsedTime = state.startedAt ? completedAt - state.startedAt : undefined;
+  
   return {
     ...state,
     phase: 'complete',
-    completedAt: Date.now(),
+    completedAt,
     finalReport: report,
     citations,
+    completionSnapshot: {
+      activityLog: [...state.activityLog],
+      stepsTaken: state.currentStep,
+      elapsedTime,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

When deep research completes and generates the final report, the research UI elements (progress bar, activity log, research plan, gathered facts, hypothesis, and knowledge gaps) now persist in a collapsible section below the report instead of vanishing.

## Changes

- **Added  field to ** - Preserves activity log, step count, and elapsed time when research completes
- **Updated  function** - Captures completion snapshot before transitioning to complete phase
- **Added collapsible Research Details section** - Appears below final report with FileSearch icon
- **Activity Timeline** - Shows the captured activity log with step count and elapsed time
- **Research Plan** - Displays questions with their final statuses and skip buttons as static visual indicators
- **Gathered Facts, Hypothesis, and Knowledge Gaps** - All preserved sections now accessible after completion
- **Default collapsed state** - Doesn't disrupt report reading experience but allows users to review research process on demand

## User Experience

- Research details section starts collapsed (default)
- Click header to expand and review the research process
- Skip buttons appear disabled/static showing final state when research concluded
- Activity timeline shows the full sequence of research steps taken

## Testing

- ✅ Frontend builds successfully
- ✅ Backend compiles successfully
- Ready for manual testing in GUI

Closes #(issue number if applicable)