### PR TITLE
refactor(frontend): simplify TOOL_ENABLED_SYSTEM_PROMPT (#253)

### DIFF
--- a/src/hooks/useGglibRuntime/agentLoop.ts
+++ b/src/hooks/useGglibRuntime/agentLoop.ts
@@ -286,14 +286,10 @@ export function checkToolLoop(
 // =============================================================================
 
 /** System prompt for tool-enabled models (agent/reasoning with Jinja) */
-export const TOOL_ENABLED_SYSTEM_PROMPT = `You are an assistant with tools.
+export const TOOL_ENABLED_SYSTEM_PROMPT = `You are a helpful assistant with access to tools.
 
-Rules:
-- If you need information or actions, use tool_calls. Do not guess.
-- Keep explanations brief while working; prefer tool use.
-- When you are done, respond naturally in plain text.
-
-Do not output chain-of-thought.`;
+When you need information or actions, use the available tools rather than guessing.
+Keep working explanations concise. When you have enough information, provide your final answer directly.`;
 
 /** System prompt for non-tool models (plain chat) */
 export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful assistant.';


### PR DESCRIPTION
## Summary

Phase 3 of #242. Simplifies `TOOL_ENABLED_SYSTEM_PROMPT` in `agentLoop.ts` by removing the structured output envelope requirement and the overly-restrictive "Do not output chain-of-thought" instruction.

## Changes

- **`src/hooks/useGglibRuntime/agentLoop.ts`**: Rewrites `TOOL_ENABLED_SYSTEM_PROMPT` with a clean, model-agnostic prompt

## Before / After

**Before:**
```
You are an assistant with tools.

Rules:
- If you need information or actions, use tool_calls. Do not guess.
- Keep explanations brief while working; prefer tool use.
- When you are done, respond naturally in plain text.

Do not output chain-of-thought.
```

**After:**
```
You are a helpful assistant with access to tools.

When you need information or actions, use the available tools rather than guessing.
Keep working explanations concise. When you have enough information, provide your final answer directly.
```

## Acceptance Criteria

- [x] No structured output requirements in the system prompt
- [x] Prompt works with models that have poor instruction following
- [x] Prompt encourages tool use without demanding specific output formats
- [x] `DEFAULT_SYSTEM_PROMPT` unchanged (`'You are a helpful assistant.'`)

Closes #253