### PR TITLE
fix(ci): use llvm-cov report subcommand for per-crate voice coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,21 +78,24 @@ jobs:
 
       - name: Run per-crate Rust coverage
         run: |
-          # Per-crate coverage. gglib-voice is intentionally excluded here:
-          # sherpa-rs (native C++ static lib) cannot be re-linked under coverage
-          # instrumentation in a per-crate build. gglib-voice is still fully
-          # covered in the combined step above (lcov.info).
-          cargo llvm-cov --all-features --package gglib-core --lcov --output-path gglib-core-lcov.info
-          cargo llvm-cov --all-features --package gglib-db --lcov --output-path gglib-db-lcov.info
-          cargo llvm-cov --all-features --package gglib-gguf --lcov --output-path gglib-gguf-lcov.info
-          cargo llvm-cov --all-features --package gglib-hf --lcov --output-path gglib-hf-lcov.info
-          cargo llvm-cov --all-features --package gglib-download --lcov --output-path gglib-download-lcov.info
-          cargo llvm-cov --all-features --package gglib-mcp --lcov --output-path gglib-mcp-lcov.info
-          cargo llvm-cov --all-features --package gglib-proxy --lcov --output-path gglib-proxy-lcov.info
-          cargo llvm-cov --all-features --package gglib-runtime --lcov --output-path gglib-runtime-lcov.info
-          cargo llvm-cov --all-features --package gglib-gui --lcov --output-path gglib-gui-lcov.info
-          cargo llvm-cov --all-features --package gglib-cli --lcov --output-path gglib-cli-lcov.info
-          cargo llvm-cov --all-features --package gglib-axum --lcov --output-path gglib-axum-lcov.info
+          # Use `cargo llvm-cov report` (report-only subcommand) to slice per-package
+          # lcov files from the profdata already collected in the combined step above.
+          # This does NOT recompile or relink anything — it just re-processes the
+          # existing profdata + instrumented binaries. This avoids the sherpa-rs
+          # (sherpa-onnx native static lib) linker error that occurs when
+          # `cargo llvm-cov --package gglib-voice` tries to build a fresh test binary.
+          cargo llvm-cov report --all-features --package gglib-core --lcov --output-path gglib-core-lcov.info
+          cargo llvm-cov report --all-features --package gglib-db --lcov --output-path gglib-db-lcov.info
+          cargo llvm-cov report --all-features --package gglib-gguf --lcov --output-path gglib-gguf-lcov.info
+          cargo llvm-cov report --all-features --package gglib-hf --lcov --output-path gglib-hf-lcov.info
+          cargo llvm-cov report --all-features --package gglib-download --lcov --output-path gglib-download-lcov.info
+          cargo llvm-cov report --all-features --package gglib-mcp --lcov --output-path gglib-mcp-lcov.info
+          cargo llvm-cov report --all-features --package gglib-proxy --lcov --output-path gglib-proxy-lcov.info
+          cargo llvm-cov report --all-features --package gglib-runtime --lcov --output-path gglib-runtime-lcov.info
+          cargo llvm-cov report --all-features --package gglib-gui --lcov --output-path gglib-gui-lcov.info
+          cargo llvm-cov report --all-features --package gglib-cli --lcov --output-path gglib-cli-lcov.info
+          cargo llvm-cov report --all-features --package gglib-axum --lcov --output-path gglib-axum-lcov.info
+          cargo llvm-cov report --all-features --package gglib-voice --lcov --output-path gglib-voice-lcov.info
 
       - name: Run TypeScript tests with coverage
         run: npm run test:coverage -- --reporter=json --reporter=default --outputFile=ts-test-results.json 2>&1 | tee ts-test-output.txt
@@ -133,6 +136,7 @@ jobs:
             gglib-gui-lcov.info
             gglib-cli-lcov.info
             gglib-axum-lcov.info
+            gglib-voice-lcov.info
             coverage/
             rust-test-output.txt
             ts-test-output.txt


### PR DESCRIPTION
Switch per-crate steps from cargo llvm-cov --package X to cargo llvm-cov report --package X. The report subcommand reads existing profdata without recompiling/relinking, avoiding the sherpa-rs SileroVad linker error. Restores gglib-voice-lcov.info so badge compliance is maintained. Supersedes #187.