### PR TITLE
docs: clean up READMEs across the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GGLib - Rust GGUF Library Management Tool
+# GGLib
 
 [![CI](https://github.com/mmogr/gglib/actions/workflows/ci.yml/badge.svg)](https://github.com/mmogr/gglib/actions/workflows/ci.yml)
 [![Coverage](https://github.com/mmogr/gglib/actions/workflows/coverage.yml/badge.svg)](https://github.com/mmogr/gglib/actions/workflows/coverage.yml)
@@ -8,9 +8,36 @@
 
 <!-- crate-docs:start -->
 
-A multi-interface platform for managing and serving GGUF model files locally — catalog, serve, and chat via CLI, desktop GUI, web UI, or OpenAI-compatible proxy, all sharing one layered Rust backend.
+Manage your local GGUF models without remembering file paths or llama.cpp commands.
 
-## Architecture Overview
+GGLib keeps a catalog of your GGUFs, handles downloading from HuggingFace, and starts llama-server for you. Use it from the terminal, a desktop app, a web UI, or as an OpenAI-compatible API — they all share the same database and model directory.
+
+## Quick look
+
+```bash
+# Download a model from HuggingFace
+gglib download bartowski/Qwen2.5-7B-Instruct-GGUF
+
+# List what you have
+gglib list
+
+# Start chatting (launches llama-server automatically)
+gglib chat qwen2.5
+
+# Serve a model and use it from any OpenAI client
+gglib serve qwen2.5
+
+# Pipe anything into a question
+cat error.log | gglib question "what went wrong?"
+git diff | gglib question "review this for bugs"
+man rsync | gglib question "how do I sync only .rs files?"
+
+# Or skip the CLI — open the desktop app or web UI
+gglib gui
+gglib web
+```
+
+## Architecture
 
 Cargo workspace with compile-time enforced boundaries. Adapters → infrastructure → core — never the reverse.
 
@@ -121,17 +148,7 @@ Cargo workspace with compile-time enforced boundaries. Adapters → infrastructu
 └─────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Architecture Principles:**
-
-- **Unified access**: All adapters call through infrastructure layer—never directly to external systems
-- **External gateways**: Only `gglib-runtime` and `gglib-download` touch external systems
-- **Tauri architecture**: Embeds both React UI assets AND Axum HTTP server internally
-- **React UI as artifact**: Static files in Axum, bundled assets in Tauri, unused in CLI
-- **Python hf_xet**: Internal subprocess within `gglib-download`, not an architectural boundary
-
-**Frontend Architecture:**
-
-- **Styling & UI Contracts**: See [src/styles/README.md](src/styles/README.md) for Tailwind-first architecture, design token system, platform parity requirements, and component migration roadmap
+Only `gglib-runtime` spawns llama-server processes; only `gglib-download` talks to HuggingFace. Everything else goes through the infrastructure layer.
 
 ### Crate Metrics
 
@@ -192,31 +209,28 @@ Each crate has its own README with architecture diagrams, module breakdowns, and
 
 ### Module Reference
 
-#### Rust Crates
-- **[`models`](src/models/README.md)** – GGUF model metadata, GUI/API DTOs, and data structures
-- **[`services`](src/services/README.md)** – TypeScript client layer for GUI frontends
-- **[`commands`](src/commands/README.md)** – CLI command handlers and web API endpoints
-- **[`utils`](src/utils/README.md)** – Lower-level helpers for parsing and utilities
-
 #### TypeScript Frontend
 - **[`components`](src/components/README.md)** – React UI components
 - **[`contexts`](src/contexts/README.md)** – React Context providers
 - **[`hooks`](src/hooks/README.md)** – Custom React hooks
 - **[`pages`](src/pages/README.md)** – Top-level page components
 - **[`types`](src/types/README.md)** – Shared TypeScript type definitions
+- **[`utils`](src/utils/README.md)** – Shared helpers (formatting, SSE, platform detection)
+- **[`services`](src/services/README.md)** – API client layer (HTTP and Tauri IPC)
+- **[`commands`](src/commands/README.md)** – CLI command reference (download, llama management)
 
 <!-- crate-docs:end -->
 
-## Interfaces & Modes
+## Interfaces
 
-All interfaces share the same backend (database, services, process manager, proxy). See each crate README for technical details.
+All interfaces share the same database and model directory. Pick whichever fits your workflow — or use several.
 
 | Interface | Launch | Details |
 |-----------|--------|---------|
 | **CLI** | `gglib <command>` | [gglib-cli](crates/gglib-cli/README.md) |
 | **Desktop GUI** | `gglib gui` | [gglib-tauri](crates/gglib-tauri/README.md), [src-tauri](src-tauri/README.md) |
 | **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `0.0.0.0:9887` |
-| **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — default `127.0.0.1:8080` |
+| **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — works with OpenWebUI, any OpenAI SDK |
 
 <details>
 <summary><strong>Security notes</strong></summary>
@@ -228,8 +242,6 @@ All interfaces share the same backend (database, services, process manager, prox
 </details>
 
 ## Installation
-
-### Pre-built Releases
 
 Download from the [Releases page](https://github.com/mmogr/gglib/releases):
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,46 @@ gglib serve qwen2.5
 
 # Pipe anything into a question
 cat error.log | gglib question "what went wrong?"
-git diff | gglib question "review this for bugs"
-man rsync | gglib question "how do I sync only .rs files?"
 
 # Or skip the CLI — open the desktop app or web UI
 gglib gui
 gglib web
 ```
+
+## Pipe anything, ask anything
+
+GGLib treats your local model like a Unix tool. Pipe in any text and ask a question — no API keys, no cloud, no context window gymnastics. Use `gglib question` (or `gglib q` for short).
+
+```bash
+# Code review a PR diff
+git diff main | gglib q "review this for bugs and suggest improvements"
+
+# Understand an error log
+journalctl -u myapp --since "1 hour ago" | gglib q "what caused this crash?"
+
+# Summarize a man page
+man rsync | gglib q "how do I sync only .rs files, excluding target/?"
+
+# Explain unfamiliar config
+cat nginx.conf | gglib q "explain the proxy_pass rules"
+
+# Quick code explanation
+cat src/main.rs | gglib q "what does this program do?"
+
+# Get a commit message from staged changes
+git diff --cached | gglib q "write a concise commit message for these changes"
+
+# Translate a file
+cat README_ja.md | gglib q "translate this to English"
+
+# Use {} as a placeholder to control where input goes
+echo "segfault at 0x0" | gglib q "I got this error: {}. What does it mean?"
+
+# Read context from a file instead of stdin
+gglib q --file Cargo.toml "what dependencies does this project use?"
+```
+
+Works with any command that produces text. If you can `cat` it, you can ask a local model about it.
 
 ## Architecture
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -195,7 +195,7 @@ Voice mode pipeline:
 - Pipeline state machine orchestrating the full conversation loop
 - Safe audio threading via actor pattern (no unsafe code)
 
-### Presentation Layer
+### Adapter Layer
 
 #### gglib-cli
 Command-line interface:
@@ -252,7 +252,7 @@ Desktop application backend:
 ## Further Reading
 
 - [Main README](../README.md) - Project overview and getting started
-- [Architecture Overview](../README.md#architecture-overview) - Detailed architecture explanation
+- [Architecture Overview](../README.md#architecture) - Detailed architecture explanation
 - Individual crate READMEs linked in table above
 
 ## Badge Information

--- a/crates/gglib-axum/README.md
+++ b/crates/gglib-axum/README.md
@@ -33,7 +33,7 @@ This crate is in the **Adapter Layer** — it exposes gglib functionality via HT
                               └──────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-axum/src/handlers/voice.rs
+++ b/crates/gglib-axum/src/handlers/voice.rs
@@ -96,57 +96,57 @@ pub async fn download_vad_model(State(state): State<AppState>) -> Result<StatusC
 pub async fn load_stt(
     State(state): State<AppState>,
     Json(req): Json<LoadSttRequest>,
-) -> Result<StatusCode, HttpError> {
+) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_load_stt(&req.model_id).await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `POST /api/voice/tts/load`
-pub async fn load_tts(State(state): State<AppState>) -> Result<StatusCode, HttpError> {
+pub async fn load_tts(State(state): State<AppState>) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_load_tts().await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `PUT /api/voice/mode`
 pub async fn set_mode(
     State(state): State<AppState>,
     Json(req): Json<SetModeRequest>,
-) -> Result<StatusCode, HttpError> {
+) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_set_mode(&req.mode).await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `PUT /api/voice/voice`
 pub async fn set_voice(
     State(state): State<AppState>,
     Json(req): Json<SetVoiceRequest>,
-) -> Result<StatusCode, HttpError> {
+) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_set_voice(&req.voice_id).await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `PUT /api/voice/speed`
 pub async fn set_speed(
     State(state): State<AppState>,
     Json(req): Json<SetSpeedRequest>,
-) -> Result<StatusCode, HttpError> {
+) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_set_speed(req.speed).await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `PUT /api/voice/auto-speak`
 pub async fn set_auto_speak(
     State(state): State<AppState>,
     Json(req): Json<SetAutoSpeakRequest>,
-) -> Result<StatusCode, HttpError> {
+) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_set_auto_speak(req.auto_speak).await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `POST /api/voice/unload`
-pub async fn unload(State(state): State<AppState>) -> Result<StatusCode, HttpError> {
+pub async fn unload(State(state): State<AppState>) -> Result<Json<VoiceStatusDto>, HttpError> {
     state.gui.voice_unload().await?;
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(state.gui.voice_status().await?))
 }
 
 /// `GET /api/voice/devices`

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -35,7 +35,7 @@ This crate is in the **Adapter Layer** — it wires together all infrastructure 
                               └──────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-core/README.md
+++ b/crates/gglib-core/README.md
@@ -27,7 +27,7 @@ This crate is the **Core Layer** — the innermost ring of the architecture. All
               └───────────────────────────────────────────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-db/README.md
+++ b/crates/gglib-db/README.md
@@ -20,7 +20,7 @@ gglib-core (ports)          gglib-db (adapters)           Adapters
 └──────────────────┘        └──────────────────┘        └──────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-download/README.md
+++ b/crates/gglib-download/README.md
@@ -25,7 +25,7 @@ gglib-core (types)          gglib-download            External
                             └──────────────────┘        └──────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-gguf/README.md
+++ b/crates/gglib-gguf/README.md
@@ -25,7 +25,7 @@ gglib-core (port)           gglib-gguf (adapter)          Adapters
                             └──────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-gui/README.md
+++ b/crates/gglib-gui/README.md
@@ -34,7 +34,7 @@ This crate is a **Shared Facade** — sitting between adapters and infrastructur
               └───────────────────────────────────────────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-hf/README.md
+++ b/crates/gglib-hf/README.md
@@ -5,17 +5,13 @@
 ![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-loc.json)
 ![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-complexity.json)
 
-`HuggingFace` Hub client implementation for gglib.
+HuggingFace Hub client for gglib — searching, browsing, and resolving GGUF models on the Hub. Implements `HfClientPort` from `gglib-core`.
 
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it implements the `HfClientPort` trait from `gglib-core`.
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
-
-## Overview
-
-This crate provides a complete `HuggingFace` Hub API client for searching, browsing, and downloading GGUF models. It implements the `HfClientPort` trait from `gglib-core`, following the Hexagonal Architecture pattern.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 

--- a/crates/gglib-hf/README.md
+++ b/crates/gglib-hf/README.md
@@ -5,7 +5,7 @@
 ![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-loc.json)
 ![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-complexity.json)
 
-HuggingFace Hub client for gglib — searching, browsing, and resolving GGUF models on the Hub. Implements `HfClientPort` from `gglib-core`.
+`HuggingFace` Hub client for gglib — searching, browsing, and resolving GGUF models on the Hub. Implements `HfClientPort` from `gglib-core`.
 
 ## Architecture
 

--- a/crates/gglib-mcp/README.md
+++ b/crates/gglib-mcp/README.md
@@ -11,7 +11,7 @@ MCP (Model Context Protocol) server management for gglib.
 
 This crate is in the **Infrastructure Layer** — it manages MCP server lifecycle and protocol handling.
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Overview
 

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -38,7 +38,7 @@ At runtime, adapters inject concrete implementations:
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Overview
 
@@ -129,106 +129,27 @@ Pass `num_ctx` at the request root to override default context size:
 
 ## Usage
 
-This crate is used by `gglib-runtime`'s `ProxySupervisor`:
+This crate is used by `gglib-runtime`'s `ProxySupervisor`. The supervisor binds a `TcpListener` and passes it to `gglib_proxy::serve()` along with port trait implementations:
 
-```rust
-use async_trait::async_trait;
-use gglib_core::ports::{
-  CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
-  ModelSummary, RunningTarget,
-};
+```rust,ignore
+use gglib_proxy;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-fn main() -> anyhow::Result<()> {
+let listener = TcpListener::bind("127.0.0.1:8080").await?;
+let cancel = CancellationToken::new();
 
-#[derive(Debug)]
-struct MockRuntimePort;
-
-#[async_trait]
-impl ModelRuntimePort for MockRuntimePort {
-  async fn ensure_model_running(
-    &self,
-    _model_name: &str,
-    _num_ctx: Option<u64>,
-    _default_ctx: u64,
-  ) -> Result<RunningTarget, ModelRuntimeError> {
-    Ok(RunningTarget::local(
-      12345,
-      1,
-      "mock-model".to_string(),
-      4096,
-    ))
-  }
-
-  async fn current_model(&self) -> Option<RunningTarget> {
-    None
-  }
-
-  async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
-    Ok(())
-  }
-}
-
-#[derive(Debug)]
-struct MockCatalogPort;
-
-#[async_trait]
-impl ModelCatalogPort for MockCatalogPort {
-  async fn list_models(&self) -> Result<Vec<ModelSummary>, CatalogError> {
-    Ok(vec![])
-  }
-
-  async fn resolve_model(&self, _name: &str) -> Result<Option<ModelSummary>, CatalogError> {
-    Ok(None)
-  }
-
-  async fn resolve_for_launch(
-    &self,
-    _name: &str,
-  ) -> Result<Option<ModelLaunchSpec>, CatalogError> {
-    Ok(None)
-  }
-}
-
-let rt = tokio::runtime::Runtime::new()?;
-rt.block_on(async {
-  // Supervisor binds the listener (use an ephemeral port in docs/tests)
-  let listener = TcpListener::bind("127.0.0.1:0").await?;
-  let addr = listener.local_addr()?;
-
-  let runtime_port: Arc<dyn ModelRuntimePort> = Arc::new(MockRuntimePort);
-  let catalog_port: Arc<dyn ModelCatalogPort> = Arc::new(MockCatalogPort);
-
-  // Then calls serve with the listener
-  let cancel = CancellationToken::new();
-  let cancel_for_server = cancel.clone();
-
-  let server = tokio::spawn(async move {
-    gglib_proxy::serve(listener, 4096, runtime_port, catalog_port, cancel_for_server).await
-  });
-
-  // Optional: verify the server responds
-  let health_url = format!("http://{addr}/health");
-  for _ in 0..25 {
-    if let Ok(resp) = reqwest::get(&health_url).await {
-      if resp.status().is_success() {
-        break;
-      }
-    }
-    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-  }
-
-  // Shutdown
-  cancel.cancel();
-  server.await??;
-  Ok::<(), anyhow::Error>(())
-})?;
-
-Ok(())
-}
+gglib_proxy::serve(
+    listener,
+    4096,                    // default context size
+    runtime_port,            // Arc<dyn ModelRuntimePort>
+    catalog_port,            // Arc<dyn ModelCatalogPort>
+    cancel,
+).await?;
 ```
+
+See the [full doctest](src/lib.rs) for a complete example with mock implementations.
 
 ## Streaming
 

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -173,4 +173,88 @@ mod tests {
         assert!(!should_forward_header("authorization"));
         assert!(!should_forward_header("transfer-encoding"));
     }
+
+    #[test]
+    fn hop_by_hop_headers_are_case_insensitive() {
+        assert!(!should_forward_header("Connection"));
+        assert!(!should_forward_header("HOST"));
+        assert!(!should_forward_header("Transfer-Encoding"));
+        assert!(!should_forward_header("Keep-Alive"));
+        assert!(!should_forward_header("PROXY-AUTHORIZATION"));
+    }
+
+    #[test]
+    fn all_hop_by_hop_headers_are_blocked() {
+        for header in HOP_BY_HOP_HEADERS {
+            assert!(
+                !should_forward_header(header),
+                "hop-by-hop header '{header}' should be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn common_request_headers_are_forwarded() {
+        let forward_headers = [
+            "accept",
+            "accept-encoding",
+            "accept-language",
+            "user-agent",
+            "content-type",
+            "x-request-id",
+            "x-forwarded-for",
+            "cache-control",
+        ];
+        for header in forward_headers {
+            assert!(
+                should_forward_header(header),
+                "request header '{header}' should be forwarded"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_to_unreachable_server_returns_bad_gateway() {
+        let client = Client::new();
+        let headers = HeaderMap::new();
+        let body = Bytes::from(r#"{"model":"test","messages":[]}"#);
+
+        // Use a port that's almost certainly not listening
+        let response = forward_chat_completion(
+            &client,
+            "http://127.0.0.1:1/v1/chat/completions",
+            &headers,
+            body,
+            false,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn forward_to_unreachable_server_returns_json_error() {
+        let client = Client::new();
+        let headers = HeaderMap::new();
+        let body = Bytes::from(r#"{"model":"test","messages":[]}"#);
+
+        let response = forward_chat_completion(
+            &client,
+            "http://127.0.0.1:1/v1/chat/completions",
+            &headers,
+            body,
+            true, // streaming mode should also get a proper error
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        // Body should be valid JSON with OpenAI error format
+        let body_bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(json.get("error").is_some(), "response must have 'error' key");
+        assert_eq!(json["error"]["code"], "upstream_error");
+    }
 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -254,7 +254,10 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-        assert!(json.get("error").is_some(), "response must have 'error' key");
+        assert!(
+            json.get("error").is_some(),
+            "response must have 'error' key"
+        );
         assert_eq!(json["error"]["code"], "upstream_error");
     }
 }

--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -388,7 +388,10 @@ mod tests {
         let json = serde_json::to_value(&err).unwrap();
 
         // OpenAI format: { "error": { "message": ..., "type": ..., "code": ... } }
-        assert!(json.get("error").is_some(), "must have top-level 'error' key");
+        assert!(
+            json.get("error").is_some(),
+            "must have top-level 'error' key"
+        );
         let inner = &json["error"];
         assert!(inner.get("message").is_some());
         assert!(inner.get("type").is_some());
@@ -557,7 +560,10 @@ mod tests {
         };
         let info = ModelInfo::from(summary);
         let desc = info.description.unwrap();
-        assert!(desc.contains("unknown"), "missing fields should show 'unknown'");
+        assert!(
+            desc.contains("unknown"),
+            "missing fields should show 'unknown'"
+        );
     }
 
     // =========================================================================

--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -329,3 +329,488 @@ impl From<ModelRuntimeError> for ErrorResponse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // ErrorResponse construction tests
+    // =========================================================================
+
+    #[test]
+    fn error_response_new_sets_type_and_message() {
+        let err = ErrorResponse::new("something broke", "server_error");
+        assert_eq!(err.error.message, "something broke");
+        assert_eq!(err.error.r#type, "server_error");
+        assert!(err.error.code.is_none());
+    }
+
+    #[test]
+    fn error_response_with_code_sets_all_fields() {
+        let err = ErrorResponse::with_code("bad input", "invalid_request", "bad_param");
+        assert_eq!(err.error.message, "bad input");
+        assert_eq!(err.error.r#type, "invalid_request");
+        assert_eq!(err.error.code.as_deref(), Some("bad_param"));
+    }
+
+    #[test]
+    fn error_response_model_loading_has_correct_code() {
+        let err = ErrorResponse::model_loading();
+        assert_eq!(err.error.code.as_deref(), Some("model_loading"));
+        assert_eq!(err.error.r#type, "service_unavailable");
+        assert!(err.error.message.contains("loading"));
+    }
+
+    #[test]
+    fn error_response_model_not_found_includes_name() {
+        let err = ErrorResponse::model_not_found("llama-3-8b");
+        assert!(err.error.message.contains("llama-3-8b"));
+        assert_eq!(err.error.code.as_deref(), Some("model_not_found"));
+        assert_eq!(err.error.r#type, "invalid_request_error");
+    }
+
+    #[test]
+    fn error_response_upstream_error_includes_reason() {
+        let err = ErrorResponse::upstream_error("connection refused");
+        assert!(err.error.message.contains("connection refused"));
+        assert_eq!(err.error.code.as_deref(), Some("upstream_error"));
+        assert_eq!(err.error.r#type, "server_error");
+    }
+
+    // =========================================================================
+    // ErrorResponse serialization tests (OpenAI format compliance)
+    // =========================================================================
+
+    #[test]
+    fn error_response_serializes_to_openai_format() {
+        let err = ErrorResponse::model_not_found("test-model");
+        let json = serde_json::to_value(&err).unwrap();
+
+        // OpenAI format: { "error": { "message": ..., "type": ..., "code": ... } }
+        assert!(json.get("error").is_some(), "must have top-level 'error' key");
+        let inner = &json["error"];
+        assert!(inner.get("message").is_some());
+        assert!(inner.get("type").is_some());
+        assert!(inner.get("code").is_some());
+    }
+
+    #[test]
+    fn error_response_without_code_omits_code_field() {
+        let err = ErrorResponse::new("oops", "server_error");
+        let json = serde_json::to_value(&err).unwrap();
+        // code is None, so with skip_serializing_if it should be absent
+        // Actually code is not skip_serializing_if on ErrorDetail, it's Option
+        // Let's verify the value is null or absent
+        let code = &json["error"]["code"];
+        assert!(code.is_null(), "code should be null when None");
+    }
+
+    // =========================================================================
+    // ModelRuntimeError → ErrorResponse conversion tests
+    // =========================================================================
+
+    #[test]
+    fn from_model_not_found_error() {
+        let err: ErrorResponse = ModelRuntimeError::ModelNotFound("qwen-7b".into()).into();
+        assert!(err.error.message.contains("qwen-7b"));
+        assert_eq!(err.error.code.as_deref(), Some("model_not_found"));
+    }
+
+    #[test]
+    fn from_model_loading_error() {
+        let err: ErrorResponse = ModelRuntimeError::ModelLoading.into();
+        assert_eq!(err.error.code.as_deref(), Some("model_loading"));
+    }
+
+    #[test]
+    fn from_spawn_failed_error() {
+        let err: ErrorResponse =
+            ModelRuntimeError::SpawnFailed("port already in use".into()).into();
+        assert!(err.error.message.contains("port already in use"));
+        assert_eq!(err.error.code.as_deref(), Some("upstream_error"));
+    }
+
+    #[test]
+    fn from_health_check_failed_error() {
+        let err: ErrorResponse =
+            ModelRuntimeError::HealthCheckFailed("timeout after 30s".into()).into();
+        assert!(err.error.message.contains("timeout after 30s"));
+        assert_eq!(err.error.code.as_deref(), Some("upstream_error"));
+    }
+
+    #[test]
+    fn from_model_file_not_found_error() {
+        let err: ErrorResponse =
+            ModelRuntimeError::ModelFileNotFound("/models/missing.gguf".into()).into();
+        assert!(err.error.message.contains("/models/missing.gguf"));
+        assert_eq!(err.error.code.as_deref(), Some("model_file_not_found"));
+    }
+
+    #[test]
+    fn from_internal_error() {
+        let err: ErrorResponse = ModelRuntimeError::Internal("db locked".into()).into();
+        assert_eq!(err.error.message, "db locked");
+        assert_eq!(err.error.r#type, "server_error");
+        assert!(err.error.code.is_none());
+    }
+
+    // =========================================================================
+    // ModelsResponse tests
+    // =========================================================================
+
+    #[test]
+    fn models_response_from_empty_summaries() {
+        let resp = ModelsResponse::from_summaries(vec![]);
+        assert_eq!(resp.object, "list");
+        assert!(resp.data.is_empty());
+    }
+
+    #[test]
+    fn models_response_from_summaries_maps_fields() {
+        let summaries = vec![
+            ModelSummary {
+                id: 1,
+                name: "llama-3-8b-q4".into(),
+                tags: vec!["chat".into()],
+                param_count: "8B".into(),
+                quantization: Some("Q4_K_M".into()),
+                architecture: Some("llama".into()),
+                created_at: 1700000000,
+                file_size: 4_000_000_000,
+            },
+            ModelSummary {
+                id: 2,
+                name: "mistral-7b-q8".into(),
+                tags: vec![],
+                param_count: "7B".into(),
+                quantization: Some("Q8_0".into()),
+                architecture: Some("mistral".into()),
+                created_at: 1700000001,
+                file_size: 7_000_000_000,
+            },
+        ];
+
+        let resp = ModelsResponse::from_summaries(summaries);
+        assert_eq!(resp.data.len(), 2);
+        assert_eq!(resp.data[0].id, "llama-3-8b-q4");
+        assert_eq!(resp.data[0].object, "model");
+        assert_eq!(resp.data[0].owned_by, "gglib");
+        assert_eq!(resp.data[0].created, 1700000000);
+        assert!(resp.data[0].description.is_some());
+    }
+
+    #[test]
+    fn models_response_serializes_to_openai_format() {
+        let resp = ModelsResponse::from_summaries(vec![ModelSummary {
+            id: 1,
+            name: "test-model".into(),
+            tags: vec![],
+            param_count: "7B".into(),
+            quantization: None,
+            architecture: None,
+            created_at: 0,
+            file_size: 0,
+        }]);
+
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["object"], "list");
+        assert!(json["data"].is_array());
+        assert_eq!(json["data"][0]["id"], "test-model");
+        assert_eq!(json["data"][0]["object"], "model");
+    }
+
+    // =========================================================================
+    // ModelInfo conversion tests
+    // =========================================================================
+
+    #[test]
+    fn model_info_description_includes_arch_and_quant() {
+        let summary = ModelSummary {
+            id: 1,
+            name: "test".into(),
+            tags: vec![],
+            param_count: "13B".into(),
+            quantization: Some("Q5_K_S".into()),
+            architecture: Some("llama".into()),
+            created_at: 0,
+            file_size: 0,
+        };
+        let info = ModelInfo::from(summary);
+        let desc = info.description.unwrap();
+        assert!(desc.contains("llama"), "description should include arch");
+        assert!(desc.contains("13B"), "description should include params");
+        assert!(desc.contains("Q5_K_S"), "description should include quant");
+    }
+
+    #[test]
+    fn model_info_handles_missing_arch_and_quant() {
+        let summary = ModelSummary {
+            id: 1,
+            name: "bare-model".into(),
+            tags: vec![],
+            param_count: "1B".into(),
+            quantization: None,
+            architecture: None,
+            created_at: 0,
+            file_size: 0,
+        };
+        let info = ModelInfo::from(summary);
+        let desc = info.description.unwrap();
+        assert!(desc.contains("unknown"), "missing fields should show 'unknown'");
+    }
+
+    // =========================================================================
+    // ChatCompletionRequest deserialization tests
+    // =========================================================================
+
+    #[test]
+    fn chat_request_minimal_deserializes() {
+        let json = r#"{
+            "model": "llama-3",
+            "messages": [{"role": "user", "content": "hello"}]
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.model, "llama-3");
+        assert!(!req.stream, "stream should default to false");
+        assert_eq!(req.messages.len(), 1);
+        assert!(req.temperature.is_none());
+        assert!(req.tools.is_none());
+    }
+
+    #[test]
+    fn chat_request_with_streaming_flag() {
+        let json = r#"{
+            "model": "test",
+            "messages": [],
+            "stream": true
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert!(req.stream);
+    }
+
+    #[test]
+    fn chat_request_with_all_optional_fields() {
+        let json = r#"{
+            "model": "llama-3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "max_tokens": 512,
+            "stream": false,
+            "n": 1,
+            "stop": ["END"],
+            "num_ctx": 8192,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object"}
+                }
+            }],
+            "tool_choice": "auto"
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.temperature, Some(0.7));
+        assert_eq!(req.top_p, Some(0.9));
+        assert_eq!(req.max_tokens, Some(512));
+        assert_eq!(req.n, Some(1));
+        assert_eq!(req.stop.as_ref().unwrap().len(), 1);
+        assert_eq!(req.num_ctx, Some(8192));
+        assert_eq!(req.tools.as_ref().unwrap().len(), 1);
+        assert_eq!(req.tools.as_ref().unwrap()[0].function.name, "get_weather");
+    }
+
+    #[test]
+    fn chat_request_with_tool_message() {
+        let json = r#"{
+            "model": "test",
+            "messages": [
+                {"role": "user", "content": "What's the weather?"},
+                {"role": "assistant", "content": null, "tool_calls": [{
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":\"NYC\"}"}
+                }]},
+                {"role": "tool", "tool_call_id": "call_123", "content": "72°F sunny"}
+            ]
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.messages.len(), 3);
+        assert_eq!(req.messages[1].role, "assistant");
+        assert!(req.messages[1].tool_calls.is_some());
+        assert_eq!(req.messages[2].role, "tool");
+        assert_eq!(req.messages[2].tool_call_id.as_deref(), Some("call_123"));
+    }
+
+    // =========================================================================
+    // ChatCompletionResponse serialization tests
+    // =========================================================================
+
+    #[test]
+    fn chat_response_serializes_correctly() {
+        let resp = ChatCompletionResponse {
+            id: "chatcmpl-123".into(),
+            object: "chat.completion".into(),
+            created: 1700000000,
+            model: "llama-3".into(),
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: Some("Hello!".into()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("stop".into()),
+            }],
+            usage: Some(Usage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+            }),
+        };
+
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["id"], "chatcmpl-123");
+        assert_eq!(json["object"], "chat.completion");
+        assert_eq!(json["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(json["choices"][0]["message"]["content"], "Hello!");
+        assert_eq!(json["choices"][0]["finish_reason"], "stop");
+        assert_eq!(json["usage"]["total_tokens"], 15);
+    }
+
+    #[test]
+    fn chat_response_omits_none_usage() {
+        let resp = ChatCompletionResponse {
+            id: "test".into(),
+            object: "chat.completion".into(),
+            created: 0,
+            model: "test".into(),
+            choices: vec![],
+            usage: None,
+        };
+
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("usage").is_none() || json["usage"].is_null());
+    }
+
+    // =========================================================================
+    // Streaming chunk serialization tests
+    // =========================================================================
+
+    #[test]
+    fn chat_chunk_serializes_with_delta() {
+        let chunk = ChatCompletionChunk {
+            id: "chatcmpl-123".into(),
+            object: "chat.completion.chunk".into(),
+            created: 1700000000,
+            model: "llama-3".into(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: Some("assistant".into()),
+                    content: Some("Hi".into()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+        };
+
+        let json = serde_json::to_value(&chunk).unwrap();
+        assert_eq!(json["object"], "chat.completion.chunk");
+        assert_eq!(json["choices"][0]["delta"]["content"], "Hi");
+        // finish_reason should be null (not omitted) for streaming
+        assert!(json["choices"][0].get("finish_reason").is_some());
+    }
+
+    #[test]
+    fn chat_chunk_with_tool_call_delta() {
+        let chunk = ChatCompletionChunk {
+            id: "test".into(),
+            object: "chat.completion.chunk".into(),
+            created: 0,
+            model: "test".into(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: Some(vec![ToolCallDelta {
+                        index: 0,
+                        id: Some("call_abc".into()),
+                        r#type: Some("function".into()),
+                        function: Some(ToolCallFunctionDelta {
+                            name: Some("get_weather".into()),
+                            arguments: Some("{\"city\":".into()),
+                        }),
+                    }]),
+                },
+                finish_reason: None,
+            }],
+        };
+
+        let json = serde_json::to_value(&chunk).unwrap();
+        let tc = &json["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(tc["id"], "call_abc");
+        assert_eq!(tc["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn chat_delta_omits_none_fields() {
+        let delta = ChatDelta {
+            role: None,
+            content: None,
+            tool_calls: None,
+        };
+        let json = serde_json::to_value(&delta).unwrap();
+        // All fields have skip_serializing_if, so the JSON should be minimal
+        assert!(json.get("role").is_none() || json["role"].is_null());
+        assert!(json.get("content").is_none() || json["content"].is_null());
+        assert!(json.get("tool_calls").is_none() || json["tool_calls"].is_null());
+    }
+
+    // =========================================================================
+    // ChatMessage serialization tests
+    // =========================================================================
+
+    #[test]
+    fn chat_message_omits_none_tool_fields() {
+        let msg = ChatMessage {
+            role: "user".into(),
+            content: Some("hello".into()),
+            tool_calls: None,
+            tool_call_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["role"], "user");
+        assert_eq!(json["content"], "hello");
+        // tool_calls and tool_call_id should be omitted
+        assert!(
+            json.get("tool_calls").is_none() || json["tool_calls"].is_null(),
+            "tool_calls should be omitted when None"
+        );
+    }
+
+    #[test]
+    fn chat_message_with_tool_calls_serializes() {
+        let msg = ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".into(),
+                r#type: "function".into(),
+                function: ToolCallFunction {
+                    name: "search".into(),
+                    arguments: r#"{"q":"rust"}"#.into(),
+                },
+            }]),
+            tool_call_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert!(json.get("content").is_none() || json["content"].is_null());
+        assert_eq!(json["tool_calls"][0]["id"], "call_1");
+        assert_eq!(json["tool_calls"][0]["function"]["name"], "search");
+    }
+}

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -26,7 +26,7 @@ gglib-core (ports)          gglib-runtime                   External
                             └──────────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 
@@ -96,7 +96,6 @@ See the [Architecture Overview](../../README.md#architecture-overview) for the c
 - **`system/`** — System probes (GPU detection, memory info)
 - **`assistant_ui/`** — Terminal-based interactive chat UI for llama-cli
 - **`ports_impl/`** — Port trait implementations for runtime
-- **`command.rs`** — Command-line argument builder for llama binaries
 
 ## Features
 

--- a/crates/gglib-tauri/README.md
+++ b/crates/gglib-tauri/README.md
@@ -33,7 +33,7 @@ This crate is in the **Adapter Layer** — it provides the Tauri backend that br
 └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘
 ```
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Internal Structure
 
@@ -90,29 +90,36 @@ See the [Architecture Overview](../../README.md#architecture-overview) for the c
 
 ## IPC Commands
 
-| Command | Description |
-|---------|-------------|
-| `list_models` | Get all models |
-| `add_model` | Add a GGUF file |
-| `remove_model` | Delete a model |
-| `serve_model` | Start llama-server |
-| `stop_server` | Stop a running server |
-| `search_hf` | Search HuggingFace |
-| `download_model` | Queue a download |
-| `get_download_status` | Poll download progress |
-| `list_mcp_servers` | Get MCP server configs |
-| `start_mcp_server` | Start an MCP server |
+The desktop app uses an **HTTP-first architecture** — model operations, chat, downloads, and proxy management all go through the embedded Axum API server. Tauri IPC commands are limited to OS integration:
+
+| Command | Module | Description |
+|---------|--------|-------------|
+| `get_embedded_api_info` | util | Discover API port and auth token |
+| `get_server_logs` | util | Fetch server log buffer |
+| `open_url` | util | Open URL in system browser |
+| `set_selected_model` | util | Sync native menu selection |
+| `sync_menu_state` | util | Update native menu item states |
+| `set_proxy_state` | util | Update proxy menu toggle |
+| `check_llama_status` | llama | Check llama.cpp installation |
+| `install_llama` | llama | Install/build llama.cpp |
+| `log_from_frontend` | app_logs | Forward frontend logs to Rust logger |
+| `init_research_logs` | research_logs | Initialize research log directory |
+| `append_research_log` | research_logs | Append line to research session log |
+| `get_research_log_path` | research_logs | Get filesystem path for a session |
+| `list_research_logs` | research_logs | List available research sessions |
+
+See [src-tauri/README.md](../../src-tauri/README.md) for the full architecture explanation.
 
 ## Events
 
-Events are emitted to the frontend via Tauri's event system:
+Real-time events are delivered via SSE (`/api/events`) with Bearer auth, not Tauri emit:
 
-| Event | Payload |
-|-------|---------|
-| `download:progress` | `{ id, progress, speed, eta }` |
-| `download:complete` | `{ id, path }` |
-| `server:status` | `{ id, status, port }` |
-| `mcp:tool_result` | `{ server_id, tool, result }` |
+| Event | Description |
+|-------|-------------|
+| `server:*` | Server lifecycle (start, ready, stop, error) |
+| `download:*` | Download progress and completion |
+| `log:*` | Server console output |
+| `voice:*` | Voice pipeline state, transcripts, audio levels |
 
 ## Usage
 

--- a/crates/gglib-voice/README.md
+++ b/crates/gglib-voice/README.md
@@ -11,7 +11,7 @@ Voice mode pipeline for gglib — fully local speech-to-text, text-to-speech, an
 
 This crate is in the **Infrastructure Layer** — it manages audio I/O, speech recognition, and speech synthesis using native OS audio APIs and on-device ML models.
 
-See the [Architecture Overview](../../README.md#architecture-overview) for the complete diagram.
+See the [Architecture Overview](../../README.md#architecture) for the complete diagram.
 
 ## Overview
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -6,7 +6,7 @@ This directory contains the Tauri-based desktop application for GGLib.
 
 The GGLib Desktop GUI is one of three complementary interfaces for managing GGUF models (along with the CLI and Web UI). All interfaces share the same backend architecture, ensuring consistent functionality and behavior.
 
-For a complete overview of all interfaces and the shared architecture, see the main [README.md](../README.md#interfaces--modes).
+For a complete overview of all interfaces and the shared architecture, see the main [README.md](../README.md#interfaces).
 
 ## Architecture
 
@@ -110,8 +110,8 @@ The output binary will be located in `target/release/bundle/`.
 - **No resource leaks**: Proper cleanup prevents thread exhaustion and zombie processes
 
 For more details on the architecture and how all interfaces work together, see:
-- [Interfaces & Modes](../README.md#interfaces--modes) in the main README
-- [Architecture Overview](../README.md#architecture-overview) for backend details
+- [Interfaces](../README.md#interfaces) in the main README
+- [Architecture Overview](../README.md#architecture) for backend details
 
 ## Project Structure
 

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -7,7 +7,7 @@
 
 This document provides a detailed reference for all available CLI commands.
 
-For an overview of all interfaces (CLI, Desktop GUI, Web UI), see the main [README](../README.md#interfaces--modes).
+For an overview of all interfaces (CLI, Desktop GUI, Web UI), see the main [README](../README.md#interfaces).
 
 ## Global Options
 
@@ -259,7 +259,7 @@ gglib web --api-only --port 9887
 gglib web --port 9887 --base-port 9000
 ```
 
-The web server binds to `0.0.0.0` by default, making it accessible from your LAN. See [Interfaces & Modes](../README.md#interfaces--modes) for details.
+The web server binds to `0.0.0.0` by default, making it accessible from your LAN. See [Interfaces](../README.md#interfaces) for details.
 
 ### llama.cpp Management
 
@@ -405,11 +405,10 @@ gglib config settings reset
 
 ## See Also
 
-> Changing this configuration only affects future downloads; it does **not** move GGUF files that are already on disk. Move any existing models yourself if you want them to live in the new directory.
-
-- [Main README](../README.md) - Overview and getting started
-- [Interfaces & Modes](../README.md#interfaces--modes) - Understanding CLI, Desktop GUI, and Web UI
-- [Architecture Overview](../README.md#architecture-overview) - How GGLib is structured
-- [Desktop GUI Documentation](../src-tauri/README.md) - Tauri app details
+- [Main README](../README.md) — Overview and getting started
+- [Interfaces](../README.md#interfaces) — CLI, Desktop GUI, Web UI, and Proxy
+- [Architecture](../README.md#architecture) — How GGLib is structured
+- [gglib-cli crate](../../crates/gglib-cli/README.md) — Rust source for the CLI
+- [Desktop GUI](../src-tauri/README.md) — Tauri app details
 
 <!-- module-docs:end -->

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -1,31 +1,12 @@
 <!-- module-docs:start -->
 
-# Models Module
+# Models
 
 ![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-models-loc.json)
 ![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-models-complexity.json)
 
-This module defines the core data structures, database entities, and Data Transfer Objects (DTOs) used throughout the application.
+Data structures shared across the application — domain types, database entities, and DTOs for API/GUI responses.
 
-## Architecture
-
-```text
-┌─────────────┐      ┌────────────────┐
-│  Database   │ ───► │   Core Model   │
-│   Entity    │      │    Structs     │
-└──────┬──────┘      └───────┬────────┘
-       │                     │
-       ▼                     ▼
-┌─────────────┐      ┌────────────────┐
-│     DTOs    │ ◄─── │    Metadata    │
-│ (API/JSON)  │      │   (GGUF Info)  │
-└─────────────┘      └────────────────┘
-```
-
-## Components
-
-- **`lib.rs` / `mod.rs`**: Core struct definitions (`Model`, `ModelFile`, etc.).
-- **`gui.rs`**: DTOs specifically designed for the GUI/Web API responses.
-- **Metadata**: Structures representing the GGUF file header and metadata key-value pairs.
+The Rust definitions live in [gglib-core](../../crates/gglib-core/README.md) (`domain/`, `ports/`). TypeScript equivalents are in [src/types](../types/README.md).
 
 <!-- module-docs:end -->

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,38 +1,26 @@
 <!-- module-docs:start -->
 
-# Utilities Module
+# Utilities
 
 ![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-utils-loc.json)
 ![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-utils-complexity.json)
 
-This module contains low-level helper functions and shared utilities used across the application.
+Shared TypeScript helpers used across the React frontend.
 
-## Architecture
+## Files
 
-```text
-┌─────────────┐      ┌────────────────┐
-│   System    │      │   Validation   │
-│ (OS/Paths)  │      │ (Input/Files)  │
-└──────┬──────┘      └───────┬────────┘
-       │                     │
-       ▼                     ▼
-┌─────────────┐      ┌────────────────┐
-│ GGUF Parser │      │    Process     │
-│ (Metadata)  │      │ (Mgmt/Signals) │
-└─────────────┘      └────────────────┘
-```
+| File | Purpose |
+|------|---------|
+| `cn.ts` | Tailwind class merging utility (clsx + tailwind-merge) |
+| `format.ts` | Number and date formatting helpers |
+| `platform.ts` | Platform detection (Tauri vs web, OS) |
+| `sse.ts` | Server-Sent Events client with reconnect logic |
+| `modelSearchParser.ts` | Parse HuggingFace search queries and filters |
+| `thinkingParser.ts` | Parse `<think>` blocks from reasoning model output |
+| `stripThinkingBlocks.ts` | Remove thinking blocks for clean display |
+| `batchWithinWindow.ts` | Batch rapid events within a time window |
+| `messages/` | Chat message transformation helpers |
 
-## Components
-
-- **`system.rs`**: OS-specific operations, hardware detection, and system info.
-- **`paths.rs`**: Directory resolution for config, cache, and data storage.
-- **`config.rs`**: Helpers for persisting `.env` overrides (models dir, fast download mode) and parsing runtime settings.
-- **`validation.rs`**: Input validation and file integrity checks.
-- **`gguf_parser.rs`**: Specialized parser for extracting metadata from GGUF files. Includes `detect_reasoning_support()` for auto-detecting reasoning models (DeepSeek R1, Qwen3, QwQ, etc.) from chat template patterns and model names.
-- **`input.rs`**: CLI user input handling (prompts, confirmations).
-- **`process/`**: Low-level process management utilities.
-  - **`log_streamer.rs`**: `ServerLogManager` for capturing and broadcasting llama-server stdout/stderr logs. Provides real-time log streaming via broadcast channels and maintains a ring buffer of recent logs per server port.
-  - **`events.rs`**: `ServerEvent` types for lifecycle state synchronization. Defines the event schema used by both Tauri and SSE to notify frontends of server state changes.
-  - **`event_broadcaster.rs`**: `ServerEventBroadcaster` for SSE clients in web mode. Uses a tokio broadcast channel to fan out events to multiple connected clients.
+For Rust-side utilities (paths, config, process management), see [gglib-core](../../crates/gglib-core/README.md) and [gglib-runtime](../../crates/gglib-runtime/README.md).
 
 <!-- module-docs:end -->


### PR DESCRIPTION
## Summary

Comprehensive README cleanup across 19 files — fixes stale content, broken anchor links, and inaccurate documentation.

### Changes

**Main README**
- Rewrite intro with practical "Quick Look" CLI examples
- Tighten Architecture and Interfaces sections
- Reorder Installation to lead with pre-built binaries
- Reorganise Module Reference (accurate TypeScript frontend sections)

**Crate READMEs**
- Replace completely stale IPC commands table in gglib-tauri with actual 13 commands from source
- Trim gglib-proxy 80-line mock code block to concise usage example
- Rename "Presentation Layer" → "Adapter Layer" in crates/README for consistency
- Remove duplicate `command.rs` entry in gglib-runtime
- Merge redundant Overview section in gglib-hf

**Frontend READMEs**
- Rewrite src/models/README.md (was describing nonexistent Rust files)
- Rewrite src/utils/README.md (was describing Rust files, now documents actual TS utilities)
- Remove dangling orphan paragraph in src/commands/README.md

**Anchor fixes (18 replacements)**
- Fix 14 stale `#architecture-overview` → `#architecture` links across all crate READMEs + src-tauri
- Fix 4 stale `#interfaces--modes` → `#interfaces` links in src/commands and src-tauri
