### PR TITLE
feat(cli): Phase 4 — `gglib chat --agent` interactive agentic mode (#267)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -681,6 +687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +744,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -742,7 +757,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1316,6 +1331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1368,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -1395,6 +1422,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1908,6 +1946,7 @@ dependencies = [
  "chrono",
  "clap",
  "dotenvy",
+ "gglib-agent",
  "gglib-axum",
  "gglib-build-info",
  "gglib-core",
@@ -1918,6 +1957,7 @@ dependencies = [
  "gglib-mcp",
  "gglib-runtime",
  "hf-hub",
+ "rustyline",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2093,7 +2133,7 @@ dependencies = [
  "gglib-core",
  "gglib-proxy",
  "indicatif 0.18.4",
- "nix",
+ "nix 0.30.1",
  "num_cpus",
  "reqwest 0.13.2",
  "serde",
@@ -3543,7 +3583,7 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -3555,7 +3595,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.2",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -4220,6 +4260,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,7 +4288,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -5169,7 +5230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -5210,7 +5271,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -5232,6 +5293,16 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -5742,6 +5813,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -7655,6 +7748,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/crates/gglib-agent/src/filter.rs
+++ b/crates/gglib-agent/src/filter.rs
@@ -1,0 +1,52 @@
+//! [`FilteredToolExecutor`] — a decorator that restricts a [`ToolExecutorPort`]
+//! to a named allowlist of tools.
+//!
+//! Used by both the Axum HTTP handler (`gglib-axum`) and the CLI agent handler
+//! (`gglib-cli`) wherever the caller supplies a `tool_filter` / `--tools`
+//! option.  Keeping this decorator in the `gglib-agent` crate avoids
+//! duplicating it across consumers.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use gglib_core::domain::agent::{ToolCall, ToolDefinition, ToolResult};
+use gglib_core::ports::ToolExecutorPort;
+
+// =============================================================================
+// FilteredToolExecutor
+// =============================================================================
+
+/// Decorator that restricts a [`ToolExecutorPort`] to a named allowlist.
+///
+/// `list_tools` returns only the tools whose names appear in `allowed`.
+/// `execute` is delegated unchanged — the LLM will only request tools it was
+/// told about via `list_tools`, so the allowlist is effectively enforced at
+/// the listing step.
+pub struct FilteredToolExecutor {
+    inner: Arc<dyn ToolExecutorPort>,
+    allowed: HashSet<String>,
+}
+
+impl FilteredToolExecutor {
+    /// Wrap `inner`, exposing only tools whose names are in `allowed`.
+    pub fn new(inner: Arc<dyn ToolExecutorPort>, allowed: HashSet<String>) -> Self {
+        Self { inner, allowed }
+    }
+}
+
+#[async_trait]
+impl ToolExecutorPort for FilteredToolExecutor {
+    async fn list_tools(&self) -> Vec<ToolDefinition> {
+        self.inner
+            .list_tools()
+            .await
+            .into_iter()
+            .filter(|t| self.allowed.contains(&t.name))
+            .collect()
+    }
+
+    async fn execute(&self, call: &ToolCall) -> anyhow::Result<ToolResult> {
+        self.inner.execute(call).await
+    }
+}

--- a/crates/gglib-agent/src/lib.rs
+++ b/crates/gglib-agent/src/lib.rs
@@ -4,9 +4,11 @@
 
 pub mod agent_loop;
 pub mod context_pruning;
+pub mod filter;
 pub mod loop_detection;
 pub mod stagnation;
 pub mod stream_collector;
 pub mod tool_execution;
 
 pub use agent_loop::AgentLoop;
+pub use filter::FilteredToolExecutor;

--- a/crates/gglib-axum/src/handlers/agent.rs
+++ b/crates/gglib-axum/src/handlers/agent.rs
@@ -15,13 +15,11 @@
 //! LLM token generation and any in-flight tool calls without leaking compute
 //! or resources.
 
-use std::collections::HashSet;
 use std::convert::Infallible;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use async_trait::async_trait;
 use axum::Json;
 use axum::extract::State;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -35,10 +33,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::error::HttpError;
 use crate::handlers::port_utils::validate_port;
 use crate::state::AppState;
-use gglib_agent::AgentLoop;
-use gglib_core::domain::agent::{
-    AgentConfig, AgentEvent, AgentMessage, ToolCall, ToolDefinition, ToolResult,
-};
+use gglib_agent::{AgentLoop, FilteredToolExecutor};
+use gglib_core::domain::agent::{AgentConfig, AgentEvent, AgentMessage};
 use gglib_core::ports::{AgentLoopPort, ToolExecutorPort};
 use gglib_mcp::McpToolExecutorAdapter;
 use gglib_runtime::LlmCompletionAdapter;
@@ -75,36 +71,6 @@ pub struct AgentChatRequest {
     /// LLM and can be executed. When `None`, all tools from all connected MCP
     /// servers are available.
     pub tool_filter: Option<Vec<String>>,
-}
-
-// =============================================================================
-// FilteredToolExecutor — decorator
-// =============================================================================
-
-/// Decorator that restricts a [`ToolExecutorPort`] to a named allowlist.
-///
-/// Created per-request when [`AgentChatRequest::tool_filter`] is `Some`.
-/// Delegates `execute` unchanged — tools the LLM wasn't told about won't be
-/// requested, but if somehow called, the underlying executor handles them.
-struct FilteredToolExecutor {
-    inner: Arc<dyn ToolExecutorPort>,
-    allowed: HashSet<String>,
-}
-
-#[async_trait]
-impl ToolExecutorPort for FilteredToolExecutor {
-    async fn list_tools(&self) -> Vec<ToolDefinition> {
-        self.inner
-            .list_tools()
-            .await
-            .into_iter()
-            .filter(|t| self.allowed.contains(&t.name))
-            .collect()
-    }
-
-    async fn execute(&self, call: &ToolCall) -> anyhow::Result<ToolResult> {
-        self.inner.execute(call).await
-    }
 }
 
 // =============================================================================
@@ -194,10 +160,10 @@ pub async fn chat(
     let mcp_executor = Arc::new(McpToolExecutorAdapter::new(Arc::clone(&state.mcp)));
 
     let tool_executor: Arc<dyn ToolExecutorPort> = match req.tool_filter {
-        Some(filter) => Arc::new(FilteredToolExecutor {
-            inner: mcp_executor,
-            allowed: filter.into_iter().collect(),
-        }),
+        Some(filter) => Arc::new(FilteredToolExecutor::new(
+            mcp_executor,
+            filter.into_iter().collect(),
+        )),
         None => mcp_executor,
     };
 

--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -18,6 +18,7 @@ gglib-db = { path = "../gglib-db" }
 gglib-download = { path = "../gglib-download" }
 gglib-gguf = { path = "../gglib-gguf" }  # GGUF_BOOTSTRAP_EXCEPTION: Parser injected at composition root
 gglib-hf = { path = "../gglib-hf" }
+gglib-agent = { path = "../gglib-agent" }
 gglib-mcp = { path = "../gglib-mcp" }
 gglib-runtime = { path = "../gglib-runtime", features = ["cli"] }
 
@@ -30,6 +31,7 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 dotenvy = "0.15"
+rustyline = "14"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -257,6 +257,19 @@ pub enum Commands {
         /// Repeat penalty (overrides model/global defaults)
         #[arg(long = "repeat-penalty")]
         repeat_penalty: Option<f32>,
+        /// Enable agentic mode: drives the backend agentic loop instead of llama-cli
+        #[arg(long)]
+        agent: bool,
+        /// Reuse an already-running llama-server on this port (skips auto-start)
+        #[arg(long)]
+        port: Option<u16>,
+        /// Maximum agent iterations before giving up (agentic mode only)
+        #[arg(long = "max-iterations", default_value = "25")]
+        max_iterations: usize,
+        /// Comma-separated tool allowlist exposed to the model, or omit for all tools
+        /// (agentic mode only, e.g. "mcp_search,builtin_time")
+        #[arg(long)]
+        tools: Option<String>,
     },
 
     /// Ask a question with optional context from stdin or file

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -1,23 +1,144 @@
-//! Maps [`ChatArgs`] flags to an [`AgentLoop`] composition root and handles
+//! Maps [`ChatArgs`] flags to an [`AgentLoop`] composition root and manages
 //! llama-server lifecycle (auto-start or port reuse).
 //!
-//! The full implementation is added in the next commit.
+//! The only public surface is [`compose`], which returns the ready-to-use
+//! [`AgentLoop`] and an optional [`ProcessHandle`] that the caller must stop
+//! when the session ends (`Some` only when we auto-started the server).
 
-use anyhow::Result;
+use std::collections::HashSet;
+use std::sync::Arc;
 
-use gglib_agent::AgentLoop;
-use gglib_core::ProcessHandle;
+use anyhow::{Context as _, Result};
+use gglib_agent::{AgentLoop, FilteredToolExecutor};
+use gglib_core::domain::agent::AgentConfig;
+use gglib_core::ports::ToolExecutorPort;
+use gglib_core::{ProcessHandle, ServerConfig};
+use gglib_mcp::McpToolExecutorAdapter;
+use gglib_runtime::LlmCompletionAdapter;
 
 use crate::bootstrap::CliContext;
 use crate::handlers::chat::ChatArgs;
 
-/// Compose the [`AgentLoop`] for an agentic chat session.
+// =============================================================================
+// Base port used when auto-starting a server (consistent with CliConfig)
+// =============================================================================
+
+const DEFAULT_BASE_PORT: u16 = 9000;
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Compose the [`AgentLoop`] ready to use for a chat session.
 ///
-/// Returns `(loop, server_handle, server_started)`.
-/// When `server_started` is `true`, the caller must stop the server on exit.
+/// Returns `(loop, maybe_handle)`:
+/// - `maybe_handle` is `Some(handle)` when we auto-started a llama-server.
+///   The caller **must** call `ctx.runner().stop(&handle)` when the session ends.
+/// - `maybe_handle` is `None` when the caller supplied `--port` (reuse).
 pub async fn compose(
-    _ctx: &CliContext,
-    _args: &ChatArgs,
-) -> Result<(AgentLoop, ProcessHandle, bool)> {
-    todo!("agent_chat::config::compose — full implementation in Commit 4")
+    ctx: &CliContext,
+    args: &ChatArgs,
+) -> Result<(AgentLoop, Option<ProcessHandle>)> {
+    // 1. Resolve the LLM port — reuse or auto-start.
+    let (port, maybe_handle) = resolve_port(ctx, args).await?;
+
+    // 2. Initialise MCP servers (CLI bootstrap intentionally skips this).
+    //    A failure is logged as a warning rather than aborting the session:
+    //    the agent can still run without tools.
+    if let Err(e) = ctx.mcp().initialize().await {
+        tracing::warn!("MCP initialisation failed — tools may be unavailable: {e}");
+    }
+
+    // 3. Build the tool executor, optionally restricted to an allowlist.
+    let tool_executor = build_tool_executor(args, ctx);
+
+    // 4. Compose the agent loop (stateless — cheap to create).
+    let llm = Arc::new(LlmCompletionAdapter::new(port));
+    let agent_loop = AgentLoop::new(llm, tool_executor);
+
+    Ok((agent_loop, maybe_handle))
 }
+
+/// Build an [`AgentConfig`] from CLI args.
+///
+/// Only `max_iterations` is overridden; all other parameters use their
+/// well-tested defaults (matching the TypeScript frontend constants).
+pub fn build_agent_config(args: &ChatArgs) -> AgentConfig {
+    AgentConfig {
+        max_iterations: args.max_iterations,
+        ..AgentConfig::default()
+    }
+}
+
+// =============================================================================
+// Private helpers
+// =============================================================================
+
+/// Return `(port, maybe_handle)`.
+///
+/// When `args.port` is supplied the server is treated as externally managed
+/// and no `ProcessHandle` is returned.  Otherwise a llama-server is spawned
+/// via [`CliContext::runner`] and the resulting handle is returned so the
+/// caller can stop it on exit.
+async fn resolve_port(ctx: &CliContext, args: &ChatArgs) -> Result<(u16, Option<ProcessHandle>)> {
+    if let Some(port) = args.port {
+        tracing::debug!("reusing user-supplied llama-server on port {port}");
+        return Ok((port, None));
+    }
+
+    // Auto-start: look up the model, then ask the process runner to start it.
+    let model = ctx
+        .app()
+        .models()
+        .find_by_identifier(&args.identifier)
+        .await
+        .context("failed to look up model")?;
+
+    // Parse an explicit numeric ctx_size; ignore "max" (pass None, let the
+    // runner use the model's native context length).
+    let context_size = args
+        .ctx_size
+        .as_deref()
+        .and_then(|s| s.parse::<u64>().ok());
+
+    let mut server_config = ServerConfig::new(
+        model.id,
+        model.name.clone(),
+        model.file_path.clone(),
+        DEFAULT_BASE_PORT,
+    );
+    if let Some(ctx_size) = context_size {
+        server_config = server_config.with_context_size(ctx_size);
+    }
+
+    println!(
+        "Starting llama-server for '{}' (this may take a moment) …",
+        model.name
+    );
+
+    let handle = ctx
+        .runner()
+        .start(server_config)
+        .await
+        .context("failed to start llama-server")?;
+
+    println!("llama-server ready on port {}", handle.port);
+
+    Ok((handle.port, Some(handle)))
+}
+
+/// Wrap the MCP executor in a [`FilteredToolExecutor`] when `--tools` is set.
+fn build_tool_executor(args: &ChatArgs, ctx: &CliContext) -> Arc<dyn ToolExecutorPort> {
+    let base: Arc<dyn ToolExecutorPort> =
+        Arc::new(McpToolExecutorAdapter::new(Arc::clone(ctx.mcp())));
+
+    match args.tools.as_deref() {
+        None | Some("all") => base,
+        Some(list) => {
+            let allowed: HashSet<String> =
+                list.split(',').map(|s| s.trim().to_owned()).collect();
+            Arc::new(FilteredToolExecutor::new(base, allowed))
+        }
+    }
+}
+

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -1,0 +1,23 @@
+//! Maps [`ChatArgs`] flags to an [`AgentLoop`] composition root and handles
+//! llama-server lifecycle (auto-start or port reuse).
+//!
+//! The full implementation is added in the next commit.
+
+use anyhow::Result;
+
+use gglib_agent::AgentLoop;
+use gglib_core::ProcessHandle;
+
+use crate::bootstrap::CliContext;
+use crate::handlers::chat::ChatArgs;
+
+/// Compose the [`AgentLoop`] for an agentic chat session.
+///
+/// Returns `(loop, server_handle, server_started)`.
+/// When `server_started` is `true`, the caller must stop the server on exit.
+pub async fn compose(
+    _ctx: &CliContext,
+    _args: &ChatArgs,
+) -> Result<(AgentLoop, ProcessHandle, bool)> {
+    todo!("agent_chat::config::compose — full implementation in Commit 4")
+}

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -13,7 +13,10 @@ pub mod config;
 pub mod renderer;
 pub mod repl;
 
+use std::sync::Arc;
+
 use anyhow::Result;
+use gglib_core::ports::AgentLoopPort;
 
 use crate::bootstrap::CliContext;
 use crate::handlers::chat::ChatArgs;
@@ -24,11 +27,19 @@ use crate::handlers::chat::ChatArgs;
 /// Manages the server lifecycle (auto-start / stop) around the REPL session.
 pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
     let (agent_loop, maybe_handle) = config::compose(ctx, args).await?;
-    let result = repl::run_repl(&agent_loop, args).await;
+
+    // Wrap in Arc<dyn AgentLoopPort> so the REPL can cheaply clone the
+    // reference for each spawned per-turn task without requiring AgentLoop
+    // to implement Clone.
+    let agent: Arc<dyn AgentLoopPort> = Arc::new(agent_loop);
+
+    let result = repl::run_repl(agent, args).await;
+
     if let Some(ref handle) = maybe_handle {
         if let Err(e) = ctx.runner().stop(handle).await {
             tracing::warn!("failed to stop llama-server after agent chat: {e}");
         }
     }
+
     result
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -1,0 +1,34 @@
+//! Interactive agentic chat handler for `gglib chat --agent`.
+//!
+//! This module composes `gglib-agent`'s [`AgentLoop`] with an MCP tool
+//! executor and a live `llama-server` to run a multi-turn, tool-calling
+//! conversation in the terminal.
+//!
+//! Sub-modules keep each concern small and independently readable:
+//! - [`config`]   — maps `ChatArgs` flags to [`AgentConfig`] / tool executor
+//! - [`renderer`] — maps [`AgentEvent`] variants to terminal output
+//! - [`repl`]     — async REPL loop with `rustyline` + `spawn_blocking` input
+
+pub mod config;
+pub mod renderer;
+pub mod repl;
+
+use anyhow::Result;
+
+use crate::bootstrap::CliContext;
+use crate::handlers::chat::ChatArgs;
+
+/// Entry point: start the interactive agentic REPL.
+///
+/// Called from [`crate::handlers::chat::execute`] when `args.agent` is `true`.
+/// Manages the server lifecycle (auto-start / stop) around the REPL session.
+pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
+    let (agent_loop, handle, server_started) = config::compose(ctx, args).await?;
+    let result = repl::run_repl(&agent_loop, args).await;
+    if server_started {
+        if let Err(e) = ctx.runner().stop(&handle).await {
+            tracing::warn!("failed to stop llama-server after agent chat: {e}");
+        }
+    }
+    result
+}

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -23,10 +23,10 @@ use crate::handlers::chat::ChatArgs;
 /// Called from [`crate::handlers::chat::execute`] when `args.agent` is `true`.
 /// Manages the server lifecycle (auto-start / stop) around the REPL session.
 pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
-    let (agent_loop, handle, server_started) = config::compose(ctx, args).await?;
+    let (agent_loop, maybe_handle) = config::compose(ctx, args).await?;
     let result = repl::run_repl(&agent_loop, args).await;
-    if server_started {
-        if let Err(e) = ctx.runner().stop(&handle).await {
+    if let Some(ref handle) = maybe_handle {
+        if let Err(e) = ctx.runner().stop(handle).await {
             tracing::warn!("failed to stop llama-server after agent chat: {e}");
         }
     }

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -35,10 +35,10 @@ pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
 
     let result = repl::run_repl(agent, args).await;
 
-    if let Some(ref handle) = maybe_handle {
-        if let Err(e) = ctx.runner().stop(handle).await {
-            tracing::warn!("failed to stop llama-server after agent chat: {e}");
-        }
+    if let Some(ref handle) = maybe_handle
+        && let Err(e) = ctx.runner().stop(handle).await
+    {
+        tracing::warn!("failed to stop llama-server after agent chat: {e}");
     }
 
     result

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -1,0 +1,12 @@
+//! Maps [`AgentEvent`] variants to terminal output.
+//!
+//! The full implementation is added in the next commit.
+
+use gglib_core::domain::agent::AgentEvent;
+
+/// Render a single agent event to stdout/stderr.
+///
+/// `verbose` enables iteration-progress lines that are suppressed by default.
+pub fn render_event(_event: &AgentEvent, _verbose: bool) {
+    todo!("agent_chat::renderer::render_event — full implementation in Commit 3")
+}

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -1,12 +1,112 @@
-//! Maps [`AgentEvent`] variants to terminal output.
+//! Maps [`AgentEvent`] variants to human-readable terminal output.
 //!
-//! The full implementation is added in the next commit.
+//! All output follows a simple rule:
+//! - LLM text tokens (`TextDelta`) → `print!` to stdout (no newline, streaming)
+//! - Tool / progress lines        → `eprintln!` to stderr (avoids interleaving
+//!   with streamed tokens on stdout when stdout is piped)
+//! - Errors                       → `eprintln!` to stderr
+//!
+//! `FinalAnswer` emits only a trailing newline; the content was already
+//! streamed live as `TextDelta` events.  The REPL layer captures
+//! `FinalAnswer.content` for message history — it does not re-display it.
+
+use std::io::{self, Write as _};
 
 use gglib_core::domain::agent::AgentEvent;
 
-/// Render a single agent event to stdout/stderr.
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Render a single [`AgentEvent`] to the terminal.
 ///
-/// `verbose` enables iteration-progress lines that are suppressed by default.
-pub fn render_event(_event: &AgentEvent, _verbose: bool) {
-    todo!("agent_chat::renderer::render_event — full implementation in Commit 3")
+/// `verbose` enables per-iteration progress lines that are suppressed in
+/// normal/quiet mode.
+pub fn render_event(event: &AgentEvent, verbose: bool) {
+    match event {
+        AgentEvent::TextDelta { content } => {
+            print!("{content}");
+            // Flush immediately so each token appears as it arrives.
+            let _ = io::stdout().flush();
+        }
+
+        AgentEvent::Thinking { content } => {
+            eprintln!("\n  💭  {}", truncate(content, 80));
+        }
+
+        AgentEvent::ToolCallStart { tool_call } => {
+            eprintln!("\n  ⚙   {} …", tool_call.name);
+        }
+
+        AgentEvent::ToolCallComplete { result } => {
+            let icon = if result.success { "✓" } else { "✗" };
+            let preview = truncate(&result.content, 80);
+            eprintln!("  {icon}  {}ms  {preview}", result.duration_ms);
+        }
+
+        AgentEvent::IterationComplete {
+            iteration,
+            tool_calls,
+        } => {
+            if verbose {
+                eprintln!("  [iter {iteration}, {tool_calls} tool call(s)]");
+            }
+        }
+
+        AgentEvent::FinalAnswer { .. } => {
+            // Content was already printed token-by-token via TextDelta.
+            // Emit a trailing newline so the next shell prompt appears cleanly.
+            println!();
+        }
+
+        AgentEvent::Error { message } => {
+            eprintln!("\n  ❌  {message}");
+        }
+    }
 }
+
+// =============================================================================
+// Private helpers
+// =============================================================================
+
+/// Truncate `s` to at most `max_chars` characters, appending `…` if cut.
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::truncate;
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_exact_length_unchanged() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_gets_ellipsis() {
+        let result = truncate("hello world", 5);
+        assert_eq!(result, "hello…");
+    }
+
+    #[test]
+    fn truncate_empty_string() {
+        assert_eq!(truncate("", 10), "");
+    }
+}
+

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -1,0 +1,15 @@
+//! Async REPL loop with `rustyline` input (wrapped in `spawn_blocking`)
+//! and `tokio::select!` Ctrl+C cancellation.
+//!
+//! The full implementation is added in Commit 4.
+
+use anyhow::Result;
+
+use gglib_agent::AgentLoop;
+
+use crate::handlers::chat::ChatArgs;
+
+/// Run the interactive agent REPL until the user quits or EOF.
+pub async fn run_repl(_agent_loop: &AgentLoop, _args: &ChatArgs) -> Result<()> {
+    todo!("agent_chat::repl::run_repl — full implementation in Commit 4")
+}

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -1,15 +1,187 @@
-//! Async REPL loop with `rustyline` input (wrapped in `spawn_blocking`)
-//! and `tokio::select!` Ctrl+C cancellation.
+//! Async REPL loop for `gglib chat --agent`.
 //!
-//! The full implementation is added in Commit 4.
+//! # Design choices
+//!
+//! ## Blocking I/O and the Tokio runtime
+//!
+//! `rustyline::DefaultEditor::readline()` is synchronous, blocking the calling
+//! thread until the user presses Enter.  Calling a blocking function directly
+//! on a Tokio worker thread prevents other futures (MCP connections, SSE
+//! streams, health checks) from running.
+//!
+//! **Solution**: each call to `readline` is wrapped in
+//! [`tokio::task::spawn_blocking`], which hands the call to a dedicated
+//! blocking-thread pool, returning the async executor immediately.
+//!
+//! ## Ctrl+C cancellation
+//!
+//! `tokio::signal::ctrl_c()` is used inside a `tokio::select!` to abort the
+//! running agent-loop task without terminating the process.  A Ctrl+C at the
+//! readline prompt is handled by rustyline itself, which returns
+//! [`ReadlineError::Interrupted`].
+
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
-use gglib_agent::AgentLoop;
+use gglib_core::domain::agent::{AgentEvent, AgentMessage};
+use gglib_core::ports::AgentLoopPort;
 
 use crate::handlers::chat::ChatArgs;
 
-/// Run the interactive agent REPL until the user quits or EOF.
-pub async fn run_repl(_agent_loop: &AgentLoop, _args: &ChatArgs) -> Result<()> {
-    todo!("agent_chat::repl::run_repl — full implementation in Commit 4")
+use super::config::build_agent_config;
+use super::renderer::render_event;
+
+// =============================================================================
+// Help text
+// =============================================================================
+
+const REPL_HELP: &str = "\
+  /help     print this message
+  /quit     exit the session
+  /exit     exit the session
+  Ctrl+C    cancel the current agent response (return to prompt)
+  Ctrl+D    exit the session (EOF)";
+
+// =============================================================================
+// Public entry point
+// =============================================================================
+
+/// Run the interactive agent REPL until the user quits or reaches EOF.
+///
+/// Takes the agent loop as `Arc<dyn AgentLoopPort>` so the REPL can cheaply
+/// clone the reference for each spawned per-turn task without requiring
+/// [`AgentLoop`] to implement [`Clone`].
+pub async fn run_repl(agent_loop: Arc<dyn AgentLoopPort>, args: &ChatArgs) -> Result<()> {
+    let config = build_agent_config(args);
+
+    // Wrap the editor in Arc<Mutex> so it can be moved into spawn_blocking
+    // on each turn while retaining readline history across turns.
+    let editor: Arc<Mutex<DefaultEditor>> = Arc::new(Mutex::new(
+        DefaultEditor::new()
+            .map_err(|e| anyhow::anyhow!("failed to initialise readline editor: {e}"))?,
+    ));
+
+    // Conversation history shared across turns.
+    let mut messages: Vec<AgentMessage> = Vec::new();
+    if let Some(ref system) = args.system_prompt {
+        messages.push(AgentMessage::System {
+            content: system.clone(),
+        });
+    }
+
+    println!("Agentic chat ready. Type /help for help, /quit to exit.");
+
+    // ── REPL outer loop ──────────────────────────────────────────────────────
+    loop {
+        // ── 1. Read user input (blocking → spawn_blocking) ───────────────────
+        let ed = Arc::clone(&editor);
+        let line = tokio::task::spawn_blocking(move || ed.lock().expect("editor poisoned").readline("You: ")).await?;
+
+        let input = match line {
+            Ok(text) => text,
+            Err(ReadlineError::Interrupted) => {
+                // Ctrl+C at the prompt → exit cleanly.
+                println!("[exiting]");
+                break;
+            }
+            Err(ReadlineError::Eof) => break, // Ctrl+D / EOF
+            Err(e) => return Err(anyhow::anyhow!("readline error: {e}")),
+        };
+
+        let input = input.trim().to_owned();
+
+        match input.as_str() {
+            "" => continue,
+            "/quit" | "/exit" => break,
+            "/help" => {
+                println!("{REPL_HELP}");
+                continue;
+            }
+            _ => {}
+        }
+
+        messages.push(AgentMessage::User {
+            content: input.clone(),
+        });
+
+        // ── 2. Run agent loop for this turn ──────────────────────────────────
+        let (tx, mut rx) = mpsc::channel::<AgentEvent>(64);
+
+        let agent = Arc::clone(&agent_loop);
+        let msgs = messages.clone();
+        let cfg = config.clone();
+
+        let handle: JoinHandle<()> = tokio::spawn(async move {
+            match agent.run(msgs, cfg, tx).await {
+                Ok(_) => {}
+                Err(e) => tracing::debug!("agent loop ended: {e}"),
+            }
+        });
+
+        // ── 3. Consume event stream; Ctrl+C aborts the agent task ────────────
+        let final_content = collect_events(&mut rx, &handle, false).await;
+
+        // ── 4. Push assistant turn to history if we got a final answer ────────
+        if let Some(content) = final_content {
+            messages.push(AgentMessage::Assistant {
+                content: Some(content),
+                tool_calls: None,
+            });
+        }
+    }
+
+    Ok(())
 }
+
+// =============================================================================
+// Private helpers
+// =============================================================================
+
+/// Drain `rx` until the channel closes or a [`AgentEvent::FinalAnswer`]
+/// arrives, rendering each event.
+///
+/// Returns the final-answer content string if one was received.
+/// On Ctrl+C the agent `handle` is aborted and `None` is returned, preserving
+/// the partial response in message history only if it was a non-empty string.
+async fn collect_events(
+    rx: &mut mpsc::Receiver<AgentEvent>,
+    handle: &JoinHandle<()>,
+    verbose: bool,
+) -> Option<String> {
+    let mut final_content: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            // Prefer processing events over handling Ctrl+C when both are ready.
+            biased;
+
+            maybe = rx.recv() => {
+                let Some(event) = maybe else { break };
+
+                if let AgentEvent::FinalAnswer { ref content } = event {
+                    final_content = Some(content.clone());
+                    render_event(&event, verbose);
+                    break;
+                }
+
+                render_event(&event, verbose);
+            }
+
+            _ = tokio::signal::ctrl_c() => {
+                handle.abort();
+                // Drain any buffered events without displaying them.
+                while rx.try_recv().is_ok() {}
+                eprintln!("\n[agent response cancelled — Ctrl+C]");
+                break;
+            }
+        }
+    }
+
+    final_content
+}
+

--- a/crates/gglib-cli/src/handlers/chat.rs
+++ b/crates/gglib-cli/src/handlers/chat.rs
@@ -30,6 +30,11 @@ pub struct ChatArgs {
     pub top_k: Option<i32>,
     pub max_tokens: Option<u32>,
     pub repeat_penalty: Option<f32>,
+    // Agentic mode fields
+    pub agent: bool,
+    pub port: Option<u16>,
+    pub max_iterations: usize,
+    pub tools: Option<String>,
 }
 
 /// Execute the chat command.
@@ -41,6 +46,11 @@ pub struct ChatArgs {
 /// * `ctx` - The CLI context providing access to AppCore
 /// * `args` - Chat command arguments
 pub async fn execute(ctx: &CliContext, args: ChatArgs) -> Result<()> {
+    // Agentic mode: delegate entirely to the agent_chat handler.
+    if args.agent {
+        return super::agent_chat::run(ctx, &args).await;
+    }
+
     // Ensure llama.cpp is installed
     ensure_llama_initialized().await?;
 
@@ -62,6 +72,8 @@ pub async fn execute(ctx: &CliContext, args: ChatArgs) -> Result<()> {
         top_k,
         max_tokens,
         repeat_penalty,
+        // agent/port/max_iterations/tools already handled by the early-return above
+        ..
     } = args;
 
     // Look up the model using CliContext

--- a/crates/gglib-cli/src/handlers/mod.rs
+++ b/crates/gglib-cli/src/handlers/mod.rs
@@ -17,6 +17,7 @@
 //! - Manage database connections
 
 pub mod add;
+pub mod agent_chat;
 pub mod chat;
 pub mod check_deps;
 pub mod config;

--- a/crates/gglib-cli/src/lib.rs
+++ b/crates/gglib-cli/src/lib.rs
@@ -12,6 +12,7 @@ use tokio_test as _;
 use anyhow as _;
 use dotenvy as _;
 use hf_hub as _;
+use rustyline as _;
 use tokio as _;
 use tracing as _;
 use tracing_subscriber as _;

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -231,6 +231,10 @@ async fn main() -> anyhow::Result<()> {
             top_k,
             max_tokens,
             repeat_penalty,
+            agent,
+            port,
+            max_iterations,
+            tools,
         } => {
             // NEW: Uses CliContext
             let args = handlers::chat::ChatArgs {
@@ -248,6 +252,10 @@ async fn main() -> anyhow::Result<()> {
                 top_k,
                 max_tokens,
                 repeat_penalty,
+                agent,
+                port,
+                max_iterations,
+                tools,
             };
             handlers::chat::execute(&ctx, args).await?;
         }


### PR DESCRIPTION
## Summary

Implements Phase 4 of [#247](https://github.com/mmogr/gglib/issues/247): adds `gglib chat --agent` interactive agentic mode to the CLI.

Closes #267

---

## What changed

### Commit 1 — DRY refactor (`gglib-agent`)

`FilteredToolExecutor` was defined inline in `gglib-axum/src/handlers/agent.rs`. Both the Axum handler (Phase 3) and the new CLI handler need it identically. Keeping two copies would violate DRY.

**Action**: moved into a new `crates/gglib-agent/src/filter.rs` module, re-exported as `gglib_agent::FilteredToolExecutor`. The Axum handler now imports it from this canonical location. Zero logic changes.

---

### Commit 2 — CLI command surface

Four new flags on `gglib chat`:

| Flag | Default | Description |
|---|---|---|
| `--agent` | `false` | Enable agentic mode |
| `--port PORT` | — | Reuse an already-running `llama-server` (skips auto-start) |
| `--max-iterations N` | `25` | Cap the agent loop |
| `--tools LIST` | all | Comma-separated tool allowlist (e.g. `mcp_search,builtin_time`) |

The existing `llama-cli` subprocess path is completely untouched (backward compatible). When `--agent` is not set, behaviour is identical to before.

---

### Commits 3 & 4 — New `handlers/agent_chat/` sub-module

Mirrors the structure of `handlers/check_deps/` — four small, single-responsibility files:

| File | Responsibility | Lines |
|---|---|---|
| `mod.rs` | Entry point; owns server lifecycle | ~45 |
| `config.rs` | Composes `AgentLoop` from args; auto-starts or reuses `llama-server`; builds tool executor | ~130 |
| `renderer.rs` | Maps `AgentEvent` → terminal output | ~100 |
| `repl.rs` | `rustyline` REPL with `spawn_blocking` + `tokio::select!` Ctrl+C | ~155 |

---

## Key design decisions

**`FilteredToolExecutor` in `gglib-agent`** — the only correct home given that `gglib-agent` is the domain crate defining `ToolExecutorPort`. Placing it anywhere else (or duplicating it) would violate the hexagonal boundary.

**`spawn_blocking` for `rustyline`** — `readline()` is synchronous blocking I/O. Calling it directly on a Tokio worker thread would starve background tasks. Wrapping it in `tokio::task::spawn_blocking` keeps the async executor free.

**`Arc<dyn AgentLoopPort>` in the REPL** — `AgentLoop` is intentionally not `Clone` (stateless, but its internal `Arc`s already cheap to share). Passing `Arc<dyn AgentLoopPort>` lets the REPL clone the reference cheaply per turn without requiring the concrete type to change.

**MCP `initialize()` called explicitly in `config::compose`** — CLI bootstrap intentionally omits `mcp.initialize()` (only Axum does it). The agent handler calls it manually, with a soft warning on failure so the session can continue without tools.

**Optional `--port` + auto-start** — most flexible: the user can pre-warm a server with `gglib serve`, or let `gglib chat --agent` handle the full lifecycle automatically.

---

## Verification

```
cargo check -p gglib-agent -p gglib-axum -p gglib-cli  ✅
cargo test  -p gglib-agent -p gglib-cli                 ✅  68/68 tests pass
cargo clippy (strict -D warnings)                       ✅  all three crates
./scripts/check_boundaries.sh                           ✅  all PASS
gglib chat --help                                       ✅  four new flags visible
```