### PR TITLE
ci: add libasound2-dev to Linux apt-get install steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
             librsvg2-dev \
             libgtk-3-dev \
             libssl-dev \
+            libasound2-dev \
             pkg-config
 
       - name: Cache Cargo registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,8 @@ jobs:
             libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            libasound2-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -458,6 +459,7 @@ jobs:
             patchelf \
             libgtk-3-dev \
             libssl-dev \
+            libasound2-dev \
             pkg-config
 
       - name: Build Tauri app


### PR DESCRIPTION
## Problem

The v0.5.0 release run had 3 job failures due to a missing system dependency:

```
error: failed to run custom build command for `alsa-sys v0.3.1`
The system library `alsa` required by crate `alsa-sys` was not found.
Process completed with exit code 101.
```

Failed jobs: Deploy Documentation, Build x86_64-unknown-linux-gnu, Build GUI x86_64-unknown-linux-gnu

## Root cause

`gglib-voice` depends on `alsa-sys` which requires the ALSA dev library at build time. `libasound2-dev` was missing from the `apt-get install` steps in `docs.yml` and `release.yml`. (`ci.yml` and `coverage.yml` already had it correctly.)

## Fix

Added `libasound2-dev` to:
- `docs.yml` - Install system dependencies
- `release.yml` - Install system dependencies (deploy-docs job)
- `release.yml` - Install system dependencies (Linux) (build-gui job)
