### PR TITLE
fix(wsl2): wrap cargo in sh -c when TASKSET is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ TASKSET ?=
 CARGO_ENV := $(shell if [ -f "$$HOME/.cargo/env" ]; then echo ". $$HOME/.cargo/env &&"; fi)
 CARGO := $(CARGO_ENV) cargo
 
+# On WSL2, TASKSET is non-empty but CARGO may start with shell built-ins (e.g. ". ~/.cargo/env &&")
+# which taskset cannot exec directly.  Wrap CARGO in `sh -c '...' --` so taskset gets a real
+# executable, then pass build args via positional parameters ($$@).
+ifneq ($(TASKSET),)
+CARGO := $(TASKSET) sh -c '$(CARGO_ENV) cargo "$$@"' --
+TASKSET :=
+endif
+
 # Cargo Optimization Flags
 export CARGO_PROFILE_RELEASE_LTO := thin
 export CARGO_PROFILE_RELEASE_CODEGEN_UNITS := 16


### PR DESCRIPTION
## Problem

On WSL2, `CARGO` expands to `. ~/.cargo/env && cargo` (shell built-ins). When `TASKSET` is non-empty, the resulting command is:

```
taskset -c 0-14 . /home/matt/.cargo/env && cargo build ...
```

`taskset` tries to `exec` the `.` shell builtin, which fails:
```
taskset: failed to execute .: Permission denied
```

This broke `make setup` (and all cargo build targets) on WSL2 machines where `cargo` is only available via `~/.cargo/env`.

## Fix

When `TASKSET` is non-empty, rewrite `CARGO` as a `sh -c` wrapper so `taskset` receives a real executable:

```makefile
ifneq ($(TASKSET),)
CARGO := $(TASKSET) sh -c '$(CARGO_ENV) cargo "$$@"' --
TASKSET :=
endif
```

Build args are forwarded via positional parameters (`$@`). `TASKSET` is cleared afterwards to avoid double-application.