### PR TITLE
feat(agent): gate tool injection on model capability detection (#244)

### DIFF
--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -384,9 +384,7 @@ fn apply_tools_to_body(
         let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
         let has_tool_choice = tool_choice.is_some();
         if has_tools || has_tool_choice {
-            tracing::debug!(
-                "Stripping tools from request — model does not support tool calling"
-            );
+            tracing::debug!("Stripping tools from request — model does not support tool calling");
         }
     }
 }
@@ -567,7 +565,12 @@ pub async fn proxy_chat(
 
     // Inject tools only when the model supports them.
     // Note: request.messages was consumed above, so we pass fields individually.
-    apply_tools_to_body(&mut forward_body, &request.tools, &request.tool_choice, capabilities);
+    apply_tools_to_body(
+        &mut forward_body,
+        &request.tools,
+        &request.tool_choice,
+        capabilities,
+    );
 
     // DEBUG: Log the exact payload sent to llama-server
     let log_path = std::env::var("HOME")
@@ -651,13 +654,18 @@ mod tests {
 
     #[test]
     fn test_tools_stripped_when_not_supported() {
-        let tools = Some(vec![serde_json::json!({"type": "function", "function": {"name": "get_weather"}})]);
+        let tools = Some(vec![
+            serde_json::json!({"type": "function", "function": {"name": "get_weather"}}),
+        ]);
         let tool_choice = Some(serde_json::json!("auto"));
         let mut body = serde_json::json!({});
         apply_tools_to_body(&mut body, &tools, &tool_choice, ModelCapabilities::empty());
 
         assert!(body.get("tools").is_none(), "tools should be stripped");
-        assert!(body.get("tool_choice").is_none(), "tool_choice should be stripped");
+        assert!(
+            body.get("tool_choice").is_none(),
+            "tool_choice should be stripped"
+        );
     }
 
     #[test]
@@ -666,13 +674,28 @@ mod tests {
         let tools = Some(vec![tool.clone()]);
         let tool_choice = Some(serde_json::json!("auto"));
         let mut body = serde_json::json!({});
-        apply_tools_to_body(&mut body, &tools, &tool_choice, ModelCapabilities::SUPPORTS_TOOL_CALLS);
+        apply_tools_to_body(
+            &mut body,
+            &tools,
+            &tool_choice,
+            ModelCapabilities::SUPPORTS_TOOL_CALLS,
+        );
 
         let tools_in_body = body.get("tools").expect("tools should be present");
-        assert_eq!(tools_in_body, &serde_json::json!([tool]), "tools should match");
+        assert_eq!(
+            tools_in_body,
+            &serde_json::json!([tool]),
+            "tools should match"
+        );
 
-        let tc_in_body = body.get("tool_choice").expect("tool_choice should be present");
-        assert_eq!(tc_in_body, &serde_json::json!("auto"), "tool_choice should match");
+        let tc_in_body = body
+            .get("tool_choice")
+            .expect("tool_choice should be present");
+        assert_eq!(
+            tc_in_body,
+            &serde_json::json!("auto"),
+            "tool_choice should match"
+        );
     }
 
     #[test]
@@ -682,7 +705,12 @@ mod tests {
         apply_tools_to_body(&mut body_no_cap, &None, &None, ModelCapabilities::empty());
 
         let mut body_with_cap = serde_json::json!({});
-        apply_tools_to_body(&mut body_with_cap, &None, &None, ModelCapabilities::SUPPORTS_TOOL_CALLS);
+        apply_tools_to_body(
+            &mut body_with_cap,
+            &None,
+            &None,
+            ModelCapabilities::SUPPORTS_TOOL_CALLS,
+        );
 
         assert!(body_no_cap.get("tools").is_none());
         assert!(body_no_cap.get("tool_choice").is_none());

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -639,3 +639,54 @@ pub async fn proxy_chat(
         Ok(Json(completion).into_response())
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gglib_core::domain::ModelCapabilities;
+
+    #[test]
+    fn test_tools_stripped_when_not_supported() {
+        let tools = Some(vec![serde_json::json!({"type": "function", "function": {"name": "get_weather"}})]);
+        let tool_choice = Some(serde_json::json!("auto"));
+        let mut body = serde_json::json!({});
+        apply_tools_to_body(&mut body, &tools, &tool_choice, ModelCapabilities::empty());
+
+        assert!(body.get("tools").is_none(), "tools should be stripped");
+        assert!(body.get("tool_choice").is_none(), "tool_choice should be stripped");
+    }
+
+    #[test]
+    fn test_tools_forwarded_when_supported() {
+        let tool = serde_json::json!({"type": "function", "function": {"name": "get_weather"}});
+        let tools = Some(vec![tool.clone()]);
+        let tool_choice = Some(serde_json::json!("auto"));
+        let mut body = serde_json::json!({});
+        apply_tools_to_body(&mut body, &tools, &tool_choice, ModelCapabilities::SUPPORTS_TOOL_CALLS);
+
+        let tools_in_body = body.get("tools").expect("tools should be present");
+        assert_eq!(tools_in_body, &serde_json::json!([tool]), "tools should match");
+
+        let tc_in_body = body.get("tool_choice").expect("tool_choice should be present");
+        assert_eq!(tc_in_body, &serde_json::json!("auto"), "tool_choice should match");
+    }
+
+    #[test]
+    fn test_no_op_when_no_tools_sent() {
+        // tools: None, tool_choice: None — body should stay empty regardless of capability
+        let mut body_no_cap = serde_json::json!({});
+        apply_tools_to_body(&mut body_no_cap, &None, &None, ModelCapabilities::empty());
+
+        let mut body_with_cap = serde_json::json!({});
+        apply_tools_to_body(&mut body_with_cap, &None, &None, ModelCapabilities::SUPPORTS_TOOL_CALLS);
+
+        assert!(body_no_cap.get("tools").is_none());
+        assert!(body_no_cap.get("tool_choice").is_none());
+        assert!(body_with_cap.get("tools").is_none());
+        assert!(body_with_cap.get("tool_choice").is_none());
+    }
+}

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -372,10 +372,10 @@ fn apply_tools_to_body(
     capabilities: gglib_core::domain::ModelCapabilities,
 ) {
     if capabilities.contains(gglib_core::domain::ModelCapabilities::SUPPORTS_TOOL_CALLS) {
-        if let Some(tools) = tools {
-            if !tools.is_empty() {
-                body["tools"] = serde_json::json!(tools);
-            }
+        if let Some(tools) = tools
+            && !tools.is_empty()
+        {
+            body["tools"] = serde_json::json!(tools);
         }
         if let Some(tc) = tool_choice {
             body["tool_choice"] = serde_json::json!(tc);

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -355,6 +355,42 @@ async fn validate_port(state: &AppState, port: u16) -> Result<(), HttpError> {
     Ok(())
 }
 
+/// Inject tools and tool_choice into the forwarded request body, gated on
+/// whether the model advertises `SUPPORTS_TOOL_CALLS`.
+///
+/// Takes `tools` and `tool_choice` as individual field references rather than
+/// the whole `ChatProxyRequest` because `request.messages` is consumed earlier
+/// in `proxy_chat` via `into_iter()`, leaving the struct partially moved.
+///
+/// When the capability flag is absent **and** the request actually contained
+/// tools or a tool_choice, a debug trace is emitted so operators can verify
+/// the strip behaviour without flooding logs on ordinary non-tool requests.
+fn apply_tools_to_body(
+    body: &mut serde_json::Value,
+    tools: &Option<Vec<serde_json::Value>>,
+    tool_choice: &Option<serde_json::Value>,
+    capabilities: gglib_core::domain::ModelCapabilities,
+) {
+    if capabilities.contains(gglib_core::domain::ModelCapabilities::SUPPORTS_TOOL_CALLS) {
+        if let Some(tools) = tools {
+            if !tools.is_empty() {
+                body["tools"] = serde_json::json!(tools);
+            }
+        }
+        if let Some(tc) = tool_choice {
+            body["tool_choice"] = serde_json::json!(tc);
+        }
+    } else {
+        let has_tools = tools.as_ref().is_some_and(|t| !t.is_empty());
+        let has_tool_choice = tool_choice.is_some();
+        if has_tools || has_tool_choice {
+            tracing::debug!(
+                "Stripping tools from request — model does not support tool calling"
+            );
+        }
+    }
+}
+
 /// Proxy chat completion requests to a running llama-server.
 ///
 /// POST /api/chat
@@ -529,15 +565,9 @@ pub async fn proxy_chat(
         "repeat_penalty": resolved.repeat_penalty,
     });
 
-    // Add tools if provided
-    if let Some(tools) = &request.tools
-        && !tools.is_empty()
-    {
-        forward_body["tools"] = serde_json::json!(tools);
-    }
-    if let Some(tool_choice) = &request.tool_choice {
-        forward_body["tool_choice"] = tool_choice.clone();
-    }
+    // Inject tools only when the model supports them.
+    // Note: request.messages was consumed above, so we pass fields individually.
+    apply_tools_to_body(&mut forward_body, &request.tools, &request.tool_choice, capabilities);
 
     // DEBUG: Log the exact payload sent to llama-server
     let log_path = std::env::var("HOME")

--- a/crates/gglib-axum/src/handlers/hf.rs
+++ b/crates/gglib-axum/src/handlers/hf.rs
@@ -6,8 +6,7 @@ use axum::extract::{Path, State};
 use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_gui::types::{
-    HfModelSummary, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse,
-    ToolSupportResponse,
+    HfModelSummary, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse, ToolSupportResponse,
 };
 
 /// Search HuggingFace for GGUF models.

--- a/crates/gglib-axum/src/handlers/hf.rs
+++ b/crates/gglib-axum/src/handlers/hf.rs
@@ -7,7 +7,7 @@ use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_gui::types::{
     HfModelSummary, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse,
-    HfToolSupportResponse,
+    ToolSupportResponse,
 };
 
 /// Search HuggingFace for GGUF models.
@@ -30,7 +30,7 @@ pub async fn quantizations(
 pub async fn tool_support(
     State(state): State<AppState>,
     Path(model_id): Path<String>,
-) -> Result<Json<HfToolSupportResponse>, HttpError> {
+) -> Result<Json<ToolSupportResponse>, HttpError> {
     Ok(Json(state.gui.get_hf_tool_support(&model_id).await?))
 }
 

--- a/crates/gglib-axum/src/handlers/servers.rs
+++ b/crates/gglib-axum/src/handlers/servers.rs
@@ -5,11 +5,24 @@ use axum::extract::{Path, State};
 
 use crate::error::HttpError;
 use crate::state::AppState;
-use gglib_gui::types::{ServerInfo, StartServerRequest, StartServerResponse};
+use gglib_gui::types::{ServerInfo, StartServerRequest, StartServerResponse, ToolSupportResponse};
 
 /// List all running servers.
 pub async fn list(State(state): State<AppState>) -> Json<Vec<ServerInfo>> {
     Json(state.gui.list_servers().await)
+}
+
+/// Get tool support status for a running server's model.
+///
+/// Sources `supports_tool_calls` from the model's `ModelCapabilities`
+/// bitflag in the database. `confidence` and `detected_format` are
+/// derived from the chat template stored in model metadata — no GGUF
+/// file parsing required.
+pub async fn tool_support(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<ToolSupportResponse>, HttpError> {
+    Ok(Json(state.gui.get_server_tool_support(id).await?))
 }
 
 // ============================================================================

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -101,6 +101,10 @@ pub(crate) fn api_routes() -> Router<AppState> {
         .route("/servers/{id}/start", post(handlers::servers::start))
         .route("/servers/{id}/stop", post(handlers::servers::stop))
         .route(
+            "/servers/{id}/tool-support",
+            get(handlers::servers::tool_support),
+        )
+        .route(
             "/servers/{port}/logs",
             get(handlers::servers::get_logs).delete(handlers::servers::clear_logs),
         )

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -335,7 +335,7 @@ impl GuiBackend {
     pub async fn get_hf_tool_support(
         &self,
         model_id: &str,
-    ) -> Result<HfToolSupportResponse, GuiError> {
+    ) -> Result<ToolSupportResponse, GuiError> {
         self.download_ops().get_hf_tool_support(model_id).await
     }
 

--- a/crates/gglib-gui/src/backend.rs
+++ b/crates/gglib-gui/src/backend.rs
@@ -339,6 +339,17 @@ impl GuiBackend {
         self.download_ops().get_hf_tool_support(model_id).await
     }
 
+    /// Get tool support detection for a running model server.
+    ///
+    /// Fast path: reads capabilities bitflag and chat template from the database
+    /// model record — no GGUF file parsing required.
+    pub async fn get_server_tool_support(
+        &self,
+        model_id: i64,
+    ) -> Result<ToolSupportResponse, GuiError> {
+        self.server_ops().get_server_tool_support(model_id).await
+    }
+
     // =========================================================================
     // Settings operations
     // =========================================================================

--- a/crates/gglib-gui/src/downloads.rs
+++ b/crates/gglib-gui/src/downloads.rs
@@ -11,7 +11,7 @@ use crate::deps::GuiDeps;
 use crate::error::GuiError;
 use crate::types::{
     HfModelSummary, HfQuantization, HfQuantizationsResponse, HfSearchRequest, HfSearchResponse,
-    HfSortField, HfToolSupportResponse,
+    HfSortField, ToolSupportResponse,
 };
 
 /// Download and HuggingFace operations handler.
@@ -222,7 +222,7 @@ impl<'a> DownloadOps<'a> {
     pub async fn get_hf_tool_support(
         &self,
         model_id: &str,
-    ) -> Result<HfToolSupportResponse, GuiError> {
+    ) -> Result<ToolSupportResponse, GuiError> {
         use gglib_core::ports::{ModelSource, ToolSupportDetectionInput};
 
         // Fetch model info from HuggingFace
@@ -240,7 +240,7 @@ impl<'a> DownloadOps<'a> {
             source: ModelSource::HuggingFace,
         });
 
-        Ok(HfToolSupportResponse::from(detection))
+        Ok(ToolSupportResponse::from(detection))
     }
 
     /// Get model summary by exact repo ID (direct API lookup).

--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -18,7 +18,7 @@ use gglib_core::ports::{ProcessHandle, ServerConfig, ServerHealthStatus};
 
 use crate::deps::GuiDeps;
 use crate::error::GuiError;
-use crate::types::{ServerInfo, StartServerRequest, StartServerResponse};
+use crate::types::{ServerInfo, ServerLogEntry, StartServerRequest, StartServerResponse, ToolSupportResponse};
 
 /// Handle for a running health monitor task.
 struct MonitorHandle {
@@ -476,6 +476,44 @@ impl<'a> ServerOps<'a> {
     /// Clear logs for a specific server port.
     pub fn clear_logs(&self, port: u16) {
         gglib_runtime::get_log_manager().clear_logs(port);
+    }
+
+    /// Get tool support detection for a running server's model.
+    ///
+    /// Sources `supports_tool_calls` from the model's `ModelCapabilities` bitflags
+    /// stored in the database (same path used by the chat proxy on every request).
+    /// `confidence` and `detected_format` are derived by running the detector with
+    /// the chat template already stored in `model.metadata` — no disk I/O required.
+    pub async fn get_server_tool_support(
+        &self,
+        model_id: i64,
+    ) -> Result<ToolSupportResponse, GuiError> {
+        use gglib_core::domain::ModelCapabilities;
+        use gglib_core::ports::{ModelSource, ToolSupportDetectionInput};
+
+        let model = self.resolve_model(model_id).await?;
+
+        // Primary boolean comes from the authoritative DB capabilities bitflag.
+        let supports_tool_calls =
+            model.capabilities.contains(ModelCapabilities::SUPPORTS_TOOL_CALLS);
+
+        // Chat template is already in model.metadata (loaded by the same DB query).
+        // Passing it to the detector ensures accurate format/confidence values even
+        // for custom-named models where filename heuristics would otherwise fail.
+        let chat_template = model.metadata.get("tokenizer.chat_template").map(String::as_str);
+
+        let detection = self.deps.tool_detector.detect(ToolSupportDetectionInput {
+            model_id: model.file_path.to_str().unwrap_or(""),
+            chat_template,
+            tags: &[],
+            source: ModelSource::LocalGguf,
+        });
+
+        Ok(ToolSupportResponse {
+            supports_tool_calls,
+            confidence: detection.confidence,
+            detected_format: detection.detected_format.map(|f| f.to_string()),
+        })
     }
 }
 

--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -494,13 +494,17 @@ impl<'a> ServerOps<'a> {
         let model = self.resolve_model(model_id).await?;
 
         // Primary boolean comes from the authoritative DB capabilities bitflag.
-        let supports_tool_calls =
-            model.capabilities.contains(ModelCapabilities::SUPPORTS_TOOL_CALLS);
+        let supports_tool_calls = model
+            .capabilities
+            .contains(ModelCapabilities::SUPPORTS_TOOL_CALLS);
 
         // Chat template is already in model.metadata (loaded by the same DB query).
         // Passing it to the detector ensures accurate format/confidence values even
         // for custom-named models where filename heuristics would otherwise fail.
-        let chat_template = model.metadata.get("tokenizer.chat_template").map(String::as_str);
+        let chat_template = model
+            .metadata
+            .get("tokenizer.chat_template")
+            .map(String::as_str);
 
         let detection = self.deps.tool_detector.detect(ToolSupportDetectionInput {
             model_id: model.file_path.to_str().unwrap_or(""),

--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -18,7 +18,7 @@ use gglib_core::ports::{ProcessHandle, ServerConfig, ServerHealthStatus};
 
 use crate::deps::GuiDeps;
 use crate::error::GuiError;
-use crate::types::{ServerInfo, ServerLogEntry, StartServerRequest, StartServerResponse, ToolSupportResponse};
+use crate::types::{ServerInfo, StartServerRequest, StartServerResponse, ToolSupportResponse};
 
 /// Handle for a running health monitor task.
 struct MonitorHandle {

--- a/crates/gglib-gui/src/types.rs
+++ b/crates/gglib-gui/src/types.rs
@@ -104,17 +104,19 @@ pub struct HfQuantizationsResponse {
 }
 
 /// Response for tool/function calling support detection.
+///
+/// Used for both HuggingFace model metadata and local running server queries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HfToolSupportResponse {
-    pub supports_tool_calling: bool,
+pub struct ToolSupportResponse {
+    pub supports_tool_calls: bool,
     pub confidence: f32,
     pub detected_format: Option<String>,
 }
 
-impl From<gglib_core::ports::ToolSupportDetection> for HfToolSupportResponse {
+impl From<gglib_core::ports::ToolSupportDetection> for ToolSupportResponse {
     fn from(detection: gglib_core::ports::ToolSupportDetection) -> Self {
         Self {
-            supports_tool_calling: detection.supports_tool_calling,
+            supports_tool_calls: detection.supports_tool_calling,
             confidence: detection.confidence,
             detected_format: detection.detected_format.map(|f| f.to_string()),
         }

--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -171,7 +171,8 @@ pub struct ChatCompletionChunk {
 pub struct ChatChunkChoice {
     pub index: u32,
     pub delta: ChatDelta,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // finish_reason must serialize as `null` for intermediate chunks per the
+    // OpenAI streaming spec — intentionally NOT using skip_serializing_if here.
     pub finish_reason: Option<String>,
 }
 

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -40,6 +40,8 @@ import { useDeepResearch } from '../../hooks/useDeepResearch';
 import type { ResearchState } from '../../hooks/useDeepResearch/types';
 import { cn } from '../../utils/cn';
 import { DEFAULT_SYSTEM_PROMPT } from '../../hooks/useGglibRuntime';
+import { ToolSupportIndicator } from '../ToolSupportIndicator';
+import { getToolRegistry } from '../../services/tools';
 
 
 interface ChatMessagesPanelProps {
@@ -62,6 +64,13 @@ interface ChatMessagesPanelProps {
   currentStreamingAssistantMessageId: string | null;
   /** Voice mode hook return (optional — only in Tauri) */
   voice?: UseVoiceModeReturn;
+  /**
+   * Whether the active model supports tool/function calling.
+   * null = unknown (capability status not yet resolved).
+   */
+  supportsToolCalls?: boolean | null;
+  /** Detected tool-calling format, e.g. "hermes" or "llama3". */
+  toolFormat?: string | null;
 }
 
 const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
@@ -83,6 +92,8 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
   timingTracker,
   currentStreamingAssistantMessageId,
   voice,
+  supportsToolCalls,
+  toolFormat,
 }) => {
   const threadRuntime = useThreadRuntime({ optional: true });
   const composerRuntime = useComposerRuntime({ optional: true });
@@ -594,6 +605,11 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
           <span className={cn('text-xs py-xs px-sm rounded-full bg-background text-text-muted shrink-0', isThreadRunning && 'bg-primary/10 text-primary animate-research-pulse')}>
             {isThreadRunning ? 'Responding…' : 'Idle'}
           </span>
+          <ToolSupportIndicator
+            supports={supportsToolCalls ?? null}
+            hasToolsConfigured={getToolRegistry().getEnabledDefinitions().length > 0}
+            toolFormat={toolFormat}
+          />
         </div>
         <div className="flex gap-sm shrink-0">
           <ToolsPopover />

--- a/src/components/HfModelPreview/HfModelPreview.tsx
+++ b/src/components/HfModelPreview/HfModelPreview.tsx
@@ -12,7 +12,7 @@ import {
   Wrench,
   XCircle,
 } from 'lucide-react';
-import { HfModelSummary, HfQuantization, HfQuantizationsResponse, HfToolSupportResponse, FitStatus } from '../../types';
+import { HfModelSummary, HfQuantization, HfQuantizationsResponse, ToolSupportResponse, FitStatus } from '../../types';
 import { getHfQuantizations, getHfToolSupport } from '../../services/clients/huggingface';
 import { openUrl } from '../../services/platform';
 import { formatBytes, formatNumber, getHuggingFaceModelUrl } from '../../utils/format';
@@ -79,7 +79,7 @@ const HfModelPreview: FC<HfModelPreviewProps> = ({
   const [quantError, setQuantError] = useState<string | null>(null);
   
   // Tool support detection state
-  const [toolSupport, setToolSupport] = useState<HfToolSupportResponse | null>(null);
+  const [toolSupport, setToolSupport] = useState<ToolSupportResponse | null>(null);
   const [loadingToolSupport, setLoadingToolSupport] = useState(true);
 
   // Memory fit checking
@@ -213,7 +213,7 @@ const HfModelPreview: FC<HfModelPreviewProps> = ({
             </span>
           )}
           {/* Tool support badge - only show when loaded and supported */}
-          {!loadingToolSupport && toolSupport?.supports_tool_calling && (
+          {!loadingToolSupport && toolSupport?.supports_tool_calls && (
             <span 
               className="inline-flex items-center gap-1 px-sm py-xs bg-[rgba(37,99,235,0.15)] text-primary-light rounded-base text-xs font-medium cursor-help transition-colors duration-150 ease-linear hover:bg-[rgba(37,99,235,0.25)]"
               title={getToolSupportTooltip()}

--- a/src/components/ToolSupportIndicator.tsx
+++ b/src/components/ToolSupportIndicator.tsx
@@ -1,0 +1,70 @@
+/**
+ * ToolSupportIndicator
+ *
+ * Small pill badge shown in the chat header to communicate whether the active
+ * model supports tool/function calling.
+ *
+ * Visibility rules (matching issue #256 spec):
+ *   - No tools configured  → render nothing
+ *   - supports = null       → render nothing (unknown / still loading)
+ *   - supports = true       → "⚡ Tools active"  (green pill)
+ *   - supports = false      → "💬 Chat only"     (amber pill, tooltip explains why)
+ */
+
+import { Zap, MessageCircle } from 'lucide-react';
+import { Icon } from './ui/Icon';
+import { cn } from '../utils/cn';
+
+export interface ToolSupportIndicatorProps {
+  /** Whether the model supports tool calls. Null means unknown — renders nothing. */
+  supports: boolean | null;
+  /** Whether any tools are currently enabled. When false the indicator is hidden. */
+  hasToolsConfigured: boolean;
+  /** Detected tool-calling format (e.g. "hermes", "llama3"). Used in hover tooltip. */
+  toolFormat?: string | null;
+  className?: string;
+}
+
+export function ToolSupportIndicator({
+  supports,
+  hasToolsConfigured,
+  toolFormat,
+  className,
+}: ToolSupportIndicatorProps) {
+  // Only show when tools are in use and we have a definitive answer
+  if (!hasToolsConfigured || supports === null) return null;
+
+  if (supports) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 py-[2px] px-2 text-[11px] font-medium rounded-[10px] shrink-0',
+          'bg-[#10b981]/15 text-[#10b981]',
+          className,
+        )}
+        title={
+          toolFormat
+            ? `Tools active — model supports tool calling (${toolFormat} format)`
+            : 'Tools active — model supports tool calling'
+        }
+      >
+        <Icon icon={Zap} size={11} />
+        Tools active
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 py-[2px] px-2 text-[11px] font-medium rounded-[10px] shrink-0',
+        'bg-[#f59e0b]/15 text-[#f59e0b]',
+        className,
+      )}
+      title="This model does not support tool/function calling — tools are disabled for this chat"
+    >
+      <Icon icon={MessageCircle} size={11} />
+      Chat only
+    </span>
+  );
+}

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -91,6 +91,13 @@ export interface RunAgenticLoopOptions {
   mkAssistantMessage: (custom?: any) => GglibMessage;
   timingTracker?: ReasoningTimingTracker;
   setCurrentStreamingAssistantMessageId?: (id: string | null) => void;
+  /**
+   * Whether the active model supports tool/function calling.
+   * - `true`  → tools sent normally
+   * - `false` → tools stripped (client-side defense-in-depth alongside backend gating)
+   * - `null` / `undefined` → unknown; treated as supported (permissive fallback)
+   */
+  supportsToolCalls?: boolean | null;
 }
 
 /**
@@ -115,23 +122,36 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     mkAssistantMessage: mkAssistant,
     timingTracker,
     setCurrentStreamingAssistantMessageId,
+    supportsToolCalls,
   } = options;
 
   let iteration = 0;
 
   // Get tool definitions
   const toolDefinitions = getToolDefinitions();
-  const hasTools = toolDefinitions.length > 0;
+
+  // Client-side gating: if model is known to NOT support tools, strip them.
+  // null/undefined (unknown) → permissive; only explicit false triggers stripping.
+  const effectiveToolDefs =
+    supportsToolCalls === false ? [] : toolDefinitions;
+
+  if (supportsToolCalls === false && toolDefinitions.length > 0) {
+    appLogger.info('hook.runtime', 'Tool calls suppressed: model does not support tools', {
+      skippedTools: toolDefinitions.length,
+    });
+  }
+
+  const hasTools = effectiveToolDefs.length > 0;
 
   appLogger.debug('hook.runtime', 'Starting agentic loop', {
     maxIterations: maxToolIterations,
     maxStagnation: maxStagnationSteps,
-    tools: hasTools ? toolDefinitions.length : 0,
+    tools: hasTools ? effectiveToolDefs.length : 0,
   });
   
   // Log available tool names for debugging
   if (hasTools) {
-    appLogger.debug('hook.runtime', 'Available tools', { toolNames: toolDefinitions.map(t => t.function.name) });
+    appLogger.debug('hook.runtime', 'Available tools', { toolNames: effectiveToolDefs.map(t => t.function.name) });
   }
 
   // Initialize agent state
@@ -214,7 +234,7 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
     const streamResult = await streamModelResponse({
       serverPort: selectedServerPort,
       messages: messagesForLLM,
-      toolDefinitions,
+      toolDefinitions: effectiveToolDefs,
       abortSignal,
       
       // Update THIS message's content by ID

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -26,6 +26,13 @@ export interface UseGglibRuntimeOptions {
   maxToolIterations?: number;
   maxStagnationSteps?: number;
   onError?: (error: Error) => void;
+  /**
+   * Whether the active model supports tool/function calling.
+   * - `true`  → tools sent normally
+   * - `false` → tools stripped (defense-in-depth)
+   * - `null` / `undefined` → unknown; treated as supported (permissive fallback)
+   */
+  supportsToolCalls?: boolean | null;
 }
 
 export interface UseGglibRuntimeReturn {
@@ -52,6 +59,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
     maxToolIterations,
     maxStagnationSteps,
     onError,
+    supportsToolCalls,
   } = options;
 
   // Message state managed externally
@@ -148,6 +156,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
         mkAssistantMessage: (custom) => mkAssistantMessage({ ...custom, ...extraMeta }),
         timingTracker,
         setCurrentStreamingAssistantMessageId,
+        supportsToolCalls,
       });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {

--- a/src/hooks/useToolSupportCache.ts
+++ b/src/hooks/useToolSupportCache.ts
@@ -88,7 +88,7 @@ export function useToolSupportCache(modelId: string | null): UseToolSupportResul
 
     const fetchPromise = getHfToolSupport(modelId)
       .then((response) => {
-        const supports = response.supports_tool_calling;
+        const supports = response.supports_tool_calls;
         toolSupportCache.set(modelId, { supports, loading: false });
         setResult({ supports, loading: false });
         return supports;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -17,6 +17,7 @@ import { useSettings } from '../hooks/useSettings';
 import { useVoiceModeContext } from '../contexts/VoiceModeContext';
 import { useToastContext } from '../contexts/ToastContext';
 import { useServerState } from '../services/serverEvents';
+import { getServerToolSupport } from '../services/clients/servers';
 import {
   listConversations,
   createConversation,
@@ -82,6 +83,26 @@ export default function ChatPage({
   const maxToolIterations = settings?.maxToolIterations ?? undefined;
   const maxStagnationSteps = settings?.maxStagnationSteps ?? undefined;
 
+  // Tool support capability for the active model.
+  // Fetched once on mount (model identity is fixed for the lifetime of ChatPage).
+  // null = unknown (permissive fallback - never gates tools when status is uncertain).
+  const [supportsToolCalls, setSupportsToolCalls] = useState<boolean | null>(null);
+  const [toolFormat, setToolFormat] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getServerToolSupport(modelId)
+      .then((data) => {
+        if (!cancelled) {
+          setSupportsToolCalls(data.supports_tool_calls);
+          setToolFormat(data.detected_format ?? null);
+        }
+      })
+      .catch(() => {
+        // Permissive fallback: leave supportsToolCalls as null (unknown)
+      });
+    return () => { cancelled = true; };
+  }, [modelId]);
+
   // Runtime - now with external message state
   const { runtime, messages, setMessages, isRunning, timingTracker, currentStreamingAssistantMessageId, setNextMessageMeta } = useGglibRuntime({
     conversationId: activeConversationId ?? undefined,
@@ -89,6 +110,7 @@ export default function ChatPage({
     onError: (error) => setChatError(error.message),
     maxToolIterations,
     maxStagnationSteps,
+    supportsToolCalls,
   });
 
   // Server state from registry - derives isServerRunning reactively
@@ -461,6 +483,8 @@ export default function ChatPage({
               timingTracker={timingTracker}
               currentStreamingAssistantMessageId={currentStreamingAssistantMessageId}
               voice={voice ?? undefined}
+              supportsToolCalls={supportsToolCalls}
+              toolFormat={toolFormat}
             />
           </div>
         </div>

--- a/src/services/clients/huggingface.ts
+++ b/src/services/clients/huggingface.ts
@@ -14,7 +14,7 @@ import type {
   HfSearchRequest,
   HfSearchResponse,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
 } from '../../types';
 
 /**
@@ -44,6 +44,6 @@ export async function getHfQuantizations(modelId: HfModelId): Promise<HfQuantiza
 /**
  * Get tool support information for a HuggingFace model.
  */
-export async function getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse> {
+export async function getHfToolSupport(modelId: HfModelId): Promise<ToolSupportResponse> {
   return getTransport().getHfToolSupport(modelId);
 }

--- a/src/services/clients/servers.ts
+++ b/src/services/clients/servers.ts
@@ -9,7 +9,7 @@
 
 import { getTransport } from '../transport';
 import type { ModelId } from '../transport/types/ids';
-import type { ServeConfig, ServerInfo } from '../../types';
+import type { ServeConfig, ServerInfo, ToolSupportResponse } from '../../types';
 import type { ServeResponse } from '../transport/types/servers';
 import type { ProxyConfig, ProxyStatus } from '../transport/types/proxy';
 
@@ -57,4 +57,8 @@ export async function startProxy(config?: Partial<ProxyConfig>): Promise<ProxySt
  */
 export async function stopProxy(): Promise<void> {
   return getTransport().stopProxy();
+}
+
+export async function getServerToolSupport(modelId: ModelId): Promise<ToolSupportResponse> {
+  return getTransport().getServerToolSupport(modelId);
 }

--- a/src/services/transport/api/models/hf.ts
+++ b/src/services/transport/api/models/hf.ts
@@ -10,7 +10,7 @@ import type {
   HfSearchRequest,
   HfSearchResponse,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
 } from '../../types/models';
 import type { HfModelSummary } from '../../../../types';
 
@@ -48,8 +48,8 @@ export async function getHfQuantizations(modelId: HfModelId): Promise<HfQuantiza
 /**
  * Get tool support information for a HuggingFace model.
  */
-export async function getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse> {
-  return get<HfToolSupportResponse>(
+export async function getHfToolSupport(modelId: HfModelId): Promise<ToolSupportResponse> {
+  return get<ToolSupportResponse>(
     `${HF_TOOL_SUPPORT_PATH}/${encodeURIComponent(modelId)}`
   );
 }

--- a/src/services/transport/api/servers.ts
+++ b/src/services/transport/api/servers.ts
@@ -6,6 +6,7 @@
 import { post, get } from './client';
 import type { ModelId } from '../types/ids';
 import type { ServeConfig, ServeResponse, ServerInfo } from '../types/servers';
+import type { ToolSupportResponse } from '../../../types';
 import { toStartServerRequest } from '../mappers';
 
 /**
@@ -28,4 +29,11 @@ export async function stopServer(modelId: ModelId): Promise<void> {
  */
 export async function listServers(): Promise<ServerInfo[]> {
   return get<ServerInfo[]>('/api/servers');
+}
+
+/**
+ * Retrieve tool-calling capability for a running server's model.
+ */
+export async function getServerToolSupport(modelId: ModelId): Promise<ToolSupportResponse> {
+  return get<ToolSupportResponse>(`/api/servers/${modelId}/tool-support`);
 }

--- a/src/services/transport/types/models.ts
+++ b/src/services/transport/types/models.ts
@@ -15,7 +15,7 @@ import type {
   HfSearchResponse,
   HfQuantization,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
   HfSortField,
   ModelFilterOptions,
   RangeValues,
@@ -33,7 +33,7 @@ export type {
   HfSearchResponse,
   HfQuantization,
   HfQuantizationsResponse,
-  HfToolSupportResponse,
+  ToolSupportResponse,
   HfSortField,
   ModelFilterOptions,
   RangeValues,
@@ -88,7 +88,7 @@ export interface ModelsTransport {
   browseHfModels(params: HfSearchRequest): Promise<HfSearchResponse>;
   getHfModelSummary(modelId: HfModelId): Promise<HfModelSummary>;
   getHfQuantizations(modelId: HfModelId): Promise<HfQuantizationsResponse>;
-  getHfToolSupport(modelId: HfModelId): Promise<HfToolSupportResponse>;
+  getHfToolSupport(modelId: HfModelId): Promise<ToolSupportResponse>;
 
   // System info
   getSystemMemory(): Promise<SystemMemoryInfo | null>;

--- a/src/services/transport/types/servers.ts
+++ b/src/services/transport/types/servers.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ModelId } from './ids';
-import type { ServeConfig, ServerInfo } from '../../../types';
+import type { ServeConfig, ServerInfo, ToolSupportResponse } from '../../../types';
 
 // Re-export existing types
 export type { ServeConfig, ServerInfo };
@@ -29,4 +29,7 @@ export interface ServersTransport {
 
   /** List all running servers. */
   listServers(): Promise<ServerInfo[]>;
+
+  /** Retrieve tool-calling capability for a running server's model. */
+  getServerToolSupport(modelId: ModelId): Promise<ToolSupportResponse>;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -334,10 +334,12 @@ export interface HfQuantizationsResponse {
 
 /**
  * Response for tool/function calling support detection.
+ *
+ * Used for both HuggingFace model metadata and local running server queries.
  */
-export interface HfToolSupportResponse {
+export interface ToolSupportResponse {
   /** Whether the model supports tool/function calling */
-  supports_tool_calling: boolean;
+  supports_tool_calls: boolean;
   /** Confidence level of the detection (0.0 to 1.0) */
   confidence: number;
   /** Detected tool calling format (e.g., "hermes", "llama3", "mistral") */

--- a/tests/ts/services/clients/huggingface.test.ts
+++ b/tests/ts/services/clients/huggingface.test.ts
@@ -11,7 +11,7 @@ import {
   getHfToolSupport,
 } from '../../../../src/services/clients/huggingface';
 import { getTransport, _resetTransport } from '../../../../src/services/transport';
-import type { HfSearchResponse, HfQuantizationsResponse, HfToolSupportResponse } from '../../../../src/types';
+import type { HfSearchResponse, HfQuantizationsResponse, ToolSupportResponse } from '../../../../src/types';
 
 // Mock the transport module
 vi.mock('../../../../src/services/transport', () => {
@@ -76,9 +76,10 @@ describe('services/clients/huggingface', () => {
   describe('getHfToolSupport', () => {
     it('delegates to transport.getHfToolSupport()', async () => {
       const modelId = 'TheBloke/Llama-2-7B-GGUF';
-      const mockResponse: HfToolSupportResponse = {
-        supports_tools: true,
-        tool_format: 'chatml',
+      const mockResponse: ToolSupportResponse = {
+        supports_tool_calls: true,
+        confidence: 0.95,
+        detected_format: 'chatml',
       };
       vi.mocked(mockTransport.getHfToolSupport).mockResolvedValue(mockResponse);
 


### PR DESCRIPTION
## Summary

Closes #244

Implements full tool/function-calling capability detection and gating across the stack, split across three phases:

---

### Phase 1 — Backend: Gate tool/tool_choice injection (#254)

- Extracted  in `gglib-axum/chat_api.rs`
- Tool definitions and `tool_choice` are now only forwarded to the llama-server when the model's `ModelCapabilities` bitflag includes `SUPPORTS_TOOL_CALLS`
- 3 unit tests covering: strip-when-not-supported, forward-when-supported, no-op-when-no-tools

---

### Phase 2 — API: Expose tool support status (#255)

- New endpoint `GET /api/servers/{id}/tool-support` → `ToolSupportResponse`
- Renamed `HfToolSupportResponse` → `ToolSupportResponse` (unified type for both HF and local server queries); field renamed `supports_tool_calling` → `supports_tool_calls` for consistency
- `ServerOps::get_server_tool_support` resolves capability from DB bitflags + chat template — no disk I/O
- Propagated rename across `gglib-gui`, `gglib-axum`, all frontend types, transport layer, clients, and tests

---

### Phase 3 — Frontend: ToolSupportIndicator and client-side gating (#256)

- New `ToolSupportIndicator` component: green ⚡ "Tools active" pill when supported, amber 💬 "Chat only" pill when not; hidden when no tools are configured or status is unknown
- `ChatPage` fetches tool support on mount via `getServerToolSupport(modelId)`; threads `supportsToolCalls` + `toolFormat` down to `ChatMessagesPanel` and `useGglibRuntime`
- `runAgenticLoop` client-side gating: when `supportsToolCalls === false`, tool definitions are stripped before the request is sent (defense-in-depth alongside backend gating)
- Permissive fallback: `null` / `undefined` capability status is treated as supported — tools are never silently dropped due to a failed status fetch

---

## Testing

- Rust unit tests: `cargo test -p gglib-axum`
- TypeScript tests updated for `ToolSupportResponse` rename
- Manual: start a tool-capable model → indicator shows green pill; start a non-tool model → indicator shows amber pill, tools absent from forwarded request