### PR TITLE
refactor(voice): pre-merge cleanup for epic #228

### DIFF
--- a/crates/gglib-axum/src/handlers/voice.rs
+++ b/crates/gglib-axum/src/handlers/voice.rs
@@ -156,7 +156,7 @@ pub async fn list_devices(
     Ok(Json(state.gui.voice_list_devices().await?))
 }
 
-// ── Audio I/O handlers (Phase 3 / PR 2) ──────────────────────────────────────
+// ── Audio I/O handlers ──────────────────────────────────────────────────────
 
 /// `POST /api/voice/start`
 ///

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -179,14 +179,14 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/voice/auto-speak", put(handlers::voice::set_auto_speak))
         .route("/voice/unload", post(handlers::voice::unload))
         .route("/voice/devices", get(handlers::voice::list_devices))
-        // Audio I/O control (Phase 3 / PR 2)
+        // Audio I/O control
         .route("/voice/start", post(handlers::voice::start))
         .route("/voice/stop", post(handlers::voice::stop))
         .route("/voice/ptt-start", post(handlers::voice::ptt_start))
         .route("/voice/ptt-stop", post(handlers::voice::ptt_stop))
         .route("/voice/speak", post(handlers::voice::speak))
         .route("/voice/stop-speaking", post(handlers::voice::stop_speaking))
-        // WebSocket audio data plane (Phase 3 / PR 3)
+        // WebSocket audio data plane
         // Browser opens this WS *before* POST /voice/start to register remote
         // audio; the pipeline then uses WebSocketAudioSource/Sink instead of
         // local cpal/rodio.  Desktop callers skip this endpoint entirely.

--- a/crates/gglib-axum/src/ws_audio.rs
+++ b/crates/gglib-axum/src/ws_audio.rs
@@ -164,8 +164,8 @@ pub struct WebSocketAudioSink {
     ///      hundred milliseconds early; browsers with echo-cancellation
     ///      on `getUserMedia` suppress TTS bleed-through regardless.
     ///
-    /// TODO: add a client→server "playback_drained" signal in a future PR
-    /// so that `SpeakingFinished` can be deferred until the browser confirms.
+    /// TODO(#230): add a client→server "playback_drained" signal so that
+    /// `SpeakingFinished` can be deferred until the browser confirms.
     on_complete: Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
 }
 

--- a/crates/gglib-core/src/ports/voice.rs
+++ b/crates/gglib-core/src/ports/voice.rs
@@ -213,7 +213,7 @@ pub trait VoicePipelinePort: Send + Sync {
     /// List available audio input devices.
     async fn list_devices(&self) -> Result<Vec<AudioDeviceDto>, VoicePortError>;
 
-    // ── Audio I/O (Phase 3 / PR 2) ────────────────────────────────────────────
+    // ── Audio I/O ────────────────────────────────────────────────────────────
 
     /// Start the voice pipeline audio I/O.
     ///

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -534,7 +534,7 @@ impl GuiBackend {
         self.voice_ops().list_devices().await
     }
 
-    // ── Voice: Audio I/O (Phase 3 / PR 2) ──────────────────────────────────
+    // ── Voice: Audio I/O ────────────────────────────────────────────────────
 
     /// Start audio I/O (mic capture + playback).
     pub async fn voice_start(&self, mode: Option<String>) -> Result<(), GuiError> {

--- a/crates/gglib-gui/src/voice.rs
+++ b/crates/gglib-gui/src/voice.rs
@@ -83,7 +83,7 @@ impl<'a> VoiceOps<'a> {
         self.voice.list_devices().await.map_err(GuiError::from)
     }
 
-    // ── Audio I/O (Phase 3 / PR 2) ─────────────────────────────────────────
+    // ── Audio I/O ───────────────────────────────────────────────────────────
 
     pub async fn start(&self, mode: Option<String>) -> Result<(), GuiError> {
         self.voice.start(mode).await.map_err(GuiError::from)

--- a/crates/gglib-voice/src/audio_io.rs
+++ b/crates/gglib-voice/src/audio_io.rs
@@ -7,7 +7,7 @@
 //! | Implementor | Where used |
 //! |---|---|
 //! | [`LocalAudioSource`](crate::audio_local::LocalAudioSource) / [`LocalAudioSink`](crate::audio_local::LocalAudioSink) | Desktop / CLI — cpal capture + rodio playback on the local machine |
-//! | `WebSocketAudioSource` / `WebSocketAudioSink` *(Phase 3)* | WebUI — PCM16 LE streaming via browser WebSocket |
+//! | `WebSocketAudioSource` / `WebSocketAudioSink` | WebUI — PCM16 LE streaming via browser WebSocket |
 //!
 //! Both traits are **object-safe** (`Box<dyn AudioSource>` / `Box<dyn AudioSink>`).
 //! All methods take `&self` to satisfy the object-safety requirement; interior
@@ -28,7 +28,7 @@ use crate::error::VoiceError;
 /// # Implementations
 /// - [`LocalAudioSource`](crate::audio_local::LocalAudioSource) — wraps
 ///   [`AudioThreadHandle`](crate::audio_thread::AudioThreadHandle) → cpal
-/// - `WebSocketAudioSource` *(Phase 3)* — receives PCM from the browser via WS
+/// - `WebSocketAudioSource` — receives PCM from the browser via WS
 pub trait AudioSource: Send + Sync {
     /// Begin capturing audio from the source.
     ///
@@ -49,7 +49,7 @@ pub trait AudioSource: Send + Sync {
     ///
     /// The local adapter always returns `Ok(None)` because the cpal audio
     /// thread does not expose a frame-by-frame polling API.  The primary
-    /// consumer of this method is `WebSocketAudioSource` (Phase 3).
+    /// consumer of this method is `WebSocketAudioSource`.
     fn read_vad_frame(&self) -> Result<Option<Vec<f32>>, VoiceError>;
 
     /// Whether audio is currently being captured.
@@ -78,7 +78,7 @@ pub trait AudioSource: Send + Sync {
 /// # Implementations
 /// - [`LocalAudioSink`](crate::audio_local::LocalAudioSink) — wraps
 ///   [`AudioThreadHandle`](crate::audio_thread::AudioThreadHandle) → rodio
-/// - `WebSocketAudioSink` *(Phase 3)* — encodes f32 → PCM16 LE and sends to
+/// - `WebSocketAudioSink` — encodes f32 → PCM16 LE and sends to
 ///   the browser via WebSocket
 pub trait AudioSink: Send + Sync {
     /// Prepare the sink for streaming playback.

--- a/crates/gglib-voice/src/audio_local.rs
+++ b/crates/gglib-voice/src/audio_local.rs
@@ -55,7 +55,7 @@ impl AudioSource for LocalAudioSource {
     /// [`AudioThreadHandle`] does not expose a frame-by-frame polling API —
     /// the cpal stream drains into an internal buffer that is returned in one
     /// shot by [`stop_capture`](AudioSource::stop_capture).  The primary
-    /// consumer of `read_vad_frame` is `WebSocketAudioSource` (Phase 3 PR 3).
+    /// consumer of `read_vad_frame` is `WebSocketAudioSource`.
     fn read_vad_frame(&self) -> Result<Option<Vec<f32>>, VoiceError> {
         Ok(None)
     }

--- a/crates/gglib-voice/src/pipeline.rs
+++ b/crates/gglib-voice/src/pipeline.rs
@@ -263,7 +263,7 @@ impl VoicePipeline {
     /// This is the primary lifecycle entry-point. Separating backend
     /// construction from injection makes the pipeline testable with mock
     /// audio without real hardware, and enables the WebSocket audio path
-    /// (Phase 3) to supply a different backend at runtime.
+    /// to supply a browser-backed source/sink at runtime.
     ///
     /// STT and TTS engines are loaded lazily on first use.
     ///

--- a/crates/gglib-voice/src/service.rs
+++ b/crates/gglib-voice/src/service.rs
@@ -132,42 +132,6 @@ impl VoiceService {
             pending_remote: std::sync::Mutex::new(None),
         }
     }
-
-    /// Create a service that shares an existing pipeline `Arc`.
-    ///
-    /// Used in Tauri bootstrap so that the HTTP layer and the remaining
-    /// Tauri audio commands share the same `VoicePipeline` instance.
-    pub fn from_arc(
-        pipeline: Arc<RwLock<Option<VoicePipeline>>>,
-        emitter: Arc<dyn AppEventEmitter>,
-    ) -> Self {
-        Self {
-            pipeline,
-            emitter,
-            config: std::sync::RwLock::new(PendingConfig::default()),
-            speak_op_lock: Mutex::new(()),
-            ptt_op_lock: Mutex::new(()),
-            pending_remote: std::sync::Mutex::new(None),
-        }
-    }
-
-    /// Return a clone of the underlying pipeline `Arc`.
-    ///
-    /// Tauri audio commands (`voice_start`, `voice_stop`, `voice_ptt_start`,
-    /// `voice_ptt_stop`, `voice_speak`, `voice_stop_speaking`) call this to
-    /// obtain the same shared lock they previously accessed via
-    /// `AppState.voice_pipeline`.
-    pub fn pipeline(&self) -> Arc<RwLock<Option<VoicePipeline>>> {
-        Arc::clone(&self.pipeline)
-    }
-
-    /// Return a clone of the event emitter.
-    ///
-    /// Used by Tauri audio commands to pass the emitter to
-    /// [`spawn_event_bridge`] when creating a new pipeline.
-    pub fn emitter(&self) -> Arc<dyn AppEventEmitter> {
-        Arc::clone(&self.emitter)
-    }
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────

--- a/src-tauri/src/app/state.rs
+++ b/src-tauri/src/app/state.rs
@@ -39,10 +39,7 @@ pub struct BackgroundTasks {
 
 impl AppState {
     /// Create a new application state.
-    pub fn new(
-        gui: Arc<GuiBackend>,
-        embedded_api: EmbeddedApiInfo,
-    ) -> Self {
+    pub fn new(gui: Arc<GuiBackend>, embedded_api: EmbeddedApiInfo) -> Self {
         Self {
             gui,
             embedded_api,

--- a/src-tauri/src/app/state.rs
+++ b/src-tauri/src/app/state.rs
@@ -2,7 +2,6 @@
 
 use gglib_axum::EmbeddedApiInfo;
 use gglib_tauri::gui_backend::GuiBackend;
-use gglib_voice::VoiceService;
 use std::sync::Arc;
 use tauri::async_runtime::JoinHandle;
 use tokio::sync::RwLock;
@@ -28,10 +27,6 @@ pub struct AppState {
     pub proxy_port: Arc<RwLock<Option<u16>>>,
     /// Background task handles for proper cleanup
     pub background_tasks: Arc<RwLock<BackgroundTasks>>,
-    /// Voice service — shared with GuiBackend (HTTP ops) and the remaining
-    /// Tauri audio commands that access the underlying pipeline via
-    /// `voice_service.pipeline()`.
-    pub voice_service: Arc<VoiceService>,
 }
 
 /// Background task handles that need to be aborted on shutdown.
@@ -47,7 +42,6 @@ impl AppState {
     pub fn new(
         gui: Arc<GuiBackend>,
         embedded_api: EmbeddedApiInfo,
-        voice_service: Arc<VoiceService>,
     ) -> Self {
         Self {
             gui,
@@ -60,7 +54,6 @@ impl AppState {
                 embedded_server: None,
                 log_emitter: None,
             })),
-            voice_service,
         }
     }
 }

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -74,22 +74,14 @@ async fn parallel_cleanup(state: &AppState) -> Result<(), String> {
         }
     }
 
-    // Explicitly unload the voice pipeline so the microphone is released and
-    // model memory is freed in a deterministic order rather than relying on
-    // the process-exit Drop path.
-    {
-        let _pipeline = state.voice_service.pipeline();
-        let mut voice = _pipeline.write().await;
-        if voice.is_some() {
-            info!("Unloading voice pipeline during shutdown");
-            if let Some(ref mut pipeline) = *voice
-                && pipeline.is_active()
-            {
-                pipeline.stop();
-            }
-            *voice = None;
-        }
-    }
+    // Explicitly stop then unload the voice pipeline so the microphone is
+    // released and model memory is freed in deterministic order rather than
+    // relying on the process-exit Drop path.
+    // Both operations are best-effort: if the pipeline is not active / not
+    // initialised the calls are no-ops (VoicePortError::NotActive / NotInitialised).
+    info!("Unloading voice pipeline during shutdown");
+    let _ = state.gui.voice_stop().await;
+    let _ = state.gui.voice_unload().await;
 
     // Run server stop and download cancel in parallel
     let (servers_result, _) = tokio::join!(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
             });
 
             // Create and manage app state
-            let app_state = AppState::new(gui.clone(), embedded_api, ctx.voice_service.clone());
+            let app_state = AppState::new(gui.clone(), embedded_api);
 
             // Store the embedded server handle for cleanup
             {

--- a/src/services/transport/api/voice.ts
+++ b/src/services/transport/api/voice.ts
@@ -65,7 +65,7 @@ export async function voiceListDevices(): Promise<AudioDeviceInfo[]> {
   return get<AudioDeviceInfo[]>('/api/voice/devices');
 }
 
-// ── Audio I/O control (Phase 3 / PR 2) ───────────────────────────────────────
+// ── Audio I/O control ─────────────────────────────────────────────────────────
 
 export async function voiceStart(mode?: VoiceInteractionMode): Promise<void> {
   return post<void>('/api/voice/start', mode ? { mode } : undefined);

--- a/src/services/transport/audio/WebAudioBridge.ts
+++ b/src/services/transport/audio/WebAudioBridge.ts
@@ -178,7 +178,7 @@ function resolveWsUrl(): string {
 // ── WebAudioBridge ────────────────────────────────────────────────────────────
 
 /**
- * Browser-side audio bridge for the WebSocket voice data plane (Phase 3).
+ * Browser-side audio bridge for the WebSocket voice data plane.
  *
  * Lifecycle:
  * 1. Call `connect()` from a user-gesture handler.

--- a/src/services/transport/types/voice.ts
+++ b/src/services/transport/types/voice.ts
@@ -73,7 +73,7 @@ export interface VoiceTransport {
   /** GET /api/voice/devices — list available audio input/output devices. */
   voiceListDevices(): Promise<AudioDeviceInfo[]>;
 
-  // ── Audio I/O control (Phase 3 / PR 2) ───────────────────────────────────
+  // ── Audio I/O control ──────────────────────────────────────────────────────
 
   /** POST /api/voice/start — activate the audio pipeline (optional mode override). */
   voiceStart(mode?: VoiceInteractionMode): Promise<void>;


### PR DESCRIPTION
## Summary

Pre-merge cleanup addressing all review findings on PR #228 (Voice Architecture Parity Epic).

## Commits

### 1. refactor(voice/service): extract parse_interaction_mode helper
The identical ptt/vad -> VoiceInteractionMode match was duplicated in both set_mode() and start(). Extracted to a single private function.

### 2. refactor(tauri): use VoicePipelinePort for shutdown; remove voice_service from AppState
lifecycle.rs was bypassing VoicePipelinePort by calling voice_service.pipeline() to grab the raw RwLock -- the one remaining architectural violation in the Tauri adapter after the epic.

Replaced with two trait-level calls: gui.voice_stop() then gui.voice_unload(). Consequently AppState.voice_service: Arc<VoiceService> is removed -- the service already lives inside GuiDeps as Arc<dyn VoicePipelinePort>.

### 3. refactor(voice/service): delete dead VoiceService accessor methods
from_arc(), emitter(), and pipeline() were dead code -- their doc comments referenced Tauri audio commands deleted in this epic. Removed all three.

### 4. chore(voice): strip phase/PR labels from section headings; remove stale refs
Section comments like // Audio I/O (Phase 3 / PR 2) are noise now that migration is complete. Replaced with plain section headers across all affected files.

### 5. chore(voice/ws_audio): reference issue #230 in playback_drained TODO
Replaced the open-ended TODO: with TODO(#230): so the deferred SpeakingFinished improvement is tracked.

## Review items addressed

| Item | Severity | Status |
|------|----------|--------|
| lifecycle bypasses VoicePipelinePort | critical | Fixed in commit 2 |
| dead from_arc / emitter / pipeline | critical | Fixed in commit 3 |
| duplicated mode-string parsing | should-fix | Fixed in commit 1 |
| phase/PR labels in section comments | should-fix | Fixed in commit 4 |
| stale doc comments | should-fix | Fixed in commits 3 and 4 |
| open issue for playback_drained | minor | Issue #230 opened; TODO updated in commit 5 |
