### PR TITLE
feat(ui): Phase 2 — real-time parallel tool execution progress (#261)

### DIFF
--- a/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
+++ b/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
@@ -15,6 +15,7 @@ import { threadMessageToTranscriptMarkdown } from '../../../utils/messages';
 import { MessageActionsContext } from './MessageActionsContext';
 import { useThinkingTiming } from '../context/ThinkingTimingContext';
 import { ToolUsageBadge } from '../../ToolUsageBadge';
+import { ToolExecutionProgress } from '../../ToolExecutionProgress';
 import { useDeepResearchContext } from '../context/DeepResearchContext';
 import { ResearchArtifact } from '../../DeepResearch';
 import type { GglibMessageCustom } from '../../../types/messages';
@@ -205,6 +206,7 @@ export const AssistantMessageBubble: React.FC = () => {
           <span className="text-text-muted animate-blink">…</span>
         )}
       </div>
+      <ToolExecutionProgress />
       <ActionBarPrimitive.Root className="flex gap-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100">
         <SpeakButton message={message} />
         <ActionBarPrimitive.Copy />

--- a/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
+++ b/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
@@ -1,0 +1,238 @@
+/**
+ * Real-time parallel tool execution progress panel.
+ *
+ * Renders one row per tool-call content part, deriving each tool's status
+ * (running / complete / error) reactively from `useMessage()`. Stays mounted
+ * as a collapsible accordion after all tools settle, preventing layout shifts.
+ *
+ * @module ToolExecutionProgress
+ */
+
+import React, { useState, useRef, useMemo } from 'react';
+import { useMessage } from '@assistant-ui/react';
+import type { ThreadMessage } from '@assistant-ui/react';
+import { CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { Icon } from '../ui/Icon';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
+
+type ToolRowState = 'running' | 'complete' | 'error';
+
+interface ToolRowData {
+  toolCallId: string;
+  toolName: string;
+  state: ToolRowState;
+  durationMs?: number;
+  /** First 80 chars of the error message, for inline display. */
+  errorSummary?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Strip mcp_ prefix and convert snake_case / kebab-case to Title Case.
+ */
+function formatToolName(name: string): string {
+  const cleaned = name.replace(/^mcp_\d+_/, '');
+  return cleaned
+    .split(/[-_]/)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Format a millisecond duration for compact display.
+ */
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Map a tool-call content part to display data.
+ * `durationMs` is a custom field stamped by runAgenticLoop when each tool settles.
+ */
+function classifyPart(part: ToolCallPart): ToolRowData {
+  const durationMs =
+    'durationMs' in part ? (part as any).durationMs as number : undefined;
+
+  if (!('result' in part)) {
+    return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'running' };
+  }
+
+  if ((part as any).isError === true) {
+    const raw = part.result as any;
+    const errorSummary = (raw?.error ?? String(raw) ?? '').slice(0, 80);
+    return {
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      state: 'error',
+      durationMs,
+      errorSummary,
+    };
+  }
+
+  return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'complete', durationMs };
+}
+
+// =============================================================================
+// Sub-components
+// =============================================================================
+
+/**
+ * A single tool execution row: icon + tool name + optional duration / error.
+ */
+const ToolRow: React.FC<{ row: ToolRowData }> = ({ row }) => (
+  <div
+    className={cn(
+      'flex items-center gap-2 py-[3px] px-2 rounded-md text-[12px]',
+      row.state === 'running' && 'text-[#60a5fa]',
+      row.state === 'complete' && 'text-[#4ade80]',
+      row.state === 'error' && 'text-[#f87171]',
+    )}
+  >
+    {row.state === 'running' && (
+      <Icon icon={Loader2} size={13} className="flex-shrink-0 animate-spin" />
+    )}
+    {row.state === 'complete' && (
+      <Icon icon={CheckCircle2} size={13} className="flex-shrink-0" />
+    )}
+    {row.state === 'error' && (
+      <Icon icon={XCircle} size={13} className="flex-shrink-0" />
+    )}
+
+    <span className="font-medium truncate">{formatToolName(row.toolName)}</span>
+
+    {row.state === 'error' && row.errorSummary && (
+      <span className="ml-1 text-text-muted truncate max-w-[160px]">
+        {row.errorSummary}
+      </span>
+    )}
+
+    {row.durationMs !== undefined && (
+      <span className="ml-auto font-mono text-[11px] text-text-muted flex-shrink-0">
+        {formatDuration(row.durationMs)}
+      </span>
+    )}
+  </div>
+);
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+/**
+ * Parallel tool execution progress panel.
+ *
+ * Reads tool-call parts from the current message via `useMessage()`. Each part
+ * is classified as `running`, `complete`, or `error` based on whether a
+ * `result` field is present (stamped by runAgenticLoop as each tool settles).
+ *
+ * The accordion defaults to expanded and **never auto-collapses** — only the
+ * user can toggle it. This prevents CLS when the last tool finishes.
+ */
+const ToolExecutionProgress: React.FC = () => {
+  const message = useMessage();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // Track which tool IDs have already been announced so we emit only once per
+  // completion, not on every re-render.
+  const announcedIds = useRef<Set<string>>(new Set());
+
+  // Extract tool-call parts from the live message content.
+  const toolParts = useMemo(
+    () =>
+      (Array.isArray(message.content) ? message.content : []).filter(
+        (p): p is ToolCallPart =>
+          typeof p !== 'string' && p.type === 'tool-call',
+      ),
+    [message.content],
+  );
+
+  const rows = useMemo(() => toolParts.map(classifyPart), [toolParts]);
+
+  // Build announcements for tools that just transitioned out of 'running'.
+  const newAnnouncements = useMemo(() => {
+    const out: string[] = [];
+    for (const row of rows) {
+      if (row.state === 'running') continue;
+      if (announcedIds.current.has(row.toolCallId)) continue;
+      announcedIds.current.add(row.toolCallId);
+
+      if (row.state === 'complete') {
+        const dur = row.durationMs !== undefined ? ` in ${formatDuration(row.durationMs)}` : '';
+        out.push(`Tool ${formatToolName(row.toolName)} complete${dur}.`);
+      } else {
+        const err = row.errorSummary ? `: ${row.errorSummary}` : '';
+        out.push(`Tool ${formatToolName(row.toolName)} failed${err}.`);
+      }
+    }
+    return out;
+  }, [rows]);
+
+  // Render nothing if the message has no tool calls.
+  if (rows.length === 0) return null;
+
+  const runningCount = rows.filter(r => r.state === 'running').length;
+  const headerLabel =
+    runningCount > 0
+      ? `Running ${runningCount} of ${rows.length} tool${rows.length === 1 ? '' : 's'}…`
+      : `${rows.length} tool${rows.length === 1 ? '' : 's'} complete`;
+
+  return (
+    <div className="mt-2 border border-border rounded-lg overflow-hidden text-sm">
+      {/* ── Accordion header ────────────────────────────────────────────── */}
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-2 bg-background-secondary text-[12px] font-medium text-text-secondary hover:bg-background-tertiary transition-colors duration-150 border-none cursor-pointer"
+        onClick={() => setIsCollapsed(prev => !prev)}
+        aria-expanded={!isCollapsed}
+        aria-controls="tool-execution-rows"
+      >
+        <Icon
+          icon={isCollapsed ? ChevronRight : ChevronDown}
+          size={13}
+          className="flex-shrink-0 transition-transform duration-150"
+        />
+        <span>{headerLabel}</span>
+        {runningCount > 0 && (
+          <Icon icon={Loader2} size={12} className="animate-spin ml-1 text-[#60a5fa]" />
+        )}
+      </button>
+
+      {/* ── Per-tool rows ────────────────────────────────────────────────── */}
+      {!isCollapsed && (
+        <div
+          id="tool-execution-rows"
+          role="list"
+          aria-label="Tool execution status"
+          className="flex flex-col gap-[2px] p-2 bg-background"
+        >
+          {rows.map(row => (
+            <div key={row.toolCallId} role="listitem">
+              <ToolRow row={row} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Screen reader live region ────────────────────────────────────── */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="false"
+        className="sr-only"
+      >
+        {newAnnouncements.join(' ')}
+      </div>
+    </div>
+  );
+};
+
+export default ToolExecutionProgress;

--- a/src/components/ToolExecutionProgress/index.ts
+++ b/src/components/ToolExecutionProgress/index.ts
@@ -1,0 +1,1 @@
+export { default as ToolExecutionProgress } from './ToolExecutionProgress';

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -99,6 +99,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
           const formattedArgs = JSON.stringify(call.args, null, 2);
           const result = 'result' in call ? call.result : null;
           const formattedResult = result ? JSON.stringify(result, null, 2) : 'No result';
+          const durationMs = 'durationMs' in call ? (call as any).durationMs as number : undefined;
 
           const StatusIcon = getStatusIcon(call);
 
@@ -115,6 +116,13 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 </span>
                 <span className="font-semibold text-text">{formatToolName(call.toolName)}</span>
                 <span className="text-[0.85rem] text-text-secondary font-mono">({call.toolName})</span>
+                {durationMs !== undefined && (
+                  <span className="ml-auto text-[0.8rem] text-text-muted font-mono">
+                    {durationMs < 1000
+                      ? `${Math.round(durationMs)}ms`
+                      : `${(durationMs / 1000).toFixed(1)}s`}
+                  </span>
+                )}
               </div>
 
               <Stack gap="xs">

--- a/src/components/ToolUsageBadge/ToolUsageBadge.tsx
+++ b/src/components/ToolUsageBadge/ToolUsageBadge.tsx
@@ -28,25 +28,23 @@ const ToolUsageBadge: React.FC = () => {
   }
 
   // Determine badge status based on tool call results
-  const getToolStatus = (): 'success' | 'error' | 'mixed' => {
+  const getToolStatus = (): 'running' | 'success' | 'error' | 'mixed' => {
     let hasSuccess = false;
     let hasError = false;
 
     for (const call of toolCalls) {
-      // Check if tool call has result
-      if ('result' in call) {
-        const result = call.result as any;
-        if (result && typeof result === 'object') {
-          if ('error' in result || result.success === false) {
-            hasError = true;
-          } else {
-            hasSuccess = true;
-          }
+      if (!('result' in call)) {
+        // At least one tool has no result yet — batch is still in flight.
+        return 'running';
+      }
+      const result = call.result as any;
+      if (result && typeof result === 'object') {
+        if ('error' in result || result.success === false) {
+          hasError = true;
         } else {
           hasSuccess = true;
         }
       } else {
-        // No result yet, treat as success
         hasSuccess = true;
       }
     }
@@ -65,17 +63,26 @@ const ToolUsageBadge: React.FC = () => {
       ? toolNames.join(', ')
       : `${toolNames.slice(0, 2).join(', ')} & ${toolNames.length - 2} more`;
 
+  const runningCount = toolCalls.filter(c => !('result' in c)).length;
+  const ariaLabel =
+    status === 'running'
+      ? `${runningCount} of ${toolCalls.length} tool${toolCalls.length === 1 ? '' : 's'} running`
+      : `${toolCalls.length} tool${toolCalls.length === 1 ? '' : 's'} ${status}`;
+
   return (
     <>
       <button
         className={cn(
           'inline-flex items-center gap-1 py-[2px] px-2 text-[11px] font-medium border-none rounded-[10px] cursor-pointer transition-all duration-150 ml-2 hover:scale-105 hover:shadow-[0_2px_4px_rgba(0,0,0,0.1)] active:scale-[0.98]',
+          status === 'running' && 'bg-[#3b82f6] text-white hover:bg-[#2563eb] animate-pulse',
           status === 'success' && 'bg-[#10b981] text-white hover:bg-[#059669]',
           status === 'error' && 'bg-[#ef4444] text-white hover:bg-[#dc2626]',
           status === 'mixed' && 'bg-[#f59e0b] text-white hover:bg-[#d97706]',
         )}
         onClick={() => setIsModalOpen(true)}
         title="Click to view tool execution details"
+        aria-live="polite"
+        aria-label={ariaLabel}
       >
         <span className="text-[12px] leading-none" aria-hidden="true">
           <Icon icon={Wrench} size={14} />

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -25,6 +25,7 @@ import {
   summarizeToolResult,
 } from './agentLoop';
 import { executeToolBatch } from './toolBatchExecution';
+import type { ToolExecutionEvent } from '../../types/events/toolExecution';
 import {
   type PromptLayer,
   injectPromptLayers,
@@ -327,19 +328,35 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
     const toolResults = await executeToolBatch(
       streamResult.toolCalls,
-      (_index, toolCall, result) => {
-        appLogger.debug('hook.runtime', 'Tool executed', { toolName: toolCall.function.name, result });
+      (event: ToolExecutionEvent) => {
+        if (event.type === 'tool-start') {
+          appLogger.debug('hook.runtime', 'Tool started', { toolName: event.toolName });
+          return;
+        }
 
-        // Accumulate digest for working memory
+        // Both 'tool-complete' and 'tool-error' settle a tool call.
+        const isSuccess = event.type === 'tool-complete';
+        const result = isSuccess
+          ? { success: true as const, data: JSON.parse(event.result) }
+          : { success: false as const, error: event.error };
+
+        appLogger.debug('hook.runtime', 'Tool settled', {
+          toolName: event.toolName,
+          type: event.type,
+          durationMs: event.durationMs,
+        });
+
+        // Accumulate digest for working memory.
         const digest: ToolDigest = {
-          sig: toolSignature(toolCall),
-          name: toolCall.function.name,
-          ok: result.success,
-          summary: summarizeToolResult(toolCall.function.name, result),
+          sig: toolSignature({ id: event.toolCallId, type: 'function', function: { name: event.toolName, arguments: '' } }),
+          name: event.toolName,
+          ok: isSuccess,
+          summary: summarizeToolResult(event.toolName, result),
         };
         agentState.toolDigests.push(digest);
 
-        // Update the tool-call part immediately as this tool completes.
+        // Update the tool-call part immediately as this tool settles.
+        // Stamp durationMs alongside result so UI can show per-tool timing.
         // Functional updater avoids stale-closure overwrites from concurrent callbacks.
         setMessages(prev =>
           prev.map(m => {
@@ -347,11 +364,12 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
             const updatedContent = Array.isArray(m.content)
               ? m.content.map((p: any) =>
-                  p.type === 'tool-call' && p.toolCallId === toolCall.id
+                  p.type === 'tool-call' && p.toolCallId === event.toolCallId
                     ? {
                         ...p,
-                        result: result.success ? result.data : { error: result.error },
-                        isError: !result.success,
+                        result: isSuccess ? result.data : { error: event.error },
+                        isError: !isSuccess,
+                        durationMs: event.durationMs,
                       }
                     : p
                 )

--- a/src/hooks/useGglibRuntime/toolBatchExecution.ts
+++ b/src/hooks/useGglibRuntime/toolBatchExecution.ts
@@ -3,8 +3,9 @@
  *
  * Houses the concurrency limiter, per-tool timeout wrapper, and the batch
  * runner. Intentionally decoupled from React — callers supply an
- * onToolSettled callback to handle UI updates and digest accumulation as each
- * tool completes, without waiting for the full batch to finish.
+ * onToolEvent callback that receives lifecycle events ('tool-start',
+ * 'tool-complete', 'tool-error') as each tool progresses, enabling live UI
+ * updates and telemetry without waiting for the full batch to finish.
  *
  * @module toolBatchExecution
  */
@@ -14,6 +15,7 @@ import type { AccumulatedToolCall } from './accumulateToolCalls';
 import type { ToolResult } from '../../services/tools';
 import { getToolRegistry } from '../../services/tools';
 import { withRetry, MAX_PARALLEL_TOOLS, TOOL_TIMEOUT_MS } from './agentLoop';
+import type { OnToolEvent } from '../../types/events/toolExecution';
 
 // =============================================================================
 // Concurrency limiter
@@ -82,53 +84,40 @@ export function withToolTimeout<T>(fn: () => Promise<T>, ms: number): Promise<T>
 // Batch executor
 // =============================================================================
 
-/**
- * Callback invoked immediately as each individual tool settles.
- *
- * @param index    The original position in the toolCalls array.
- * @param toolCall The tool call that settled.
- * @param result   Normalised ToolResult (success or failure).
- */
-export type OnToolSettled = (
-  index: number,
-  toolCall: AccumulatedToolCall,
-  result: ToolResult,
-) => void;
+// OnToolSettled is superseded by OnToolEvent (re-exported for any legacy callers).
+export type { OnToolEvent } from '../../types/events/toolExecution';
 
 /**
  * Execute all tool calls concurrently with a concurrency cap and per-tool
  * timeout, streaming results to the caller as each tool finishes.
  *
  * Guarantees:
- * - `onToolSettled` is called as soon as each individual tool settles, so the
- *   UI can reflect completed tools without waiting for the whole batch.
- * - The original array `index` is preserved in `onToolSettled`, regardless of
- *   which promise resolves first, so order-sensitive data structures stay
- *   consistent.
- * - Synchronous errors thrown by `onToolSettled` are caught and logged so a
+ * - `onToolEvent` is called for each lifecycle stage ('tool-start',
+ *   'tool-complete', 'tool-error') so callers can update UI and telemetry
+ *   without waiting for the whole batch to finish.
+ * - `performance.now()` is used for duration measurement — immune to system
+ *   clock adjustments and higher-precision than `Date.now()`.
+ * - The original array `index` is preserved in results, regardless of which
+ *   promise resolves first, so order-sensitive data structures stay consistent.
+ * - Synchronous errors thrown by `onToolEvent` are caught and logged so a
  *   UI rendering failure cannot crash the rest of the batch.
  * - Returns `ToolResult[]` in the same order as the input array, ready for
  *   inclusion in the API message history.
  */
 export async function executeToolBatch(
   toolCalls: AccumulatedToolCall[],
-  onToolSettled: OnToolSettled,
+  onToolEvent: OnToolEvent,
 ): Promise<ToolResult[]> {
   const limit = createConcurrencyLimiter(MAX_PARALLEL_TOOLS);
   const results: ToolResult[] = new Array(toolCalls.length);
 
-  const notifySettled = (
-    index: number,
-    toolCall: AccumulatedToolCall,
-    result: ToolResult,
-  ): void => {
-    results[index] = result;
+  const safeEmit = (event: Parameters<OnToolEvent>[0]): void => {
     try {
-      onToolSettled(index, toolCall, result);
+      onToolEvent(event);
     } catch (cbErr) {
-      appLogger.warn('hook.runtime', 'onToolSettled callback threw', {
-        index,
-        toolName: toolCall.function.name,
+      appLogger.warn('hook.runtime', 'onToolEvent callback threw', {
+        type: event.type,
+        toolName: event.toolName,
         error: String(cbErr),
       });
     }
@@ -136,8 +125,17 @@ export async function executeToolBatch(
 
   await Promise.allSettled(
     toolCalls.map((toolCall, index) =>
-      limit(() =>
-        withToolTimeout(
+      limit(() => {
+        // Record start time before invoking the tool; emit 'tool-start'.
+        const startPerf = performance.now();
+        safeEmit({
+          type: 'tool-start',
+          toolCallId: toolCall.id,
+          toolName: toolCall.function.name,
+          timestamp: Date.now(),
+        });
+
+        return withToolTimeout(
           () =>
             withRetry(
               () =>
@@ -149,18 +147,36 @@ export async function executeToolBatch(
               { maxRetries: 2, baseDelayMs: 250 },
             ),
           TOOL_TIMEOUT_MS,
-        ),
-      ).then(
-        (result) => {
-          notifySettled(index, toolCall, result);
-        },
-        (err: unknown) => {
-          const error = `[${toolCall.function.name}] ${String(
-            (err as { message?: string })?.message ?? err ?? 'Unknown error',
-          )}`;
-          notifySettled(index, toolCall, { success: false, error });
-        },
-      ),
+        ).then(
+          (result) => {
+            const durationMs = performance.now() - startPerf;
+            results[index] = result;
+            safeEmit({
+              type: 'tool-complete',
+              toolCallId: toolCall.id,
+              toolName: toolCall.function.name,
+              timestamp: Date.now(),
+              result: result.success ? JSON.stringify(result.data) : '{}',
+              durationMs,
+            });
+          },
+          (err: unknown) => {
+            const durationMs = performance.now() - startPerf;
+            const error = `[${toolCall.function.name}] ${String(
+              (err as { message?: string })?.message ?? err ?? 'Unknown error',
+            )}`;
+            results[index] = { success: false, error };
+            safeEmit({
+              type: 'tool-error',
+              toolCallId: toolCall.id,
+              toolName: toolCall.function.name,
+              timestamp: Date.now(),
+              error,
+              durationMs,
+            });
+          },
+        );
+      }),
     ),
   );
 

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Event type barrel — re-exports all lifecycle event types.
+ */
+
+export type { ToolExecutionEvent, ToolStartEvent, ToolCompleteEvent, ToolErrorEvent, OnToolEvent } from './toolExecution';

--- a/src/types/events/toolExecution.ts
+++ b/src/types/events/toolExecution.ts
@@ -1,0 +1,46 @@
+/**
+ * Tool execution progress events.
+ *
+ * Emitted by executeToolBatch as each individual tool starts and settles,
+ * providing a unified event stream for UI feedback and telemetry.
+ *
+ * @module types/events/toolExecution
+ */
+
+/** Fired immediately before a tool's function is invoked. */
+export interface ToolStartEvent {
+  type: 'tool-start';
+  toolCallId: string;
+  toolName: string;
+  timestamp: number;
+}
+
+/** Fired when a tool returns a successful result. */
+export interface ToolCompleteEvent {
+  type: 'tool-complete';
+  toolCallId: string;
+  toolName: string;
+  timestamp: number;
+  /** Stringified result payload. */
+  result: string;
+  /** Elapsed wall-clock time measured with performance.now(), in milliseconds. */
+  durationMs: number;
+}
+
+/** Fired when a tool fails (execution error or timeout). */
+export interface ToolErrorEvent {
+  type: 'tool-error';
+  toolCallId: string;
+  toolName: string;
+  timestamp: number;
+  /** Human-readable error message. */
+  error: string;
+  /** Elapsed wall-clock time measured with performance.now(), in milliseconds. */
+  durationMs: number;
+}
+
+/** Union of all tool execution lifecycle events. */
+export type ToolExecutionEvent = ToolStartEvent | ToolCompleteEvent | ToolErrorEvent;
+
+/** Callback type for receiving tool execution lifecycle events. */
+export type OnToolEvent = (event: ToolExecutionEvent) => void;


### PR DESCRIPTION
## Closes #261 · Parent epic #245

## Summary

Adds real-time UI feedback for parallel tool execution. Users can now see which tools are running, which have completed, and which failed — with per-tool durations — without waiting for the full batch to finish.

## Changes

### `src/types/events/toolExecution.ts` _(new)_
Defines the `ToolExecutionEvent` union type (`'tool-start'` | `'tool-complete'` | `'tool-error'`) and the `OnToolEvent` callback type. Each event carries `toolCallId`, `toolName`, `timestamp`, and settled events include `durationMs` (measured with `performance.now()`).

### `src/types/events/index.ts` _(new)_
Barrel re-export for all event types.

### `src/hooks/useGglibRuntime/toolBatchExecution.ts`
- Replaced `OnToolSettled` with the unified `OnToolEvent` interface
- Emits `'tool-start'` immediately before the tool function is invoked (inside `limit()`, so only when a concurrency slot is available)
- Emits `'tool-complete'` / `'tool-error'` with `durationMs` computed via `performance.now()` — immune to system clock adjustments
- `safeEmit()` guard prevents callback throws from crashing the batch

### `src/hooks/useGglibRuntime/runAgenticLoop.ts`
- Wired the unified `onToolEvent` handler into `executeToolBatch`
- `'tool-start'`: debug log only (extensible for telemetry)
- `'tool-complete'` / `'tool-error'`: accumulates `ToolDigest` + calls `setMessages` to stamp `result`, `isError`, and **`durationMs`** onto the matching tool-call content part

### `src/components/ToolUsageBadge/ToolUsageBadge.tsx`
- Added `'running'` status: animated blue badge (`animate-pulse`) while any tool-call part lacks a `result`
- Fixed bug: no-result was previously (incorrectly) counted as success
- Added `aria-live="polite"` + descriptive `aria-label` (e.g. "2 of 3 tools running") on the button for screen reader announcements

### `src/components/ToolUsageBadge/ToolDetailsModal.tsx`
- Reads `durationMs` stamped on content parts
- Displays formatted duration (e.g. `350ms` / `1.2s`) in each tool's header row

### `src/components/ToolExecutionProgress/ToolExecutionProgress.tsx` _(new)_
- Reads tool-call content parts from `useMessage()` — no props, no event bus
- Classifies each part as `running` / `complete` / `error` by checking for `result` and `isError`
- **One row per tool**: `Loader2` spinner (running), `CheckCircle2` (complete), `XCircle` (error) + tool name + duration/error summary
- `toolCallId` used as React key — prevents UI tearing on out-of-order promise resolution
- Accordion: `isCollapsed` defaults to `false` (expanded); **never auto-collapses** — only user-triggered, preventing CLS when the last tool settles
- Visually-hidden `aria-live="polite"` / `role="status"` region announces individual completions once (tracked via `useRef` set)
- Returns `null` when the message has no tool-call parts — zero render cost on non-tool messages

### `src/components/ToolExecutionProgress/index.ts` _(new)_
Barrel export.

### `src/components/ChatMessagesPanel/components/MessageBubbles.tsx`
- Renders `<ToolExecutionProgress />` in `AssistantMessageBubble` between message text content and the action bar

## Acceptance Criteria

- [x] Users can see which tools are running in parallel (individual rows, not aggregate)
- [x] Completed tools show duration (via `durationMs` on content parts, displayed in both `ToolExecutionProgress` and `ToolDetailsModal`)
- [x] Failed tools show error summary
- [x] Progress updates in real-time (each `setMessages` call fires as soon as its tool settles)
- [x] UI doesn't flicker or cause layout shifts (accordion stays mounted; `toolCallId` keys)
- [x] Accessible (screen reader live region + `aria-live` on badge button)

## Test Coverage

- TypeScript: `npx tsc --noEmit` — zero errors
- Rust test suite: 270 passed, 0 failed