### PR TITLE
fix: Tauri GUI blank white screen in production builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,10 @@ build-tauri:
 	# Step A: Build frontend
 	UV_USE_IO_URING=0 npm run build:tauri
 	# Step B: Unified cargo build - both CLI and Tauri app share dependency compilation
-	$(TASKSET) $(CARGO) build --release -p gglib-cli -p gglib-app
+	# custom-protocol is required for Tauri to serve bundled frontend assets via
+	# its asset protocol.  Without it the WebView falls back to devUrl and shows
+	# a blank white screen in production.
+	$(TASKSET) $(CARGO) build --release -p gglib-cli -p gglib-app --features gglib-app/custom-protocol
 	# Step C: Bundle the already-built binary into platform installers
 	# On Linux: use --bundles deb,rpm to avoid AppImage issues on Arch.
 	# linuxdeploy's embedded strip fails on Arch due to RELR relocations (linuxdeploy#272).

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>gglib needs microphone access for voice mode — local speech-to-text input via Whisper. Audio is processed entirely on-device and never leaves your machine.</string>
 </dict>


### PR DESCRIPTION
Fixes #296

## Problem

Running `gglib gui` after `make setup` / `make build-tauri` shows a blank white screen. The DevTools console showed:

```
Failed to load resource: Could not connect to the server
```

## Root Cause

The `build-tauri` Makefile target was calling `cargo build` **without** the `custom-protocol` Cargo feature:

```makefile
# Before (broken)
$(TASKSET) $(CARGO) build --release -p gglib-cli -p gglib-app
```

`custom-protocol` (defined in `src-tauri/Cargo.toml` as `tauri/custom-protocol`) is required for the production binary to serve the bundled frontend assets via the `tauri://` asset protocol. Without it, Tauri falls back to the `devUrl` (`http://localhost:5173`) — no dev server is running in production so every fetch fails and the app shows a blank screen.

`npm run tauri build` (VS Code tasks) was unaffected because the Tauri CLI enables this feature automatically.

## Changes

### `Makefile`
- Add `--features gglib-app/custom-protocol` to the `cargo build` step in `build-tauri`

### `src-tauri/Info.plist`
- Add `NSAllowsLocalNetworking` App Transport Security exception so WKWebView can make HTTP requests to the embedded Axum API server at `http://127.0.0.1:{ephemeral-port}` on macOS