### PR TITLE
Phase 3: DRY layout primitives & Label component

### DIFF
--- a/src/components/AddMcpServerModal.tsx
+++ b/src/components/AddMcpServerModal.tsx
@@ -11,6 +11,7 @@ import { Input } from "./ui/Input";
 import { ServerTemplatePicker, type ServerTemplate } from "./AddMcpServerModal/ServerTemplatePicker";
 import { ServerTypeConfig } from "./AddMcpServerModal/ServerTypeConfig";
 import { EnvVarManager } from "./AddMcpServerModal/EnvVarManager";
+import { Stack } from './primitives';
 
 interface AddMcpServerModalProps {
   isOpen: boolean;
@@ -202,7 +203,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
             {!isEditing && <ServerTemplatePicker onSelectTemplate={applyTemplate} />}
 
             {/* Basic Info */}
-            <div className="flex flex-col gap-xs">
+            <Stack gap="xs">
               <label className="text-sm font-semibold text-text" htmlFor="mcp-name">
                 Server Name *
               </label>
@@ -215,7 +216,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
                 disabled={saving}
                 required
               />
-            </div>
+            </Stack>
 
             <ServerTypeConfig
               serverType={serverType}
@@ -249,7 +250,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
             />
 
             {/* Options */}
-            <div className="flex flex-col gap-xs">
+            <Stack gap="xs">
               <label className="flex items-center gap-sm text-sm text-text cursor-pointer [&>input]:m-0 [&>input]:w-4 [&>input]:h-4 [&>input]:accent-primary">
                 <input
                   type="checkbox"
@@ -268,7 +269,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
                 />
                 <span>Enabled (tools included in chat)</span>
               </label>
-            </div>
+            </Stack>
 
             {error && (
               <div className="p-md bg-[rgba(239,68,68,0.15)] text-[#ef4444] rounded-base text-sm" role="alert">

--- a/src/components/AddMcpServerModal/EnvVarManager.tsx
+++ b/src/components/AddMcpServerModal/EnvVarManager.tsx
@@ -3,6 +3,7 @@ import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { Icon } from "../ui/Icon";
 import { Plus, X } from "lucide-react";
+import { Stack, Label } from '../primitives';
 
 interface EnvVarManagerProps {
   envVars: [string, string][];
@@ -20,9 +21,9 @@ export const EnvVarManager: FC<EnvVarManagerProps> = ({
   disabled,
 }) => {
   return (
-    <div className="flex flex-col gap-xs">
+    <Stack gap="xs">
       <div className="flex justify-between items-center">
-        <label className="text-sm font-semibold text-text">Environment Variables</label>
+        <Label size="sm">Environment Variables</Label>
         <Button
           type="button"
           variant="ghost"
@@ -72,6 +73,6 @@ export const EnvVarManager: FC<EnvVarManagerProps> = ({
           ))}
         </div>
       )}
-    </div>
+    </Stack>
   );
 };

--- a/src/components/AddMcpServerModal/ServerTemplatePicker.tsx
+++ b/src/components/AddMcpServerModal/ServerTemplatePicker.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 import type { McpServerType } from "../../services/transport/types/mcp";
+import { Stack, Label } from '../primitives';
 
 interface ServerTemplatePickerProps {
   onSelectTemplate: (template: ServerTemplate) => void;
@@ -51,8 +52,8 @@ export const SERVER_TEMPLATES: ServerTemplate[] = [
 
 export const ServerTemplatePicker: FC<ServerTemplatePickerProps> = ({ onSelectTemplate }) => {
   return (
-    <div className="flex flex-col gap-xs">
-      <label className="text-sm font-semibold text-text">Quick Start Templates</label>
+    <Stack gap="xs">
+      <Label size="sm">Quick Start Templates</Label>
       <div className="grid grid-cols-2 gap-sm">
         {SERVER_TEMPLATES.map((template) => (
           <button
@@ -66,6 +67,6 @@ export const ServerTemplatePicker: FC<ServerTemplatePickerProps> = ({ onSelectTe
           </button>
         ))}
       </div>
-    </div>
+    </Stack>
   );
 };

--- a/src/components/AddMcpServerModal/ServerTypeConfig.tsx
+++ b/src/components/AddMcpServerModal/ServerTypeConfig.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import type { McpServerType } from "../../services/transport/types/mcp";
 import { Input } from "../ui/Input";
+import { Stack, Label } from '../primitives';
 
 interface StdioConfigFieldsProps {
   command: string;
@@ -37,8 +38,8 @@ export const ServerTypeConfig: FC<ServerTypeConfigProps> = ({
 }) => {
   return (
     <>
-      <div className="flex flex-col gap-xs">
-        <label className="text-sm font-semibold text-text">Connection Type</label>
+      <Stack gap="xs">
+        <Label size="sm">Connection Type</Label>
         <div className="flex gap-lg">
           <label className="flex items-center gap-sm text-sm text-text cursor-pointer [&>input]:m-0 [&>input]:accent-primary">
             <input
@@ -61,7 +62,7 @@ export const ServerTypeConfig: FC<ServerTypeConfigProps> = ({
             <span>SSE (connect to URL)</span>
           </label>
         </div>
-      </div>
+      </Stack>
 
       {serverType === "stdio" && <StdioConfigFields {...stdioProps} />}
       {serverType === "sse" && <SseConfigFields {...sseProps} />}
@@ -82,10 +83,10 @@ const StdioConfigFields: FC<StdioConfigFieldsProps> = ({
 }) => {
   return (
     <>
-      <div className="flex flex-col gap-xs">
-        <label className="text-sm font-semibold text-text" htmlFor="mcp-command">
+      <Stack gap="xs">
+        <Label size="sm" htmlFor="mcp-command">
           Command *
-        </label>
+        </Label>
         <Input
           id="mcp-command"
           type="text"
@@ -97,12 +98,12 @@ const StdioConfigFields: FC<StdioConfigFieldsProps> = ({
         <span className="text-xs text-text-secondary">
           Single executable name or path (no arguments). Will be resolved via PATH.
         </span>
-      </div>
+      </Stack>
 
-      <div className="flex flex-col gap-xs">
-        <label className="text-sm font-semibold text-text" htmlFor="mcp-args">
+      <Stack gap="xs">
+        <Label size="sm" htmlFor="mcp-args">
           Arguments
-        </label>
+        </Label>
         <Input
           id="mcp-args"
           type="text"
@@ -112,12 +113,12 @@ const StdioConfigFields: FC<StdioConfigFieldsProps> = ({
           disabled={disabled}
         />
         <span className="text-xs text-text-secondary">Space-separated arguments</span>
-      </div>
+      </Stack>
 
-      <div className="flex flex-col gap-xs">
-        <label className="text-sm font-semibold text-text" htmlFor="mcp-working-dir">
+      <Stack gap="xs">
+        <Label size="sm" htmlFor="mcp-working-dir">
           Working Directory
-        </label>
+        </Label>
         <Input
           id="mcp-working-dir"
           type="text"
@@ -127,12 +128,12 @@ const StdioConfigFields: FC<StdioConfigFieldsProps> = ({
           disabled={disabled}
         />
         <span className="text-xs text-text-secondary">Must be absolute if specified</span>
-      </div>
+      </Stack>
 
-      <div className="flex flex-col gap-xs">
-        <label className="text-sm font-semibold text-text" htmlFor="mcp-path-extra">
+      <Stack gap="xs">
+        <Label size="sm" htmlFor="mcp-path-extra">
           Additional PATH Entries
-        </label>
+        </Label>
         <Input
           id="mcp-path-extra"
           type="text"
@@ -142,17 +143,17 @@ const StdioConfigFields: FC<StdioConfigFieldsProps> = ({
           disabled={disabled}
         />
         <span className="text-xs text-text-secondary">Colon-separated paths added to child process PATH</span>
-      </div>
+      </Stack>
     </>
   );
 };
 
 const SseConfigFields: FC<SseConfigFieldsProps> = ({ url, setUrl, disabled }) => {
   return (
-    <div className="flex flex-col gap-xs">
-      <label className="text-sm font-semibold text-text" htmlFor="mcp-url">
+    <Stack gap="xs">
+      <Label size="sm" htmlFor="mcp-url">
         Server URL *
-      </label>
+      </Label>
       <Input
         id="mcp-url"
         type="url"
@@ -161,6 +162,6 @@ const SseConfigFields: FC<SseConfigFieldsProps> = ({ url, setUrl, disabled }) =>
         placeholder="http://localhost:3001/sse"
         disabled={disabled}
       />
-    </div>
+    </Stack>
   );
 };

--- a/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
+++ b/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
@@ -6,6 +6,7 @@ import { useServerState } from '../../services/serverEvents';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
 import { cn } from '../../utils/cn';
+import { Stack } from '../primitives';
 
 interface ConsoleInfoPanelProps {
   modelId: number;
@@ -175,10 +176,10 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
         </div>
 
         <div className="flex items-start justify-between gap-md">
-          <div className="flex flex-col gap-xs">
+          <Stack gap="xs">
             <span className="text-xs text-text-muted uppercase tracking-[0.05em]">Server running</span>
             <h2 className="m-0 text-lg font-semibold text-text break-words">{modelName}</h2>
-          </div>
+          </Stack>
         </div>
       </div>
 
@@ -187,7 +188,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
           {/* Server Info Section */}
           <section className="flex flex-col gap-sm">
             <h3 className="m-0 text-sm font-semibold text-text-muted uppercase tracking-[0.05em]">Server Info</h3>
-            <div className="flex flex-col gap-xs">
+            <Stack gap="xs">
               <div className="flex justify-between items-center gap-sm py-xs">
                 <span className="text-sm text-text-muted">Port</span>
                 <span className="text-sm text-text flex items-center gap-xs [&_code]:bg-background [&_code]:py-[2px] [&_code]:px-[6px] [&_code]:rounded-xs [&_code]:font-mono [&_code]:text-xs">
@@ -213,14 +214,14 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
                   <span className="text-sm text-text">{contextLength.toLocaleString()} tokens</span>
                 </div>
               )}
-            </div>
+            </Stack>
           </section>
 
           {/* Context Usage Section */}
           <section className="flex flex-col gap-sm">
             <h3 className="m-0 text-sm font-semibold text-text-muted uppercase tracking-[0.05em]">Context Usage</h3>
             {contextUsagePercent !== null ? (
-              <div className="flex flex-col gap-xs">
+              <Stack gap="xs">
                 <div className="h-[8px] bg-background rounded-sm overflow-hidden">
                   <div 
                     className={cn(
@@ -238,7 +239,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
                     </span>
                   )}
                 </div>
-              </div>
+              </Stack>
             ) : (
               <p className="text-xs text-text-muted m-0">
                 No usage yet
@@ -250,7 +251,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
           {metrics && (
             <section className="flex flex-col gap-sm">
               <h3 className="m-0 text-sm font-semibold text-text-muted uppercase tracking-[0.05em]">Statistics</h3>
-              <div className="flex flex-col gap-xs">
+              <Stack gap="xs">
                 <div className="flex justify-between items-center gap-sm py-xs">
                   <span className="text-sm text-text-muted">Prompt Tokens</span>
                   <span className="text-sm text-text">{metrics.promptTokensTotal.toLocaleString()}</span>
@@ -263,14 +264,14 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
                   <span className="text-sm text-text-muted">Active Requests</span>
                   <span className="text-sm text-text">{metrics.requestsProcessing}</span>
                 </div>
-              </div>
+              </Stack>
             </section>
           )}
 
           {/* API Endpoints Section */}
           <section className="flex flex-col gap-sm">
             <h3 className="m-0 text-sm font-semibold text-text-muted uppercase tracking-[0.05em]">API Endpoints</h3>
-            <div className="flex flex-col gap-xs">
+            <Stack gap="xs">
               <div className="flex flex-col gap-[2px] py-xs px-sm bg-background rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text">
                 <code>POST /v1/chat/completions</code>
                 <span className="text-[10px] text-text-muted">OpenAI-compatible chat</span>
@@ -283,7 +284,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
                 <code>GET /health</code>
                 <span className="text-[10px] text-text-muted">Health check</span>
               </div>
-            </div>
+            </Stack>
           </section>
 
           {/* Stop Server Button */}

--- a/src/components/ConversationListPanel/ConversationListPanel.tsx
+++ b/src/components/ConversationListPanel/ConversationListPanel.tsx
@@ -6,6 +6,7 @@ import SidebarTabs from '../ModelLibraryPanel/SidebarTabs';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
+import { Stack } from '../primitives';
 import { cn } from '../../utils/cn';
 
 interface ConversationListPanelProps {
@@ -74,10 +75,10 @@ const ConversationListPanel: FC<ConversationListPanelProps> = ({
         </div>
 
         <div className="flex justify-between items-start gap-md max-mobile:flex-col max-mobile:gap-sm">
-          <div className="flex flex-col gap-xs min-w-0">
+          <Stack gap="xs" className="min-w-0">
             <span className="text-xs uppercase tracking-[1px] text-text-muted">Chatting with</span>
             <h2 className="text-lg font-semibold m-0 text-text overflow-hidden text-ellipsis whitespace-nowrap">{modelName}</h2>
-          </div>
+          </Stack>
           <div className="flex gap-sm items-center shrink-0 max-mobile:w-full max-mobile:justify-between">
             <Button
               variant="primary"
@@ -131,12 +132,12 @@ const ConversationListPanel: FC<ConversationListPanelProps> = ({
                 )}
                 onClick={() => onSelectConversation(conversation.id)}
               >
-                <div className="flex flex-col gap-xs min-w-0 flex-1">
+                <Stack gap="xs" className="min-w-0 flex-1">
                   <span className="font-medium text-text overflow-hidden text-ellipsis whitespace-nowrap">{conversation.title}</span>
                   <span className="text-sm text-text-muted">
                     {formatRelativeTime(conversation.updated_at)}
                   </span>
-                </div>
+                </Stack>
                 <button
                   type="button"
                   className="opacity-0 group-hover/item:opacity-100 border-0 bg-transparent text-text-muted cursor-pointer p-xs rounded-sm transition-all duration-200 shrink-0 hover:bg-danger/10 hover:text-danger"

--- a/src/components/FilterPopover/FilterPopover.tsx
+++ b/src/components/FilterPopover/FilterPopover.tsx
@@ -3,6 +3,7 @@ import { useClickOutside } from '../../hooks/useClickOutside';
 import { RangeSlider } from '../RangeSlider';
 import { ModelFilterOptions } from '../../types';
 import { Button } from '../ui/Button';
+import { Stack } from '../primitives';
 import { cn } from '../../utils/cn';
 
 export interface FilterState {
@@ -208,7 +209,7 @@ const FilterPopover: FC<FilterPopoverProps> = ({
           <div className={cn("py-sm border-b border-border last:border-b-0", !quantizationsHaveVariety && "opacity-50")}>
             <span className="block text-sm font-medium text-text mb-xs">Quantization</span>
             {quantizationsHaveVariety ? (
-              <div className="flex flex-col gap-xs mt-xs">
+              <Stack gap="xs" className="mt-xs">
                 {filterOptions!.quantizations.map(quant => (
                   <label key={quant} className="flex items-center gap-sm cursor-pointer py-[4px] hover:bg-surface-elevated hover:rounded-sm hover:mx-[-4px] hover:px-[4px]">
                     <input
@@ -220,7 +221,7 @@ const FilterPopover: FC<FilterPopoverProps> = ({
                     <span className="text-sm text-text">{quant}</span>
                   </label>
                 ))}
-              </div>
+              </Stack>
             ) : (
               <span className="block text-xs text-text-muted italic mt-xs">All models same quantization</span>
             )}

--- a/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
+++ b/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
@@ -6,6 +6,7 @@ import type { QueueRunSummary } from '../../services/transport/types/events';
 import { formatBytes, formatTime } from '../../utils/format';
 import DownloadQueuePopover from './DownloadQueuePopover';
 import { Icon } from '../ui/Icon';
+import { Stack } from '../primitives';
 import { cn } from '../../utils/cn';
 
 interface GlobalDownloadStatusProps {
@@ -83,7 +84,7 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
               {uniqueTotal === 1 ? 'Download Complete' : `${uniqueTotal} Downloads Complete`}
             </span>
           </div>
-          <div className="flex flex-col gap-xs p-sm bg-surface-raised rounded-base max-h-[120px] overflow-y-auto">
+          <Stack gap="xs" className="p-sm bg-surface-raised rounded-base max-h-[120px] overflow-y-auto">
             {displayItems.length > 0 ? (
               <>
                 {displayItems.map((item, idx) => (
@@ -109,7 +110,7 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
                 {lastQueueSummary.truncated && ' (details truncated)'}
               </div>
             )}
-          </div>
+          </Stack>
           {hasRetries && (
             <div className="text-sm text-text-secondary">
               <span className="text-sm" aria-hidden>

--- a/src/components/HuggingFaceBrowser/HuggingFaceBrowser.tsx
+++ b/src/components/HuggingFaceBrowser/HuggingFaceBrowser.tsx
@@ -7,6 +7,13 @@ import { Select } from "../ui/Select";
 import { Stack, Row, EmptyState } from "../primitives";
 import { cn } from '../../utils/cn';
 
+/** Glass-effect form label */
+const glassLabel = "block text-[0.8rem] font-medium text-text-secondary mb-[0.35rem] uppercase tracking-[0.03em]";
+/** Glass-effect input override (small) */
+const glassInput = "w-full px-3 py-2 bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-[6px] text-text text-[0.85rem] transition-all duration-200 ease-linear focus:outline-none focus:border-[rgba(34,211,238,0.5)] focus:bg-[rgba(255,255,255,0.07)] placeholder:text-[#64748b]";
+/** Glass-effect input override (search box) */
+const glassInputLg = "w-full px-[0.9rem] py-[0.6rem] bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg text-text text-[0.95rem] transition-all duration-200 ease-linear focus:outline-none focus:border-[rgba(34,211,238,0.5)] focus:bg-[rgba(255,255,255,0.07)] focus:shadow-[0_0_0_3px_rgba(34,211,238,0.1)] placeholder:text-text-muted";
+
 interface HuggingFaceBrowserProps {
   /** Callback when a model is selected (clicked) for preview */
   onSelectModel?: (model: HfModelSummary | null) => void;
@@ -58,15 +65,15 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
   } = useHuggingFaceSearch({ onSelectModel });
 
   return (
-    <Stack gap="base" className="flex flex-col h-full overflow-hidden">
+    <Stack gap="base" className="h-full overflow-hidden">
       {/* Search Section */}
       <Stack gap="sm" className="p-4 bg-[rgba(255,255,255,0.02)] border-b border-[rgba(255,255,255,0.08)]">
-        <Row gap="sm" className="flex gap-3 items-end" align="end">
+        <Row gap="sm" align="end">
           <Stack gap="xs" className="flex-1">
-            <label className="block text-[0.8rem] font-medium text-text-secondary mb-[0.35rem] uppercase tracking-[0.03em]">Search Models</label>
+            <label className={glassLabel}>Search Models</label>
             <Input
               type="text"
-              className="w-full px-[0.9rem] py-[0.6rem] bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg text-text text-[0.95rem] transition-all duration-200 ease-linear focus:outline-none focus:border-[rgba(34,211,238,0.5)] focus:bg-[rgba(255,255,255,0.07)] focus:shadow-[0_0_0_3px_rgba(34,211,238,0.1)] placeholder:text-text-muted"
+              className={glassInputLg}
               variant={searchError ? "error" : "default"}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -92,12 +99,12 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
           </button>
         </Row>
 
-        <Row gap="base" className="flex gap-3 mt-3 items-end flex-wrap" wrap>
+        <Row gap="base" className="mt-3" align="end" wrap>
           <Stack gap="xs" className="flex-1 min-w-[120px] max-w-[180px]">
-            <label className="block text-[0.8rem] font-medium text-text-secondary mb-[0.35rem] uppercase tracking-[0.03em]">Min Params (B)</label>
+            <label className={glassLabel}>Min Params (B)</label>
             <Input
               type="number"
-              className="w-full px-3 py-2 bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-[6px] text-text text-[0.85rem] transition-all duration-200 ease-linear focus:outline-none focus:border-[rgba(34,211,238,0.5)] focus:bg-[rgba(255,255,255,0.07)] placeholder:text-[#64748b]"
+              className={glassInput}
               value={minParams}
               onChange={(e) => setMinParams(e.target.value)}
               placeholder="e.g. 3"
@@ -106,10 +113,10 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
             />
           </Stack>
           <Stack gap="xs" className="flex-1 min-w-[120px] max-w-[180px]">
-            <label className="block text-[0.8rem] font-medium text-text-secondary mb-[0.35rem] uppercase tracking-[0.03em]">Max Params (B)</label>
+            <label className={glassLabel}>Max Params (B)</label>
             <Input
               type="number"
-              className="w-full px-3 py-2 bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-[6px] text-text text-[0.85rem] transition-all duration-200 ease-linear focus:outline-none focus:border-[rgba(34,211,238,0.5)] focus:bg-[rgba(255,255,255,0.07)] placeholder:text-[#64748b]"
+              className={glassInput}
               value={maxParams}
               onChange={(e) => setMaxParams(e.target.value)}
               placeholder="e.g. 13"
@@ -118,8 +125,8 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
             />
           </Stack>
           <Stack gap="xs" className="flex-1 min-w-[120px] max-w-[180px]">
-            <label className="block text-[0.8rem] font-medium text-text-secondary mb-[0.35rem] uppercase tracking-[0.03em]">Sort By</label>
-            <Row gap="xs" className="flex gap-1 min-w-0">
+            <label className={glassLabel}>Sort By</label>
+            <Row gap="xs" className="min-w-0">
               <Select
                 className="flex-1 min-w-0 px-3 py-2 bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-[6px] text-[#f1f5f9] text-[0.85rem] cursor-pointer transition-all duration-200 ease-linear appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns=\x27http://www.w3.org/2000/svg\x27%20width=\x2712\x27%20height=\x2712\x27%20viewBox=\x270%200%2024%2024\x27%20fill=\x27none\x27%20stroke=\x27%2394a3b8\x27%20stroke-width=\x272\x27%3E%3Cpath%20d=\x27M6%209l6%206%206-6\x27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_0.5rem_center] pr-7 focus:outline-none focus:border-[rgba(34,211,238,0.5)] focus:bg-[rgba(255,255,255,0.07)]"
                 value={sortBy}

--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -17,6 +17,7 @@ import {
 import type { McpServerInfo } from "../services/clients/mcp";
 import { Icon } from "./ui/Icon";
 import { Button } from "./ui/Button";
+import { Stack } from './primitives';
 import { cn } from "../utils/cn";
 
 const statusBadge = "inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full";
@@ -237,7 +238,7 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
 
             return (
               <div key={id} className="flex justify-between items-start gap-md p-md bg-background-secondary border border-border rounded-base">
-                <div className="flex-1 min-w-0 flex flex-col gap-xs">
+                <Stack gap="xs" className="flex-1 min-w-0">
                   <div className="flex items-center gap-sm">
                     <span className="font-semibold text-text">{info.server.name}</span>
                     {getStatusBadge(info)}
@@ -287,7 +288,7 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
                       {getServerErrorMessage(info)}
                     </div>
                   )}
-                </div>
+                </Stack>
                 <div className="flex gap-xs shrink-0">
                   {!info.server.is_valid && info.server.server_type === "stdio" && (
                     <Button

--- a/src/components/ProxyControl.tsx
+++ b/src/components/ProxyControl.tsx
@@ -7,6 +7,7 @@ import { Icon } from "./ui/Icon";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
 import { cn } from '../utils/cn';
+import { Stack, Label } from './primitives';
 
 interface ProxyStatus {
   running: boolean;
@@ -135,8 +136,8 @@ const ProxyControl: FC<ProxyControlProps> = ({
           {status.running ? (
             <>
               <div className="mb-base">
-                <div className="flex flex-col gap-xs mb-sm">
-                  <label className="text-xs font-semibold text-text-secondary uppercase">URL:</label>
+                <Stack gap="xs" className="mb-sm">
+                  <Label size="xs" muted>URL:</Label>
                   <div className="flex gap-sm items-center">
                     <code className="flex-1 bg-surface-elevated p-sm rounded-base text-sm border border-border font-mono">http://{config.host}:{status.port}/v1</code>
                     <Button 
@@ -150,12 +151,12 @@ const ProxyControl: FC<ProxyControlProps> = ({
                       <Icon icon={ClipboardCopy} size={14} />
                     </Button>
                   </div>
-                </div>
+                </Stack>
                 {status.current_model && (
-                  <div className="flex flex-col gap-xs">
-                    <label className="text-xs font-semibold text-text-secondary uppercase">Current Model:</label>
+                  <Stack gap="xs">
+                    <Label size="xs" muted>Current Model:</Label>
                     <span>{status.current_model}</span>
-                  </div>
+                  </Stack>
                 )}
               </div>
 

--- a/src/components/ServerStatus.tsx
+++ b/src/components/ServerStatus.tsx
@@ -6,6 +6,7 @@ import { safeStopServer } from "../services/server/safeActions";
 import type { ServerInfo } from "../types";
 import type { ProxyStatus } from "../services/transport/types/proxy";
 import { Icon } from "./ui/Icon";
+import { Stack } from './primitives';
 import { cn } from "../utils/cn";
 
 interface ServerStatusProps {
@@ -73,7 +74,7 @@ const ServerStatus: FC<ServerStatusProps> = ({ onOpenChat }) => {
           <span className="text-xl leading-none" aria-hidden>
             <Icon icon={RotateCcw} size={16} />
           </span>
-          <div className="flex flex-col gap-xs text-white text-sm">
+          <Stack gap="xs" className="text-white text-sm">
             <strong className="font-semibold">Proxy Active</strong>
             <span className="text-xs opacity-90">
               Port {proxyStatus.port}
@@ -81,7 +82,7 @@ const ServerStatus: FC<ServerStatusProps> = ({ onOpenChat }) => {
                 <> • {proxyStatus.current_model} on port {proxyStatus.model_port}</>
               )}
             </span>
-          </div>
+          </Stack>
         </div>
       )}
 
@@ -91,10 +92,10 @@ const ServerStatus: FC<ServerStatusProps> = ({ onOpenChat }) => {
           <span className={cn('text-xl leading-none', isServerHealthy(server) && 'animate-pulse')} aria-hidden>
             <Icon icon={Circle} size={14} />
           </span>
-          <div className="flex flex-col gap-xs text-white text-sm">
+          <Stack gap="xs" className="text-white text-sm">
             <strong className="font-semibold">{server.modelName}</strong>
             <span className="text-xs opacity-90">Port {server.port}</span>
-          </div>
+          </Stack>
           {isServerHealthy(server) && onOpenChat && (
             <button
               className="bg-white/20 border-none rounded-base px-sm py-xs cursor-pointer text-base transition-all text-white flex items-center justify-center hover:bg-white/30 hover:-translate-y-px active:translate-y-0"

--- a/src/components/SettingsModal/GeneralSettings.tsx
+++ b/src/components/SettingsModal/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import { InferenceParametersForm } from "../InferenceParametersForm";
 import { DEFAULT_TITLE_GENERATION_PROMPT } from "../../services/clients/chat";
 import type { ModelsDirectoryInfo, GgufModel, InferenceConfig } from "../../types";
 import { cn } from '../../utils/cn';
+import { Row, Label } from '../primitives';
 
 interface GeneralSettingsProps {
   // Directory state
@@ -109,9 +110,9 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
 
   return (
     <form className="flex flex-col gap-md" onSubmit={onSubmit}>
-      <label className="font-semibold text-text" htmlFor="models-dir-input">
+      <Label htmlFor="models-dir-input">
         Default Download Path
-      </label>
+      </Label>
       <Input
         id="models-dir-input"
         value={pathInput}
@@ -119,14 +120,14 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         placeholder="/path/to/models"
         disabled={saving}
       />
-      <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+      <Row justify="between" gap="sm" className="text-text-secondary text-sm">
         {sourceDescription && <span>{sourceDescription}</span>}
         {info?.defaultPath && (
           <button type="button" className="bg-none border-none text-primary cursor-pointer text-sm underline p-0" onClick={onReset}>
             Reset to defaults
           </button>
         )}
-      </div>
+      </Row>
 
       {info && (
         <div className="flex gap-sm flex-wrap" role="status" aria-live="polite">
@@ -153,9 +154,9 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
 
       <div className="border-t border-border my-md" />
 
-      <label className="font-semibold text-text" htmlFor="context-size-input">
+      <Label htmlFor="context-size-input">
         Default Context Size
-      </label>
+      </Label>
       <Input
         id="context-size-input"
         type="number"
@@ -166,13 +167,13 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         max="1000000"
         disabled={saving}
       />
-      <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+      <Row justify="between" gap="sm" className="text-text-secondary text-sm">
         <span>Default context size for models (e.g., 4096, 8192, 16384)</span>
-      </div>
+      </Row>
 
-      <label className="font-semibold text-text" htmlFor="default-model-select">
+      <Label htmlFor="default-model-select">
         Default Model
-      </label>
+      </Label>
       <Select
         id="default-model-select"
         value={defaultModelInput}
@@ -186,13 +187,13 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
           </option>
         ))}
       </Select>
-      <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+      <Row justify="between" gap="sm" className="text-text-secondary text-sm">
         <span>Model to use for quick commands like <code>gglib question</code></span>
-      </div>
+      </Row>
 
-      <label className="font-semibold text-text" htmlFor="proxy-port-input">
+      <Label htmlFor="proxy-port-input">
         Proxy Server Port
-      </label>
+      </Label>
       <Input
         id="proxy-port-input"
         type="number"
@@ -203,13 +204,13 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         max="65535"
         disabled={saving}
       />
-      <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+      <Row justify="between" gap="sm" className="text-text-secondary text-sm">
         <span>Port for the OpenAI-compatible proxy server</span>
-      </div>
+      </Row>
 
-      <label className="font-semibold text-text" htmlFor="server-port-input">
+      <Label htmlFor="server-port-input">
         Base Server Port
-      </label>
+      </Label>
       <Input
         id="server-port-input"
         type="number"
@@ -220,13 +221,13 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         max="65535"
         disabled={saving}
       />
-      <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+      <Row justify="between" gap="sm" className="text-text-secondary text-sm">
         <span>Starting port for llama-server instances</span>
-      </div>
+      </Row>
 
-      <label className="font-semibold text-text" htmlFor="max-queue-size-input">
+      <Label htmlFor="max-queue-size-input">
         Max Download Queue Size
-      </label>
+      </Label>
       <Input
         id="max-queue-size-input"
         type="number"
@@ -237,9 +238,9 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         max="50"
         disabled={saving}
       />
-      <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+      <Row justify="between" gap="sm" className="text-text-secondary text-sm">
         <span>Maximum number of models that can be queued for download (1-50)</span>
-      </div>
+      </Row>
 
       <div className="border-t border-border my-md" />
 
@@ -254,9 +255,9 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
           />
           <span className="font-semibold text-text">Show memory fit indicators</span>
         </label>
-        <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+        <Row justify="between" gap="sm" className="text-text-secondary text-sm">
           <span>Display fit status indicators in the HuggingFace browser showing if models fit in your system memory</span>
-        </div>
+        </Row>
       </div>
 
       {/* Advanced Settings Section */}
@@ -273,9 +274,9 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
 
       {isAdvancedOpen && (
         <div className="flex flex-col gap-md pl-md border-l-2 border-l-border mt-sm animate-slide-down">
-          <label className="font-semibold text-text" htmlFor="max-tool-iterations-input">
+          <Label htmlFor="max-tool-iterations-input">
             Max Tool Iterations
-          </label>
+          </Label>
           <Input
             id="max-tool-iterations-input"
             type="number"
@@ -286,13 +287,13 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
             max="100"
             disabled={saving}
           />
-          <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+          <Row justify="between" gap="sm" className="text-text-secondary text-sm">
             <span>Maximum iterations for tool calling in agentic loop (default: 25)</span>
-          </div>
+          </Row>
 
-          <label className="font-semibold text-text" htmlFor="max-stagnation-steps-input">
+          <Label htmlFor="max-stagnation-steps-input">
             Max Stagnation Steps
-          </label>
+          </Label>
           <Input
             id="max-stagnation-steps-input"
             type="number"
@@ -303,13 +304,13 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
             max="20"
             disabled={saving}
           />
-          <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+          <Row justify="between" gap="sm" className="text-text-secondary text-sm">
             <span>Maximum repeated outputs before stopping (prevents infinite loops, default: 5)</span>
-          </div>
+          </Row>
 
-          <label className="font-semibold text-text" htmlFor="title-prompt-input">
+          <Label htmlFor="title-prompt-input">
             Chat Title Generation Prompt
-          </label>
+          </Label>
           <Textarea
             id="title-prompt-input"
             value={titlePromptInput}
@@ -318,7 +319,7 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
             rows={3}
             disabled={saving}
           />
-          <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+          <Row justify="between" gap="sm" className="text-text-secondary text-sm">
             <span>Prompt used when AI generates chat titles. Leave empty to use the default.</span>
             <button
               type="button"
@@ -327,20 +328,20 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
             >
               Reset to default
             </button>
-          </div>
+          </Row>
 
           <div className="border-t border-border my-md" />
-          <label className="font-semibold text-text">
+          <Label>
             Global Inference Parameter Defaults
-          </label>
+          </Label>
           <InferenceParametersForm
             value={inferenceDefaultsInput}
             onChange={setInferenceDefaultsInput}
             disabled={saving}
           />
-          <div className="flex justify-between items-center gap-sm text-text-secondary text-sm">
+          <Row justify="between" gap="sm" className="text-text-secondary text-sm">
             <span>Default inference parameters for all models. Can be overridden per-model in the model inspector.</span>
-          </div>
+          </Row>
         </div>
       )}
 

--- a/src/components/SettingsModal/VoiceSettings.tsx
+++ b/src/components/SettingsModal/VoiceSettings.tsx
@@ -15,6 +15,7 @@ import { Select } from "../ui/Select";
 import { useVoiceModeContext } from "../../contexts/VoiceModeContext";
 import { useSettingsContext } from "../../contexts/SettingsContext";
 import type { VoiceInteractionMode } from "../../services/clients/voice";
+import { Stack, Label } from '../primitives';
 
 interface VoiceSettingsProps {
   onClose: () => void;
@@ -153,11 +154,11 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
 
   if (!voice || !voice.isSupported) {
     return (
-      <div className="flex flex-col gap-xs">
+      <Stack gap="xs">
         <p className="text-sm text-text-secondary">
           Voice mode is only available in the desktop application.
         </p>
-      </div>
+      </Stack>
     );
   }
 
@@ -190,7 +191,7 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
       )}
 
       {/* ── STT Model Section ──────────────────────────────────── */}
-      <div className="flex flex-col gap-xs">
+      <Stack gap="xs">
         <h3 className="font-semibold text-text">Speech-to-Text</h3>
         <p className="text-sm text-text-secondary">
           Choose an STT model for speech recognition. Larger models are more
@@ -198,8 +199,8 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
         </p>
 
         {/* Download row: pick any catalog model and download it */}
-        <div className="flex flex-col gap-xs">
-          <label className="font-semibold text-text">Download a Model</label>
+        <Stack gap="xs">
+          <Label>Download a Model</Label>
           <div className="flex gap-2 items-center">
             <Select
               value={downloadTarget}
@@ -222,11 +223,11 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
               {sttButtonLabel}
             </Button>
           </div>
-        </div>
+        </Stack>
 
         {/* Default model selector: only downloaded models */}
-        <div className="flex flex-col gap-xs">
-          <label className="font-semibold text-text">Default STT Model</label>
+        <Stack gap="xs">
+          <Label>Default STT Model</Label>
           {downloadedSttModels.length > 0 ? (
             <Select
               value={defaultSttModel ?? ''}
@@ -246,18 +247,18 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
               Download a model above to set a default.
             </p>
           )}
-        </div>
-      </div>
+        </Stack>
+      </Stack>
 
       {/* ── TTS Section ────────────────────────────────────────── */}
-      <div className="flex flex-col gap-xs">
+      <Stack gap="xs">
         <h3 className="font-semibold text-text">Text-to-Speech</h3>
         <p className="text-sm text-text-secondary">
           High-quality local TTS. The model will be downloaded on first use (~300 MB).
         </p>
 
-        <div className="flex flex-col gap-xs">
-          <label className="font-semibold text-text">TTS Model</label>
+        <Stack gap="xs">
+          <Label>TTS Model</Label>
           <div className="flex gap-2 items-center">
             <span className="flex-1 text-sm text-text-secondary">
               {voice?.models?.ttsModel?.name ?? 'TTS Model'}
@@ -271,10 +272,10 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
               {ttsButtonLabel}
             </Button>
           </div>
-        </div>
+        </Stack>
 
-        <div className="flex flex-col gap-xs">
-          <label className="font-semibold text-text">Default Voice</label>
+        <Stack gap="xs">
+          <Label>Default Voice</Label>
           <Select
             value={selectedVoice}
             onChange={(e) => handleVoiceChange(e.target.value)}
@@ -285,10 +286,10 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
               </option>
             )) ?? <option>Loading...</option>}
           </Select>
-        </div>
+        </Stack>
 
-        <div className="flex flex-col gap-xs">
-          <label className="font-semibold text-text">Speed ({speedInput.toFixed(1)}x)</label>
+        <Stack gap="xs">
+          <Label>Speed ({speedInput.toFixed(1)}x)</Label>
           <input
             type="range"
             min="0.5"
@@ -298,15 +299,15 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
             onChange={handleSpeedChange}
             className="w-full"
           />
-        </div>
-      </div>
+        </Stack>
+      </Stack>
 
       {/* ── Interaction Mode ───────────────────────────────────── */}
-      <div className="flex flex-col gap-xs">
+      <Stack gap="xs">
         <h3 className="font-semibold text-text">Interaction Mode</h3>
 
-        <div className="flex flex-col gap-xs">
-          <label className="font-semibold text-text">Mode</label>
+        <Stack gap="xs">
+          <Label>Mode</Label>
           <Select
             value={voice?.mode ?? 'ptt'}
             onChange={(e) => handleModeChange(e.target.value)}
@@ -314,12 +315,12 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
             <option value="ptt">Push to Talk (Space bar)</option>
             <option value="vad">Voice Activity Detection (hands-free)</option>
           </Select>
-        </div>
+        </Stack>
 
         {/* VAD model download — shown when VAD mode is selected */}
         {voice?.mode === 'vad' && (
-          <div className="flex flex-col gap-xs">
-            <label className="font-semibold text-text">Silero VAD Model</label>
+          <Stack gap="xs">
+            <Label>Silero VAD Model</Label>
             <p className="text-sm text-text-secondary">
               Neural-network voice detection for more accurate hands-free mode.
               Falls back to energy-based detection if not downloaded.
@@ -337,10 +338,10 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
                 {downloading === 'vad' ? 'Downloading…' : vadDownloaded ? '✓ Downloaded' : 'Download'}
               </Button>
             </div>
-          </div>
+          </Stack>
         )}
 
-        <div className="flex flex-col gap-xs">
+        <Stack gap="xs">
           <label className="font-semibold text-text flex items-center gap-2">
             <input
               type="checkbox"
@@ -352,15 +353,15 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
           <p className="text-sm text-text-secondary">
             Automatically read LLM responses aloud using TTS.
           </p>
-        </div>
-      </div>
+        </Stack>
+      </Stack>
 
       {/* ── Audio Devices ──────────────────────────────────────── */}
       {(voice?.devices?.length ?? 0) > 0 && (
-        <div className="flex flex-col gap-xs">
+        <Stack gap="xs">
           <h3 className="font-semibold text-text">Audio Devices</h3>
-          <div className="flex flex-col gap-xs">
-            <label className="font-semibold text-text">Input Device</label>
+          <Stack gap="xs">
+            <Label>Input Device</Label>
             <Select value="" onChange={() => {}}>
               {voice?.devices?.map((d) => (
                 <option key={d.name} value={d.name}>
@@ -368,13 +369,13 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
                 </option>
               ))}
             </Select>
-          </div>
-        </div>
+          </Stack>
+        </Stack>
       )}
 
       {/* ── Download Progress ──────────────────────────────────── */}
       {voice?.downloadProgress && (
-        <div className="flex flex-col gap-xs">
+        <Stack gap="xs">
           <p className="text-sm text-text-secondary">
             Downloading {voice.downloadProgress.modelId}…{' '}
             {voice.downloadProgress.percent.toFixed(0)}%
@@ -385,11 +386,11 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
               style={{ width: `${voice?.downloadProgress?.percent ?? 0}%` }}
             />
           </div>
-        </div>
+        </Stack>
       )}
 
       {/* ── Status ─────────────────────────────────────────────── */}
-      <div className="flex flex-col gap-xs">
+      <Stack gap="xs">
         <h3 className="font-semibold text-text">Status</h3>
         <div className="text-sm text-text-secondary">
           <div>Pipeline: {voice?.isActive ? '🟢 Active' : '⚪ Inactive'}</div>
@@ -399,7 +400,7 @@ export const VoiceSettings: FC<VoiceSettingsProps> = ({ onClose }) => {
           <div>Default Voice: {selectedVoice}</div>
           <div>State: {voice?.voiceState}</div>
         </div>
-      </div>
+      </Stack>
 
       {/* ── Actions ────────────────────────────────────────────── */}
       <div className="flex gap-sm pt-md">

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui/Button';
 import { Icon } from '../ui/Icon';
 import { Modal } from '../ui/Modal';
 import { cn } from '../../utils/cn';
+import { Stack } from '../primitives';
 
 type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
 
@@ -116,7 +117,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 <span className="text-[0.85rem] text-text-secondary font-mono">({call.toolName})</span>
               </div>
 
-              <div className="flex flex-col gap-xs">
+              <Stack gap="xs">
                 <div className="flex items-center gap-xs w-full bg-background border border-border rounded-lg py-2 px-3 cursor-pointer transition-[border-color,background] duration-150 hover:border-primary hover:bg-background-tertiary" onClick={() => toggleSection(argsId)} role="button" tabIndex={0}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -142,9 +143,9 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                   </Button>
                 </div>
                 {argsExpanded && <pre className="m-0 p-3 bg-background border border-border rounded-lg font-mono text-[0.9rem] leading-normal text-text overflow-x-auto whitespace-pre max-h-[300px]">{formattedArgs}</pre>}
-              </div>
+              </Stack>
 
-              <div className="flex flex-col gap-xs">
+              <Stack gap="xs">
                 <div className="flex items-center gap-xs w-full bg-background border border-border rounded-lg py-2 px-3 cursor-pointer transition-[border-color,background] duration-150 hover:border-primary hover:bg-background-tertiary" onClick={() => toggleSection(resultId)} role="button" tabIndex={0}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -170,7 +171,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                   </Button>
                 </div>
                 {resultExpanded && <pre className="m-0 p-3 bg-background border border-border rounded-lg font-mono text-[0.9rem] leading-normal text-text overflow-x-auto whitespace-pre max-h-[300px]">{formattedResult}</pre>}
-              </div>
+              </Stack>
             </div>
           );
         })}

--- a/src/components/primitives/Label.tsx
+++ b/src/components/primitives/Label.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  children: React.ReactNode;
+  size?: 'xs' | 'sm' | 'base';
+  muted?: boolean;
+}
+
+const sizeClasses = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  base: '',
+} as const;
+
+/**
+ * Label - Consistent form label with semantic HTML
+ * Default: font-semibold text-text
+ * muted: text-text-secondary + uppercase tracking
+ */
+export const Label: React.FC<LabelProps> = ({
+  children,
+  className,
+  size = 'base',
+  muted = false,
+  ...props
+}) => {
+  return (
+    <label
+      className={cn(
+        'font-semibold',
+        muted ? 'text-text-secondary uppercase' : 'text-text',
+        sizeClasses[size],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </label>
+  );
+};
+
+Label.displayName = 'Label';

--- a/src/components/primitives/Row.tsx
+++ b/src/components/primitives/Row.tsx
@@ -4,7 +4,7 @@ import { cn } from '../../utils/cn';
 interface RowProps {
   children: React.ReactNode;
   className?: string;
-  gap?: 'none' | 'xs' | 'sm' | 'base' | 'lg' | 'xl';
+  gap?: 'none' | 'xs' | 'sm' | 'md' | 'base' | 'lg' | 'xl';
   align?: 'start' | 'center' | 'end' | 'stretch';
   justify?: 'start' | 'center' | 'end' | 'between' | 'around';
   wrap?: boolean;
@@ -12,11 +12,12 @@ interface RowProps {
 
 const gapClasses = {
   none: 'gap-0',
-  xs: 'gap-1',
-  sm: 'gap-2',
-  base: 'gap-4',
-  lg: 'gap-6',
-  xl: 'gap-8',
+  xs: 'gap-xs',
+  sm: 'gap-sm',
+  md: 'gap-md',
+  base: 'gap-base',
+  lg: 'gap-lg',
+  xl: 'gap-xl',
 } as const;
 
 const alignClasses = {

--- a/src/components/primitives/Stack.tsx
+++ b/src/components/primitives/Stack.tsx
@@ -4,18 +4,19 @@ import { cn } from '../../utils/cn';
 interface StackProps {
   children: React.ReactNode;
   className?: string;
-  gap?: 'none' | 'xs' | 'sm' | 'base' | 'lg' | 'xl';
+  gap?: 'none' | 'xs' | 'sm' | 'md' | 'base' | 'lg' | 'xl';
   align?: 'start' | 'center' | 'end' | 'stretch';
   justify?: 'start' | 'center' | 'end' | 'between' | 'around';
 }
 
 const gapClasses = {
   none: 'gap-0',
-  xs: 'gap-1',
-  sm: 'gap-2',
-  base: 'gap-4',
-  lg: 'gap-6',
-  xl: 'gap-8',
+  xs: 'gap-xs',
+  sm: 'gap-sm',
+  md: 'gap-md',
+  base: 'gap-base',
+  lg: 'gap-lg',
+  xl: 'gap-xl',
 } as const;
 
 const alignClasses = {

--- a/src/components/primitives/index.ts
+++ b/src/components/primitives/index.ts
@@ -1,4 +1,5 @@
 export { Card } from './Card';
 export { Stack } from './Stack';
 export { Row } from './Row';
+export { Label } from './Label';
 export { EmptyState } from './EmptyState';


### PR DESCRIPTION
## Summary

Phase 3 of the Tailwind CSS cleanup: replace repetitive layout divs with semantic primitives and create a Label component.

### Changes

**Stack primitive adoption (34 to 0 instances)**
- Replaced all `<div className="flex flex-col gap-xs">` with `<Stack gap="xs">` across 13 component files
- Also replaced 9 variants with extra classes (e.g. `mb-sm`, `min-w-0 flex-1`) as `<Stack gap="xs" className="...">`
- 1 instance skipped (Header.tsx) - conditional hidden/flex toggle conflicts with Stack

**Row primitive adoption (11 settings rows)**
- Replaced 11 identical settings rows in GeneralSettings.tsx with `<Row justify="between" gap="sm">`

**Label primitive (new, 28 replacements)**
- Created `src/components/primitives/Label.tsx` with `size` (xs/sm/base) and `muted` props
- Replaced 28 label elements across 6 files
- Supports `htmlFor` passthrough via React label attributes

**Design token alignment**
- Updated Stack and Row gap maps to use design tokens (gap-xs, gap-sm, gap-md)
- Added `md` gap option to both Stack and Row

**HuggingFaceBrowser cleanup**
- Extracted 3 glass-effect class constants (glassLabel, glassInput, glassInputLg)
- Removed redundant Tailwind classes on Stack/Row

### Files changed: 19 (239 insertions, 172 deletions)

### Testing
- `npx tsc --noEmit` passes with zero errors
