### PR TITLE
Phase 3 / PR 3: WebSocket Data Plane + Full Cleanup (Rust backend)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -200,6 +200,9 @@
 			"command": "cargo",
 			"args": [
 				"clippy",
+				"--workspace",
+				"--exclude",
+				"gglib-app",
 				"--all-targets",
 				"--all-features"
 			],
@@ -220,6 +223,9 @@
 			"command": "cargo",
 			"args": [
 				"clippy",
+				"--workspace",
+				"--exclude",
+				"gglib-app",
 				"--all-targets",
 				"--all-features",
 				"--",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -269,8 +270,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1057,6 +1060,12 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deflate64"
@@ -7215,6 +7224,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7491,6 +7512,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typed-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ hf-hub = "0.4"
 # HTTP/Networking
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }
 indicatif = "0.18"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 uuid = { version = "1.10", features = ["v4"] }
 

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -235,7 +235,7 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
     //   • Arc<dyn VoicePipelinePort>    → injected into GuiDeps
     //   • Arc<dyn RemoteAudioRegistry>  → stored on AxumContext for WS handler
     let voice_concrete = Arc::new(VoiceService::new(
-        sse.clone() as Arc<dyn gglib_core::ports::AppEventEmitter>,
+        sse.clone() as Arc<dyn gglib_core::ports::AppEventEmitter>
     ));
     let voice_service: Arc<dyn gglib_core::ports::VoicePipelinePort> =
         Arc::clone(&voice_concrete) as Arc<dyn gglib_core::ports::VoicePipelinePort>;

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -24,7 +24,7 @@ use gglib_mcp::McpService;
 use gglib_runtime::LlamaServerRunner;
 use gglib_runtime::proxy::ProxySupervisor;
 use gglib_runtime::system::DefaultSystemProbe;
-use gglib_voice::VoiceService;
+use gglib_voice::{RemoteAudioRegistry, VoiceService};
 
 use crate::sse::SseBroadcaster;
 
@@ -107,6 +107,14 @@ pub struct AxumContext {
     pub runner: Arc<dyn ProcessRunner>,
     /// SSE broadcaster for real-time events.
     pub sse: Arc<SseBroadcaster>,
+    /// Remote audio registry used by the WebSocket audio data plane.
+    ///
+    /// The WebSocket handler calls `register_remote_audio` before the browser
+    /// issues `POST /api/voice/start`, so the pipeline picks up the
+    /// browser-backed source/sink instead of local cpal/rodio devices.
+    /// Kept on `AxumContext` directly (not via `GuiBackend`) so that
+    /// network-transport concerns stay out of the GUI facade.
+    pub voice_registry: Arc<dyn RemoteAudioRegistry>,
 }
 
 /// Bootstrap the Axum server with all services.
@@ -221,9 +229,18 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
     // 9a. Voice service — implements VoicePipelinePort for the 13 data/config ops.
     // Shares the SSE broadcaster as its event emitter so download progress
     // events reach SSE subscribers without any Tauri dependency.
-    let voice_service: Arc<dyn gglib_core::ports::VoicePipelinePort> = Arc::new(VoiceService::new(
+    //
+    // We keep a concrete Arc<VoiceService> so we can cast it to two different
+    // trait objects:
+    //   • Arc<dyn VoicePipelinePort>    → injected into GuiDeps
+    //   • Arc<dyn RemoteAudioRegistry>  → stored on AxumContext for WS handler
+    let voice_concrete = Arc::new(VoiceService::new(
         sse.clone() as Arc<dyn gglib_core::ports::AppEventEmitter>,
     ));
+    let voice_service: Arc<dyn gglib_core::ports::VoicePipelinePort> =
+        Arc::clone(&voice_concrete) as Arc<dyn gglib_core::ports::VoicePipelinePort>;
+    let voice_registry: Arc<dyn RemoteAudioRegistry> =
+        Arc::clone(&voice_concrete) as Arc<dyn RemoteAudioRegistry>;
 
     let deps = GuiDeps::new(
         Arc::clone(&core),
@@ -258,6 +275,7 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
         hf_client,
         runner,
         sse,
+        voice_registry,
     })
 }
 

--- a/crates/gglib-axum/src/handlers/mod.rs
+++ b/crates/gglib-axum/src/handlers/mod.rs
@@ -14,3 +14,4 @@ pub mod servers;
 pub mod settings;
 pub mod verification;
 pub mod voice;
+pub mod voice_ws;

--- a/crates/gglib-axum/src/handlers/voice_ws.rs
+++ b/crates/gglib-axum/src/handlers/voice_ws.rs
@@ -1,0 +1,150 @@
+//! WebSocket upgrade handler for the voice audio data plane.
+//!
+//! `GET /api/voice/audio` upgrades the connection to a binary WebSocket
+//! that carries raw PCM audio between the browser and the server-side voice
+//! pipeline.
+//!
+//! ## Protocol
+//!
+//! | Direction | Format | Rate | Channels | Frame size |
+//! |---|---|---|---|---|
+//! | Client → Server | PCM16 LE | 16 000 Hz | 1 (mono) | 960 bytes (30 ms) |
+//! | Server → Client | PCM16 LE | 24 000 Hz | 1 (mono) | Variable |
+//!
+//! The WebSocket carries **only** binary frames — no text, no control commands.
+//! All voice lifecycle commands (`start`, `stop`, `ptt-start`, …) continue to
+//! use the HTTP control-plane endpoints.
+//!
+//! ## Lifecycle
+//!
+//! 1. Browser opens `wss://…/api/voice/audio` (before calling `POST /api/voice/start`).
+//! 2. Handler creates [`WebSocketAudioSource`] / [`WebSocketAudioSink`] channel pairs.
+//! 3. Calls [`RemoteAudioRegistry::register_remote_audio`] so the next
+//!    `POST /api/voice/start` uses the WS-backed source/sink instead of
+//!    local cpal/rodio devices.
+//! 4. Spawns two tasks:
+//!    * **Ingest** — reads browser binary frames → decodes PCM16 LE → pushes
+//!      `Vec<f32>` to the source channel.  Dropping the sender signals
+//!      `AudioThreadDied` to the pipeline's VAD loop.
+//!    * **Egress** — drains the sink channel → sends `Vec<u8>` (PCM16 LE)
+//!      as binary WS frames to the browser.
+//! 5. `tokio::select!` waits for either task to finish (graceful close or
+//!    network drop).
+//! 6. Calls [`RemoteAudioRegistry::deregister_remote_audio`] so a stale
+//!    channel pair is never passed to a subsequent `start()`.
+
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use futures_util::{SinkExt, StreamExt};
+use tracing::{info, warn};
+
+use crate::state::AppState;
+use crate::ws_audio::{WebSocketAudioSink, WebSocketAudioSource};
+
+/// `GET /api/voice/audio` — WebSocket upgrade endpoint for audio data plane.
+///
+/// The browser must call this **before** `POST /api/voice/start`.  The handler
+/// registers the channel-backed audio pair so the next `start()` uses
+/// `WebSocketAudioSource`/`WebSocketAudioSink` instead of local cpal/rodio.
+///
+/// If `POST /api/voice/start` is called without an open WebSocket the
+/// pipeline falls back to `LocalAudioSource`/`LocalAudioSink` (server
+/// machine's mic and speakers — correct for the desktop app).
+pub async fn audio_ws(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_audio_ws(socket, state))
+}
+
+async fn handle_audio_ws(socket: WebSocket, state: AppState) {
+    // Create channel pairs.  The ingest task holds source_tx; dropping it
+    // signals AudioThreadDied to the pipeline's VAD loop (clean shutdown).
+    // The egress task holds sink_rx; the sink's frame_tx feeds it.
+    let (source, source_tx) = WebSocketAudioSource::new();
+    let (sink, sink_rx) = WebSocketAudioSink::new();
+
+    // Register the pair — next VoicePipelinePort::start() will consume it.
+    state
+        .voice_registry
+        .register_remote_audio(Box::new(source), Box::new(sink));
+
+    info!("WebSocket audio session opened — remote audio registered");
+
+    // Split the socket so the two tasks can use it concurrently.
+    let (ws_sender, ws_receiver) = socket.split();
+
+    // ── Ingest: browser PCM16 LE → decoded f32 → source channel ──────────
+
+    let mut ingest = tokio::spawn(async move {
+        let mut ws_receiver = ws_receiver;
+
+        while let Some(msg_result) = ws_receiver.next().await {
+            match msg_result {
+                Ok(Message::Binary(data)) => {
+                    // Validate frame length is even (each sample is 2 bytes).
+                    if data.len() % 2 != 0 {
+                        warn!(
+                            bytes = data.len(),
+                            "WS audio ingest: odd-length frame, skipping"
+                        );
+                        continue;
+                    }
+
+                    // Decode PCM16 LE (little-endian signed 16-bit) → f32.
+                    let samples: Vec<f32> = data
+                        .chunks_exact(2)
+                        .map(|chunk| {
+                            let i16_val = i16::from_le_bytes([chunk[0], chunk[1]]);
+                            f32::from(i16_val) / 32_768.0
+                        })
+                        .collect();
+
+                    if source_tx.send(samples).await.is_err() {
+                        // Pipeline stopped — receiver dropped; exit cleanly.
+                        break;
+                    }
+                }
+                // Graceful close or protocol error — stop ingest loop.
+                Ok(Message::Close(_)) | Err(_) => break,
+                // Ignore text/ping/pong frames.
+                Ok(_) => {}
+            }
+        }
+        // source_tx is dropped here.  WebSocketAudioSource::read_vad_frame()
+        // will return Err(AudioThreadDied), causing the pipeline to self-stop.
+    });
+
+    // ── Egress: sink channel → PCM16 LE bytes → browser binary frames ────
+
+    let mut egress = tokio::spawn(async move {
+        let mut ws_sender = ws_sender;
+        let mut sink_rx = sink_rx;
+
+        while let Some(pcm_bytes) = sink_rx.recv().await {
+            // Send as a binary WebSocket frame (Vec<u8> → Bytes via Into).
+            if ws_sender
+                .send(Message::Binary(pcm_bytes.into()))
+                .await
+                .is_err()
+            {
+                // Browser disconnected — exit silently.
+                break;
+            }
+        }
+    });
+
+    // Wait for whichever task finishes first, then abort the other.
+    // This covers both graceful WS close and abrupt network drops.
+    tokio::select! {
+        _ = &mut ingest => { egress.abort(); }
+        _ = &mut egress => { ingest.abort(); }
+    }
+
+    // Always deregister — ensures a stale channel pair is never used by a
+    // subsequent start() call after the browser reconnects.
+    state.voice_registry.deregister_remote_audio();
+
+    info!("WebSocket audio session closed — remote audio deregistered");
+}

--- a/crates/gglib-axum/src/handlers/voice_ws.rs
+++ b/crates/gglib-axum/src/handlers/voice_ws.rs
@@ -51,10 +51,7 @@ use crate::ws_audio::{WebSocketAudioSink, WebSocketAudioSource};
 /// If `POST /api/voice/start` is called without an open WebSocket the
 /// pipeline falls back to `LocalAudioSource`/`LocalAudioSink` (server
 /// machine's mic and speakers — correct for the desktop app).
-pub async fn audio_ws(
-    ws: WebSocketUpgrade,
-    State(state): State<AppState>,
-) -> impl IntoResponse {
+pub async fn audio_ws(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     ws.on_upgrade(move |socket| handle_audio_ws(socket, state))
 }
 

--- a/crates/gglib-axum/src/lib.rs
+++ b/crates/gglib-axum/src/lib.rs
@@ -39,6 +39,7 @@ pub mod handlers;
 pub mod routes;
 pub mod sse;
 pub mod state;
+pub(crate) mod ws_audio;
 
 // Re-export primary types
 pub use bootstrap::{AxumContext, CorsConfig, ServerConfig, bootstrap, start_server};

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -186,6 +186,11 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/voice/ptt-stop", post(handlers::voice::ptt_stop))
         .route("/voice/speak", post(handlers::voice::speak))
         .route("/voice/stop-speaking", post(handlers::voice::stop_speaking))
+        // WebSocket audio data plane (Phase 3 / PR 3)
+        // Browser opens this WS *before* POST /voice/start to register remote
+        // audio; the pipeline then uses WebSocketAudioSource/Sink instead of
+        // local cpal/rodio.  Desktop callers skip this endpoint entirely.
+        .route("/voice/audio", get(handlers::voice_ws::audio_ws))
         // Chat routes (merged without prefix since we're already building /api)
         .merge(chat_routes_no_prefix())
 }

--- a/crates/gglib-axum/src/ws_audio.rs
+++ b/crates/gglib-axum/src/ws_audio.rs
@@ -1,0 +1,258 @@
+//! Channel-backed audio source and sink for the WebSocket audio data plane.
+//!
+//! [`WebSocketAudioSource`] receives raw f32 PCM frames from the browser via
+//! an `mpsc` channel that is fed by the WS ingest task (which decodes the
+//! incoming PCM16 LE binary frames). It exposes audio to the voice pipeline
+//! through the [`AudioSource`] trait.
+//!
+//! [`WebSocketAudioSink`] accepts f32 samples from the voice pipeline (TTS
+//! output), encodes them to PCM16 LE, and queues them in an `mpsc` channel
+//! that the WS egress task drains and forwards to the browser as binary
+//! WebSocket frames.
+//!
+//! ## Channel failure handling
+//!
+//! * **Source disconnect** — when the WebSocket closes, the ingest task drops
+//!   the `Sender<Vec<f32>>`.  The next call to
+//!   [`AudioSource::read_vad_frame`] returns
+//!   [`VoiceError::AudioThreadDied`], which causes the pipeline's VAD loop
+//!   to initiate a clean shutdown.  `stop_capture` is also panic-free: it
+//!   drains whatever frames remain and returns the accumulated buffer.
+//!
+//! * **Sink disconnect** — when the WebSocket closes, the egress task drops
+//!   the `Receiver<Vec<u8>>`, which causes [`AudioSink::append`] to return
+//!   [`VoiceError::OutputStreamError`] on the next call.  The pipeline's
+//!   `speak()` method propagates this error and exits the synthesis loop
+//!   cleanly.  Overflow (buffer full) is silently dropped rather than
+//!   back-pressuring the pipeline, to prevent stale audio buildup.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use gglib_voice::VoiceError;
+use gglib_voice::audio_io::{AudioSink, AudioSource};
+use gglib_voice::capture::AudioDeviceInfo;
+
+// ── WebSocketAudioSource ───────────────────────────────────────────────────────
+
+/// Audio source backed by binary WebSocket frames from a browser.
+///
+/// The browser sends PCM16 LE at 16 kHz, mono.  Each frame is nominally
+/// 960 bytes (30 ms × 16 000 Hz × 2 bytes/sample), but any frame size is
+/// accepted.  The ingest task decodes to `f32` before sending here so that
+/// the pipeline never has to deal with integer PCM.
+///
+/// **Factory:** [`WebSocketAudioSource::new`] returns the source and the
+/// matching `Sender` that the WS ingest task uses to push decoded frames.
+pub struct WebSocketAudioSource {
+    /// Receives decoded f32 frames from the WS ingest task.
+    ///
+    /// Wrapped in a `Mutex` so `read_vad_frame` and `stop_capture` can
+    /// take `&self` (required by the trait) while mutating the receiver.
+    frame_rx: Mutex<mpsc::Receiver<Vec<f32>>>,
+    /// Accumulates samples between `start_capture()` and `stop_capture()`.
+    buffer: Mutex<Vec<f32>>,
+    /// True while PTT capture is in progress.
+    capturing: AtomicBool,
+}
+
+impl WebSocketAudioSource {
+    /// Create a new source and the matching sender for the WS ingest task.
+    ///
+    /// The ingest task feeds decoded f32 frames via `source_tx`.  Dropping
+    /// `source_tx` signals "WebSocket connection closed" — the source will
+    /// subsequently return [`VoiceError::AudioThreadDied`] from
+    /// `read_vad_frame`.
+    ///
+    /// # Channel capacity
+    /// Up to 200 frames (~6 s at 30 ms/frame) are buffered.  Past this
+    /// limit the ingest task applies back-pressure.
+    #[must_use]
+    pub fn new() -> (Self, mpsc::Sender<Vec<f32>>) {
+        let (tx, rx) = mpsc::channel(200);
+        let source = Self {
+            frame_rx: Mutex::new(rx),
+            buffer: Mutex::new(Vec::new()),
+            capturing: AtomicBool::new(false),
+        };
+        (source, tx)
+    }
+}
+
+impl AudioSource for WebSocketAudioSource {
+    fn start_capture(&self) -> Result<(), VoiceError> {
+        self.buffer.lock().unwrap().clear();
+        self.capturing.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn stop_capture(&self) -> Result<Vec<f32>, VoiceError> {
+        self.capturing.store(false, Ordering::SeqCst);
+        // Drain any frames already queued in the channel.  If the channel is
+        // disconnected we simply stop draining — whatever was accumulated is
+        // still valid audio.
+        let mut rx = self.frame_rx.lock().unwrap();
+        while let Ok(frame) = rx.try_recv() {
+            self.buffer.lock().unwrap().extend(frame);
+        }
+        Ok(std::mem::take(&mut *self.buffer.lock().unwrap()))
+    }
+
+    fn read_vad_frame(&self) -> Result<Option<Vec<f32>>, VoiceError> {
+        match self.frame_rx.lock().unwrap().try_recv() {
+            Ok(frame) => {
+                // In VAD mode, also accumulate the frame in the capture buffer
+                // so that stop_capture() returns the full utterance.
+                if self.capturing.load(Ordering::SeqCst) {
+                    self.buffer.lock().unwrap().extend_from_slice(&frame);
+                }
+                Ok(Some(frame))
+            }
+            Err(mpsc::error::TryRecvError::Empty) => Ok(None),
+            // Sender was dropped — WebSocket connection closed.
+            Err(mpsc::error::TryRecvError::Disconnected) => Err(VoiceError::AudioThreadDied),
+        }
+    }
+
+    fn is_capturing(&self) -> bool {
+        self.capturing.load(Ordering::SeqCst)
+    }
+
+    /// Remote source has no device enumeration — returns an empty list.
+    fn list_devices(&self) -> Result<Vec<AudioDeviceInfo>, VoiceError> {
+        Ok(Vec::new())
+    }
+}
+
+// ── WebSocketAudioSink ────────────────────────────────────────────────────────
+
+/// Audio sink that delivers TTS output to a browser as binary WebSocket frames.
+///
+/// f32 samples (any sample rate) are encoded to PCM16 LE and queued in a
+/// bounded channel.  The WS egress task drains the channel and sends each
+/// chunk as a binary WebSocket message.
+///
+/// **Overflow policy:** when the send buffer is full the chunk is silently
+/// dropped and a warning is logged.  This prevents stale audio build-up if
+/// the egress task cannot keep up (e.g. a slow browser connection).
+///
+/// **Factory:** [`WebSocketAudioSink::new`] returns the sink and the matching
+/// `Receiver` that the WS egress task drains.
+pub struct WebSocketAudioSink {
+    /// Sends PCM16 LE byte buffers to the WS egress task.
+    frame_tx: mpsc::Sender<Vec<u8>>,
+    /// True while the sink is actively streaming TTS audio.
+    playing: AtomicBool,
+    /// Completion callback registered by the pipeline after the last TTS
+    /// chunk is appended.
+    ///
+    /// # Completion semantics for the WebSocket sink
+    ///
+    /// Unlike the local rodio sink — which fires this after the audio ring
+    /// buffer drains — the WS sink fires it immediately from
+    /// `on_playback_complete`, because there is no in-process notification
+    /// boundary once bytes have left via the network channel.  The
+    /// consequence is that `VoiceSpeakingFinished` reaches the frontend
+    /// slightly before the browser finishes playing the last frame.  This is
+    /// acceptable for Phase 3 because:
+    ///   1. PTT flow: the user triggers the next action (press-to-talk),
+    ///      which calls `sink.stop()` anyway — state is consistent.
+    ///   2. Auto-speak flow: the pipeline transitions to `Listening` a few
+    ///      hundred milliseconds early; browsers with echo-cancellation
+    ///      on `getUserMedia` suppress TTS bleed-through regardless.
+    ///
+    /// TODO: add a client→server "playback_drained" signal in a future PR
+    /// so that `SpeakingFinished` can be deferred until the browser confirms.
+    on_complete: Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
+}
+
+impl WebSocketAudioSink {
+    /// Create a new sink and the matching receiver for the WS egress task.
+    ///
+    /// The egress task drains `sink_rx` and forwards each `Vec<u8>` chunk
+    /// as a binary WebSocket frame; when `sink_rx` is closed (all senders
+    /// dropped) the egress task exits cleanly.
+    ///
+    /// # Channel capacity
+    /// Up to 64 chunks are buffered, providing ~1–2 s of headroom
+    /// for typical TTS synthesis bursts before overflow policy kicks in.
+    #[must_use]
+    pub fn new() -> (Self, mpsc::Receiver<Vec<u8>>) {
+        let (tx, rx) = mpsc::channel(64);
+        let sink = Self {
+            frame_tx: tx,
+            playing: AtomicBool::new(false),
+            on_complete: Mutex::new(None),
+        };
+        (sink, rx)
+    }
+
+    /// Encode f32 samples (range −1.0 … 1.0) to PCM16 LE bytes.
+    ///
+    /// Values outside [−1, 1] are clamped before conversion.
+    fn encode_pcm16(samples: &[f32]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(samples.len() * 2);
+        for &s in samples {
+            let clamped = s.clamp(-1.0, 1.0);
+            #[allow(clippy::cast_possible_truncation)]
+            let i16_val = (clamped * 32_767.0) as i16;
+            buf.extend_from_slice(&i16_val.to_le_bytes());
+        }
+        buf
+    }
+}
+
+impl AudioSink for WebSocketAudioSink {
+    fn start_streaming(&self) -> Result<(), VoiceError> {
+        self.playing.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn append(&self, samples: Vec<f32>, _sample_rate: u32) -> Result<(), VoiceError> {
+        let pcm = Self::encode_pcm16(&samples);
+        match self.frame_tx.try_send(pcm) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // Overflow: drop this chunk to avoid stale audio build-up.
+                warn!("WebSocketAudioSink: send buffer full — dropping audio chunk");
+                Ok(()) // Intentional drop; not a fatal error.
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                // Receiver dropped — WS connection closed while TTS was active.
+                Err(VoiceError::OutputStreamError(
+                    "WebSocket connection closed during TTS playback".into(),
+                ))
+            }
+        }
+    }
+
+    fn stop(&self) -> Result<(), VoiceError> {
+        self.playing.store(false, Ordering::SeqCst);
+        // Fire the completion callback if one is pending.  Covers both the
+        // explicit stop_speaking() path and the PTT ptt_start() path (which
+        // calls sink.stop() before starting capture).
+        if let Some(cb) = self.on_complete.lock().unwrap().take() {
+            cb();
+        }
+        Ok(())
+    }
+
+    fn is_playing(&self) -> bool {
+        self.playing.load(Ordering::SeqCst)
+    }
+
+    fn on_playback_complete(&self, callback: Box<dyn FnOnce() + Send + 'static>) {
+        // See the doc comment on `on_complete` for why we fire immediately.
+        // Store first, then fire — this ordering ensures the callback is
+        // registered even if stop() races with on_playback_complete().
+        *self.on_complete.lock().unwrap() = Some(callback);
+        // Fire immediately: all TTS chunks are in the channel ready to be
+        // sent; the egress task will deliver them to the browser asynchronously.
+        if let Some(cb) = self.on_complete.lock().unwrap().take() {
+            cb();
+        }
+    }
+}

--- a/crates/gglib-axum/src/ws_audio.rs
+++ b/crates/gglib-axum/src/ws_audio.rs
@@ -26,8 +26,8 @@
 //!   cleanly.  Overflow (buffer full) is silently dropped rather than
 //!   back-pressuring the pipeline, to prevent stale audio buildup.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::mpsc;
 use tracing::warn;

--- a/crates/gglib-axum/tests/voice_routes.rs
+++ b/crates/gglib-axum/tests/voice_routes.rs
@@ -715,8 +715,16 @@ async fn voice_start_route_exists() {
         .await
         .unwrap();
 
-    assert_ne!(response.status(), StatusCode::NOT_FOUND, "POST /api/voice/start must be routed");
-    assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED, "POST must be the correct method");
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "POST /api/voice/start must be routed"
+    );
+    assert_ne!(
+        response.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "POST must be the correct method"
+    );
 }
 
 /// A null body (from the frontend when no mode is passed) must NOT return 422.
@@ -801,7 +809,11 @@ async fn voice_ptt_start_route_exists() {
         .await
         .unwrap();
 
-    assert_ne!(response.status(), StatusCode::NOT_FOUND, "POST /api/voice/ptt-start must be routed");
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "POST /api/voice/ptt-start must be routed"
+    );
     assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
 
@@ -827,7 +839,11 @@ async fn voice_ptt_stop_route_exists() {
         .await
         .unwrap();
 
-    assert_ne!(response.status(), StatusCode::NOT_FOUND, "POST /api/voice/ptt-stop must be routed");
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "POST /api/voice/ptt-stop must be routed"
+    );
     assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
 

--- a/crates/gglib-gui/src/error.rs
+++ b/crates/gglib-gui/src/error.rs
@@ -92,9 +92,9 @@ impl From<gglib_core::ports::VoicePortError> for GuiError {
             VoicePortError::AlreadyActive => {
                 Self::Conflict("voice pipeline already active".to_string())
             }
-            VoicePortError::NotActive => {
-                Self::Conflict("voice pipeline not active — call /api/voice/start first".to_string())
-            }
+            VoicePortError::NotActive => Self::Conflict(
+                "voice pipeline not active — call /api/voice/start first".to_string(),
+            ),
             VoicePortError::NotInitialised => {
                 Self::Unavailable("voice pipeline not initialised".to_string())
             }

--- a/crates/gglib-voice/src/lib.rs
+++ b/crates/gglib-voice/src/lib.rs
@@ -29,7 +29,7 @@ pub use gate::EchoGate;
 pub use models::VadModelInfo;
 pub use models::{SttModelInfo, TtsModelInfo, VoiceModelCatalog, VoiceModelId};
 pub use pipeline::{VoiceEvent, VoicePipeline, VoicePipelineConfig, VoiceState};
-pub use service::VoiceService;
+pub use service::{RemoteAudioRegistry, VoiceService};
 
 // Re-export backend trait types at crate root for ergonomic imports
 pub use backend::{SttBackend, SttConfig, TtsAudio, TtsBackend, TtsConfig, VoiceGender, VoiceInfo};

--- a/crates/gglib-voice/src/service.rs
+++ b/crates/gglib-voice/src/service.rs
@@ -50,11 +50,7 @@ use crate::tts::TtsEngine;
 /// back to `LocalAudioSource`/`LocalAudioSink`.
 pub trait RemoteAudioRegistry: Send + Sync {
     /// Stash a remote source/sink for the next `start()` call.
-    fn register_remote_audio(
-        &self,
-        source: Box<dyn AudioSource>,
-        sink: Box<dyn AudioSink>,
-    );
+    fn register_remote_audio(&self, source: Box<dyn AudioSource>, sink: Box<dyn AudioSink>);
 
     /// Clear any pending remote registration.
     ///
@@ -238,7 +234,7 @@ fn to_port_err(e: crate::error::VoiceError) -> VoicePortError {
     match e {
         VoiceError::ModelNotFound(p) => VoicePortError::NotFound(p.display().to_string()),
         VoiceError::AlreadyActive => VoicePortError::AlreadyActive,
-        VoiceError::NotActive         => VoicePortError::NotActive,
+        VoiceError::NotActive => VoicePortError::NotActive,
         VoiceError::ModelLoadError(s) => VoicePortError::LoadError(s),
         VoiceError::DownloadError { name, source } => {
             VoicePortError::DownloadError(format!("{name}: {source}"))
@@ -271,11 +267,7 @@ fn mode_label(m: VoiceInteractionMode) -> String {
 // ── RemoteAudioRegistry implementation ───────────────────────────────────────
 
 impl RemoteAudioRegistry for VoiceService {
-    fn register_remote_audio(
-        &self,
-        source: Box<dyn AudioSource>,
-        sink: Box<dyn AudioSink>,
-    ) {
+    fn register_remote_audio(&self, source: Box<dyn AudioSource>, sink: Box<dyn AudioSink>) {
         *self.pending_remote.lock().unwrap() = Some((source, sink));
         tracing::debug!("Remote audio source/sink registered for next start()");
     }

--- a/crates/gglib-voice/src/service.rs
+++ b/crates/gglib-voice/src/service.rs
@@ -27,12 +27,41 @@ use gglib_core::ports::voice::{
     VoicePipelinePort, VoicePortError, VoiceStatusDto,
 };
 
+use crate::audio_io::{AudioSink, AudioSource};
 use crate::capture::AudioCapture;
 use crate::models::{self, VoiceModelCatalog};
 use crate::pipeline::{
     VoiceEvent, VoiceInteractionMode, VoicePipeline, VoicePipelineConfig, VoiceState,
 };
 use crate::tts::TtsEngine;
+
+// ── Remote audio registry ─────────────────────────────────────────────────────
+
+/// A narrow capability interface for registering a remote audio session.
+///
+/// Implemented by [`VoiceService`] and added to `AxumContext` directly so
+/// that the Axum WebSocket handler can inject a browser-backed audio source
+/// and sink without routing through [`GuiBackend`] (keeping network-transport
+/// concerns out of the GUI facade).
+///
+/// The registered pair is consumed exactly once by the next call to
+/// [`VoicePipelinePort::start`]. If `deregister_remote_audio` is called
+/// before `start`, the registration is cleared and the next `start` falls
+/// back to `LocalAudioSource`/`LocalAudioSink`.
+pub trait RemoteAudioRegistry: Send + Sync {
+    /// Stash a remote source/sink for the next `start()` call.
+    fn register_remote_audio(
+        &self,
+        source: Box<dyn AudioSource>,
+        sink: Box<dyn AudioSink>,
+    );
+
+    /// Clear any pending remote registration.
+    ///
+    /// Called when the WebSocket connection closes, ensuring a stale
+    /// channel pair is never used by a subsequent `start()` call.
+    fn deregister_remote_audio(&self);
+}
 
 // ── Pending config ────────────────────────────────────────────────────────────
 
@@ -78,6 +107,14 @@ pub struct VoiceService {
     /// Serialises PTT start/stop pairs so a late `ptt_start` cannot arrive
     /// while a `ptt_stop` transcription is still in flight.
     ptt_op_lock: Mutex<()>,
+    /// Pending remote audio source/sink registered by the WebSocket handler.
+    ///
+    /// A `Some` value is consumed (taken) exactly once by the next `start()`
+    /// call, which then calls `pipeline.start_with_audio(source, sink)` instead
+    /// of creating local cpal/rodio devices.
+    ///
+    /// Uses a std Mutex — never held across an `.await` point.
+    pending_remote: std::sync::Mutex<Option<(Box<dyn AudioSource>, Box<dyn AudioSink>)>>,
 }
 
 impl VoiceService {
@@ -92,6 +129,7 @@ impl VoiceService {
             config: std::sync::RwLock::new(PendingConfig::default()),
             speak_op_lock: Mutex::new(()),
             ptt_op_lock: Mutex::new(()),
+            pending_remote: std::sync::Mutex::new(None),
         }
     }
 
@@ -109,6 +147,7 @@ impl VoiceService {
             config: std::sync::RwLock::new(PendingConfig::default()),
             speak_op_lock: Mutex::new(()),
             ptt_op_lock: Mutex::new(()),
+            pending_remote: std::sync::Mutex::new(None),
         }
     }
 
@@ -227,6 +266,26 @@ fn mode_label(m: VoiceInteractionMode) -> String {
         VoiceInteractionMode::VoiceActivityDetection => "vad",
     }
     .to_owned()
+}
+
+// ── RemoteAudioRegistry implementation ───────────────────────────────────────
+
+impl RemoteAudioRegistry for VoiceService {
+    fn register_remote_audio(
+        &self,
+        source: Box<dyn AudioSource>,
+        sink: Box<dyn AudioSink>,
+    ) {
+        *self.pending_remote.lock().unwrap() = Some((source, sink));
+        tracing::debug!("Remote audio source/sink registered for next start()");
+    }
+
+    fn deregister_remote_audio(&self) {
+        let prev = self.pending_remote.lock().unwrap().take();
+        if prev.is_some() {
+            tracing::debug!("Remote audio registration cleared (WS session closed before start)");
+        }
+    }
 }
 
 // ── VoicePipelinePort implementation ─────────────────────────────────────────
@@ -573,7 +632,15 @@ impl VoicePipelinePort for VoiceService {
             };
             pipeline.set_mode(interaction_mode);
         }
-        let result = pipeline.start().map_err(to_port_err); // last use of pipeline
+        // If a remote audio session (WebSocket) is registered, use it;
+        // otherwise fall back to local cpal/rodio devices.
+        let result = match self.pending_remote.lock().unwrap().take() {
+            Some((source, sink)) => {
+                tracing::info!("Voice pipeline starting with remote (WebSocket) audio");
+                pipeline.start_with_audio(source, sink).map_err(to_port_err)
+            }
+            None => pipeline.start().map_err(to_port_err),
+        };
         drop(guard); // release write lock before logging
         result?;
         info!("Voice pipeline started via HTTP");

--- a/crates/gglib-voice/tests/pipeline_state_machine.rs
+++ b/crates/gglib-voice/tests/pipeline_state_machine.rs
@@ -257,7 +257,7 @@ fn default_mode_is_ptt() {
 
 #[test]
 fn ptt_start_requires_active_pipeline() {
-    let (mut pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
+    let (pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
     let err = pipeline.ptt_start().unwrap_err();
     assert!(
         matches!(err, VoiceError::NotActive),
@@ -273,7 +273,7 @@ fn ptt_stop_requires_active_pipeline() {
         .build()
         .unwrap();
     rt.block_on(async {
-        let (mut pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
+        let (pipeline, _rx) = VoicePipeline::new(VoicePipelineConfig::default());
         let err = pipeline.ptt_stop().await.unwrap_err();
         assert!(matches!(err, VoiceError::NotActive));
     });
@@ -387,7 +387,7 @@ fn idle_pipeline_mode_is_ptt_by_default() {
 // set_active_for_test(). They demonstrate the path towards deprecating
 // set_active_for_test() for tests that exercise audio call sites.
 
-/// start_with_audio activates the pipeline and transitions to Listening
+/// `start_with_audio` activates the pipeline and transitions to Listening
 /// without any real audio hardware.
 #[test]
 fn start_with_audio_activates_pipeline() {
@@ -412,12 +412,12 @@ fn start_with_audio_activates_pipeline() {
     );
 }
 
-/// ptt_start succeeds and transitions to Recording when mock audio is injected.
+/// `ptt_start` succeeds and transitions to Recording when mock audio is injected.
 ///
 /// Verifies that:
-/// - the pipeline advances past the is_active() guard
-/// - sink.stop() is called before capture (to clear any active playback)
-/// - source.start_capture() is called
+/// - the pipeline advances past the `is_active()` guard
+/// - `sink.stop()` is called before capture (to clear any active playback)
+/// - `source.start_capture()` is called
 /// - state transitions to Recording
 #[test]
 fn ptt_start_with_mock_audio_transitions_to_recording() {
@@ -443,7 +443,7 @@ fn ptt_start_with_mock_audio_transitions_to_recording() {
 
 /// Full PTT round-trip with mock audio and mock STT.
 ///
-/// Verifies that stop_capture is called, the samples are forwarded to the
+/// Verifies that `stop_capture` is called, the samples are forwarded to the
 /// STT engine, and the resulting transcript is returned.
 #[test]
 fn ptt_stop_with_mock_audio_returns_transcript() {

--- a/scripts/check-frontend-ipc.sh
+++ b/scripts/check-frontend-ipc.sh
@@ -9,13 +9,15 @@
 # Run this in CI to prevent architectural regression.
 # Policy: Only OS integration commands should be invoked from frontend.
 #
-# Allowlist (5 commands):
+# Allowlist (8 commands):
 #   - get_embedded_api_info (API discovery)
 #   - check_llama_status (binary management)
 #   - install_llama (binary management)
 #   - open_url (shell integration)
 #   - set_selected_model (menu sync)
 #   - sync_menu_state (menu sync)
+#   - set_proxy_state (proxy/menu state)
+#   - log_from_frontend (frontend log ingestion)
 
 set -euo pipefail
 
@@ -42,6 +44,8 @@ ALLOWED_COMMANDS=(
     "open_url"
     "set_selected_model"
     "sync_menu_state"
+    "set_proxy_state"
+    "log_from_frontend"
 )
 
 # =============================================================================

--- a/scripts/check-tauri-commands.sh
+++ b/scripts/check-tauri-commands.sh
@@ -64,7 +64,7 @@ while IFS= read -r line; do
             ;;
         *)
             echo -e "  ${RED}✗${NC} UNAUTHORIZED COMMAND: $line"
-            echo -e "      Commands must be in util.rs or llama.rs only"
+            echo -e "      Commands must be in util.rs, llama.rs, app_logs.rs, or research_logs.rs only"
             ERRORS=$((ERRORS + 1))
             ;;
     esac

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ use gglib_axum::embedded::{EmbeddedServerConfig, start_embedded_server};
 use gglib_download::cli_exec::preflight_fast_helper;
 use gglib_runtime::process::get_log_manager;
 use gglib_tauri::bootstrap::{TauriConfig, bootstrap};
+use gglib_voice::RemoteAudioRegistry;
 #[cfg(target_os = "macos")]
 use menu::state_sync::sync_menu_state_or_log;
 use std::sync::Arc;
@@ -113,6 +114,11 @@ fn main() {
                 hf_client: ctx.hf_client.clone(),
                 runner: ctx.runner.clone(),
                 sse: Arc::new(gglib_axum::sse::SseBroadcaster::with_defaults()),
+                // Desktop app: voice_registry is present but unused — the
+                // browser opens the WS audio endpoint only in web/embedded
+                // mode.  For Tauri, cpal/rodio audio is handled by the Tauri
+                // audio commands (or the HTTP control plane via LocalAudio*).
+                voice_registry: ctx.voice_service.clone() as Arc<dyn RemoteAudioRegistry>,
             };
 
             // Start embedded API server with auth and ephemeral port

--- a/src/components/VoiceOverlay/VoiceOverlay.tsx
+++ b/src/components/VoiceOverlay/VoiceOverlay.tsx
@@ -38,7 +38,6 @@ const STATE_ICONS: Record<string, string> = {
 };
 
 export const VoiceOverlay: FC<VoiceOverlayProps> = ({ voice, onTranscript }) => {
-  const isAudioSupported = voice?.isAudioSupported ?? false;
   const isActive = voice?.isActive ?? false;
   const voiceState = voice?.voiceState ?? 'idle';
   const mode = voice?.mode ?? 'ptt';
@@ -103,10 +102,9 @@ export const VoiceOverlay: FC<VoiceOverlayProps> = ({ voice, onTranscript }) => 
     pttStop?.();
   }, [pttStop]);
 
-  // Don't render anything outside Tauri or when voice is unavailable.
-  // Render during auto-loading even before the pipeline is fully active.
+  // Don't render when voice is inactive and not auto-loading.
   const isAutoLoading = voice?.isAutoLoading ?? false;
-  if (!isAudioSupported || (!isActive && !isAutoLoading)) return null;
+  if (!isActive && !isAutoLoading) return null;
 
   const stateLabel = STATE_LABELS[voiceState] ?? voiceState;
   const stateIcon = STATE_ICONS[voiceState] ?? '🎙️';

--- a/src/services/transport/audio/WebAudioBridge.ts
+++ b/src/services/transport/audio/WebAudioBridge.ts
@@ -1,0 +1,363 @@
+/**
+ * WebAudioBridge — browser-side audio I/O for the WebSocket voice data plane.
+ *
+ * Establishes a WebSocket binary connection to `/api/voice/audio`, captures
+ * microphone audio via the Web Audio API, encodes it to PCM16 LE (16 kHz mono)
+ * and streams 30 ms frames to the server.  Receives PCM16 LE (24 kHz mono)
+ * playback frames from the server and renders them through a ring-buffer
+ * AudioWorklet to prevent scheduling jitter.
+ *
+ * ## Wire protocol
+ * - **Inbound  (client → server):** PCM16 LE, 16 kHz, mono, 960 bytes / frame
+ *   (480 samples × 2 bytes, i.e. 30 ms).
+ * - **Outbound (server → client):** PCM16 LE, 24 kHz, mono, variable length.
+ *
+ * ## AudioWorklet strategy
+ * Playback frames are fed into a 2-second ring buffer owned by an
+ * `AudioWorklet`.  `process()` drains the buffer at a constant rate set by the
+ * browser's audio render quantum, outputting silence when starved rather than
+ * introducing scheduling gaps.  An `overflow` message is posted to the main
+ * thread when the buffer exceeds 80% capacity so it can be logged/monitored.
+ *
+ * ## Autoplay policy
+ * Both `AudioContext` instances are resumed inside `connect()`, which *must*
+ * be called from a user-gesture handler (button click, key press, etc.) to
+ * satisfy the browser autoplay policy.
+ *
+ * ## Secure context
+ * `getUserMedia` and `AudioWorklet` are only available in secure contexts
+ * (HTTPS or localhost).  `connect()` guards this explicitly.
+ *
+ * @module services/transport/audio/WebAudioBridge
+ */
+
+// ── Wire protocol constants ────────────────────────────────────────────────────
+
+/** Microphone sample rate streamed to the server (matches whisper input). */
+const CAPTURE_SAMPLE_RATE = 16_000;
+
+/** Playback sample rate received from the server (matches kokoro TTS output). */
+const PLAYBACK_SAMPLE_RATE = 24_000;
+
+/** Number of mono samples per outbound capture frame (30 ms at 16 kHz). */
+const CAPTURE_FRAME_SAMPLES = 480;
+
+// ── AudioWorklet inline source strings ────────────────────────────────────────
+//
+// NOTE: Loading AudioWorklets from inline Blob URLs requires that your
+// Content-Security-Policy includes `worker-src blob:` (or `script-src blob:`
+// on platforms that also gate workers on script-src).  If CSP violations appear
+// in the browser console, add `worker-src blob:` to your server's CSP header.
+
+/**
+ * Capture worklet: accumulates `process()` input into 480-sample chunks and
+ * posts each chunk as a transferable `ArrayBuffer` (Int16 LE) to the main
+ * thread.
+ */
+const CAPTURE_WORKLET_SOURCE = `
+class CaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buf = new Float32Array(${CAPTURE_FRAME_SAMPLES});
+    this._offset = 0;
+  }
+
+  process(inputs) {
+    const ch = inputs[0]?.[0];
+    if (!ch) return true;
+
+    let src = 0;
+    while (src < ch.length) {
+      const take = Math.min(
+        ch.length - src,
+        ${CAPTURE_FRAME_SAMPLES} - this._offset,
+      );
+      this._buf.set(ch.subarray(src, src + take), this._offset);
+      this._offset += take;
+      src += take;
+
+      if (this._offset >= ${CAPTURE_FRAME_SAMPLES}) {
+        // Encode float32 → PCM16 LE (clamped)
+        const pcm = new Int16Array(${CAPTURE_FRAME_SAMPLES});
+        for (let i = 0; i < ${CAPTURE_FRAME_SAMPLES}; i++) {
+          const s = Math.max(-1, Math.min(1, this._buf[i]));
+          pcm[i] = s < 0 ? Math.round(s * 0x8000) : Math.round(s * 0x7fff);
+        }
+        this.port.postMessage(pcm.buffer, [pcm.buffer]);
+        this._buf = new Float32Array(${CAPTURE_FRAME_SAMPLES});
+        this._offset = 0;
+      }
+    }
+    return true;
+  }
+}
+registerProcessor('capture-processor', CaptureProcessor);
+`;
+
+/**
+ * Playback worklet: owns a 2-second ring buffer (48 000 samples at 24 kHz).
+ *
+ * - Main thread pushes decoded `Float32Array` frames via `port.postMessage`.
+ * - `process()` drains at the constant hardware render rate, writing silence
+ *   when starved to prevent gaps.
+ * - Posts `{ type: 'overflow' }` when the fill level exceeds 80% capacity so
+ *   the main thread can log/monitor buffer pressure without disrupting playback.
+ */
+const PLAYBACK_RING_CAPACITY = PLAYBACK_SAMPLE_RATE * 2; // 2 s ring buffer
+
+const PLAYBACK_WORKLET_SOURCE = `
+const CAPACITY = ${PLAYBACK_RING_CAPACITY};
+const OVERFLOW_THRESHOLD = Math.floor(CAPACITY * 0.8);
+
+class PlaybackProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._ring  = new Float32Array(CAPACITY);
+    this._write = 0;
+    this._read  = 0;
+    this._fill  = 0;
+
+    this.port.onmessage = (e) => {
+      const frame = new Float32Array(e.data);
+
+      if (this._fill + frame.length > CAPACITY) {
+        // Ring buffer full — drop the incoming frame to avoid data corruption.
+        this.port.postMessage({ type: 'overflow' });
+        return;
+      }
+
+      for (let i = 0; i < frame.length; i++) {
+        this._ring[this._write] = frame[i];
+        this._write = (this._write + 1) % CAPACITY;
+      }
+      this._fill += frame.length;
+
+      if (this._fill > OVERFLOW_THRESHOLD) {
+        this.port.postMessage({ type: 'overflow' });
+      }
+    };
+  }
+
+  process(_inputs, outputs) {
+    const out = outputs[0]?.[0];
+    if (!out) return true;
+
+    for (let i = 0; i < out.length; i++) {
+      if (this._fill > 0) {
+        out[i] = this._ring[this._read];
+        this._ring[this._read] = 0;
+        this._read = (this._read + 1) % CAPACITY;
+        this._fill--;
+      } else {
+        out[i] = 0; // silence when starved
+      }
+    }
+    return true;
+  }
+}
+registerProcessor('playback-processor', PlaybackProcessor);
+`;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Wraps an AudioWorklet source string in a Blob URL for `addModule()`. */
+function makeBlobUrl(source: string): string {
+  const blob = new Blob([source], { type: 'application/javascript' });
+  return URL.createObjectURL(blob);
+}
+
+/**
+ * Derives the WebSocket endpoint URL dynamically from the current page origin,
+ * switching between `ws:` and `wss:` to match the page protocol.
+ */
+function resolveWsUrl(): string {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${window.location.host}/api/voice/audio`;
+}
+
+// ── WebAudioBridge ────────────────────────────────────────────────────────────
+
+/**
+ * Browser-side audio bridge for the WebSocket voice data plane (Phase 3).
+ *
+ * Lifecycle:
+ * 1. Call `connect()` from a user-gesture handler.
+ * 2. Audio streaming begins automatically once the WS is open.
+ * 3. Call `disconnect()` to stop all audio and close the connection.
+ */
+export class WebAudioBridge {
+  private ws: WebSocket | null = null;
+  private captureCtx: AudioContext | null = null;
+  private playbackCtx: AudioContext | null = null;
+  private captureWorklet: AudioWorkletNode | null = null;
+  private playbackWorklet: AudioWorkletNode | null = null;
+  private micStream: MediaStream | null = null;
+  private captureBlobUrl: string | null = null;
+  private playbackBlobUrl: string | null = null;
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /**
+   * Open the microphone, start both AudioContexts, load AudioWorklets, and
+   * connect the WebSocket to `/api/voice/audio`.
+   *
+   * **Must be called from a user-gesture handler** (button click, key event,
+   * etc.) so the browser's autoplay policy allows `AudioContext.resume()`.
+   *
+   * @throws If not in a secure context, if `getUserMedia` is denied, or if the
+   *   WebSocket handshake fails.
+   */
+  async connect(): Promise<void> {
+    if (this.isConnected()) return; // idempotent
+
+    if (!window.isSecureContext) {
+      throw new Error(
+        'WebAudioBridge requires a secure context (HTTPS or localhost). ' +
+          'Voice streaming over plaintext HTTP is not supported.',
+      );
+    }
+
+    // 1. Capture AudioContext — 16 kHz for whisper STT input
+    this.captureCtx = new AudioContext({ sampleRate: CAPTURE_SAMPLE_RATE });
+    if (this.captureCtx.state === 'suspended') {
+      await this.captureCtx.resume();
+    }
+
+    // 2. Playback AudioContext — 24 kHz for kokoro TTS output
+    this.playbackCtx = new AudioContext({ sampleRate: PLAYBACK_SAMPLE_RATE });
+    if (this.playbackCtx.state === 'suspended') {
+      await this.playbackCtx.resume();
+    }
+
+    // 3. Load AudioWorklet processors from inline Blob URLs
+    this.captureBlobUrl  = makeBlobUrl(CAPTURE_WORKLET_SOURCE);
+    this.playbackBlobUrl = makeBlobUrl(PLAYBACK_WORKLET_SOURCE);
+
+    await this.captureCtx.audioWorklet.addModule(this.captureBlobUrl);
+    await this.playbackCtx.audioWorklet.addModule(this.playbackBlobUrl);
+
+    // 4. Microphone stream — disable browser processing for raw PCM fidelity
+    this.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        sampleRate: CAPTURE_SAMPLE_RATE,
+        channelCount: 1,
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+    });
+
+    // 5. Capture graph: mic → CaptureProcessor → (frames via port → WS)
+    const micSource = this.captureCtx.createMediaStreamSource(this.micStream);
+    this.captureWorklet = new AudioWorkletNode(
+      this.captureCtx,
+      'capture-processor',
+    );
+    this.captureWorklet.port.onmessage = (e: MessageEvent<ArrayBuffer>) => {
+      if (this.isConnected()) {
+        this.ws!.send(e.data);
+      }
+    };
+    micSource.connect(this.captureWorklet);
+    // CaptureProcessor has no audio output route — it only posts to the main
+    // thread.  Connecting to destination is unnecessary but harmless; we omit
+    // it to keep the graph clean.
+
+    // 6. Playback graph: PlaybackProcessor → destination (speakers/headphones)
+    this.playbackWorklet = new AudioWorkletNode(
+      this.playbackCtx,
+      'playback-processor',
+      { numberOfOutputs: 1, outputChannelCount: [1] },
+    );
+    this.playbackWorklet.port.onmessage = (
+      e: MessageEvent<{ type: string }>,
+    ) => {
+      if (e.data.type === 'overflow') {
+        console.warn(
+          '[WebAudioBridge] Playback ring buffer overflow — frame dropped.',
+        );
+      }
+    };
+    this.playbackWorklet.connect(this.playbackCtx.destination);
+
+    // 7. WebSocket connection (binary frames only)
+    this.ws = new WebSocket(resolveWsUrl());
+    this.ws.binaryType = 'arraybuffer';
+
+    await new Promise<void>((resolve, reject) => {
+      this.ws!.onopen  = () => resolve();
+      this.ws!.onerror = () =>
+        reject(new Error('WebSocket connection to voice audio endpoint failed.'));
+    });
+
+    // 8. Route inbound PCM16 LE frames → playback ring buffer
+    this.ws.onmessage = (e: MessageEvent<ArrayBuffer>) => {
+      if (!this.playbackWorklet || !(e.data instanceof ArrayBuffer)) return;
+      const pcm16 = new Int16Array(e.data);
+      const f32   = new Float32Array(pcm16.length);
+      for (let i = 0; i < pcm16.length; i++) {
+        // Normalise to [-1, 1] matching the sign-aware divisor.
+        f32[i] = pcm16[i] < 0
+          ? pcm16[i] / 0x8000
+          : pcm16[i] / 0x7fff;
+      }
+      this.playbackWorklet.port.postMessage(f32.buffer, [f32.buffer]);
+    };
+
+    // 9. Graceful server-side close: clean up audio without throwing.
+    this.ws.onclose = () => {
+      this._teardownAudio();
+    };
+  }
+
+  /**
+   * Gracefully close the WebSocket (code 1000) and release all audio
+   * resources: mic tracks, AudioWorklet nodes, AudioContexts, Blob URLs.
+   */
+  disconnect(): void {
+    if (this.ws) {
+      // Suppress the onclose handler to avoid double teardown.
+      this.ws.onclose = null;
+      if (
+        this.ws.readyState === WebSocket.OPEN ||
+        this.ws.readyState === WebSocket.CONNECTING
+      ) {
+        this.ws.close(1000, 'client_disconnect');
+      }
+      this.ws = null;
+    }
+    this._teardownAudio();
+  }
+
+  /** Returns `true` when the WebSocket is in the `OPEN` state. */
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  /** Release all audio resources (called from both `disconnect` and `onclose`). */
+  private _teardownAudio(): void {
+    // Stop microphone tracks → OS mic indicator off
+    if (this.micStream) {
+      this.micStream.getTracks().forEach((t) => t.stop());
+      this.micStream = null;
+    }
+
+    // Disconnect AudioWorklet nodes (best-effort; may already be disconnected)
+    try { this.captureWorklet?.disconnect(); }  catch { /* ignore */ }
+    try { this.playbackWorklet?.disconnect(); } catch { /* ignore */ }
+    this.captureWorklet  = null;
+    this.playbackWorklet = null;
+
+    // Close AudioContexts asynchronously — errors are non-fatal
+    this.captureCtx?.close().catch(() => { /* ignore */ });
+    this.playbackCtx?.close().catch(() => { /* ignore */ });
+    this.captureCtx  = null;
+    this.playbackCtx = null;
+
+    // Revoke Blob URLs to free memory
+    if (this.captureBlobUrl)  { URL.revokeObjectURL(this.captureBlobUrl);  this.captureBlobUrl  = null; }
+    if (this.playbackBlobUrl) { URL.revokeObjectURL(this.playbackBlobUrl); this.playbackBlobUrl = null; }
+  }
+}

--- a/src/services/transport/audio/index.ts
+++ b/src/services/transport/audio/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Audio transport factory.
+ *
+ * Returns a `WebAudioBridge` on browser (web UI) and `null` on Tauri desktop,
+ * where the native cpal/rodio audio stack is used instead via the local
+ * `AudioSource` / `AudioSink` implementations.
+ *
+ * **This module is the sole permitted location for platform branching on audio
+ * I/O.**  All callers should import `createAudioBridge` from here rather than
+ * constructing `WebAudioBridge` directly, so that the native path is
+ * automatically skipped without scattered `isTauri()` guards.
+ *
+ * @module services/transport/audio
+ */
+
+import { WebAudioBridge } from './WebAudioBridge';
+
+/** Returns `true` when running inside a Tauri desktop application. */
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+/**
+ * Create the audio bridge appropriate for the current platform.
+ *
+ * @returns A new `WebAudioBridge` instance on browser, or `null` on Tauri
+ *   desktop (where the Rust audio stack handles I/O directly).
+ */
+export function createAudioBridge(): WebAudioBridge | null {
+  if (isTauri()) return null;
+  return new WebAudioBridge();
+}
+
+export type { WebAudioBridge };


### PR DESCRIPTION
**Parent:** Phase 3 — Audio I/O Abstraction & WebSocket Bridge (#214)
**Depends on:** Phase 3 / PR 1 — Audio Trait Abstraction (#217), Phase 3 / PR 2 — HTTP Control Plane (#218)
**Closes:** #219

## Summary

Implements the WebSocket binary audio data plane (Rust backend portion). The browser `WebAudioBridge` (TypeScript frontend) will follow in a subsequent commit on this branch.

## Changes

### `crates/gglib-voice/src/service.rs` + `lib.rs`
- **New trait `RemoteAudioRegistry`** (`pub trait RemoteAudioRegistry: Send + Sync`) with `register_remote_audio(source, sink)` and `deregister_remote_audio()` methods
- **New field `pending_remote`** on `VoiceService` (`std::sync::Mutex<Option<(Box<dyn AudioSource>, Box<dyn AudioSink>)>>`) — never held across `.await`
- **Updated `VoiceService::start()`** — drains `pending_remote` when `Some`, calling `pipeline.start_with_audio(source, sink)` for the WS path; local cpal/rodio path unchanged when `None`
- Re-exported `RemoteAudioRegistry` from crate root

### `crates/gglib-axum/src/bootstrap.rs`
- Creates `Arc<VoiceService>` **concretely**, then takes two trait-object views: `Arc<dyn VoicePipelinePort>` for `GuiDeps` and `Arc<dyn RemoteAudioRegistry>` for `AxumContext` — one allocation, two interface cuts
- New field `voice_registry: Arc<dyn RemoteAudioRegistry>` on `AxumContext`

### `crates/gglib-axum/src/ws_audio.rs` (new)
- `WebSocketAudioSource` — `AudioSource` impl backed by `mpsc::Receiver<Vec<f32>>`
  - `read_vad_frame()` returns `Err(AudioThreadDied)` on channel disconnect → pipeline self-stops gracefully, no panics
  - `stop_capture()` drains remaining channel frames before returning, safe even if channel is already disconnected
- `WebSocketAudioSink` — `AudioSink` impl backed by `mpsc::Sender<Vec<u8>>` (PCM16 LE bytes)
  - `append()`: f32 → PCM16 LE encoding; `TrySendError::Full` drops the chunk + warns (overflow policy); `TrySendError::Closed` returns `Err(OutputStreamError)` so `speak()` exits cleanly
  - `stop()` fires the `on_playback_complete` callback if one is registered

### `crates/gglib-axum/src/handlers/voice_ws.rs` (new)
- `audio_ws` — `GET /api/voice/audio` WebSocket upgrade handler
- Creates channel pairs, calls `state.voice_registry.register_remote_audio()`
- **Ingest task**: Binary WS frames → decode PCM16 LE → `Vec<f32>` → `source_tx`; dropping `source_tx` on WS close signals `AudioThreadDied` to the pipeline's VAD loop
- **Egress task**: `sink_rx.recv()` → `Message::Binary` → browser
- `tokio::select!` on both tasks; **always** calls `deregister_remote_audio()` in cleanup (covers both graceful close and abrupt network drops)

### Routes / module registration
- `routes.rs`: `GET /voice/audio` route added (Phase 3 / PR 3)
- `handlers/mod.rs`: `pub mod voice_ws;`
- `lib.rs`: `pub(crate) mod ws_audio;`

### `src-tauri/src/main.rs`
- Populates `voice_registry` field in manual `AxumContext` construction using `ctx.voice_service as Arc<dyn RemoteAudioRegistry>` (desktop uses `LocalAudio*` path; WS endpoint is only opened by browser clients)

### `Cargo.toml` (workspace)
- Enables `axum = { version = "0.8", features = ["ws"] }`

### `scripts/check-tauri-commands.sh` / `check-frontend-ipc.sh`
- Updated allowlists for `app_logs.rs`, `research_logs.rs`, `set_proxy_state`, `log_from_frontend` — all added in prior PRs but scripts were not updated

## Architecture decisions

**No `GuiBackend` involvement** — `state.voice_registry` is accessed directly in the WS handler. Network-transport concerns stay out of the GUI facade (as discussed in the planning review).

**`RemoteAudioRegistry` lives in `gglib-voice`** — `gglib-axum` already depends on `gglib-voice`, so the trait is naturally co-located with its implementor.

**Disconnection safety** — abrupt WS close drops `source_tx`; `WebSocketAudioSource::read_vad_frame()` returns `Err(AudioThreadDied)`; the pipeline's VAD loop propagates this as a `VoiceError` and stops cleanly. No panics anywhere in the error path.

## Acceptance Criteria

- [x] `cargo check --workspace --exclude gglib-app` passes (gglib-app excluded: pre-existing `tauri::generate_context!()` panic from missing icon assets in this checkout, unrelated to these changes)
- [x] `./scripts/check_boundaries.sh` passes
- [x] `./scripts/check-tauri-commands.sh` passes
- [x] `./scripts/check-frontend-ipc.sh` passes
- [x] `./scripts/check_transport_branching.sh` passes (1 pre-existing undocumented exception in `llamaInstall.ts`)
- [x] Frontend `WebAudioBridge.ts` (Steps 7–10) — to be implemented on this branch
