### PR TITLE
feat(deep-research): adaptive multi-perspective research architecture

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -265,6 +265,10 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
       currentRound: 1,
       maxRounds: 3,
       roundSummaries: [],
+      // Multi-perspective research fields
+      complexity: 'simple',
+      perspectives: [],
+      currentPerspective: undefined,
     };
 
     const assistantMessage: ThreadMessageLike = {

--- a/src/components/DeepResearch/ResearchArtifact.module.css
+++ b/src/components/DeepResearch/ResearchArtifact.module.css
@@ -160,6 +160,25 @@
   margin-left: 6px;
 }
 
+/* === Perspective Badge === */
+.perspectiveBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 10px;
+  font-weight: 600;
+  background: rgba(147, 51, 234, 0.25);
+  color: #c4b5fd;
+  margin-left: 6px;
+  border: 1px solid rgba(147, 51, 234, 0.4);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* === Progress Bar === */
 .progressContainer {
   padding: 0 14px 12px;
@@ -877,6 +896,13 @@
   font-size: 12px;
   font-weight: 600;
   color: #a78bfa;
+}
+
+.roundPerspective {
+  font-weight: 500;
+  color: #c4b5fd;
+  font-style: italic;
+  margin-left: 4px;
 }
 
 .roundMeta {

--- a/src/components/DeepResearch/ResearchArtifact.tsx
+++ b/src/components/DeepResearch/ResearchArtifact.tsx
@@ -548,6 +548,11 @@ const PreviousRoundsSection: React.FC<{
                 <span className={styles.roundNumber}>
                   <Icon icon={Layers} size={12} />
                   Round {round.round}
+                  {round.perspective && (
+                    <span className={styles.roundPerspective}>
+                      ({round.perspective})
+                    </span>
+                  )}
                 </span>
                 <span className={styles.roundMeta}>
                   {round.factCountAtEnd} facts · {round.questionsAnsweredThisRound.length} questions
@@ -754,6 +759,11 @@ export const ResearchArtifact: React.FC<ResearchArtifactProps> = ({
             {effectiveState.maxRounds > 1 && (
               <span className={styles.roundBadge}>
                 Round {effectiveState.currentRound}/{effectiveState.maxRounds}
+              </span>
+            )}
+            {effectiveState.currentPerspective && (
+              <span className={styles.perspectiveBadge}>
+                🎭 {effectiveState.currentPerspective}
               </span>
             )}
           </div>

--- a/src/hooks/useDeepResearch/buildTurnMessages.ts
+++ b/src/hooks/useDeepResearch/buildTurnMessages.ts
@@ -80,14 +80,28 @@ export const PHASE_INSTRUCTIONS: Record<ResearchPhase, string> = {
 
 You are decomposing the user's research query into actionable sub-questions.
 
-INSTRUCTIONS:
-1. Analyze the query to identify 3-7 distinct sub-questions that need answering
-2. Form an initial hypothesis based on your existing knowledge
+STEP 1 - CLASSIFY COMPLEXITY:
+Analyze the query and classify it as one of:
+- "simple": Straightforward factual question (e.g., "What year was X founded?")
+- "multi-faceted": Complex topic with multiple valid angles (e.g., "What are the pros and cons of X?")
+- "controversial": Topic with competing viewpoints (e.g., "Is X better than Y?" or politically/ethically debated topics)
+
+STEP 2 - GENERATE PERSPECTIVES (if not simple):
+For "multi-faceted" or "controversial" queries, generate 2-3 distinct research perspectives:
+- Each perspective represents a different lens to examine the topic
+- For controversial topics: include opposing viewpoints (e.g., "Proponent view", "Critic view", "Neutral analyst")
+- For multi-faceted topics: cover different angles (e.g., "Technical perspective", "Business perspective", "User perspective")
+
+STEP 3 - CREATE RESEARCH PLAN:
+1. Form an initial hypothesis based on your existing knowledge
+2. Identify 3-7 distinct sub-questions that need answering
 3. Identify what you DON'T know (knowledge gaps)
 
 RESPOND WITH JSON:
 {
   "type": "plan",
+  "complexity": "simple" | "multi-faceted" | "controversial",
+  "perspectives": ["Perspective 1", "Perspective 2"],
   "hypothesis": "Your initial working hypothesis...",
   "questions": [
     {"question": "Sub-question 1?", "priority": 1},
@@ -95,6 +109,11 @@ RESPOND WITH JSON:
   ],
   "gaps": ["What we don't know yet..."]
 }
+
+NOTES:
+- For "simple" queries, "perspectives" should be an empty array []
+- For "multi-faceted"/"controversial", provide 2-3 meaningful perspectives
+- Each round of research will explore one perspective in depth
 
 Do NOT use tools in planning phase. Output ONLY the JSON.`,
 

--- a/src/hooks/useDeepResearch/runResearchLoop.ts
+++ b/src/hooks/useDeepResearch/runResearchLoop.ts
@@ -305,6 +305,230 @@ function tryParseStructuredResponse(content: string): StructuredResponse | null 
 }
 
 // =============================================================================
+// Intelligent Synthesis Decision Logic
+// =============================================================================
+
+/**
+ * Result from the synthesis readiness calculation.
+ * Contains all factors used to make the decision + reasoning.
+ */
+interface SynthesisDecision {
+  shouldSynthesize: boolean;
+  reason: string;
+  /** Raw evaluation score from LLM */
+  rawScore: number;
+  /** Score adjusted for perspective coverage gaps */
+  adjustedScore: number;
+  /** Threshold required for synthesis (varies by complexity) */
+  threshold: number;
+  /** Fraction of declared perspectives that have been researched */
+  perspectiveCoverage: number;
+  /** Diversity score based on fact distribution across perspectives */
+  factDiversity: number;
+}
+
+/**
+ * Calculate whether research is ready for synthesis.
+ * 
+ * This implements adaptive, intelligent decision-making based on:
+ * 1. Query complexity (simple vs multi-faceted vs controversial)
+ * 2. Perspective coverage (have we explored all declared angles?)
+ * 3. Fact diversity (are facts distributed across perspectives?)
+ * 4. Research depth (facts per perspective)
+ * 
+ * For simple queries: Standard threshold of 7 applies
+ * For multi-faceted: Requires exploring majority of perspectives
+ * For controversial: Requires balanced coverage of opposing viewpoints
+ * 
+ * The score is adjusted downward if perspective coverage is insufficient,
+ * effectively requiring more rounds before synthesis can occur.
+ */
+function calculateSynthesisReadiness(
+  state: ResearchState,
+  rawScore: number,
+  modelShouldContinue: boolean
+): SynthesisDecision {
+  const { complexity, perspectives, roundSummaries, gatheredFacts, currentRound, maxRounds } = state;
+  const canContinue = canContinueResearch(state);
+  
+  // === Calculate perspective coverage ===
+  // Which perspectives have we actually researched (based on round summaries)?
+  const exploredPerspectives = new Set<string>();
+  for (const summary of roundSummaries) {
+    if (summary.perspective) {
+      exploredPerspectives.add(summary.perspective.toLowerCase().trim());
+    }
+  }
+  // Also count current perspective if we're in round 1+ and have gathered facts
+  if (state.currentPerspective && gatheredFacts.length > 0) {
+    exploredPerspectives.add(state.currentPerspective.toLowerCase().trim());
+  }
+  
+  const totalPerspectives = perspectives.length || 1;
+  const perspectiveCoverage = totalPerspectives > 0 
+    ? exploredPerspectives.size / totalPerspectives 
+    : 1.0;
+  
+  // === Calculate fact diversity ===
+  // For multi-perspective topics, we want facts from different angles
+  // Heuristic: count facts per perspective based on round they were gathered
+  const factsPerRound: Map<number, number> = new Map();
+  for (const fact of gatheredFacts) {
+    // Approximate which round this fact is from based on step
+    const roundBoundaries = calculateRoundBoundaries(maxRounds, state.maxSteps);
+    const factRound = roundBoundaries.findIndex((end, idx) => 
+      fact.gatheredAtStep <= end && (idx === 0 || fact.gatheredAtStep > roundBoundaries[idx - 1])
+    ) + 1 || 1;
+    
+    factsPerRound.set(factRound, (factsPerRound.get(factRound) || 0) + 1);
+  }
+  
+  // Diversity score: entropy-based measure of fact distribution
+  // Higher when facts are spread across rounds (perspectives)
+  const totalFacts = gatheredFacts.length || 1;
+  let entropy = 0;
+  for (const count of factsPerRound.values()) {
+    const p = count / totalFacts;
+    if (p > 0) entropy -= p * Math.log2(p);
+  }
+  // Normalize to 0-1 scale (max entropy for N rounds is log2(N))
+  const maxEntropy = totalPerspectives > 1 ? Math.log2(totalPerspectives) : 1;
+  const factDiversity = maxEntropy > 0 ? Math.min(1, entropy / maxEntropy) : 1.0;
+  
+  // === Determine thresholds based on complexity ===
+  let baseThreshold: number;
+  let minPerspectiveCoverage: number;
+  
+  switch (complexity) {
+    case 'controversial':
+      // Controversial topics need balanced coverage of opposing views
+      baseThreshold = 8; // Higher bar
+      minPerspectiveCoverage = 0.67; // Need at least 2/3 of perspectives
+      break;
+    case 'multi-faceted':
+      // Multi-faceted topics need good breadth
+      baseThreshold = 7;
+      minPerspectiveCoverage = 0.5; // Need at least half of perspectives
+      break;
+    case 'simple':
+    default:
+      // Simple topics can synthesize more readily
+      baseThreshold = 7;
+      minPerspectiveCoverage = 0; // No perspective requirement
+      break;
+  }
+  
+  // === Calculate adjusted score ===
+  // Penalize the score if perspective coverage is insufficient
+  let adjustedScore = rawScore;
+  let coverageDeficit = '';
+  
+  if (complexity !== 'simple' && perspectiveCoverage < minPerspectiveCoverage && canContinue) {
+    // Apply progressive penalty based on coverage gap
+    const coverageGap = minPerspectiveCoverage - perspectiveCoverage;
+    const penalty = Math.min(3, coverageGap * 5); // Up to 3-point penalty
+    adjustedScore = Math.max(1, rawScore - penalty);
+    
+    const explored = exploredPerspectives.size;
+    const needed = Math.ceil(totalPerspectives * minPerspectiveCoverage);
+    coverageDeficit = `(explored ${explored}/${totalPerspectives} perspectives, need ${needed})`;
+  }
+  
+  // Also penalize if fact diversity is very low for complex topics
+  if (complexity !== 'simple' && factDiversity < 0.3 && currentRound === 1 && canContinue && totalPerspectives > 1) {
+    // Low diversity on first round - nudge toward more research
+    adjustedScore = Math.max(1, adjustedScore - 1);
+  }
+  
+  // === Make the decision ===
+  // Hard stops that bypass score-based logic
+  if (!canContinue) {
+    return {
+      shouldSynthesize: true,
+      reason: `Maximum rounds (${maxRounds}) reached`,
+      rawScore,
+      adjustedScore: rawScore,
+      threshold: baseThreshold,
+      perspectiveCoverage,
+      factDiversity,
+    };
+  }
+  
+  // Check if model explicitly says to stop (unless we have coverage issues)
+  if (!modelShouldContinue && perspectiveCoverage >= minPerspectiveCoverage) {
+    return {
+      shouldSynthesize: true,
+      reason: 'Model indicates research complete',
+      rawScore,
+      adjustedScore,
+      threshold: baseThreshold,
+      perspectiveCoverage,
+      factDiversity,
+    };
+  }
+  
+  // Score-based decision with adjusted score
+  if (adjustedScore >= baseThreshold) {
+    // Check for minimum perspective coverage override
+    if (complexity !== 'simple' && perspectiveCoverage < minPerspectiveCoverage) {
+      return {
+        shouldSynthesize: false,
+        reason: `Score ${rawScore}/10 but insufficient perspective coverage ${coverageDeficit}`,
+        rawScore,
+        adjustedScore,
+        threshold: baseThreshold,
+        perspectiveCoverage,
+        factDiversity,
+      };
+    }
+    
+    return {
+      shouldSynthesize: true,
+      reason: `Research quality sufficient (${adjustedScore}/10)`,
+      rawScore,
+      adjustedScore,
+      threshold: baseThreshold,
+      perspectiveCoverage,
+      factDiversity,
+    };
+  }
+  
+  // Score below threshold - continue researching
+  return {
+    shouldSynthesize: false,
+    reason: `Score ${adjustedScore}/10 < ${baseThreshold} threshold`,
+    rawScore,
+    adjustedScore,
+    threshold: baseThreshold,
+    perspectiveCoverage,
+    factDiversity,
+  };
+}
+
+/**
+ * Calculate step boundaries for each round based on 60/30/10 split.
+ * Returns cumulative end steps for each round.
+ */
+function calculateRoundBoundaries(maxRounds: number, maxSteps: number): number[] {
+  if (maxRounds === 1) return [maxSteps];
+  if (maxRounds === 2) return [Math.floor(maxSteps * 0.7), maxSteps];
+  
+  // 60/30/10 split for 3 rounds
+  const r1End = Math.floor(maxSteps * 0.6);
+  const r2End = r1End + Math.floor(maxSteps * 0.3);
+  const r3End = maxSteps;
+  
+  const boundaries = [r1End, r2End, r3End];
+  
+  // Add extra rounds if needed
+  for (let i = 3; i < maxRounds; i++) {
+    boundaries.push(maxSteps);
+  }
+  
+  return boundaries;
+}
+
+// =============================================================================
 // Tool Execution with Resilience
 // =============================================================================
 
@@ -659,6 +883,16 @@ async function handlePlanningPhase(
   const parsed = tryParseStructuredResponse(llmResponse.content);
   console.debug('[runResearchLoop] Parsed plan:', parsed?.type, parsed && 'questions' in parsed ? parsed.questions?.length : 0);
   
+  // Log complexity/perspectives if present
+  if (parsed && parsed.type === 'plan') {
+    console.log('[runResearchLoop] Planning parsed:', {
+      complexity: parsed.complexity ?? 'not specified',
+      perspectives: parsed.perspectives ?? [],
+      questions: parsed.questions?.length ?? 0,
+      hypothesis: parsed.hypothesis?.slice(0, 80) + '...',
+    });
+  }
+  
   if (!parsed || parsed.type !== 'plan') {
     // Model didn't follow protocol - try to extract anything useful
     console.warn('[runResearchLoop] Planning phase: invalid response format, creating default plan');
@@ -786,8 +1020,9 @@ async function handleGatheringPhase(
     
     const targetQuestionId = targetQuestion?.id ?? 'unknown';
     
-    // Extract facts
-    const newFacts: GatheredFact[] = parsed.facts.map((f) =>
+    // Extract facts (with defensive handling for missing facts array)
+    const factsArray = Array.isArray(parsed.facts) ? parsed.facts : [];
+    const newFacts: GatheredFact[] = factsArray.map((f) =>
       createFact(
         f.claim,
         f.sourceUrl,
@@ -933,31 +1168,32 @@ async function handleEvaluatingPhase(
   // We'll store them in a temporary field that gets cleared after use
   (newState as ResearchState & { _pendingFollowups?: EvaluationResponse['suggestedFollowups'] })._pendingFollowups = suggestedFollowups;
   
-  // Decision logic
-  const scoreThreshold = 7;
-  const shouldProceedToSynthesis = 
-    adequacyScore >= scoreThreshold || 
-    !shouldContinue || 
-    !canContinueResearch(newState);
+  // === Intelligent Synthesis Decision Logic ===
+  // Adapts based on complexity, perspective coverage, and fact diversity
+  const synthesisDecision = calculateSynthesisReadiness(newState, adequacyScore, shouldContinue);
   
-  if (shouldProceedToSynthesis) {
-    const reason = adequacyScore >= scoreThreshold
-      ? 'Research quality sufficient'
-      : !canContinueResearch(newState)
-        ? `Maximum rounds (${newState.maxRounds}) reached`
-        : 'Model indicates no further research needed';
-    
-    console.log(`[runResearchLoop] Evaluation → Synthesis: ${reason}`);
-    newState = pushActivityLog(newState, `${reason}, synthesizing...`);
+  console.log('[runResearchLoop] Synthesis decision:', {
+    rawScore: adequacyScore,
+    adjustedScore: synthesisDecision.adjustedScore,
+    threshold: synthesisDecision.threshold,
+    perspectiveCoverage: synthesisDecision.perspectiveCoverage,
+    factDiversity: synthesisDecision.factDiversity,
+    shouldSynthesize: synthesisDecision.shouldSynthesize,
+    reason: synthesisDecision.reason,
+  });
+  
+  if (synthesisDecision.shouldSynthesize) {
+    console.log(`[runResearchLoop] Evaluation → Synthesis: ${synthesisDecision.reason}`);
+    newState = pushActivityLog(newState, `${synthesisDecision.reason}, synthesizing...`);
     newState = setPhase(newState, 'synthesizing');
   } else {
     console.log(
-      `[runResearchLoop] Evaluation → Compressing: score ${adequacyScore} < ${scoreThreshold}, ` +
+      `[runResearchLoop] Evaluation → Compressing: ${synthesisDecision.reason}, ` +
       `round ${newState.currentRound}/${newState.maxRounds}`
     );
     newState = pushActivityLog(
       newState,
-      `Score ${adequacyScore}/10, starting round ${newState.currentRound + 1}...`
+      `${synthesisDecision.reason}, starting round ${newState.currentRound + 1}...`
     );
     newState = setPhase(newState, 'compressing');
   }
@@ -1030,11 +1266,19 @@ async function handleCompressingPhase(
   
   // Advance to next round
   newState = advanceRound(newState);
-  console.log(`[runResearchLoop] Advanced to round ${newState.currentRound}/${newState.maxRounds}`);
+  console.log(`[runResearchLoop] Advanced to round ${newState.currentRound}/${newState.maxRounds}`, {
+    perspective: newState.currentPerspective ?? 'none',
+    complexity: newState.complexity ?? 'simple',
+  });
   
   // Transition back to gathering
   newState = setPhase(newState, 'gathering');
-  newState = pushActivityLog(newState, `Starting round ${newState.currentRound}...`);
+  
+  // Build descriptive activity log message
+  const perspectiveNote = newState.currentPerspective
+    ? ` (Perspective: ${newState.currentPerspective})`
+    : '';
+  newState = pushActivityLog(newState, `Starting round ${newState.currentRound}${perspectiveNote}...`);
   
   return newState;
 }

--- a/src/hooks/useDeepResearch/runResearchLoop.ts
+++ b/src/hooks/useDeepResearch/runResearchLoop.ts
@@ -699,6 +699,12 @@ async function handlePlanningPhase(
     ? perspectives[0]
     : undefined;
   
+  // Adjust maxRounds to cover all perspectives (minimum 3 rounds)
+  // This ensures each perspective gets at least one round of focused research
+  const adjustedMaxRounds = perspectives.length > 0
+    ? Math.max(perspectives.length, state.maxRounds)
+    : state.maxRounds;
+  
   // Log planning completion for user visibility
   let newState: ResearchState = {
     ...state,
@@ -708,6 +714,7 @@ async function handlePlanningPhase(
     complexity,
     perspectives,
     currentPerspective,
+    maxRounds: adjustedMaxRounds,
     phase: 'gathering',
   };
   
@@ -986,7 +993,8 @@ async function handleCompressingPhase(
   }
   
   // Create the round summary (this captures current fact IDs for dual-layer context)
-  let newState = createRoundSummary(state, summary);
+  // Also record the perspective this round was researching
+  let newState = createRoundSummary(state, summary, state.currentPerspective);
   newState = pushActivityLog(newState, `Round ${newState.currentRound} compressed`);
   
   // Convert pending follow-ups into new research questions

--- a/src/hooks/useDeepResearch/types.ts
+++ b/src/hooks/useDeepResearch/types.ts
@@ -436,6 +436,15 @@ export const MAX_ACTIVITY_LOG_ENTRIES = 5;
  * 2. Token-efficient (no raw search results)
  * 3. Resumable (can reload and continue)
  */
+
+/**
+ * Classification of query complexity - determines research strategy.
+ * - 'simple': Straightforward factual question, single perspective sufficient
+ * - 'multi-faceted': Complex topic with multiple valid angles to explore
+ * - 'controversial': Topic with competing viewpoints that need balanced coverage
+ */
+export type ResearchComplexity = 'simple' | 'multi-faceted' | 'controversial';
+
 export interface ResearchState {
   // === Identity & Persistence ===
   /** Original user query that initiated this research */
@@ -470,6 +479,14 @@ export interface ResearchState {
   maxRounds: number;
   /** Summaries from completed rounds (for token-efficient context) */
   roundSummaries: RoundSummary[];
+
+  // === Complexity & Perspective (Adaptive Planner) ===
+  /** Classified complexity of the query (determines research strategy) */
+  complexity: ResearchComplexity;
+  /** Generated perspectives for multi-faceted/controversial topics */
+  perspectives: string[];
+  /** Active perspective for current round (undefined = neutral/simple) */
+  currentPerspective: string | undefined;
 
   // === Execution Tracking ===
   /** Current step number (1-indexed) */
@@ -566,6 +583,11 @@ export function createInitialState(
     currentRound: 1,
     maxRounds: options.maxRounds ?? 3,
     roundSummaries: [],
+
+    // Complexity & Perspective (set by planner, defaults to simple)
+    complexity: 'simple',
+    perspectives: [],
+    currentPerspective: undefined,
 
     // Execution
     currentStep: 0,


### PR DESCRIPTION
## 🎭 Adaptive Multi-Perspective Research Architecture

### Summary
This PR introduces an intelligent multi-perspective research system that automatically detects controversial or multi-faceted queries and explores them from distinct viewpoints before synthesizing a balanced final report.

### Problem
Previously, deep research used a single-perspective approach. For complex or controversial topics (e.g., "Is nuclear energy worth the risks?"), this led to potentially biased or incomplete coverage depending on which sources were found first.

### Solution: Sequential Multi-Perspective ("Rounds-as-Agents")
Instead of parallel agents (which risk React state race conditions), we repurpose **research rounds as perspective lenses**:

| Round | Perspective | Focus |
|-------|------------|-------|
| 1 | "Proponent View" | Evidence supporting one side |
| 2 | "Critic View" | Evidence for opposing view |
| 3 | "Neutral Analyst" | Balanced/meta analysis |

### Key Changes

**Step 1 - Adaptive Planner**
- `ResearchComplexity` type: `'simple' | 'multi-faceted' | 'controversial'`
- Planning prompt now classifies query complexity and generates 2-3 perspectives
- New state fields: `complexity`, `perspectives`, `currentPerspective`

**Step 2 - Perspective-Shifting Execution**
- `advanceRound()` shifts to next perspective automatically
- `maxRounds` expands to fit all perspectives
- GATHERING prompt injects: *"You are researching from the angle of: [Perspective]"*
- UI shows active perspective badge: `🎭 Economic Impact`

**Step 3 - Context & Synthesis**
- `RoundSummary.perspective` records which angle each round explored
- EVALUATING prompt: score coverage for *this perspective only*
- SYNTHESIZING prompt: structure report with sections per viewpoint + final synthesis
- Previous rounds display: `Round 1 [Perspective: Proponent View]`

### Files Changed
- `src/hooks/useDeepResearch/types.ts` - New types and state fields
- `src/hooks/useDeepResearch/buildTurnMessages.ts` - Phase-specific perspective injection
- `src/hooks/useDeepResearch/runResearchLoop.ts` - Planning and compression handlers
- `src/components/DeepResearch/ResearchArtifact.tsx` - UI perspective badges
- `src/components/DeepResearch/ResearchArtifact.module.css` - Badge styling
- `src/components/ChatMessagesPanel/ChatMessagesPanel.tsx` - Initial state fields

### Testing
- [x] Build passes (`npm run build`)
- [ ] Manual test with controversial query
- [ ] Verify synthesis report has per-perspective sections