### PR TITLE
feat(agent): Phase 1 — replace sequential tool execution with Promise.allSettled + concurrency limit (#260)

### DIFF
--- a/src/hooks/useGglibRuntime/agentLoop.ts
+++ b/src/hooks/useGglibRuntime/agentLoop.ts
@@ -19,6 +19,10 @@ export const DEFAULT_MAX_TOOL_ITERS = 25;
 export const MAX_SAME_SIGNATURE_HITS = 2;
 export const MAX_STAGNATION_STEPS = 5;
 
+/** Parallel tool execution */
+export const MAX_PARALLEL_TOOLS = 5;
+export const TOOL_TIMEOUT_MS = 30_000;
+
 /** Memory management */
 export const MAX_CONTEXT_CHARS = 180_000;
 export const KEEP_LAST_TOOL_MESSAGES = 10;

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -23,8 +23,8 @@ import {
   checkToolLoop,
   pruneForBudget,
   summarizeToolResult,
-  withRetry,
 } from './agentLoop';
+import { executeToolBatch } from './toolBatchExecution';
 import {
   type PromptLayer,
   injectPromptLayers,
@@ -322,78 +322,61 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
       break;
     }
 
-    // Execute tools and UPDATE tool-call parts with results
+    // Execute tools in parallel and UPDATE tool-call parts as each one settles
     appLogger.debug('hook.runtime', 'Executing tools', { toolCount: streamResult.toolCalls.length });
-    
-    const toolCallsForApiHistory: any[] = [];
-    const toolResultsForApiHistory: any[] = [];
-    
-    for (const toolCall of streamResult.toolCalls) {
-      // Execute tool
-      const registry = getToolRegistry();
-      const result = await withRetry(
-        () =>
-          registry.executeRawCall({
-            id: toolCall.id,
-            type: 'function',
-            function: toolCall.function,
-          }),
-        { maxRetries: 2, baseDelayMs: 250 }
-      ).catch((e) => ({
-        success: false as const,
-        error: String((e as { message?: string })?.message ?? e ?? 'Unknown error'),
-      }));
 
-      appLogger.debug('hook.runtime', 'Tool executed', { toolName: toolCall.function.name, result });
+    const toolResults = await executeToolBatch(
+      streamResult.toolCalls,
+      (_index, toolCall, result) => {
+        appLogger.debug('hook.runtime', 'Tool executed', { toolName: toolCall.function.name, result });
 
-      // Create digest for working memory
-      const digest: ToolDigest = {
-        sig: toolSignature(toolCall),
-        name: toolCall.function.name,
-        ok: result.success,
-        summary: summarizeToolResult(toolCall.function.name, result),
-      };
-      agentState.toolDigests.push(digest);
-
-      // Update the tool-call part with result
-      setMessages(prev =>
-        prev.map(m => {
-          if (m.id !== assistantMessageId) return m;
-          
-          const updatedContent = Array.isArray(m.content)
-            ? m.content.map((p: any) =>
-                p.type === 'tool-call' && p.toolCallId === toolCall.id
-                  ? {
-                      ...p,
-                      result: result.success ? result.data : { error: result.error },
-                      isError: !result.success,
-                    }
-                  : p
-              )
-            : m.content;
-          
-          return { ...m, content: updatedContent as GglibContent };
-        })
-      );
-
-      // Add to API messages for next iteration (OpenAI format requires tool results)
-      toolCallsForApiHistory.push({
-        id: toolCall.id,
-        type: 'function',
-        function: {
+        // Accumulate digest for working memory
+        const digest: ToolDigest = {
+          sig: toolSignature(toolCall),
           name: toolCall.function.name,
-          arguments: toolCall.function.arguments,
-        },
-      });
+          ok: result.success,
+          summary: summarizeToolResult(toolCall.function.name, result),
+        };
+        agentState.toolDigests.push(digest);
 
-      toolResultsForApiHistory.push({
-        role: 'tool',
-        tool_call_id: toolCall.id,
-        content: JSON.stringify(result.success ? result.data : { error: result.error }),
-      });
-    }
+        // Update the tool-call part immediately as this tool completes.
+        // Functional updater avoids stale-closure overwrites from concurrent callbacks.
+        setMessages(prev =>
+          prev.map(m => {
+            if (m.id !== assistantMessageId) return m;
 
-    // Add to API messages for next iteration
+            const updatedContent = Array.isArray(m.content)
+              ? m.content.map((p: any) =>
+                  p.type === 'tool-call' && p.toolCallId === toolCall.id
+                    ? {
+                        ...p,
+                        result: result.success ? result.data : { error: result.error },
+                        isError: !result.success,
+                      }
+                    : p
+                )
+              : m.content;
+
+            return { ...m, content: updatedContent as GglibContent };
+          })
+        );
+      },
+    );
+
+    // Build API history in original toolCalls order (required by OpenAI protocol)
+    const toolCallsForApiHistory = streamResult.toolCalls.map(tc => ({
+      id: tc.id,
+      type: 'function',
+      function: { name: tc.function.name, arguments: tc.function.arguments },
+    }));
+
+    const toolResultsForApiHistory = toolResults.map((result, i) => ({
+      role: 'tool',
+      tool_call_id: streamResult.toolCalls[i].id,
+      content: JSON.stringify(result.success ? result.data : { error: result.error }),
+    }));
+
+    // Add assistant turn + tool results to API messages for next iteration
     apiMessages.push({
       role: 'assistant',
       content: streamResult.textContent || null,

--- a/src/hooks/useGglibRuntime/toolBatchExecution.ts
+++ b/src/hooks/useGglibRuntime/toolBatchExecution.ts
@@ -1,0 +1,168 @@
+/**
+ * Parallel tool batch execution utilities.
+ *
+ * Houses the concurrency limiter, per-tool timeout wrapper, and the batch
+ * runner. Intentionally decoupled from React — callers supply an
+ * onToolSettled callback to handle UI updates and digest accumulation as each
+ * tool completes, without waiting for the full batch to finish.
+ *
+ * @module toolBatchExecution
+ */
+
+import { appLogger } from '../../services/platform';
+import type { AccumulatedToolCall } from './accumulateToolCalls';
+import type { ToolResult } from '../../services/tools';
+import { getToolRegistry } from '../../services/tools';
+import { withRetry, MAX_PARALLEL_TOOLS, TOOL_TIMEOUT_MS } from './agentLoop';
+
+// =============================================================================
+// Concurrency limiter
+// =============================================================================
+
+/**
+ * Create a simple concurrency semaphore.
+ *
+ * Ensures at most `concurrency` wrapped promises run simultaneously.
+ * A `finally` block decrements the active count so a rejected promise never
+ * permanently stalls the queue.
+ */
+export function createConcurrencyLimiter(concurrency: number) {
+  let active = 0;
+  const queue: (() => void)[] = [];
+
+  return function limit<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        active++;
+        fn()
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            queue.shift()?.();
+          });
+      };
+
+      if (active < concurrency) {
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+  };
+}
+
+// =============================================================================
+// Per-tool timeout wrapper
+// =============================================================================
+
+/**
+ * Race a promise-returning function against a timeout.
+ *
+ * Clears the timeout handle in a `finally` block to prevent a leaked
+ * `setTimeout` accumulating across a long agentic session with many tool calls.
+ *
+ * NOTE: `Promise.race` leaves the underlying `fn()` executing as a detached
+ * background task if the timeout fires first. Consider piping an AbortSignal
+ * into `executeRawCall` in a future pass to enable real cancellation.
+ */
+export function withToolTimeout<T>(fn: () => Promise<T>, ms: number): Promise<T> {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    handle = setTimeout(
+      () => reject(new Error(`Tool timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([fn(), timeoutPromise]).finally(() => {
+    clearTimeout(handle);
+  });
+}
+
+// =============================================================================
+// Batch executor
+// =============================================================================
+
+/**
+ * Callback invoked immediately as each individual tool settles.
+ *
+ * @param index    The original position in the toolCalls array.
+ * @param toolCall The tool call that settled.
+ * @param result   Normalised ToolResult (success or failure).
+ */
+export type OnToolSettled = (
+  index: number,
+  toolCall: AccumulatedToolCall,
+  result: ToolResult,
+) => void;
+
+/**
+ * Execute all tool calls concurrently with a concurrency cap and per-tool
+ * timeout, streaming results to the caller as each tool finishes.
+ *
+ * Guarantees:
+ * - `onToolSettled` is called as soon as each individual tool settles, so the
+ *   UI can reflect completed tools without waiting for the whole batch.
+ * - The original array `index` is preserved in `onToolSettled`, regardless of
+ *   which promise resolves first, so order-sensitive data structures stay
+ *   consistent.
+ * - Synchronous errors thrown by `onToolSettled` are caught and logged so a
+ *   UI rendering failure cannot crash the rest of the batch.
+ * - Returns `ToolResult[]` in the same order as the input array, ready for
+ *   inclusion in the API message history.
+ */
+export async function executeToolBatch(
+  toolCalls: AccumulatedToolCall[],
+  onToolSettled: OnToolSettled,
+): Promise<ToolResult[]> {
+  const limit = createConcurrencyLimiter(MAX_PARALLEL_TOOLS);
+  const results: ToolResult[] = new Array(toolCalls.length);
+
+  const notifySettled = (
+    index: number,
+    toolCall: AccumulatedToolCall,
+    result: ToolResult,
+  ): void => {
+    results[index] = result;
+    try {
+      onToolSettled(index, toolCall, result);
+    } catch (cbErr) {
+      appLogger.warn('hook.runtime', 'onToolSettled callback threw', {
+        index,
+        toolName: toolCall.function.name,
+        error: String(cbErr),
+      });
+    }
+  };
+
+  await Promise.allSettled(
+    toolCalls.map((toolCall, index) =>
+      limit(() =>
+        withToolTimeout(
+          () =>
+            withRetry(
+              () =>
+                getToolRegistry().executeRawCall({
+                  id: toolCall.id,
+                  type: 'function',
+                  function: toolCall.function,
+                }),
+              { maxRetries: 2, baseDelayMs: 250 },
+            ),
+          TOOL_TIMEOUT_MS,
+        ),
+      ).then(
+        (result) => {
+          notifySettled(index, toolCall, result);
+        },
+        (err: unknown) => {
+          const error = `[${toolCall.function.name}] ${String(
+            (err as { message?: string })?.message ?? err ?? 'Unknown error',
+          )}`;
+          notifySettled(index, toolCall, { success: false, error });
+        },
+      ),
+    ),
+  );
+
+  return results;
+}


### PR DESCRIPTION
## Summary

Implements #260 (Phase 1 of epic #245).

Replaces the sequential `for...of` tool execution loop in `runAgenticLoop.ts` with parallel execution backed by a concurrency limiter and per-tool timeout. UI updates are streamed as each tool completes rather than batched at the end.

---

## Changes

### `src/hooks/useGglibRuntime/agentLoop.ts`
Added two new agent policy constants alongside the existing ones:
- `MAX_PARALLEL_TOOLS = 5` — concurrency cap for parallel tool execution
- `TOOL_TIMEOUT_MS = 30_000` — per-tool timeout before treating the call as failed

### `src/hooks/useGglibRuntime/toolBatchExecution.ts` *(new file)*
Single-responsibility module owning all parallelism concerns:

- **`createConcurrencyLimiter(concurrency)`** — inline semaphore (no `p-limit` dependency). A `finally` block always decrements `active` so a rejected promise can never permanently stall the queue.
- **`withToolTimeout(fn, ms)`** — `Promise.race` against a timed rejection. Clears the timeout handle in a `finally` block to prevent leaked `setTimeout` handles accumulating across long sessions. Includes a comment noting the dangling-background-execution caveat and flagging `AbortSignal` threading into `executeRawCall` as future work.
- **`executeToolBatch(toolCalls, onToolSettled)`** — maps tool calls through the limiter + timeout + retry chain and runs them via `Promise.allSettled`. Calls `onToolSettled(index, toolCall, result)` **immediately** as each individual tool settles for progressive UI updates. Catches synchronous errors thrown by `onToolSettled` so a UI rendering failure cannot crash the batch. Returns `ToolResult[]` in original-call order.

### `src/hooks/useGglibRuntime/runAgenticLoop.ts`
- Removed `withRetry` import (encapsulated inside `toolBatchExecution`)
- Replaced the sequential `for (const toolCall of streamResult.toolCalls)` loop with a single `await executeToolBatch(...)` call
- `onToolSettled` callback uses the `setMessages(prev => ...)` **functional updater pattern** on every invocation to avoid stale-closure overwrites from concurrent callbacks
- API history (`tool_calls` + `tool` messages) is built from `streamResult.toolCalls` and the ordered `toolResults` array *after* `executeToolBatch` resolves, preserving the original order required by the OpenAI protocol

---

## Acceptance Criteria

- [x] Multiple tool calls in a single LLM response execute concurrently (up to `MAX_PARALLEL_TOOLS`)
- [x] Individual tool failures don't crash the entire batch (`Promise.allSettled`)
- [x] Tool results are returned to the LLM in the same order as the original tool calls
- [x] Per-tool timeout prevents hanging on stuck tools (`TOOL_TIMEOUT_MS`)
- [x] Concurrency limit prevents resource exhaustion (`createConcurrencyLimiter`)
- [x] Error messages from failed tools are informative (include tool name and error)
- [x] UI updates stream in as each tool completes (`onToolSettled` called immediately per-tool)
- [x] `setMessages` uses functional updater pattern throughout to avoid stale React closures
- [x] Timeout handle cleared in `finally` — no `setTimeout` memory leaks
- [x] Limiter uses `finally` — rejected promises cannot permanently stall the queue

---

## Commit Log

1. `feat(agent): add MAX_PARALLEL_TOOLS and TOOL_TIMEOUT_MS constants`
2. `feat(agent): add toolBatchExecution module (concurrency limiter + timeout)`
3. `feat(agent): replace sequential tool loop with parallel executeToolBatch`

Closes #260.