### PR TITLE
sub(#243) Phase 1: Extract system prompt builder module

### DIFF
--- a/src/hooks/useGglibRuntime/agentLoop.ts
+++ b/src/hooks/useGglibRuntime/agentLoop.ts
@@ -285,18 +285,5 @@ export function checkToolLoop(
 // Prompts
 // =============================================================================
 
-/** System prompt for tool-enabled models (agent/reasoning with Jinja) */
-export const TOOL_ENABLED_SYSTEM_PROMPT = `You are a helpful assistant with access to tools.
-
-When you need information or actions, use the available tools rather than guessing.
-Keep working explanations concise. When you have enough information, provide your final answer directly.`;
-
-/** System prompt for non-tool models (plain chat) */
+/** Default system prompt for plain chat (no tools). */
 export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful assistant.';
-
-/**
- * Get appropriate system prompt based on tool availability.
- */
-export function getSystemPrompt(hasTools: boolean): string {
-  return hasTools ? TOOL_ENABLED_SYSTEM_PROMPT : DEFAULT_SYSTEM_PROMPT;
-}

--- a/src/hooks/useGglibRuntime/index.ts
+++ b/src/hooks/useGglibRuntime/index.ts
@@ -54,9 +54,7 @@ export {
 // Agent loop utilities (exported for testing and configuration)
 export {
   DEFAULT_MAX_TOOL_ITERS,
-  TOOL_ENABLED_SYSTEM_PROMPT,
   DEFAULT_SYSTEM_PROMPT,
-  getSystemPrompt,
   type AgentLoopState,
   type ToolDigest,
   type ChatMessage,
@@ -69,3 +67,12 @@ export {
   pruneForBudget,
   summarizeToolResult,
 } from './agentLoop';
+
+// Prompt composition (exported for testing and reuse)
+export {
+  buildSystemPrompt,
+  TOOL_INSTRUCTIONS_LAYER,
+  FORMAT_REMINDER,
+  FORMAT_REMINDER_LAYER,
+  type PromptLayer,
+} from './promptBuilder';

--- a/src/hooks/useGglibRuntime/promptBuilder.ts
+++ b/src/hooks/useGglibRuntime/promptBuilder.ts
@@ -1,0 +1,88 @@
+/**
+ * Prompt composition utilities — additive injection of prompt layers.
+ *
+ * Instead of hot-swapping system prompts by exact string match, callers
+ * build a final system prompt by composing a base string with an ordered
+ * set of `PromptLayer` fragments. Layers are sorted by `priority` (lower
+ * value = earlier), then split into prepends (inserted before the base)
+ * and appends (inserted after the base). Empty segments are filtered
+ * before joining so no dangling newlines appear when the base is empty.
+ *
+ * @module promptBuilder
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface PromptLayer {
+  /** Unique identifier for this layer. */
+  id: string;
+  /** Prompt fragment text to inject. */
+  content: string;
+  /** Whether this layer is inserted before or after the base prompt. */
+  position: 'prepend' | 'append';
+  /** Ordering key — lower numbers appear first within each position group. */
+  priority: number;
+}
+
+// =============================================================================
+// Core builder
+// =============================================================================
+
+/**
+ * Compose a final system prompt from a base string and an ordered list of
+ * `PromptLayer` fragments.
+ *
+ * Layers are sorted by `priority`, then split into `prepend` and `append`
+ * groups. The final string is:
+ *
+ *   [...prepends, basePrompt, ...appends].join('\n\n')
+ *
+ * Empty or whitespace-only segments are filtered out before joining so that
+ * an empty `basePrompt` never introduces a leading or trailing blank block.
+ *
+ * @param basePrompt - The user-supplied or default system prompt.
+ * @param layers     - Layers to inject around the base prompt.
+ * @returns Composed system prompt string.
+ */
+export function buildSystemPrompt(basePrompt: string, layers: PromptLayer[]): string {
+  const sorted = [...layers].sort((a, b) => a.priority - b.priority);
+  const prepends = sorted.filter(l => l.position === 'prepend').map(l => l.content);
+  const appends  = sorted.filter(l => l.position === 'append').map(l => l.content);
+
+  return [...prepends, basePrompt, ...appends]
+    .filter(s => s && s.trim() !== '')
+    .join('\n\n');
+}
+
+// =============================================================================
+// Standard layers
+// =============================================================================
+
+/**
+ * Tool-usage instructions appended when the model has access to tools.
+ * This is the single source of truth for tool guidance text; it is injected
+ * additively on top of whichever base system prompt the user has configured.
+ */
+export const TOOL_INSTRUCTIONS_LAYER: PromptLayer = {
+  id: 'tool-instructions',
+  content:
+    'When you need information or actions, use the available tools rather than guessing.\n' +
+    'Keep working explanations concise. When you have enough information, provide your final answer directly.',
+  position: 'append',
+  priority: 100,
+};
+
+/**
+ * General format reminder appended after all tool instructions.
+ * Intended as a lightweight nudge; content can be refined in a later phase.
+ */
+export const FORMAT_REMINDER = 'Please respond clearly and directly.';
+
+export const FORMAT_REMINDER_LAYER: PromptLayer = {
+  id: 'format-reminder',
+  content: FORMAT_REMINDER,
+  position: 'append',
+  priority: 200,
+};

--- a/src/hooks/useGglibRuntime/streamModelResponse.ts
+++ b/src/hooks/useGglibRuntime/streamModelResponse.ts
@@ -15,24 +15,37 @@ import { createToolCallAccumulator, type AccumulatedToolCall } from './accumulat
 import { createThinkingContentHandler } from './thinkingContentHandler';
 import { PartsAccumulator } from './partsAccumulator';
 import type { GglibContent } from '../../types/messages';
-import { DEFAULT_SYSTEM_PROMPT, TOOL_ENABLED_SYSTEM_PROMPT, withRetry } from './agentLoop';
+import { withRetry } from './agentLoop';
+import { buildSystemPrompt, TOOL_INSTRUCTIONS_LAYER } from './promptBuilder';
 import type { ReasoningTimingTracker } from './reasoningTiming';
 
-function hotSwapDefaultSystemPrompt(messages: any[], hasTools: boolean): any[] {
+/**
+ * Additively inject tool instructions into the system message.
+ *
+ * Unlike the old `hotSwapDefaultSystemPrompt`, this function:
+ * - Never performs an exact-string match on the base prompt
+ * - Always appends tool guidance when tools are present, regardless of
+ *   whether the user customised the system prompt
+ * - Composes via string join rather than array splicing
+ */
+function injectToolInstructions(messages: any[], hasTools: boolean): any[] {
   if (!hasTools) return messages;
 
-  // Only swap when the stored system prompt is *exactly* the default prompt.
-  // This preserves user customizations (even minor edits/whitespace changes).
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (msg?.role === 'system' && typeof msg.content === 'string' && msg.content === DEFAULT_SYSTEM_PROMPT) {
-      const cloned = messages.slice();
-      cloned[i] = { ...msg, content: TOOL_ENABLED_SYSTEM_PROMPT };
-      return cloned;
-    }
+  const sysIdx = messages.findIndex(
+    (m: any) => m?.role === 'system' && typeof m.content === 'string',
+  );
+
+  if (sysIdx >= 0) {
+    const cloned = messages.slice();
+    cloned[sysIdx] = {
+      ...cloned[sysIdx],
+      content: buildSystemPrompt(cloned[sysIdx].content as string, [TOOL_INSTRUCTIONS_LAYER]),
+    };
+    return cloned;
   }
 
-  return messages;
+  // No existing system message — prepend a composed one.
+  return [{ role: 'system', content: buildSystemPrompt('', [TOOL_INSTRUCTIONS_LAYER]) }, ...messages];
 }
 
 export interface StreamModelResponseOptions {
@@ -65,7 +78,7 @@ export async function streamModelResponse(
   const { serverPort, messages, toolDefinitions, abortSignal, onContentUpdate, messageId, timingTracker } = options;
 
   const hasTools = toolDefinitions.length > 0;
-  const effectiveMessages = hotSwapDefaultSystemPrompt(messages, hasTools);
+  const effectiveMessages = injectToolInstructions(messages, hasTools);
 
   const requestBody = {
     port: serverPort,

--- a/tests/ts/hooks/useGglibRuntime/promptBuilder.test.ts
+++ b/tests/ts/hooks/useGglibRuntime/promptBuilder.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the promptBuilder composition utilities.
+ *
+ * Coverage:
+ * - buildSystemPrompt() — no layers, single prepend, single append, priority
+ *   ordering, mixed prepend+append, empty base prompt filtering
+ * - TOOL_INSTRUCTIONS_LAYER and FORMAT_REMINDER_LAYER shape invariants
+ * - Key regression: injectToolInstructions-style composition works for
+ *   *any* base prompt, not just the exact DEFAULT_SYSTEM_PROMPT string
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildSystemPrompt,
+  TOOL_INSTRUCTIONS_LAYER,
+  FORMAT_REMINDER_LAYER,
+  FORMAT_REMINDER,
+  type PromptLayer,
+} from '../../../../src/hooks/useGglibRuntime/promptBuilder';
+
+// =============================================================================
+// helpers
+// =============================================================================
+
+function layer(overrides: Partial<PromptLayer> & Pick<PromptLayer, 'id' | 'content'>): PromptLayer {
+  return {
+    position: 'append',
+    priority: 100,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// buildSystemPrompt
+// =============================================================================
+
+describe('buildSystemPrompt', () => {
+  describe('no layers', () => {
+    it('returns the base prompt unchanged', () => {
+      expect(buildSystemPrompt('You are a helpful assistant.', [])).toBe(
+        'You are a helpful assistant.',
+      );
+    });
+
+    it('returns an empty string when both base and layers are empty', () => {
+      expect(buildSystemPrompt('', [])).toBe('');
+    });
+  });
+
+  describe('single append layer', () => {
+    it('appends the layer content after the base prompt', () => {
+      const l = layer({ id: 'a', content: 'Use tools.' });
+      expect(buildSystemPrompt('You are a helpful assistant.', [l])).toBe(
+        'You are a helpful assistant.\n\nUse tools.',
+      );
+    });
+  });
+
+  describe('single prepend layer', () => {
+    it('prepends the layer content before the base prompt', () => {
+      const l = layer({ id: 'a', content: 'Context preamble.', position: 'prepend' });
+      expect(buildSystemPrompt('You are a helpful assistant.', [l])).toBe(
+        'Context preamble.\n\nYou are a helpful assistant.',
+      );
+    });
+  });
+
+  describe('priority ordering', () => {
+    it('sorts multiple append layers by ascending priority', () => {
+      const high = layer({ id: 'high', content: 'HIGH', priority: 50 });
+      const low  = layer({ id: 'low',  content: 'LOW',  priority: 200 });
+      const mid  = layer({ id: 'mid',  content: 'MID',  priority: 100 });
+
+      // Intentionally pass in reverse order to prove sorting is applied.
+      expect(buildSystemPrompt('BASE', [low, high, mid])).toBe(
+        'BASE\n\nHIGH\n\nMID\n\nLOW',
+      );
+    });
+
+    it('sorts multiple prepend layers by ascending priority', () => {
+      const first  = layer({ id: 'first',  content: 'FIRST',  position: 'prepend', priority: 10 });
+      const second = layer({ id: 'second', content: 'SECOND', position: 'prepend', priority: 20 });
+
+      expect(buildSystemPrompt('BASE', [second, first])).toBe(
+        'FIRST\n\nSECOND\n\nBASE',
+      );
+    });
+  });
+
+  describe('mixed prepend and append layers', () => {
+    it('places prepends before base and appends after base', () => {
+      const pre  = layer({ id: 'pre',  content: 'PRE',  position: 'prepend', priority: 10 });
+      const post = layer({ id: 'post', content: 'POST', position: 'append',  priority: 10 });
+
+      expect(buildSystemPrompt('BASE', [post, pre])).toBe('PRE\n\nBASE\n\nPOST');
+    });
+  });
+
+  describe('empty segment filtering', () => {
+    it('does not produce a leading newline when the base prompt is empty', () => {
+      const l = layer({ id: 'a', content: 'Use tools.' });
+      const result = buildSystemPrompt('', [l]);
+      expect(result).toBe('Use tools.');
+      expect(result.startsWith('\n')).toBe(false);
+    });
+
+    it('does not produce a trailing newline when an append layer is empty', () => {
+      const empty = layer({ id: 'empty', content: '   ' });
+      const result = buildSystemPrompt('BASE', [empty]);
+      expect(result).toBe('BASE');
+      expect(result.endsWith('\n')).toBe(false);
+    });
+
+    it('skips whitespace-only layer content', () => {
+      const blank = layer({ id: 'blank', content: '\n  \n' });
+      const real  = layer({ id: 'real',  content: 'Real.',  priority: 200 });
+      expect(buildSystemPrompt('BASE', [blank, real])).toBe('BASE\n\nReal.');
+    });
+  });
+
+  describe('does not mutate the input layers array', () => {
+    it('leaves the original layers array unsorted', () => {
+      const layers: PromptLayer[] = [
+        layer({ id: 'z', content: 'Z', priority: 300 }),
+        layer({ id: 'a', content: 'A', priority: 100 }),
+      ];
+      buildSystemPrompt('BASE', layers);
+      expect(layers[0].id).toBe('z');
+      expect(layers[1].id).toBe('a');
+    });
+  });
+});
+
+// =============================================================================
+// Standard layer shape invariants
+// =============================================================================
+
+describe('TOOL_INSTRUCTIONS_LAYER', () => {
+  it('has id "tool-instructions"', () => {
+    expect(TOOL_INSTRUCTIONS_LAYER.id).toBe('tool-instructions');
+  });
+
+  it('appends at priority 100', () => {
+    expect(TOOL_INSTRUCTIONS_LAYER.position).toBe('append');
+    expect(TOOL_INSTRUCTIONS_LAYER.priority).toBe(100);
+  });
+
+  it('contains non-empty tool guidance text', () => {
+    expect(TOOL_INSTRUCTIONS_LAYER.content.trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe('FORMAT_REMINDER_LAYER', () => {
+  it('has id "format-reminder"', () => {
+    expect(FORMAT_REMINDER_LAYER.id).toBe('format-reminder');
+  });
+
+  it('appends after tool instructions (priority 200 > 100)', () => {
+    expect(FORMAT_REMINDER_LAYER.position).toBe('append');
+    expect(FORMAT_REMINDER_LAYER.priority).toBe(200);
+    expect(FORMAT_REMINDER_LAYER.priority).toBeGreaterThan(TOOL_INSTRUCTIONS_LAYER.priority);
+  });
+
+  it('content matches the exported FORMAT_REMINDER constant', () => {
+    expect(FORMAT_REMINDER_LAYER.content).toBe(FORMAT_REMINDER);
+  });
+});
+
+// =============================================================================
+// Regression: tool injection works for any base prompt
+// =============================================================================
+
+describe('tool injection regression (any base prompt)', () => {
+  const customPrompts = [
+    'You are a helpful assistant.',               // exact DEFAULT_SYSTEM_PROMPT
+    'You are a pirate assistant.',                // customised
+    'You are a helpful assistant. Be concise.',   // minor edit that old exact-match would miss
+    'Custom system prompt with extra context.\nMultiple lines.',
+  ];
+
+  it.each(customPrompts)(
+    'injects tool instructions regardless of base prompt content: "%s"',
+    (base) => {
+      const result = buildSystemPrompt(base, [TOOL_INSTRUCTIONS_LAYER]);
+      expect(result).toContain(base);
+      expect(result).toContain(TOOL_INSTRUCTIONS_LAYER.content);
+      // Tool instructions come AFTER the base prompt.
+      expect(result.indexOf(base)).toBeLessThan(result.indexOf(TOOL_INSTRUCTIONS_LAYER.content));
+    },
+  );
+});


### PR DESCRIPTION
## Parent: #243 — Replace system prompt hot-swap with additive injection

## Summary

Implements issue #257: extracts system prompt construction logic into a dedicated `promptBuilder.ts` module and replaces the fragile `hotSwapDefaultSystemPrompt()` hot-swap with an always-on additive injection pattern.

## Changes

### Created
- `src/hooks/useGglibRuntime/promptBuilder.ts` — `PromptLayer` type, `buildSystemPrompt()` function, `TOOL_INSTRUCTIONS_LAYER`, `FORMAT_REMINDER_LAYER` constants
- `tests/ts/hooks/useGglibRuntime/promptBuilder.test.ts` — 21 unit tests

### Modified
- `src/hooks/useGglibRuntime/streamModelResponse.ts` — renamed `hotSwapDefaultSystemPrompt` → `injectToolInstructions`, uses `buildSystemPrompt` via string composition (no exact-match guard)
- `src/hooks/useGglibRuntime/agentLoop.ts` — **deleted** `TOOL_ENABLED_SYSTEM_PROMPT` and `getSystemPrompt` entirely (clean break, no alias)
- `src/hooks/useGglibRuntime/index.ts` — removed deleted symbols, added `promptBuilder` re-exports

## Acceptance Criteria

- [x] `promptBuilder.ts` created with `PromptLayer` interface and `buildSystemPrompt()`
- [x] Standard prompt layers extracted as named constants
- [x] `hotSwapDefaultSystemPrompt()` removed; replaced by `injectToolInstructions()` which delegates to the new builder
- [x] Unit tests covering ordering, empty-segment filtering, immutability
- [x] Regression suite proves injection fires for **any** base prompt — not just exact `DEFAULT_SYSTEM_PROMPT`
- [x] `TOOL_ENABLED_SYSTEM_PROMPT` and `getSystemPrompt` deleted with no backward-compat alias

## Test results

```
Tests  21 passed (21)
```

Pre-existing `thinkingContentHandler` failures are unrelated to this PR and present on `main`.
