### PR TITLE
safety(voice): remove unsafe impl Send/Sync via audio thread actor

### DIFF
--- a/crates/gglib-voice/Cargo.toml
+++ b/crates/gglib-voice/Cargo.toml
@@ -8,10 +8,9 @@ authors.workspace = true
 description = "Voice mode for gglib - local STT and TTS pipeline via sherpa-onnx"
 publish = false
 
-# gglib-voice wraps FFI crates (cpal, sherpa-rs) that need unsafe Send/Sync impls,
-# so we override the workspace-level deny(unsafe_code) to warn.
+# No unsafe code — audio I/O is isolated on a dedicated OS thread via channels.
 [lints.rust]
-unsafe_code = "warn"
+unsafe_code = "deny"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/crates/gglib-voice/src/audio_thread.rs
+++ b/crates/gglib-voice/src/audio_thread.rs
@@ -31,9 +31,7 @@ enum AudioCommand {
     },
 
     /// Query whether the microphone is currently recording.
-    IsRecording {
-        reply: mpsc::Sender<bool>,
-    },
+    IsRecording { reply: mpsc::Sender<bool> },
 
     /// Prepare a streaming playback sink (echo gate activated).
     StartStreaming {
@@ -51,9 +49,7 @@ enum AudioCommand {
     StopPlayback,
 
     /// Query whether audio is currently playing.
-    IsPlaying {
-        reply: mpsc::Sender<bool>,
-    },
+    IsPlaying { reply: mpsc::Sender<bool> },
 
     /// Spawn a background watcher that fires `on_done` when the sink drains.
     SpawnCompletionWatcher {
@@ -99,12 +95,12 @@ impl AudioThreadHandle {
             .spawn(move || {
                 Self::run(gate_clone, cmd_rx, init_tx);
             })
-            .map_err(|e| VoiceError::InputStreamError(format!("failed to spawn audio thread: {e}")))?;
+            .map_err(|e| {
+                VoiceError::InputStreamError(format!("failed to spawn audio thread: {e}"))
+            })?;
 
         // Wait for the audio thread to finish initialisation.
-        init_rx
-            .recv()
-            .map_err(|_| VoiceError::AudioThreadDied)??;
+        init_rx.recv().map_err(|_| VoiceError::AudioThreadDied)??;
 
         Ok(Self {
             cmd_tx,
@@ -183,10 +179,7 @@ impl AudioThreadHandle {
 
     /// Like `send_and_recv` but for simple queries that return a bare value
     /// (no `Result` wrapper). Returns `None` if the thread is dead.
-    fn query<T>(
-        &self,
-        build: impl FnOnce(mpsc::Sender<T>) -> AudioCommand,
-    ) -> Option<T> {
+    fn query<T>(&self, build: impl FnOnce(mpsc::Sender<T>) -> AudioCommand) -> Option<T> {
         let (tx, rx) = mpsc::channel();
         self.cmd_tx.send(build(tx)).ok()?;
         rx.recv().ok()

--- a/crates/gglib-voice/src/audio_thread.rs
+++ b/crates/gglib-voice/src/audio_thread.rs
@@ -84,7 +84,7 @@ impl AudioThreadHandle {
     ///
     /// Errors from `AudioCapture::new` / `AudioPlayback::new` are propagated
     /// back to the caller via a one-shot init channel.
-    pub fn spawn(echo_gate: EchoGate) -> Result<Self, VoiceError> {
+    pub fn spawn(echo_gate: &EchoGate) -> Result<Self, VoiceError> {
         let (cmd_tx, cmd_rx) = mpsc::channel::<AudioCommand>();
         let (init_tx, init_rx) = mpsc::channel::<Result<(), VoiceError>>();
 
@@ -190,6 +190,7 @@ impl AudioThreadHandle {
     /// The body of the dedicated audio thread. Owns `AudioCapture` and
     /// `AudioPlayback` for their entire lifetime — they never cross thread
     /// boundaries.
+    #[allow(clippy::needless_pass_by_value)] // cmd_rx and init_tx are consumed
     fn run(
         echo_gate: EchoGate,
         cmd_rx: mpsc::Receiver<AudioCommand>,

--- a/crates/gglib-voice/src/audio_thread.rs
+++ b/crates/gglib-voice/src/audio_thread.rs
@@ -1,0 +1,287 @@
+//! Dedicated audio I/O thread — isolates `!Send` audio resources from the async runtime.
+//!
+//! `cpal::Stream` (capture) and `rodio::OutputStream` (playback) are `!Send` on
+//! some platforms. Rather than using `unsafe impl Send/Sync` on the pipeline, we
+//! confine both types to a single OS thread and communicate via channels.
+//!
+//! The public [`AudioThreadHandle`] is the `Send + Sync` proxy that the pipeline
+//! holds. It exposes the same logical operations as `AudioCapture` / `AudioPlayback`
+//! but routes every call through an [`AudioCommand`] sent to the actor thread.
+
+use std::sync::mpsc;
+use std::thread;
+
+use crate::capture::AudioCapture;
+use crate::error::VoiceError;
+use crate::gate::EchoGate;
+use crate::playback::{AudioPlayback, PlaybackDoneCallback};
+
+// ── Commands ───────────────────────────────────────────────────────
+
+/// A command sent from the pipeline to the audio thread.
+enum AudioCommand {
+    /// Begin recording from the microphone.
+    StartCapture {
+        reply: mpsc::Sender<Result<(), VoiceError>>,
+    },
+
+    /// Stop recording and return the captured 16 kHz mono PCM samples.
+    StopCapture {
+        reply: mpsc::Sender<Result<Vec<f32>, VoiceError>>,
+    },
+
+    /// Query whether the microphone is currently recording.
+    IsRecording {
+        reply: mpsc::Sender<bool>,
+    },
+
+    /// Prepare a streaming playback sink (echo gate activated).
+    StartStreaming {
+        reply: mpsc::Sender<Result<(), VoiceError>>,
+    },
+
+    /// Append audio samples to the current playback sink.
+    Append {
+        samples: Vec<f32>,
+        sample_rate: u32,
+        reply: mpsc::Sender<Result<(), VoiceError>>,
+    },
+
+    /// Stop any active playback immediately (fire-and-forget).
+    StopPlayback,
+
+    /// Query whether audio is currently playing.
+    IsPlaying {
+        reply: mpsc::Sender<bool>,
+    },
+
+    /// Spawn a background watcher that fires `on_done` when the sink drains.
+    SpawnCompletionWatcher {
+        on_done: Option<PlaybackDoneCallback>,
+    },
+
+    /// Shut down the audio thread, releasing all resources.
+    Shutdown,
+}
+
+// ── Handle (Send + Sync proxy) ─────────────────────────────────────
+
+/// `Send + Sync` handle to the dedicated audio I/O thread.
+///
+/// `cpal::Stream` and `rodio::OutputStream` are `!Send` on some platforms
+/// (macOS CoreAudio, etc.). This handle confines both types to a single OS
+/// thread and proxies every operation through an `mpsc` channel, making the
+/// pipeline naturally `Send + Sync` without any `unsafe` impls.
+///
+/// All methods take `&self` — the underlying `mpsc::Sender` supports shared
+/// access. Request–reply methods block the caller until the audio thread
+/// responds; this latency is negligible (microseconds of local channel I/O
+/// plus the audio operation itself).
+pub struct AudioThreadHandle {
+    cmd_tx: mpsc::Sender<AudioCommand>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl AudioThreadHandle {
+    /// Spawn the audio thread, initialise capture + playback, and return
+    /// the handle.
+    ///
+    /// Errors from `AudioCapture::new` / `AudioPlayback::new` are propagated
+    /// back to the caller via a one-shot init channel.
+    pub fn spawn(echo_gate: EchoGate) -> Result<Self, VoiceError> {
+        let (cmd_tx, cmd_rx) = mpsc::channel::<AudioCommand>();
+        let (init_tx, init_rx) = mpsc::channel::<Result<(), VoiceError>>();
+
+        let gate_clone = echo_gate.clone();
+
+        let thread = thread::Builder::new()
+            .name("gglib-audio".into())
+            .spawn(move || {
+                Self::run(gate_clone, cmd_rx, init_tx);
+            })
+            .map_err(|e| VoiceError::InputStreamError(format!("failed to spawn audio thread: {e}")))?;
+
+        // Wait for the audio thread to finish initialisation.
+        init_rx
+            .recv()
+            .map_err(|_| VoiceError::AudioThreadDied)??;
+
+        Ok(Self {
+            cmd_tx,
+            thread: Some(thread),
+        })
+    }
+
+    // ── Capture ────────────────────────────────────────────────────
+
+    /// Begin recording from the microphone.
+    pub fn start_capture(&self) -> Result<(), VoiceError> {
+        self.send_and_recv(|reply| AudioCommand::StartCapture { reply })
+    }
+
+    /// Stop recording and return captured 16 kHz mono PCM samples.
+    pub fn stop_capture(&self) -> Result<Vec<f32>, VoiceError> {
+        self.send_and_recv(|reply| AudioCommand::StopCapture { reply })
+    }
+
+    /// Check whether the microphone is currently recording.
+    pub fn is_recording(&self) -> bool {
+        self.query(|reply| AudioCommand::IsRecording { reply })
+            .unwrap_or(false)
+    }
+
+    // ── Playback ───────────────────────────────────────────────────
+
+    /// Prepare a streaming playback sink (echo gate activated).
+    pub fn start_streaming(&self) -> Result<(), VoiceError> {
+        self.send_and_recv(|reply| AudioCommand::StartStreaming { reply })
+    }
+
+    /// Append audio samples to the current playback sink.
+    pub fn append(&self, samples: Vec<f32>, sample_rate: u32) -> Result<(), VoiceError> {
+        self.send_and_recv(|reply| AudioCommand::Append {
+            samples,
+            sample_rate,
+            reply,
+        })
+    }
+
+    /// Stop any active playback immediately (fire-and-forget).
+    pub fn stop_playback(&self) {
+        let _ = self.cmd_tx.send(AudioCommand::StopPlayback);
+    }
+
+    /// Check whether audio is currently playing.
+    pub fn is_playing(&self) -> bool {
+        self.query(|reply| AudioCommand::IsPlaying { reply })
+            .unwrap_or(false)
+    }
+
+    /// Spawn a background watcher that fires `on_done` when the sink drains.
+    pub fn spawn_completion_watcher(&self, on_done: Option<PlaybackDoneCallback>) {
+        let _ = self
+            .cmd_tx
+            .send(AudioCommand::SpawnCompletionWatcher { on_done });
+    }
+
+    // ── Internal helpers ───────────────────────────────────────────
+
+    /// Send a command that expects a `Result<T, VoiceError>` reply. Creates
+    /// a one-shot reply channel, sends the command, and blocks until the
+    /// audio thread responds. Channel failures map to
+    /// [`VoiceError::AudioThreadDied`].
+    fn send_and_recv<T>(
+        &self,
+        build: impl FnOnce(mpsc::Sender<Result<T, VoiceError>>) -> AudioCommand,
+    ) -> Result<T, VoiceError> {
+        let (tx, rx) = mpsc::channel();
+        self.cmd_tx
+            .send(build(tx))
+            .map_err(|_| VoiceError::AudioThreadDied)?;
+        rx.recv().map_err(|_| VoiceError::AudioThreadDied)?
+    }
+
+    /// Like `send_and_recv` but for simple queries that return a bare value
+    /// (no `Result` wrapper). Returns `None` if the thread is dead.
+    fn query<T>(
+        &self,
+        build: impl FnOnce(mpsc::Sender<T>) -> AudioCommand,
+    ) -> Option<T> {
+        let (tx, rx) = mpsc::channel();
+        self.cmd_tx.send(build(tx)).ok()?;
+        rx.recv().ok()
+    }
+
+    // ── Audio thread event loop ────────────────────────────────────
+
+    /// The body of the dedicated audio thread. Owns `AudioCapture` and
+    /// `AudioPlayback` for their entire lifetime — they never cross thread
+    /// boundaries.
+    fn run(
+        echo_gate: EchoGate,
+        cmd_rx: mpsc::Receiver<AudioCommand>,
+        init_tx: mpsc::Sender<Result<(), VoiceError>>,
+    ) {
+        // ── Initialise audio I/O on *this* thread ──────────────────
+        let capture = match AudioCapture::new(echo_gate.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = init_tx.send(Err(e));
+                return;
+            }
+        };
+
+        let playback = match AudioPlayback::new(echo_gate) {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = init_tx.send(Err(e));
+                return;
+            }
+        };
+
+        // Signal successful init.
+        if init_tx.send(Ok(())).is_err() {
+            // Caller dropped — nothing to do.
+            return;
+        }
+
+        let mut capture = capture;
+        let mut playback = playback;
+
+        // ── Command loop (tight: recv → execute → reply → recv) ────
+        while let Ok(cmd) = cmd_rx.recv() {
+            match cmd {
+                AudioCommand::StartCapture { reply } => {
+                    let _ = reply.send(capture.start_recording());
+                }
+
+                AudioCommand::StopCapture { reply } => {
+                    let _ = reply.send(capture.stop_recording());
+                }
+
+                AudioCommand::IsRecording { reply } => {
+                    let _ = reply.send(capture.is_recording());
+                }
+
+                AudioCommand::StartStreaming { reply } => {
+                    let _ = reply.send(playback.start_streaming());
+                }
+
+                AudioCommand::Append {
+                    samples,
+                    sample_rate,
+                    reply,
+                } => {
+                    let _ = reply.send(playback.append(samples, sample_rate));
+                }
+
+                AudioCommand::StopPlayback => {
+                    playback.stop();
+                }
+
+                AudioCommand::IsPlaying { reply } => {
+                    let _ = reply.send(playback.is_playing());
+                }
+
+                AudioCommand::SpawnCompletionWatcher { on_done } => {
+                    playback.spawn_completion_watcher(on_done);
+                }
+
+                AudioCommand::Shutdown => break,
+            }
+        }
+
+        // `capture` and `playback` are dropped here, on the audio thread.
+        tracing::debug!("Audio thread shutting down");
+    }
+}
+
+impl Drop for AudioThreadHandle {
+    fn drop(&mut self) {
+        // Best-effort shutdown — the thread may already be dead.
+        let _ = self.cmd_tx.send(AudioCommand::Shutdown);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/crates/gglib-voice/src/error.rs
+++ b/crates/gglib-voice/src/error.rs
@@ -68,4 +68,8 @@ pub enum VoiceError {
     /// Pipeline was cancelled.
     #[error("Voice operation cancelled")]
     Cancelled,
+
+    /// The dedicated audio I/O thread died unexpectedly (panic or driver crash).
+    #[error("Audio thread died unexpectedly")]
+    AudioThreadDied,
 }

--- a/crates/gglib-voice/src/lib.rs
+++ b/crates/gglib-voice/src/lib.rs
@@ -7,6 +7,7 @@ use tempfile as _;
 #[cfg(test)]
 use tokio_test as _;
 
+pub mod audio_thread;
 pub mod backend;
 pub mod capture;
 pub mod error;

--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -19,11 +19,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
+use crate::audio_thread::AudioThreadHandle;
 use crate::backend::{SttBackend, SttConfig, TtsBackend, TtsConfig};
-use crate::capture::AudioCapture;
 use crate::error::VoiceError;
 use crate::gate::EchoGate;
-use crate::playback::AudioPlayback;
 use crate::text_utils;
 use crate::vad::{VadConfig, VadEvent, VoiceActivityDetector};
 
@@ -154,11 +153,8 @@ pub struct VoicePipeline {
     /// Shared echo gate.
     echo_gate: EchoGate,
 
-    /// Audio capture (microphone).
-    capture: Option<AudioCapture>,
-
-    /// Audio playback (speakers).
-    playback: Option<AudioPlayback>,
+    /// Audio I/O actor — owns capture + playback on a dedicated OS thread.
+    audio: Option<AudioThreadHandle>,
 
     /// Speech-to-text engine (loaded lazily).
     stt: Option<Box<dyn SttBackend>>,
@@ -179,16 +175,6 @@ pub struct VoicePipeline {
     config: VoicePipelineConfig,
 }
 
-// Safety: VoicePipeline is always accessed behind a tokio::sync::RwLock in AppState,
-// ensuring exclusive mutable access. The only !Send field is cpal::Stream inside
-// AudioCapture, which is only created/accessed through pipeline methods. On macOS
-// (CoreAudio) the stream is actually thread-safe; the !Send marker is a conservative
-// cross-platform constraint in cpal.
-#[allow(unsafe_code, clippy::non_send_fields_in_send_ty)]
-unsafe impl Send for VoicePipeline {}
-#[allow(unsafe_code, clippy::non_send_fields_in_send_ty)]
-unsafe impl Sync for VoicePipeline {}
-
 impl VoicePipeline {
     /// Create a new voice pipeline.
     ///
@@ -202,8 +188,7 @@ impl VoicePipeline {
             state: VoiceState::Idle,
             mode: config.mode,
             echo_gate,
-            capture: None,
-            playback: None,
+            audio: None,
             stt: None,
             tts: None,
             vad: None,
@@ -246,12 +231,9 @@ impl VoicePipeline {
 
         tracing::info!(mode = ?self.mode, "Starting voice pipeline");
 
-        // Initialise audio I/O
-        let capture = AudioCapture::new(self.echo_gate.clone())?;
-        let playback = AudioPlayback::new(self.echo_gate.clone())?;
-
-        self.capture = Some(capture);
-        self.playback = Some(playback);
+        // Initialise audio I/O on a dedicated OS thread.
+        let audio = AudioThreadHandle::spawn(self.echo_gate.clone())?;
+        self.audio = Some(audio);
 
         // In VAD mode, initialise the detector
         if self.mode == VoiceInteractionMode::VoiceActivityDetection {
@@ -286,17 +268,15 @@ impl VoicePipeline {
     pub fn stop(&mut self) {
         tracing::info!("Stopping voice pipeline");
 
-        // Stop any active recording
-        if let Some(ref mut capture) = self.capture {
-            if capture.is_recording() {
-                let _ = capture.stop_recording();
+        // Stop any active recording / playback and join the audio thread.
+        if let Some(ref audio) = self.audio {
+            if audio.is_recording() {
+                let _ = audio.stop_capture();
             }
+            audio.stop_playback();
         }
-
-        // Stop any active playback
-        if let Some(ref mut playback) = self.playback {
-            playback.stop();
-        }
+        // Drop the handle — sends Shutdown and joins the thread.
+        self.audio.take();
 
         // Stop VAD
         if let Some(ref mut vad) = self.vad {
@@ -369,12 +349,9 @@ impl VoicePipeline {
         }
 
         // Stop any active playback first
-        if let Some(ref mut playback) = self.playback {
-            playback.stop();
-        }
-
-        let capture = self.capture.as_mut().ok_or(VoiceError::NoInputDevice)?;
-        capture.start_recording()?;
+        let audio = self.audio.as_ref().ok_or(VoiceError::NotActive)?;
+        audio.stop_playback();
+        audio.start_capture()?;
         self.set_state(VoiceState::Recording);
 
         Ok(())
@@ -388,8 +365,8 @@ impl VoicePipeline {
             return Err(VoiceError::NotActive);
         }
 
-        let capture = self.capture.as_mut().ok_or(VoiceError::NoInputDevice)?;
-        let audio = capture.stop_recording()?;
+        let audio_handle = self.audio.as_ref().ok_or(VoiceError::NotActive)?;
+        let audio = audio_handle.stop_capture()?;
 
         if audio.is_empty() {
             self.set_state(VoiceState::Listening);
@@ -495,11 +472,11 @@ impl VoicePipeline {
         let tts = self.tts.as_ref().ok_or(VoiceError::TtsModelNotLoaded)?;
 
         // Prepare a streaming playback sink before synthesis begins.
-        let playback = self
-            .playback
-            .as_mut()
-            .ok_or_else(|| VoiceError::OutputStreamError("Playback not initialized".to_string()))?;
-        playback.start_streaming()?;
+        let audio = self
+            .audio
+            .as_ref()
+            .ok_or_else(|| VoiceError::OutputStreamError("Audio thread not running".to_string()))?;
+        audio.start_streaming()?;
 
         let mut any_audio = false;
         let mut total_duration = std::time::Duration::ZERO;
@@ -530,9 +507,9 @@ impl VoicePipeline {
                         let _ = self.event_tx.send(VoiceEvent::SpeakingStarted);
                     }
 
-                    // Re-borrow playback after the &self calls above.
-                    let pb = self.playback.as_mut().expect("playback initialised above");
-                    pb.append(audio.samples, audio.sample_rate)?;
+                    // audio_thread methods take &self, so no re-borrow needed.
+                    let a = self.audio.as_ref().expect("audio thread started above");
+                    a.append(audio.samples, audio.sample_rate)?;
                     total_duration += audio.duration;
                 }
                 Err(e) => {
@@ -558,8 +535,8 @@ impl VoicePipeline {
 
         if !any_audio {
             // Every chunk failed — tear down the empty sink and report error.
-            if let Some(ref mut pb) = self.playback {
-                pb.stop();
+            if let Some(ref a) = self.audio {
+                a.stop_playback();
             }
             return Err(VoiceError::SynthesisError(
                 "all chunks failed to synthesize".to_string(),
@@ -586,16 +563,16 @@ impl VoicePipeline {
             ));
         });
 
-        let playback = self.playback.as_ref().expect("playback initialised above");
-        playback.spawn_completion_watcher(Some(on_done));
+        let audio = self.audio.as_ref().expect("audio thread started above");
+        audio.spawn_completion_watcher(Some(on_done));
 
         Ok(())
     }
 
     /// Stop any active TTS playback immediately.
     pub fn stop_speaking(&mut self) {
-        if let Some(ref mut playback) = self.playback {
-            playback.stop();
+        if let Some(ref audio) = self.audio {
+            audio.stop_playback();
         }
         self.emit(VoiceEvent::SpeakingFinished);
         if self.is_active() {
@@ -606,9 +583,9 @@ impl VoicePipeline {
     /// Check if TTS playback is currently active.
     #[must_use]
     pub fn is_speaking(&self) -> bool {
-        self.playback
+        self.audio
             .as_ref()
-            .is_some_and(AudioPlayback::is_playing)
+            .is_some_and(|a| a.is_playing())
     }
 
     // ── Configuration ──────────────────────────────────────────────

--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -232,7 +232,7 @@ impl VoicePipeline {
         tracing::info!(mode = ?self.mode, "Starting voice pipeline");
 
         // Initialise audio I/O on a dedicated OS thread.
-        let audio = AudioThreadHandle::spawn(self.echo_gate.clone())?;
+        let audio = AudioThreadHandle::spawn(&self.echo_gate)?;
         self.audio = Some(audio);
 
         // In VAD mode, initialise the detector
@@ -583,7 +583,9 @@ impl VoicePipeline {
     /// Check if TTS playback is currently active.
     #[must_use]
     pub fn is_speaking(&self) -> bool {
-        self.audio.as_ref().is_some_and(|a| a.is_playing())
+        self.audio
+            .as_ref()
+            .is_some_and(AudioThreadHandle::is_playing)
     }
 
     // ── Configuration ──────────────────────────────────────────────

--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -583,9 +583,7 @@ impl VoicePipeline {
     /// Check if TTS playback is currently active.
     #[must_use]
     pub fn is_speaking(&self) -> bool {
-        self.audio
-            .as_ref()
-            .is_some_and(|a| a.is_playing())
+        self.audio.as_ref().is_some_and(|a| a.is_playing())
     }
 
     // ── Configuration ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Removes the unsound `unsafe impl Send` / `unsafe impl Sync` from `VoicePipeline` by extracting all `!Send` audio I/O types onto a dedicated OS thread.

Closes #178.

## Problem

`VoicePipeline` held `AudioCapture` (wrapping `cpal::Stream`) and `AudioPlayback` (wrapping `rodio::OutputStream`) directly — both are `!Send` on some platforms. The `unsafe impl Send/Sync` papered over this, but was unsound: Tauri async commands run on the tokio thread pool, so the pipeline *will* cross threads between `start()` and `stop()` calls.

## Solution

**Actor pattern** — spawn a dedicated `std::thread` ("gglib-audio") that owns both `AudioCapture` and `AudioPlayback` for their entire lifetime. The pipeline communicates via `std::sync::mpsc` channels.

### New type: `AudioThreadHandle`

A `Send + Sync` proxy that routes every capture/playback operation through an `AudioCommand` enum to the audio thread, with reply channels for request-response calls.

Key design decisions:
- `std::sync::mpsc` for command + reply channels (audio thread is a plain OS thread)
- DRY `send_and_recv` / `query` helpers eliminate per-command boilerplate
- Channel errors map to `VoiceError::AudioThreadDied` — no panics on thread death
- All methods take `&self` — `mpsc::Sender` supports shared access, eliminating the awkward `playback` re-borrow dance in `speak()`
- `Drop` impl sends `Shutdown` and joins the thread

### Changes

| File | Change |
|------|--------|
| `crates/gglib-voice/src/error.rs` | Add `VoiceError::AudioThreadDied` variant |
| `crates/gglib-voice/src/audio_thread.rs` | **New** — `AudioCommand` enum + `AudioThreadHandle` actor |
| `crates/gglib-voice/src/lib.rs` | Register `audio_thread` module |
| `crates/gglib-voice/src/pipeline.rs` | Replace `capture`/`playback` fields with `audio: Option<AudioThreadHandle>`, remove `unsafe impl Send/Sync` |
| `crates/gglib-voice/Cargo.toml` | Tighten `unsafe_code` lint from `"warn"` to `"deny"` |

### No downstream changes needed

`VoicePipeline` is now naturally `Send + Sync`. The Tauri state (`Arc<RwLock<Option<VoicePipeline>>>`) and all voice commands compile without modification.

## Testing

- `cargo check -p gglib-voice` — compiles clean
- `cargo check -p gglib-gui` — compiles clean
- `cargo check -p gglib-cli` — compiles clean
- `cargo check -p gglib-tauri` — compiles clean
- `cargo test -p gglib-voice` — 25/25 tests pass
- Zero `unsafe` remaining in crate (`deny(unsafe_code)` enforced)
