### PR TITLE
fix(proxy): add user-facing terminal output for proxy command

### DIFF
--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -71,17 +71,42 @@ pub async fn start_proxy_standalone(
         default_context,
     };
 
+    // Show startup banner
+    println!();
+    println!("  🚀 gglib proxy starting...");
+    println!();
+    println!("  Host:            {}", host);
+    println!("  Port:            {}", port);
+    println!("  Llama base port: {}", llama_base_port);
+    println!("  Default context: {}", default_context);
+    println!();
+
     let addr = supervisor
         .start(config, runtime_port, catalog_port)
         .await
         .map_err(|e| anyhow!("{e}"))?;
     tracing::info!("Proxy started on {addr}");
 
+    // Show success message with configuration URL
+    println!("  ✓ Proxy started successfully on {}", addr);
+    println!();
+    println!("  Configure OpenWebUI to use: http://{}/v1", addr);
+    println!();
+    println!("  Press Ctrl+C to stop");
+    println!();
+
     // Wait for Ctrl-C
     tokio::signal::ctrl_c().await?;
 
+    // Show shutdown message
+    println!();
+    println!("  Shutting down proxy...");
+
     // Stop proxy
     supervisor.stop().await.map_err(|e| anyhow!("{e}"))?;
+
+    println!("  Proxy stopped");
+    println!();
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #155 - The `gglib proxy` command was appearing to hang with no output due to relying solely on `tracing::info!()` which doesn't print to stdout by default.

## Root Cause

**Regression from PR #145** (commit a892b06) - "Consolidate logging patterns"

The logging consolidation migrated all user-facing output to structured logging, but the proxy command needed dual-layer output (both user-facing `println!()` and structured `tracing::info!()`).

## Changes

Added user-friendly terminal output to `start_proxy_standalone()`:

**Before starting:**
```
  🚀 gglib proxy starting...

  Host:            127.0.0.1
  Port:            8080
  Llama base port: 5500
  Default context: 4096
```

**After successful start:**
```
  ✓ Proxy started successfully on 127.0.0.1:8080

  Configure OpenWebUI to use: http://127.0.0.1:8080/v1

  Press Ctrl+C to stop
```

**On shutdown (Ctrl+C):**
``
Fixes #155 - The `gglib proxy` command was appearing to hang with no output due to relying solely onle 
## Root Cause

**Regression from PR #145** (commit a892b06) - "Consolidate logging patterns"

The logging consolidation migrated all user-facing output to structomm
**Regressio se
The logging consolidation migrated all user-facing output to structured loggifor
## Changes

Added user-friendly terminal output to `start_proxy_standalone()`:

**Before starting:**
```
  🚀 gglib proxy starting...

  Host:            127.0.0.1
  Port:            8080
 ✅
Added usocu
**Before starting:**
```
  🚀 gglib proxy starting...

  Hoststi```
  🚀 ggliber  ? 
  Host:            127.0.0.1**R  Port:            808n**: PR  Llama base port: 550
-  Default context: 40936```

**After succes p
**Afns```