### PR TITLE
Phase 2: Voice Events via SSE (#213)

### DIFF
--- a/crates/gglib-core/src/events/mod.rs
+++ b/crates/gglib-core/src/events/mod.rs
@@ -208,6 +208,42 @@ pub enum AppEvent {
     },
 
     // ========== Voice Events ==========
+    /// Voice pipeline state changed (idle → listening → recording → …).
+    VoiceStateChanged {
+        /// Lowercase state label: `"idle"`, `"listening"`, `"recording"`,
+        /// `"transcribing"`, `"thinking"`, `"speaking"`, or `"error"`.
+        state: String,
+    },
+
+    /// Speech transcript produced by the STT engine.
+    VoiceTranscript {
+        /// Transcript text.
+        text: String,
+        /// Whether this is a final (committed) transcript.
+        #[serde(rename = "isFinal")]
+        is_final: bool,
+    },
+
+    /// TTS playback has started.
+    VoiceSpeakingStarted,
+
+    /// TTS playback has finished.
+    VoiceSpeakingFinished,
+
+    /// Microphone audio level sample (0.0 – 1.0) for UI visualisation.
+    ///
+    /// Throttled to ≤ 20 fps at the SSE bridge before entering the bus.
+    VoiceAudioLevel {
+        /// Normalised audio level in `[0.0, 1.0]`.
+        level: f32,
+    },
+
+    /// Voice pipeline encountered a non-fatal error.
+    VoiceError {
+        /// Human-readable error message.
+        message: String,
+    },
+
     /// Download progress for a voice model (STT / TTS / VAD).
     ///
     /// Emitted by `VoiceService` during `download_stt_model`,
@@ -251,8 +287,46 @@ impl AppEvent {
             Self::McpServerStarted { .. } => "mcp:started",
             Self::McpServerStopped { .. } => "mcp:stopped",
             Self::McpServerError { .. } => "mcp:error",
+            Self::VoiceStateChanged { .. } => "voice:state-changed",
+            Self::VoiceTranscript { .. } => "voice:transcript",
+            Self::VoiceSpeakingStarted => "voice:speaking-started",
+            Self::VoiceSpeakingFinished => "voice:speaking-finished",
+            Self::VoiceAudioLevel { .. } => "voice:audio-level",
+            Self::VoiceError { .. } => "voice:error",
             Self::VoiceModelDownloadProgress { .. } => "voice:model-download-progress",
         }
+    }
+}
+
+impl AppEvent {
+    /// Create a [`VoiceStateChanged`] event.
+    pub fn voice_state_changed(state: impl Into<String>) -> Self {
+        Self::VoiceStateChanged { state: state.into() }
+    }
+
+    /// Create a [`VoiceTranscript`] event.
+    pub fn voice_transcript(text: impl Into<String>, is_final: bool) -> Self {
+        Self::VoiceTranscript { text: text.into(), is_final }
+    }
+
+    /// Create a [`VoiceSpeakingStarted`] event.
+    pub fn voice_speaking_started() -> Self {
+        Self::VoiceSpeakingStarted
+    }
+
+    /// Create a [`VoiceSpeakingFinished`] event.
+    pub fn voice_speaking_finished() -> Self {
+        Self::VoiceSpeakingFinished
+    }
+
+    /// Create a [`VoiceAudioLevel`] event.
+    pub fn voice_audio_level(level: f32) -> Self {
+        Self::VoiceAudioLevel { level }
+    }
+
+    /// Create a [`VoiceError`] event.
+    pub fn voice_error(message: impl Into<String>) -> Self {
+        Self::VoiceError { message: message.into() }
     }
 }
 
@@ -309,5 +383,40 @@ mod tests {
         for (event, expected_name) in cases {
             assert_eq!(event.event_name(), expected_name);
         }
+    }
+
+    /// Lock down voice event names to prevent frontend subscription mismatches.
+    ///
+    /// Both the Serde `type` tag (SSE/WebUI path) and the `event_name()` return
+    /// (Tauri IPC path) are validated here.
+    ///
+    /// If this test fails, update `VOICE_EVENT_NAMES` in
+    /// `src/services/transport/events/eventNames.ts` to match.
+    #[test]
+    fn voice_event_names_are_stable() {
+        let cases = vec![
+            (AppEvent::voice_state_changed("idle"), "voice:state-changed"),
+            (AppEvent::voice_transcript("hello", true), "voice:transcript"),
+            (AppEvent::voice_speaking_started(), "voice:speaking-started"),
+            (AppEvent::voice_speaking_finished(), "voice:speaking-finished"),
+            (AppEvent::voice_audio_level(0.5), "voice:audio-level"),
+            (AppEvent::voice_error("oops"), "voice:error"),
+        ];
+        for (event, expected_name) in cases {
+            assert_eq!(event.event_name(), expected_name);
+        }
+
+        // Also assert Serde type tags match the frontend SSE routing prefix.
+        let json =
+            serde_json::to_string(&AppEvent::voice_state_changed("idle")).unwrap();
+        assert!(json.contains("\"type\":\"voice_state_changed\""), "bad serde tag: {json}");
+
+        let json =
+            serde_json::to_string(&AppEvent::voice_audio_level(0.5)).unwrap();
+        assert!(json.contains("\"type\":\"voice_audio_level\""), "bad serde tag: {json}");
+
+        let json =
+            serde_json::to_string(&AppEvent::voice_error("oops")).unwrap();
+        assert!(json.contains("\"type\":\"voice_error\""), "bad serde tag: {json}");
     }
 }

--- a/crates/gglib-voice/src/service.rs
+++ b/crates/gglib-voice/src/service.rs
@@ -142,14 +142,14 @@ pub fn spawn_event_bridge(
     emitter: Arc<dyn AppEventEmitter>,
 ) {
     tokio::spawn(async move {
-        let mut last_level_emit = Instant::now();
+        let mut last_level_emit: Option<Instant> = None;
 
         while let Some(event) = event_rx.recv().await {
             match event {
                 VoiceEvent::AudioLevel(level) => {
-                    if last_level_emit.elapsed() >= AUDIO_LEVEL_THROTTLE {
+                    if last_level_emit.map_or(true, |t| t.elapsed() >= AUDIO_LEVEL_THROTTLE) {
                         emitter.emit(AppEvent::VoiceAudioLevel { level });
-                        last_level_emit = Instant::now();
+                        last_level_emit = Some(Instant::now());
                     }
                     // else: drop — never queue, never delay
                 }

--- a/src/hooks/useVoiceMode.ts
+++ b/src/hooks/useVoiceMode.ts
@@ -13,7 +13,6 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { UnlistenFn } from '@tauri-apps/api/event';
 import {
   voiceStart,
   voiceStop,
@@ -34,13 +33,7 @@ import {
   voiceDownloadVadModel,
   voiceLoadStt,
   voiceLoadTts,
-  onVoiceStateChanged,
-  onVoiceTranscript,
-  onVoiceSpeakingStarted,
-  onVoiceSpeakingFinished,
-  onVoiceAudioLevel,
-  onVoiceError,
-  onModelDownloadProgress,
+  subscribeVoiceEvents,
 } from '../services/clients/voice';
 import type {
   VoiceState,
@@ -192,8 +185,6 @@ export function useVoiceMode(defaults?: VoiceDefaults): UseVoiceModeReturn {
   const [isAutoLoading, setIsAutoLoading] = useState(false);
 
   // Cleanup refs
-  const unlistenRefs = useRef<UnlistenFn[]>([]);
-
   // Race-condition guard: monotonically increasing load generation.
   // When a new load is requested, the generation advances; any
   // in-flight load with an older generation bails out before
@@ -207,54 +198,46 @@ export function useVoiceMode(defaults?: VoiceDefaults): UseVoiceModeReturn {
 
   // ── Event subscriptions ────────────────────────────────────────
 
-  const subscribeToEvents = useCallback(async () => {
-    // All voice events are emitted by the Tauri audio pipeline — not available
-    // in a plain web browser until Phase 3 (WebSocket audio bridge).
-    if (!isAudioSupported) return;
-
-    const unlisteners = await Promise.all([
-      onVoiceStateChanged(({ state }) => {
-        setVoiceState(state);
-      }),
-      onVoiceTranscript(({ text, isFinal }) => {
-        if (isFinal) {
-          setLastTranscript(text);
-        }
-      }),
-      onVoiceSpeakingStarted(() => {
-        setIsTtsGenerating(false);
-        setIsSpeaking(true);
-      }),
-      onVoiceSpeakingFinished(() => {
-        setIsSpeaking(false);
-        setIsTtsGenerating(false);
-      }),
-      onVoiceAudioLevel(({ level }) => {
-        setAudioLevel(level);
-      }),
-      onVoiceError(({ message }) => {
-        setError(message);
-      }),
-      onModelDownloadProgress((progress) => {
-        setDownloadProgress(progress);
-        // Clear progress when complete
-        if (progress.totalBytes && progress.bytesDownloaded >= progress.totalBytes) {
-          setTimeout(() => setDownloadProgress(null), 1000);
-        }
-      }),
-    ]);
-
-    unlistenRefs.current = unlisteners;
-  }, [isAudioSupported]);
-  // Subscribe on mount, cleanup on unmount
+  // Subscribe on mount, cleanup on unmount.
+  // Events are delivered via SSE in WebUI and Tauri IPC on desktop —
+  // no platform guard needed; the transport layer handles routing.
   useEffect(() => {
-    subscribeToEvents();
+    const unsub = subscribeVoiceEvents((event) => {
+      switch (event.type) {
+        case 'voice_state_changed':
+          setVoiceState(event.state);
+          break;
+        case 'voice_transcript':
+          if (event.isFinal) setLastTranscript(event.text);
+          break;
+        case 'voice_speaking_started':
+          setIsTtsGenerating(false);
+          setIsSpeaking(true);
+          break;
+        case 'voice_speaking_finished':
+          setIsSpeaking(false);
+          setIsTtsGenerating(false);
+          break;
+        case 'voice_audio_level':
+          setAudioLevel(event.level);
+          break;
+        case 'voice_error':
+          setError(event.message);
+          break;
+        case 'voice_model_download_progress': {
+          const { modelId, bytesDownloaded, totalBytes, percent } = event;
+          const progress: ModelDownloadProgressPayload = { modelId, bytesDownloaded, totalBytes, percent };
+          setDownloadProgress(progress);
+          if (totalBytes && bytesDownloaded >= totalBytes) {
+            setTimeout(() => setDownloadProgress(null), 1000);
+          }
+          break;
+        }
+      }
+    });
 
     return () => {
-      for (const unlisten of unlistenRefs.current) {
-        unlisten();
-      }
-      unlistenRefs.current = [];
+      unsub();
 
       // Release the microphone if voice is still active when this component
       // unmounts (e.g. user navigates away). voiceStop pauses the pipeline
@@ -273,7 +256,7 @@ export function useVoiceMode(defaults?: VoiceDefaults): UseVoiceModeReturn {
           });
       }
     };
-  }, [subscribeToEvents, isAudioSupported]);
+  }, [isAudioSupported]);
 
   // ── Sync status on mount ───────────────────────────────────────
 

--- a/src/services/transport/events/eventNames.ts
+++ b/src/services/transport/events/eventNames.ts
@@ -66,6 +66,24 @@ export const VERIFICATION_EVENT_NAMES = [
 ] as const;
 
 /**
+ * Voice-related event names.
+ *
+ * These are the colon-kebab strings returned by `AppEvent::event_name()` in
+ * Rust and used as Tauri IPC event names by `TauriEventEmitter`.
+ * The SSE path uses the snake_case Serde `type` tag (e.g. `voice_state_changed`)
+ * — see `getEventCategory()` in sse.ts.
+ */
+export const VOICE_EVENT_NAMES = [
+  'voice:state-changed',
+  'voice:transcript',
+  'voice:speaking-started',
+  'voice:speaking-finished',
+  'voice:audio-level',
+  'voice:error',
+  'voice:model-download-progress',
+] as const;
+
+/**
  * Type helper to extract event name literals.
  */
 export type DownloadEventName = typeof DOWNLOAD_EVENT_NAMES[number];
@@ -74,3 +92,4 @@ export type LogEventName = typeof LOG_EVENT_NAMES[number];
 export type McpEventName = typeof MCP_EVENT_NAMES[number];
 export type ModelEventName = typeof MODEL_EVENT_NAMES[number];
 export type VerificationEventName = typeof VERIFICATION_EVENT_NAMES[number];
+export type VoiceEventName = typeof VOICE_EVENT_NAMES[number];

--- a/src/services/transport/events/sse.ts
+++ b/src/services/transport/events/sse.ts
@@ -274,6 +274,8 @@ class SseConnection<T> {
     if (outerType === 'log' || outerType.startsWith('log_')) return 'log';
     // Verification events
     if (outerType.startsWith('verification_') || outerType.startsWith('verification:')) return 'verification';
+    // Voice events — all Serde type tags start with 'voice_'
+    if (outerType.startsWith('voice_')) return 'voice';
     return null;
   }
 

--- a/src/services/transport/events/tauri.ts
+++ b/src/services/transport/events/tauri.ts
@@ -12,6 +12,7 @@ import {
   SERVER_EVENT_NAMES,
   LOG_EVENT_NAMES,
   VERIFICATION_EVENT_NAMES,
+  VOICE_EVENT_NAMES,
 } from './eventNames';
 
 const eventModulePromise = import('@tauri-apps/api/event');
@@ -25,6 +26,7 @@ const TAURI_EVENT_NAMES: Record<AppEventType, readonly string[]> = {
   'download': DOWNLOAD_EVENT_NAMES,
   'log': LOG_EVENT_NAMES,
   'verification': VERIFICATION_EVENT_NAMES,
+  'voice': VOICE_EVENT_NAMES,
 };
 
 /**

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -5,6 +5,7 @@
 
 import type { Unsubscribe, EventHandler } from './common';
 import type { DownloadId } from './ids';
+import type { VoiceState } from '../../../types/voice';
 
 // ============================================================================
 // Server Events
@@ -163,23 +164,13 @@ export type VerificationEvent = VerificationProgressEvent | VerificationComplete
 // ============================================================================
 
 /**
- * Voice pipeline state — mirrors the Rust `VoiceState` enum.
- * Inlined here so the transport layer has no dependency on src/types/voice.ts.
- */
-export type VoiceState =
-  | 'idle'
-  | 'listening'
-  | 'recording'
-  | 'transcribing'
-  | 'thinking'
-  | 'speaking'
-  | 'error';
-
-/**
  * Voice events received from the SSE bus (or Tauri IPC on desktop).
  *
  * The `type` discriminator values are the Serde snake_case tag emitted by
  * the Rust `AppEvent` enum (e.g. `"voice_state_changed"`).
+ *
+ * `VoiceState` is imported from `src/types/voice.ts` (canonical definition)
+ * to avoid a duplicate named-export collision in the transport/types barrel.
  */
 export type VoiceEvent =
   | { type: 'voice_state_changed'; state: VoiceState }

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -159,6 +159,44 @@ export interface VerificationCompleteEvent {
 export type VerificationEvent = VerificationProgressEvent | VerificationCompleteEvent;
 
 // ============================================================================
+// Voice Events
+// ============================================================================
+
+/**
+ * Voice pipeline state — mirrors the Rust `VoiceState` enum.
+ * Inlined here so the transport layer has no dependency on src/types/voice.ts.
+ */
+export type VoiceState =
+  | 'idle'
+  | 'listening'
+  | 'recording'
+  | 'transcribing'
+  | 'thinking'
+  | 'speaking'
+  | 'error';
+
+/**
+ * Voice events received from the SSE bus (or Tauri IPC on desktop).
+ *
+ * The `type` discriminator values are the Serde snake_case tag emitted by
+ * the Rust `AppEvent` enum (e.g. `"voice_state_changed"`).
+ */
+export type VoiceEvent =
+  | { type: 'voice_state_changed'; state: VoiceState }
+  | { type: 'voice_transcript'; text: string; isFinal: boolean }
+  | { type: 'voice_speaking_started' }
+  | { type: 'voice_speaking_finished' }
+  | { type: 'voice_audio_level'; level: number }
+  | { type: 'voice_error'; message: string }
+  | {
+      type: 'voice_model_download_progress';
+      modelId: string;
+      bytesDownloaded: number;
+      totalBytes: number;
+      percent: number;
+    };
+
+// ============================================================================
 // App Event Map
 // ============================================================================
 
@@ -174,6 +212,7 @@ export interface AppEventMap {
   'download': { type: 'download'; event: DownloadEvent };
   'log': LogEvent;
   'verification': VerificationEvent;
+  'voice': VoiceEvent;
 }
 
 export type AppEventType = keyof AppEventMap;


### PR DESCRIPTION
Routes all six live voice pipeline events through the shared `AppEvent` / `AppEventEmitter` system, replacing the Tauri-only `spawn_event_forwarder`. After this PR both the WebUI (SSE) and the Tauri desktop app receive real-time voice state, transcripts, audio levels, and errors through a single path.

Closes #213. Part of #211.

## Commits

1. **feat(events): add voice pipeline AppEvent variants** — 6 new variants, lock-down test `voice_event_names_are_stable`, two wire-format namespaces (`snake_case` Serde tag for SSE, `colon-kebab` `event_name()` for Tauri IPC)
2. **feat(voice): wire VoiceEvent→AppEvent bridge in VoiceService** — `spawn_event_bridge()` with `AudioLevel` load-shedding at 50 ms (20 fps), self-terminating task, `emitter()` accessor returns `Arc` by value
3. **refactor(tauri): remove spawn_event_forwarder** — delete `event_names` mod, payload structs, helpers; `voice_start` no longer takes `AppHandle`
4. **feat(transport): add voice event types and routing** — `VoiceEvent` union in `events.ts`, `VOICE_EVENT_NAMES` in `eventNames.ts`, `getEventCategory()` prefix match, `TAURI_EVENT_NAMES` extended
5. **refactor(frontend): route voice events through transport layer** — `subscribeVoiceEvents()` in `voice.ts`; synchronous `useEffect` switch/case in `useVoiceMode`; `isAudioSupported` gate removed from event subscription

## Design Decisions

| Decision | Rationale |
|---|---|
| `AudioLevel` load-shedded at 50 ms | VAD emits ~533 events/sec; frontend needs ~20 fps |
| Free function `spawn_event_bridge` (not method) | Avoids `'static` lifetime issues on `&self` |
| `VoiceState` imported from `types/voice` not redefined | Prevents TS2308 duplicate export in barrel |
| Sync `useEffect` replaces async `subscribeToEvents` | Eliminates race between mount/unmount and `Promise.all` |

## Verification

- `cargo test -p gglib-core`: 130 tests pass including `voice_event_names_are_stable`
- `cargo check -p gglib-app`: full workspace compiles cleanly
- `npx tsc --noEmit`: zero TypeScript errors
