### PR TITLE
refactor(frontend): Phase 2 — fortify primitives & cn() integration

### DIFF
--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -17,6 +17,11 @@ import {
 import type { McpServerInfo } from "../services/clients/mcp";
 import { Icon } from "./ui/Icon";
 import { Button } from "./ui/Button";
+import { cn } from "../utils/cn";
+
+const statusBadge = "inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full";
+
+const errorBox = "p-md bg-[rgba(239,68,68,0.15)] text-[#ef4444] rounded-base text-sm";
 
 interface McpServersPanelProps {
   onAddServer?: () => void;
@@ -143,15 +148,15 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
 
   const getStatusBadge = (info: McpServerInfo) => {
     if (isServerRunning(info)) {
-      return <span className="inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full bg-[rgba(16,185,129,0.15)] text-[#10b981]">Running</span>;
+      return <span className={cn(statusBadge, "bg-[rgba(16,185,129,0.15)] text-[#10b981]")}>Running</span>;
     }
     if (hasServerError(info)) {
-      return <span className="inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full bg-[rgba(239,68,68,0.15)] text-[#ef4444]">Error</span>;
+      return <span className={cn(statusBadge, "bg-[rgba(239,68,68,0.15)] text-[#ef4444]")}>Error</span>;
     }
     if (info.status === "starting") {
-      return <span className="inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full bg-[rgba(245,158,11,0.15)] text-[#f59e0b]">Starting...</span>;
+      return <span className={cn(statusBadge, "bg-[rgba(245,158,11,0.15)] text-[#f59e0b]")}>Starting...</span>;
     }
-    return <span className="inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full bg-background-tertiary text-text-secondary">Stopped</span>;
+    return <span className={cn(statusBadge, "bg-background-tertiary text-text-secondary")}>Stopped</span>;
   };
 
   if (loading) {
@@ -195,13 +200,13 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
       </div>
 
       {error && (
-        <div className="p-md bg-[rgba(239,68,68,0.15)] text-[#ef4444] rounded-base text-sm" role="alert">
+        <div className={errorBox} role="alert">
           {error}
         </div>
       )}
 
       {actionError && (
-        <div className="p-md bg-[rgba(239,68,68,0.15)] text-[#ef4444] rounded-base text-sm" role="alert">
+        <div className={errorBox} role="alert">
           {actionError}
         </div>
       )}

--- a/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
+++ b/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
@@ -1,5 +1,6 @@
 import { FC, useCallback, useState, useEffect } from 'react';
 import { Shield, CloudSync } from 'lucide-react';
+import { cn } from '../../utils/cn';
 import { appLogger } from '../../services/platform';
 import { GgufModel, ServerInfo, HfModelSummary } from '../../types';
 import { queueDownload } from '../../services/clients/downloads';
@@ -27,6 +28,10 @@ import {
   InspectorActions,
 } from './components';
 import { Input } from '../ui/Input';
+
+const panelContainer = "flex flex-col h-full min-h-0 overflow-y-auto overflow-x-hidden relative flex-1 max-md:h-auto max-md:max-h-none bg-surface";
+
+const circleIconBtn = "flex items-center justify-center w-button-height-base h-button-height-base p-0 rounded-full border border-border bg-background-elevated cursor-pointer transition-all hover:enabled:border-border-hover hover:enabled:bg-background-hover disabled:opacity-50 disabled:cursor-not-allowed";
 
 interface ModelInspectorPanelProps {
   model: GgufModel | null;
@@ -164,7 +169,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
   // If HuggingFace model is selected, show HF model preview
   if (selectedHfModel) {
     return (
-      <div className="flex flex-col h-full min-h-0 overflow-hidden relative flex-1 max-md:h-auto max-md:max-h-none bg-surface">
+      <div className={cn(panelContainer, "overflow-hidden")}>
         <HfModelPreview
           model={selectedHfModel}
           onDownload={handleHfDownload}
@@ -178,7 +183,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
   // Empty state
   if (!model) {
     return (
-      <div className="flex flex-col h-full min-h-0 overflow-y-auto overflow-x-hidden relative flex-1 max-md:h-auto max-md:max-h-none bg-surface">
+      <div className={panelContainer}>
         <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col">
           <div className="flex flex-col items-center justify-center min-h-[300px] py-3xl px-xl text-center">
             <div className="text-4xl mb-base opacity-50 text-text-disabled">👈</div>
@@ -190,7 +195,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
   }
 
   return (
-    <div className="flex flex-col h-full min-h-0 overflow-y-auto overflow-x-hidden relative flex-1 max-md:h-auto max-md:max-h-none bg-surface">
+    <div className={panelContainer}>
       <div className="p-base border-b border-border bg-background shrink-0">
         <div className="flex items-center justify-between gap-base w-full">
           {editMode.isEditMode ? (
@@ -208,7 +213,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
             <div className="flex items-center gap-xs">
               <button
                 type="button"
-                className="flex items-center justify-center w-button-height-base h-button-height-base p-0 rounded-full border border-border bg-background-elevated cursor-pointer transition-all hover:enabled:border-border-hover hover:enabled:bg-background-hover disabled:opacity-50 disabled:cursor-not-allowed"
+                className={circleIconBtn}
                 onClick={() => setShowVerifyModal(true)}
                 title="Verify model integrity"
                 aria-label="Verify model integrity"
@@ -217,7 +222,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
               </button>
               <button
                 type="button"
-                className="flex items-center justify-center w-button-height-base h-button-height-base p-0 rounded-full border border-border bg-background-elevated cursor-pointer transition-all hover:enabled:border-border-hover hover:enabled:bg-background-hover disabled:opacity-50 disabled:cursor-not-allowed"
+                className={circleIconBtn}
                 onClick={() => setShowUpdateModal(true)}
                 disabled={!model.hfRepoId}
                 title={model.hfRepoId ? "Check for updates on HuggingFace" : "No HuggingFace repo linked"}

--- a/src/components/primitives/Row.tsx
+++ b/src/components/primitives/Row.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '../../utils/cn';
 
 interface RowProps {
   children: React.ReactNode;
@@ -9,49 +10,56 @@ interface RowProps {
   wrap?: boolean;
 }
 
+const gapClasses = {
+  none: 'gap-0',
+  xs: 'gap-1',
+  sm: 'gap-2',
+  base: 'gap-4',
+  lg: 'gap-6',
+  xl: 'gap-8',
+} as const;
+
+const alignClasses = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch',
+} as const;
+
+const justifyClasses = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+  around: 'justify-around',
+} as const;
+
 /**
  * Row - Horizontal layout container with consistent spacing
  * Uses Tailwind flex utilities
  */
 export const Row: React.FC<RowProps> = ({
   children,
-  className = '',
+  className,
   gap = 'base',
   align = 'center',
   justify = 'start',
   wrap = false,
 }) => {
-  const gapClasses = {
-    none: 'gap-0',
-    xs: 'gap-1',
-    sm: 'gap-2',
-    base: 'gap-4',
-    lg: 'gap-6',
-    xl: 'gap-8',
-  };
-
-  const alignClasses = {
-    start: 'items-start',
-    center: 'items-center',
-    end: 'items-end',
-    stretch: 'items-stretch',
-  };
-
-  const justifyClasses = {
-    start: 'justify-start',
-    center: 'justify-center',
-    end: 'justify-end',
-    between: 'justify-between',
-    around: 'justify-around',
-  };
-
-  const wrapClass = wrap ? 'flex-wrap' : '';
-
   return (
     <div
-      className={`flex flex-row ${gapClasses[gap]} ${alignClasses[align]} ${justifyClasses[justify]} ${wrapClass} ${className}`}
+      className={cn(
+        'flex flex-row',
+        gapClasses[gap],
+        alignClasses[align],
+        justifyClasses[justify],
+        wrap && 'flex-wrap',
+        className,
+      )}
     >
       {children}
     </div>
   );
 };
+
+Row.displayName = 'Row';

--- a/src/components/primitives/Stack.tsx
+++ b/src/components/primitives/Stack.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '../../utils/cn';
 
 interface StackProps {
   children: React.ReactNode;
@@ -8,46 +9,54 @@ interface StackProps {
   justify?: 'start' | 'center' | 'end' | 'between' | 'around';
 }
 
+const gapClasses = {
+  none: 'gap-0',
+  xs: 'gap-1',
+  sm: 'gap-2',
+  base: 'gap-4',
+  lg: 'gap-6',
+  xl: 'gap-8',
+} as const;
+
+const alignClasses = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch',
+} as const;
+
+const justifyClasses = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+  around: 'justify-around',
+} as const;
+
 /**
  * Stack - Vertical layout container with consistent spacing
  * Uses Tailwind flex utilities
  */
 export const Stack: React.FC<StackProps> = ({
   children,
-  className = '',
+  className,
   gap = 'base',
   align = 'stretch',
   justify = 'start',
 }) => {
-  const gapClasses = {
-    none: 'gap-0',
-    xs: 'gap-1',
-    sm: 'gap-2',
-    base: 'gap-4',
-    lg: 'gap-6',
-    xl: 'gap-8',
-  };
-
-  const alignClasses = {
-    start: 'items-start',
-    center: 'items-center',
-    end: 'items-end',
-    stretch: 'items-stretch',
-  };
-
-  const justifyClasses = {
-    start: 'justify-start',
-    center: 'justify-center',
-    end: 'justify-end',
-    between: 'justify-between',
-    around: 'justify-around',
-  };
-
   return (
     <div
-      className={`flex flex-col ${gapClasses[gap]} ${alignClasses[align]} ${justifyClasses[justify]} ${className}`}
+      className={cn(
+        'flex flex-col',
+        gapClasses[gap],
+        alignClasses[align],
+        justifyClasses[justify],
+        className,
+      )}
     >
       {children}
     </div>
   );
 };
+
+Stack.displayName = 'Stack';

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from "react";
 import type { ComponentPropsWithoutRef } from "react";
 import type { LucideIcon } from "lucide-react";
+import { cn } from "../../utils/cn";
 
 interface IconProps extends ComponentPropsWithoutRef<"span"> {
   icon: LucideIcon;
@@ -9,11 +10,11 @@ interface IconProps extends ComponentPropsWithoutRef<"span"> {
 }
 
 export const Icon = forwardRef<HTMLSpanElement, IconProps>(
-  ({ icon: IconComponent, size = 16, strokeWidth = 1.6, className = "", ...props }, ref) => {
+  ({ icon: IconComponent, size = 16, strokeWidth = 1.6, className, ...props }, ref) => {
     return (
       <span
         ref={ref}
-        className={`inline-flex items-center justify-center ${className}`}
+        className={cn("inline-flex items-center justify-center", className)}
         aria-hidden="true"
         {...props}
       >


### PR DESCRIPTION
Phase 2 of phased cleanup for PR #202. Migrates Stack, Row, Icon to cn(), hoists class maps to module scope, adds displayName. Extracts shared class constants in ModelInspectorPanel (panelContainer, circleIconBtn) and McpServersPanel (statusBadge, errorBox) to eliminate duplication.