### PR TITLE
fix: extract startGeneration helper and fix onEdit message vanish bug

### DIFF
--- a/src/hooks/useChatPersistence.ts
+++ b/src/hooks/useChatPersistence.ts
@@ -241,6 +241,12 @@ export function useChatPersistence({
       // Skip messages without IDs or system messages
       if (!m.id || m.role === 'system') continue;
 
+      // Skip assistant messages that are still streaming (not yet finalized).
+      // The agentic loop sets timingFinalized after streaming completes;
+      // without this guard, partial content is saved as a new DB row on every
+      // streaming update and then the completed content creates another row.
+      if (m.role === 'assistant' && !(m.metadata as any)?.custom?.timingFinalized) continue;
+
       // Skip if already processing this message ID
       if (processingRef.current.has(m.id) || isPersistingRef.current) continue;
 

--- a/src/hooks/useChatPersistence.ts
+++ b/src/hooks/useChatPersistence.ts
@@ -10,7 +10,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { appLogger } from '../services/platform';
 import type { ThreadMessageLike } from '@assistant-ui/react';
-import { getMessages, saveMessage } from '../services/clients/chat';
+import { getMessages, saveMessage, updateMessage, deleteMessage } from '../services/clients/chat';
 import type { ChatMessage } from '../services/clients/chat';
 import { threadMessageToTranscriptMarkdown } from '../utils/messages';
 import type { ReasoningTimingTracker } from './useGglibRuntime/reasoningTiming';
@@ -190,6 +190,52 @@ export function useChatPersistence({
     const conversationId = activeConversationId;
     if (!conversationId) return;
 
+    // --- Detect and delete truncated messages ---
+    // When onEdit truncates the in-memory array, old messages remain in the DB.
+    // Compare current message IDs against persistedByMessageId to find orphans,
+    // then cascade-delete the first one (backend removes it and all subsequent).
+    const currentIds = new Set(messages.map(m => m.id));
+    let firstOrphanDbId: number | null = null;
+
+    for (const [runtimeId, dbId] of persistedByMessageId.current.entries()) {
+      if (!currentIds.has(runtimeId)) {
+        // This persisted message is no longer in the current array
+        if (firstOrphanDbId === null || dbId < firstOrphanDbId) {
+          firstOrphanDbId = dbId;
+        }
+        // Clean up tracking state for the removed message
+        persistedByMessageId.current.delete(runtimeId);
+        lastDigestByMessageId.current.delete(runtimeId);
+        const timer = updateTimers.current.get(runtimeId);
+        if (timer) {
+          window.clearTimeout(timer);
+          updateTimers.current.delete(runtimeId);
+        }
+        const ct = cleanupTimers.current.get(runtimeId);
+        if (ct) {
+          window.clearTimeout(ct);
+          cleanupTimers.current.delete(runtimeId);
+        }
+      }
+    }
+
+    if (firstOrphanDbId !== null) {
+      // Cascade delete: backend removes this message and all with higher IDs
+      // in the same conversation
+      const dbIdToDelete = firstOrphanDbId;
+      (async () => {
+        try {
+          const result = await deleteMessage(dbIdToDelete);
+          appLogger.info('hook.persistence', 'Cascade-deleted truncated messages from DB', {
+            firstDeletedDbId: dbIdToDelete,
+            deletedCount: result.deletedCount,
+          });
+        } catch (error) {
+          appLogger.error('hook.persistence', 'Failed to delete truncated messages', { error });
+        }
+      })();
+    }
+
     // Process each message
     for (const m of messages) {
       // Skip messages without IDs or system messages
@@ -263,11 +309,7 @@ export function useChatPersistence({
                 : undefined
             );
             if (text.trim() && existingDbId) {
-              await saveMessage(
-                conversationId,
-                m.role as ChatMessage['role'],
-                text
-              );
+              await updateMessage(existingDbId, text);
               await syncConversations({ silent: true });
               
               // Cleanup timing data after successful persist (prevent memory growth)


### PR DESCRIPTION
## Summary

Fixes #174 — Three layers of bugs caused message editing to break and produce duplicate/fragmented messages in the database.

## Root Causes & Fixes

### Commit 1: Runtime bugs (`useGglibRuntime.ts`)

Three compounding bugs in `onEdit`:

1. **Off-by-one truncation**: `msg.parentId` is the message *before* the edited one. `slice(0, parentIdx)` excluded it. Fixed to `slice(0, parentIdx + 1)`.

2. **Infinite recursion**: `onEdit` called `runtime.thread.append(msg)` which re-entered `onEdit` (stale internal state) → stack overflow → silent failure.

3. **Stale `messagesRef`**: Synced via `useEffect` (post-render), so async callbacks saw old data.

**Fix**: Extract shared `startGeneration()` helper used by both `onNew` and `onEdit`. Synchronises `messagesRef.current` immediately, invokes `runAgenticLoop` directly.

### Commit 2: Persistence truncation (`useChatPersistence.ts`)

4. **No deletion of truncated messages**: When `onEdit` truncated the in-memory array, old messages remained in the DB. On reload, hydration loaded all of them → duplicated/fragmented messages.

5. **Case 2 used `saveMessage` instead of `updateMessage`**: Content updates during streaming created duplicate DB rows instead of updating in-place.

**Fix**: Effect 2 now detects orphaned messages (persisted IDs not in current array), cascade-deletes the first one. Case 2 calls `updateMessage`.

### Commit 3: Duplicate persistence hooks

6. **Two persistence hooks running simultaneously**: `ChatPage.tsx` used the hooks-level `useChatPersistence` (for ExternalStoreRuntime), while `ChatMessagesPanel.tsx` also had a component-level `useChatPersistence` (legacy, for LocalRuntime). Both independently saved every message → every user message saved twice, every assistant message saved as fragment + full.

**Fix**: Remove the persist effect from the component-level hook (keep hydration + `dbIdByPosition` for delete UI). Add a streaming guard in the hooks-level hook: skip assistant messages until `timingFinalized` is set (after streaming completes), preventing partial content from being saved as separate DB rows.

## Changes

- `src/hooks/useGglibRuntime/useGglibRuntime.ts`: Extract `startGeneration` helper; fix `onEdit` truncation, recursion, and stale ref
- `src/hooks/useChatPersistence.ts`: Detect and cascade-delete orphaned messages; fix update path; guard against streaming saves
- `src/components/ChatMessagesPanel/hooks/useChatPersistence.ts`: Remove persist effect (now handled exclusively by hooks-level hook); clean up unused imports

## Testing

- Edit a user message mid-conversation → preceding messages preserved, edited message replaced, new response streams in
- Reopen app after editing → messages consistent, no duplicates or fragments
- Each user message appears exactly once in DB
- Each assistant message appears exactly once in DB (only after streaming completes)
- Message deletion UI still works (dbIdByPosition preserved)
- Cancel during regeneration → generation stops cleanly