### PR TITLE
feat(agent): parallelize tool execution in agentic loop (#245)

### DIFF
--- a/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
+++ b/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
@@ -15,6 +15,7 @@ import { threadMessageToTranscriptMarkdown } from '../../../utils/messages';
 import { MessageActionsContext } from './MessageActionsContext';
 import { useThinkingTiming } from '../context/ThinkingTimingContext';
 import { ToolUsageBadge } from '../../ToolUsageBadge';
+import { ToolExecutionProgress } from '../../ToolExecutionProgress';
 import { useDeepResearchContext } from '../context/DeepResearchContext';
 import { ResearchArtifact } from '../../DeepResearch';
 import type { GglibMessageCustom } from '../../../types/messages';
@@ -205,6 +206,7 @@ export const AssistantMessageBubble: React.FC = () => {
           <span className="text-text-muted animate-blink">…</span>
         )}
       </div>
+      <ToolExecutionProgress />
       <ActionBarPrimitive.Root className="flex gap-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100">
         <SpeakButton message={message} />
         <ActionBarPrimitive.Copy />

--- a/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
+++ b/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
@@ -1,0 +1,238 @@
+/**
+ * Real-time parallel tool execution progress panel.
+ *
+ * Renders one row per tool-call content part, deriving each tool's status
+ * (running / complete / error) reactively from `useMessage()`. Stays mounted
+ * as a collapsible accordion after all tools settle, preventing layout shifts.
+ *
+ * @module ToolExecutionProgress
+ */
+
+import React, { useState, useRef, useMemo } from 'react';
+import { useMessage } from '@assistant-ui/react';
+import type { ThreadMessage } from '@assistant-ui/react';
+import { CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { Icon } from '../ui/Icon';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
+
+type ToolRowState = 'running' | 'complete' | 'error';
+
+interface ToolRowData {
+  toolCallId: string;
+  toolName: string;
+  state: ToolRowState;
+  durationMs?: number;
+  /** First 80 chars of the error message, for inline display. */
+  errorSummary?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Strip mcp_ prefix and convert snake_case / kebab-case to Title Case.
+ */
+function formatToolName(name: string): string {
+  const cleaned = name.replace(/^mcp_\d+_/, '');
+  return cleaned
+    .split(/[-_]/)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Format a millisecond duration for compact display.
+ */
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Map a tool-call content part to display data.
+ * `durationMs` is a custom field stamped by runAgenticLoop when each tool settles.
+ */
+function classifyPart(part: ToolCallPart): ToolRowData {
+  const durationMs =
+    'durationMs' in part ? (part as any).durationMs as number : undefined;
+
+  if (!('result' in part)) {
+    return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'running' };
+  }
+
+  if ((part as any).isError === true) {
+    const raw = part.result as any;
+    const errorSummary = (raw?.error ?? String(raw) ?? '').slice(0, 80);
+    return {
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      state: 'error',
+      durationMs,
+      errorSummary,
+    };
+  }
+
+  return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'complete', durationMs };
+}
+
+// =============================================================================
+// Sub-components
+// =============================================================================
+
+/**
+ * A single tool execution row: icon + tool name + optional duration / error.
+ */
+const ToolRow: React.FC<{ row: ToolRowData }> = ({ row }) => (
+  <div
+    className={cn(
+      'flex items-center gap-2 py-[3px] px-2 rounded-md text-[12px]',
+      row.state === 'running' && 'text-[#60a5fa]',
+      row.state === 'complete' && 'text-[#4ade80]',
+      row.state === 'error' && 'text-[#f87171]',
+    )}
+  >
+    {row.state === 'running' && (
+      <Icon icon={Loader2} size={13} className="flex-shrink-0 animate-spin" />
+    )}
+    {row.state === 'complete' && (
+      <Icon icon={CheckCircle2} size={13} className="flex-shrink-0" />
+    )}
+    {row.state === 'error' && (
+      <Icon icon={XCircle} size={13} className="flex-shrink-0" />
+    )}
+
+    <span className="font-medium truncate">{formatToolName(row.toolName)}</span>
+
+    {row.state === 'error' && row.errorSummary && (
+      <span className="ml-1 text-text-muted truncate max-w-[160px]">
+        {row.errorSummary}
+      </span>
+    )}
+
+    {row.durationMs !== undefined && (
+      <span className="ml-auto font-mono text-[11px] text-text-muted flex-shrink-0">
+        {formatDuration(row.durationMs)}
+      </span>
+    )}
+  </div>
+);
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+/**
+ * Parallel tool execution progress panel.
+ *
+ * Reads tool-call parts from the current message via `useMessage()`. Each part
+ * is classified as `running`, `complete`, or `error` based on whether a
+ * `result` field is present (stamped by runAgenticLoop as each tool settles).
+ *
+ * The accordion defaults to expanded and **never auto-collapses** — only the
+ * user can toggle it. This prevents CLS when the last tool finishes.
+ */
+const ToolExecutionProgress: React.FC = () => {
+  const message = useMessage();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // Track which tool IDs have already been announced so we emit only once per
+  // completion, not on every re-render.
+  const announcedIds = useRef<Set<string>>(new Set());
+
+  // Extract tool-call parts from the live message content.
+  const toolParts = useMemo(
+    () =>
+      (Array.isArray(message.content) ? message.content : []).filter(
+        (p): p is ToolCallPart =>
+          typeof p !== 'string' && p.type === 'tool-call',
+      ),
+    [message.content],
+  );
+
+  const rows = useMemo(() => toolParts.map(classifyPart), [toolParts]);
+
+  // Build announcements for tools that just transitioned out of 'running'.
+  const newAnnouncements = useMemo(() => {
+    const out: string[] = [];
+    for (const row of rows) {
+      if (row.state === 'running') continue;
+      if (announcedIds.current.has(row.toolCallId)) continue;
+      announcedIds.current.add(row.toolCallId);
+
+      if (row.state === 'complete') {
+        const dur = row.durationMs !== undefined ? ` in ${formatDuration(row.durationMs)}` : '';
+        out.push(`Tool ${formatToolName(row.toolName)} complete${dur}.`);
+      } else {
+        const err = row.errorSummary ? `: ${row.errorSummary}` : '';
+        out.push(`Tool ${formatToolName(row.toolName)} failed${err}.`);
+      }
+    }
+    return out;
+  }, [rows]);
+
+  // Render nothing if the message has no tool calls.
+  if (rows.length === 0) return null;
+
+  const runningCount = rows.filter(r => r.state === 'running').length;
+  const headerLabel =
+    runningCount > 0
+      ? `Running ${runningCount} of ${rows.length} tool${rows.length === 1 ? '' : 's'}…`
+      : `${rows.length} tool${rows.length === 1 ? '' : 's'} complete`;
+
+  return (
+    <div className="mt-2 border border-border rounded-lg overflow-hidden text-sm">
+      {/* ── Accordion header ────────────────────────────────────────────── */}
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-2 bg-background-secondary text-[12px] font-medium text-text-secondary hover:bg-background-tertiary transition-colors duration-150 border-none cursor-pointer"
+        onClick={() => setIsCollapsed(prev => !prev)}
+        aria-expanded={!isCollapsed}
+        aria-controls="tool-execution-rows"
+      >
+        <Icon
+          icon={isCollapsed ? ChevronRight : ChevronDown}
+          size={13}
+          className="flex-shrink-0 transition-transform duration-150"
+        />
+        <span>{headerLabel}</span>
+        {runningCount > 0 && (
+          <Icon icon={Loader2} size={12} className="animate-spin ml-1 text-[#60a5fa]" />
+        )}
+      </button>
+
+      {/* ── Per-tool rows ────────────────────────────────────────────────── */}
+      {!isCollapsed && (
+        <div
+          id="tool-execution-rows"
+          role="list"
+          aria-label="Tool execution status"
+          className="flex flex-col gap-[2px] p-2 bg-background"
+        >
+          {rows.map(row => (
+            <div key={row.toolCallId} role="listitem">
+              <ToolRow row={row} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Screen reader live region ────────────────────────────────────── */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="false"
+        className="sr-only"
+      >
+        {newAnnouncements.join(' ')}
+      </div>
+    </div>
+  );
+};
+
+export default ToolExecutionProgress;

--- a/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
+++ b/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
@@ -21,6 +21,18 @@ import { Icon } from '../ui/Icon';
 
 type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
 
+/**
+ * Extends the base ToolCallPart with runtime fields stamped by runAgenticLoop
+ * as each tool settles. These fields are not part of the @assistant-ui/react
+ * type surface because they are added dynamically.
+ */
+type AugmentedToolCallPart = ToolCallPart & {
+  /** Elapsed wall-clock time in milliseconds (present once the tool has settled). */
+  durationMs?: number;
+  /** True when the tool result represents an error condition. */
+  isError?: boolean;
+};
+
 type ToolRowState = 'running' | 'complete' | 'error';
 
 interface ToolRowData {
@@ -56,19 +68,22 @@ function formatDuration(ms: number): string {
 
 /**
  * Map a tool-call content part to display data.
- * `durationMs` is a custom field stamped by runAgenticLoop when each tool settles.
+ * `durationMs` and `isError` are custom fields stamped by runAgenticLoop when each tool settles.
  */
 function classifyPart(part: ToolCallPart): ToolRowData {
-  const durationMs =
-    'durationMs' in part ? (part as any).durationMs as number : undefined;
+  const augmented = part as AugmentedToolCallPart;
+  const durationMs = augmented.durationMs;
 
   if (!('result' in part)) {
     return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'running' };
   }
 
-  if ((part as any).isError === true) {
-    const raw = part.result as any;
-    const errorSummary = (raw?.error ?? String(raw) ?? '').slice(0, 80);
+  if (augmented.isError === true) {
+    const raw = part.result as { error?: string } | string | null;
+    const errorSummary = (typeof raw === 'object' && raw !== null
+      ? (raw.error ?? String(raw))
+      : String(raw ?? '')
+    ).slice(0, 80);
     return {
       toolCallId: part.toolCallId,
       toolName: part.toolName,

--- a/src/components/ToolExecutionProgress/index.ts
+++ b/src/components/ToolExecutionProgress/index.ts
@@ -1,0 +1,1 @@
+export { default as ToolExecutionProgress } from './ToolExecutionProgress';

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -9,6 +9,16 @@ import { Stack } from '../primitives';
 
 type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
 
+/**
+ * Extends the base ToolCallPart with runtime fields stamped by runAgenticLoop
+ * as each tool settles. These fields are not part of the @assistant-ui/react
+ * type surface because they are added dynamically.
+ */
+type AugmentedToolCallPart = ToolCallPart & {
+  /** Elapsed wall-clock time in milliseconds (present once the tool has settled). */
+  durationMs?: number;
+};
+
 interface ToolDetailsModalProps {
   toolCalls: ToolCallPart[];
   isOpen?: boolean;
@@ -99,7 +109,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
           const formattedArgs = JSON.stringify(call.args, null, 2);
           const result = 'result' in call ? call.result : null;
           const formattedResult = result ? JSON.stringify(result, null, 2) : 'No result';
-          const durationMs = 'durationMs' in call ? (call as any).durationMs as number : undefined;
+          const durationMs = (call as AugmentedToolCallPart).durationMs;
 
           const StatusIcon = getStatusIcon(call);
 

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -99,6 +99,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
           const formattedArgs = JSON.stringify(call.args, null, 2);
           const result = 'result' in call ? call.result : null;
           const formattedResult = result ? JSON.stringify(result, null, 2) : 'No result';
+          const durationMs = 'durationMs' in call ? (call as any).durationMs as number : undefined;
 
           const StatusIcon = getStatusIcon(call);
 
@@ -115,6 +116,13 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 </span>
                 <span className="font-semibold text-text">{formatToolName(call.toolName)}</span>
                 <span className="text-[0.85rem] text-text-secondary font-mono">({call.toolName})</span>
+                {durationMs !== undefined && (
+                  <span className="ml-auto text-[0.8rem] text-text-muted font-mono">
+                    {durationMs < 1000
+                      ? `${Math.round(durationMs)}ms`
+                      : `${(durationMs / 1000).toFixed(1)}s`}
+                  </span>
+                )}
               </div>
 
               <Stack gap="xs">

--- a/src/components/ToolUsageBadge/ToolUsageBadge.tsx
+++ b/src/components/ToolUsageBadge/ToolUsageBadge.tsx
@@ -28,25 +28,23 @@ const ToolUsageBadge: React.FC = () => {
   }
 
   // Determine badge status based on tool call results
-  const getToolStatus = (): 'success' | 'error' | 'mixed' => {
+  const getToolStatus = (): 'running' | 'success' | 'error' | 'mixed' => {
     let hasSuccess = false;
     let hasError = false;
 
     for (const call of toolCalls) {
-      // Check if tool call has result
-      if ('result' in call) {
-        const result = call.result as any;
-        if (result && typeof result === 'object') {
-          if ('error' in result || result.success === false) {
-            hasError = true;
-          } else {
-            hasSuccess = true;
-          }
+      if (!('result' in call)) {
+        // At least one tool has no result yet — batch is still in flight.
+        return 'running';
+      }
+      const result = call.result as any;
+      if (result && typeof result === 'object') {
+        if ('error' in result || result.success === false) {
+          hasError = true;
         } else {
           hasSuccess = true;
         }
       } else {
-        // No result yet, treat as success
         hasSuccess = true;
       }
     }
@@ -65,17 +63,26 @@ const ToolUsageBadge: React.FC = () => {
       ? toolNames.join(', ')
       : `${toolNames.slice(0, 2).join(', ')} & ${toolNames.length - 2} more`;
 
+  const runningCount = toolCalls.filter(c => !('result' in c)).length;
+  const ariaLabel =
+    status === 'running'
+      ? `${runningCount} of ${toolCalls.length} tool${toolCalls.length === 1 ? '' : 's'} running`
+      : `${toolCalls.length} tool${toolCalls.length === 1 ? '' : 's'} ${status}`;
+
   return (
     <>
       <button
         className={cn(
           'inline-flex items-center gap-1 py-[2px] px-2 text-[11px] font-medium border-none rounded-[10px] cursor-pointer transition-all duration-150 ml-2 hover:scale-105 hover:shadow-[0_2px_4px_rgba(0,0,0,0.1)] active:scale-[0.98]',
+          status === 'running' && 'bg-[#3b82f6] text-white hover:bg-[#2563eb] animate-pulse',
           status === 'success' && 'bg-[#10b981] text-white hover:bg-[#059669]',
           status === 'error' && 'bg-[#ef4444] text-white hover:bg-[#dc2626]',
           status === 'mixed' && 'bg-[#f59e0b] text-white hover:bg-[#d97706]',
         )}
         onClick={() => setIsModalOpen(true)}
         title="Click to view tool execution details"
+        aria-live="polite"
+        aria-label={ariaLabel}
       >
         <span className="text-[12px] leading-none" aria-hidden="true">
           <Icon icon={Wrench} size={14} />

--- a/src/hooks/useGglibRuntime/agentLoop.ts
+++ b/src/hooks/useGglibRuntime/agentLoop.ts
@@ -44,7 +44,6 @@ export interface ChatMessage {
 }
 
 export interface ToolDigest {
-  sig: string;
   name: string;
   ok: boolean;
   summary: string;

--- a/src/hooks/useGglibRuntime/agentLoop.ts
+++ b/src/hooks/useGglibRuntime/agentLoop.ts
@@ -19,6 +19,10 @@ export const DEFAULT_MAX_TOOL_ITERS = 25;
 export const MAX_SAME_SIGNATURE_HITS = 2;
 export const MAX_STAGNATION_STEPS = 5;
 
+/** Parallel tool execution */
+export const MAX_PARALLEL_TOOLS = 5;
+export const TOOL_TIMEOUT_MS = 30_000;
+
 /** Memory management */
 export const MAX_CONTEXT_CHARS = 180_000;
 export const KEEP_LAST_TOOL_MESSAGES = 10;

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -18,7 +18,6 @@ import {
   type ToolDigest,
   DEFAULT_MAX_TOOL_ITERS,
   MAX_STAGNATION_STEPS,
-  toolSignature,
   recordAssistantProgress,
   checkToolLoop,
   pruneForBudget,
@@ -337,7 +336,7 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
         // Both 'tool-complete' and 'tool-error' settle a tool call.
         const isSuccess = event.type === 'tool-complete';
         const result = isSuccess
-          ? { success: true as const, data: JSON.parse(event.result) }
+          ? { success: true as const, data: event.data }
           : { success: false as const, error: event.error };
 
         appLogger.debug('hook.runtime', 'Tool settled', {
@@ -348,7 +347,6 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
         // Accumulate digest for working memory.
         const digest: ToolDigest = {
-          sig: toolSignature({ id: event.toolCallId, type: 'function', function: { name: event.toolName, arguments: '' } }),
           name: event.toolName,
           ok: isSuccess,
           summary: summarizeToolResult(event.toolName, result),

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -23,8 +23,8 @@ import {
   checkToolLoop,
   pruneForBudget,
   summarizeToolResult,
-  withRetry,
 } from './agentLoop';
+import { executeToolBatch } from './toolBatchExecution';
 import {
   type PromptLayer,
   injectPromptLayers,
@@ -322,78 +322,61 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
       break;
     }
 
-    // Execute tools and UPDATE tool-call parts with results
+    // Execute tools in parallel and UPDATE tool-call parts as each one settles
     appLogger.debug('hook.runtime', 'Executing tools', { toolCount: streamResult.toolCalls.length });
-    
-    const toolCallsForApiHistory: any[] = [];
-    const toolResultsForApiHistory: any[] = [];
-    
-    for (const toolCall of streamResult.toolCalls) {
-      // Execute tool
-      const registry = getToolRegistry();
-      const result = await withRetry(
-        () =>
-          registry.executeRawCall({
-            id: toolCall.id,
-            type: 'function',
-            function: toolCall.function,
-          }),
-        { maxRetries: 2, baseDelayMs: 250 }
-      ).catch((e) => ({
-        success: false as const,
-        error: String((e as { message?: string })?.message ?? e ?? 'Unknown error'),
-      }));
 
-      appLogger.debug('hook.runtime', 'Tool executed', { toolName: toolCall.function.name, result });
+    const toolResults = await executeToolBatch(
+      streamResult.toolCalls,
+      (_index, toolCall, result) => {
+        appLogger.debug('hook.runtime', 'Tool executed', { toolName: toolCall.function.name, result });
 
-      // Create digest for working memory
-      const digest: ToolDigest = {
-        sig: toolSignature(toolCall),
-        name: toolCall.function.name,
-        ok: result.success,
-        summary: summarizeToolResult(toolCall.function.name, result),
-      };
-      agentState.toolDigests.push(digest);
-
-      // Update the tool-call part with result
-      setMessages(prev =>
-        prev.map(m => {
-          if (m.id !== assistantMessageId) return m;
-          
-          const updatedContent = Array.isArray(m.content)
-            ? m.content.map((p: any) =>
-                p.type === 'tool-call' && p.toolCallId === toolCall.id
-                  ? {
-                      ...p,
-                      result: result.success ? result.data : { error: result.error },
-                      isError: !result.success,
-                    }
-                  : p
-              )
-            : m.content;
-          
-          return { ...m, content: updatedContent as GglibContent };
-        })
-      );
-
-      // Add to API messages for next iteration (OpenAI format requires tool results)
-      toolCallsForApiHistory.push({
-        id: toolCall.id,
-        type: 'function',
-        function: {
+        // Accumulate digest for working memory
+        const digest: ToolDigest = {
+          sig: toolSignature(toolCall),
           name: toolCall.function.name,
-          arguments: toolCall.function.arguments,
-        },
-      });
+          ok: result.success,
+          summary: summarizeToolResult(toolCall.function.name, result),
+        };
+        agentState.toolDigests.push(digest);
 
-      toolResultsForApiHistory.push({
-        role: 'tool',
-        tool_call_id: toolCall.id,
-        content: JSON.stringify(result.success ? result.data : { error: result.error }),
-      });
-    }
+        // Update the tool-call part immediately as this tool completes.
+        // Functional updater avoids stale-closure overwrites from concurrent callbacks.
+        setMessages(prev =>
+          prev.map(m => {
+            if (m.id !== assistantMessageId) return m;
 
-    // Add to API messages for next iteration
+            const updatedContent = Array.isArray(m.content)
+              ? m.content.map((p: any) =>
+                  p.type === 'tool-call' && p.toolCallId === toolCall.id
+                    ? {
+                        ...p,
+                        result: result.success ? result.data : { error: result.error },
+                        isError: !result.success,
+                      }
+                    : p
+                )
+              : m.content;
+
+            return { ...m, content: updatedContent as GglibContent };
+          })
+        );
+      },
+    );
+
+    // Build API history in original toolCalls order (required by OpenAI protocol)
+    const toolCallsForApiHistory = streamResult.toolCalls.map(tc => ({
+      id: tc.id,
+      type: 'function',
+      function: { name: tc.function.name, arguments: tc.function.arguments },
+    }));
+
+    const toolResultsForApiHistory = toolResults.map((result, i) => ({
+      role: 'tool',
+      tool_call_id: streamResult.toolCalls[i].id,
+      content: JSON.stringify(result.success ? result.data : { error: result.error }),
+    }));
+
+    // Add assistant turn + tool results to API messages for next iteration
     apiMessages.push({
       role: 'assistant',
       content: streamResult.textContent || null,

--- a/src/hooks/useGglibRuntime/runAgenticLoop.ts
+++ b/src/hooks/useGglibRuntime/runAgenticLoop.ts
@@ -25,6 +25,7 @@ import {
   summarizeToolResult,
 } from './agentLoop';
 import { executeToolBatch } from './toolBatchExecution';
+import type { ToolExecutionEvent } from '../../types/events/toolExecution';
 import {
   type PromptLayer,
   injectPromptLayers,
@@ -327,19 +328,35 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
     const toolResults = await executeToolBatch(
       streamResult.toolCalls,
-      (_index, toolCall, result) => {
-        appLogger.debug('hook.runtime', 'Tool executed', { toolName: toolCall.function.name, result });
+      (event: ToolExecutionEvent) => {
+        if (event.type === 'tool-start') {
+          appLogger.debug('hook.runtime', 'Tool started', { toolName: event.toolName });
+          return;
+        }
 
-        // Accumulate digest for working memory
+        // Both 'tool-complete' and 'tool-error' settle a tool call.
+        const isSuccess = event.type === 'tool-complete';
+        const result = isSuccess
+          ? { success: true as const, data: JSON.parse(event.result) }
+          : { success: false as const, error: event.error };
+
+        appLogger.debug('hook.runtime', 'Tool settled', {
+          toolName: event.toolName,
+          type: event.type,
+          durationMs: event.durationMs,
+        });
+
+        // Accumulate digest for working memory.
         const digest: ToolDigest = {
-          sig: toolSignature(toolCall),
-          name: toolCall.function.name,
-          ok: result.success,
-          summary: summarizeToolResult(toolCall.function.name, result),
+          sig: toolSignature({ id: event.toolCallId, type: 'function', function: { name: event.toolName, arguments: '' } }),
+          name: event.toolName,
+          ok: isSuccess,
+          summary: summarizeToolResult(event.toolName, result),
         };
         agentState.toolDigests.push(digest);
 
-        // Update the tool-call part immediately as this tool completes.
+        // Update the tool-call part immediately as this tool settles.
+        // Stamp durationMs alongside result so UI can show per-tool timing.
         // Functional updater avoids stale-closure overwrites from concurrent callbacks.
         setMessages(prev =>
           prev.map(m => {
@@ -347,11 +364,12 @@ export async function runAgenticLoop(options: RunAgenticLoopOptions): Promise<vo
 
             const updatedContent = Array.isArray(m.content)
               ? m.content.map((p: any) =>
-                  p.type === 'tool-call' && p.toolCallId === toolCall.id
+                  p.type === 'tool-call' && p.toolCallId === event.toolCallId
                     ? {
                         ...p,
-                        result: result.success ? result.data : { error: result.error },
-                        isError: !result.success,
+                        result: isSuccess ? result.data : { error: event.error },
+                        isError: !isSuccess,
+                        durationMs: event.durationMs,
                       }
                     : p
                 )

--- a/src/hooks/useGglibRuntime/toolBatchExecution.ts
+++ b/src/hooks/useGglibRuntime/toolBatchExecution.ts
@@ -3,8 +3,9 @@
  *
  * Houses the concurrency limiter, per-tool timeout wrapper, and the batch
  * runner. Intentionally decoupled from React — callers supply an
- * onToolSettled callback to handle UI updates and digest accumulation as each
- * tool completes, without waiting for the full batch to finish.
+ * onToolEvent callback that receives lifecycle events ('tool-start',
+ * 'tool-complete', 'tool-error') as each tool progresses, enabling live UI
+ * updates and telemetry without waiting for the full batch to finish.
  *
  * @module toolBatchExecution
  */
@@ -14,6 +15,7 @@ import type { AccumulatedToolCall } from './accumulateToolCalls';
 import type { ToolResult } from '../../services/tools';
 import { getToolRegistry } from '../../services/tools';
 import { withRetry, MAX_PARALLEL_TOOLS, TOOL_TIMEOUT_MS } from './agentLoop';
+import type { OnToolEvent } from '../../types/events/toolExecution';
 
 // =============================================================================
 // Concurrency limiter
@@ -82,53 +84,40 @@ export function withToolTimeout<T>(fn: () => Promise<T>, ms: number): Promise<T>
 // Batch executor
 // =============================================================================
 
-/**
- * Callback invoked immediately as each individual tool settles.
- *
- * @param index    The original position in the toolCalls array.
- * @param toolCall The tool call that settled.
- * @param result   Normalised ToolResult (success or failure).
- */
-export type OnToolSettled = (
-  index: number,
-  toolCall: AccumulatedToolCall,
-  result: ToolResult,
-) => void;
+// OnToolSettled is superseded by OnToolEvent (re-exported for any legacy callers).
+export type { OnToolEvent } from '../../types/events/toolExecution';
 
 /**
  * Execute all tool calls concurrently with a concurrency cap and per-tool
  * timeout, streaming results to the caller as each tool finishes.
  *
  * Guarantees:
- * - `onToolSettled` is called as soon as each individual tool settles, so the
- *   UI can reflect completed tools without waiting for the whole batch.
- * - The original array `index` is preserved in `onToolSettled`, regardless of
- *   which promise resolves first, so order-sensitive data structures stay
- *   consistent.
- * - Synchronous errors thrown by `onToolSettled` are caught and logged so a
+ * - `onToolEvent` is called for each lifecycle stage ('tool-start',
+ *   'tool-complete', 'tool-error') so callers can update UI and telemetry
+ *   without waiting for the whole batch to finish.
+ * - `performance.now()` is used for duration measurement — immune to system
+ *   clock adjustments and higher-precision than `Date.now()`.
+ * - The original array `index` is preserved in results, regardless of which
+ *   promise resolves first, so order-sensitive data structures stay consistent.
+ * - Synchronous errors thrown by `onToolEvent` are caught and logged so a
  *   UI rendering failure cannot crash the rest of the batch.
  * - Returns `ToolResult[]` in the same order as the input array, ready for
  *   inclusion in the API message history.
  */
 export async function executeToolBatch(
   toolCalls: AccumulatedToolCall[],
-  onToolSettled: OnToolSettled,
+  onToolEvent: OnToolEvent,
 ): Promise<ToolResult[]> {
   const limit = createConcurrencyLimiter(MAX_PARALLEL_TOOLS);
   const results: ToolResult[] = new Array(toolCalls.length);
 
-  const notifySettled = (
-    index: number,
-    toolCall: AccumulatedToolCall,
-    result: ToolResult,
-  ): void => {
-    results[index] = result;
+  const safeEmit = (event: Parameters<OnToolEvent>[0]): void => {
     try {
-      onToolSettled(index, toolCall, result);
+      onToolEvent(event);
     } catch (cbErr) {
-      appLogger.warn('hook.runtime', 'onToolSettled callback threw', {
-        index,
-        toolName: toolCall.function.name,
+      appLogger.warn('hook.runtime', 'onToolEvent callback threw', {
+        type: event.type,
+        toolName: event.toolName,
         error: String(cbErr),
       });
     }
@@ -136,8 +125,17 @@ export async function executeToolBatch(
 
   await Promise.allSettled(
     toolCalls.map((toolCall, index) =>
-      limit(() =>
-        withToolTimeout(
+      limit(() => {
+        // Record start time before invoking the tool; emit 'tool-start'.
+        const startPerf = performance.now();
+        safeEmit({
+          type: 'tool-start',
+          toolCallId: toolCall.id,
+          toolName: toolCall.function.name,
+          timestamp: Date.now(),
+        });
+
+        return withToolTimeout(
           () =>
             withRetry(
               () =>
@@ -149,18 +147,36 @@ export async function executeToolBatch(
               { maxRetries: 2, baseDelayMs: 250 },
             ),
           TOOL_TIMEOUT_MS,
-        ),
-      ).then(
-        (result) => {
-          notifySettled(index, toolCall, result);
-        },
-        (err: unknown) => {
-          const error = `[${toolCall.function.name}] ${String(
-            (err as { message?: string })?.message ?? err ?? 'Unknown error',
-          )}`;
-          notifySettled(index, toolCall, { success: false, error });
-        },
-      ),
+        ).then(
+          (result) => {
+            const durationMs = performance.now() - startPerf;
+            results[index] = result;
+            safeEmit({
+              type: 'tool-complete',
+              toolCallId: toolCall.id,
+              toolName: toolCall.function.name,
+              timestamp: Date.now(),
+              result: result.success ? JSON.stringify(result.data) : '{}',
+              durationMs,
+            });
+          },
+          (err: unknown) => {
+            const durationMs = performance.now() - startPerf;
+            const error = `[${toolCall.function.name}] ${String(
+              (err as { message?: string })?.message ?? err ?? 'Unknown error',
+            )}`;
+            results[index] = { success: false, error };
+            safeEmit({
+              type: 'tool-error',
+              toolCallId: toolCall.id,
+              toolName: toolCall.function.name,
+              timestamp: Date.now(),
+              error,
+              durationMs,
+            });
+          },
+        );
+      }),
     ),
   );
 

--- a/src/hooks/useGglibRuntime/toolBatchExecution.ts
+++ b/src/hooks/useGglibRuntime/toolBatchExecution.ts
@@ -1,0 +1,168 @@
+/**
+ * Parallel tool batch execution utilities.
+ *
+ * Houses the concurrency limiter, per-tool timeout wrapper, and the batch
+ * runner. Intentionally decoupled from React — callers supply an
+ * onToolSettled callback to handle UI updates and digest accumulation as each
+ * tool completes, without waiting for the full batch to finish.
+ *
+ * @module toolBatchExecution
+ */
+
+import { appLogger } from '../../services/platform';
+import type { AccumulatedToolCall } from './accumulateToolCalls';
+import type { ToolResult } from '../../services/tools';
+import { getToolRegistry } from '../../services/tools';
+import { withRetry, MAX_PARALLEL_TOOLS, TOOL_TIMEOUT_MS } from './agentLoop';
+
+// =============================================================================
+// Concurrency limiter
+// =============================================================================
+
+/**
+ * Create a simple concurrency semaphore.
+ *
+ * Ensures at most `concurrency` wrapped promises run simultaneously.
+ * A `finally` block decrements the active count so a rejected promise never
+ * permanently stalls the queue.
+ */
+export function createConcurrencyLimiter(concurrency: number) {
+  let active = 0;
+  const queue: (() => void)[] = [];
+
+  return function limit<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        active++;
+        fn()
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            queue.shift()?.();
+          });
+      };
+
+      if (active < concurrency) {
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+  };
+}
+
+// =============================================================================
+// Per-tool timeout wrapper
+// =============================================================================
+
+/**
+ * Race a promise-returning function against a timeout.
+ *
+ * Clears the timeout handle in a `finally` block to prevent a leaked
+ * `setTimeout` accumulating across a long agentic session with many tool calls.
+ *
+ * NOTE: `Promise.race` leaves the underlying `fn()` executing as a detached
+ * background task if the timeout fires first. Consider piping an AbortSignal
+ * into `executeRawCall` in a future pass to enable real cancellation.
+ */
+export function withToolTimeout<T>(fn: () => Promise<T>, ms: number): Promise<T> {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    handle = setTimeout(
+      () => reject(new Error(`Tool timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([fn(), timeoutPromise]).finally(() => {
+    clearTimeout(handle);
+  });
+}
+
+// =============================================================================
+// Batch executor
+// =============================================================================
+
+/**
+ * Callback invoked immediately as each individual tool settles.
+ *
+ * @param index    The original position in the toolCalls array.
+ * @param toolCall The tool call that settled.
+ * @param result   Normalised ToolResult (success or failure).
+ */
+export type OnToolSettled = (
+  index: number,
+  toolCall: AccumulatedToolCall,
+  result: ToolResult,
+) => void;
+
+/**
+ * Execute all tool calls concurrently with a concurrency cap and per-tool
+ * timeout, streaming results to the caller as each tool finishes.
+ *
+ * Guarantees:
+ * - `onToolSettled` is called as soon as each individual tool settles, so the
+ *   UI can reflect completed tools without waiting for the whole batch.
+ * - The original array `index` is preserved in `onToolSettled`, regardless of
+ *   which promise resolves first, so order-sensitive data structures stay
+ *   consistent.
+ * - Synchronous errors thrown by `onToolSettled` are caught and logged so a
+ *   UI rendering failure cannot crash the rest of the batch.
+ * - Returns `ToolResult[]` in the same order as the input array, ready for
+ *   inclusion in the API message history.
+ */
+export async function executeToolBatch(
+  toolCalls: AccumulatedToolCall[],
+  onToolSettled: OnToolSettled,
+): Promise<ToolResult[]> {
+  const limit = createConcurrencyLimiter(MAX_PARALLEL_TOOLS);
+  const results: ToolResult[] = new Array(toolCalls.length);
+
+  const notifySettled = (
+    index: number,
+    toolCall: AccumulatedToolCall,
+    result: ToolResult,
+  ): void => {
+    results[index] = result;
+    try {
+      onToolSettled(index, toolCall, result);
+    } catch (cbErr) {
+      appLogger.warn('hook.runtime', 'onToolSettled callback threw', {
+        index,
+        toolName: toolCall.function.name,
+        error: String(cbErr),
+      });
+    }
+  };
+
+  await Promise.allSettled(
+    toolCalls.map((toolCall, index) =>
+      limit(() =>
+        withToolTimeout(
+          () =>
+            withRetry(
+              () =>
+                getToolRegistry().executeRawCall({
+                  id: toolCall.id,
+                  type: 'function',
+                  function: toolCall.function,
+                }),
+              { maxRetries: 2, baseDelayMs: 250 },
+            ),
+          TOOL_TIMEOUT_MS,
+        ),
+      ).then(
+        (result) => {
+          notifySettled(index, toolCall, result);
+        },
+        (err: unknown) => {
+          const error = `[${toolCall.function.name}] ${String(
+            (err as { message?: string })?.message ?? err ?? 'Unknown error',
+          )}`;
+          notifySettled(index, toolCall, { success: false, error });
+        },
+      ),
+    ),
+  );
+
+  return results;
+}

--- a/src/hooks/useGglibRuntime/toolBatchExecution.ts
+++ b/src/hooks/useGglibRuntime/toolBatchExecution.ts
@@ -156,7 +156,7 @@ export async function executeToolBatch(
               toolCallId: toolCall.id,
               toolName: toolCall.function.name,
               timestamp: Date.now(),
-              result: result.success ? JSON.stringify(result.data) : '{}',
+              data: result.success ? result.data : {},
               durationMs,
             });
           },

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Event type barrel — re-exports all lifecycle event types.
+ */
+
+export type { ToolExecutionEvent, ToolStartEvent, ToolCompleteEvent, ToolErrorEvent, OnToolEvent } from './toolExecution';

--- a/src/types/events/toolExecution.ts
+++ b/src/types/events/toolExecution.ts
@@ -21,8 +21,8 @@ export interface ToolCompleteEvent {
   toolCallId: string;
   toolName: string;
   timestamp: number;
-  /** Stringified result payload. */
-  result: string;
+  /** Raw result payload — not serialised. */
+  data: unknown;
   /** Elapsed wall-clock time measured with performance.now(), in milliseconds. */
   durationMs: number;
 }

--- a/src/types/events/toolExecution.ts
+++ b/src/types/events/toolExecution.ts
@@ -1,0 +1,46 @@
+/**
+ * Tool execution progress events.
+ *
+ * Emitted by executeToolBatch as each individual tool starts and settles,
+ * providing a unified event stream for UI feedback and telemetry.
+ *
+ * @module types/events/toolExecution
+ */
+
+/** Fired immediately before a tool's function is invoked. */
+export interface ToolStartEvent {
+  type: 'tool-start';
+  toolCallId: string;
+  toolName: string;
+  timestamp: number;
+}
+
+/** Fired when a tool returns a successful result. */
+export interface ToolCompleteEvent {
+  type: 'tool-complete';
+  toolCallId: string;
+  toolName: string;
+  timestamp: number;
+  /** Stringified result payload. */
+  result: string;
+  /** Elapsed wall-clock time measured with performance.now(), in milliseconds. */
+  durationMs: number;
+}
+
+/** Fired when a tool fails (execution error or timeout). */
+export interface ToolErrorEvent {
+  type: 'tool-error';
+  toolCallId: string;
+  toolName: string;
+  timestamp: number;
+  /** Human-readable error message. */
+  error: string;
+  /** Elapsed wall-clock time measured with performance.now(), in milliseconds. */
+  durationMs: number;
+}
+
+/** Union of all tool execution lifecycle events. */
+export type ToolExecutionEvent = ToolStartEvent | ToolCompleteEvent | ToolErrorEvent;
+
+/** Callback type for receiving tool execution lifecycle events. */
+export type OnToolEvent = (event: ToolExecutionEvent) => void;

--- a/tests/ts/hooks/useGglibRuntime/toolBatchExecution.test.ts
+++ b/tests/ts/hooks/useGglibRuntime/toolBatchExecution.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for toolBatchExecution utilities.
+ *
+ * Covers:
+ * - createConcurrencyLimiter: cap enforcement, sequential queuing, failure tolerance
+ * - withToolTimeout: resolves before timeout, rejects after timeout
+ * - executeToolBatch: index preservation, concurrency limit, failure isolation,
+ *   onToolEvent lifecycle ordering, degenerate single-tool case
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createConcurrencyLimiter,
+  withToolTimeout,
+  executeToolBatch,
+} from '../../../../src/hooks/useGglibRuntime/toolBatchExecution';
+import type { AccumulatedToolCall } from '../../../../src/hooks/useGglibRuntime/accumulateToolCalls';
+import type { ToolExecutionEvent } from '../../../../src/types/events/toolExecution';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolCall(id: string, name = 'tool'): AccumulatedToolCall {
+  return {
+    id,
+    type: 'function',
+    function: { name, arguments: '{}' },
+  };
+}
+
+function makeSuccessResult(data: unknown = { ok: true }) {
+  return { success: true as const, data };
+}
+
+function makeErrorResult(error = 'boom') {
+  return { success: false as const, error };
+}
+
+// ---------------------------------------------------------------------------
+// createConcurrencyLimiter
+// ---------------------------------------------------------------------------
+
+describe('createConcurrencyLimiter', () => {
+  it('runs tasks immediately when under the concurrency cap', async () => {
+    const limit = createConcurrencyLimiter(3);
+    const order: number[] = [];
+
+    await Promise.all([
+      limit(() => Promise.resolve().then(() => { order.push(1); })),
+      limit(() => Promise.resolve().then(() => { order.push(2); })),
+      limit(() => Promise.resolve().then(() => { order.push(3); })),
+    ]);
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('queues tasks beyond the concurrency cap', async () => {
+    const limit = createConcurrencyLimiter(2);
+    let active = 0;
+    let maxConcurrent = 0;
+
+    const makeTask = () =>
+      limit(async () => {
+        active++;
+        maxConcurrent = Math.max(maxConcurrent, active);
+        // yield to allow other microtasks to run
+        await new Promise(r => setTimeout(r, 0));
+        active--;
+      });
+
+    await Promise.all([makeTask(), makeTask(), makeTask(), makeTask()]);
+
+    // At most 2 should have been running simultaneously
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+  });
+
+  it('decrements the active count on rejection so the queue is not permanently stalled', async () => {
+    const limit = createConcurrencyLimiter(1);
+    const results: Array<'ok' | 'err'> = [];
+
+    await Promise.allSettled([
+      limit(() => Promise.reject(new Error('fail'))).catch(() => { results.push('err'); }),
+      limit(() => Promise.resolve()).then(() => { results.push('ok'); }),
+    ]);
+
+    expect(results).toEqual(['err', 'ok']);
+  });
+
+  it('passes the resolved value through unchanged', async () => {
+    const limit = createConcurrencyLimiter(2);
+    const result = await limit(() => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withToolTimeout
+// ---------------------------------------------------------------------------
+
+describe('withToolTimeout', () => {
+  it('resolves with the function result when it finishes before the timeout', async () => {
+    const result = await withToolTimeout(() => Promise.resolve('done'), 100);
+    expect(result).toBe('done');
+  });
+
+  it('rejects with a timeout error when the function takes too long', async () => {
+    const never = () => new Promise<never>(() => {/* never resolves */});
+    await expect(withToolTimeout(never, 10)).rejects.toThrow('timed out');
+  });
+
+  it('clears the timeout handle when the function resolves (no leaked timer)', async () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    await withToolTimeout(() => Promise.resolve(), 1000);
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+
+  it('clears the timeout handle when the function rejects (no leaked timer)', async () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    await withToolTimeout(() => Promise.reject(new Error('fail')), 1000).catch(() => {});
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeToolBatch
+// ---------------------------------------------------------------------------
+
+// Mock the modules that executeToolBatch imports
+vi.mock('../../../../src/services/platform', () => ({
+  appLogger: {
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../src/hooks/useGglibRuntime/agentLoop', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/hooks/useGglibRuntime/agentLoop')>();
+  return {
+    ...actual,
+    MAX_PARALLEL_TOOLS: 3,
+    TOOL_TIMEOUT_MS: 5000,
+    withRetry: (fn: () => Promise<unknown>) => fn(),
+  };
+});
+
+// The registry mock is set per-test below
+const mockExecuteRawCall = vi.fn();
+vi.mock('../../../../src/services/tools', () => ({
+  getToolRegistry: () => ({ executeRawCall: mockExecuteRawCall }),
+}));
+
+describe('executeToolBatch', () => {
+  beforeEach(() => {
+    mockExecuteRawCall.mockReset();
+  });
+
+  // ── Degenerate / happy path ─────────────────────────────────────────────
+
+  it('returns an empty array for zero tool calls', async () => {
+    const results = await executeToolBatch([], vi.fn());
+    expect(results).toEqual([]);
+  });
+
+  it('degenerate single-tool: resolves and returns the result', async () => {
+    const data = { answer: 42 };
+    mockExecuteRawCall.mockResolvedValueOnce(makeSuccessResult(data));
+
+    const results = await executeToolBatch([makeToolCall('t1')], vi.fn());
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(makeSuccessResult(data));
+  });
+
+  // ── Result ordering ─────────────────────────────────────────────────────
+
+  it('preserves original index order regardless of completion order', async () => {
+    // Tools resolve in reverse order (slowest first declared = index 0)
+    let resolveLast!: (v: unknown) => void;
+    const slow = new Promise(r => { resolveLast = r; });
+
+    mockExecuteRawCall
+      .mockReturnValueOnce(slow.then(() => makeSuccessResult({ id: 0 })))
+      .mockResolvedValueOnce(makeSuccessResult({ id: 1 }))
+      .mockResolvedValueOnce(makeSuccessResult({ id: 2 }));
+
+    const calls = [makeToolCall('t0'), makeToolCall('t1'), makeToolCall('t2')];
+    const batchPromise = executeToolBatch(calls, vi.fn());
+
+    // Let tools 1 and 2 settle first
+    await Promise.resolve();
+    resolveLast(undefined);
+
+    const results = await batchPromise;
+    expect(results[0]).toEqual(makeSuccessResult({ id: 0 }));
+    expect(results[1]).toEqual(makeSuccessResult({ id: 1 }));
+    expect(results[2]).toEqual(makeSuccessResult({ id: 2 }));
+  });
+
+  // ── Failure isolation ───────────────────────────────────────────────────
+
+  it('does not cancel other tools when one tool fails', async () => {
+    mockExecuteRawCall
+      .mockRejectedValueOnce(new Error('tool A exploded'))
+      .mockResolvedValueOnce(makeSuccessResult({ b: true }));
+
+    const results = await executeToolBatch(
+      [makeToolCall('tA'), makeToolCall('tB')],
+      vi.fn(),
+    );
+
+    expect(results[0]).toEqual({ success: false, error: expect.stringContaining('tool A exploded') });
+    expect(results[1]).toEqual(makeSuccessResult({ b: true }));
+  });
+
+  it('synthesises a failure ToolResult when a tool rejects', async () => {
+    mockExecuteRawCall.mockRejectedValueOnce(new Error('network gone'));
+
+    const results = await executeToolBatch([makeToolCall('t1')], vi.fn());
+
+    expect(results[0].success).toBe(false);
+    expect((results[0] as { success: false; error: string }).error).toContain('network gone');
+  });
+
+  // ── onToolEvent lifecycle ───────────────────────────────────────────────
+
+  it('emits tool-start before tool-complete for a successful tool', async () => {
+    mockExecuteRawCall.mockResolvedValueOnce(makeSuccessResult());
+
+    const events: ToolExecutionEvent[] = [];
+    await executeToolBatch([makeToolCall('t1', 'search')], e => events.push(e));
+
+    expect(events[0].type).toBe('tool-start');
+    expect(events[0].toolName).toBe('search');
+    expect(events[0].toolCallId).toBe('t1');
+
+    expect(events[1].type).toBe('tool-complete');
+    expect(events[1].toolCallId).toBe('t1');
+  });
+
+  it('emits tool-start before tool-error for a failing tool', async () => {
+    mockExecuteRawCall.mockRejectedValueOnce(new Error('oops'));
+
+    const events: ToolExecutionEvent[] = [];
+    await executeToolBatch([makeToolCall('t1', 'write')], e => events.push(e));
+
+    expect(events[0].type).toBe('tool-start');
+    expect(events[1].type).toBe('tool-error');
+    expect(events[1].toolCallId).toBe('t1');
+  });
+
+  it('includes durationMs on settled events', async () => {
+    mockExecuteRawCall.mockResolvedValueOnce(makeSuccessResult());
+
+    const events: ToolExecutionEvent[] = [];
+    await executeToolBatch([makeToolCall('t1')], e => events.push(e));
+
+    const complete = events.find(e => e.type === 'tool-complete');
+    expect(complete).toBeDefined();
+    expect((complete as { durationMs: number }).durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits data (not a JSON string) on tool-complete events', async () => {
+    const payload = { nested: { value: 99 } };
+    mockExecuteRawCall.mockResolvedValueOnce(makeSuccessResult(payload));
+
+    const events: ToolExecutionEvent[] = [];
+    await executeToolBatch([makeToolCall('t1')], e => events.push(e));
+
+    const complete = events.find(e => e.type === 'tool-complete') as Extract<
+      ToolExecutionEvent,
+      { type: 'tool-complete' }
+    >;
+    expect(complete).toBeDefined();
+    // data must be the raw object, not a JSON string
+    expect(typeof complete.data).not.toBe('string');
+    expect(complete.data).toEqual(payload);
+  });
+
+  it('emits events for all tools in a batch, even when some fail', async () => {
+    mockExecuteRawCall
+      .mockRejectedValueOnce(new Error('a failed'))
+      .mockResolvedValueOnce(makeSuccessResult())
+      .mockRejectedValueOnce(new Error('c failed'));
+
+    const events: ToolExecutionEvent[] = [];
+    await executeToolBatch(
+      [makeToolCall('tA'), makeToolCall('tB'), makeToolCall('tC')],
+      e => events.push(e),
+    );
+
+    const starts  = events.filter(e => e.type === 'tool-start');
+    const settled = events.filter(e => e.type !== 'tool-start');
+    expect(starts).toHaveLength(3);
+    expect(settled).toHaveLength(3);
+  });
+
+  it('continues the batch when the onToolEvent callback throws', async () => {
+    mockExecuteRawCall.mockResolvedValue(makeSuccessResult());
+
+    let callCount = 0;
+    const throwingCb = () => {
+      callCount++;
+      if (callCount === 1) throw new Error('cb crash');
+    };
+
+    // Should not throw
+    const results = await executeToolBatch(
+      [makeToolCall('t1'), makeToolCall('t2')],
+      throwingCb,
+    );
+
+    expect(results).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #245

## Summary

Replaces the sequential `for...of` tool execution loop in `runAgenticLoop.ts` with parallel execution via a custom concurrency semaphore + `Promise.allSettled` semantics, matching the pattern already used in `runResearchLoop.ts`.

---

## Changes

### Phase 1 — Core parallel execution (`#260`)
- Added `MAX_PARALLEL_TOOLS = 5` and `TOOL_TIMEOUT_MS = 30_000` constants to `agentLoop.ts`
- Created `toolBatchExecution.ts` with `createConcurrencyLimiter`, `withToolTimeout`, and `executeToolBatch`
- Replaced the sequential loop in `runAgenticLoop.ts` with `executeToolBatch`

### Phase 2 — Live UI feedback (`#261`)
- Added `ToolExecutionEvent` union type (`tool-start`, `tool-complete`, `tool-error`) with `OnToolEvent` callback
- Wired `onToolEvent` into `runAgenticLoop` — each tool updates its message part immediately as it settles (functional `setMessages` updater avoids stale-closure overwrites)
- Added `ToolUsageBadge` `running` state with animated blue badge
- Created `ToolExecutionProgress` accordion component showing per-tool status + duration in real time
- Added `durationMs` to `ToolDetailsModal` per-tool header row

### Review fixes (this commit)
- **Removed `sig` from `ToolDigest`** — was always populated with empty arguments and never consumed; dropped `toolSignature` import from `runAgenticLoop`
- **Eliminated `JSON.stringify` → `JSON.parse` round-trip** — `ToolCompleteEvent.result: string` → `data: unknown`; callers receive the raw object directly
- **Type-safe UI field access** — added `AugmentedToolCallPart` in `ToolExecutionProgress` and `ToolDetailsModal` to replace `as any` casts for `durationMs` and `isError`
- **Added 19 unit tests** for `toolBatchExecution` covering: concurrency cap, queue drain on rejection, timeout resolve/reject/timer-leak, index preservation regardless of completion order, failure isolation, full `onToolEvent` lifecycle ordering, `data` is a raw object (not a JSON string), throwing callbacks don't crash the batch, degenerate empty/single-tool cases

---

## Acceptance Criteria

- [x] Independent tool calls execute in parallel via `Promise.allSettled` semantics
- [x] Individual tool failures don't crash other parallel tools
- [x] UI updates (tool result parts) happen correctly per tool, as each settles
- [x] Tool digests and working memory populated correctly
- [x] API message history maintains correct `tool_calls` → tool results pairing
- [x] Concurrency limit (`MAX_PARALLEL_TOOLS = 5`) prevents overwhelming MCP servers
- [x] No behaviour change when only 1 tool call is made (degenerate case)
