### PR TITLE
feat(#256): Phase 3 — Frontend tool support indicator and client-side gating

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -40,6 +40,8 @@ import { useDeepResearch } from '../../hooks/useDeepResearch';
 import type { ResearchState } from '../../hooks/useDeepResearch/types';
 import { cn } from '../../utils/cn';
 import { DEFAULT_SYSTEM_PROMPT } from '../../hooks/useGglibRuntime';
+import { ToolSupportIndicator } from '../ToolSupportIndicator';
+import { getToolRegistry } from '../../services/tools';
 
 
 interface ChatMessagesPanelProps {
@@ -62,6 +64,13 @@ interface ChatMessagesPanelProps {
   currentStreamingAssistantMessageId: string | null;
   /** Voice mode hook return (optional — only in Tauri) */
   voice?: UseVoiceModeReturn;
+  /**
+   * Whether the active model supports tool/function calling.
+   * null = unknown (capability status not yet resolved).
+   */
+  supportsToolCalls?: boolean | null;
+  /** Detected tool-calling format, e.g. "hermes" or "llama3". */
+  toolFormat?: string | null;
 }
 
 const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
@@ -83,6 +92,8 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
   timingTracker,
   currentStreamingAssistantMessageId,
   voice,
+  supportsToolCalls,
+  toolFormat,
 }) => {
   const threadRuntime = useThreadRuntime({ optional: true });
   const composerRuntime = useComposerRuntime({ optional: true });
@@ -594,6 +605,11 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
           <span className={cn('text-xs py-xs px-sm rounded-full bg-background text-text-muted shrink-0', isThreadRunning && 'bg-primary/10 text-primary animate-research-pulse')}>
             {isThreadRunning ? 'Responding…' : 'Idle'}
           </span>
+          <ToolSupportIndicator
+            supports={supportsToolCalls ?? null}
+            hasToolsConfigured={getToolRegistry().getEnabledDefinitions().length > 0}
+            toolFormat={toolFormat}
+          />
         </div>
         <div className="flex gap-sm shrink-0">
           <ToolsPopover />

--- a/src/components/ToolSupportIndicator.tsx
+++ b/src/components/ToolSupportIndicator.tsx
@@ -1,0 +1,70 @@
+/**
+ * ToolSupportIndicator
+ *
+ * Small pill badge shown in the chat header to communicate whether the active
+ * model supports tool/function calling.
+ *
+ * Visibility rules (matching issue #256 spec):
+ *   - No tools configured  → render nothing
+ *   - supports = null       → render nothing (unknown / still loading)
+ *   - supports = true       → "⚡ Tools active"  (green pill)
+ *   - supports = false      → "💬 Chat only"     (amber pill, tooltip explains why)
+ */
+
+import { Zap, MessageCircle } from 'lucide-react';
+import { Icon } from './ui/Icon';
+import { cn } from '../utils/cn';
+
+export interface ToolSupportIndicatorProps {
+  /** Whether the model supports tool calls. Null means unknown — renders nothing. */
+  supports: boolean | null;
+  /** Whether any tools are currently enabled. When false the indicator is hidden. */
+  hasToolsConfigured: boolean;
+  /** Detected tool-calling format (e.g. "hermes", "llama3"). Used in hover tooltip. */
+  toolFormat?: string | null;
+  className?: string;
+}
+
+export function ToolSupportIndicator({
+  supports,
+  hasToolsConfigured,
+  toolFormat,
+  className,
+}: ToolSupportIndicatorProps) {
+  // Only show when tools are in use and we have a definitive answer
+  if (!hasToolsConfigured || supports === null) return null;
+
+  if (supports) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 py-[2px] px-2 text-[11px] font-medium rounded-[10px] shrink-0',
+          'bg-[#10b981]/15 text-[#10b981]',
+          className,
+        )}
+        title={
+          toolFormat
+            ? `Tools active — model supports tool calling (${toolFormat} format)`
+            : 'Tools active — model supports tool calling'
+        }
+      >
+        <Icon icon={Zap} size={11} />
+        Tools active
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 py-[2px] px-2 text-[11px] font-medium rounded-[10px] shrink-0',
+        'bg-[#f59e0b]/15 text-[#f59e0b]',
+        className,
+      )}
+      title="This model does not support tool/function calling — tools are disabled for this chat"
+    >
+      <Icon icon={MessageCircle} size={11} />
+      Chat only
+    </span>
+  );
+}

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -91,6 +91,13 @@ export interface RunAgenticLoopOptions {
   mkAssistantMessage: (custom?: any) => GglibMessage;
   timingTracker?: ReasoningTimingTracker;
   setCurrentStreamingAssistantMessageId?: (id: string | null) => void;
+  /**
+   * Whether the active model supports tool/function calling.
+   * - `true`  → tools sent normally
+   * - `false` → tools stripped (client-side defense-in-depth alongside backend gating)
+   * - `null` / `undefined` → unknown; treated as supported (permissive fallback)
+   */
+  supportsToolCalls?: boolean | null;
 }
 
 /**
@@ -115,23 +122,36 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     mkAssistantMessage: mkAssistant,
     timingTracker,
     setCurrentStreamingAssistantMessageId,
+    supportsToolCalls,
   } = options;
 
   let iteration = 0;
 
   // Get tool definitions
   const toolDefinitions = getToolDefinitions();
-  const hasTools = toolDefinitions.length > 0;
+
+  // Client-side gating: if model is known to NOT support tools, strip them.
+  // null/undefined (unknown) → permissive; only explicit false triggers stripping.
+  const effectiveToolDefs =
+    supportsToolCalls === false ? [] : toolDefinitions;
+
+  if (supportsToolCalls === false && toolDefinitions.length > 0) {
+    appLogger.info('hook.runtime', 'Tool calls suppressed: model does not support tools', {
+      skippedTools: toolDefinitions.length,
+    });
+  }
+
+  const hasTools = effectiveToolDefs.length > 0;
 
   appLogger.debug('hook.runtime', 'Starting agentic loop', {
     maxIterations: maxToolIterations,
     maxStagnation: maxStagnationSteps,
-    tools: hasTools ? toolDefinitions.length : 0,
+    tools: hasTools ? effectiveToolDefs.length : 0,
   });
   
   // Log available tool names for debugging
   if (hasTools) {
-    appLogger.debug('hook.runtime', 'Available tools', { toolNames: toolDefinitions.map(t => t.function.name) });
+    appLogger.debug('hook.runtime', 'Available tools', { toolNames: effectiveToolDefs.map(t => t.function.name) });
   }
 
   // Initialize agent state
@@ -214,7 +234,7 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     const streamResult = await streamModelResponse({
       serverPort: selectedServerPort,
       messages: messagesForLLM,
-      toolDefinitions,
+      toolDefinitions: effectiveToolDefs,
       abortSignal,
       
       // Update THIS message's content by ID

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -26,6 +26,13 @@ export interface UseGglibRuntimeOptions {
   maxToolIterations?: number;
   maxStagnationSteps?: number;
   onError?: (error: Error) => void;
+  /**
+   * Whether the active model supports tool/function calling.
+   * - `true`  → tools sent normally
+   * - `false` → tools stripped (defense-in-depth)
+   * - `null` / `undefined` → unknown; treated as supported (permissive fallback)
+   */
+  supportsToolCalls?: boolean | null;
 }
 
 export interface UseGglibRuntimeReturn {
@@ -52,6 +59,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
     maxToolIterations,
     maxStagnationSteps,
     onError,
+    supportsToolCalls,
   } = options;
 
   // Message state managed externally
@@ -148,6 +156,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
         mkAssistantMessage: (custom) => mkAssistantMessage({ ...custom, ...extraMeta }),
         timingTracker,
         setCurrentStreamingAssistantMessageId,
+        supportsToolCalls,
       });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {

--- a/src/hooks/useToolSupportCache.ts
+++ b/src/hooks/useToolSupportCache.ts
@@ -88,7 +88,7 @@ export function useToolSupportCache(modelId: string | null): UseToolSupportResul
 
     const fetchPromise = getHfToolSupport(modelId)
       .then((response) => {
-        const supports = response.supports_tool_calling;
+        const supports = response.supports_tool_calls;
         toolSupportCache.set(modelId, { supports, loading: false });
         setResult({ supports, loading: false });
         return supports;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -17,6 +17,7 @@ import { useSettings } from '../hooks/useSettings';
 import { useVoiceModeContext } from '../contexts/VoiceModeContext';
 import { useToastContext } from '../contexts/ToastContext';
 import { useServerState } from '../services/serverEvents';
+import { getServerToolSupport } from '../services/clients/servers';
 import {
   listConversations,
   createConversation,
@@ -82,6 +83,26 @@ export default function ChatPage({
   const maxToolIterations = settings?.maxToolIterations ?? undefined;
   const maxStagnationSteps = settings?.maxStagnationSteps ?? undefined;
 
+  // Tool support capability for the active model.
+  // Fetched once on mount (model identity is fixed for the lifetime of ChatPage).
+  // null = unknown (permissive fallback - never gates tools when status is uncertain).
+  const [supportsToolCalls, setSupportsToolCalls] = useState<boolean | null>(null);
+  const [toolFormat, setToolFormat] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getServerToolSupport(modelId)
+      .then((data) => {
+        if (!cancelled) {
+          setSupportsToolCalls(data.supports_tool_calls);
+          setToolFormat(data.detected_format ?? null);
+        }
+      })
+      .catch(() => {
+        // Permissive fallback: leave supportsToolCalls as null (unknown)
+      });
+    return () => { cancelled = true; };
+  }, [modelId]);
+
   // Runtime - now with external message state
   const { runtime, messages, setMessages, isRunning, timingTracker, currentStreamingAssistantMessageId, setNextMessageMeta } = useGglibRuntime({
     conversationId: activeConversationId ?? undefined,
@@ -89,6 +110,7 @@ export default function ChatPage({
     onError: (error) => setChatError(error.message),
     maxToolIterations,
     maxStagnationSteps,
+    supportsToolCalls,
   });
 
   // Server state from registry - derives isServerRunning reactively
@@ -461,6 +483,8 @@ export default function ChatPage({
               timingTracker={timingTracker}
               currentStreamingAssistantMessageId={currentStreamingAssistantMessageId}
               voice={voice ?? undefined}
+              supportsToolCalls={supportsToolCalls}
+              toolFormat={toolFormat}
             />
           </div>
         </div>

--- a/src/services/clients/servers.ts
+++ b/src/services/clients/servers.ts
@@ -9,7 +9,7 @@
 
 import { getTransport } from '../transport';
 import type { ModelId } from '../transport/types/ids';
-import type { ServeConfig, ServerInfo } from '../../types';
+import type { ServeConfig, ServerInfo, ToolSupportResponse } from '../../types';
 import type { ServeResponse } from '../transport/types/servers';
 import type { ProxyConfig, ProxyStatus } from '../transport/types/proxy';
 
@@ -57,4 +57,8 @@ export async function startProxy(config?: Partial<ProxyConfig>): Promise<ProxySt
  */
 export async function stopProxy(): Promise<void> {
   return getTransport().stopProxy();
+}
+
+export async function getServerToolSupport(modelId: ModelId): Promise<ToolSupportResponse> {
+  return getTransport().getServerToolSupport(modelId);
 }

--- a/src/services/transport/api/servers.ts
+++ b/src/services/transport/api/servers.ts
@@ -6,6 +6,7 @@
 import { post, get } from './client';
 import type { ModelId } from '../types/ids';
 import type { ServeConfig, ServeResponse, ServerInfo } from '../types/servers';
+import type { ToolSupportResponse } from '../../../types';
 import { toStartServerRequest } from '../mappers';
 
 /**
@@ -28,4 +29,11 @@ export async function stopServer(modelId: ModelId): Promise<void> {
  */
 export async function listServers(): Promise<ServerInfo[]> {
   return get<ServerInfo[]>('/api/servers');
+}
+
+/**
+ * Retrieve tool-calling capability for a running server's model.
+ */
+export async function getServerToolSupport(modelId: ModelId): Promise<ToolSupportResponse> {
+  return get<ToolSupportResponse>(`/api/servers/${modelId}/tool-support`);
 }

--- a/src/services/transport/types/servers.ts
+++ b/src/services/transport/types/servers.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ModelId } from './ids';
-import type { ServeConfig, ServerInfo } from '../../../types';
+import type { ServeConfig, ServerInfo, ToolSupportResponse } from '../../../types';
 
 // Re-export existing types
 export type { ServeConfig, ServerInfo };
@@ -29,4 +29,7 @@ export interface ServersTransport {
 
   /** List all running servers. */
   listServers(): Promise<ServerInfo[]>;
+
+  /** Retrieve tool-calling capability for a running server's model. */
+  getServerToolSupport(modelId: ModelId): Promise<ToolSupportResponse>;
 }


### PR DESCRIPTION
## Summary

Closes #256 — Phase 3 of #244 (Gate tool injection on model capability detection).

Fetches tool-calling capability from the Phase 2 endpoint, displays a visual indicator in the chat header, and gates tool definitions client-side when a model is known to not support them.

---

## Changes

### Transport layer
- Added `getServerToolSupport(modelId)` to the HTTP API transport (`GET /api/servers/{id}/tool-support`), `ServersTransport` interface, and servers client module.

### Agentic loop client-side gating
- Added `supportsToolCalls?: boolean | null` to `RunAgenticLoopOptions` and `UseGglibRuntimeOptions`.
- When `supportsToolCalls === false`, tool definitions are stripped before each `streamModelResponse` call (`effectiveToolDefs = []`). With no tools, `hasTools = false`, tools are not sent in the request body, `finishReason` will be `'stop'`, and the loop exits after one iteration — no special branch required.
- `null` / `undefined` is permissive fallback: tools are sent normally (safe for unknown/loading/error states).

### ChatPage inline fetch
- `useEffect` on mount calls `getServerToolSupport(modelId)` and stores `supportsToolCalls` + `toolFormat` in local state.
- Error path is permissive (`supportsToolCalls` stays `null`).
- Both values are forwarded to `useGglibRuntime` (runtime gating) and `ChatMessagesPanel` (indicator).

### ToolSupportIndicator component
New `src/components/ToolSupportIndicator.tsx` pill badge in the chat header:

| State | Renders |
|-------|---------|
| `supports = true` | Green pill: ⚡ Tools active (+ tooltip with format) |
| `supports = false` | Amber pill: 💬 Chat only (+ tooltip explaining why) |
| `supports = null` | Hidden (unknown / loading) |
| No tools configured | Hidden regardless of model capability |

Rendered immediately after the existing Idle/Responding status pill, matching the same pill style.

### Bug fix
- `useToolSupportCache`: corrected `response.supports_tool_calling` → `response.supports_tool_calls` after the Phase 2 rename.

---

## Acceptance Criteria

- [x] Tool support status fetched when model starts
- [x] Visual indicator in chat UI shows tool capability
- [x] Tools not sent in request when model doesn't support them
- [x] Agentic loop not entered when model can't use tools (falls through to single-response mode via empty effectiveToolDefs)
- [x] No regression when model does support tools (null → permissive, true → tools sent normally)
