### PR TITLE
fix(voice): address all PR #228 review items (Required + Recommended)

### DIFF
--- a/crates/gglib-axum/src/handlers/voice_ws.rs
+++ b/crates/gglib-axum/src/handlers/voice_ws.rs
@@ -123,9 +123,7 @@ async fn handle_audio_ws(socket: WebSocket, state: AppState) {
                     // Fire the pending completion callback so the pipeline emits
                     // VoiceSpeakingFinished at the correct moment.
                     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
-                        if json.get("type").and_then(|v| v.as_str())
-                            == Some("playback_drained")
-                        {
+                        if json.get("type").and_then(|v| v.as_str()) == Some("playback_drained") {
                             if let Some(cb) = drain_callbacks.lock().unwrap().take() {
                                 cb();
                             }

--- a/crates/gglib-axum/src/handlers/voice_ws.rs
+++ b/crates/gglib-axum/src/handlers/voice_ws.rs
@@ -11,9 +11,23 @@
 //! | Client → Server | PCM16 LE | 16 000 Hz | 1 (mono) | 960 bytes (30 ms) |
 //! | Server → Client | PCM16 LE | 24 000 Hz | 1 (mono) | Variable |
 //!
-//! The WebSocket carries **only** binary frames — no text, no control commands.
-//! All voice lifecycle commands (`start`, `stop`, `ptt-start`, …) continue to
-//! use the HTTP control-plane endpoints.
+//! The WebSocket carries binary PCM frames for audio data and a single text
+//! frame type for the playback-drained acknowledgement:
+//!
+//! | Direction | Type | Content |
+//! |---|---|---|
+//! | Client → Server | Binary, 960 bytes | PCM16 LE capture frame (30 ms) |
+//! | Server → Client | Binary, variable | PCM16 LE playback frame |
+//! | Client → Server | Text | `{"type":"playback_drained"}` |
+//!
+//! The `playback_drained` text frame is sent by the browser's `AudioWorklet`
+//! main-thread handler when its ring buffer transitions from non-empty to
+//! empty — i.e. all TTS PCM frames have been rendered.  The ingest task
+//! recognises this sentinel and fires the pending completion callback stored
+//! in [`WebSocketAudioSink`], causing the pipeline to emit the
+//! `VoiceSpeakingFinished` SSE event at the precise moment the browser has
+//! finished playing.  All voice lifecycle commands (`start`, `stop`,
+//! `ptt-start`, …) continue to use the HTTP control-plane endpoints.
 //!
 //! ## Lifecycle
 //!
@@ -60,7 +74,7 @@ async fn handle_audio_ws(socket: WebSocket, state: AppState) {
     // signals AudioThreadDied to the pipeline's VAD loop (clean shutdown).
     // The egress task holds sink_rx; the sink's frame_tx feeds it.
     let (source, source_tx) = WebSocketAudioSource::new();
-    let (sink, sink_rx) = WebSocketAudioSink::new();
+    let (sink, sink_rx, drain_callbacks) = WebSocketAudioSink::new();
 
     // Register the pair — next VoicePipelinePort::start() will consume it.
     state
@@ -103,9 +117,26 @@ async fn handle_audio_ws(socket: WebSocket, state: AppState) {
                         break;
                     }
                 }
+                Ok(Message::Text(text)) => {
+                    // `playback_drained`: the browser's AudioWorklet ring buffer
+                    // has fully drained — all TTS PCM frames have been rendered.
+                    // Fire the pending completion callback so the pipeline emits
+                    // VoiceSpeakingFinished at the correct moment.
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                        if json.get("type").and_then(|v| v.as_str())
+                            == Some("playback_drained")
+                        {
+                            if let Some(cb) = drain_callbacks.lock().unwrap().take() {
+                                cb();
+                            }
+                        } else {
+                            warn!(msg = %text, "WS audio ingest: unexpected text frame");
+                        }
+                    }
+                }
                 // Graceful close or protocol error — stop ingest loop.
                 Ok(Message::Close(_)) | Err(_) => break,
-                // Ignore text/ping/pong frames.
+                // Ignore ping/pong frames.
                 Ok(_) => {}
             }
         }

--- a/crates/gglib-axum/src/ws_audio.rs
+++ b/crates/gglib-axum/src/ws_audio.rs
@@ -26,8 +26,9 @@
 //!   cleanly.  Overflow (buffer full) is silently dropped rather than
 //!   back-pressuring the pipeline, to prevent stale audio buildup.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -129,6 +130,15 @@ impl AudioSource for WebSocketAudioSource {
 
 // ── WebSocketAudioSink ────────────────────────────────────────────────────────
 
+/// Server-side timeout for the `playback_drained` acknowledgement.
+///
+/// If the browser does not send `playback_drained` within this many seconds
+/// after the last TTS chunk has been queued, the completion callback is fired
+/// unconditionally so the pipeline is never left waiting indefinitely.
+/// 8 s is generous enough for long TTS utterances while still providing a
+/// reliable safety net for disconnected or stalled browsers.
+const DRAIN_TIMEOUT_SECS: u64 = 8;
+
 /// Audio sink that delivers TTS output to a browser as binary WebSocket frames.
 ///
 /// f32 samples (any sample rate) are encoded to PCM16 LE and queued in a
@@ -176,13 +186,18 @@ pub struct WebSocketAudioSink {
     ///      hundred milliseconds early; browsers with echo-cancellation
     ///      on `getUserMedia` suppress TTS bleed-through regardless.
     ///
-    /// ## Required fix (GitHub issue #230)
-    /// Add a client→server "playback_drained" signal — a text WebSocket frame
-    /// sent by the `AudioWorklet`'s main-thread message handler when its ring
-    /// buffer drains to zero — and defer the `SpeakingFinished` SSE event
-    /// until that acknowledgement arrives (with a server-side timeout fallback
-    /// so a stalled browser does not freeze the pipeline indefinitely).
-    on_complete: Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
+    /// ## Fix (GitHub issue #230)
+    /// The callback is now deferred: `on_playback_complete` stores it and the
+    /// WS ingest task fires it when the browser sends a `playback_drained`
+    /// text frame confirming the AudioWorklet ring buffer has drained.  A
+    /// server-side timeout fires it after [`DRAIN_TIMEOUT_SECS`] so a stalled
+    /// or disconnected browser cannot freeze the pipeline.
+    /// `stop()` fires it immediately as the fallback for PTT and explicit
+    /// stop_speaking() paths.
+    ///
+    /// Shared with the WS ingest task — the third value returned by
+    /// [`WebSocketAudioSink::new`] is a clone of this `Arc`.
+    pending_completion: Arc<Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>>,
 }
 
 impl WebSocketAudioSink {
@@ -195,15 +210,26 @@ impl WebSocketAudioSink {
     /// # Channel capacity
     /// Up to 64 chunks are buffered, providing ~1–2 s of headroom
     /// for typical TTS synthesis bursts before overflow policy kicks in.
+    ///
+    /// # Return values
+    /// 1. The sink (implements [`AudioSink`]).
+    /// 2. The `Receiver` the WS egress task drains.
+    /// 3. An `Arc` of the pending-completion slot — pass this to the WS
+    ///    ingest task so it can fire the callback on `playback_drained`.
     #[must_use]
-    pub fn new() -> (Self, mpsc::Receiver<Vec<u8>>) {
+    pub fn new() -> (
+        Self,
+        mpsc::Receiver<Vec<u8>>,
+        Arc<Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>>,
+    ) {
         let (tx, rx) = mpsc::channel(64);
+        let pending = Arc::new(Mutex::new(None::<Box<dyn FnOnce() + Send + 'static>>));
         let sink = Self {
             frame_tx: tx,
             playing: AtomicBool::new(false),
-            on_complete: Mutex::new(None),
+            pending_completion: Arc::clone(&pending),
         };
-        (sink, rx)
+        (sink, rx, pending)
     }
 
     /// Encode f32 samples (range −1.0 … 1.0) to PCM16 LE bytes.
@@ -247,10 +273,11 @@ impl AudioSink for WebSocketAudioSink {
 
     fn stop(&self) -> Result<(), VoiceError> {
         self.playing.store(false, Ordering::SeqCst);
-        // Fire the completion callback if one is pending.  Covers both the
-        // explicit stop_speaking() path and the PTT ptt_start() path (which
-        // calls sink.stop() before starting capture).
-        if let Some(cb) = self.on_complete.lock().unwrap().take() {
+        // Fire immediately.  Covers both the explicit stop_speaking() path and
+        // the PTT ptt_start() path (which calls sink.stop() before starting
+        // capture).  `.take()` ensures the timeout task is a no-op if it fires
+        // after this.
+        if let Some(cb) = self.pending_completion.lock().unwrap().take() {
             cb();
         }
         Ok(())
@@ -261,14 +288,27 @@ impl AudioSink for WebSocketAudioSink {
     }
 
     fn on_playback_complete(&self, callback: Box<dyn FnOnce() + Send + 'static>) {
-        // See the doc comment on `on_complete` for why we fire immediately.
-        // Store first, then fire — this ordering ensures the callback is
-        // registered even if stop() races with on_playback_complete().
-        *self.on_complete.lock().unwrap() = Some(callback);
-        // Fire immediately: all TTS chunks are in the channel ready to be
-        // sent; the egress task will deliver them to the browser asynchronously.
-        if let Some(cb) = self.on_complete.lock().unwrap().take() {
-            cb();
+        // Store the callback — it will be fired by whichever wins the race:
+        //   1. The WS ingest task, when the browser sends `playback_drained`,
+        //      confirming the AudioWorklet ring buffer has fully drained.
+        //   2. `stop()`, for PTT and explicit stop_speaking() paths.
+        //   3. The server-side timeout task below, so a stalled or disconnected
+        //      browser cannot freeze the pipeline indefinitely.
+        *self.pending_completion.lock().unwrap() = Some(callback);
+
+        let pending = Arc::clone(&self.pending_completion);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                tokio::time::sleep(Duration::from_secs(DRAIN_TIMEOUT_SECS)).await;
+                if let Some(cb) = pending.lock().unwrap().take() {
+                    warn!(
+                        timeout_secs = DRAIN_TIMEOUT_SECS,
+                        "WebSocketAudioSink: playback_drained not received within \
+                         timeout — firing completion callback"
+                    );
+                    cb();
+                }
+            });
         }
     }
 }

--- a/crates/gglib-axum/src/ws_audio.rs
+++ b/crates/gglib-axum/src/ws_audio.rs
@@ -26,8 +26,8 @@
 //!   cleanly.  Overflow (buffer full) is silently dropped rather than
 //!   back-pressuring the pipeline, to prevent stale audio buildup.
 
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::mpsc;

--- a/crates/gglib-core/src/ports/voice.rs
+++ b/crates/gglib-core/src/ports/voice.rs
@@ -157,6 +157,14 @@ pub enum VoicePortError {
     /// Unexpected internal error.
     #[error("Internal voice error: {0}")]
     Internal(String),
+
+    /// Feature not yet implemented.
+    ///
+    /// Maps to HTTP 501 Not Implemented.  Used to surface partial-implementation
+    /// gaps (e.g. VAD mode frame-polling loop) as actionable API errors rather
+    /// than silent no-ops.
+    #[error("Not implemented: {0}")]
+    Unimplemented(String),
 }
 
 // ── Port trait ────────────────────────────────────────────────────────────────

--- a/crates/gglib-gui/src/error.rs
+++ b/crates/gglib-gui/src/error.rs
@@ -103,9 +103,9 @@ impl From<gglib_core::ports::VoicePortError> for GuiError {
                 Self::Internal(format!("voice download error: {msg}"))
             }
             VoicePortError::Internal(msg) => Self::Internal(msg),
-        // 400 Bad Request: caller should change the request (switch to PTT mode)
-        // rather than retry. 503 Unavailable would imply a transient failure.
-        VoicePortError::Unimplemented(msg) => Self::ValidationFailed(msg),
+            // 400 Bad Request: caller should change the request (switch to PTT mode)
+            // rather than retry. 503 Unavailable would imply a transient failure.
+            VoicePortError::Unimplemented(msg) => Self::ValidationFailed(msg),
         }
     }
 }

--- a/crates/gglib-gui/src/error.rs
+++ b/crates/gglib-gui/src/error.rs
@@ -103,6 +103,9 @@ impl From<gglib_core::ports::VoicePortError> for GuiError {
                 Self::Internal(format!("voice download error: {msg}"))
             }
             VoicePortError::Internal(msg) => Self::Internal(msg),
+        // 400 Bad Request: caller should change the request (switch to PTT mode)
+        // rather than retry. 503 Unavailable would imply a transient failure.
+        VoicePortError::Unimplemented(msg) => Self::ValidationFailed(msg),
         }
     }
 }

--- a/src/services/transport/audio/WebAudioBridge.ts
+++ b/src/services/transport/audio/WebAudioBridge.ts
@@ -270,8 +270,9 @@ export class WebAudioBridge {
     // Validate that the browser honoured the requested sample rate.
     // Some browsers (notably Safari on iOS/macOS) may ignore sampleRate and
     // use the hardware native rate (44.1 kHz or 48 kHz instead).
-    // TODO: implement a software resampler (e.g. a WebAssembly module or a
-    //   dedicated AudioWorklet) to support these browsers without distortion.
+    // TODO(#230): implement a software resampler (e.g. a WebAssembly resampler
+    //   AudioWorklet) so Safari and other non-compliant browsers can be
+    //   re-enabled.  Until then isSupported() returns false on Safari.
     if (this.captureCtx.sampleRate !== CAPTURE_SAMPLE_RATE) {
       const actual = this.captureCtx.sampleRate;
       await this.captureCtx.close();
@@ -290,7 +291,7 @@ export class WebAudioBridge {
     }
     // Same validation for playback: a mismatched rate causes TTS audio to play
     // at the wrong speed/pitch.
-    // TODO: implement a software resampler for browsers that ignore sampleRate.
+    // TODO(#230): software resampler needed (same as capture above).
     if (this.playbackCtx.sampleRate !== PLAYBACK_SAMPLE_RATE) {
       const actual = this.playbackCtx.sampleRate;
       await this.playbackCtx.close();

--- a/src/services/transport/audio/index.ts
+++ b/src/services/transport/audio/index.ts
@@ -38,7 +38,13 @@ export function createAudioBridge(): WebAudioBridge | null {
  * - **Tauri desktop**: always `true` — the native cpal/rodio stack is always
  *   available.
  * - **Browser**: delegates to {@link WebAudioBridge.isSupported}, which checks
- *   for a secure context, `AudioWorkletNode`, and `getUserMedia`.
+ *   for a secure context, `AudioWorkletNode`, `getUserMedia`, and the absence
+ *   of a Safari UA.  Safari (non-Chromium) does not honour the `sampleRate`
+ *   option passed to `new AudioContext({ sampleRate })`, which would cause STT
+ *   capture and TTS playback to operate at the wrong sample rate.  Safari
+ *   support requires a software resampler (tracked in TODO #230) and is
+ *   currently disabled so callers receive `false` and can show a graceful
+ *   "not supported" UI rather than an in-call error.
  */
 export function isAudioSupported(): boolean {
   if (isTauri()) return true; // native audio stack — always available


### PR DESCRIPTION
Closes #230

Implements every Required and Recommended item from the review of PR #228.

## 1 fix(voice): return 400 Unimplemented for VAD mode start [Required]

VAD mode had no server-side polling loop. The microphone opened, speech was never detected, session hung.
- Added VoicePortError::Unimplemented(String) to port error enum
- Mapped to GuiError::ValidationFailed (HTTP 400, not 503)
- VoiceService::start() returns Err(Unimplemented) for VAD with a message directing to PTT

## 2 fix(useVoiceMode): lazy WebAudioBridge init [Recommended]

useRef(createAudioBridge()) called new WebAudioBridge() on every render; React discards all but the first. Fixed with undefined sentinel + assign-once guard.

## 3 fix(voice): Safari UA guard in isAudioSupported [Recommended]

Safari ignores new AudioContext({ sampleRate }), degrading STT/TTS. UA-based pre-flight added to WebAudioBridge.isSupported(). JSDoc updated with TODO #230 reference.

## 4 docs(voice): expand SpeakingFinished timing-gap comment [Recommended]

Added Timing gap section (network + ring-buffer drain up to ~2 s) and concrete Required fix description (playback_drained WS signal). Unified two bare // TODO: to // TODO(#230): in WebAudioBridge.ts.
## 5 feat(voice): defer SpeakingFinished until browser confirms audio drained [Implements #230]

WebSocketAudioSink::on_playback_complete previously fired its callback immediately after all TTS chunks were enqueued, before the browser had rendered the last frame. VoiceSpeakingFinished reached the frontend too early.

Three-part fix:
- **Rust (ws_audio.rs)**: pending_completion is now an Arc<Mutex<...>> shared with the ingest task. on_playback_complete stores the callback and spawns an 8 s server-side timeout fallback. stop() still fires immediately (PTT/explicit-stop paths unchanged).
- **Rust (voice_ws.rs)**: ingest task handles {"type":"playback_drained"} text frames and fires the pending callback.
- **TypeScript (WebAudioBridge.ts)**: PlaybackProcessor tracks _hasAudio; fires {type:"drained"} to the main thread when the ring buffer transitions from non-empty to empty. Main thread sends {"type":"playback_drained"} over the WebSocket.

