### PR TITLE
fix: route title generation and deep research through /api/chat proxy

### DIFF
--- a/src/hooks/useDeepResearch/useDeepResearch.ts
+++ b/src/hooks/useDeepResearch/useDeepResearch.ts
@@ -22,6 +22,7 @@ import {
 } from './runResearchLoop';
 import type { TurnMessage } from './buildTurnMessages';
 import { getToolRegistry } from '../../services/tools';
+import { getAuthenticatedFetchConfig } from '../../services/transport/api/client';
 
 // =============================================================================
 // Configuration
@@ -116,9 +117,10 @@ function createLLMCaller(): (
   }
 ) => Promise<LLMResponse> {
   return async (messages, { tools, endpoint, abortSignal }) => {
-    const url = `http://127.0.0.1:${endpoint.port}/v1/chat/completions`;
+    const { baseUrl, headers: authHeaders } = await getAuthenticatedFetchConfig();
 
     const body: Record<string, unknown> = {
+      port: endpoint.port,
       messages,
       stream: false, // Non-streaming for research loop
     };
@@ -128,12 +130,13 @@ function createLLMCaller(): (
       body.tool_choice = 'auto';
     }
 
+    const url = `${baseUrl}/api/chat`;
     appLogger.debug('research.hook', '[LLMCaller] Request', { url, messagesCount: messages.length, toolsCount: tools?.length ?? 0 });
 
     try {
       const response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify(body),
         signal: abortSignal,
       });

--- a/src/services/transport/api/chat.ts
+++ b/src/services/transport/api/chat.ts
@@ -3,7 +3,7 @@
  * Handles conversations and messages for the chat feature.
  */
 
-import { get, post, put, del } from './client';
+import { get, post, put, del, getAuthenticatedFetchConfig } from './client';
 import { sanitizeMessagesForLlamaServer } from '../sanitizeMessages';
 import { parseGeneratedTitle } from '../parseTitleResponse';
 import type { ConversationId, MessageId } from '../types/ids';
@@ -129,13 +129,16 @@ export async function generateChatTitle(params: GenerateTitleParams): Promise<st
     },
   ];
 
-  const response = await fetch(`http://127.0.0.1:${serverPort}/v1/chat/completions`, {
+  const { baseUrl, headers: authHeaders } = await getAuthenticatedFetchConfig();
+  const response = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
     body: JSON.stringify({
+      port: serverPort,
       messages: llamaMessages,
       temperature: 0.7,
       max_tokens: 20,
+      stream: false,
     }),
   });
 


### PR DESCRIPTION
Closes #299

## Problem

The **Generate Title** button and **Deep Research** LLM calls both used raw `fetch()` directly to `http://127.0.0.1:{port}/v1/chat/completions` (llama-server). In the web UI this is cross-origin and fails CORS checks:

```
Fetch API cannot load http://127.0.0.1:9000/v1/chat/completions due to access control checks.
```

## Solution

Route both calls through `POST /api/chat` — the existing authenticated proxy endpoint — using `getAuthenticatedFetchConfig()` for `baseUrl` + auth headers. This is the same pattern already used by `streamModelResponse.ts`.

The proxy accepts a `port` field, handles capability-aware message transforms, and returns a plain `ChatCompletionResponse` JSON object when `stream: false`.

## Changes

| File | Change |
|---|---|
| `src/services/transport/api/chat.ts` | `generateChatTitle()`: POST to `${baseUrl}/api/chat` with `port` + auth headers |
| `src/hooks/useDeepResearch/useDeepResearch.ts` | `createLLMCaller()`: same — POST to `${baseUrl}/api/chat` with `port` + auth headers |

No backend changes required — `ChatProxyRequest` already has a `port: u16` field and `stream: false` already returns plain JSON.