### PR TITLE
Fix Platform Parity for Model Import (`add` Command)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,6 @@ name = "gglib-gui"
 version = "0.3.1"
 dependencies = [
  "async-trait",
- "chrono",
  "dirs",
  "futures-util",
  "gglib-core",

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -197,6 +197,9 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
     let system_probe: Arc<dyn gglib_core::ports::SystemProbePort> =
         Arc::new(DefaultSystemProbe::new());
 
+    // GGUF parser for model metadata extraction
+    let gguf_parser: Arc<dyn gglib_core::ports::GgufParserPort> = Arc::new(GgufParser::new());
+
     let deps = GuiDeps::new(
         Arc::clone(&core),
         downloads.clone(),
@@ -209,6 +212,7 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
         proxy_supervisor,
         model_repo,
         system_probe,
+        gguf_parser,
     );
     let gui = Arc::new(GuiBackend::new(deps));
 

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -104,7 +104,7 @@ impl ModelService {
     /// 3. Capability detection (reasoning, tool-calling from metadata)
     /// 4. Chat template inference (additional capability signals)
     /// 5. Auto-tag generation from detected capabilities
-    /// 6. Model persistence with complete NewModel struct
+    /// 6. Model persistence with complete `NewModel` struct
     pub async fn import_from_file(
         &self,
         file_path: &Path,
@@ -118,7 +118,7 @@ impl ModelService {
                 .to_str()
                 .ok_or_else(|| CoreError::Validation("Invalid file path encoding".to_string()))?,
         )
-        .map_err(|e| CoreError::Validation(format!("GGUF validation failed: {}", e)))?;
+        .map_err(|e| CoreError::Validation(format!("GGUF validation failed: {e}")))?;
 
         // 2. Resolve parameter count (override > metadata > 0.0 fallback)
         let param_count_b = param_count_override

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -1,7 +1,8 @@
 //! Model service - orchestrates model CRUD operations.
 
 use crate::domain::{Model, NewModel};
-use crate::ports::{CoreError, ModelRepository, RepositoryError};
+use crate::ports::{CoreError, GgufParserPort, ModelRepository, RepositoryError};
+use std::path::Path;
 use std::sync::Arc;
 
 /// Service for model operations.
@@ -78,6 +79,92 @@ impl ModelService {
     /// Add a new model.
     pub async fn add(&self, model: NewModel) -> Result<Model, CoreError> {
         self.repo.insert(&model).await.map_err(CoreError::from)
+    }
+
+    /// Import a model from a local GGUF file with full metadata extraction.
+    ///
+    /// Validates file, parses GGUF metadata, detects capabilities, and registers
+    /// with rich metadata. This is the canonical way to add local models.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_path` - Absolute path to the GGUF file
+    /// * `gguf_parser` - Parser implementation for metadata extraction
+    /// * `param_count_override` - Optional user override for parameter count
+    ///
+    /// # Returns
+    ///
+    /// Returns the registered `Model` with full metadata, or validation error.
+    ///
+    /// # Design
+    ///
+    /// This method orchestrates:
+    /// 1. File validation (existence, extension)
+    /// 2. GGUF metadata parsing (architecture, quantization, context)
+    /// 3. Capability detection (reasoning, tool-calling from metadata)
+    /// 4. Chat template inference (additional capability signals)
+    /// 5. Auto-tag generation from detected capabilities
+    /// 6. Model persistence with complete NewModel struct
+    pub async fn import_from_file(
+        &self,
+        file_path: &Path,
+        gguf_parser: &dyn GgufParserPort,
+        param_count_override: Option<f64>,
+    ) -> Result<Model, CoreError> {
+        // 1. Validate and parse GGUF file
+        let gguf_metadata = crate::utils::validation::validate_and_parse_gguf(
+            gguf_parser,
+            file_path.to_str().ok_or_else(|| {
+                CoreError::Validation("Invalid file path encoding".to_string())
+            })?,
+        )
+        .map_err(|e| CoreError::Validation(format!("GGUF validation failed: {}", e)))?;
+
+        // 2. Resolve parameter count (override > metadata > 0.0 fallback)
+        let param_count_b = param_count_override
+            .or(gguf_metadata.param_count_b)
+            .unwrap_or(0.0);
+
+        // 3. Detect capabilities from GGUF metadata
+        let gguf_capabilities = gguf_parser.detect_capabilities(&gguf_metadata);
+        let auto_tags = gguf_capabilities.to_tags();
+
+        // 4. Infer additional capabilities from chat template
+        let template = gguf_metadata.metadata.get("tokenizer.chat_template");
+        let name = gguf_metadata.metadata.get("general.name");
+        let model_capabilities = crate::domain::infer_from_chat_template(
+            template.map(String::as_str),
+            name.map(String::as_str),
+        );
+
+        // 5. Construct fully-populated NewModel
+        let new_model = NewModel {
+            name: name.cloned().unwrap_or_else(|| {
+                file_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("Unknown Model")
+                    .to_string()
+            }),
+            file_path: file_path.to_path_buf(),
+            param_count_b,
+            architecture: gguf_metadata.architecture,
+            quantization: gguf_metadata.quantization,
+            context_length: gguf_metadata.context_length,
+            metadata: gguf_metadata.metadata,
+            added_at: chrono::Utc::now(),
+            hf_repo_id: None,
+            hf_commit_sha: None,
+            hf_filename: None,
+            download_date: None,
+            last_update_check: None,
+            tags: auto_tags,
+            file_paths: None,
+            capabilities: model_capabilities,
+        };
+
+        // 6. Persist to repository
+        self.repo.insert(&new_model).await.map_err(CoreError::from)
     }
 
     /// Update a model.

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -114,9 +114,9 @@ impl ModelService {
         // 1. Validate and parse GGUF file
         let gguf_metadata = crate::utils::validation::validate_and_parse_gguf(
             gguf_parser,
-            file_path.to_str().ok_or_else(|| {
-                CoreError::Validation("Invalid file path encoding".to_string())
-            })?,
+            file_path
+                .to_str()
+                .ok_or_else(|| CoreError::Validation("Invalid file path encoding".to_string()))?,
         )
         .map_err(|e| CoreError::Validation(format!("GGUF validation failed: {}", e)))?;
 

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -1038,7 +1038,9 @@ impl DownloadManagerImpl {
             .collect()
     }
 
-    fn calculate_total_attempts(items: &[gglib_core::download::CompletionDetail]) -> (u32, u32, u32) {
+    fn calculate_total_attempts(
+        items: &[gglib_core::download::CompletionDetail],
+    ) -> (u32, u32, u32) {
         items.iter().fold((0, 0, 0), |(d, f, c), detail| {
             (
                 d + detail.attempt_counts.downloaded,
@@ -1048,7 +1050,9 @@ impl DownloadManagerImpl {
         })
     }
 
-    fn calculate_unique_counts(items: &[gglib_core::download::CompletionDetail]) -> (u32, u32, u32) {
+    fn calculate_unique_counts(
+        items: &[gglib_core::download::CompletionDetail],
+    ) -> (u32, u32, u32) {
         use gglib_core::download::CompletionKind;
 
         items

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -895,26 +895,38 @@ impl DownloadManagerImpl {
     async fn handle_drain_transitions(&self, is_drained: bool) {
         let mut prev = self.prev_is_drained.lock().await;
 
-        if *prev && !is_drained {
-            // Transition: drained → busy (start new run)
-            *self.current_run.lock().await = Some(QueueRunState::new());
-            tracing::info!(target: "gglib.download", "Queue run STARTED");
-        } else if !*prev && is_drained {
-            // Transition: busy → drained (finalize and emit)
-            let run = self.current_run.lock().await.take();
-            if let Some(run) = run {
+        let was_drained = *prev;
+        if was_drained && !is_drained {
+            self.start_new_queue_run().await;
+        } else if !was_drained && is_drained {
+            self.finalize_queue_run().await;
+        }
+
+        *prev = is_drained;
+    }
+
+    /// Start a new queue run when transitioning from drained to busy.
+    async fn start_new_queue_run(&self) {
+        *self.current_run.lock().await = Some(QueueRunState::new());
+        tracing::info!(target: "gglib.download", "Queue run STARTED");
+    }
+
+    /// Finalize and emit the current queue run when transitioning from busy to drained.
+    async fn finalize_queue_run(&self) {
+        let run = self.current_run.lock().await.take();
+        match run {
+            Some(run) => {
                 tracing::info!(
                     target: "gglib.download",
                     unique_downloaded = run.completions.len(),
                     "Queue run COMPLETED - emitting summary"
                 );
                 self.emit_queue_run_complete(run);
-            } else {
+            }
+            None => {
                 tracing::warn!(target: "gglib.download", "Queue drained but no run state found");
             }
         }
-
-        *prev = is_drained;
     }
 
     /// Emit the `QueueSnapshot` event to subscribers.
@@ -948,62 +960,17 @@ impl DownloadManagerImpl {
 
     /// Emit queue run complete event with summary.
     fn emit_queue_run_complete(&self, run: QueueRunState) {
-        use gglib_core::download::{AttemptCounts, CompletionDetail, QueueRunSummary};
-        use std::time::SystemTime;
+        use gglib_core::download::QueueRunSummary;
 
-        let completed_at_ms = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-            .try_into()
-            .unwrap_or(0);
-
-        // Build completion details from aggregates
-        let mut items: Vec<CompletionDetail> = run
-            .completions
-            .into_iter()
-            .map(|(key, agg)| {
-                let attempt_counts = AttemptCounts {
-                    downloaded: agg.success_count,
-                    failed: agg.failure_count,
-                    cancelled: agg.cancelled_count,
-                };
-
-                CompletionDetail {
-                    key,
-                    display_name: agg.display_name,
-                    download_ids: agg.download_ids,
-                    attempt_counts,
-                    last_result: agg.last_result,
-                    last_completed_at_ms: agg.last_attempt_ms,
-                }
-            })
-            .collect();
-
-        // Sort by most recent first
+        let completed_at_ms = Self::get_current_timestamp_ms();
+        let mut items = Self::build_completion_details(run.completions);
         items.sort_by(|a, b| b.last_completed_at_ms.cmp(&a.last_completed_at_ms));
 
-        // Calculate total attempt counts and unique counts
         let (total_attempts_downloaded, total_attempts_failed, total_attempts_cancelled) =
-            items.iter().fold((0, 0, 0), |(d, f, c), detail| {
-                (
-                    d + detail.attempt_counts.downloaded,
-                    f + detail.attempt_counts.failed,
-                    c + detail.attempt_counts.cancelled,
-                )
-            });
-
-        // Count unique models by last_result
+            Self::calculate_total_attempts(&items);
         let (unique_downloaded, unique_failed, unique_cancelled) =
-            items
-                .iter()
-                .fold((0, 0, 0), |(d, f, c), detail| match detail.last_result {
-                    CompletionKind::Downloaded | CompletionKind::AlreadyPresent => (d + 1, f, c),
-                    CompletionKind::Failed => (d, f + 1, c),
-                    CompletionKind::Cancelled => (d, f, c + 1),
-                });
+            Self::calculate_unique_counts(&items);
 
-        // Truncate to 20 items
         let truncated = items.len() > 20;
         items.truncate(20);
 
@@ -1032,6 +999,65 @@ impl DownloadManagerImpl {
 
         self.event_emitter
             .emit(DownloadEvent::QueueRunComplete { summary });
+    }
+
+    fn get_current_timestamp_ms() -> u64 {
+        use std::time::SystemTime;
+
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(0)
+    }
+
+    fn build_completion_details(
+        completions: indexmap::IndexMap<gglib_core::download::CompletionKey, CompletionAggregate>,
+    ) -> Vec<gglib_core::download::CompletionDetail> {
+        use gglib_core::download::{AttemptCounts, CompletionDetail};
+
+        completions
+            .into_iter()
+            .map(|(key, agg)| {
+                let attempt_counts = AttemptCounts {
+                    downloaded: agg.success_count,
+                    failed: agg.failure_count,
+                    cancelled: agg.cancelled_count,
+                };
+
+                CompletionDetail {
+                    key,
+                    display_name: agg.display_name,
+                    download_ids: agg.download_ids,
+                    attempt_counts,
+                    last_result: agg.last_result,
+                    last_completed_at_ms: agg.last_attempt_ms,
+                }
+            })
+            .collect()
+    }
+
+    fn calculate_total_attempts(items: &[gglib_core::download::CompletionDetail]) -> (u32, u32, u32) {
+        items.iter().fold((0, 0, 0), |(d, f, c), detail| {
+            (
+                d + detail.attempt_counts.downloaded,
+                f + detail.attempt_counts.failed,
+                c + detail.attempt_counts.cancelled,
+            )
+        })
+    }
+
+    fn calculate_unique_counts(items: &[gglib_core::download::CompletionDetail]) -> (u32, u32, u32) {
+        use gglib_core::download::CompletionKind;
+
+        items
+            .iter()
+            .fold((0, 0, 0), |(d, f, c), detail| match detail.last_result {
+                CompletionKind::Downloaded | CompletionKind::AlreadyPresent => (d + 1, f, c),
+                CompletionKind::Failed => (d, f + 1, c),
+                CompletionKind::Cancelled => (d, f, c + 1),
+            })
     }
 }
 

--- a/crates/gglib-gui/Cargo.toml
+++ b/crates/gglib-gui/Cargo.toml
@@ -23,7 +23,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-chrono = { workspace = true }
 dirs = { workspace = true }
 
 # Async

--- a/crates/gglib-gui/README.md
+++ b/crates/gglib-gui/README.md
@@ -121,6 +121,7 @@ use std::sync::Arc;
 #     proxy_supervisor: Arc<gglib_runtime::proxy::ProxySupervisor>,
 #     model_repo: Arc<dyn gglib_core::ports::ModelRepository>,
 #     system_probe: Arc<dyn gglib_core::ports::SystemProbePort>,
+#     gguf_parser: Arc<dyn gglib_core::ports::GgufParserPort>,
 # ) {
 // Construct backend with dependency injection
 let deps = GuiDeps::new(
@@ -135,6 +136,7 @@ let deps = GuiDeps::new(
     proxy_supervisor,
     model_repo,
     system_probe,
+    gguf_parser,
 );
 
 let backend = GuiBackend::new(deps);

--- a/crates/gglib-gui/src/deps.rs
+++ b/crates/gglib-gui/src/deps.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use gglib_core::events::ServerEvents;
 use gglib_core::ports::{
-    AppEventEmitter, DownloadManagerPort, HfClientPort, ModelRepository, ProcessRunner,
-    SystemProbePort, ToolSupportDetectorPort,
+    AppEventEmitter, DownloadManagerPort, GgufParserPort, HfClientPort, ModelRepository,
+    ProcessRunner, SystemProbePort, ToolSupportDetectorPort,
 };
 use gglib_core::services::AppCore;
 use gglib_mcp::McpService;
@@ -47,6 +47,8 @@ pub struct GuiDeps {
     pub(crate) model_repo: Arc<dyn ModelRepository>,
     /// System probe for hardware detection and memory info.
     pub(crate) system_probe: Arc<dyn SystemProbePort>,
+    /// GGUF parser for file validation and metadata extraction.
+    pub(crate) gguf_parser: Arc<dyn GgufParserPort>,
 }
 
 impl GuiDeps {
@@ -67,6 +69,7 @@ impl GuiDeps {
         proxy_supervisor: Arc<ProxySupervisor>,
         model_repo: Arc<dyn ModelRepository>,
         system_probe: Arc<dyn SystemProbePort>,
+        gguf_parser: Arc<dyn GgufParserPort>,
     ) -> Self {
         Self {
             core,
@@ -80,6 +83,7 @@ impl GuiDeps {
             proxy_supervisor,
             model_repo,
             system_probe,
+            gguf_parser,
         }
     }
 
@@ -110,5 +114,10 @@ impl GuiDeps {
     /// Access the server event emitter.
     pub fn server_events(&self) -> &Arc<dyn ServerEvents> {
         &self.server_events
+    }
+
+    /// Access the GGUF parser.
+    pub fn gguf_parser(&self) -> &Arc<dyn GgufParserPort> {
+        &self.gguf_parser
     }
 }

--- a/crates/gglib-gui/src/models.rs
+++ b/crates/gglib-gui/src/models.rs
@@ -94,11 +94,11 @@ impl<'a> ModelOps<'a> {
                 gglib_core::ports::CoreError::Validation(msg) => GuiError::ValidationFailed(msg),
                 gglib_core::ports::CoreError::Repository(
                     gglib_core::ports::RepositoryError::AlreadyExists(_),
-                ) => GuiError::AlreadyExists {
-                    entity: "model",
-                    identifier: request.file_path.clone(),
-                },
-                _ => GuiError::Internal(format!("Failed to add model: {}", e)),
+                ) => GuiError::Conflict(format!(
+                    "Model at path '{}' already exists in database",
+                    request.file_path
+                )),
+                _ => GuiError::Internal(format!("Failed to add model: {e}")),
             })?;
 
         // Return with serving status

--- a/crates/gglib-gui/src/models.rs
+++ b/crates/gglib-gui/src/models.rs
@@ -91,9 +91,7 @@ impl<'a> ModelOps<'a> {
             .import_from_file(&path, self.deps.gguf_parser().as_ref(), None)
             .await
             .map_err(|e| match e {
-                gglib_core::ports::CoreError::Validation(msg) => {
-                    GuiError::ValidationFailed(msg)
-                }
+                gglib_core::ports::CoreError::Validation(msg) => GuiError::ValidationFailed(msg),
                 gglib_core::ports::CoreError::Repository(
                     gglib_core::ports::RepositoryError::AlreadyExists(_),
                 ) => GuiError::AlreadyExists {

--- a/crates/gglib-mcp/src/service.rs
+++ b/crates/gglib-mcp/src/service.rs
@@ -185,13 +185,15 @@ impl McpService {
 
         // Step 2: Cache miss or invalid - resolve from command
         let user_search_paths = Self::extract_user_search_paths(&server);
-        
+
         match crate::resolver::resolve_executable(&command, &user_search_paths) {
             Ok(result) => {
-                self.handle_resolution_success(&mut server, &command, result).await
+                self.handle_resolution_success(&mut server, &command, result)
+                    .await
             }
             Err(e) => {
-                self.handle_resolution_failure(&mut server, &command, e).await
+                self.handle_resolution_failure(&mut server, &command, e)
+                    .await
             }
         }
     }
@@ -336,7 +338,9 @@ impl McpService {
         })
     }
 
-    fn extract_attempts_from_error(error: &crate::resolver::ResolveError) -> Vec<ResolutionAttempt> {
+    fn extract_attempts_from_error(
+        error: &crate::resolver::ResolveError,
+    ) -> Vec<ResolutionAttempt> {
         if let crate::resolver::ResolveError::NotResolved {
             attempts: err_attempts,
             ..

--- a/crates/gglib-tauri/src/bootstrap.rs
+++ b/crates/gglib-tauri/src/bootstrap.rs
@@ -150,6 +150,9 @@ impl TauriContext {
         let system_probe: Arc<dyn gglib_core::ports::SystemProbePort> =
             Arc::new(DefaultSystemProbe::new());
 
+        // GGUF parser for model metadata extraction
+        let gguf_parser: Arc<dyn gglib_core::ports::GgufParserPort> = Arc::new(GgufParser::new());
+
         let deps = GuiDeps::new(
             Arc::clone(&self.app),
             self.downloads.clone(),
@@ -162,6 +165,7 @@ impl TauriContext {
             self.proxy_supervisor.clone(),
             self.model_repo.clone(),
             system_probe,
+            gguf_parser,
         );
         GuiBackend::new(deps)
     }


### PR DESCRIPTION
## Summary

This PR fixes a critical architectural flaw where GGUF metadata extraction logic was trapped in the CLI adapter, causing severe data quality inconsistency when models were added via Web/GUI frontends. Models added through GUI/Web had **hardcoded empty metadata** (param_count=0.0, no quantization, no architecture, no capabilities), while CLI-added models had rich extracted metadata.

**Related Issues:**
- Addresses #135 (Platform Parity Testing Checklist - fixes `add` command parity)
- Part of #139 (Q1 2026 Technical Debt Remediation - Phase 5)

---

## Problem Statement

**Code-level parity analysis revealed:**

| Field | CLI `add` | GUI/Web `add` (before) |
|-------|-----------|------------------------|
| `param_count_b` | Extracted from GGUF or prompted | **Hardcoded 0.0** |
| `architecture` | Extracted from GGUF | **None (missing)** |
| `quantization` | Extracted from GGUF | **None (missing)** |
| `context_length` | Extracted from GGUF | **None (missing)** |
| `metadata` HashMap | Full GGUF metadata | **Empty** |
| `tags` | Auto-detected from capabilities | **Empty** |
| `capabilities` | Inferred from chat template | **Default (empty)** |
| Model name | From GGUF `general.name` | From filename stem |

**Impact:** Models added via Web/GUI were functionally degraded—missing critical metadata needed for server configuration, model selection, and capability detection. Database quality was inconsistent depending on which frontend added the model.

---

## Solution Architecture

**Moved shared logic from CLI adapter to `gglib-core`:**

```
Before:
┌─────────────────────────────────────────────────────┐
│  CLI Handler (add.rs)                               │
│  ┌───────────────────────────────────────────────┐  │
│  │ • GGUF parsing                                │  │
│  │ • Capability detection                        │  │
│  │ • Tag generation                              │  │
│  │ • Chat template inference                     │  │
│  │ • NewModel construction (RICH METADATA)       │  │
│  └───────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────┘
         ↓
    ModelService::add(NewModel)

┌─────────────────────────────────────────────────────┐
│  GUI Handler (models.rs)                            │
│  ┌───────────────────────────────────────────────┐  │
│  │ • File existence check only                   │  │
│  │ • NewModel construction (EMPTY METADATA)      │  │
│  └───────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────┘
         ↓
    ModelService::add(NewModel)

After:
┌─────────────────────────────────────────────────────┐
│  CLI Handler (add.rs)                               │
│  ┌───────────────────────────────────────────────┐  │
│  │ • Preview metadata (CLI-specific UX)          │  │
│  │ • Interactive param override (CLI-specific)   │  │
│  └───────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────┘
         ↓
    ModelService::import_from_file(path, parser, override)

┌─────────────────────────────────────────────────────┐
│  GUI Handler (models.rs)                            │
│  └─ No custom logic, delegates immediately         │
└─────────────────────────────────────────────────────┘
         ↓
    ModelService::import_from_file(path, parser, None)

                          ↓
┌─────────────────────────────────────────────────────┐
│  ModelService::import_from_file() [NEW]             │
│  ┌───────────────────────────────────────────────┐  │
│  │ 1. Validate file (existence, extension)      │  │
│  │ 2. Parse GGUF metadata                        │  │
│  │ 3. Detect capabilities from metadata          │  │
│  │ 4. Infer from chat template                   │  │
│  │ 5. Generate auto-tags                         │  │
│  │ 6. Construct fully-populated NewModel         │  │
│  │ 7. Persist to repository                      │  │
│  └───────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────┘
```

---

## Changes

### 1. Core Logic (gglib-core) [Commit 6217f17]

**Added:** `ModelService::import_from_file(file_path, gguf_parser, param_count_override)`

**Orchestrates:**
- File validation via `validate_and_parse_gguf()`
- GGUF metadata extraction (architecture, quantization, context, param_count)
- Capability detection via `GgufParserPort::detect_capabilities()`
- Chat template inference via `infer_from_chat_template()`
- Auto-tag generation from detected capabilities
- Complete `NewModel` construction with all metadata fields populated

**Design rationale:** This is now the **canonical way** to add local models across all adapters, ensuring identical metadata quality.

### 2. CLI Adapter (gglib-cli) [Commit d457ee4]

**Refactored:** `handlers/add.rs`

**Preserves CLI-specific UX:**
- Metadata preview before saving
- Interactive parameter count override prompt

**Delegates to:** `ctx.app().models().import_from_file()`

**Removed duplication:** ~40 lines of GGUF parsing, `NewModel` construction, capability detection, and tag generation logic.

### 3. GUI Adapter (gglib-gui, gglib-axum, gglib-tauri) [Commit 8c39904]

**Added:** `gguf_parser: Arc<dyn GgufParserPort>` to `GuiDeps`

**Updated:**
- `GuiDeps::new()` signature to accept parser
- Axum bootstrap to inject `GgufParser` into `GuiDeps`
- Tauri bootstrap to inject `GgufParser` into `GuiDeps`

**Refactored:** `ModelOps::add()` to delegate to `import_from_file()`

**Result:** GUI/Web now get **identical rich metadata** extraction as CLI.

---

## Impact: Parity Achieved

| Field | CLI `add` | GUI/Web `add` (after) | ✅ Parity |
|-------|-----------|------------------------|-----------|
| `param_count_b` | Extracted from GGUF | Extracted from GGUF | ✅ **Fixed** |
| `architecture` | Extracted from GGUF | Extracted from GGUF | ✅ **Fixed** |
| `quantization` | Extracted from GGUF | Extracted from GGUF | ✅ **Fixed** |
| `context_length` | Extracted from GGUF | Extracted from GGUF | ✅ **Fixed** |
| `metadata` HashMap | Full GGUF metadata | Full GGUF metadata | ✅ **Fixed** |
| `tags` | Auto-detected | Auto-detected | ✅ **Fixed** |
| `capabilities` | Inferred | Inferred | ✅ **Fixed** |
| Model name | From GGUF `general.name` | From GGUF `general.name` | ✅ **Fixed** |

**All three adapters (CLI, Axum Web, Tauri GUI) now use the same core import logic, ensuring consistent database quality regardless of which frontend adds the model.**

---

## Testing

**Build verification:** ✅ `cargo check --package gglib-core --package gglib-cli --package gglib-gui` passes

**Recommended integration test:**
```rust
#[tokio::test]
async fn test_add_command_parity_cli_vs_web() {
    // Add same model via CLI and Web
    let cli_model = add_via_cli("model.gguf").await?;
    let web_model = add_via_web("model.gguf").await?;
    
    // Assert identical metadata extraction
    assert_eq!(cli_model.quantization, web_model.quantization);
    assert_eq!(cli_model.architecture, web_model.architecture);
    assert_eq!(cli_model.context_length, web_model.context_length);
    assert_eq!(cli_model.capabilities, web_model.capabilities);
    assert!(!web_model.metadata.is_empty());
}
```

---

## Migration Notes

**No breaking changes:**
- `ModelService::add(NewModel)` still exists for programmatic use
- `import_from_file()` is a new method, not a replacement
- All existing code continues to work

**Backward compatibility:**
- Existing models in database are unaffected
- Models added pre-refactor may have empty metadata (historical issue)
- Future models added via any frontend will have rich metadata

---

## Follow-up Opportunities

1. **Optimization:** CLI currently parses GGUF twice (preview + import). Could add `import_from_file_with_metadata()` variant.
2. **Consistency:** `ModelRegistrar::register_model()` (for downloads) has similar logic. Could extract common helper.
3. **Validation:** Add `ModelService::validate_metadata()` to check for empty/missing critical fields.
4. **Migration:** Add CLI command to re-enrich existing models with empty metadata (e.g., `gglib enrich <model_id>`).

---

## Commits

1. **6217f17** `feat(core): add import_from_file method to ModelService`
2. **d457ee4** `refactor(cli): delegate model import to shared core logic`
3. **8c39904** `refactor(gui): delegate model import to shared core logic`