### PR TITLE
Fix: GUI serialization mismatch causing NaN model data

### DIFF
--- a/src/components/HfModelPreview/HfModelPreview.tsx
+++ b/src/components/HfModelPreview/HfModelPreview.tsx
@@ -85,7 +85,7 @@ const HfModelPreview: FC<HfModelPreviewProps> = ({
   // Memory fit checking
   const { checkFit, getTooltip, loading: memoryLoading } = useSystemMemory();
   const { settings } = useSettings();
-  const showFitIndicators = settings?.show_memory_fit_indicators ?? true;
+  const showFitIndicators = settings?.showMemoryFitIndicators ?? true;
 
   // Format last modified date
   const formatLastModified = (dateStr?: string | null): string => {

--- a/src/components/ModelInspectorPanel/components/ModelEditForm.tsx
+++ b/src/components/ModelInspectorPanel/components/ModelEditForm.tsx
@@ -39,7 +39,7 @@ export const ModelEditForm: FC<ModelEditFormProps> = ({
       <div className="metadata-grid">
         <div className="metadata-row">
           <span className="metadata-label">Size:</span>
-          <span className="metadata-value">{formatParamCount(model.param_count_b)}</span>
+          <span className="metadata-value">{formatParamCount(model.paramCountB)}</span>
         </div>
         {model.architecture && (
           <div className="metadata-row">
@@ -57,10 +57,10 @@ export const ModelEditForm: FC<ModelEditFormProps> = ({
             placeholder="e.g., Q4_0"
           />
         </div>
-        {model.context_length && (
+        {model.contextLength && (
           <div className="metadata-row">
             <span className="metadata-label">Context Length:</span>
-            <span className="metadata-value">{model.context_length.toLocaleString()}</span>
+            <span className="metadata-value">{model.contextLength.toLocaleString()}</span>
           </div>
         )}
         <div className="metadata-row">
@@ -73,15 +73,15 @@ export const ModelEditForm: FC<ModelEditFormProps> = ({
             placeholder="File path"
           />
         </div>
-        {model.hf_repo_id && (
+        {model.hfRepoId && (
           <div className="metadata-row">
             <span className="metadata-label">HuggingFace:</span>
             <span className="metadata-value hf-link-container">
-              <span className="hf-repo-id">{model.hf_repo_id}</span>
+              <span className="hf-repo-id">{model.hfRepoId}</span>
               <button
                 className="hf-link-button"
                 onClick={() => {
-                  const url = getHuggingFaceUrl(model.hf_repo_id);
+                  const url = getHuggingFaceUrl(model.hfRepoId);
                   if (url) openUrl(url);
                 }}
                 title="Open on HuggingFace"

--- a/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
+++ b/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
@@ -25,7 +25,7 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model }) => {
       <div className="metadata-grid">
         <div className="metadata-row">
           <span className="metadata-label">Size:</span>
-          <span className="metadata-value">{formatParamCount(model.param_count_b)}</span>
+          <span className="metadata-value">{formatParamCount(model.paramCountB)}</span>
         </div>
         {model.architecture && (
           <div className="metadata-row">
@@ -39,20 +39,20 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model }) => {
             <span className="metadata-value quantization">{model.quantization}</span>
           </div>
         )}
-        {model.context_length && (
+        {model.contextLength && (
           <div className="metadata-row">
             <span className="metadata-label">Context Length:</span>
-            <span className="metadata-value">{model.context_length.toLocaleString()}</span>
+            <span className="metadata-value">{model.contextLength.toLocaleString()}</span>
           </div>
         )}
         <div className="metadata-row">
           <span className="metadata-label">Path:</span>
           <span className="metadata-value path">
-            {model.file_path}
+            {model.filePath}
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => copyToClipboard(model.file_path)}
+              onClick={() => copyToClipboard(model.filePath)}
               title="Copy path"
               iconOnly
             >
@@ -60,15 +60,15 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model }) => {
             </Button>
           </span>
         </div>
-        {model.hf_repo_id && (
+        {model.hfRepoId && (
           <div className="metadata-row">
             <span className="metadata-label">HuggingFace:</span>
             <span className="metadata-value hf-link-container">
-              <span className="hf-repo-id">{model.hf_repo_id}</span>
+              <span className="hf-repo-id">{model.hfRepoId}</span>
               <button
                 className="hf-link-button"
                 onClick={() => {
-                  const url = getHuggingFaceUrl(model.hf_repo_id);
+                  const url = getHuggingFaceUrl(model.hfRepoId);
                   if (url) openUrl(url);
                 }}
                 title="Open on HuggingFace"

--- a/src/components/ModelInspectorPanel/components/ServeModal.tsx
+++ b/src/components/ModelInspectorPanel/components/ServeModal.tsx
@@ -60,7 +60,7 @@ export const ServeModal: FC<ServeModalProps> = ({
       <div className="modal-body">
         <div className="model-info">
           <strong>{model.name}</strong>
-          <span className="model-size">{formatParamCount(model.param_count_b)}</span>
+          <span className="model-size">{formatParamCount(model.paramCountB)}</span>
         </div>
 
         <div className="form-group">
@@ -73,10 +73,10 @@ export const ServeModal: FC<ServeModalProps> = ({
             type="number"
             className="context-input"
             placeholder={
-              settings?.default_context_size
-                ? `Default: ${settings.default_context_size.toLocaleString()}`
-                : model.context_length
-                  ? `Model max: ${model.context_length.toLocaleString()}`
+              settings?.defaultContextSize
+                ? `Default: ${settings.defaultContextSize.toLocaleString()}`
+                : model.contextLength
+                  ? `Model max: ${model.contextLength.toLocaleString()}`
                   : 'Enter context length'
             }
             value={customContext}
@@ -85,8 +85,8 @@ export const ServeModal: FC<ServeModalProps> = ({
             min="1"
           />
           <p className="input-help">
-            {model.context_length
-              ? `Model's maximum: ${model.context_length.toLocaleString()} tokens`
+            {model.contextLength
+              ? `Model's maximum: ${model.contextLength.toLocaleString()} tokens`
               : 'No model context metadata available'}
           </p>
         </div>
@@ -101,8 +101,8 @@ export const ServeModal: FC<ServeModalProps> = ({
             type="number"
             className="context-input"
             placeholder={
-              settings?.llama_base_port
-                ? `Auto (from ${settings.llama_base_port})`
+              settings?.llamaBasePort
+                ? `Auto (from ${settings.llamaBasePort})`
                 : 'Auto (from 9000)'
             }
             value={customPort}

--- a/src/components/ModelInspectorPanel/hooks/useEditMode.ts
+++ b/src/components/ModelInspectorPanel/hooks/useEditMode.ts
@@ -31,7 +31,7 @@ export function useEditMode(model: GgufModel | null): EditModeState {
     if (!model) return;
     setEditedName(model.name);
     setEditedQuantization(model.quantization || '');
-    setEditedFilePath(model.file_path);
+    setEditedFilePath(model.filePath);
     setEditedInferenceDefaults(model.inferenceDefaults || undefined);
     setIsEditMode(true);
   }, [model]);

--- a/src/components/ModelInspectorPanel/hooks/useServerActions.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServerActions.ts
@@ -76,7 +76,7 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
     resetEditState,
   } = config;
 
-  const activeServer = model?.id ? servers.find(s => s.model_id === model.id) : undefined;
+  const activeServer = model?.id ? servers.find(s => s.modelId === model.id) : undefined;
   const isRunning = !!activeServer;
 
   const handleStartServer = useCallback(async () => {
@@ -91,10 +91,10 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
         if (!isNaN(parsed) && parsed > 0) {
           contextLength = parsed;
         }
-      } else if (settings?.default_context_size) {
-        contextLength = settings.default_context_size;
-      } else if (model.context_length) {
-        contextLength = model.context_length;
+      } else if (settings?.defaultContextSize) {
+        contextLength = settings.defaultContextSize;
+      } else if (model.contextLength) {
+        contextLength = model.contextLength;
       }
 
       // Parse port if specified (must be >= 1024)
@@ -112,16 +112,16 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
 
       const serveConfig: ServeConfig = {
         id: model.id,
-        context_length: contextLength,
+        contextLength: contextLength,
         port,
         mlock: false,
         jinja: jinjaOverride === null ? (hasAgentTag ? true : undefined) : jinjaOverride,
         // Inference parameters for this session
         temperature: inferenceParams?.temperature,
-        top_p: inferenceParams?.topP,
-        top_k: inferenceParams?.topK,
-        max_tokens: inferenceParams?.maxTokens,
-        repeat_penalty: inferenceParams?.repeatPenalty,
+        topP: inferenceParams?.topP,
+        topK: inferenceParams?.topK,
+        maxTokens: inferenceParams?.maxTokens,
+        repeatPenalty: inferenceParams?.repeatPenalty,
       };
 
       const result = await serveModel(serveConfig);
@@ -130,8 +130,8 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
       
       if (onServerStarted && result) {
         onServerStarted({
-          model_id: model.id,
-          model_name: model.name,
+          modelId: model.id,
+          modelName: model.name,
           port: result.port,
           status: 'running',
         });
@@ -190,7 +190,7 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
   const handleSave = useCallback(async () => {
     if (!model?.id) return;
     try {
-      const updates: { name?: string; quantization?: string; file_path?: string; inferenceDefaults?: InferenceConfig } = {};
+      const updates: { name?: string; quantization?: string; filePath?: string; inferenceDefaults?: InferenceConfig } = {};
       
       if (editedName !== model.name) {
         updates.name = editedName;
@@ -198,8 +198,8 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
       if (editedQuantization !== (model.quantization || '')) {
         updates.quantization = editedQuantization || undefined;
       }
-      if (editedFilePath !== model.file_path) {
-        updates.file_path = editedFilePath;
+      if (editedFilePath !== model.filePath) {
+        updates.filePath = editedFilePath;
       }
       // Always include inferenceDefaults if it was edited (even if set to empty object to clear)
       if (JSON.stringify(editedInferenceDefaults) !== JSON.stringify(model.inferenceDefaults)) {

--- a/src/components/ModelLibraryPanel/ModelsListContent.tsx
+++ b/src/components/ModelLibraryPanel/ModelsListContent.tsx
@@ -24,7 +24,7 @@ const ModelsListContent: FC<ModelsListContentProps> = ({
 }) => {
   const isModelRunning = (modelId?: number) => {
     if (!modelId) return false;
-    return servers.some(s => s.model_id === modelId);
+    return servers.some(s => s.modelId === modelId);
   };
 
   if (loading && models.length === 0) {
@@ -68,7 +68,7 @@ const ModelsListContent: FC<ModelsListContentProps> = ({
               )}
             </div>
             <div className="model-metadata">
-              <span className="metadata-item">{formatParamCount(model.param_count_b)}</span>
+              <span className="metadata-item">{formatParamCount(model.paramCountB)}</span>
               {model.architecture && (
                 <span className="metadata-item">{model.architecture}</span>
               )}

--- a/src/components/ModelList.tsx
+++ b/src/components/ModelList.tsx
@@ -51,21 +51,21 @@ const ModelRow: FC<ModelRowProps> = ({ model, removing, onServe, onRemove }) => 
           {model.name}
           {isRunning && <ServerHealthIndicator modelId={model.id ?? 0} />}
         </Row>
-        {model.hf_repo_id && (
+        {model.hfRepoId && (
           <Row gap="xs" align="center" className="name-secondary">
             <Icon icon={Package} size={14} className="shrink-0" />
-            <span>{model.hf_repo_id}</span>
+            <span>{model.hfRepoId}</span>
           </Row>
         )}
       </div>
-      <div className="cell">{formatParamCount(model.param_count_b)}</div>
+      <div className="cell">{formatParamCount(model.paramCountB)}</div>
       <div className="cell">{model.architecture || "—"}</div>
       <div className="cell">
         <span className="quantization-badge">
           {model.quantization || "—"}
         </span>
       </div>
-      <div className="cell">{new Date(model.added_at).toLocaleDateString()}</div>
+      <div className="cell">{new Date(model.addedAt).toLocaleDateString()}</div>
       <div className="cell actions">
         <button
           onClick={() => onServe(model)}
@@ -144,13 +144,13 @@ const ModelList: FC<ModelListProps> = ({
         if (!isNaN(parsed) && parsed > 0) {
           contextLength = parsed;
         }
-      } else if (servingModel.context_length) {
-        contextLength = servingModel.context_length;
+      } else if (servingModel.contextLength) {
+        contextLength = servingModel.contextLength;
       }
       
       await serveModel({
         id: servingModel.id,
-        context_length: contextLength,
+        contextLength: contextLength,
         mlock: false,
         jinja: enableJinja || jinjaAutoEnabled,
       });
@@ -248,7 +248,7 @@ const ModelList: FC<ModelListProps> = ({
             <div className="modal-body">
               <div className="model-info">
                 <strong>{servingModel.name}</strong>
-                <span className="model-size">{formatParamCount(servingModel.param_count_b)}</span>
+                <span className="model-size">{formatParamCount(servingModel.paramCountB)}</span>
               </div>
               
               {/* Capability Badges */}
@@ -284,15 +284,15 @@ const ModelList: FC<ModelListProps> = ({
                   id="context-input"
                   type="number"
                   className="context-input"
-                  placeholder={servingModel.context_length ? `Default: ${servingModel.context_length.toLocaleString()}` : 'Use model default'}
+                  placeholder={servingModel.contextLength ? `Default: ${servingModel.contextLength.toLocaleString()}` : 'Use model default'}
                   value={customContext}
                   onChange={(e) => setCustomContext(e.target.value)}
                   disabled={isServing}
                   min="1"
                 />
                 <p className="input-help">
-                  {servingModel.context_length 
-                    ? `Model's maximum: ${servingModel.context_length.toLocaleString()} tokens`
+                  {servingModel.contextLength 
+                    ? `Model's maximum: ${servingModel.contextLength.toLocaleString()} tokens`
                     : 'Leave empty to use model default'}
                 </p>
               </div>

--- a/src/components/ServerList/ServerList.tsx
+++ b/src/components/ServerList/ServerList.tsx
@@ -86,17 +86,17 @@ const ServerList: FC<ServerListProps> = ({
       <div className="server-list-items">
         {servers.map((server) => (
           <div
-            key={server.model_id}
-            className={`server-item ${expandedServerId === server.model_id ? 'expanded' : ''}`}
+            key={server.modelId}
+            className={`server-item ${expandedServerId === server.modelId ? 'expanded' : ''}`}
           >
             <div 
               className={`server-item-header ${onSelectModel ? 'clickable' : ''}`}
-              onClick={() => handleServerClick(server.model_id)}
+              onClick={() => handleServerClick(server.modelId)}
             >
               <div className="server-info">
                 <Row gap="sm" align="center" className="server-name">
-                  {server.model_name}
-                  <ServerHealthIndicator modelId={server.model_id} />
+                  {server.modelName}
+                  <ServerHealthIndicator modelId={server.modelId} />
                 </Row>
                 <div className="server-details">
                   <span className="server-port">:{server.port}</span>
@@ -107,19 +107,19 @@ const ServerList: FC<ServerListProps> = ({
                 variant="danger"
                 size="sm"
                 className={`server-stop-btn ${compact ? 'compact' : ''}`}
-                onClick={(e) => handleStop(server.model_id, e)}
+                onClick={(e) => handleStop(server.modelId, e)}
                 title="Stop server"
                 leftIcon={<Icon icon={Square} size={14} />}
               >
                 {!compact && 'Stop'}
               </Button>
             </div>
-            {expandedServerId === server.model_id && onSelectModel && (
+            {expandedServerId === server.modelId && onSelectModel && (
               <div className="server-item-tabs">
                 <SidebarTabs<ChatPageTabId>
                   tabs={CHAT_PAGE_TABS}
                   activeTab="chat"
-                  onTabChange={(tab) => handleTabSelect(server.model_id, tab)}
+                  onTabChange={(tab) => handleTabSelect(server.modelId, tab)}
                 />
               </div>
             )}

--- a/src/components/ServerStatus.tsx
+++ b/src/components/ServerStatus.tsx
@@ -87,18 +87,18 @@ const ServerStatus: FC<ServerStatusProps> = ({ onOpenChat }) => {
 
       {/* Running Servers */}
       {servers.map((server) => (
-        <div key={server.model_id} className={styles.statusItem}>
+        <div key={server.modelId} className={styles.statusItem}>
           <span className={`${styles.statusIcon} ${isServerHealthy(server) ? styles.healthy : ''}`} aria-hidden>
             <Icon icon={Circle} size={14} />
           </span>
           <div className={styles.statusInfo}>
-            <strong>{server.model_name}</strong>
+            <strong>{server.modelName}</strong>
             <span className={styles.statusDetail}>Port {server.port}</span>
           </div>
           {isServerHealthy(server) && onOpenChat && (
             <button
               className={styles.chatButton}
-              onClick={() => onOpenChat(server.port, server.model_name)}
+              onClick={() => onOpenChat(server.port, server.modelName)}
               title="Open chat"
             >
               <Icon icon={MessageCircle} size={14} />
@@ -106,7 +106,7 @@ const ServerStatus: FC<ServerStatusProps> = ({ onOpenChat }) => {
           )}
           <button
             className={styles.stopButton}
-            onClick={() => handleStopServer(server.model_id)}
+            onClick={() => handleStopServer(server.modelId)}
             title="Stop server"
           >
             <Icon icon={Square} size={14} />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -62,15 +62,15 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
 
   useEffect(() => {
     if (settings) {
-      setContextSizeInput(settings.default_context_size?.toString() || "");
-      setProxyPortInput(settings.proxy_port?.toString() || "");
-      setServerPortInput(settings.llama_base_port?.toString() || "");
-      setMaxQueueSizeInput(settings.max_download_queue_size?.toString() || "");
-      setTitlePromptInput(settings.title_generation_prompt || "");
-      setMaxToolIterationsInput(settings.max_tool_iterations?.toString() || "");
-      setMaxStagnationStepsInput(settings.max_stagnation_steps?.toString() || "");
-      setShowFitIndicators(settings.show_memory_fit_indicators !== false);
-      setDefaultModelInput(settings.default_model_id?.toString() || "");
+      setContextSizeInput(settings.defaultContextSize?.toString() || "");
+      setProxyPortInput(settings.proxyPort?.toString() || "");
+      setServerPortInput(settings.llamaBasePort?.toString() || "");
+      setMaxQueueSizeInput(settings.maxDownloadQueueSize?.toString() || "");
+      setTitlePromptInput(settings.titleGenerationPrompt || "");
+      setMaxToolIterationsInput(settings.maxToolIterations?.toString() || "");
+      setMaxStagnationStepsInput(settings.maxStagnationSteps?.toString() || "");
+      setShowFitIndicators(settings.showMemoryFitIndicators !== false);
+      setDefaultModelInput(settings.defaultModelId?.toString() || "");
       setInferenceDefaultsInput(settings.inferenceDefaults || undefined);
     }
   }, [settings]);
@@ -95,29 +95,29 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
 
         // Update other settings
         const updates: UpdateSettingsRequest = {
-          default_context_size: parseNumericInput(contextSizeInput),
-          proxy_port: parseNumericInput(proxyPortInput),
-          llama_base_port: parseNumericInput(serverPortInput),
-          max_download_queue_size: parseNumericInput(maxQueueSizeInput),
-          title_generation_prompt: titlePromptInput.trim() || null,
-          max_tool_iterations: parseNumericInput(maxToolIterationsInput),
-          max_stagnation_steps: parseNumericInput(maxStagnationStepsInput),
-          show_memory_fit_indicators: showFitIndicators,
-          default_model_id: parseNumericInput(defaultModelInput),
+          defaultContextSize: parseNumericInput(contextSizeInput),
+          proxyPort: parseNumericInput(proxyPortInput),
+          llamaBasePort: parseNumericInput(serverPortInput),
+          maxDownloadQueueSize: parseNumericInput(maxQueueSizeInput),
+          titleGenerationPrompt: titlePromptInput.trim() || null,
+          maxToolIterations: parseNumericInput(maxToolIterationsInput),
+          maxStagnationSteps: parseNumericInput(maxStagnationStepsInput),
+          showMemoryFitIndicators: showFitIndicators,
+          defaultModelId: parseNumericInput(defaultModelInput),
           inferenceDefaults: inferenceDefaultsInput,
         };
 
         // Check if any updates were made
         const hasUpdates = 
-          updates.default_context_size !== undefined ||
-          updates.proxy_port !== undefined ||
-          updates.llama_base_port !== undefined ||
-          updates.max_download_queue_size !== undefined ||
-          updates.title_generation_prompt !== undefined ||
-          updates.max_tool_iterations !== undefined ||
-          updates.max_stagnation_steps !== undefined ||
-          updates.show_memory_fit_indicators !== undefined ||
-          updates.default_model_id !== undefined ||
+          updates.defaultContextSize !== undefined ||
+          updates.proxyPort !== undefined ||
+          updates.llamaBasePort !== undefined ||
+          updates.maxDownloadQueueSize !== undefined ||
+          updates.titleGenerationPrompt !== undefined ||
+          updates.maxToolIterations !== undefined ||
+          updates.maxStagnationSteps !== undefined ||
+          updates.showMemoryFitIndicators !== undefined ||
+          updates.defaultModelId !== undefined ||
           updates.inferenceDefaults !== undefined;
 
         if (hasUpdates) {
@@ -148,14 +148,14 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   );
 
   const handleReset = useCallback(() => {
-    if (info?.default_path) {
-      setPathInput(info.default_path);
+    if (info?.defaultPath) {
+      setPathInput(info.defaultPath);
     }
     if (settings) {
-      setContextSizeInput(settings.default_context_size?.toString() || "4096");
-      setProxyPortInput(settings.proxy_port?.toString() || "8080");
-      setServerPortInput(settings.llama_base_port?.toString() || "9000");
-      setMaxQueueSizeInput(settings.max_download_queue_size?.toString() || "10");
+      setContextSizeInput(settings.defaultContextSize?.toString() || "4096");
+      setProxyPortInput(settings.proxyPort?.toString() || "8080");
+      setServerPortInput(settings.llamaBasePort?.toString() || "9000");
+      setMaxQueueSizeInput(settings.maxDownloadQueueSize?.toString() || "10");
       setTitlePromptInput(""); // Reset to default (empty uses DEFAULT_TITLE_GENERATION_PROMPT)
       setShowFitIndicators(true); // Default is enabled
     }

--- a/src/components/SettingsModal/GeneralSettings.tsx
+++ b/src/components/SettingsModal/GeneralSettings.tsx
@@ -121,7 +121,7 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
       />
       <div className={styles.helperText}>
         {sourceDescription && <span>{sourceDescription}</span>}
-        {info?.default_path && (
+        {info?.defaultPath && (
           <button type="button" className={styles.resetLink} onClick={onReset}>
             Reset to defaults
           </button>

--- a/src/hooks/useModels.ts
+++ b/src/hooks/useModels.ts
@@ -61,14 +61,14 @@ export function useModels() {
   const updateModel = useCallback(async (id: number, updates: {
     name?: string;
     quantization?: string;
-    file_path?: string;
+    filePath?: string;
     inferenceDefaults?: InferenceConfig;
   }) => {
     await updateModelService({ 
       id, 
       name: updates.name,
       quantization: updates.quantization,
-      filePath: updates.file_path,
+      filePath: updates.filePath,
       inferenceDefaults: updates.inferenceDefaults,
     });
     await loadModels();

--- a/src/hooks/useSystemMemory.ts
+++ b/src/hooks/useSystemMemory.ts
@@ -89,7 +89,7 @@ export function useSystemMemory(): UseSystemMemoryReturn {
   const { settings } = useSettings();
 
   // Context length from settings, default to 4096
-  const contextLength = settings?.default_context_size ?? 4096;
+  const contextLength = settings?.defaultContextSize ?? 4096;
 
   const loadMemoryInfo = useCallback(async () => {
     try {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -79,9 +79,9 @@ export default function ChatPage({
 
   // Settings for title generation prompt and agent loop
   const { settings } = useSettings();
-  const titleGenerationPrompt = settings?.title_generation_prompt || DEFAULT_TITLE_GENERATION_PROMPT;
-  const maxToolIterations = settings?.max_tool_iterations ?? undefined;
-  const maxStagnationSteps = settings?.max_stagnation_steps ?? undefined;
+  const titleGenerationPrompt = settings?.titleGenerationPrompt || DEFAULT_TITLE_GENERATION_PROMPT;
+  const maxToolIterations = settings?.maxToolIterations ?? undefined;
+  const maxStagnationSteps = settings?.maxStagnationSteps ?? undefined;
 
   // Runtime - now with external message state
   const { runtime, messages, setMessages, timingTracker, currentStreamingAssistantMessageId } = useGglibRuntime({

--- a/src/pages/ModelControlCenterPage.tsx
+++ b/src/pages/ModelControlCenterPage.tsx
@@ -103,12 +103,12 @@ export default function ModelControlCenterPage({
 
   const openChatSession = useCallback(
     (modelId: number, view: 'chat' | 'console') => {
-      const server = servers.find((s) => s.model_id === modelId);
+      const server = servers.find((s) => s.modelId === modelId);
       if (server) {
         setChatSession({
           serverPort: server.port,
-          modelId: server.model_id,
-          modelName: server.model_name,
+          modelId: server.modelId,
+          modelName: server.modelName,
           initialView: view,
         });
       }
@@ -197,8 +197,8 @@ export default function ModelControlCenterPage({
     // Server started, open chat
     setChatSession({
       serverPort: serverInfo.port,
-      modelId: serverInfo.model_id,
-      modelName: serverInfo.model_name,
+      modelId: serverInfo.modelId,
+      modelName: serverInfo.modelName,
       initialView: 'chat',
     });
   };

--- a/src/pages/modelControlCenter/useMccFilters.ts
+++ b/src/pages/modelControlCenter/useMccFilters.ts
@@ -61,7 +61,7 @@ export function useMccFilters({
         !searchQuery ||
         model.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
         model.architecture?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        model.hf_repo_id?.toLowerCase().includes(searchQuery.toLowerCase());
+        model.hfRepoId?.toLowerCase().includes(searchQuery.toLowerCase());
 
       const matchesTags =
         filters.selectedTags.length === 0 ||
@@ -69,13 +69,13 @@ export function useMccFilters({
 
       const matchesParams =
         filters.paramRange === null ||
-        (model.param_count_b >= filters.paramRange[0] && model.param_count_b <= filters.paramRange[1]);
+        (model.paramCountB >= filters.paramRange[0] && model.paramCountB <= filters.paramRange[1]);
 
       const matchesContext =
         filters.contextRange === null ||
-        model.context_length === undefined ||
-        model.context_length === null ||
-        (model.context_length >= filters.contextRange[0] && model.context_length <= filters.contextRange[1]);
+        model.contextLength === undefined ||
+        model.contextLength === null ||
+        (model.contextLength >= filters.contextRange[0] && model.contextLength <= filters.contextRange[1]);
 
       const matchesQuantization =
         filters.selectedQuantizations.length === 0 ||

--- a/src/pages/modelControlCenter/useMccMenuActions.ts
+++ b/src/pages/modelControlCenter/useMccMenuActions.ts
@@ -74,7 +74,7 @@ export function useMccMenuActions({
         
         if (selectedModelId) {
           // Try to find server for selected model
-          serverToOpen = servers.find((s) => s.model_id === selectedModelId);
+          serverToOpen = servers.find((s) => s.modelId === selectedModelId);
         }
         
         if (!serverToOpen && servers.length > 0) {
@@ -83,7 +83,7 @@ export function useMccMenuActions({
         }
         
         if (serverToOpen) {
-          openChatSession(serverToOpen.model_id, 'chat');
+          openChatSession(serverToOpen.modelId, 'chat');
         } else {
           // No servers running - show helpful message
           showToast('No servers are currently running. Start a server first to use chat.', 'warning');
@@ -100,7 +100,7 @@ export function useMccMenuActions({
       },
       stopServer: async () => {
         if (!selectedModelId) return;
-        const runningServer = servers.find((s) => s.model_id === selectedModelId);
+        const runningServer = servers.find((s) => s.modelId === selectedModelId);
         if (runningServer) {
           await stopServer(selectedModelId);
           if (chatSessionModelId === selectedModelId) {
@@ -128,7 +128,7 @@ export function useMccMenuActions({
       },
       selectModel: (modelId: number, view?: 'chat' | 'console') => {
         if (view) {
-          const server = servers.find((s) => s.model_id === modelId);
+          const server = servers.find((s) => s.modelId === modelId);
           if (server) {
             openChatSession(modelId, view);
           }

--- a/src/services/transport/mappers.ts
+++ b/src/services/transport/mappers.ts
@@ -69,21 +69,21 @@ export interface UpdateConversationRequest {
 export function toStartServerRequest(config: ServeConfig): StartServerRequest {
   // Build inference params object only if any values are set
   const hasInferenceParams = config.temperature !== undefined || 
-    config.top_p !== undefined || 
-    config.top_k !== undefined || 
-    config.max_tokens !== undefined || 
-    config.repeat_penalty !== undefined;
+    config.topP !== undefined || 
+    config.topK !== undefined || 
+    config.maxTokens !== undefined || 
+    config.repeatPenalty !== undefined;
   
   const inferenceParams = hasInferenceParams ? {
     temperature: config.temperature,
-    topP: config.top_p,
-    topK: config.top_k,
-    maxTokens: config.max_tokens,
-    repeatPenalty: config.repeat_penalty,
+    topP: config.topP,
+    topK: config.topK,
+    maxTokens: config.maxTokens,
+    repeatPenalty: config.repeatPenalty,
   } : undefined;
 
   return {
-    contextLength: config.context_length,
+    contextLength: config.contextLength,
     port: config.port,
     mlock: config.mlock ?? false,
     jinja: config.jinja,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,16 +32,16 @@ export interface InferenceConfig {
 export interface GgufModel {
   id?: number;
   name: string;
-  file_path: string;
-  param_count_b: number;
+  filePath: string;
+  paramCountB: number;
   architecture?: string;
   quantization?: string;
-  context_length?: number;
-  added_at: string;
-  hf_repo_id?: string;
+  contextLength?: number;
+  addedAt: string;
+  hfRepoId?: string;
   tags?: string[];
   // Server status
-  is_serving?: boolean;
+  isServing?: boolean;
   port?: number;
   // Inference defaults
   inferenceDefaults?: InferenceConfig;
@@ -54,21 +54,21 @@ export interface DownloadConfig {
 
 export interface ServeConfig {
   id: number;
-  context_length?: number;
+  contextLength?: number;
   mlock?: boolean;
   port?: number;
   jinja?: boolean;
   // Inference parameters for this serve session
   temperature?: number;
-  top_p?: number;
-  top_k?: number;
-  max_tokens?: number;
-  repeat_penalty?: number;
+  topP?: number;
+  topK?: number;
+  maxTokens?: number;
+  repeatPenalty?: number;
 }
 
 export interface ServerInfo {
-  model_id: number;
-  model_name: string;
+  modelId: number;
+  modelName: string;
   port: number;
   status: string;
 }
@@ -76,43 +76,43 @@ export interface ServerInfo {
 export interface ModelsDirectoryInfo {
   path: string;
   source: 'explicit' | 'env' | 'default';
-  default_path: string;
+  defaultPath: string;
   exists: boolean;
   writable: boolean;
 }
 
 export interface AppSettings {
-  default_download_path?: string | null;
-  default_context_size?: number | null;
-  proxy_port?: number | null;
-  llama_base_port?: number | null;
-  max_download_queue_size?: number | null;
-  title_generation_prompt?: string | null;
-  show_memory_fit_indicators?: boolean | null;
+  defaultDownloadPath?: string | null;
+  defaultContextSize?: number | null;
+  proxyPort?: number | null;
+  llamaBasePort?: number | null;
+  maxDownloadQueueSize?: number | null;
+  titleGenerationPrompt?: string | null;
+  showMemoryFitIndicators?: boolean | null;
   /** Maximum iterations for tool calling agentic loop (default: 25) */
-  max_tool_iterations?: number | null;
+  maxToolIterations?: number | null;
   /** Maximum stagnation steps before stopping agent loop (default: 5) */
-  max_stagnation_steps?: number | null;
+  maxStagnationSteps?: number | null;
   /** Default model ID for quick commands (e.g., `gglib question`) */
-  default_model_id?: number | null;
+  defaultModelId?: number | null;
   /** Global inference parameter defaults */
   inferenceDefaults?: InferenceConfig | null;
 }
 
 export interface UpdateSettingsRequest {
-  default_download_path?: string | null | undefined;
-  default_context_size?: number | null | undefined;
-  proxy_port?: number | null | undefined;
-  llama_base_port?: number | null | undefined;
-  max_download_queue_size?: number | null | undefined;
-  title_generation_prompt?: string | null | undefined;
-  show_memory_fit_indicators?: boolean | null | undefined;
+  defaultDownloadPath?: string | null | undefined;
+  defaultContextSize?: number | null | undefined;
+  proxyPort?: number | null | undefined;
+  llamaBasePort?: number | null | undefined;
+  maxDownloadQueueSize?: number | null | undefined;
+  titleGenerationPrompt?: string | null | undefined;
+  showMemoryFitIndicators?: boolean | null | undefined;
   /** Maximum iterations for tool calling agentic loop (default: 25) */
-  max_tool_iterations?: number | null | undefined;
+  maxToolIterations?: number | null | undefined;
   /** Maximum stagnation steps before stopping agent loop (default: 5) */
-  max_stagnation_steps?: number | null | undefined;
+  maxStagnationSteps?: number | null | undefined;
   /** Default model ID for quick commands (e.g., `gglib question`) */
-  default_model_id?: number | null | undefined;
+  defaultModelId?: number | null | undefined;
   /** Global inference parameter defaults */
   inferenceDefaults?: InferenceConfig | null | undefined;
 }


### PR DESCRIPTION
Closes #151

## Summary

Fixes the GUI display bug where model data was showing as "NaNM" for size and empty paths after downloads. This was caused by an incomplete refactoring in commit e1af0cd where the backend switched to camelCase serialization but the frontend TypeScript interfaces weren't fully updated.

## Root Cause

In commit e1af0cd ("feat: Per-Model and Global Inference Parameter Defaults with Hierarchy Resolution #149"), the backend added `#[serde(rename_all = "camelCase")]` to the `GuiModel` struct, changing API serialization from snake_case to camelCase for all fields. However, only the new `inferenceDefaults` field was added to the TypeScript interface in camelCase - existing fields were not updated to match.

This caused the frontend to receive `undefined` values when accessing properties like `param_count_b` (API sends `paramCountB`), resulting in "NaNM" display and other UI issues.

## Changes

### Commit 1: Type Definitions (f17e0b7)
Updated all TypeScript interfaces in `src/types/index.ts` to use camelCase:
- `GgufModel`: `file_path` → `filePath`, `param_count_b` → `paramCountB`, etc.
- `ServeConfig`: `context_length` → `contextLength`, `top_p` → `topP`, etc.
- `ServerInfo`: `model_id` → `modelId`, `model_name` → `modelName`
- `ModelsDirectoryInfo`: `default_path` → `defaultPath`
- `AppSettings`: All settings fields to camelCase
- `UpdateSettingsRequest`: All fields to camelCase

### Commit 2: Component Updates (c448aff)
Updated 19 component/hook files to use the new camelCase properties:
- Model Inspector components (ModelMetadataGrid, ModelEditForm, ServeModal)
- Model list views (ModelList, ModelsListContent)
- Server components (ServerList, ServerStatus)
- Settings components (SettingsModal, GeneralSettings)
- Hooks (useModels, useEditMode, useServerActions, useSystemMemory)
- Pages (ChatPage, ModelControlCenterPage, MCC filters/actions)
- Transport layer (mappers for API request payloads)

## Verification

- **Database**: ✅ Contains correct data (verified with SQL query)
- **CLI**: ✅ Displays correctly (verified with `gglib list`)
- **API**: ✅ Returns correct data in camelCase format (verified with curl)
- **TypeScript**: ✅ All compilation checks pass (`npx tsc --noEmit`)
- **Frontend**: Ready for testing - should now display model data correctly

## Testing

After this PR is merged:
1. Open the GUI at http://localhost:5173
2. Navigate to model inspector panel
3. Verify DeepSeek-R1-Distill-Qwen-32B shows "32.0B" instead of "NaNM"
4. Verify file path displays correctly
5. Check all model metadata fields render properly across all views

## Impact

- **Breaking**: None - this completes an incomplete backend change
- **Database**: No migration needed
- **CLI**: No changes
- **GUI**: Fixes display bug, restores proper model data visualization
