### PR TITLE
feat(#258): Phase 2 - wire additive prompt composition into agentic loop

### DIFF
--- a/src/hooks/useGglibRuntime/agentLoop.ts
+++ b/src/hooks/useGglibRuntime/agentLoop.ts
@@ -163,45 +163,6 @@ export function summarizeToolResult(_name: string, res: ToolResult): string {
 }
 
 /**
- * Build working memory system message from tool digests.
- */
-export function buildWorkingMemory(digests: ToolDigest[]): string {
-  const lines: string[] = ['WORKING_MEMORY:'];
-  for (const d of digests.slice(-KEEP_LAST_TOOL_MESSAGES)) {
-    lines.push(`- ${d.name} (${d.ok ? 'ok' : 'fail'}): ${d.summary}`);
-  }
-  return lines.join('\n');
-}
-
-/**
- * Upsert working memory system message in conversation.
- */
-export function upsertWorkingMemory(
-  messages: ChatMessage[],
-  memory: string
-): ChatMessage[] {
-  const idx = messages.findIndex(
-    (m) => m.role === 'system' && m.content?.startsWith('WORKING_MEMORY:')
-  );
-  const memMsg: ChatMessage = { role: 'system', content: memory };
-
-  if (idx === -1) {
-    // Insert after first system message if present, else at top
-    const firstSys = messages.findIndex((m) => m.role === 'system');
-    if (firstSys >= 0) {
-      const out = messages.slice();
-      out.splice(firstSys + 1, 0, memMsg);
-      return out;
-    }
-    return [memMsg, ...messages];
-  }
-
-  const out = messages.slice();
-  out[idx] = memMsg;
-  return out;
-}
-
-/**
  * Calculate total character count of messages.
  */
 function totalChars(messages: ChatMessage[]): number {
@@ -214,16 +175,12 @@ function totalChars(messages: ChatMessage[]): number {
 export function pruneForBudget(messages: ChatMessage[]): ChatMessage[] {
   if (totalChars(messages) <= MAX_CONTEXT_CHARS) return messages;
 
-  const isWorkingMemory = (m: ChatMessage) =>
-    m.role === 'system' && m.content?.startsWith('WORKING_MEMORY:');
-
   const toolMsgs = messages.filter((m) => m.role === 'tool');
   const keepToolIds = new Set(
     toolMsgs.slice(-KEEP_LAST_TOOL_MESSAGES).map((m) => m.tool_call_id)
   );
 
   let out = messages.filter((m) => {
-    if (isWorkingMemory(m)) return true;
     if (m.role !== 'tool') return true;
     return keepToolIds.has(m.tool_call_id);
   });

--- a/src/hooks/useGglibRuntime/index.ts
+++ b/src/hooks/useGglibRuntime/index.ts
@@ -62,8 +62,6 @@ export {
   withRetry,
   recordAssistantProgress,
   checkToolLoop,
-  buildWorkingMemory,
-  upsertWorkingMemory,
   pruneForBudget,
   summarizeToolResult,
 } from './agentLoop';
@@ -71,6 +69,8 @@ export {
 // Prompt composition (exported for testing and reuse)
 export {
   buildSystemPrompt,
+  injectPromptLayers,
+  createWorkingMemoryLayer,
   TOOL_INSTRUCTIONS_LAYER,
   FORMAT_REMINDER,
   FORMAT_REMINDER_LAYER,

--- a/src/hooks/useGglibRuntime/promptBuilder.ts
+++ b/src/hooks/useGglibRuntime/promptBuilder.ts
@@ -86,3 +86,77 @@ export const FORMAT_REMINDER_LAYER: PromptLayer = {
   position: 'append',
   priority: 200,
 };
+
+// =============================================================================
+// Message-array injection
+// =============================================================================
+
+/**
+ * Inject a set of `PromptLayer` fragments into an OpenAI-style message array,
+ * composing them into the first system message via `buildSystemPrompt`.
+ *
+ * ### Immutability contract
+ * - **Always returns a new array** (via `slice()`).
+ * - The system-message object is replaced with a spread copy:
+ *   `cloned[idx] = { ...original, content: composed }`.
+ *   **Never** `cloned[idx].content = composed` — `slice()` is a shallow copy,
+ *   so direct property mutation would bleed back into the caller's array.
+ *
+ * ### Double-injection safety
+ * `buildSystemPrompt` is **not** idempotent — it does not check whether a
+ * layer is already present before appending.  Sequential calls (e.g. once in
+ * `runAgenticLoop.ts` for working memory, then again in
+ * `streamModelResponse.ts` for tool/format layers) are safe **only** because
+ * the caller keeps its `apiMessages` array pristine and passes a fresh clone
+ * into each call.  The architectural guarantee lives in the caller, not here.
+ *
+ * @param messages - Source message array; never mutated.
+ * @param layers   - Layers to inject.  If empty, returns a defensive clone.
+ * @returns New array with the composed system message in place.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function injectPromptLayers(messages: readonly any[], layers: PromptLayer[]): any[] {
+  // Defensive clone even when there is nothing to inject.
+  if (layers.length === 0) return messages.slice();
+
+  const cloned = messages.slice();
+
+  const sysIdx = cloned.findIndex(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (m: any) => m?.role === 'system' && typeof m.content === 'string',
+  );
+
+  if (sysIdx >= 0) {
+    // ⚠ Spread-replace the object — do NOT assign .content directly.
+    cloned[sysIdx] = {
+      ...cloned[sysIdx],
+      content: buildSystemPrompt(cloned[sysIdx].content as string, layers),
+    };
+    return cloned;
+  }
+
+  // No existing system message — prepend one built from the layers alone.
+  return [{ role: 'system', content: buildSystemPrompt('', layers) }, ...messages];
+}
+
+// =============================================================================
+// Working-memory layer factory
+// =============================================================================
+
+/**
+ * Create a transient `PromptLayer` from pre-formatted working-memory digest
+ * lines.  Priority 300 places it after `TOOL_INSTRUCTIONS_LAYER` (100) and
+ * `FORMAT_REMINDER_LAYER` (200) so dynamic, iteration-specific context lands
+ * last in the composed system message — where models tend to weight it most.
+ *
+ * @param digestLines - One pre-formatted line per tool digest, e.g.
+ *   `"- search (ok): <summary>"`.
+ */
+export function createWorkingMemoryLayer(digestLines: string[]): PromptLayer {
+  return {
+    id: 'working-memory',
+    content: '## Working Memory\n' + digestLines.join('\n'),
+    position: 'append',
+    priority: 300,
+  };
+}

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -21,12 +21,15 @@ import {
   toolSignature,
   recordAssistantProgress,
   checkToolLoop,
-  buildWorkingMemory,
-  upsertWorkingMemory,
   pruneForBudget,
   summarizeToolResult,
   withRetry,
 } from './agentLoop';
+import {
+  type PromptLayer,
+  injectPromptLayers,
+  createWorkingMemoryLayer,
+} from './promptBuilder';
 
 /**
  * Convert GglibMessage[] to API message format for LLM
@@ -157,8 +160,7 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     }))
   });
   
-  // Initialize working memory
-  apiMessages = upsertWorkingMemory(apiMessages, buildWorkingMemory(agentState.toolDigests));
+  // Prune initial context to budget before the loop starts.
   apiMessages = pruneForBudget(apiMessages);
 
   // AGENTIC LOOP - one iteration = one assistant message
@@ -194,10 +196,24 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     // Mark this message as currently streaming (for live timer)
     setCurrentStreamingAssistantMessageId?.(assistantMessageId);
 
+    // Compose working memory as a transient layer for this iteration only.
+    // apiMessages is NEVER modified — injectPromptLayers returns a fresh array
+    // and replaces the system-message object via spread, so no object references
+    // from apiMessages bleed through.
+    const iterLayers: PromptLayer[] = [];
+    if (agentState.toolDigests.length > 0) {
+      iterLayers.push(
+        createWorkingMemoryLayer(
+          agentState.toolDigests.map(d => `- ${d.name} (${d.ok ? 'ok' : 'fail'}): ${d.summary}`),
+        ),
+      );
+    }
+    const messagesForLLM = injectPromptLayers(apiMessages, iterLayers);
+
     // Stream LLM response INTO this specific message
     const streamResult = await streamModelResponse({
       serverPort: selectedServerPort,
-      messages: apiMessages,
+      messages: messagesForLLM,
       toolDefinitions,
       abortSignal,
       
@@ -366,8 +382,7 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
     apiMessages.push(...toolResultsForApiHistory);
 
-    // Update working memory and prune for next iteration
-    apiMessages = upsertWorkingMemory(apiMessages, buildWorkingMemory(agentState.toolDigests));
+    // Prune context budget; working memory is injected transiently above, never stored here.
     apiMessages = pruneForBudget(apiMessages);
 
     appLogger.debug('hook.runtime', 'Continuing to next iteration');

--- a/src/hooks/useGglibRuntime/streamModelResponse.ts
+++ b/src/hooks/useGglibRuntime/streamModelResponse.ts
@@ -16,37 +16,9 @@ import { createThinkingContentHandler } from './thinkingContentHandler';
 import { PartsAccumulator } from './partsAccumulator';
 import type { GglibContent } from '../../types/messages';
 import { withRetry } from './agentLoop';
-import { buildSystemPrompt, TOOL_INSTRUCTIONS_LAYER } from './promptBuilder';
+import { injectPromptLayers, TOOL_INSTRUCTIONS_LAYER, FORMAT_REMINDER_LAYER } from './promptBuilder';
+import type { PromptLayer } from './promptBuilder';
 import type { ReasoningTimingTracker } from './reasoningTiming';
-
-/**
- * Additively inject tool instructions into the system message.
- *
- * Unlike the old `hotSwapDefaultSystemPrompt`, this function:
- * - Never performs an exact-string match on the base prompt
- * - Always appends tool guidance when tools are present, regardless of
- *   whether the user customised the system prompt
- * - Composes via string join rather than array splicing
- */
-function injectToolInstructions(messages: any[], hasTools: boolean): any[] {
-  if (!hasTools) return messages;
-
-  const sysIdx = messages.findIndex(
-    (m: any) => m?.role === 'system' && typeof m.content === 'string',
-  );
-
-  if (sysIdx >= 0) {
-    const cloned = messages.slice();
-    cloned[sysIdx] = {
-      ...cloned[sysIdx],
-      content: buildSystemPrompt(cloned[sysIdx].content as string, [TOOL_INSTRUCTIONS_LAYER]),
-    };
-    return cloned;
-  }
-
-  // No existing system message — prepend a composed one.
-  return [{ role: 'system', content: buildSystemPrompt('', [TOOL_INSTRUCTIONS_LAYER]) }, ...messages];
-}
 
 export interface StreamModelResponseOptions {
   serverPort: number;
@@ -78,7 +50,11 @@ export async function streamModelResponse(
   const { serverPort, messages, toolDefinitions, abortSignal, onContentUpdate, messageId, timingTracker } = options;
 
   const hasTools = toolDefinitions.length > 0;
-  const effectiveMessages = injectToolInstructions(messages, hasTools);
+  // FORMAT_REMINDER_LAYER is always active; TOOL_INSTRUCTIONS_LAYER only when tools are present.
+  // Priority ordering guarantees: tool-instructions (100) → format-reminder (200).
+  const activeLayers: PromptLayer[] = [FORMAT_REMINDER_LAYER];
+  if (hasTools) activeLayers.push(TOOL_INSTRUCTIONS_LAYER);
+  const effectiveMessages = injectPromptLayers(messages, activeLayers);
 
   const requestBody = {
     port: serverPort,


### PR DESCRIPTION
## Closes #258 · Part of Epic #243

## Summary

Wires the `promptBuilder` module (landed in Phase 1 / #257) throughout the agentic loop, completing the replacement of the brittle hot-swap pattern.

## Changes

### `promptBuilder.ts` — new exports
- **`injectPromptLayers(messages, layers)`** — composes `PromptLayer` fragments into the first system message of an OpenAI-style message array via `buildSystemPrompt()`. Always returns a new array; the system-message object is replaced via spread (`{ ...original, content: composed }`) — never via direct property assignment — so the caller's array is never mutated. JSDoc documents the double-injection safety contract explicitly.
- **`createWorkingMemoryLayer(digestLines)`** — factory that wraps per-tool digest lines in a `PromptLayer` at priority 300 (after tool-instructions: 100 and format-reminder: 200).

### `streamModelResponse.ts` — simplification
- Deleted private `injectToolInstructions()`; its logic now lives in the shared `injectPromptLayers()`.
- `FORMAT_REMINDER_LAYER` is now always active (tool-enabled or not); `TOOL_INSTRUCTIONS_LAYER` remains gated on `hasTools`.
- Composed system message order: *tool-instructions → format-reminder*.

### `runAgenticLoop.ts` — transient working memory
- Removed `buildWorkingMemory` / `upsertWorkingMemory` imports and both call sites.
- At the top of every loop iteration, working memory is composed transiently into `messagesForLLM` via `injectPromptLayers(apiMessages, iterLayers)`. `apiMessages` is never touched.
- `streamModelResponse` receives `messagesForLLM`; its second `injectPromptLayers` call appends tool/format layers safely on top because `messagesForLLM` is a fully independent array (fresh `slice()` + fresh spread objects).

### `agentLoop.ts` + `index.ts` — dead-code removal
- Deleted `buildWorkingMemory()`, `upsertWorkingMemory()`.
- Removed the `isWorkingMemory` / `WORKING_MEMORY:` guard from `pruneForBudget()`.
- Updated `index.ts` re-exports accordingly; added `injectPromptLayers` and `createWorkingMemoryLayer` to the public surface.

## Architecture invariants

| Invariant | Enforcement |
|---|---|
| `apiMessages` is never mutated | `injectPromptLayers` always `slice()`s the input array and spreads modified objects |
| Double-injection is safe | Each call gets a fresh clone; `buildSystemPrompt` is not idempotent but never sees stale composed content |
| Working memory is transient | Composed fresh each iteration, discarded after `streamModelResponse` returns |
| `buildSystemPrompt` is not idempotent | Documented in JSDoc; callers are responsible for passing a clean base |

## Acceptance criteria

- [x] `hotSwapDefaultSystemPrompt` does not exist anywhere in the codebase
- [x] `upsertWorkingMemory` / `buildWorkingMemory` have no callers
- [x] `WORKING_MEMORY:` prefix guard removed from `pruneForBudget()`
- [x] All system prompt composition uses `buildSystemPrompt()` via `injectPromptLayers()`
- [x] Working memory uses prompt layers instead of direct message injection
- [x] `runResearchLoop.ts` unaffected
- [x] `npx tsc --noEmit` → zero errors
