### PR TITLE
Phase 3 / PR 1: Audio Trait Abstraction (gglib-voice internal) (#217)

### DIFF
--- a/crates/gglib-voice/src/audio_io.rs
+++ b/crates/gglib-voice/src/audio_io.rs
@@ -1,0 +1,107 @@
+//! `AudioSource` and `AudioSink` trait abstractions for voice pipeline audio I/O.
+//!
+//! These traits decouple the [`VoicePipeline`](crate::pipeline::VoicePipeline)
+//! from any specific audio backend, enabling different backends to be injected
+//! at runtime:
+//!
+//! | Implementor | Where used |
+//! |---|---|
+//! | [`LocalAudioSource`](crate::audio_local::LocalAudioSource) / [`LocalAudioSink`](crate::audio_local::LocalAudioSink) | Desktop / CLI — cpal capture + rodio playback on the local machine |
+//! | `WebSocketAudioSource` / `WebSocketAudioSink` *(Phase 3)* | WebUI — PCM16 LE streaming via browser WebSocket |
+//!
+//! Both traits are **object-safe** (`Box<dyn AudioSource>` / `Box<dyn AudioSink>`).
+//! All methods take `&self` to satisfy the object-safety requirement; interior
+//! mutability (channels, atomic flags) handles state changes inside each
+//! implementation.
+
+use crate::capture::AudioDeviceInfo;
+use crate::error::VoiceError;
+
+// ── AudioSource ────────────────────────────────────────────────────
+
+/// Abstraction over an audio input source (microphone capture).
+///
+/// # Object safety
+/// All methods take `&self`, so the trait is object-safe and usable as
+/// `Box<dyn AudioSource>` inside [`VoicePipeline`](crate::pipeline::VoicePipeline).
+///
+/// # Implementations
+/// - [`LocalAudioSource`](crate::audio_local::LocalAudioSource) — wraps
+///   [`AudioThreadHandle`](crate::audio_thread::AudioThreadHandle) → cpal
+/// - `WebSocketAudioSource` *(Phase 3)* — receives PCM from the browser via WS
+pub trait AudioSource: Send + Sync {
+    /// Begin capturing audio from the source.
+    ///
+    /// For local audio this activates the cpal stream; for the WebSocket source
+    /// it arms the sample accumulation buffer.
+    fn start_capture(&self) -> Result<(), VoiceError>;
+
+    /// Stop capturing and return all accumulated 16 kHz mono f32 PCM samples.
+    ///
+    /// The returned buffer starts from just after the most recent call to
+    /// [`start_capture`](AudioSource::start_capture).
+    fn stop_capture(&self) -> Result<Vec<f32>, VoiceError>;
+
+    /// Read a single VAD frame (continuous VAD mode).
+    ///
+    /// Returns `Ok(Some(frame))` if a new frame is available, `Ok(None)` if
+    /// nothing is ready yet, or an `Err` if the source has died.
+    ///
+    /// The local adapter always returns `Ok(None)` because the cpal audio
+    /// thread does not expose a frame-by-frame polling API.  The primary
+    /// consumer of this method is `WebSocketAudioSource` (Phase 3).
+    fn read_vad_frame(&self) -> Result<Option<Vec<f32>>, VoiceError>;
+
+    /// Whether audio is currently being captured.
+    fn is_capturing(&self) -> bool;
+
+    /// List available audio input devices.
+    ///
+    /// Takes `&self` to preserve object safety.  The local implementation
+    /// delegates to the static [`AudioCapture::list_devices`] from within the
+    /// instance method body, which is legal in Rust.  The WebSocket
+    /// implementation returns `Ok(vec![])` — the browser handles device
+    /// enumeration.
+    ///
+    /// [`AudioCapture::list_devices`]: crate::capture::AudioCapture::list_devices
+    fn list_devices(&self) -> Result<Vec<AudioDeviceInfo>, VoiceError>;
+}
+
+// ── AudioSink ──────────────────────────────────────────────────────
+
+/// Abstraction over an audio output sink (TTS playback).
+///
+/// # Object safety
+/// All methods take `&self`, so the trait is object-safe and usable as
+/// `Box<dyn AudioSink>` inside [`VoicePipeline`](crate::pipeline::VoicePipeline).
+///
+/// # Implementations
+/// - [`LocalAudioSink`](crate::audio_local::LocalAudioSink) — wraps
+///   [`AudioThreadHandle`](crate::audio_thread::AudioThreadHandle) → rodio
+/// - `WebSocketAudioSink` *(Phase 3)* — encodes f32 → PCM16 LE and sends to
+///   the browser via WebSocket
+pub trait AudioSink: Send + Sync {
+    /// Prepare the sink for streaming playback.
+    ///
+    /// Creates a fresh playback sink and activates the echo gate so that mic
+    /// capture is suppressed during playback.
+    fn start_streaming(&self) -> Result<(), VoiceError>;
+
+    /// Append audio samples to the playback buffer.
+    ///
+    /// For the local sink this queues samples in the rodio sink; for the
+    /// WebSocket sink it converts to PCM16 LE and sends over the wire.
+    fn append(&self, samples: Vec<f32>, sample_rate: u32) -> Result<(), VoiceError>;
+
+    /// Stop playback immediately.
+    fn stop(&self) -> Result<(), VoiceError>;
+
+    /// Whether audio is currently playing.
+    fn is_playing(&self) -> bool;
+
+    /// Register a one-shot callback that fires when all queued audio drains.
+    ///
+    /// `callback` must be `Send + 'static` because it is dispatched from a
+    /// background watcher thread/task.
+    fn on_playback_complete(&self, callback: Box<dyn FnOnce() + Send + 'static>);
+}

--- a/crates/gglib-voice/src/audio_local.rs
+++ b/crates/gglib-voice/src/audio_local.rs
@@ -1,0 +1,133 @@
+//! Local (cpal/rodio) adapters for the [`AudioSource`] and [`AudioSink`] traits.
+//!
+//! [`LocalAudioSource`] and [`LocalAudioSink`] are thin, zero-overhead wrappers
+//! around [`AudioThreadHandle`].  They share a **single** `Arc<AudioThreadHandle>`
+//! — the audio OS thread owns both the cpal capture stream and the rodio
+//! playback sink, so one handle is all that is needed.
+//!
+//! [`Arc`] without a `Mutex` is correct here because every method on
+//! [`AudioThreadHandle`] takes `&self`; internal state transitions happen on
+//! the dedicated OS thread via `std::sync::mpsc` channels.  The proxy struct
+//! itself is never mutably borrowed across the `Arc`.
+//!
+//! # Construction
+//!
+//! Use [`new_pair`] to create both adapters at once:
+//!
+//! ```no_run
+//! use gglib_voice::audio_local::LocalAudioSource; // illustrative
+//! # use gglib_voice::{EchoGate, VoiceError};
+//! # use gglib_voice::audio_local::new_pair;
+//! let echo_gate = EchoGate::new();
+//! let (source, sink) = new_pair(&echo_gate)?;
+//! # Ok::<(), VoiceError>(())
+//! ```
+
+use std::sync::Arc;
+
+use crate::audio_io::{AudioSink, AudioSource};
+use crate::audio_thread::AudioThreadHandle;
+use crate::capture::{AudioCapture, AudioDeviceInfo};
+use crate::error::VoiceError;
+use crate::gate::EchoGate;
+
+// ── LocalAudioSource ───────────────────────────────────────────────
+
+/// Local audio input adapter — delegates to cpal via [`AudioThreadHandle`].
+///
+/// Created by [`new_pair`].  Shares the underlying handle with the paired
+/// [`LocalAudioSink`] — both operate on the same audio OS thread.
+pub struct LocalAudioSource {
+    handle: Arc<AudioThreadHandle>,
+}
+
+impl AudioSource for LocalAudioSource {
+    fn start_capture(&self) -> Result<(), VoiceError> {
+        self.handle.start_capture()
+    }
+
+    fn stop_capture(&self) -> Result<Vec<f32>, VoiceError> {
+        self.handle.stop_capture()
+    }
+
+    /// Returns `Ok(None)` for the local adapter.
+    ///
+    /// [`AudioThreadHandle`] does not expose a frame-by-frame polling API —
+    /// the cpal stream drains into an internal buffer that is returned in one
+    /// shot by [`stop_capture`](AudioSource::stop_capture).  The primary
+    /// consumer of `read_vad_frame` is `WebSocketAudioSource` (Phase 3 PR 3).
+    fn read_vad_frame(&self) -> Result<Option<Vec<f32>>, VoiceError> {
+        Ok(None)
+    }
+
+    fn is_capturing(&self) -> bool {
+        self.handle.is_recording()
+    }
+
+    /// List available audio input devices.
+    ///
+    /// Delegates to the static [`AudioCapture::list_devices`] from within
+    /// this `&self` method, which is legal in Rust and keeps the trait
+    /// object-safe.
+    fn list_devices(&self) -> Result<Vec<AudioDeviceInfo>, VoiceError> {
+        AudioCapture::list_devices()
+    }
+}
+
+// ── LocalAudioSink ─────────────────────────────────────────────────
+
+/// Local audio output adapter — delegates to rodio via [`AudioThreadHandle`].
+///
+/// Created by [`new_pair`].  Shares the underlying handle with the paired
+/// [`LocalAudioSource`] — both operate on the same audio OS thread.
+pub struct LocalAudioSink {
+    handle: Arc<AudioThreadHandle>,
+}
+
+impl AudioSink for LocalAudioSink {
+    fn start_streaming(&self) -> Result<(), VoiceError> {
+        self.handle.start_streaming()
+    }
+
+    fn append(&self, samples: Vec<f32>, sample_rate: u32) -> Result<(), VoiceError> {
+        self.handle.append(samples, sample_rate)
+    }
+
+    /// Stop playback immediately.
+    ///
+    /// [`AudioThreadHandle::stop_playback`] is fire-and-forget (returns `()`);
+    /// we wrap it in `Ok(())` to satisfy the `Result`-returning trait signature.
+    fn stop(&self) -> Result<(), VoiceError> {
+        self.handle.stop_playback();
+        Ok(())
+    }
+
+    fn is_playing(&self) -> bool {
+        self.handle.is_playing()
+    }
+
+    fn on_playback_complete(&self, callback: Box<dyn FnOnce() + Send + 'static>) {
+        self.handle.spawn_completion_watcher(Some(callback));
+    }
+}
+
+// ── Constructor ────────────────────────────────────────────────────
+
+/// Spawn one [`AudioThreadHandle`] and return a matched source/sink adapter
+/// pair that share it.
+///
+/// Exactly one OS thread is created for the combined capture + playback
+/// pipeline, matching the pre-abstraction architecture.
+///
+/// # Errors
+///
+/// Returns [`VoiceError`] if the audio thread fails to start (e.g. no audio
+/// device present).
+pub fn new_pair(echo_gate: &EchoGate) -> Result<(LocalAudioSource, LocalAudioSink), VoiceError> {
+    let handle = Arc::new(AudioThreadHandle::spawn(echo_gate)?);
+    let source = LocalAudioSource {
+        handle: Arc::clone(&handle),
+    };
+    let sink = LocalAudioSink { handle };
+    Ok((source, sink))
+}

--- a/crates/gglib-voice/src/lib.rs
+++ b/crates/gglib-voice/src/lib.rs
@@ -7,6 +7,8 @@ use tempfile as _;
 #[cfg(test)]
 use tokio_test as _;
 
+pub mod audio_io;
+pub mod audio_local;
 pub mod audio_thread;
 pub mod backend;
 pub mod capture;

--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
-use crate::audio_thread::AudioThreadHandle;
+use crate::audio_io::{AudioSink, AudioSource};
 use crate::backend::{SttBackend, SttConfig, TtsBackend, TtsConfig};
 use crate::error::VoiceError;
 use crate::gate::EchoGate;
@@ -153,8 +153,11 @@ pub struct VoicePipeline {
     /// Shared echo gate.
     echo_gate: EchoGate,
 
-    /// Audio I/O actor — owns capture + playback on a dedicated OS thread.
-    audio: Option<AudioThreadHandle>,
+    /// Audio input source — mic capture via cpal (local) or WebSocket stream (web).
+    source: Option<Box<dyn AudioSource>>,
+
+    /// Audio output sink — TTS playback via rodio (local) or WebSocket stream (web).
+    sink: Option<Box<dyn AudioSink>>,
 
     /// Speech-to-text engine (loaded lazily).
     stt: Option<Box<dyn SttBackend>>,
@@ -195,7 +198,8 @@ impl VoicePipeline {
             state: VoiceState::Idle,
             mode: config.mode,
             echo_gate,
-            audio: None,
+            source: None,
+            sink: None,
             stt: None,
             tts: None,
             vad: None,
@@ -240,20 +244,32 @@ impl VoicePipeline {
 
     // ── Lifecycle ──────────────────────────────────────────────────
 
-    /// Start the voice pipeline.
+    /// Start the voice pipeline with explicitly provided audio I/O backends.
     ///
-    /// Initialises audio capture and playback. STT and TTS engines are
-    /// loaded lazily on first use.
-    pub fn start(&mut self) -> Result<(), VoiceError> {
+    /// This is the primary lifecycle entry-point. Separating backend
+    /// construction from injection makes the pipeline testable with mock
+    /// audio without real hardware, and enables the WebSocket audio path
+    /// (Phase 3) to supply a different backend at runtime.
+    ///
+    /// STT and TTS engines are loaded lazily on first use.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VoiceError::AlreadyActive`] if the pipeline is already
+    /// running.
+    pub fn start_with_audio(
+        &mut self,
+        source: Box<dyn AudioSource>,
+        sink: Box<dyn AudioSink>,
+    ) -> Result<(), VoiceError> {
         if self.is_active() {
             return Err(VoiceError::AlreadyActive);
         }
 
         tracing::info!(mode = ?self.mode, "Starting voice pipeline");
 
-        // Initialise audio I/O on a dedicated OS thread.
-        let audio = AudioThreadHandle::spawn(&self.echo_gate)?;
-        self.audio = Some(audio);
+        self.source = Some(source);
+        self.sink = Some(sink);
 
         // In VAD mode, initialise the detector
         if self.mode == VoiceInteractionMode::VoiceActivityDetection {
@@ -284,19 +300,42 @@ impl VoicePipeline {
         Ok(())
     }
 
+    /// Start the voice pipeline using the local cpal/rodio audio backends.
+    ///
+    /// Convenience wrapper around
+    /// [`start_with_audio`](VoicePipeline::start_with_audio) that creates a
+    /// [`LocalAudioSource`](crate::audio_local::LocalAudioSource) /
+    /// [`LocalAudioSink`](crate::audio_local::LocalAudioSink) pair backed by
+    /// a single [`AudioThreadHandle`](crate::audio_thread::AudioThreadHandle).
+    ///
+    /// Preserved for backward compatibility with existing tests and the CLI.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VoiceError`] if the audio thread fails to start or the
+    /// pipeline is already active.
+    pub fn start(&mut self) -> Result<(), VoiceError> {
+        let (source, sink) = crate::audio_local::new_pair(&self.echo_gate)?;
+        self.start_with_audio(Box::new(source), Box::new(sink))
+    }
+
     /// Stop the voice pipeline and release all resources.
     pub fn stop(&mut self) {
         tracing::info!("Stopping voice pipeline");
 
-        // Stop any active recording / playback and join the audio thread.
-        if let Some(ref audio) = self.audio {
-            if audio.is_recording() {
-                let _ = audio.stop_capture();
+        // Stop any active recording.
+        if let Some(ref source) = self.source {
+            if source.is_capturing() {
+                let _ = source.stop_capture();
             }
-            audio.stop_playback();
         }
-        // Drop the handle — sends Shutdown and joins the thread.
-        self.audio.take();
+        // Stop any active playback.
+        if let Some(ref sink) = self.sink {
+            let _ = sink.stop();
+        }
+        // Drop both handles — for LocalAudio* this joins the audio OS thread.
+        self.source.take();
+        self.sink.take();
 
         // Stop VAD
         if let Some(ref mut vad) = self.vad {
@@ -377,10 +416,11 @@ impl VoicePipeline {
             return Err(VoiceError::NotActive);
         }
 
-        // Stop any active playback first
-        let audio = self.audio.as_ref().ok_or(VoiceError::NotActive)?;
-        audio.stop_playback();
-        audio.start_capture()?;
+        // Stop any active playback first, then start capture.
+        let sink = self.sink.as_ref().ok_or(VoiceError::NotActive)?;
+        sink.stop()?;
+        let source = self.source.as_ref().ok_or(VoiceError::NotActive)?;
+        source.start_capture()?;
         self.set_state(VoiceState::Recording);
 
         Ok(())
@@ -394,8 +434,8 @@ impl VoicePipeline {
             return Err(VoiceError::NotActive);
         }
 
-        let audio_handle = self.audio.as_ref().ok_or(VoiceError::NotActive)?;
-        let audio = audio_handle.stop_capture()?;
+        let source = self.source.as_ref().ok_or(VoiceError::NotActive)?;
+        let audio = source.stop_capture()?;
 
         if audio.is_empty() {
             self.set_state(VoiceState::Listening);
@@ -501,11 +541,11 @@ impl VoicePipeline {
         let tts = self.tts.as_ref().ok_or(VoiceError::TtsModelNotLoaded)?;
 
         // Prepare a streaming playback sink before synthesis begins.
-        let audio = self
-            .audio
+        let sink = self
+            .sink
             .as_ref()
             .ok_or_else(|| VoiceError::OutputStreamError("Audio thread not running".to_string()))?;
-        audio.start_streaming()?;
+        sink.start_streaming()?;
 
         let mut any_audio = false;
         let mut total_duration = std::time::Duration::ZERO;
@@ -536,9 +576,9 @@ impl VoicePipeline {
                         let _ = self.event_tx.send(VoiceEvent::SpeakingStarted);
                     }
 
-                    // audio_thread methods take &self, so no re-borrow needed.
-                    let a = self.audio.as_ref().expect("audio thread started above");
-                    a.append(audio.samples, audio.sample_rate)?;
+                    // AudioSink methods take &self, so no re-borrow needed.
+                    let s = self.sink.as_ref().expect("audio sink started above");
+                    s.append(audio.samples, audio.sample_rate)?;
                     total_duration += audio.duration;
                 }
                 Err(e) => {
@@ -564,8 +604,8 @@ impl VoicePipeline {
 
         if !any_audio {
             // Every chunk failed — tear down the empty sink and report error.
-            if let Some(ref a) = self.audio {
-                a.stop_playback();
+            if let Some(ref s) = self.sink {
+                let _ = s.stop();
             }
             return Err(VoiceError::SynthesisError(
                 "all chunks failed to synthesize".to_string(),
@@ -592,16 +632,16 @@ impl VoicePipeline {
             ));
         });
 
-        let audio = self.audio.as_ref().expect("audio thread started above");
-        audio.spawn_completion_watcher(Some(on_done));
+        let sink = self.sink.as_ref().expect("audio sink started above");
+        sink.on_playback_complete(on_done);
 
         Ok(())
     }
 
     /// Stop any active TTS playback immediately.
     pub fn stop_speaking(&mut self) {
-        if let Some(ref audio) = self.audio {
-            audio.stop_playback();
+        if let Some(ref sink) = self.sink {
+            let _ = sink.stop();
         }
         self.emit(VoiceEvent::SpeakingFinished);
         if self.is_active() {
@@ -612,9 +652,9 @@ impl VoicePipeline {
     /// Check if TTS playback is currently active.
     #[must_use]
     pub fn is_speaking(&self) -> bool {
-        self.audio
+        self.sink
             .as_ref()
-            .is_some_and(AudioThreadHandle::is_playing)
+            .is_some_and(|s| s.is_playing())
     }
 
     // ── Configuration ──────────────────────────────────────────────

--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -782,11 +782,33 @@ impl VoicePipeline {
     /// require an active pipeline (e.g. `ptt_start`), but only test state
     /// transitions — not actual audio I/O.
     ///
+    /// For tests that also need audio call sites to succeed, prefer calling
+    /// [`start_with_audio`](VoicePipeline::start_with_audio) directly with
+    /// `MockAudioSource`/`MockAudioSink` — that is the replacement for this
+    /// helper.
+    ///
     /// # Test helper
     #[doc(hidden)]
     pub fn set_active_for_test(&mut self) {
         self.is_active.store(true, Ordering::SeqCst);
         self.set_state(VoiceState::Listening);
+    }
+
+    /// Inject mock audio backends and activate the pipeline, bypassing real
+    /// hardware initialisation.
+    ///
+    /// Equivalent to calling
+    /// [`start_with_audio`](VoicePipeline::start_with_audio); provided as a
+    /// named helper so test code reads intention-first.
+    ///
+    /// # Test helper
+    #[doc(hidden)]
+    pub fn inject_audio(
+        &mut self,
+        source: Box<dyn AudioSource>,
+        sink: Box<dyn AudioSink>,
+    ) -> Result<(), VoiceError> {
+        self.start_with_audio(source, sink)
     }
 }
 

--- a/crates/gglib-voice/tests/pipeline_state_machine.rs
+++ b/crates/gglib-voice/tests/pipeline_state_machine.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use gglib_voice::{
     SttBackend, TtsAudio, TtsBackend, VoiceError, VoiceInfo,
+    audio_io::{AudioSink, AudioSource},
+    capture::AudioDeviceInfo,
     pipeline::{VoiceEvent, VoiceInteractionMode, VoicePipeline, VoicePipelineConfig, VoiceState},
 };
 
@@ -80,6 +82,119 @@ impl TtsBackend for MockTts {
     }
     fn available_voices(&self) -> Vec<VoiceInfo> {
         vec![]
+    }
+}
+
+// ── Mock audio backends ────────────────────────────────────────────
+
+/// Recorded state for the mock audio source, inspectable after a test.
+#[derive(Default)]
+struct MockSourceState {
+    /// Whether `start_capture` was called.
+    pub capture_started: bool,
+    /// Whether `stop_capture` was called.
+    pub stop_capture_called: bool,
+    /// Samples to hand back from `stop_capture`.
+    pub samples_to_return: Vec<f32>,
+}
+
+/// Mock [`AudioSource`] that records which methods were called.
+///
+/// Backed by `Arc<Mutex<MockSourceState>>` so the test can inspect
+/// its state after handing it to the pipeline.
+struct MockAudioSource {
+    state: std::sync::Arc<std::sync::Mutex<MockSourceState>>,
+}
+
+impl MockAudioSource {
+    fn new() -> (Self, std::sync::Arc<std::sync::Mutex<MockSourceState>>) {
+        let state = std::sync::Arc::new(std::sync::Mutex::new(MockSourceState::default()));
+        (Self { state: std::sync::Arc::clone(&state) }, state)
+    }
+
+    fn with_samples(samples: Vec<f32>) -> (Self, std::sync::Arc<std::sync::Mutex<MockSourceState>>) {
+        let state = std::sync::Arc::new(std::sync::Mutex::new(MockSourceState {
+            samples_to_return: samples,
+            ..Default::default()
+        }));
+        (Self { state: std::sync::Arc::clone(&state) }, state)
+    }
+}
+
+impl AudioSource for MockAudioSource {
+    fn start_capture(&self) -> Result<(), VoiceError> {
+        self.state.lock().unwrap().capture_started = true;
+        Ok(())
+    }
+
+    fn stop_capture(&self) -> Result<Vec<f32>, VoiceError> {
+        let mut s = self.state.lock().unwrap();
+        s.stop_capture_called = true;
+        Ok(std::mem::take(&mut s.samples_to_return))
+    }
+
+    fn read_vad_frame(&self) -> Result<Option<Vec<f32>>, VoiceError> {
+        Ok(None)
+    }
+
+    fn is_capturing(&self) -> bool {
+        self.state.lock().unwrap().capture_started
+    }
+
+    fn list_devices(&self) -> Result<Vec<AudioDeviceInfo>, VoiceError> {
+        Ok(vec![])
+    }
+}
+
+/// Recorded state for the mock audio sink, inspectable after a test.
+#[derive(Default)]
+struct MockSinkState {
+    /// Whether `start_streaming` was called.
+    pub streaming_started: bool,
+    /// Whether `stop` was called.
+    pub stop_called: bool,
+    /// All samples passed to `append`, in order.
+    pub appended_samples: Vec<f32>,
+}
+
+/// Mock [`AudioSink`] that records which methods were called.
+///
+/// The `on_playback_complete` callback is invoked synchronously on
+/// registration, so tests do not need to drive a background watcher.
+struct MockAudioSink {
+    state: std::sync::Arc<std::sync::Mutex<MockSinkState>>,
+}
+
+impl MockAudioSink {
+    fn new() -> (Self, std::sync::Arc<std::sync::Mutex<MockSinkState>>) {
+        let state = std::sync::Arc::new(std::sync::Mutex::new(MockSinkState::default()));
+        (Self { state: std::sync::Arc::clone(&state) }, state)
+    }
+}
+
+impl AudioSink for MockAudioSink {
+    fn start_streaming(&self) -> Result<(), VoiceError> {
+        self.state.lock().unwrap().streaming_started = true;
+        Ok(())
+    }
+
+    fn append(&self, samples: Vec<f32>, _sample_rate: u32) -> Result<(), VoiceError> {
+        self.state.lock().unwrap().appended_samples.extend(samples);
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), VoiceError> {
+        self.state.lock().unwrap().stop_called = true;
+        Ok(())
+    }
+
+    fn is_playing(&self) -> bool {
+        false
+    }
+
+    /// Fires the callback immediately (synchronous, no real playback queue).
+    fn on_playback_complete(&self, callback: Box<dyn FnOnce() + Send + 'static>) {
+        callback();
     }
 }
 
@@ -247,4 +362,85 @@ fn state_changed_event_emitted_on_set_active() {
 fn idle_pipeline_mode_is_ptt_by_default() {
     let (pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
     assert_eq!(pipeline.mode(), VoiceInteractionMode::PushToTalk);
+}
+
+// ── MockAudioSource / MockAudioSink tests ──────────────────────────
+//
+// These tests use inject_audio() / start_with_audio() instead of
+// set_active_for_test(). They demonstrate the path towards deprecating
+// set_active_for_test() for tests that exercise audio call sites.
+
+/// start_with_audio activates the pipeline and transitions to Listening
+/// without any real audio hardware.
+#[test]
+fn start_with_audio_activates_pipeline() {
+    let (mut pipeline, mut rx) = VoicePipeline::new(VoicePipelineConfig::default());
+    let (src, _src_state) = MockAudioSource::new();
+    let (snk, _snk_state) = MockAudioSink::new();
+
+    pipeline
+        .inject_audio(Box::new(src), Box::new(snk))
+        .expect("inject_audio should succeed with mock backends");
+
+    assert!(pipeline.is_active(), "pipeline should be active after inject_audio");
+    assert_eq!(pipeline.state(), VoiceState::Listening);
+
+    let states = states_from(&drain_events(&mut rx));
+    assert!(
+        states.contains(&VoiceState::Listening),
+        "expected StateChanged(Listening) event, got {states:?}"
+    );
+}
+
+/// ptt_start succeeds and transitions to Recording when mock audio is injected.
+///
+/// Verifies that:
+/// - the pipeline advances past the is_active() guard
+/// - sink.stop() is called before capture (to clear any active playback)
+/// - source.start_capture() is called
+/// - state transitions to Recording
+#[test]
+fn ptt_start_with_mock_audio_transitions_to_recording() {
+    let (mut pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
+    let (src, src_state) = MockAudioSource::new();
+    let (snk, snk_state) = MockAudioSink::new();
+
+    pipeline.inject_audio(Box::new(src), Box::new(snk)).unwrap();
+    pipeline.ptt_start().expect("ptt_start should succeed with mock backends");
+
+    assert_eq!(pipeline.state(), VoiceState::Recording);
+    assert!(src_state.lock().unwrap().capture_started, "start_capture should have been called");
+    assert!(snk_state.lock().unwrap().stop_called, "sink.stop() should have been called before capture");
+}
+
+/// Full PTT round-trip with mock audio and mock STT.
+///
+/// Verifies that stop_capture is called, the samples are forwarded to the
+/// STT engine, and the resulting transcript is returned.
+#[test]
+fn ptt_stop_with_mock_audio_returns_transcript() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let (mut pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
+
+        // Provide a non-empty audio buffer so ptt_stop doesn't short-circuit.
+        let (src, src_state) = MockAudioSource::with_samples(vec![0.1f32; 160]);
+        let (snk, _snk_state) = MockAudioSink::new();
+
+        pipeline.inject_audio(Box::new(src), Box::new(snk)).unwrap();
+        pipeline.inject_stt(Box::new(MockStt::new("hello from mock")));
+
+        pipeline.ptt_start().unwrap();
+        let transcript = pipeline.ptt_stop().await.expect("ptt_stop should succeed");
+
+        assert_eq!(transcript, "hello from mock");
+        assert!(
+            src_state.lock().unwrap().stop_capture_called,
+            "stop_capture should have been called"
+        );
+    });
 }


### PR DESCRIPTION
**Parent issue:** #217 · part of Phase 3 (#214) · part of Voice Architecture Parity (#211)
Closes #217 

## Summary

Pure `gglib-voice`-internal refactor. No other crate is touched, no frontend changes.

Introduces the `AudioSource`/`AudioSink` trait abstraction and wraps the existing `AudioThreadHandle` behind it, establishing the seam that Phase 3 PRs 2 and 3 build on.

## Changes

- **`src/audio_io.rs`** (new) — defines object-safe `AudioSource` and `AudioSink` traits; all methods take `&self`
- **`src/audio_local.rs`** (new) — `LocalAudioSource` / `LocalAudioSink` as thin adapters over `Arc<AudioThreadHandle>`; shared `Arc` (no `Mutex`) because every handle method takes `&self`; `new_pair()` spawns one audio OS thread for both
- **`src/pipeline.rs`** — replaces `audio: Option<AudioThreadHandle>` with `source: Option<Box<dyn AudioSource>>` + `sink: Option<Box<dyn AudioSink>>`; adds `start_with_audio(source, sink)`; keeps `start()` as backward-compat convenience; all call sites (`ptt_start`, `ptt_stop`, `speak`, `stop_speaking`, `stop`, `is_speaking`) routed through trait objects; adds `inject_audio()` test helper
- **`src/lib.rs`** — adds `pub mod audio_io` and `pub mod audio_local`
- **`tests/pipeline_state_machine.rs`** — adds `MockAudioSource` / `MockAudioSink` backed by `Arc<Mutex<State>>` and three new tests: `start_with_audio_activates_pipeline`, `ptt_start_with_mock_audio_transitions_to_recording`, `ptt_stop_with_mock_audio_returns_transcript`

## Acceptance Criteria

- [x] `cargo test -p gglib-voice` passes — all 15 integration tests + 34 unit tests green
- [x] No changes outside `gglib-voice`
- [x] `LocalAudioSource`/`LocalAudioSink` are the sole users of `AudioThreadHandle` methods — zero direct calls remain in `pipeline.rs` or `service.rs`