### PR TITLE
perf(voice): stream model downloads with incremental progress reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "async-trait",
  "bzip2 0.5.2",
  "cpal",
+ "futures-util",
  "gglib-core",
  "reqwest 0.13.2",
  "rodio",

--- a/crates/gglib-voice/Cargo.toml
+++ b/crates/gglib-voice/Cargo.toml
@@ -62,6 +62,9 @@ sherpa-rs = { version = "0.6", features = ["tts", "download-binaries", "static"]
 # HTTP client for model downloads
 reqwest = { workspace = true }
 
+# Stream adaptor — provides StreamExt::next() for reqwest byte streams
+futures-util = "0.3"
+
 # Archive extraction for sherpa-onnx model bundles (tar.bz2)
 tar = "0.4"
 bzip2 = "0.5"

--- a/crates/gglib-voice/src/models.rs
+++ b/crates/gglib-voice/src/models.rs
@@ -453,32 +453,54 @@ pub async fn download_and_extract_archive(
         });
     }
 
+    // Content-Length may be absent; treat 0 as "unknown size".
     let total_size = response.content_length().unwrap_or(0);
-    let archive_bytes =
-        response
-            .bytes()
-            .await
-            .map_err(|e| crate::error::VoiceError::DownloadError {
-                name: url.to_string(),
-                source: e.into(),
-            })?;
 
-    on_progress(
-        archive_bytes.len() as u64,
-        total_size.max(archive_bytes.len() as u64),
-    );
+    // Stream the archive to a temp file instead of buffering it in memory.
+    // For large models (e.g. small.en ~610 MB) this avoids potential OOM.
+    let tmp_path = dest_dir.join(format!(".{dir_name}.tar.bz2.tmp"));
+    let file = tokio::fs::File::create(&tmp_path).await?;
+    let mut writer = BufWriter::new(file);
+    let mut stream = response.bytes_stream();
+    let mut downloaded: u64 = 0;
+    let mut last_reported: u64 = 0;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| crate::error::VoiceError::DownloadError {
+            name: url.to_string(),
+            source: e.into(),
+        })?;
+        writer.write_all(&chunk).await?;
+        downloaded += chunk.len() as u64;
+        if downloaded - last_reported >= 100_000 {
+            on_progress(downloaded, total_size);
+            last_reported = downloaded;
+        }
+    }
+
+    // Flush the BufWriter and drop it explicitly so the file handle is fully
+    // released before the blocking thread opens the same path for extraction.
+    writer.flush().await?;
+    drop(writer);
+    on_progress(downloaded, total_size.max(downloaded));
 
     tracing::info!(
-        size_mb = archive_bytes.len() / 1_048_576,
+        size_mb = downloaded / 1_048_576,
         "Archive downloaded, extracting"
     );
 
     // Extract in a blocking thread to avoid blocking the async runtime.
+    // Open the temp file from disk rather than using an in-memory Cursor.
     let dest_owned = dest_dir.to_path_buf();
-    let bytes_vec = archive_bytes.to_vec();
+    let tmp_path_owned = tmp_path.clone();
     tokio::task::spawn_blocking(move || {
-        let cursor = std::io::Cursor::new(bytes_vec);
-        let decompressor = bzip2::read::BzDecoder::new(cursor);
+        let file = std::fs::File::open(&tmp_path_owned).map_err(|e| {
+            crate::error::VoiceError::DownloadError {
+                name: "archive".to_string(),
+                source: anyhow::anyhow!("Failed to open temp archive: {e}"),
+            }
+        })?;
+        let decompressor = bzip2::read::BzDecoder::new(file);
         let mut archive = tar::Archive::new(decompressor);
         archive
             .unpack(&dest_owned)
@@ -493,6 +515,9 @@ pub async fn download_and_extract_archive(
         name: url.to_string(),
         source: anyhow::anyhow!("Join error: {e}"),
     })??;
+
+    // Remove the temp archive now that extraction is complete.
+    let _ = tokio::fs::remove_file(&tmp_path).await;
 
     tracing::info!(path = %extract_path.display(), "Archive extracted successfully");
     Ok(extract_path)

--- a/crates/gglib-voice/src/models.rs
+++ b/crates/gglib-voice/src/models.rs
@@ -7,7 +7,9 @@
 
 use std::path::{Path, PathBuf};
 
+use futures_util::StreamExt as _;
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncWriteExt as _, BufWriter};
 
 // ── Model identifiers ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #179.

Model downloads in `gglib-voice` previously called `response.bytes().await`, buffering the entire archive in RAM before writing to disk. For `small.en` (~610 MB) this caused ~1.2 GB peak RSS and a progress bar that jumped from 0% to 100% instantly.

## Changes

### `crates/gglib-voice/Cargo.toml`
- Add `futures-util = "0.3"` as a direct dependency (already transitive via reqwest; needed to call `StreamExt::next()` explicitly).

### `crates/gglib-voice/src/models.rs`

**`download_voice_model`** (VAD `.onnx` downloads)
- Replace `response.bytes().await` with `response.bytes_stream()` + `StreamExt::next()` loop.
- Write chunks via `BufWriter<tokio::fs::File>` to reduce syscall pressure.
- Call `on_progress` every 100 KB; emit one unconditional call after `flush()` to guarantee 100% is always reported.

**`download_and_extract_archive`** (STT/TTS `.tar.bz2` downloads)
- Stream archive chunks into a `BufWriter<tokio::fs::File>` at a hidden temp path (`.{dir_name}.tar.bz2.tmp`).
- `flush().await?` + explicit `drop(writer)` before `spawn_blocking` — ensures the async file handle is fully released before the blocking thread opens the same path (prevents stale data / file-lock issues on macOS).
- In `spawn_blocking`, open the temp file via `std::fs::File::open` and pipe through `bzip2::read::BzDecoder` → `tar::Archive::unpack`. Eliminates the `std::io::Cursor::new(bytes_vec)` in-memory approach entirely.
- Remove the temp file after successful extraction.
- Same 100 KB throttle + unconditional final `on_progress` as above.

**No changes** to `src-tauri/src/commands/voice.rs` — the three Tauri download commands already forward every `on_progress(downloaded, total)` call to `app.emit("voice:model-download-progress", ...)`.

## Result

| | Before | After |
|---|---|---|
| Peak RAM (610 MB model) | ~1.2 GB | ~8 KB (BufWriter buffer) |
| Progress events per download | 1 (at 100%) | ~6,100 (every 100 KB) |
| Archive held in memory | Yes (full `Vec<u8>`) | No (temp file on disk) |
