### PR TITLE
fix(voice): preserve pipeline across stop/start and track loaded model IDs (#182)

### DIFF
--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -319,7 +319,11 @@ impl VoicePipeline {
     /// `model_id` is stored verbatim and returned by
     /// [`stt_model_id`](VoicePipeline::stt_model_id) so the frontend can
     /// display which model is currently active without querying the catalog.
-    pub fn load_stt(&mut self, model_path: &std::path::Path, model_id: &str) -> Result<(), VoiceError> {
+    pub fn load_stt(
+        &mut self,
+        model_path: &std::path::Path,
+        model_id: &str,
+    ) -> Result<(), VoiceError> {
         use crate::backend::sherpa_stt::{SherpaSttBackend, SherpaSttConfig};
 
         tracing::info!(path = %model_path.display(), model_id, "Loading STT engine");

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -492,7 +492,9 @@ pub async fn voice_load_stt(
         pipeline.stop();
     }
 
-    pipeline.load_stt(&path, &model_id).map_err(|e| format!("{e}"))
+    pipeline
+        .load_stt(&path, &model_id)
+        .map_err(|e| format!("{e}"))
 }
 
 /// Load the TTS model into the pipeline (auto-creates an idle pipeline if needed).

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -222,16 +222,45 @@ pub async fn voice_start(
     Ok(())
 }
 
-/// Stop the voice pipeline.
+/// Stop the voice pipeline, releasing audio resources (microphone + playback)
+/// but keeping loaded STT/TTS models in memory.
+///
+/// This allows the user to toggle voice off and back on without the
+/// 5–10 second model-reload delay. The pipeline transitions to `Idle` and
+/// the OS microphone indicator turns off immediately.
+///
+/// To also free the model memory, call [`voice_unload`] instead.
 #[tauri::command]
 pub async fn voice_stop(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let mut voice = state.voice_pipeline.write().await;
     if let Some(ref mut pipeline) = *voice {
         pipeline.stop();
     }
+    // Intentionally keep *voice = Some(pipeline) so loaded models stay warm.
+
+    info!("Voice pipeline stopped (models retained)");
+    Ok(())
+}
+
+/// Fully unload the voice pipeline, freeing all model memory (STT + TTS weights).
+///
+/// Use this for explicit "unload" actions (e.g. switching models, low-memory
+/// situations, or app shutdown). After this call [`voice_status`] will report
+/// `sttLoaded: false` and `ttsLoaded: false`.
+///
+/// For simply pausing voice mode while keeping models warm, use [`voice_stop`].
+#[tauri::command]
+pub async fn voice_unload(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let mut voice = state.voice_pipeline.write().await;
+    if let Some(ref mut pipeline) = *voice {
+        // Ensure audio is stopped and mic released before dropping.
+        if pipeline.is_active() {
+            pipeline.stop();
+        }
+    }
     *voice = None;
 
-    info!("Voice pipeline stopped");
+    info!("Voice pipeline unloaded (models freed)");
     Ok(())
 }
 
@@ -248,8 +277,8 @@ pub async fn voice_status(
             mode: mode_string(pipeline.mode()),
             stt_loaded: pipeline.is_stt_loaded(),
             tts_loaded: pipeline.is_tts_loaded(),
-            stt_model_id: None, // TODO: track in pipeline
-            tts_voice: None,    // TODO: track in pipeline
+            stt_model_id: pipeline.stt_model_id().map(str::to_owned),
+            tts_voice: Some(pipeline.tts_voice().to_owned()),
             auto_speak: pipeline.auto_speak(),
         }),
         None => Ok(VoiceStatusResponse {
@@ -422,12 +451,19 @@ pub async fn voice_download_vad_model(app: AppHandle) -> Result<(), String> {
 }
 
 /// Load an STT model into the pipeline (auto-creates an idle pipeline if needed).
+///
+/// If the pipeline is currently active (mic open / transcribing), it is
+/// automatically paused first to prevent a hot-swap race with an in-flight
+/// transcription. Audio resources are released and the pipeline can be
+/// restarted with [`voice_start`] after loading completes.
 #[tauri::command]
 pub async fn voice_load_stt(
     model_id: String,
     app: AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    // Resolve catalog metadata and path *before* acquiring the write lock,
+    // so we hold the lock for as short a time as possible.
     let model = VoiceModelCatalog::find_stt_model(&model_id)
         .ok_or_else(|| format!("Unknown STT model: {model_id}"))?;
 
@@ -446,7 +482,17 @@ pub async fn voice_load_stt(
         info!("Created idle voice pipeline for model preloading");
     }
     let pipeline = voice.as_mut().unwrap();
-    pipeline.load_stt(&path).map_err(|e| format!("{e}"))
+
+    // Safety: pause the pipeline before swapping the STT engine.
+    // ptt_stop / vad_process_frame hold this same write lock during transcription,
+    // so the lock itself serialises access — but an explicit stop here ensures
+    // the audio thread is also quiesced and the mic is released.
+    if pipeline.is_active() {
+        info!(model_id = %model_id, "Pausing active pipeline before STT model hot-swap");
+        pipeline.stop();
+    }
+
+    pipeline.load_stt(&path, &model_id).map_err(|e| format!("{e}"))
 }
 
 /// Load the TTS model into the pipeline (auto-creates an idle pipeline if needed).

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -81,10 +81,10 @@ async fn parallel_cleanup(state: &AppState) -> Result<(), String> {
         let mut voice = state.voice_pipeline.write().await;
         if voice.is_some() {
             info!("Unloading voice pipeline during shutdown");
-            if let Some(ref mut pipeline) = *voice {
-                if pipeline.is_active() {
-                    pipeline.stop();
-                }
+            if let Some(ref mut pipeline) = *voice
+                && pipeline.is_active()
+            {
+                pipeline.stop();
             }
             *voice = None;
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -221,6 +221,7 @@ fn main() {
             // Voice mode: OS-specific audio pipeline
             commands::voice::voice_start,
             commands::voice::voice_stop,
+            commands::voice::voice_unload,
             commands::voice::voice_status,
             commands::voice::voice_ptt_start,
             commands::voice::voice_ptt_stop,

--- a/src/hooks/useVoiceMode.ts
+++ b/src/hooks/useVoiceMode.ts
@@ -302,6 +302,8 @@ export function useVoiceMode(defaults?: VoiceDefaults): UseVoiceModeReturn {
           mode: 'ptt',
           sttLoaded: false,
           ttsLoaded: false,
+          sttModelId: null,
+          ttsVoice: null,
           autoSpeak: true,
         };
       }

--- a/src/services/clients/voice.ts
+++ b/src/services/clients/voice.ts
@@ -29,6 +29,10 @@ export interface VoiceStatusResponse {
   mode: VoiceInteractionMode;
   sttLoaded: boolean;
   ttsLoaded: boolean;
+  /** ID of the currently loaded STT model, or null if none is loaded. */
+  sttModelId: string | null;
+  /** Currently configured TTS voice ID, or null if no pipeline exists. */
+  ttsVoice: string | null;
   autoSpeak: boolean;
 }
 
@@ -124,6 +128,17 @@ export async function voiceStart(mode?: VoiceInteractionMode): Promise<void> {
 
 export async function voiceStop(): Promise<void> {
   await invokeTauri('voice_stop');
+}
+
+/**
+ * Fully unload the voice pipeline, freeing STT/TTS model memory.
+ *
+ * Use this when the user explicitly changes models or when memory must be
+ * reclaimed. For simply pausing voice mode while keeping models warm,
+ * use {@link voiceStop} instead.
+ */
+export async function voiceUnload(): Promise<void> {
+  await invokeTauri('voice_unload');
 }
 
 export async function voiceStatus(): Promise<VoiceStatusResponse> {


### PR DESCRIPTION
## Summary

Closes #182.

Two related issues with the voice pipeline lifecycle are fixed:

### 1. `voice_stop` no longer drops the pipeline

Previously `voice_stop` called `*voice = None`, destroying the loaded STT/TTS engines and forcing a 5–10s model reload on every toggle.

**Fix:** `voice_stop` now calls `pipeline.stop()` (which synchronously releases the microphone and joins the audio thread — OS mic indicator turns off immediately) but keeps the pipeline struct alive. Loaded model weights remain warm in memory.

A new `voice_unload` command handles explicit full teardown (model switching, app exit, low-memory). It is also called from `perform_shutdown` so the mic is released in deterministic order on app quit.

### 2. `voice_status` now returns real model IDs

`stt_model_id` and `tts_voice` were hardcoded `None` / `TODO`. The Settings UI had no way to highlight the active model.

**Fix:**
- `VoicePipeline` gains a `loaded_stt_model_id: Option<String>` field, populated when `load_stt()` succeeds.
- `load_stt()` signature updated to `load_stt(path, model_id)`.
- New public accessors: `stt_model_id() -> Option<&str>` and `tts_voice() -> &str`.
- `voice_status` populates both fields from the pipeline.
- `VoiceStatusResponse` TypeScript interface updated with `sttModelId: string | null` and `ttsVoice: string | null`.

### 3. Hot-swap safety

`voice_load_stt` now explicitly calls `pipeline.stop()` before swapping the STT engine if the pipeline is active, preventing any risk of a mid-transcription model replacement.

### 4. Frontend unmount cleanup

`useVoiceMode` now calls `voiceStop()` in the `useEffect` cleanup if voice is active when the component unmounts (e.g. user navigates away). This ensures the mic indicator turns off on navigation. Models stay warm for a fast return (per design decision — `voiceUnload()` is available for explicit teardown).

## Files changed

- `crates/gglib-voice/src/pipeline.rs` — new field, updated `load_stt` signature, new accessors
- `src-tauri/src/commands/voice.rs` — `voice_stop`, new `voice_unload`, hot-swap guard, `voice_status` populated
- `src-tauri/src/lifecycle.rs` — explicit voice teardown in `perform_shutdown`
- `src-tauri/src/main.rs` — `voice_unload` registered in handler
- `src/services/clients/voice.ts` — updated interface, `voiceUnload` export
- `src/hooks/useVoiceMode.ts` — `unload` action, unmount cleanup, fallback status fix

## Testing

- `cargo check --workspace` ✅
- `npx tsc --noEmit` ✅
