### PR TITLE
feat(deep-research): add iterative multi-round research with evaluation loop

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -260,6 +260,11 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
       activityLog: [],
       activeToolCalls: [],
       isLLMGenerating: false,
+      // Multi-round research fields
+      searchHistory: [],
+      currentRound: 1,
+      maxRounds: 3,
+      roundSummaries: [],
     };
 
     const assistantMessage: ThreadMessageLike = {

--- a/src/components/DeepResearch/ResearchArtifact.module.css
+++ b/src/components/DeepResearch/ResearchArtifact.module.css
@@ -136,6 +136,30 @@
   color: #f87171;
 }
 
+.phaseEvaluating {
+  background: rgba(251, 146, 60, 0.2);
+  color: #fb923c;
+}
+
+.phaseCompressing {
+  background: rgba(147, 51, 234, 0.2);
+  color: #a78bfa;
+}
+
+/* === Round Badge === */
+.roundBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 10px;
+  font-weight: 600;
+  background: rgba(100, 116, 139, 0.2);
+  color: #94a3b8;
+  margin-left: 6px;
+}
+
 /* === Progress Bar === */
 .progressContainer {
   padding: 0 14px 12px;
@@ -187,6 +211,17 @@
   content: '›';
   margin-right: 6px;
   color: var(--text-muted, #666);
+}
+
+/* Skipped/duplicate query styling */
+.activitySkipped {
+  color: var(--text-muted, #666);
+  font-style: italic;
+}
+
+.activitySkipped::before {
+  content: '⊘';
+  color: rgba(251, 146, 60, 0.6);
 }
 
 /* === Expanded Content === */
@@ -811,4 +846,61 @@
 .skipButton:disabled:hover {
   background: transparent;
   color: var(--text-muted, #666);
+}
+/* === Previous Rounds Section === */
+.previousRoundsContent {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.roundSummaryCard {
+  padding: 12px;
+  background: var(--bg-tertiary, #252525);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 8px;
+  border-left: 3px solid #a78bfa;
+}
+
+.roundSummaryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.roundNumber {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #a78bfa;
+}
+
+.roundMeta {
+  font-size: 11px;
+  color: var(--text-muted, #666);
+}
+
+.roundSummaryText {
+  font-size: 12px;
+  color: var(--text-secondary, #a0a0a0);
+  line-height: 1.5;
+  margin-bottom: 8px;
+}
+
+.roundInsights {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color, #333);
+}
+
+.roundInsight {
+  font-size: 11px;
+  color: var(--text-muted, #666);
+  line-height: 1.4;
 }

--- a/src/hooks/useDeepResearch/buildTurnMessages.ts
+++ b/src/hooks/useDeepResearch/buildTurnMessages.ts
@@ -21,6 +21,7 @@ import {
   serializeForPrompt,
   renderContextForSystemPrompt,
   DEFAULT_BUDGET,
+  INTERNAL_RESEARCH_TOOLS,
   type SerializationBudget,
 } from './types';
 
@@ -99,18 +100,26 @@ Do NOT use tools in planning phase. Output ONLY the JSON.`,
 
   gathering: `## Current Task: GATHERING
 
-You are searching for information to answer the research questions.
+You are an ACTIVE researcher, not a passive executor. Search intelligently, reflect on progress, and pivot when needed.
 
-INSTRUCTIONS:
-1. Check the "🎯 Current Focus" section to see which question you are working on
-2. Use the search tool to find relevant information for that question
-3. When you have enough information, provide an AnswerResponse
+CORE LOOP:
+1. Search for information relevant to the current focus question
+2. Every 3-4 tool calls, use \`assess_progress\` to reflect on coverage
+3. If searches aren't yielding results, PIVOT your strategy
+4. When you have sufficient evidence (minimum 4 facts), call \`request_synthesis\`
 
-IF YOU NEED TO SEARCH:
-Call the appropriate search tool (e.g., tavily_search) with a well-crafted query.
+AVAILABLE ACTIONS:
 
-IF YOU CAN ANSWER THE CURRENT FOCUS QUESTION:
-Respond with JSON:
+1. SEARCH: Call tavily_search (or similar) with a specific, targeted query
+   - Avoid broad queries - be specific
+   - If a search returns nothing useful, try different keywords
+
+2. ASSESS PROGRESS: Call \`assess_progress\` to reflect (do this often!)
+   - What claims from the original query have evidence?
+   - What gaps remain?
+   - Should you pivot your search strategy?
+
+3. ANSWER A QUESTION: When you have facts for the current focus, respond with JSON:
 {
   "type": "answer",
   "questionIndex": 1,
@@ -127,10 +136,16 @@ Respond with JSON:
   "newGaps": ["Newly discovered unknowns..."]
 }
 
+4. REQUEST SYNTHESIS: Call \`request_synthesis\` when research is complete
+   - Requires minimum 4 facts gathered
+   - Will be REJECTED if you haven't gathered enough evidence
+   - Provide justification for why research is sufficient
+
 IMPORTANT:
 - "questionIndex" is the Q number from the Research Plan (Q1, Q2, etc.)
-- Check the "🎯 Current Focus" section for the exact questionIndex to use
-- Choose ONE action: either call a tool OR output JSON. Not both.`,
+- Check the "🎯 Current Focus" section for the exact questionIndex
+- Be an ACTIVE thinker: if something isn't working, change approach
+- Don't repeat failed searches - pivot to different angles`,
 
   evaluating: `## Current Task: EVALUATING
 
@@ -478,6 +493,23 @@ export function filterResearchTools<T extends { function: { name: string } }>(
       (prefix) => name.includes(prefix.toLowerCase())
     );
   });
+}
+
+/**
+ * Get the complete set of research tools including internal agentic tools.
+ * Appends assess_progress and request_synthesis to the filtered external tools.
+ */
+export function getResearchToolsWithInternals<T extends { type: string; function: { name: string } }>(
+  allTools: T[],
+  allowedPrefixes: string[] = ['tavily', 'search', 'web', 'extract', 'fetch']
+): T[] {
+  const externalTools = filterResearchTools(allTools, allowedPrefixes);
+  // Cast internal tools to match the generic type (they're structurally compatible)
+  return [
+    ...externalTools,
+    INTERNAL_RESEARCH_TOOLS[0] as unknown as T,
+    INTERNAL_RESEARCH_TOOLS[1] as unknown as T,
+  ];
 }
 
 // =============================================================================

--- a/src/hooks/useDeepResearch/buildTurnMessages.ts
+++ b/src/hooks/useDeepResearch/buildTurnMessages.ts
@@ -132,6 +132,57 @@ IMPORTANT:
 - Check the "🎯 Current Focus" section for the exact questionIndex to use
 - Choose ONE action: either call a tool OR output JSON. Not both.`,
 
+  evaluating: `## Current Task: EVALUATING
+
+You are assessing whether the gathered research adequately answers the original query.
+
+INSTRUCTIONS:
+1. Review the original query and all gathered facts
+2. Assess how completely the research addresses the query (1-10 scale)
+3. Identify specific aspects that are still missing or underexplored
+4. Suggest targeted follow-up questions if more research would help
+
+RESPOND WITH JSON:
+{
+  "type": "evaluation",
+  "adequacyScore": 7,
+  "assessment": "Brief explanation of the score...",
+  "missingAspects": ["Aspect 1 not covered", "Aspect 2 needs more depth"],
+  "suggestedFollowups": [
+    {"question": "Follow-up question 1?", "priority": 1, "rationale": "Why this matters..."},
+    {"question": "Follow-up question 2?", "priority": 2, "rationale": "Why this matters..."}
+  ],
+  "shouldContinue": true
+}
+
+SCORING GUIDELINES:
+- 1-3: Critical gaps, key aspects unanswered
+- 4-6: Partial coverage, significant gaps remain  
+- 7-8: Good coverage, minor gaps acceptable
+- 9-10: Comprehensive, ready for synthesis
+
+Set "shouldContinue": false if score >= 7 OR if follow-ups would be redundant.
+Do NOT use tools in evaluation phase. Output ONLY the JSON.`,
+
+  compressing: `## Current Task: COMPRESSING
+
+You are summarizing the current round's findings before starting a new research round.
+
+INSTRUCTIONS:
+1. Review all facts gathered in this round
+2. Create a concise summary capturing the key findings (~500 chars max)
+3. Focus on information most relevant to the original query
+
+RESPOND WITH JSON:
+{
+  "type": "roundSummary",
+  "summary": "Concise summary of this round's key findings...",
+  "keyInsights": ["Most important insight 1", "Most important insight 2"]
+}
+
+Keep the summary factual and dense - it will be used as context for the next research round.
+Do NOT use tools in compression phase. Output ONLY the JSON.`,
+
   synthesizing: `## Current Task: SYNTHESIZING
 
 You are producing the final research report from gathered facts.

--- a/src/hooks/useDeepResearch/index.ts
+++ b/src/hooks/useDeepResearch/index.ts
@@ -26,6 +26,9 @@ export type {
   SearchRecord,
   // Round summaries (multi-round context compression)
   RoundSummary,
+  // Internal tool args
+  AssessProgressArgs,
+  RequestSynthesisArgs,
   // Core state
   ResearchPhase,
   ResearchState,
@@ -70,6 +73,12 @@ export {
   canContinueResearch,
   getRoundStepBudget,
   shouldTriggerRoundSoftLanding,
+  // Internal research tools
+  ASSESS_PROGRESS_TOOL,
+  REQUEST_SYNTHESIS_TOOL,
+  INTERNAL_RESEARCH_TOOLS,
+  isInternalResearchTool,
+  MIN_FACTS_FOR_SYNTHESIS,
   // Validation
   validateState,
   // UI helpers
@@ -91,6 +100,7 @@ export {
   isWithinBudget,
   shouldIncludeTools,
   filterResearchTools,
+  getResearchToolsWithInternals,
   summarizeTurnMessages,
 } from './buildTurnMessages';
 

--- a/src/hooks/useDeepResearch/index.ts
+++ b/src/hooks/useDeepResearch/index.ts
@@ -22,6 +22,10 @@ export type {
   Contradiction,
   // Observations
   PendingObservation,
+  // Search history (multi-round deduplication)
+  SearchRecord,
+  // Round summaries (multi-round context compression)
+  RoundSummary,
   // Core state
   ResearchPhase,
   ResearchState,
@@ -56,6 +60,16 @@ export {
   setPhase,
   setError,
   completeResearch,
+  // Search history helpers
+  isSearchDuplicate,
+  addSearchRecord,
+  linkSearchToFacts,
+  // Round management helpers
+  createRoundSummary,
+  advanceRound,
+  canContinueResearch,
+  getRoundStepBudget,
+  shouldTriggerRoundSoftLanding,
   // Validation
   validateState,
   // UI helpers

--- a/src/hooks/useDeepResearch/types.ts
+++ b/src/hooks/useDeepResearch/types.ts
@@ -209,6 +209,53 @@ export interface PendingObservation {
 }
 
 // =============================================================================
+// Search History Tracking (Query Deduplication)
+// =============================================================================
+
+/**
+ * A record of a search query executed during research.
+ * Used for query deduplication across rounds to prevent redundant searches.
+ */
+export interface SearchRecord {
+  /** The search query string */
+  query: string;
+  /** Tool used for the search */
+  toolName: string;
+  /** When the search was executed (Unix timestamp ms) */
+  timestamp: number;
+  /** Which question this search was for (if applicable) */
+  forQuestionId?: string;
+  /** IDs of facts that were extracted from this search result */
+  factIdsProduced: string[];
+  /** Which research round this search occurred in */
+  round: number;
+}
+
+// =============================================================================
+// Round Summaries (Multi-Round Context Compression)
+// =============================================================================
+
+/**
+ * Summary of a completed research round.
+ * Used for token-efficient context in subsequent rounds while
+ * preserving full facts in global state for final synthesis.
+ */
+export interface RoundSummary {
+  /** Which round this summary is for (1-indexed) */
+  round: number;
+  /** Compressed summary of facts gathered in this round (~500 chars) */
+  summary: string;
+  /** Number of facts in gatheredFacts at end of this round */
+  factCountAtEnd: number;
+  /** Fact IDs that existed at the start of this round (for filtering "new" facts) */
+  factIdsAtRoundStart: string[];
+  /** When this summary was generated (Unix timestamp ms) */
+  timestamp: number;
+  /** Questions that were answered during this round */
+  questionsAnsweredThisRound: string[];
+}
+
+// =============================================================================
 // Research Phases
 // =============================================================================
 
@@ -217,6 +264,8 @@ export interface PendingObservation {
  *
  * PLANNING:     Decompose query into sub-questions, form initial hypothesis
  * GATHERING:    Execute searches, extract facts, update hypothesis
+ * EVALUATING:   Assess if gathered facts adequately answer the original query
+ * COMPRESSING:  Generate round summary before starting another gathering round
  * SYNTHESIZING: Merge facts, resolve contradictions, generate final report
  * COMPLETE:     Research finished, final report available
  * ERROR:        Research failed (error stored in errorMessage)
@@ -224,6 +273,8 @@ export interface PendingObservation {
 export type ResearchPhase =
   | 'planning'
   | 'gathering'
+  | 'evaluating'
+  | 'compressing'
   | 'synthesizing'
   | 'complete'
   | 'error';
@@ -307,6 +358,18 @@ export interface ResearchState {
   /** Gathered facts from searches (max ~50, LRU pruned) */
   gatheredFacts: GatheredFact[];
 
+  // === Search History (Query Deduplication) ===
+  /** History of all search queries executed (for deduplication across rounds) */
+  searchHistory: SearchRecord[];
+
+  // === Multi-Round Support ===
+  /** Current research round (1-indexed, starts at 1) */
+  currentRound: number;
+  /** Maximum rounds allowed before forcing synthesis */
+  maxRounds: number;
+  /** Summaries from completed rounds (for token-efficient context) */
+  roundSummaries: RoundSummary[];
+
   // === Execution Tracking ===
   /** Current step number (1-indexed) */
   currentStep: number;
@@ -378,6 +441,7 @@ export function createInitialState(
   options: {
     conversationId?: number;
     maxSteps?: number;
+    maxRounds?: number;
   } = {}
 ): ResearchState {
   return {
@@ -393,6 +457,14 @@ export function createInitialState(
 
     // Knowledge
     gatheredFacts: [],
+
+    // Search History
+    searchHistory: [],
+
+    // Multi-Round
+    currentRound: 1,
+    maxRounds: options.maxRounds ?? 3,
+    roundSummaries: [],
 
     // Execution
     currentStep: 0,
@@ -484,6 +556,15 @@ export interface ResearchContextInjection {
     questionsTotal: number;
     factsGathered: number;
   };
+  /** Multi-round context */
+  round: {
+    current: number;
+    max: number;
+  };
+  /** Summaries from previous rounds (for token-efficient context in Round 2+) */
+  previousRoundSummaries: string[];
+  /** Whether we're in synthesis phase (triggers full fact access) */
+  isSynthesisPhase: boolean;
 }
 
 /**
@@ -557,11 +638,22 @@ function renderObservations(
  *
  * This is the core function that renders the scratchpad into text that
  * can be injected into the system prompt, staying within token limits.
+ *
+ * DUAL-LAYER CONTEXT LOGIC:
+ * - Round 1: Include all gatheredFacts (within budget)
+ * - Round 2+: Include previousRoundSummaries + only current round's facts
+ * - Synthesis phase: Include ALL gatheredFacts (full access for citations)
+ *
+ * Key invariant: gatheredFacts in global state is append-only. Compression
+ * produces a VIEW for prompts, not a mutation of state. Synthesis always
+ * sees the full fact corpus.
  */
 export function serializeForPrompt(
   state: ResearchState,
   budget: SerializationBudget = DEFAULT_BUDGET
 ): ResearchContextInjection {
+  const isSynthesisPhase = state.phase === 'synthesizing';
+
   // === Hypothesis ===
   const hypothesis = state.currentHypothesis
     ? state.currentHypothesis.slice(0, budget.hypothesisChars)
@@ -595,8 +687,29 @@ export function serializeForPrompt(
     planSummary = truncatedLines.join('\n');
   }
 
-  // === Facts Summary (prioritize recent + referenced) ===
-  const scoredFacts = state.gatheredFacts.map((f) => ({
+  // === Facts Summary (DUAL-LAYER LOGIC) ===
+  let factsToRender: GatheredFact[];
+
+  if (isSynthesisPhase) {
+    // SYNTHESIS: Full access to ALL facts for accurate citations
+    factsToRender = state.gatheredFacts;
+  } else if (state.currentRound === 1 || state.roundSummaries.length === 0) {
+    // ROUND 1: Include all facts (no previous round summaries exist)
+    factsToRender = state.gatheredFacts;
+  } else {
+    // ROUND 2+: Only include facts gathered AFTER the last round summary
+    // Previous rounds' facts are represented by their compressed summaries
+    const lastRoundSummary = state.roundSummaries[state.roundSummaries.length - 1];
+    const previousRoundFactIds = new Set(lastRoundSummary.factIdsAtRoundStart);
+
+    // Filter to only facts that didn't exist at the start of the last summarized round
+    factsToRender = state.gatheredFacts.filter(
+      (f) => !previousRoundFactIds.has(f.id)
+    );
+  }
+
+  // Score and sort facts for rendering
+  const scoredFacts = factsToRender.map((f) => ({
     fact: f,
     score:
       (state.currentStep - f.gatheredAtStep) * -1 + // Recency (newer = higher)
@@ -617,6 +730,17 @@ export function serializeForPrompt(
     factChars += line.length + 1;
   }
   const factsSummary = factLines.join('\n') || '(No facts gathered yet)';
+
+  // === Previous Round Summaries (for Round 2+, non-synthesis) ===
+  const previousRoundSummaries: string[] = [];
+  if (!isSynthesisPhase && state.currentRound > 1 && state.roundSummaries.length > 0) {
+    for (const rs of state.roundSummaries) {
+      previousRoundSummaries.push(
+        `**Round ${rs.round}** (${rs.questionsAnsweredThisRound.length} questions answered, ` +
+        `${rs.factCountAtEnd} facts total):\n${rs.summary}`
+      );
+    }
+  }
 
   // === Observations ===
   const observations = renderObservations(
@@ -661,6 +785,12 @@ export function serializeForPrompt(
       questionsTotal: state.researchPlan.length,
       factsGathered: state.gatheredFacts.length,
     },
+    round: {
+      current: state.currentRound,
+      max: state.maxRounds,
+    },
+    previousRoundSummaries,
+    isSynthesisPhase,
   };
 }
 
@@ -672,10 +802,11 @@ export function renderContextForSystemPrompt(
 ): string {
   const sections: string[] = [];
 
-  // Progress header
-  const { progress } = injection;
+  // Progress header (now includes round info)
+  const { progress, round } = injection;
+  const roundInfo = round.max > 1 ? ` [Round ${round.current}/${round.max}]` : '';
   sections.push(
-    `## Research Progress [Step ${progress.step}/${progress.maxSteps}] — Phase: ${injection.phase.toUpperCase()}`
+    `## Research Progress [Step ${progress.step}/${progress.maxSteps}]${roundInfo} — Phase: ${injection.phase.toUpperCase()}`
   );
   sections.push(
     `Questions: ${progress.questionsAnswered}/${progress.questionsTotal} answered | Facts: ${progress.factsGathered} gathered`
@@ -717,8 +848,26 @@ export function renderContextForSystemPrompt(
     sections.push('');
   }
 
+  // Previous round summaries (Round 2+ only, not during synthesis)
+  if (injection.previousRoundSummaries.length > 0) {
+    sections.push('## Previous Research Rounds');
+    sections.push('*Compressed summaries from earlier research rounds:*');
+    sections.push('');
+    for (const summary of injection.previousRoundSummaries) {
+      sections.push(summary);
+      sections.push('');
+    }
+  }
+
   // Gathered facts
-  sections.push('## Gathered Facts');
+  if (injection.isSynthesisPhase) {
+    sections.push('## All Gathered Facts (Full Access for Synthesis)');
+  } else if (injection.previousRoundSummaries.length > 0) {
+    sections.push('## Current Round Facts');
+    sections.push('*Facts gathered in this round (previous rounds summarized above):*');
+  } else {
+    sections.push('## Gathered Facts');
+  }
   sections.push(injection.factsSummary);
   sections.push('');
 
@@ -997,6 +1146,195 @@ export function setError(state: ResearchState, message: string): ResearchState {
   return { ...state, phase: 'error', errorMessage: message };
 }
 
+// =============================================================================
+// Search History & Deduplication Helpers
+// =============================================================================
+
+/** Similarity threshold for search query deduplication (0-1, higher = stricter) */
+const SEARCH_DEDUP_THRESHOLD = 0.8;
+
+/**
+ * Check if a search query is similar to one already executed.
+ * Uses Jaccard similarity on tokenized queries.
+ *
+ * @returns Object with isDuplicate flag and matching record if found
+ */
+export function isSearchDuplicate(
+  query: string,
+  searchHistory: SearchRecord[]
+): { isDuplicate: boolean; existingRecord?: SearchRecord } {
+  const queryTokens = tokenize(query);
+
+  for (const record of searchHistory) {
+    const recordTokens = tokenize(record.query);
+    const similarity = jaccardSimilarity(queryTokens, recordTokens);
+
+    if (similarity >= SEARCH_DEDUP_THRESHOLD) {
+      return { isDuplicate: true, existingRecord: record };
+    }
+  }
+
+  return { isDuplicate: false };
+}
+
+/**
+ * Add a search record to the history.
+ */
+export function addSearchRecord(
+  state: ResearchState,
+  record: Omit<SearchRecord, 'timestamp' | 'round'>
+): ResearchState {
+  const newRecord: SearchRecord = {
+    ...record,
+    timestamp: Date.now(),
+    round: state.currentRound,
+  };
+
+  return {
+    ...state,
+    searchHistory: [...state.searchHistory, newRecord],
+  };
+}
+
+/**
+ * Update a search record with the fact IDs it produced.
+ * Called after fact extraction to link searches to their results.
+ */
+export function linkSearchToFacts(
+  state: ResearchState,
+  toolCallId: string,
+  factIds: string[]
+): ResearchState {
+  return {
+    ...state,
+    searchHistory: state.searchHistory.map((record) =>
+      record.toolName === toolCallId || 
+      state.searchHistory.find(r => r.query && r.factIdsProduced.length === 0)?.query === record.query
+        ? { ...record, factIdsProduced: [...record.factIdsProduced, ...factIds] }
+        : record
+    ),
+  };
+}
+
+// =============================================================================
+// Round Management Helpers
+// =============================================================================
+
+/**
+ * Create a round summary and prepare for next round.
+ * Called during COMPRESSING phase.
+ */
+export function createRoundSummary(
+  state: ResearchState,
+  summary: string
+): ResearchState {
+  // Track which questions were answered this round
+  const questionsAnsweredThisRound = state.researchPlan
+    .filter((q) => q.status === 'answered')
+    .map((q) => q.id);
+
+  const roundSummary: RoundSummary = {
+    round: state.currentRound,
+    summary: summary.slice(0, 500), // Enforce max length
+    factCountAtEnd: state.gatheredFacts.length,
+    factIdsAtRoundStart: state.currentRound === 1
+      ? [] // Round 1 starts with no facts
+      : state.roundSummaries[state.roundSummaries.length - 1]?.factIdsAtRoundStart ?? [],
+    timestamp: Date.now(),
+    questionsAnsweredThisRound,
+  };
+
+  // Update factIdsAtRoundStart for the NEXT round
+  // (all facts that exist now will be "previous round" facts for Round N+1)
+  const updatedSummary: RoundSummary = {
+    ...roundSummary,
+    factIdsAtRoundStart: state.gatheredFacts.map((f) => f.id),
+  };
+
+  return {
+    ...state,
+    roundSummaries: [...state.roundSummaries, updatedSummary],
+  };
+}
+
+/**
+ * Advance to the next research round.
+ * Called after COMPRESSING phase completes.
+ */
+export function advanceRound(state: ResearchState): ResearchState {
+  return {
+    ...state,
+    currentRound: state.currentRound + 1,
+  };
+}
+
+/**
+ * Check if more research rounds are allowed.
+ */
+export function canContinueResearch(state: ResearchState): boolean {
+  return state.currentRound < state.maxRounds;
+}
+
+/**
+ * Calculate the step budget for the current round.
+ * Uses 60/30/10 split across 3 rounds.
+ */
+export function getRoundStepBudget(state: ResearchState): {
+  roundBudget: number;
+  stepsUsedThisRound: number;
+  stepsRemainingThisRound: number;
+} {
+  const { currentRound, maxRounds, maxSteps, currentStep } = state;
+
+  // Calculate step budget per round (60/30/10 split for 3 rounds)
+  let roundBudgets: number[];
+  if (maxRounds === 1) {
+    roundBudgets = [maxSteps];
+  } else if (maxRounds === 2) {
+    roundBudgets = [Math.floor(maxSteps * 0.7), Math.floor(maxSteps * 0.3)];
+  } else {
+    // 60/30/10 split for 3+ rounds
+    roundBudgets = [
+      Math.floor(maxSteps * 0.6),
+      Math.floor(maxSteps * 0.3),
+      Math.floor(maxSteps * 0.1),
+    ];
+    // Distribute remaining budget equally to additional rounds
+    if (maxRounds > 3) {
+      const remaining = maxSteps - roundBudgets.reduce((a, b) => a + b, 0);
+      const extraRounds = maxRounds - 3;
+      const perExtraRound = Math.floor(remaining / extraRounds);
+      for (let i = 0; i < extraRounds; i++) {
+        roundBudgets.push(perExtraRound);
+      }
+    }
+  }
+
+  // Calculate steps used before this round
+  let stepsBeforeThisRound = 0;
+  for (let r = 0; r < currentRound - 1 && r < roundBudgets.length; r++) {
+    stepsBeforeThisRound += roundBudgets[r];
+  }
+
+  const roundBudget = roundBudgets[Math.min(currentRound - 1, roundBudgets.length - 1)];
+  const stepsUsedThisRound = Math.max(0, currentStep - stepsBeforeThisRound);
+  const stepsRemainingThisRound = Math.max(0, roundBudget - stepsUsedThisRound);
+
+  return {
+    roundBudget,
+    stepsUsedThisRound,
+    stepsRemainingThisRound,
+  };
+}
+
+/**
+ * Check if the current round should trigger soft landing (80% of round budget).
+ */
+export function shouldTriggerRoundSoftLanding(state: ResearchState): boolean {
+  const { roundBudget, stepsUsedThisRound } = getRoundStepBudget(state);
+  return stepsUsedThisRound >= roundBudget * 0.8;
+}
+
 /**
  * Complete research with final report.
  */
@@ -1193,6 +1531,8 @@ export function getArtifactProgress(state: ResearchState): ResearchArtifactProgr
   const phaseLabels: Record<ResearchPhase, string> = {
     planning: 'Planning research...',
     gathering: 'Gathering information...',
+    evaluating: 'Evaluating research quality...',
+    compressing: 'Compressing findings...',
     synthesizing: 'Synthesizing findings...',
     complete: 'Research complete',
     error: 'Research failed',


### PR DESCRIPTION
## Summary

Transforms the deep research flow from a linear fire-and-forget pipeline into an iterative loop that evaluates research quality and can gather more information if needed.

## New Flow
```
PLANNING → GATHERING → EVALUATING → [COMPRESSING → GATHERING]* → SYNTHESIZING → COMPLETE
```

## Key Changes

### Foundation (types.ts)
- Add `SearchRecord` interface for query deduplication tracking
- Add `RoundSummary` interface for compressed round context
- Add `evaluating` and `compressing` phases to `ResearchPhase`
- Extend `ResearchState` with `searchHistory`, `currentRound`, `maxRounds`, `roundSummaries`
- Implement dual-layer context in `serializeForPrompt()` - compressed summaries for LLM prompts, full facts retained for synthesis
- Add helpers: `isSearchDuplicate()`, `addSearchRecord()`, `createRoundSummary()`, `advanceRound()`, `canContinueResearch()`, `getRoundStepBudget()`

### Logic (runResearchLoop.ts, buildTurnMessages.ts)
- Add deduplication guard in `executeToolsBatch()` using Jaccard similarity (0.8 threshold)
- Track all searches in `searchHistory` for cross-round deduplication
- Add `handleEvaluatingPhase()` - assesses adequacy (1-10 score), decides synthesis vs. continue
- Add `handleCompressingPhase()` - generates summary, converts follow-ups to new questions, advances round
- Update soft landing to use round-based budgets (60/30/10 split across 3 rounds)
- Add `PHASE_INSTRUCTIONS` for evaluating and compressing phases

### UI (ResearchArtifact.tsx, ResearchArtifact.module.css)
- Add `evaluating` and `compressing` phase badges with distinct colors
- Add round indicator badge showing "Round X/Y" in header
- Add `PreviousRoundsSection` component showing compressed round summaries
- Style skipped/duplicate queries distinctively in activity log
- Update `getLiveActivity()` with round-aware status messages

### State Initialization (ChatMessagesPanel.tsx)
- Add `searchHistory`, `currentRound`, `maxRounds`, `roundSummaries` to initial state

## Testing
- [x] TypeScript compiles with no errors
- [x] `npm run build` succeeds