### PR TITLE
refactor(voice): pre-merge DRY + isAudioSupported (pre-#228)

### DIFF
--- a/crates/gglib-voice/src/service.rs
+++ b/crates/gglib-voice/src/service.rs
@@ -175,9 +175,9 @@ impl VoiceService {
 impl VoiceService {
     /// Ensure a pipeline exists in `slot`, creating one lazily if `None`.
     ///
-    /// Accepts `&mut Option<VoicePipeline>` so callers can pass `&mut *guard`
-    /// for a write-lock guard without coupling this helper to any particular
-    /// `RwLockWriteGuard` type.
+    /// Accepts `&mut Option<VoicePipeline>` so callers can pass `&mut guard`
+    /// for a write-lock guard: Rust auto-derefs through `DerefMut` without
+    /// coupling this helper to any particular `RwLockWriteGuard` type.
     ///
     /// When a new pipeline is created its event channel is bridged to the
     /// service's emitter via [`spawn_event_bridge`].
@@ -315,7 +315,7 @@ fn mode_label(m: VoiceInteractionMode) -> String {
 fn progress_callback(
     emitter: Arc<dyn AppEventEmitter>,
     model_id: String,
-) -> impl FnMut(u64, u64) {
+) -> impl Fn(u64, u64) {
     move |downloaded, total| {
         let percent = if total > 0 {
             (downloaded as f64 / total as f64) * 100.0
@@ -491,7 +491,7 @@ impl VoicePipelinePort for VoiceService {
         }
 
         let mut guard = self.pipeline.write().await;
-        self.ensure_pipeline(&mut *guard);
+        self.ensure_pipeline(&mut guard);
         let pipeline = guard.as_mut().expect("ensure_pipeline guarantees Some");
         if pipeline.is_active() {
             pipeline.stop();
@@ -514,7 +514,7 @@ impl VoicePipelinePort for VoiceService {
         }
 
         let mut guard = self.pipeline.write().await;
-        self.ensure_pipeline(&mut *guard);
+        self.ensure_pipeline(&mut guard);
         let pipeline = guard.as_mut().expect("ensure_pipeline guarantees Some");
         pipeline.load_tts(&tts_dir).await.map_err(to_port_err)?;
         self.apply_pending_config(pipeline);

--- a/src/components/VoiceOverlay/VoiceOverlay.tsx
+++ b/src/components/VoiceOverlay/VoiceOverlay.tsx
@@ -54,6 +54,7 @@ export const VoiceOverlay: FC<VoiceOverlayProps> = ({ voice, onTranscript }) => 
   const stop = voice?.stop;
   const stopSpeaking = voice?.stopSpeaking;
   const clearError = voice?.clearError;
+  const isAudioSupported = voice?.isAudioSupported ?? true;
 
   // Forward transcripts to chat
   useEffect(() => {
@@ -105,6 +106,25 @@ export const VoiceOverlay: FC<VoiceOverlayProps> = ({ voice, onTranscript }) => 
   // Don't render when voice is inactive and not auto-loading.
   const isAutoLoading = voice?.isAutoLoading ?? false;
   if (!isActive && !isAutoLoading) return null;
+
+  // Show an unsupported-platform warning banner when audio I/O is unavailable.
+  if (!isAudioSupported) {
+    return (
+      <div className="fixed bottom-lg left-1/2 -translate-x-1/2 flex items-center gap-sm px-md py-sm bg-surface border border-[var(--color-warning,#f9e2af)] rounded-lg shadow-[0_4px_24px_rgba(0,0,0,0.3)] z-[1000] min-w-[320px] max-w-[600px] backdrop-blur-[8px]">
+        <span className="text-[1.1em]">⚠️</span>
+        <span className="text-sm text-text-secondary flex-1">
+          Voice mode requires HTTPS and microphone access (<code>getUserMedia</code>).
+        </span>
+        <button
+          className="bg-transparent border-none text-[var(--color-error,#f38ba8)] cursor-pointer p-[2px] text-[0.7rem] shrink-0"
+          onClick={() => stop?.()}
+          title="Close voice mode"
+        >
+          ✕
+        </button>
+      </div>
+    );
+  }
 
   const stateLabel = STATE_LABELS[voiceState] ?? voiceState;
   const stateIcon = STATE_ICONS[voiceState] ?? '🎙️';

--- a/src/services/transport/audio/WebAudioBridge.ts
+++ b/src/services/transport/audio/WebAudioBridge.ts
@@ -195,6 +195,31 @@ export class WebAudioBridge {
   private captureBlobUrl: string | null = null;
   private playbackBlobUrl: string | null = null;
 
+  // ── Static capability check ────────────────────────────────────────────────
+
+  /**
+   * Returns `true` when the browser environment supports the Web Audio API
+   * features required by this bridge.
+   *
+   * Checks:
+   * - Running in a **secure context** (HTTPS or localhost)
+   * - `AudioWorkletNode` is available
+   * - `navigator.mediaDevices.getUserMedia` is available (microphone access)
+   *
+   * This is intentionally a static check that does **not** request permissions;
+   * it only tests API availability.
+   */
+  static isSupported(): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      window.isSecureContext === true &&
+      typeof AudioWorkletNode !== 'undefined' &&
+      typeof navigator !== 'undefined' &&
+      typeof navigator.mediaDevices !== 'undefined' &&
+      typeof navigator.mediaDevices.getUserMedia === 'function'
+    );
+  }
+
   // ── Public API ─────────────────────────────────────────────────────────────
 
   /**

--- a/src/services/transport/audio/index.ts
+++ b/src/services/transport/audio/index.ts
@@ -31,4 +31,18 @@ export function createAudioBridge(): WebAudioBridge | null {
   return new WebAudioBridge();
 }
 
+/**
+ * Returns `true` when the current platform supports the audio I/O required
+ * for voice mode.
+ *
+ * - **Tauri desktop**: always `true` — the native cpal/rodio stack is always
+ *   available.
+ * - **Browser**: delegates to {@link WebAudioBridge.isSupported}, which checks
+ *   for a secure context, `AudioWorkletNode`, and `getUserMedia`.
+ */
+export function isAudioSupported(): boolean {
+  if (isTauri()) return true; // native audio stack — always available
+  return WebAudioBridge.isSupported();
+}
+
 export type { WebAudioBridge };


### PR DESCRIPTION
## Summary

Pre-merge refactors for the Voice Architecture Parity epic (PR #228 → branch `211-voice-architecture-parity-epic`).

Eliminates three categories of duplication and adds a missing browser capability gate, all identified in the PR #228 review.

---

## Changes

### Rust — `gglib-voice`

**`service.rs`**
- **Extract `progress_callback`** free function: three identical 10-line download-progress closures in `download_stt_model`, `download_tts_model`, and `download_vad_model` are replaced by a single `fn progress_callback(emitter, model_id) -> impl Fn(u64, u64)`. The `#[allow(clippy::cast_precision_loss)]` is now centralised here; each download method no longer needs its own suppression attribute.
- **Extract `ensure_pipeline`** private method: the 5-line "create pipeline if None" block duplicated in `load_stt` and `load_tts` is extracted to `fn ensure_pipeline(&self, slot: &mut Option<VoicePipeline>)`. Callers pass `&mut guard`; Rust auto-derefs through `DerefMut`.
- **Extract `apply_pending_config`** private method: the 7-line "apply pending config" block duplicated in both load methods is extracted to `fn apply_pending_config(&self, pipeline: &mut VoicePipeline)`.

**`pipeline.rs`**
- **Extract `create_and_start_vad`** private method: the 12-line VAD initialisation block duplicated in `start_with_audio` and `set_mode` is extracted to `fn create_and_start_vad(&self) -> VoiceActivityDetector`. Also normalises the two slightly different warning messages to one canonical form.

### TypeScript / React

- **`WebAudioBridge.isSupported()`**: new static method that checks `window.isSecureContext`, `AudioWorkletNode`, `navigator.mediaDevices`, and `navigator.mediaDevices.getUserMedia` — non-permission-requesting capability detection only.
- **`isAudioSupported()`** export in `audio/index.ts`: returns `true` on Tauri (native audio stack), delegates to `WebAudioBridge.isSupported()` on browser.
- **`useVoiceMode`**: imports and exposes `isAudioSupported` in `UseVoiceModeReturn`; adds an early guard in `start()` that sets a user-facing error and returns immediately if the platform cannot handle audio I/O.
- **`VoiceOverlay`**: reads `isAudioSupported` from the `voice` prop; renders a small unsupported-platform warning banner (with a dismiss button) instead of the normal overlay when audio is unavailable.

---

## Verification

- `cargo check -p gglib-voice`: ✅ clean
- `cargo test -p gglib-voice --lib`: ✅ 34/34 passed
- `cargo clippy -p gglib-voice --all-targets`: ✅ zero new warnings

Closes the pre-merge review comments before #228 is merged to main.
