### PR TITLE
Fix HuggingFace search tags display and import HF tags during registration

### DIFF
--- a/crates/gglib-core/src/ports/model_registrar.rs
+++ b/crates/gglib-core/src/ports/model_registrar.rs
@@ -34,6 +34,8 @@ pub struct CompletedDownload {
     pub total_bytes: u64,
     /// Ordered list of all file paths for sharded models (None for single-file models).
     pub file_paths: Option<Vec<std::path::PathBuf>>,
+    /// HuggingFace tags for the model.
+    pub hf_tags: Vec<String>,
 }
 
 impl CompletedDownload {

--- a/crates/gglib-core/src/ports/model_registrar.rs
+++ b/crates/gglib-core/src/ports/model_registrar.rs
@@ -34,7 +34,7 @@ pub struct CompletedDownload {
     pub total_bytes: u64,
     /// Ordered list of all file paths for sharded models (None for single-file models).
     pub file_paths: Option<Vec<std::path::PathBuf>>,
-    /// HuggingFace tags for the model.
+    /// `HuggingFace` tags for the model.
     pub hf_tags: Vec<String>,
 }
 

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -257,7 +257,7 @@ pub struct DownloadManagerImpl {
     _download_repo: Arc<dyn DownloadStateRepositoryPort>,
     /// Event emitter for download events.
     event_emitter: Arc<dyn DownloadEventEmitterPort>,
-    /// HuggingFace client for fetching model metadata.
+    /// `HuggingFace` client for fetching model metadata.
     hf_client: Arc<dyn HfClientPort>,
     /// File resolver.
     resolver: HfQuantizationResolver,

--- a/crates/gglib-download/src/manager/shard_group_tracker.rs
+++ b/crates/gglib-download/src/manager/shard_group_tracker.rs
@@ -25,7 +25,7 @@ pub struct GroupMetadata {
     pub quantization: Quantization,
     /// Primary filename (first shard filename).
     pub primary_filename: String,
-    /// HuggingFace tags for the model.
+    /// `HuggingFace` tags for the model.
     pub hf_tags: Vec<String>,
 }
 

--- a/crates/gglib-download/src/manager/shard_group_tracker.rs
+++ b/crates/gglib-download/src/manager/shard_group_tracker.rs
@@ -25,6 +25,8 @@ pub struct GroupMetadata {
     pub quantization: Quantization,
     /// Primary filename (first shard filename).
     pub primary_filename: String,
+    /// HuggingFace tags for the model.
+    pub hf_tags: Vec<String>,
 }
 
 /// State for a shard group being tracked.
@@ -209,6 +211,7 @@ mod tests {
             commit_sha: "abc123".to_string(),
             quantization: Quantization::Q4KM,
             primary_filename: "model-00001-of-00003.gguf".to_string(),
+            hf_tags: vec![],
         }
     }
 

--- a/crates/gglib-gui/src/downloads.rs
+++ b/crates/gglib-gui/src/downloads.rs
@@ -178,7 +178,7 @@ impl<'a> DownloadOps<'a> {
                     last_modified: m.last_modified,
                     parameters_b: m.parameters_b,
                     description: m.description,
-                    tags: vec![],
+                    tags: m.tags,
                 })
                 .collect(),
             has_more: response.has_more,

--- a/crates/gglib-hf/src/url.rs
+++ b/crates/gglib-hf/src/url.rs
@@ -10,7 +10,7 @@ use crate::models::{HfConfig, HfRepoRef, HfSearchQuery};
 use url::Url;
 
 /// Fields to explicitly expand in API requests.
-const EXPAND_FIELDS: &[&str] = &["siblings", "gguf", "likes", "downloads"];
+const EXPAND_FIELDS: &[&str] = &["siblings", "gguf", "likes", "downloads", "tags"];
 
 /// Build the expand parameters string for API URLs.
 fn build_expand_params() -> String {
@@ -110,7 +110,8 @@ mod tests {
         assert!(params.contains("expand[]=gguf"));
         assert!(params.contains("expand[]=likes"));
         assert!(params.contains("expand[]=downloads"));
-        assert_eq!(params.matches("expand[]=").count(), 4);
+        assert!(params.contains("expand[]=tags"));
+        assert_eq!(params.matches("expand[]=").count(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #164 

This PR addresses the missing tags issue in HuggingFace search results and enhances model registration by importing HuggingFace tags with intelligent filtering.

## Changes

### 1. Fix Missing Tags in Search Results (Commit 1)
**Problem:** Tags were being discarded when displaying models from search results, even though the data was available.

**Solution:** Changed `tags: vec![]` to `tags: m.tags` in [downloads.rs:180](https://github.com/mmogr/gglib/blob/fix/hf-search-tags/crates/gglib-gui/src/downloads.rs#L180)

**Impact:** Tags now display consistently whether viewing a model directly or from search results.

### 2. Import HuggingFace Tags During Model Registration (Commit 2)
**Problem:** Only GGUF-derived capability tags (reasoning, agent, vision) were stored in the database. HF tags containing architecture names, task types, and other metadata were discarded.

**Solution:**
- Add `hf_tags` field to `CompletedDownload` and `GroupMetadata` structs
- Store `HfClient` in `DownloadManagerImpl` to fetch model metadata
- Automatically fetch HF model info during download completion
- Implement blocklist filter to remove noisy tags:
  - `gguf` (redundant - everything is GGUF)
  - `arxiv:*` (paper references)
  - `region:*` (geographic metadata)
  - `license:*` (legal metadata - stored separately if needed)
  - `dataset:*` (training data references)
- Merge filtered HF tags with GGUF-derived tags
- Deduplicate final tag list (GGUF tags prioritized)

**Impact:**
- Improved offline model discovery with architecture tags (llama, mistral, qwen, etc.)
- Better categorization with task tags (conversational, instruction, coding, etc.)
- Richer metadata without manual tagging
- No backwards compatibility issues (only affects new downloads)

## Implementation Details

**Data Flow:**
1. Download completes → `register_completed_model()` called
2. Fetch HF model info to get tags (soft fail if unavailable)
3. Pass tags through `CompletedDownload` to `ModelRegistrar`
4. Filter tags with blocklist, merge with GGUF tags, deduplicate
5. Store final tag list in database

**Example Tag Result:**
```
GGUF-derived: ["reasoning", "vision"]
HF tags:      ["llama", "conversational", "multilingual", "4bit", "gguf", "arxiv:2305.03047"]
Filtered HF:  ["llama", "conversational", "multilingual"]
Final:        ["reasoning", "vision", "llama", "conversational", "multilingual"]
```

## Testing

- ✅ All packages compile successfully
- ✅ Existing tests pass with struct updates
- ✅ Manual testing recommended:
  - Search for a model → verify tags appear
  - Download a new model → verify both GGUF and HF tags are stored
  - Verify blocklisted tags are excluded

## Backwards Compatibility

No concerns - this only affects new model downloads. Existing models retain their current tags.

## Future Enhancements

- Add UI visual distinction for tag sources (system vs HF)
- Periodic tag sync/refresh option
- User-customizable blocklist