### PR TITLE
fix(frontend): replace dynamic import with static import in GeneralSettings

### DIFF
--- a/src/components/SettingsModal/GeneralSettings.tsx
+++ b/src/components/SettingsModal/GeneralSettings.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_TITLE_GENERATION_PROMPT } from "../../services/clients/chat";
 import type { ModelsDirectoryInfo, GgufModel, InferenceConfig } from "../../types";
 import { cn } from '../../utils/cn';
 import { Row, Label } from '../primitives';
+import { updateSettings } from '../../services/transport/api/settings';
 
 interface GeneralSettingsProps {
   // Directory state
@@ -361,10 +362,8 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
           size="sm"
           onClick={() => {
             // Reset setup_completed to false and reload page to trigger wizard
-            import('../../services/transport/api/settings').then(({ updateSettings: update }) => {
-              update({ setupCompleted: false }).then(() => {
-                window.location.reload();
-              });
+            updateSettings({ setupCompleted: false }).then(() => {
+              window.location.reload();
             });
           }}
           disabled={saving}


### PR DESCRIPTION
## Summary

`GeneralSettings.tsx` was dynamically importing `settings.ts` inside the "Re-run Wizard" click handler, presumably to lazy-load it. However, `settings.ts` is already statically imported by both `SetupWizard.tsx` and `api/index.ts`, so it is always part of the initial bundle — the dynamic import provided no code-splitting benefit and generated a Vite build warning:

```
(!) .../settings.ts is dynamically imported by .../GeneralSettings.tsx but also
statically imported by .../SetupWizard.tsx, .../api/index.ts,
dynamic import will not move module into another chunk.
```

The fix converts the dynamic import to a static one, eliminating unnecessary async wrapping and the build warning.

## Change

- Added `import { updateSettings } from '../../services/transport/api/settings'` to the static imports
- Replaced the `import(...).then(...)` pattern in the click handler with a direct `updateSettings(...)` call
