### PR TITLE
feat(tools): Phase 1 — sanitizeToolName, reverse name map, collision detection (#262)

### DIFF
--- a/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
+++ b/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
@@ -14,6 +14,8 @@ import type { ThreadMessage } from '@assistant-ui/react';
 import { CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import { Icon } from '../ui/Icon';
+import { getToolRegistry } from '../../services/tools/registry';
+import { formatToolDisplayName } from '../../services/tools/nameUtils';
 
 // =============================================================================
 // Types
@@ -49,14 +51,15 @@ interface ToolRowData {
 // =============================================================================
 
 /**
- * Strip mcp_ prefix and convert snake_case / kebab-case to Title Case.
+ * Resolve a (possibly sanitized) tool registry key to a human-readable label.
+ *
+ * Looks up the original raw MCP tool name via the reverse name map so that
+ * tools with special characters (dots, spaces, unicode) display correctly.
+ * Falls back to the sanitized name itself for non-MCP / built-in tools.
  */
 function formatToolName(name: string): string {
-  const cleaned = name.replace(/^mcp_\d+_/, '');
-  return cleaned
-    .split(/[-_]/)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+  const raw = getToolRegistry().getOriginalName(name) ?? name;
+  return formatToolDisplayName(raw);
 }
 
 /**

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -6,6 +6,8 @@ import { Icon } from '../ui/Icon';
 import { Modal } from '../ui/Modal';
 import { cn } from '../../utils/cn';
 import { Stack } from '../primitives';
+import { getToolRegistry } from '../../services/tools/registry';
+import { formatToolDisplayName } from '../../services/tools/nameUtils';
 
 type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
 
@@ -64,12 +66,11 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
   };
 
   const formatToolName = (name: string): string => {
-    // Remove mcp_ prefix and format
-    const cleaned = name.replace(/^mcp_\d+_/, '');
-    return cleaned
-      .split(/[-_]/)
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    // Resolve sanitized registry key to the original raw MCP tool name so that
+    // tools with dots, spaces, or other special characters display correctly.
+    // Falls back to the name itself for built-in tools with no mapping.
+    const raw = getToolRegistry().getOriginalName(name) ?? name;
+    return formatToolDisplayName(raw);
   };
 
   const getStatusIcon = (call: ToolCallPart): typeof CheckCircle2 => {

--- a/src/services/tools/index.ts
+++ b/src/services/tools/index.ts
@@ -37,6 +37,7 @@ export {
   getToolRegistry,
   resetToolRegistry,
   type ToolSource,
+  type NameMapEntry,
 } from './registry';
 
 // Re-export MCP integration
@@ -56,3 +57,10 @@ registerBuiltinTools();
 
 // Re-export builtin tools for direct access
 export { registerBuiltinTools } from './builtin';
+
+// Re-export name utilities
+export {
+  sanitizeToolName,
+  detectCollisions,
+  formatToolDisplayName,
+} from './nameUtils';

--- a/src/services/tools/mcpIntegration.ts
+++ b/src/services/tools/mcpIntegration.ts
@@ -15,6 +15,7 @@ import {
 import type { McpTool, McpServerId } from '../clients/mcp';
 import { getToolRegistry, ToolSource } from './registry';
 import type { ToolDefinition, ToolExecutor, ToolResult } from './types';
+import { sanitizeToolName, detectCollisions } from './nameUtils';
 import { appLogger } from '../platform';
 
 /**
@@ -33,6 +34,9 @@ function mcpToolToDefinition(tool: McpTool): ToolDefinition {
 
 /**
  * Create an executor that calls an MCP tool.
+ * IMPORTANT: The executor must always call the MCP server with the original
+ * raw tool name, never the sanitized registry key. The MCP server only knows
+ * its own naming scheme.
  */
 function createMcpExecutor(serverId: McpServerId, toolName: string): ToolExecutor {
   return async (args: Record<string, unknown>): Promise<ToolResult> => {
@@ -79,29 +83,66 @@ export function registerMcpTools(serverId: McpServerId, tools: McpTool[]): numbe
   const source = getMcpSource(serverId);
   let count = 0;
 
+  // ── Collision detection ───────────────────────────────────────────────────
+  // Build the fully-namespaced raw names for the entire batch first, so that
+  // any two tools that sanitize to the same string (e.g. due to the 64-char
+  // truncation or special-char normalisation) are caught before registration.
+  const namespacedRawNames = tools.map((t) => `mcp_${serverId}_${t.name}`);
+  const collisions = detectCollisions(namespacedRawNames);
+
+  if (collisions.size > 0) {
+    for (const [sanitized, originals] of collisions) {
+      appLogger.warn('service.mcp', 'MCP tool name collision detected — skipping affected tools', {
+        serverId,
+        sanitizedName: sanitized,
+        collidingRawNames: originals,
+      });
+    }
+  }
+
+  // Flatten colliding raw names into a Set for O(1) skip checks in the loop.
+  const toSkip = new Set<string>([...collisions.values()].flat());
+
+  // ── Registration loop ─────────────────────────────────────────────────────
   for (const tool of tools) {
+    const namespacedRaw = `mcp_${serverId}_${tool.name}`;
+
+    if (toSkip.has(namespacedRaw)) {
+      // Already warned above; skip silently.
+      continue;
+    }
+
+    const sanitizedName = sanitizeToolName(namespacedRaw);
+
+    if (sanitizedName !== namespacedRaw) {
+      appLogger.warn('service.mcp', 'MCP tool name was sanitized', {
+        serverId,
+        original: namespacedRaw,
+        sanitized: sanitizedName,
+      });
+    }
+
     const definition = mcpToolToDefinition(tool);
+    // The executor closes over tool.name (raw) — it must never receive the
+    // sanitized name because the MCP server only understands its own naming.
     const executor = createMcpExecutor(serverId, tool.name);
 
     try {
-      // Use a namespaced name to avoid collisions: mcp_serverId_toolName
-      const namespacedName = `mcp_${serverId}_${tool.name}`;
       const namespacedDef: ToolDefinition = {
         ...definition,
         function: {
           ...definition.function,
-          name: namespacedName,
-          // Keep original description but add server context
-          description: definition.function.description 
+          name: sanitizedName,
+          description: definition.function.description
             ? `[MCP:${serverId}] ${definition.function.description}`
             : `MCP tool from server ${serverId}`,
         },
       };
 
-      registry.register(namespacedDef, executor, source);
+      registry.registerWithNameMapping(tool.name, serverId, sanitizedName, namespacedDef, executor, source);
       count++;
     } catch (err) {
-      // Tool might already exist from another source - log and continue
+      // Tool might already exist from another source — log and continue.
       appLogger.warn('service.mcp', 'Failed to register MCP tool', { toolName: tool.name, error: err });
     }
   }

--- a/src/services/tools/nameUtils.ts
+++ b/src/services/tools/nameUtils.ts
@@ -1,0 +1,114 @@
+/**
+ * Utilities for sanitizing and displaying MCP tool names.
+ *
+ * MCP tool names can contain arbitrary characters (dots, spaces, hyphens, unicode)
+ * that are invalid for OpenAI function calling, which requires `^[a-zA-Z0-9_-]{1,64}$`.
+ * These pure, dependency-free functions handle sanitization, collision detection,
+ * and display formatting.
+ */
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Maximum length enforced by the OpenAI function-calling API. */
+const MAX_TOOL_NAME_LENGTH = 64;
+
+/** Fallback name used when sanitization produces an empty string. */
+const FALLBACK_NAME = 'unnamed_tool';
+
+// =============================================================================
+// sanitizeToolName
+// =============================================================================
+
+/**
+ * Sanitizes a raw tool name string for OpenAI function-calling compatibility.
+ *
+ * Transforms the input so the result always matches `^[a-zA-Z0-9_-]{1,64}$`:
+ * - Invalid characters (anything not `a-zA-Z0-9_-`) are replaced with `_`
+ * - Consecutive underscores are collapsed into a single `_`
+ * - Leading and trailing underscores are trimmed
+ * - Result is truncated to 64 characters
+ * - Empty result (e.g. all-special input) falls back to `'unnamed_tool'`
+ *
+ * Hyphens are intentionally preserved — they are valid per the OpenAI spec
+ * and commonly used in MCP tool names (e.g. `get-weather`).
+ *
+ * Pass the fully-namespaced string (including the `mcp_${serverId}_` prefix) so
+ * the entire result is validated within the 64-character budget.
+ *
+ * @example
+ * sanitizeToolName('mcp_my.server_get data!') // → 'mcp_my_server_get_data'
+ * sanitizeToolName('get-weather')             // → 'get-weather'
+ * sanitizeToolName('file.read')               // → 'file_read'
+ * sanitizeToolName('!!!')                     // → 'unnamed_tool'
+ */
+export function sanitizeToolName(raw: string): string {
+  return (
+    raw
+      .replace(/[^a-zA-Z0-9_-]/g, '_')  // Replace invalid chars with underscore
+      .replace(/_+/g, '_')              // Collapse consecutive underscores
+      .replace(/^_+|_+$/g, '')          // Trim leading/trailing underscores
+      .slice(0, MAX_TOOL_NAME_LENGTH)   // Enforce max length
+    || FALLBACK_NAME                    // Fallback when result is empty
+  );
+}
+
+// =============================================================================
+// detectCollisions
+// =============================================================================
+
+/**
+ * Finds tool name collisions — cases where two or more distinct raw names
+ * sanitize to the same output string.
+ *
+ * Pass fully-namespaced names (e.g. `mcp_${serverId}_${tool.name}`) so that
+ * 64-character truncation collisions are caught before any registration occurs.
+ *
+ * @param names - Fully-namespaced tool name strings to check
+ * @returns Map of `sanitizedName → originalNames[]` containing only entries
+ *          with two or more originals (i.e. actual collisions)
+ *
+ * @example
+ * detectCollisions(['mcp_s_ab!', 'mcp_s_ab?'])
+ * // → Map { 'mcp_s_ab' → ['mcp_s_ab!', 'mcp_s_ab?'] }
+ */
+export function detectCollisions(names: string[]): Map<string, string[]> {
+  const grouped = new Map<string, string[]>();
+
+  for (const name of names) {
+    const sanitized = sanitizeToolName(name);
+    const existing = grouped.get(sanitized) ?? [];
+    existing.push(name);
+    grouped.set(sanitized, existing);
+  }
+
+  // Return only entries where two or more originals collide
+  return new Map(
+    [...grouped.entries()].filter(([, originals]) => originals.length > 1),
+  );
+}
+
+// =============================================================================
+// formatToolDisplayName
+// =============================================================================
+
+/**
+ * Converts a raw MCP tool name into a human-readable Title Case string.
+ *
+ * Splits on hyphens, underscores, dots, and whitespace so that any of the
+ * common MCP naming conventions are handled correctly.
+ *
+ * @example
+ * formatToolDisplayName('get-weather')      // → 'Get Weather'
+ * formatToolDisplayName('file.read')        // → 'File Read'
+ * formatToolDisplayName('my tool')          // → 'My Tool'
+ * formatToolDisplayName('get_current_time') // → 'Get Current Time'
+ */
+export function formatToolDisplayName(raw: string): string {
+  return raw
+    .split(/[-_.\s]+/)
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -31,12 +31,28 @@ interface RegisteredToolWithSource extends RegisteredTool {
  * Registry for managing tools available to the LLM.
  * Handles tool registration, lookup, and execution.
  */
+/**
+ * Metadata stored in the reverse name map for each sanitized MCP tool name.
+ */
+export interface NameMapEntry {
+  /** The original raw tool name from the MCP server (e.g. 'get data!'). */
+  originalName: string;
+  /** The MCP server ID that owns this tool. */
+  serverId: string;
+}
+
 export class ToolRegistry {
   private tools = new Map<string, RegisteredToolWithSource>();
   // Secure-by-default: tools are disabled unless explicitly enabled.
   // We keep an allowlist instead of a denylist so registration cannot
   // accidentally re-enable tools (e.g., during MCP resync).
   private enabledTools = new Set<string>();
+
+  /**
+   * Reverse map: sanitized tool name → { originalName, serverId }.
+   * Populated only for MCP tools registered via registerWithNameMapping().
+   */
+  private _nameMap = new Map<string, NameMapEntry>();
 
   /**
    * Register a tool with its definition and executor.
@@ -54,6 +70,48 @@ export class ToolRegistry {
     // Newly registered tools are disabled by default.
     // Intentionally do not mutate enable-state here so that if a tool is
     // re-registered after being enabled (e.g., MCP resync), it stays enabled.
+  }
+
+  /**
+   * Register an MCP tool and record the sanitized → original name mapping.
+   *
+   * Use this instead of register() for all MCP tools so that UI components
+   * and routing logic can retrieve the original MCP name and owning server
+   * from a sanitized name.
+   *
+   * @param originalName - Raw tool name from the MCP server (e.g. 'get data!')
+   * @param serverId     - MCP server ID that owns this tool
+   * @param sanitizedName - Sanitized name used as the registry key
+   * @param definition   - ToolDefinition whose function.name must equal sanitizedName
+   * @param execute      - Executor (must call MCP with originalName, not sanitizedName)
+   * @param source       - Tool source (e.g. 'mcp:server-id')
+   */
+  registerWithNameMapping(
+    originalName: string,
+    serverId: string,
+    sanitizedName: string,
+    definition: ToolDefinition,
+    execute: ToolExecutor,
+    source: ToolSource,
+  ): void {
+    this._nameMap.set(sanitizedName, { originalName, serverId });
+    this.register(definition, execute, source);
+  }
+
+  /**
+   * Look up the original MCP tool name for a sanitized registry key.
+   * @returns Original raw name, or undefined if no mapping exists.
+   */
+  getOriginalName(sanitizedName: string): string | undefined {
+    return this._nameMap.get(sanitizedName)?.originalName;
+  }
+
+  /**
+   * Look up the MCP server ID that owns a sanitized tool name.
+   * @returns Server ID string, or undefined if no mapping exists.
+   */
+  getServerId(sanitizedName: string): string | undefined {
+    return this._nameMap.get(sanitizedName)?.serverId;
   }
 
   /**
@@ -209,16 +267,18 @@ export class ToolRegistry {
   }
 
   /**
-   * Clear all registered tools.
+   * Clear all registered tools and the reverse name map.
    */
   clear(): void {
     this.tools.clear();
     this.enabledTools.clear();
+    this._nameMap.clear();
   }
 
   /**
    * Unregister all tools from a specific source.
    * Useful for removing all tools when an MCP server disconnects.
+   * Also removes any reverse name-map entries owned by the same server.
    * @param source - Source identifier (e.g., 'mcp:server-1')
    * @returns Number of tools removed
    */
@@ -230,6 +290,18 @@ export class ToolRegistry {
         count++;
       }
     }
+
+    // Clean up reverse name-map entries for this server.
+    // Extract serverId from 'mcp:${serverId}' source string.
+    if (source.startsWith('mcp:')) {
+      const serverId = source.slice('mcp:'.length);
+      for (const [key, value] of this._nameMap.entries()) {
+        if (value.serverId === serverId) {
+          this._nameMap.delete(key);
+        }
+      }
+    }
+
     return count;
   }
 

--- a/tests/ts/services/tools/mcpIntegration.test.ts
+++ b/tests/ts/services/tools/mcpIntegration.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerMcpTools, unregisterMcpTools, getMcpSource } from '../../../../src/services/tools/mcpIntegration';
+import { resetToolRegistry, getToolRegistry } from '../../../../src/services/tools/registry';
+import type { McpTool } from '../../../../src/services/clients/mcp';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+// Mock the MCP client so we never make real Tauri IPC calls in unit tests.
+vi.mock('../../../../src/services/clients/mcp', () => ({
+  listMcpServers: vi.fn(),
+  callMcpTool: vi.fn(),
+  isServerRunning: vi.fn(),
+}));
+
+// vi.mock factories are hoisted to the top of the file, so any variables they
+// reference must also be hoisted via vi.hoisted() to avoid TDZ errors.
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }));
+
+// Mock appLogger to prevent console noise and allow assertion on warn calls.
+vi.mock('../../../../src/services/platform', () => ({
+  appLogger: {
+    warn: mockWarn,
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeTool(name: string, description = `Description for ${name}`): McpTool {
+  return {
+    name,
+    description,
+    input_schema: { type: 'object', properties: {} },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('registerMcpTools', () => {
+  beforeEach(() => {
+    resetToolRegistry();
+    mockWarn.mockClear();
+  });
+
+  // ── Basic registration ─────────────────────────────────────────────────────
+
+  it('registers tools with sanitized names and returns count', () => {
+    const count = registerMcpTools('my-server', [
+      makeTool('get-weather'),
+      makeTool('list_files'),
+    ]);
+    expect(count).toBe(2);
+  });
+
+  it('registers tools under the correct source', () => {
+    registerMcpTools('srv1', [makeTool('get_time')]);
+    const registry = getToolRegistry();
+    expect(registry.getSource('mcp_srv1_get_time')).toBe('mcp:srv1');
+  });
+
+  it('stores the sanitized name as the registry key', () => {
+    registerMcpTools('my.server', [makeTool('get data!')]);
+    const registry = getToolRegistry();
+    // 'mcp_my.server_get data!' sanitizes to 'mcp_my_server_get_data'
+    expect(registry.has('mcp_my_server_get_data')).toBe(true);
+    expect(registry.has('mcp_my.server_get data!')).toBe(false);
+  });
+
+  // ── Reverse name map ───────────────────────────────────────────────────────
+
+  it('getOriginalName returns the raw MCP tool name for a sanitized key', () => {
+    registerMcpTools('my.server', [makeTool('get data!')]);
+    const registry = getToolRegistry();
+    expect(registry.getOriginalName('mcp_my_server_get_data')).toBe('get data!');
+  });
+
+  it('getServerId returns the server ID for a sanitized key', () => {
+    registerMcpTools('my.server', [makeTool('get data!')]);
+    const registry = getToolRegistry();
+    expect(registry.getServerId('mcp_my_server_get_data')).toBe('my.server');
+  });
+
+  it('lookup returns undefined for non-MCP built-in tool names', () => {
+    const registry = getToolRegistry();
+    expect(registry.getOriginalName('get_current_time')).toBeUndefined();
+  });
+
+  it('lookup works for clean names with no sanitization needed', () => {
+    registerMcpTools('srv1', [makeTool('list_files')]);
+    const registry = getToolRegistry();
+    expect(registry.getOriginalName('mcp_srv1_list_files')).toBe('list_files');
+    expect(registry.getServerId('mcp_srv1_list_files')).toBe('srv1');
+  });
+
+  // ── Sanitization warnings ──────────────────────────────────────────────────
+
+  it('logs a warn when sanitization changes the tool name', () => {
+    registerMcpTools('my.server', [makeTool('get data!')]);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'service.mcp',
+      'MCP tool name was sanitized',
+      expect.objectContaining({
+        serverId: 'my.server',
+        original: 'mcp_my.server_get data!',
+        sanitized: 'mcp_my_server_get_data',
+      }),
+    );
+  });
+
+  it('does not warn when no sanitization is needed', () => {
+    mockWarn.mockClear();
+    registerMcpTools('srv1', [makeTool('get_weather')]);
+    // mockWarn should not have been called with 'MCP tool name was sanitized'
+    const sanitizeWarnings = mockWarn.mock.calls.filter(
+      ([, msg]) => msg === 'MCP tool name was sanitized',
+    );
+    expect(sanitizeWarnings).toHaveLength(0);
+  });
+
+  // ── Collision detection ────────────────────────────────────────────────────
+
+  it('skips both tools when two names collide and logs a warning', () => {
+    // 'get!data' and 'get?data' both sanitize to 'mcp_s_get_data'
+    const count = registerMcpTools('s', [makeTool('get!data'), makeTool('get?data')]);
+    expect(count).toBe(0);
+    const registry = getToolRegistry();
+    expect(registry.has('mcp_s_get_data')).toBe(false);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'service.mcp',
+      'MCP tool name collision detected \u2014 skipping affected tools',
+      expect.objectContaining({ serverId: 's' }),
+    );
+  });
+
+  it('registers non-colliding tools even when some in the batch collide', () => {
+    const count = registerMcpTools('s', [
+      makeTool('get!data'),   // collides
+      makeTool('get?data'),   // collides
+      makeTool('list_files'), // safe
+    ]);
+    expect(count).toBe(1);
+    const registry = getToolRegistry();
+    expect(registry.has('mcp_s_list_files')).toBe(true);
+  });
+
+  // ── Executor uses raw tool name ────────────────────────────────────────────
+
+  it('executor calls callMcpTool with the raw original tool name, not the sanitized name', async () => {
+    const { callMcpTool } = await import('../../../../src/services/clients/mcp');
+    const mockCallMcpTool = vi.mocked(callMcpTool);
+    mockCallMcpTool.mockResolvedValueOnce({ success: true, data: 'result' });
+
+    registerMcpTools('my.server', [makeTool('get data!')]);
+
+    const registry = getToolRegistry();
+    // Execute via the sanitized key
+    await registry.execute('mcp_my_server_get_data', {});
+
+    expect(mockCallMcpTool).toHaveBeenCalledWith(
+      'my.server',
+      'get data!',  // raw name, not 'mcp_my_server_get_data'
+      {},
+    );
+  });
+});
+
+// =============================================================================
+// unregisterMcpTools
+// =============================================================================
+
+describe('unregisterMcpTools', () => {
+  beforeEach(() => {
+    resetToolRegistry();
+    mockWarn.mockClear();
+  });
+
+  it('removes registered tools and returns the count', () => {
+    registerMcpTools('srv1', [makeTool('get_weather'), makeTool('list_files')]);
+    const removed = unregisterMcpTools('srv1');
+    expect(removed).toBe(2);
+    const registry = getToolRegistry();
+    expect(registry.has('mcp_srv1_get_weather')).toBe(false);
+    expect(registry.has('mcp_srv1_list_files')).toBe(false);
+  });
+
+  it('clears name-map entries for the unregistered server', () => {
+    registerMcpTools('my.server', [makeTool('get data!')]);
+    unregisterMcpTools('my.server');
+    const registry = getToolRegistry();
+    expect(registry.getOriginalName('mcp_my_server_get_data')).toBeUndefined();
+    expect(registry.getServerId('mcp_my_server_get_data')).toBeUndefined();
+  });
+
+  it('does not remove tools from a different server', () => {
+    registerMcpTools('srv1', [makeTool('tool_a')]);
+    registerMcpTools('srv2', [makeTool('tool_b')]);
+    unregisterMcpTools('srv1');
+    const registry = getToolRegistry();
+    expect(registry.has('mcp_srv2_tool_b')).toBe(true);
+    expect(registry.getOriginalName('mcp_srv2_tool_b')).toBe('tool_b');
+  });
+
+  it('returns 0 when the server has no registered tools', () => {
+    expect(unregisterMcpTools('nonexistent')).toBe(0);
+  });
+});
+
+// =============================================================================
+// getMcpSource
+// =============================================================================
+
+describe('getMcpSource', () => {
+  it('returns the correct source prefix format', () => {
+    expect(getMcpSource('my-server')).toBe('mcp:my-server');
+    expect(getMcpSource('123')).toBe('mcp:123');
+  });
+});

--- a/tests/ts/services/tools/nameUtils.test.ts
+++ b/tests/ts/services/tools/nameUtils.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeToolName,
+  detectCollisions,
+  formatToolDisplayName,
+} from '../../../../src/services/tools/nameUtils';
+
+// =============================================================================
+// sanitizeToolName
+// =============================================================================
+
+describe('sanitizeToolName', () => {
+  // ── Fallback ───────────────────────────────────────────────────────────────
+
+  it('returns "unnamed_tool" for an empty string', () => {
+    expect(sanitizeToolName('')).toBe('unnamed_tool');
+  });
+
+  it('returns "unnamed_tool" for a string of only special characters', () => {
+    expect(sanitizeToolName('!!!')).toBe('unnamed_tool');
+    expect(sanitizeToolName('...')).toBe('unnamed_tool');
+    expect(sanitizeToolName('   ')).toBe('unnamed_tool');
+  });
+
+  // ── Already-valid names ────────────────────────────────────────────────────
+
+  it('returns an already-valid name unchanged', () => {
+    expect(sanitizeToolName('get_current_time')).toBe('get_current_time');
+    expect(sanitizeToolName('myTool')).toBe('myTool');
+    expect(sanitizeToolName('tool123')).toBe('tool123');
+  });
+
+  it('preserves hyphens (valid per OpenAI spec)', () => {
+    expect(sanitizeToolName('get-weather')).toBe('get-weather');
+    expect(sanitizeToolName('my-mcp-tool')).toBe('my-mcp-tool');
+  });
+
+  // ── Dot replacement ────────────────────────────────────────────────────────
+
+  it('replaces dots with underscores', () => {
+    expect(sanitizeToolName('file.read')).toBe('file_read');
+    expect(sanitizeToolName('a.b.c')).toBe('a_b_c');
+  });
+
+  // ── Space replacement ──────────────────────────────────────────────────────
+
+  it('replaces spaces with underscores', () => {
+    expect(sanitizeToolName('my tool')).toBe('my_tool');
+    expect(sanitizeToolName('get current time')).toBe('get_current_time');
+  });
+
+  // ── Underscore collapsing ──────────────────────────────────────────────────
+
+  it('collapses consecutive underscores into one', () => {
+    expect(sanitizeToolName('a..b')).toBe('a_b');
+    expect(sanitizeToolName('a  b')).toBe('a_b');
+    expect(sanitizeToolName('a___b')).toBe('a_b');
+  });
+
+  // ── Trim leading/trailing underscores ──────────────────────────────────────
+
+  it('trims leading and trailing underscores', () => {
+    expect(sanitizeToolName('_foo_')).toBe('foo');
+    expect(sanitizeToolName('__bar__')).toBe('bar');
+  });
+
+  // ── Unicode ────────────────────────────────────────────────────────────────
+
+  it('replaces unicode characters with underscores', () => {
+    expect(sanitizeToolName('get\u00e9weather')).toBe('get_weather');
+    expect(sanitizeToolName('\u4e2d\u6587tool')).toBe('tool');
+    expect(sanitizeToolName('emoji\uD83D\uDE00name')).toBe('emoji_name');
+  });
+
+  // ── Truncation ─────────────────────────────────────────────────────────────
+
+  it('truncates names longer than 64 characters to exactly 64', () => {
+    const long = 'a'.repeat(65);
+    const result = sanitizeToolName(long);
+    expect(result).toHaveLength(64);
+    expect(result).toBe('a'.repeat(64));
+  });
+
+  it('truncation does not create a trailing underscore', () => {
+    // 63 valid chars + one invalid char that becomes '_' at position 64
+    const input = 'a'.repeat(63) + '!';
+    const result = sanitizeToolName(input);
+    // After replacement: 'a'.repeat(63) + '_', length 64, trim won't fire
+    // because we truncate after collapsing but before trimming... wait
+    // actually per the implementation: replace -> collapse -> trim -> slice
+    // so at slice(0,64): 'a'.repeat(63) followed by '_'
+    // the trim happens BEFORE slice, so '_' at end is removed first:
+    // 'a'.repeat(63) + '_' -> trim -> 'a'.repeat(63) -> length 63
+    expect(result).toHaveLength(63);
+    expect(result).toBe('a'.repeat(63));
+  });
+
+  it('result from a 65-char valid string is exactly 64 chars', () => {
+    // All valid chars, no underscore trimming possible
+    const input = 'ab'.repeat(32) + 'a'; // 65 chars
+    const result = sanitizeToolName(input);
+    expect(result).toHaveLength(64);
+    expect(result).toBe(input.slice(0, 64));
+  });
+
+  // ── Full namespaced MCP name ───────────────────────────────────────────────
+
+  it('sanitizes a fully-namespaced MCP name with special chars', () => {
+    const result = sanitizeToolName('mcp_my.server_get data!');
+    expect(result).toBe('mcp_my_server_get_data');
+    expect(result).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+  });
+
+  it('sanitizes a namespaced MCP name with hyphens and keeps them', () => {
+    const result = sanitizeToolName('mcp_my-server_get-weather');
+    expect(result).toBe('mcp_my-server_get-weather');
+    expect(result).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+  });
+
+  it('result always matches the OpenAI function-calling regex', () => {
+    const inputs = [
+      'get-weather',
+      'file.read',
+      'my tool name',
+      'mcp_srv.1_do something!',
+      '!@#$%^&*()',
+      '\u00e9\u00e0\u00fc',
+      'a'.repeat(100),
+    ];
+
+    for (const input of inputs) {
+      const result = sanitizeToolName(input);
+      expect(result).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    }
+  });
+});
+
+// =============================================================================
+// detectCollisions
+// =============================================================================
+
+describe('detectCollisions', () => {
+  it('returns an empty map for an empty input array', () => {
+    expect(detectCollisions([])).toEqual(new Map());
+  });
+
+  it('returns an empty map when no two names collide', () => {
+    const names = ['mcp_s_get_weather', 'mcp_s_list_files', 'mcp_s_read_file'];
+    expect(detectCollisions(names)).toEqual(new Map());
+  });
+
+  it('detects a collision when two names sanitize to the same string', () => {
+    const names = ['mcp_s_ab!', 'mcp_s_ab?'];
+    const result = detectCollisions(names);
+    expect(result.size).toBe(1);
+    const [sanitized, originals] = [...result.entries()][0];
+    expect(sanitized).toBe('mcp_s_ab');
+    expect(originals).toContain('mcp_s_ab!');
+    expect(originals).toContain('mcp_s_ab?');
+  });
+
+  it('detects multiple independent collisions in the same batch', () => {
+    const names = [
+      'mcp_s_ab!',  // collides with mcp_s_ab?
+      'mcp_s_ab?',
+      'mcp_s_xy.',  // collides with mcp_s_xy 
+      'mcp_s_xy ',
+      'mcp_s_unique',
+    ];
+    const result = detectCollisions(names);
+    expect(result.size).toBe(2);
+  });
+
+  it('does not include non-colliding names in the result', () => {
+    const names = ['mcp_s_ab!', 'mcp_s_ab?', 'mcp_s_unique'];
+    const result = detectCollisions(names);
+    expect(result.has('mcp_s_unique')).toBe(false);
+  });
+
+  it('detects 64-char truncation collisions', () => {
+    // Two names that differ only after position 64
+    const base = 'mcp_s_' + 'a'.repeat(58); // 64 chars total after sanitize
+    const name1 = base + 'X';
+    const name2 = base + 'Y';
+    const result = detectCollisions([name1, name2]);
+    expect(result.size).toBe(1);
+  });
+});
+
+// =============================================================================
+// formatToolDisplayName
+// =============================================================================
+
+describe('formatToolDisplayName', () => {
+  it('Title Cases hyphen-separated names', () => {
+    expect(formatToolDisplayName('get-weather')).toBe('Get Weather');
+    expect(formatToolDisplayName('my-mcp-tool')).toBe('My Mcp Tool');
+  });
+
+  it('Title Cases underscore-separated names', () => {
+    expect(formatToolDisplayName('get_current_time')).toBe('Get Current Time');
+    expect(formatToolDisplayName('file_read')).toBe('File Read');
+  });
+
+  it('Title Cases dot-separated names (raw MCP names with dots)', () => {
+    expect(formatToolDisplayName('file.read')).toBe('File Read');
+    expect(formatToolDisplayName('server.get.data')).toBe('Server Get Data');
+  });
+
+  it('Title Cases space-separated names (raw MCP names with spaces)', () => {
+    expect(formatToolDisplayName('my tool')).toBe('My Tool');
+    expect(formatToolDisplayName('get current time')).toBe('Get Current Time');
+  });
+
+  it('handles mixed delimiters', () => {
+    expect(formatToolDisplayName('my-tool_name.here')).toBe('My Tool Name Here');
+  });
+
+  it('collapses consecutive delimiters', () => {
+    expect(formatToolDisplayName('a..b')).toBe('A B');
+    expect(formatToolDisplayName('a--b')).toBe('A B');
+  });
+
+  it('handles a single word with no delimiters', () => {
+    expect(formatToolDisplayName('weather')).toBe('Weather');
+    expect(formatToolDisplayName('Weather')).toBe('Weather');
+  });
+
+  it('handles an already Title Cased string', () => {
+    expect(formatToolDisplayName('Get Weather')).toBe('Get Weather');
+  });
+});


### PR DESCRIPTION
Closes #262. Part of epic #246.

## What

Implements the three acceptance criteria from issue #262 in four focused, incremental commits.

## Changes

### `src/services/tools/nameUtils.ts` (new)
Pure, dependency-free utilities:
- **`sanitizeToolName(raw)`** — replaces `[^a-zA-Z0-9_-]` with `_`, collapses consecutive underscores, trims leading/trailing underscores, truncates to 64 chars, falls back to `'unnamed_tool'`. Always receives the full `mcp_${serverId}_${tool.name}` string so the whole result is validated within the 64-char budget.
- **`detectCollisions(names[])`** — returns only entries where ≥2 raw names sanitize to the same output. Callers flatten values to `Set<string>` for O(1) skip checks.
- **`formatToolDisplayName(raw)`** — splits on `/[-_.\s]+/` and Title Cases each word; handles all real-world MCP naming conventions (`file.read` → `File Read`, `get-weather` → `Get Weather`).

### `src/services/tools/registry.ts`
- Added `NameMapEntry` interface `{ originalName: string; serverId: string }`
- Added private `_nameMap: Map<string, NameMapEntry>` keyed by sanitized name
- `registerWithNameMapping(originalName, serverId, sanitizedName, ...)` — stores mapping then delegates to `register()`
- `getOriginalName(sanitizedName)` and `getServerId(sanitizedName)` — O(1) lookups
- `unregisterBySource()` iterates `_nameMap.entries()` and deletes entries where `value.serverId` matches; safe during `for...of` iteration
- `clear()` also calls `_nameMap.clear()`

### `src/services/tools/mcpIntegration.ts`
- Collision detection runs on the entire batch before the registration loop; colliding tools are **skipped** (not silently truncated) with a `warn` log per collision group
- Skip-set is a `Set<string>` flattened from collision map values for O(1) checks
- Sanitization applied to the full `mcp_${serverId}_${tool.name}` string; warns when result differs from input
- Executor closure captures **raw `tool.name`** and passes it unchanged to `callMcpTool` — the MCP server only understands its own naming scheme
- Uses `registerWithNameMapping()` instead of `register()`

### UI components (`ToolExecutionProgress`, `ToolDetailsModal`) — bug fix included
Both components had `formatToolName()` using `/^mcp_\d+_/` which **only matched numeric server IDs**, silently displaying full namespaced names for string-ID servers. Replaced with `getToolRegistry().getOriginalName(name) ?? name` then `formatToolDisplayName()`.

### `src/services/tools/index.ts`
Re-exports `NameMapEntry`, `sanitizeToolName`, `detectCollisions`, `formatToolDisplayName` from the barrel.

## Tests — 50 passing (46 new + 4 existing)

**`tests/ts/services/tools/nameUtils.test.ts`** (29 tests):
- `sanitizeToolName`: empty string, all-special, already-valid, hyphens preserved, dots, spaces, unicode, underscore collapsing, leading/trailing trim, 64-char truncation, full namespaced MCP names, OpenAI regex assertion for all edge cases
- `detectCollisions`: empty array, no collision, collision pair, multiple independent collisions, non-colliders absent, truncation-induced collision
- `formatToolDisplayName`: all delimiter types, mixed, single word, consecutive delimiters

**`tests/ts/services/tools/mcpIntegration.test.ts`** (17 tests):
- Registration count, source, sanitized key in registry
- `getOriginalName` / `getServerId` round-trips
- Sanitization warn fired / not fired
- Collision: both tools skipped, warn logged, non-colliders still register
- Executor passes raw `tool.name` to `callMcpTool` (asserted on mock)
- `unregisterMcpTools` clears only the target server's name-map entries