### PR TITLE
feat(#255): expose tool support status in server status API

### DIFF
--- a/crates/gglib-axum/src/handlers/hf.rs
+++ b/crates/gglib-axum/src/handlers/hf.rs
@@ -7,7 +7,7 @@ use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_gui::types::{
     HfModelSummary, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse,
-    HfToolSupportResponse,
+    ToolSupportResponse,
 };
 
 /// Search HuggingFace for GGUF models.
@@ -30,7 +30,7 @@ pub async fn quantizations(
 pub async fn tool_support(
     State(state): State<AppState>,
     Path(model_id): Path<String>,
-) -> Result<Json<HfToolSupportResponse>, HttpError> {
+) -> Result<Json<ToolSupportResponse>, HttpError> {
     Ok(Json(state.gui.get_hf_tool_support(&model_id).await?))
 }
 

--- a/crates/gglib-axum/src/handlers/servers.rs
+++ b/crates/gglib-axum/src/handlers/servers.rs
@@ -5,11 +5,24 @@ use axum::extract::{Path, State};
 
 use crate::error::HttpError;
 use crate::state::AppState;
-use gglib_gui::types::{ServerInfo, StartServerRequest, StartServerResponse};
+use gglib_gui::types::{ServerInfo, StartServerRequest, StartServerResponse, ToolSupportResponse};
 
 /// List all running servers.
 pub async fn list(State(state): State<AppState>) -> Json<Vec<ServerInfo>> {
     Json(state.gui.list_servers().await)
+}
+
+/// Get tool support status for a running server's model.
+///
+/// Sources `supports_tool_calls` from the model's `ModelCapabilities`
+/// bitflag in the database. `confidence` and `detected_format` are
+/// derived from the chat template stored in model metadata — no GGUF
+/// file parsing required.
+pub async fn tool_support(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<ToolSupportResponse>, HttpError> {
+    Ok(Json(state.gui.get_server_tool_support(id).await?))
 }
 
 // ============================================================================

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -101,6 +101,10 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/servers/{id}/start", post(handlers::servers::start))
         .route("/servers/{id}/stop", post(handlers::servers::stop))
         .route(
+            "/servers/{id}/tool-support",
+            get(handlers::servers::tool_support),
+        )
+        .route(
             "/servers/{port}/logs",
             get(handlers::servers::get_logs).delete(handlers::servers::clear_logs),
         )

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -335,7 +335,7 @@ impl GuiBackend {
     pub async fn get_hf_tool_support(
         &self,
         model_id: &str,
-    ) -> Result<HfToolSupportResponse, GuiError> {
+    ) -> Result<ToolSupportResponse, GuiError> {
         self.download_ops().get_hf_tool_support(model_id).await
     }
 

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -339,6 +339,17 @@ impl GuiBackend {
         self.download_ops().get_hf_tool_support(model_id).await
     }
 
+    /// Get tool support detection for a running model server.
+    ///
+    /// Fast path: reads capabilities bitflag and chat template from the database
+    /// model record — no GGUF file parsing required.
+    pub async fn get_server_tool_support(
+        &self,
+        model_id: i64,
+    ) -> Result<ToolSupportResponse, GuiError> {
+        self.server_ops().get_server_tool_support(model_id).await
+    }
+
     // =========================================================================
     // Settings operations
     // =========================================================================

--- a/crates/gglib-gui/src/downloads.rs
+++ b/crates/gglib-gui/src/downloads.rs
@@ -11,7 +11,7 @@ use crate::deps::GuiDeps;
 use crate::error::GuiError;
 use crate::types::{
     HfModelSummary, HfQuantization, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse,
-    HfSortField, HfToolSupportResponse,
+    HfSortField, ToolSupportResponse,
 };
 
 /// Download and HuggingFace operations handler.
@@ -222,7 +222,7 @@ impl<'a> DownloadOps<'a> {
     pub async fn get_hf_tool_support(
         &self,
         model_id: &str,
-    ) -> Result<HfToolSupportResponse, GuiError> {
+    ) -> Result<ToolSupportResponse, GuiError> {
         use gglib_core::ports::{ModelSource, ToolSupportDetectionInput};
 
         // Fetch model info from HuggingFace
@@ -240,7 +240,7 @@ impl<'a> DownloadOps<'a> {
             source: ModelSource::HuggingFace,
         });
 
-        Ok(HfToolSupportResponse::from(detection))
+        Ok(ToolSupportResponse::from(detection))
     }
 
     /// Get model summary by exact repo ID (direct API lookup).

--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -18,7 +18,7 @@ use gglib_core::ports::{ProcessHandle, ServerConfig, ServerHealthStatus};
 
 use crate::deps::GuiDeps;
 use crate::error::GuiError;
-use crate::types::{ServerInfo, StartServerRequest, StartServerResponse};
+use crate::types::{ServerInfo, ServerLogEntry, StartServerRequest, StartServerResponse, ToolSupportResponse};
 
 /// Handle for a running health monitor task.
 struct MonitorHandle {
@@ -476,6 +476,44 @@ impl<'a> ServerOps<'a> {
     /// Clear logs for a specific server port.
     pub fn clear_logs(&self, port: u16) {
         gglib_runtime::get_log_manager().clear_logs(port);
+    }
+
+    /// Get tool support detection for a running server's model.
+    ///
+    /// Sources `supports_tool_calls` from the model's `ModelCapabilities` bitflags
+    /// stored in the database (same path used by the chat proxy on every request).
+    /// `confidence` and `detected_format` are derived by running the detector with
+    /// the chat template already stored in `model.metadata` — no disk I/O required.
+    pub async fn get_server_tool_support(
+        &self,
+        model_id: i64,
+    ) -> Result<ToolSupportResponse, GuiError> {
+        use gglib_core::domain::ModelCapabilities;
+        use gglib_core::ports::{ModelSource, ToolSupportDetectionInput};
+
+        let model = self.resolve_model(model_id).await?;
+
+        // Primary boolean comes from the authoritative DB capabilities bitflag.
+        let supports_tool_calls =
+            model.capabilities.contains(ModelCapabilities::SUPPORTS_TOOL_CALLS);
+
+        // Chat template is already in model.metadata (loaded by the same DB query).
+        // Passing it to the detector ensures accurate format/confidence values even
+        // for custom-named models where filename heuristics would otherwise fail.
+        let chat_template = model.metadata.get("tokenizer.chat_template").map(String::as_str);
+
+        let detection = self.deps.tool_detector.detect(ToolSupportDetectionInput {
+            model_id: model.file_path.to_str().unwrap_or(""),
+            chat_template,
+            tags: &[],
+            source: ModelSource::LocalGguf,
+        });
+
+        Ok(ToolSupportResponse {
+            supports_tool_calls,
+            confidence: detection.confidence,
+            detected_format: detection.detected_format.map(|f| f.to_string()),
+        })
     }
 }
 

--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -18,7 +18,7 @@ use gglib_core::ports::{ProcessHandle, ServerConfig, ServerHealthStatus};
 
 use crate::deps::GuiDeps;
 use crate::error::GuiError;
-use crate::types::{ServerInfo, ServerLogEntry, StartServerRequest, StartServerResponse, ToolSupportResponse};
+use crate::types::{ServerInfo, StartServerRequest, StartServerResponse, ToolSupportResponse};
 
 /// Handle for a running health monitor task.
 struct MonitorHandle {

--- a/crates/gglib-gui/src/types.rs
+++ b/crates/gglib-gui/src/types.rs
@@ -104,17 +104,19 @@ pub struct HfQuantizationsResponse {
 }
 
 /// Response for tool/function calling support detection.
+///
+/// Used for both HuggingFace model metadata and local running server queries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HfToolSupportResponse {
-    pub supports_tool_calling: bool,
+pub struct ToolSupportResponse {
+    pub supports_tool_calls: bool,
     pub confidence: f32,
     pub detected_format: Option<String>,
 }
 
-impl From<gglib_core::ports::ToolSupportDetection> for HfToolSupportResponse {
+impl From<gglib_core::ports::ToolSupportDetection> for ToolSupportResponse {
     fn from(detection: gglib_core::ports::ToolSupportDetection) -> Self {
         Self {
-            supports_tool_calling: detection.supports_tool_calling,
+            supports_tool_calls: detection.supports_tool_calling,
             confidence: detection.confidence,
             detected_format: detection.detected_format.map(|f| f.to_string()),
         }

--- a/src/components/HfModelPreview/HfModelPreview.tsx
+++ b/src/components/HfModelPreview/HfModelPreview.tsx
@@ -12,7 +12,7 @@ import {
   Wrench,
   XCircle,
 } from 'lucide-react';
-import { HfModelSummary, HfQuantization, HfQuantizationsResponse, HfToolSupportResponse, FitStatus } from '../../types';
+import { HfModelSummary, HfQuantization, HfQuantizationsResponse, ToolSupportResponse, FitStatus } from '../../types';
 import { getHfQuantizations, getHfToolSupport } from '../../services/clients/huggingface';
 import { openUrl } from '../../services/platform';
 import { formatBytes, formatNumber, getHuggingFaceModelUrl } from '../../utils/format';
@@ -79,7 +79,7 @@ const HfModelPreview: FC<HfModelPreviewProps> = ({
   const [quantError, setQuantError] = useState<string | null>(null);
   
   // Tool support detection state
-  const [toolSupport, setToolSupport] = useState<HfToolSupportResponse | null>(null);
+  const [toolSupport, setToolSupport] = useState<ToolSupportResponse | null>(null);
   const [loadingToolSupport, setLoadingToolSupport] = useState(true);
 
   // Memory fit checking
@@ -213,7 +213,7 @@ const HfModelPreview: FC<HfModelPreviewProps> = ({
             </span>
           )}
           {/* Tool support badge - only show when loaded and supported */}
-          {!loadingToolSupport && toolSupport?.supports_tool_calling && (
+          {!loadingToolSupport && toolSupport?.supports_tool_calls && (
             <span 
               className="inline-flex items-center gap-1 px-sm py-xs bg-[rgba(37,99,235,0.15)] text-primary-light rounded-base text-xs font-medium cursor-help transition-colors duration-150 ease-linear hover:bg-[rgba(37,99,235,0.25)]"
               title={getToolSupportTooltip()}

--- a/src/services/clients/huggingface.ts
+++ b/src/services/clients/huggingface.ts
@@ -14,7 +14,7 @@ import type {
   HfSearchRequest,
   HfSearchResponse,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
 } from '../../types';
 
 /**
@@ -44,6 +44,6 @@ export async function getHfQuantizations(modelId: HfModelId): Promise<HfQuantiza
 /**
  * Get tool support information for a HuggingFace model.
  */
-export async function getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse> {
+export async function getHfToolSupport(modelId: HfModelId): Promise<ToolSupportResponse> {
   return getTransport().getHfToolSupport(modelId);
 }

--- a/src/services/transport/api/models/hf.ts
+++ b/src/services/transport/api/models/hf.ts
@@ -10,7 +10,7 @@ import type {
   HfSearchRequest,
   HfSearchResponse,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
 } from '../../types/models';
 import type { HfModelSummary } from '../../../../types';
 
@@ -48,8 +48,8 @@ export async function getHfQuantizations(modelId: HfModelId): Promise<HfQuantiza
 /**
  * Get tool support information for a HuggingFace model.
  */
-export async function getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse> {
-  return get<HfToolSupportResponse>(
+export async function getHfToolSupport(modelId: HfModelId): Promise<ToolSupportResponse> {
+  return get<ToolSupportResponse>(
     `${HF_TOOL_SUPPORT_PATH}/${encodeURIComponent(modelId)}`
   );
 }

--- a/src/services/transport/types/models.ts
+++ b/src/services/transport/types/models.ts
@@ -15,7 +15,7 @@ import type {
   HfSearchResponse,
   HfQuantization,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
   HfSortField,
   ModelFilterOptions,
   RangeValues,
@@ -33,7 +33,7 @@ export type {
   HfSearchResponse,
   HfQuantization,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
   HfSortField,
   ModelFilterOptions,
   RangeValues,
@@ -88,7 +88,7 @@ export interface ModelsTransport {
   browseHfModels(params: HfSearchRequest): Promise<HfSearchResponse>;
   getHfModelSummary(modelId: HfModelId): Promise<HfModelSummary>;
   getHfQuantizations(modelId: HfModelId): Promise<HfQuantizationsResponse>;
-  getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse>;
+  getHfToolSupport(modelId: HfModelId): Promise<ToolSupportResponse>;
 
   // System info
   getSystemMemory(): Promise<SystemMemoryInfo | null>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -334,10 +334,12 @@ export interface HfQuantizationsResponse {
 
 /**
  * Response for tool/function calling support detection.
+ *
+ * Used for both HuggingFace model metadata and local running server queries.
  */
-export interface HfToolSupportResponse {
+export interface ToolSupportResponse {
   /** Whether the model supports tool/function calling */
-  supports_tool_calling: boolean;
+  supports_tool_calls: boolean;
   /** Confidence level of the detection (0.0 to 1.0) */
   confidence: number;
   /** Detected tool calling format (e.g., "hermes", "llama3", "mistral") */

--- a/tests/ts/services/clients/huggingface.test.ts
+++ b/tests/ts/services/clients/huggingface.test.ts
@@ -11,7 +11,7 @@ import {
   getHfToolSupport,
 } from '../../../../src/services/clients/huggingface';
 import { getTransport, _resetTransport } from '../../../../src/services/transport';
-import type { HfSearchResponse, HfQuantizationsResponse, HfToolSupportResponse } from '../../../../src/types';
+import type { HfSearchResponse, HfQuantizationsResponse, ToolSupportResponse } from '../../../../src/types';
 
 // Mock the transport module
 vi.mock('../../../../src/services/transport', () => {
@@ -76,9 +76,10 @@ describe('services/clients/huggingface', () => {
   describe('getHfToolSupport', () => {
     it('delegates to transport.getHfToolSupport()', async () => {
       const modelId = 'TheBloke/Llama-2-7B-GGUF';
-      const mockResponse: HfToolSupportResponse = {
-        supports_tools: true,
-        tool_format: 'chatml',
+      const mockResponse: ToolSupportResponse = {
+        supports_tool_calls: true,
+        confidence: 0.95,
+        detected_format: 'chatml',
       };
       vi.mocked(mockTransport.getHfToolSupport).mockResolvedValue(mockResponse);
 


### PR DESCRIPTION
## Summary

Implements issue #255 (Phase 2 of epic #244).

Adds a new `GET /api/servers/{id}/tool-support` endpoint that returns tool capability information for any running model server.

## Changes

### refactor: rename HfToolSupportResponse → ToolSupportResponse
- Removes HF-specific prefix; DTO is now shared across HF browsing and local server queries
- Renames field `supports_tool_calling` → `supports_tool_calls` to match AC wire format exactly
- Fixes stale test mock (wrong field names)
- 10 files updated (4 Rust, 6 TypeScript)

### feat(gglib-gui): add get_server_tool_support to ServerOps
- Sources `supports_tool_calls` from `model.capabilities` DB bitflag (same path as chat proxy)
- Extracts `tokenizer.chat_template` from `model.metadata` (already in-memory — zero disk I/O)
- Passes the actual template to ToolSupportDetectorPort for accurate format/confidence even for custom-named models
- GuiBackend delegates to ServerOps

### feat(gglib-axum): add GET /api/servers/{id}/tool-support
- Handler wired at `/api/servers/{id}/tool-support`
- Same pattern as existing `/api/hf/tool-support/{model_id}`

## Response shape
```json
{ "supports_tool_calls": true, "confidence": 0.9, "detected_format": "hermes" }
```

## Acceptance Criteria
- [x] `supports_tool_calls`, `detected_format`, `confidence` in response
- [x] Data sourced from actual GGUF metadata of running model
- [x] Frontend can query tool support before sending chat requests

Closes #255 | Part of epic #244