### PR TITLE
refactor(docs): reshape main README as navigation hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ make setup   # check deps → build frontend → install CLI → offer llama.cpp
 
 ### Prerequisites
 
-- **Rust** 1.70+ — [rustup.rs](https://rustup.rs/)
+- **Rust** 1.70+ (MSRV). Tooling/CI currently pins Rust **1.91.0** via `rust-toolchain.toml` — using that version is recommended. — [rustup.rs](https://rustup.rs/)
 - **Python 3 via Miniconda** — [miniconda](https://docs.conda.io/en/latest/miniconda.html) (for hf_xet fast downloads)
-- **Node.js** 18+ — [nodejs.org](https://nodejs.org/) (for web UI)
+- **Node.js** 20.19+ (matches the `package.json` `engines` field) — [nodejs.org](https://nodejs.org/) (for web UI)
 - **SQLite** 3.x
 - **Build tools**: macOS `xcode-select --install` + `brew install cmake` · Ubuntu `build-essential cmake git` · Windows VS 2022 C++ + CMake
 

--- a/README.md
+++ b/README.md
@@ -8,33 +8,11 @@
 
 <!-- crate-docs:start -->
 
-A multi-interface platform for managing and serving GGUF (GPT-Generated Unified Format) model files, providing CLI, desktop GUI, and web-based access.
-
-## Overview
-
-gglib provides a simple interface to catalog, organize, and serve GGUF models locally. It maintains a SQLite database of your models with their metadata, making it easy to find and work with specific models.
-
-## Features
-
-- **Add models**: Import GGUF files and extract metadata automatically
-- **List models**: View all models with their properties in a clean table format
-- **Update models**: Edit model metadata including name, parameters, and custom fields
-- **Remove models**: Clean removal of models from your database
-- **Serve models**: Start llama-server with automatic context size detection
-- **Chat via CLI**: Launch llama-cli directly for quick terminal chat sessions
-- **Question command**: Ask one-shot questions with optional piped context (`cat file | gglib question "summarize"`)
-- **OpenAI-compatible Proxy**: Automatic model swapping with OpenAI API compatibility
-- **HuggingFace Hub Integration**: Download models directly from HuggingFace Hub
-- **Fast-path Downloads**: Managed Python helper (hf_xet) via Miniconda for multi-gigabyte transfers
-- **Search & Browse**: Discover GGUF models on HuggingFace with search and browse commands
-- **Quantization Support**: Intelligent detection and handling of various quantization formats
-- **Rich metadata**: Support for complex metadata operations and Unicode content
-- **Model Verification**: SHA256 integrity checking against HuggingFace LFS OIDs with per-shard progress, update detection, and automatic repair of corrupt files
-- **Reasoning Model Support**: Auto-detection and streaming of thinking/reasoning phases with collapsible UI for models like DeepSeek R1, Qwen3, and QwQ
+A multi-interface platform for managing and serving GGUF model files locally — catalog, serve, and chat via CLI, desktop GUI, web UI, or OpenAI-compatible proxy, all sharing one layered Rust backend.
 
 ## Architecture Overview
 
-GGLib is organized as a Cargo workspace with compile-time enforced boundaries. The architecture follows a layered design where adapters depend on infrastructure, which depends on core—never the reverse.
+Cargo workspace with compile-time enforced boundaries. Adapters → infrastructure → core — never the reverse.
 
 ![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/tests.json)
 ![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/coverage.json)
@@ -155,8 +133,7 @@ GGLib is organized as a Cargo workspace with compile-time enforced boundaries. T
 
 - **Styling & UI Contracts**: See [src/styles/README.md](src/styles/README.md) for Tailwind-first architecture, design token system, platform parity requirements, and component migration roadmap
 
-<details>
-<summary><strong>Crate Metrics</strong></summary>
+### Crate Metrics
 
 #### Core Layer
 | Crate | Tests | Coverage | LOC | Complexity |
@@ -192,7 +169,26 @@ GGLib is organized as a Cargo workspace with compile-time enforced boundaries. T
 |-------|-------|----------|-----|------------|
 | [gglib-build-info](crates/gglib-build-info) | ![N/A](https://img.shields.io/badge/tests-N%2FA-lightgrey) | ![N/A](https://img.shields.io/badge/coverage-N%2FA-lightgrey) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-build-info-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-build-info-complexity.json) |
 
-</details>
+### Crate Documentation
+
+Each crate has its own README with architecture diagrams, module breakdowns, and design decisions:
+
+| Layer | Crate | Description |
+|-------|-------|-------------|
+| **Core** | [gglib-core](crates/gglib-core/README.md) | Pure domain types, ports & traits |
+| **Infra** | [gglib-db](crates/gglib-db/README.md) | SQLite repository implementations |
+| **Infra** | [gglib-gguf](crates/gglib-gguf/README.md) | GGUF file format parser |
+| **Infra** | [gglib-hf](crates/gglib-hf/README.md) | HuggingFace Hub client |
+| **Infra** | [gglib-download](crates/gglib-download/README.md) | Download queue & manager |
+| **Infra** | [gglib-mcp](crates/gglib-mcp/README.md) | MCP server management |
+| **Infra** | [gglib-proxy](crates/gglib-proxy/README.md) | OpenAI-compatible proxy server |
+| **Infra** | [gglib-runtime](crates/gglib-runtime/README.md) | Process manager & system probes |
+| **Infra** | [gglib-voice](crates/gglib-voice/README.md) | Voice pipeline (STT/TTS/VAD) |
+| **Facade** | [gglib-gui](crates/gglib-gui/README.md) | Shared GUI backend (feature parity) |
+| **Adapter** | [gglib-cli](crates/gglib-cli/README.md) | CLI interface |
+| **Adapter** | [gglib-axum](crates/gglib-axum/README.md) | HTTP API server |
+| **Adapter** | [gglib-tauri](crates/gglib-tauri/README.md) | Desktop GUI (Tauri + React) |
+| **Utility** | [gglib-build-info](crates/gglib-build-info/README.md) | Compile-time version & git metadata |
 
 ### Module Reference
 
@@ -209,386 +205,168 @@ GGLib is organized as a Cargo workspace with compile-time enforced boundaries. T
 - **[`pages`](src/pages/README.md)** – Top-level page components
 - **[`types`](src/types/README.md)** – Shared TypeScript type definitions
 
-### Crate Documentation
-
-Each crate has its own README with architecture diagrams, module breakdowns, and usage examples:
-
-| Layer | Crate | Description |
-|-------|-------|-------------|
-| **Core** | [gglib-core](crates/gglib-core/README.md) | Pure domain types, ports & traits |
-| **Infra** | [gglib-db](crates/gglib-db/README.md) | SQLite repository implementations |
-| **Infra** | [gglib-gguf](crates/gglib-gguf/README.md) | GGUF file format parser |
-| **Infra** | [gglib-hf](crates/gglib-hf/README.md) | HuggingFace Hub client |
-| **Infra** | [gglib-download](crates/gglib-download/README.md) | Download queue & manager |
-| **Infra** | [gglib-mcp](crates/gglib-mcp/README.md) | MCP server management |
-| **Infra** | [gglib-proxy](crates/gglib-proxy/README.md) | OpenAI-compatible proxy server |
-| **Infra** | [gglib-runtime](crates/gglib-runtime/README.md) | Process manager & system probes |
-| **Facade** | [gglib-gui](crates/gglib-gui/README.md) | Shared GUI backend (feature parity) |
-| **Adapter** | [gglib-cli](crates/gglib-cli/README.md) | CLI interface |
-| **Adapter** | [gglib-axum](crates/gglib-axum/README.md) | HTTP API server |
-| **Adapter** | [gglib-tauri](crates/gglib-tauri/README.md) | Desktop GUI (Tauri + React) |
-| **Utility** | [gglib-build-info](crates/gglib-build-info/README.md) | Compile-time version & git metadata |
-
 <!-- crate-docs:end -->
-
-## Installation
-
-GGLib provides a streamlined installation process using the included Makefile for the best developer and user experience.
-
-### Pre-built Releases
-
-Download the latest release for your platform from the [Releases page](https://github.com/mmogr/gglib/releases).
-
-#### macOS
-
-1. Download the macOS release tarball for your architecture:
-   - `gglib-gui-*-aarch64-apple-darwin.tar.gz` for Apple Silicon (M1/M2/M3)
-   - `gglib-gui-*-x86_64-apple-darwin.tar.gz` for Intel Macs
-2. Extract the archive: `tar -xzf gglib-gui-*.tar.gz`
-3. Double-click `macos-install.command` (or run `./macos-install.command` in Terminal)
-4. The script will remove the quarantine attribute and optionally install to `/Applications`
-
-> **Note:** macOS marks downloaded apps as "damaged" because they are not code-signed. The install script fixes this automatically by removing the quarantine attribute.
-
-#### Windows
-
-Download and extract the Windows release (`gglib-gui-*-x86_64-pc-windows-msvc.zip`), then run `gglib-gui.exe`.
-
-#### Linux
-
-Download and extract the Linux release (`gglib-gui-*-x86_64-unknown-linux-gnu.tar.gz`), then run the `gglib-gui` binary.
-
-### Quick Install (From Source)
-
-The recommended way to install GGLib is using the Makefile:
-
-```bash
-# Clone the repository
-git clone https://github.com/mmogr/gglib.git
-cd gglib
-
-# Full setup: check dependencies, build, and install
-make setup
-```
-
-The `make setup` command will:
-- Check for required system dependencies (Rust, Node.js, build tools)
-- Provision the managed Miniconda environment used by the hf_xet fast download helper
-- Build the web UI frontend
-- Build and install the CLI tool to `~/.cargo/bin/`
-- Optionally install llama.cpp with automatic GPU detection
-
-`make setup` (and `gglib check-deps`) exits with an error if Python/Miniconda is missing or the fast download helper cannot be prepared. Run those commands first on new machines so large downloads succeed without manual intervention.
-
-**Note:** When installed via `make setup`, GGLib operates in **Developer Mode**. It will keep its database (`gglib.db`), configuration (`.env`), and `llama.cpp` binaries inside your repository folder. This keeps your development environment self-contained. (Downloaded models are still stored in `~/.local/share/llama_models` by default).
-
-### Makefile Utilities
-
-The Makefile provides several convenient targets:
-
-**Installation & Setup:**
-- `make setup` - Full setup (dependencies + build + install + llama.cpp)
-- `make install` - Build and install CLI to `~/.cargo/bin/`
-- `make uninstall` - **Full Cleanup**: Removes binary, system data, database, and cleans the repo. (Preserves downloaded models).
-
-**Building:**
-- `make build` - Build release binary
-- `make build-dev` - Build debug binary
-- `make build-gui` - Build web UI frontend
-- `make build-tauri` - Build desktop GUI application
-- `make build-all` - Build everything (CLI + web UI)
-
-**Development:**
-- `make test` - Run all tests
-- `make check` - Check code without building
-- `make fmt` - Format code
-- `make lint` - Run clippy linter
-- `make doc` - Generate and open documentation
-
-**llama.cpp Management:**
-- `make llama-install-auto` - Install llama.cpp with auto GPU detection
-- `make llama-status` - Show llama.cpp installation status
-- `make llama-update` - Update llama.cpp to latest version
-
-**Running:**
-- `make run-gui` - Launch desktop GUI
-- `make run-web` - Start web server
-- `make run-serve` - Run model server
-- `make run-proxy` - Run OpenAI-compatible proxy
-
-**Cleaning:**
-- `make clean` - Remove build artifacts
-- `make clean-gui` - Remove web UI build
-- `make clean-llama` - Remove llama.cpp installation
-- `make clean-db` - Remove database files
-
-### Manual Installation (Alternative)
-
-If you prefer to use Cargo directly:
-
-```bash
-# Install from source
-cargo install --path .
-
-# Or install from crates.io (when published)
-cargo install gglib
-```
-
-### Prerequisites
-
-- **Rust** 1.70 or later - [Install Rust](https://rustup.rs/)
-- **Python 3 via Miniconda** (required for the hf_xet fast download helper) - [Install Miniconda](https://docs.conda.io/en/latest/miniconda.html)
-- **Node.js** 18+ (for web UI) - [Install Node.js](https://nodejs.org/)
-- **SQLite** 3.x
-- **Build tools** (platform-specific):
-  - **macOS**: `xcode-select --install` and `brew install cmake`
-  - **Ubuntu/Debian**: `sudo apt install build-essential cmake git`
-  - **Fedora/RHEL**: `sudo dnf install gcc-c++ cmake git`
-  - **Arch Linux**: `sudo pacman -S base-devel cmake git`
-  - **Windows**: Visual Studio 2022 with C++ tools, CMake, and Git
-
-**Note:** llama.cpp is managed by GGLib itself. You don't need to install it separately!
-
-### Configuring the models directory
-
-Downloaded GGUF files now live in a user-configurable directory (default: `~/.local/share/llama_models`). You can change it at any time using whichever interface is most convenient:
-
-- **During `make setup`** – the installer now prompts for the location and accepts Enter to keep the default.
-- **Environment file** – copy `.env.example` to `.env` and set `GGLIB_MODELS_DIR=/absolute/path`, or edit the value via `gglib config models-dir set` (see below). All helpers expand `~/` and will create the directory when needed.
-- **CLI overrides** – use `gglib --models-dir /tmp/models download …` for a one-off run, or persist the change with `gglib config models-dir prompt|set <path>`.
-- **GUI/Web settings** – click the gear icon in the header to open the Settings modal, review the current directory, and update it without touching the CLI.
-
-The precedence order is: CLI `--models-dir` flag → `GGLIB_MODELS_DIR` from the environment/.env → default path. All download code paths rely on the shared helper in `src/utils/paths.rs`, so whichever option you choose applies consistently across CLI, desktop, web, and background tasks.
-
-## Development Setup
-
-### Running the Development Environment
-
-GGLib uses a split development setup with separate processes for frontend and backend:
-
-1. **Start the Backend API Server:**
-   ```bash
-   # Using VS Code task (recommended):
-   # Press Cmd/Ctrl+Shift+P → "Tasks: Run Task" → "🧠 Run Backend Dev (API-only)"
-   
-   # Or manually:
-   cargo run --package gglib-cli -- web --api-only --port 9887 --base-port 9000
-   ```
-
-2. **Start the Frontend Dev Server:**
-   ```bash
-   npm run dev
-   # Vite will start on port 5173 and proxy API requests to port 9887
-   ```
-
-3. **Access the application:**
-   - Open your browser to `http://localhost:5173`
-   - The frontend proxies all `/api/*` requests to the backend on port 9887
-
-### Configuring Development Ports
-
-You can customize the API port using the `VITE_GGLIB_WEB_PORT` environment variable. Both the backend and frontend will automatically use this value:
-
-```bash
-# Create a .env file in the project root
-echo "VITE_GGLIB_WEB_PORT=9999" > .env
-
-# Now start both servers - they'll both use port 9999
-cargo run --package gglib-cli -- web --api-only
-npm run dev
-```
-
-**How it works:**
-- The Rust backend reads `VITE_GGLIB_WEB_PORT` via clap's environment support
-- Vite's proxy configuration reads the same variable via `process.env.VITE_GGLIB_WEB_PORT`
-- The frontend client code reads it via `import.meta.env.VITE_GGLIB_WEB_PORT`
-- Default port is `9887` if the variable is not set
-
-**Note:** 
-- The `VITE_` prefix is required for Vite to expose the variable to the frontend
-- Port configuration only affects **dev mode** - production builds use same-origin relative paths
-- Tauri (desktop) mode uses dynamic port discovery and ignores this variable
-
-### VS Code Tasks
-
-The repository includes pre-configured VS Code tasks for common development workflows:
-
-- **🚀 Run Dev (Frontend + Backend)** - Starts both frontend and backend in parallel
-- **🧠 Run Backend Dev (API-only)** - Backend server for web development
-- **🎨 Run Frontend Dev** - Vite dev server only
-- **🖥️ Run GUI (Dev)** - Launch Tauri desktop app in development mode
-- **🧪 Run All Tests** - Execute the full test suite
-- **📎 Clippy (Linter)** - Run Rust linter
-- **🎨 Format Code** - Auto-format Rust and TypeScript code
-
-### Production Builds
-
-The production build workflow differs from development:
-
-1. **Build Frontend:**
-   ```bash
-   npm run build
-   # Output: ./web_ui/ directory with static assets
-   ```
-
-2. **Run Backend with Static Serving:**
-   ```bash
-   cargo run --package gglib-cli -- web --port 9887 --static-dir ./web_ui
-   # Backend serves both API and static frontend on single port
-   ```
-
-In production mode, the frontend uses relative URLs (no hardcoded ports) and communicates with the backend on the same origin.
-
-Changing the directory only affects future downloads and servers—it does **not** move any GGUF files you already downloaded. If you want your existing models in the new location, move them manually and then rescan/add them as needed.
-
-### Accelerated downloads via hf_xet
-
-Large GGUFs can saturate a single HTTP stream, so gglib bundles a managed Python helper that talks to Hugging Face's [hf_xet](https://github.com/huggingface/hf-xet) service. Fast downloads are now the only path—if the helper is missing or broken, commands like `gglib download` will fail until you repair the environment.
-
-- On the first run (or after `gglib check-deps`/`make setup`), gglib provisions a Miniconda environment under `<data_root>/.conda/gglib-hf-xet` and installs `huggingface_hub>=1.1.5` plus `hf_xet>=0.6`. A tiny helper script lives in `<data_root>/.gglib-runtime/python/hf_xet_downloader.py`.
-- The helper emits newline-delimited JSON so both the CLI and GUI can keep their existing progress indicators.
-- Missing Python packages are treated as errors. Run `gglib check-deps` or `make setup` to reinstall the managed environment; there is no legacy Rust HTTP fallback anymore.
-
-Requirements: install Miniconda (or another Python 3 distribution with `venv` support) and ensure enough disk space to populate the per-user `.conda/gglib-hf-xet` directory. The helper respects the same Hugging Face tokens you pass to `gglib download` and does not change how downloads are recorded in the SQLite database.
 
 ## Interfaces & Modes
 
-GGLib provides three complementary interfaces for interacting with GGUF models. All interfaces share the same backend implementation (database, services, process manager, and proxy), ensuring consistent behavior and data across all modes.
+All interfaces share the same backend (database, services, process manager, proxy). See each crate README for technical details.
 
-### CLI (Command-Line Interface)
+| Interface | Launch | Details |
+|-----------|--------|---------|
+| **CLI** | `gglib <command>` | [gglib-cli](crates/gglib-cli/README.md) |
+| **Desktop GUI** | `gglib gui` | [gglib-tauri](crates/gglib-tauri/README.md), [src-tauri](src-tauri/README.md) |
+| **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `0.0.0.0:9887` |
+| **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — default `127.0.0.1:8080` |
 
-Command-line interface for GGUF model management and service control.
+<details>
+<summary><strong>Security notes</strong></summary>
 
-**Capabilities:**
-- Model operations: `gglib add`, `gglib list`, `gglib remove`, `gglib update`
-- HuggingFace Hub integration: `gglib download`, `gglib search`, `gglib browse`
-- Direct terminal chat: `gglib chat <id|name>`
-- Server management: `gglib serve`, `gglib proxy`
-- Interface launchers: `gglib gui`, `gglib web`
-- llama.cpp management: `gglib llama install`, `gglib llama update`
+- Web server binds `0.0.0.0` (LAN-accessible); proxy binds `127.0.0.1` (local only) by default
+- No authentication — designed for trusted networks
+- Use firewall rules, private subnets, or VPN; do not expose to the public internet without additional auth
 
-### Desktop GUI (Tauri)
+</details>
 
-Cross-platform desktop application built with Tauri (Rust backend) and React frontend.
+## Installation
 
-**Technical details:**
-- Launched via `gglib gui` command
-- Uses shared `GuiBackend` service for all operations
-- Spawns embedded HTTP API server on localhost for frontend-backend communication
-- React frontend communicates via standard HTTP endpoints (`/api/models`, `/api/servers`, etc.)
-- Same API routes as standalone web server
-- Shares business logic, data model, and process management with other interfaces
+### Pre-built Releases
 
-### Web UI + HTTP API
+Download from the [Releases page](https://github.com/mmogr/gglib/releases):
 
-Browser-based interface backed by Axum HTTP server.
+| Platform | Archive | Post-install |
+|----------|---------|--------------|
+| **macOS (Apple Silicon)** | `gglib-gui-*-aarch64-apple-darwin.tar.gz` | Run `macos-install.command` to remove quarantine |
+| **macOS (Intel)** | `gglib-gui-*-x86_64-apple-darwin.tar.gz` | Same as above |
+| **Linux** | `gglib-gui-*-x86_64-unknown-linux-gnu.tar.gz` | Run `gglib-gui` |
+| **Windows** | `gglib-gui-*-x86_64-pc-windows-msvc.zip` | Run `gglib-gui.exe` |
 
-**Technical details:**
-- Started via `gglib web` command
-- Default binding: `0.0.0.0:9887` (LAN accessible)
-- API routes: `/api/models`, `/api/servers`, `/api/chat`, `/api/proxy/...`
-- React frontend (in `src/`) uses same HTTP endpoints as Tauri embedded server
-- Services layer (`TauriService`, `ChatService`) detects environment and uses either Tauri IPC (`invoke`) or HTTP calls
-
-## Web UI Server
-
-The web server provides browser-based access to GGLib's functionality via an Axum HTTP API.
-
-**Configuration:**
-```bash
-# Start web server (binds to 0.0.0.0:9887 by default)
-gglib web --port 9887 --base-port 9000
-```
-
-**Access:**
-- Local: `http://localhost:9887/`
-- Network: `http://<HOST_IP>:9887/`
-- API: `http://<HOST_IP>:9887/api`
-
-**Parameters:**
-- `--port`: Web server port (default: 9887)
-- `--base-port`: Starting port for llama-server instances (default: 9000)
-
-## OpenAI-Compatible Proxy
-
-The proxy provides OpenAI API-compatible endpoints for model inference. This enables GGLib to work seamlessly with OpenWebUI and other tools that support the OpenAI API format.
-
-**Configuration:**
-```bash
-# Start proxy (binds to 127.0.0.1:8080 by default)
-gglib proxy --host 0.0.0.0 --port 8080 --llama-port 5500
-```
-
-**Endpoints:**
-- Base URL: `http://<HOST_IP>:8080/v1/`
-- `/v1/models` - List available models
-- `/v1/chat/completions` - Chat completions
-- `/health` - Health check
-
-**Parameters:**
-- `--host`: Bind address (default: 127.0.0.1, use 0.0.0.0 for network access)
-- `--port`: Proxy port (default: 8080)
-- `--llama-port`: Starting port for llama-server instances (default: 5500)
-- `--default-context`: Default context size (default: 4096)
-
-**Features:**
-- Automatic model server management (start/stop on demand)
-- Request routing to appropriate llama-server instances
-- Full OpenAI SDK compatibility
-- Seamless integration with OpenWebUI
-
-**OpenWebUI Integration:**
-
-To use GGLib with OpenWebUI:
-
-1. Start the proxy with network access: `gglib proxy --host 0.0.0.0 --port 8080`
-2. In OpenWebUI settings, configure:
-   - API Base URL: `http://localhost:8080/v1`
-   - API Key: (any value, not validated)
-3. Select models from the dropdown - GGLib will automatically start the appropriate llama-server
-
-For details on developing the desktop GUI, see [src-tauri/README.md](src-tauri/README.md).
-
-The desktop build embeds the same REST API that powers `gglib gui web`. It binds to `http://localhost:8888` by default; make sure that port is free before running `gglib gui`. You can pick a different port by setting `GGLIB_GUI_API_PORT=<port>` before launching. The desktop UI now detects the port at runtime, so no frontend rebuild is required.
-
-### Testing
+### From Source
 
 ```bash
-export OPENAI_BASE_URL="http://localhost:8080/v1"
-export OPENAI_API_KEY="dummy"
+git clone https://github.com/mmogr/gglib.git && cd gglib
+make setup   # check deps → build frontend → install CLI → offer llama.cpp install
 ```
 
-Then use any OpenAI-compatible client library as you normally would.
+`make setup` checks for Rust, Node.js, and build tools; provisions the Miniconda environment for the `hf_xet` fast download helper; builds the web UI; and installs the CLI to `~/.cargo/bin/`. It exits with an error if Python/Miniconda is missing — run it first on new machines.
 
-### Security Considerations
+> **Developer Mode:** When installed via `make setup`, the database (`gglib.db`), config (`.env`), and llama.cpp binaries live inside your repo folder. Downloaded models default to `~/.local/share/llama_models`.
 
-**Network Binding:**
-- Web server binds to `0.0.0.0` by default (network accessible)
-- Proxy binds to `127.0.0.1` by default (local only)
-- Use `--host 0.0.0.0` for network access to proxy
+### Prerequisites
 
-**Authentication:**
-- No authentication required by default
-- Designed for trusted network environments
+- **Rust** 1.70+ — [rustup.rs](https://rustup.rs/)
+- **Python 3 via Miniconda** — [miniconda](https://docs.conda.io/en/latest/miniconda.html) (for hf_xet fast downloads)
+- **Node.js** 18+ — [nodejs.org](https://nodejs.org/) (for web UI)
+- **SQLite** 3.x
+- **Build tools**: macOS `xcode-select --install` + `brew install cmake` · Ubuntu `build-essential cmake git` · Windows VS 2022 C++ + CMake
 
-**Recommendations:**
-- Use firewall rules to restrict access to trusted IP ranges
-- Only expose on private networks (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
-- Use VPN for access from outside local network
-- Do not port-forward to public internet without additional authentication
+llama.cpp is managed by GGLib — no separate install needed.
 
-## 📖 Documentation
+<details>
+<summary><strong>Makefile targets</strong></summary>
 
-**[📚 View Full API Documentation →](https://mmogr.github.io/gglib)**
+**Installation & Setup:**
+- `make setup` — Full setup (dependencies + build + install + llama.cpp)
+- `make install` — Build and install CLI to `~/.cargo/bin/`
+- `make uninstall` — Full cleanup (removes binary, system data, database; preserves models)
 
-The complete API documentation is automatically generated from the source code and hosted on GitHub Pages. It includes:
+**Building:**
+- `make build` / `make build-dev` — Release / debug binary
+- `make build-gui` — Web UI frontend
+- `make build-tauri` — Desktop GUI
+- `make build-all` — Everything (CLI + web UI)
 
-- 🔍 **Detailed API reference** for all public functions and types
-- 💡 **Usage examples** and code snippets
-- 🏗️ **Architecture overview** of the codebase
-- 🔧 **Developer guides** for contributing
+**Development:**
+- `make test` / `make check` / `make fmt` / `make lint` / `make doc`
 
-The documentation is automatically updated with every release, so you'll always have access to the latest information.
+**llama.cpp:**
+- `make llama-install-auto` / `make llama-status` / `make llama-update`
+
+**Running:**
+- `make run-gui` / `make run-web` / `make run-serve` / `make run-proxy`
+
+**Cleaning:**
+- `make clean` / `make clean-gui` / `make clean-llama` / `make clean-db`
+
+</details>
+
+<details>
+<summary><strong>Manual installation (Cargo)</strong></summary>
+
+```bash
+cargo install --path .
+```
+
+</details>
+
+<details>
+<summary><strong>Configuring the models directory</strong></summary>
+
+Default: `~/.local/share/llama_models`. Change via any of:
+
+- `make setup` prompt
+- `.env` file: `GGLIB_MODELS_DIR=/absolute/path`
+- CLI: `gglib config models-dir set <path>` or `gglib --models-dir <path> download …`
+- GUI/Web: Settings modal (gear icon)
+
+Precedence: CLI flag → env var → default. Changing the directory does **not** move existing files.
+
+</details>
+
+## Development
+
+Start the backend and frontend in separate terminals:
+
+```bash
+# Backend API server
+cargo run --package gglib-cli -- web --api-only --port 9887 --base-port 9000
+
+# Frontend dev server (proxies /api/* to backend)
+npm run dev
+# → http://localhost:5173
+```
+
+Or use the VS Code task **🚀 Run Dev (Frontend + Backend)** to launch both in parallel.
+
+<details>
+<summary><strong>Port configuration</strong></summary>
+
+Set `VITE_GGLIB_WEB_PORT` in `.env` to change the API port (default `9887`). Both the Rust backend (via clap env) and Vite proxy read this value. The `VITE_` prefix is required for Vite. Port config only affects dev mode — production uses same-origin relative paths. Tauri uses dynamic port discovery.
+
+</details>
+
+<details>
+<summary><strong>Production builds</strong></summary>
+
+```bash
+npm run build                                                      # → ./web_ui/
+cargo run --package gglib-cli -- web --port 9887 --static-dir ./web_ui  # single-port serving
+```
+
+</details>
+
+<details>
+<summary><strong>Accelerated downloads (hf_xet)</strong></summary>
+
+gglib bundles a managed Python helper for [hf_xet](https://github.com/huggingface/hf-xet) fast downloads. On first run (or after `make setup` / `gglib check-deps`), it provisions a Miniconda environment under `<data_root>/.conda/gglib-hf-xet` and installs `huggingface_hub>=1.1.5` + `hf_xet>=0.6`. There is no legacy Rust HTTP fallback — if the helper is missing, `gglib download` will fail until the environment is repaired.
+
+</details>
+
+<details>
+<summary><strong>VS Code tasks</strong></summary>
+
+- **🚀 Run Dev (Frontend + Backend)** — parallel launch
+- **🧠 Run Backend Dev (API-only)** — backend only
+- **🎨 Run Frontend Dev** — Vite dev server
+- **🖥️ Run GUI (Dev)** — Tauri desktop in dev mode
+- **🧪 Run All Tests** / **📎 Clippy** / **🎨 Format Code**
+
+</details>
+
+## Documentation
+
+**[View Full API Documentation →](https://mmogr.github.io/gglib)**
+
+Auto-generated from source and updated with every release.
 
 ## Acknowledgments
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -112,7 +112,6 @@ The output binary will be located in `target/release/bundle/`.
 For more details on the architecture and how all interfaces work together, see:
 - [Interfaces & Modes](../README.md#interfaces--modes) in the main README
 - [Architecture Overview](../README.md#architecture-overview) for backend details
-- [LAN Server Mode](../README.md#running-gglib-as-a-lan-llm-server) for remote access options
 
 ## Project Structure
 

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -259,7 +259,7 @@ gglib web --api-only --port 9887
 gglib web --port 9887 --base-port 9000
 ```
 
-The web server binds to `0.0.0.0` by default, making it accessible from your LAN. See the [LAN Server Mode documentation](../README.md#running-gglib-as-a-lan-llm-server) for details.
+The web server binds to `0.0.0.0` by default, making it accessible from your LAN. See [Interfaces & Modes](../README.md#interfaces--modes) for details.
 
 ### llama.cpp Management
 
@@ -410,7 +410,6 @@ gglib config settings reset
 - [Main README](../README.md) - Overview and getting started
 - [Interfaces & Modes](../README.md#interfaces--modes) - Understanding CLI, Desktop GUI, and Web UI
 - [Architecture Overview](../README.md#architecture-overview) - How GGLib is structured
-- [LAN Server Mode](../README.md#running-gglib-as-a-lan-llm-server) - Running GGLib as a network server
 - [Desktop GUI Documentation](../src-tauri/README.md) - Tauri app details
 
 <!-- module-docs:end -->


### PR DESCRIPTION
Align root README with the crate-level README pattern: let architecture diagrams, metrics tables, and crate links do the talking instead of long prose descriptions.

Changes:
- Remove Overview + Features prose (redundant with diagram/crate table)
- Promote Crate Metrics out of collapsed details
- Replace Interfaces & Modes paragraphs with compact launch table
- Collapse Makefile targets, port config, hf_xet, VS Code tasks
  into details blocks
- Condense Installation + Development sections
- Fold Security Considerations into Interfaces section
- Remove Web UI Server / OpenAI Proxy user-guides (belong in crate READMEs)
- Fix broken running-gglib-as-a-lan-llm-server anchors in src/commands/README.md and src-tauri/README.md

Preserved:
- crate-docs:start/end markers
- Architecture Overview anchor (12+ crate READMEs link to it)
- Interfaces and Modes anchor (commands + tauri READMEs link to it)
- All badge URLs unchanged
- Full architecture diagram unchanged
- All crate metric badge tables unchanged

612 to 389 lines (36% reduction)