### PR TITLE
fix(ci): exclude gglib-app from docs workflows to fix web_ui dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,10 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Build documentation
-        run: cargo doc --workspace --no-deps --document-private-items
+        # Exclude gglib-app (Tauri desktop) as it requires the web_ui directory to be built.
+        # gglib-app has minimal API documentation (6 items) and is not the primary doc target.
+        # gglib-core (119 items) is the comprehensive library documentation.
+        run: cargo doc --workspace --no-deps --document-private-items --exclude gglib-app
 
       - name: Create index.html redirect
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,10 @@ jobs:
           npm run build
 
       - name: Build documentation
-        run: cargo doc --workspace --no-deps --document-private-items
+        # Exclude gglib-app (Tauri desktop) as it requires the web_ui directory to be built.
+        # gglib-app has minimal API documentation (6 items) and is not the primary doc target.
+        # gglib-core (119 items) is the comprehensive library documentation.
+        run: cargo doc --workspace --no-deps --document-private-items --exclude gglib-app
 
       - name: Create index.html redirect
         run: |
@@ -188,8 +191,8 @@ jobs:
           <head>
             <meta charset="utf-8">
             <title>gglib Documentation</title>
-            <meta http-equiv="refresh" content="0; url=gglib/index.html">
-            <link rel="canonical" href="gglib/index.html">
+            <meta http-equiv="refresh" content="0; url=gglib_core/index.html">
+            <link rel="canonical" href="gglib_core/index.html">
             <style>
               body { 
                 font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -212,8 +215,8 @@ jobs:
           <body>
             <div class="container">
               <h1>🦀 gglib Documentation</h1>
-              <p>Redirecting to the <a href="gglib/index.html">gglib documentation</a>...</p>
-              <p><small>If you're not redirected automatically, <a href="gglib/index.html">click here</a>.</small></p>
+              <p>Redirecting to the <a href="gglib_core/index.html">gglib-core documentation</a>...</p>
+              <p><small>If you're not redirected automatically, <a href="gglib_core/index.html">click here</a>.</small></p>
             </div>
           </body>
           </html>


### PR DESCRIPTION
## Problem

Both documentation deployment workflows (`docs.yml` and `release.yml`) are failing when building documentation:

- **docs.yml**: `gglib-app` expects `web_ui` directory but it doesn't exist (Tauri macro panics)
- **release.yml**: Initially failed on system deps, still has inconsistent redirect target

## Root Cause

After the virtual workspace conversion (#132), `cargo doc --workspace` includes `gglib-app` (Tauri desktop app), which requires the built frontend (`web_ui/`) to compile. The docs workflows don't build the web UI because:

1. **Unnecessary overhead**: Adds ~30-60s + npm dependencies to doc builds
2. **Minimal value**: gglib-app only has 6 exported items (Tauri commands)
3. **Wrong target**: Library docs are the primary documentation need

## Solution

**Phase 1 - Fix the Failures (this PR):**
- ✅ Exclude `gglib-app` from cargo doc in both workflows
- ✅ Standardize redirect to `gglib_core/index.html` (119 items vs 2 in gglib binary)
- ✅ Add explanatory comments documenting the rationale

**Phase 2 - Consolidation (future PR):**
- Extract common docs build logic into reusable workflow component
- Reduces duplication and maintenance burden

## Changes

### docs.yml
- Added `--exclude gglib-app` to cargo doc command
- Added comment explaining exclusion rationale
- Kept redirect to `gglib_core/index.html` (already correct)

### release.yml  
- Added `--exclude gglib-app` to cargo doc command
- Changed redirect from `gglib/index.html` → `gglib_core/index.html`
- Added comment explaining exclusion rationale

## Verification

✅ **Local testing**: `cargo doc --workspace --no-deps --document-private-items --exclude gglib-app` builds successfully

✅ **Doc target validation**:
- `gglib_core`: 119 exported items ✅ (comprehensive library docs)
- `gglib_cli`: 21 exported items ✅ (library components)
- `gglib`: 2 exported items (binary entry point only)
- `gglib_app`: 6 exported items (minimal Tauri commands)

✅ **No side effects**: Verified `gglib-gui` (library crate) builds without web assets

## Related

Fixes #142

## Checklist

- [x] Excluded `gglib-app` from both workflows
- [x] Standardized redirect to `gglib_core/index.html`
- [x] Added explanatory comments
- [x] Verified builds locally with exclusion
- [x] Small, descriptive commits