### PR TITLE
feat(agent): Phase 5 — integration tests for the backend agent loop

### DIFF
--- a/crates/gglib-agent/Cargo.toml
+++ b/crates/gglib-agent/Cargo.toml
@@ -23,7 +23,13 @@ tracing      = { workspace = true }
 serde_json   = { workspace = true }
 
 [dev-dependencies]
-tokio      = { workspace = true, features = ["macros", "rt-multi-thread"] }
+gglib-core    = { path = "../gglib-core" }
+tokio         = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json    = { workspace = true }
+futures-util  = "0.3"
+futures-core  = "0.3"
+async-trait   = { workspace = true }
+anyhow        = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/gglib-agent/tests/common/mock_llm.rs
+++ b/crates/gglib-agent/tests/common/mock_llm.rs
@@ -1,0 +1,174 @@
+//! Mock implementation of [`LlmCompletionPort`] for integration testing.
+//!
+//! Serves pre-scripted sequences of [`LlmStreamEvent`] values, one response
+//! per `chat_stream` call.  Build the response queue using the builder API:
+//!
+//! ```rust,ignore
+//! let llm = MockLlmPort::new()
+//!     .push(MockLlmResponse::tool_call("tc1", "search", serde_json::json!({})))
+//!     .push(MockLlmResponse::text("Here are the results."));
+//! ```
+
+use std::collections::VecDeque;
+use std::pin::Pin;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures_util::stream;
+use gglib_core::domain::agent::{AgentMessage, LlmStreamEvent, ToolCall, ToolDefinition};
+use gglib_core::ports::LlmCompletionPort;
+use tokio::sync::Mutex;
+
+// =============================================================================
+// MockLlmResponse — one scripted turn
+// =============================================================================
+
+/// A single scripted response that [`MockLlmPort`] will emit for one
+/// `chat_stream` call.
+///
+/// Converts into the sequence of [`LlmStreamEvent`] values:
+/// `TextDelta?` → `ToolCallDelta*` → `Done`.
+pub struct MockLlmResponse {
+    /// Optional assistant text (emitted as one [`LlmStreamEvent::TextDelta`]).
+    pub content: Option<String>,
+    /// Tool invocations the model "requests".
+    pub tool_calls: Vec<ToolCall>,
+    /// The OpenAI finish reason (`"stop"`, `"tool_calls"`, etc.).
+    pub finish_reason: String,
+}
+
+impl MockLlmResponse {
+    /// A plain-text response with `finish_reason = "stop"`.
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content: Some(content.into()),
+            tool_calls: vec![],
+            finish_reason: "stop".into(),
+        }
+    }
+
+    /// A single-tool-call response with `finish_reason = "tool_calls"`.
+    pub fn tool_call(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        args: serde_json::Value,
+    ) -> Self {
+        Self {
+            content: None,
+            tool_calls: vec![ToolCall {
+                id: id.into(),
+                name: name.into(),
+                arguments: args,
+            }],
+            finish_reason: "tool_calls".into(),
+        }
+    }
+
+    /// A multi-tool response with `finish_reason = "tool_calls"`.
+    pub fn tool_calls(calls: Vec<ToolCall>) -> Self {
+        Self {
+            content: None,
+            tool_calls: calls,
+            finish_reason: "tool_calls".into(),
+        }
+    }
+
+    /// Expand into the raw [`LlmStreamEvent`] sequence the adapter would emit.
+    fn into_events(self) -> Vec<LlmStreamEvent> {
+        let mut events = Vec::new();
+        if let Some(text) = self.content {
+            events.push(LlmStreamEvent::TextDelta { content: text });
+        }
+        for (index, call) in self.tool_calls.into_iter().enumerate() {
+            // Emit one delta per tool call — id and name in the first delta,
+            // full arguments in the same delta (single chunk, as compatible
+            // with the stream_collector's accumulation logic).
+            events.push(LlmStreamEvent::ToolCallDelta {
+                index,
+                id: Some(call.id),
+                name: Some(call.name),
+                arguments: Some(call.arguments.to_string()),
+            });
+        }
+        events.push(LlmStreamEvent::Done {
+            finish_reason: self.finish_reason,
+        });
+        events
+    }
+}
+
+// =============================================================================
+// MockLlmPort
+// =============================================================================
+
+/// Mock [`LlmCompletionPort`] that returns pre-scripted responses in FIFO order.
+///
+/// If `chat_stream` is called after the queue is exhausted, it returns an
+/// `Err` — which the agent loop surfaces as `AgentError::Internal`.  In
+/// practice, tests should push at least as many responses as the expected
+/// number of LLM calls.
+pub struct MockLlmPort {
+    responses: Mutex<VecDeque<Vec<LlmStreamEvent>>>,
+}
+
+impl MockLlmPort {
+    /// Create an empty mock with no scripted responses.
+    pub fn new() -> Self {
+        Self {
+            responses: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Append one scripted response to the queue (builder-style, takes `self`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called concurrently — this is a build-time helper.
+    pub fn push(self, response: MockLlmResponse) -> Self {
+        self.responses
+            .try_lock()
+            .expect("MockLlmPort::push called concurrently")
+            .push_back(response.into_events());
+        self
+    }
+
+    /// Append many responses from an iterator (builder-style).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called concurrently — this is a build-time helper.
+    pub fn push_many(self, responses: impl IntoIterator<Item = MockLlmResponse>) -> Self {
+        let mut guard = self
+            .responses
+            .try_lock()
+            .expect("MockLlmPort::push_many called concurrently");
+        for r in responses {
+            guard.push_back(r.into_events());
+        }
+        drop(guard);
+        self
+    }
+}
+
+impl Default for MockLlmPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LlmCompletionPort for MockLlmPort {
+    async fn chat_stream(
+        &self,
+        _messages: &[AgentMessage],
+        _tools: &[ToolDefinition],
+    ) -> Result<Pin<Box<dyn futures_core::Stream<Item = Result<LlmStreamEvent>> + Send>>> {
+        let events = self
+            .responses
+            .lock()
+            .await
+            .pop_front()
+            .ok_or_else(|| anyhow::anyhow!("MockLlmPort: no more scripted responses"))?;
+        Ok(Box::pin(stream::iter(events.into_iter().map(Ok))))
+    }
+}

--- a/crates/gglib-agent/tests/common/mock_tools.rs
+++ b/crates/gglib-agent/tests/common/mock_tools.rs
@@ -1,0 +1,191 @@
+//! Mock implementation of [`ToolExecutorPort`] for integration testing.
+//!
+//! Allows configuring per-tool behaviour and records all invocations so tests
+//! can assert on which tools were called and with what arguments.
+//!
+//! ```rust,ignore
+//! let executor = MockToolExecutorPort::new()
+//!     .with_tool(
+//!         ToolDefinition::new("search"),
+//!         MockToolBehavior::Immediate { content: "results…".into() },
+//!     )
+//!     .with_tool(
+//!         ToolDefinition::new("slow_io"),
+//!         MockToolBehavior::Delayed { millis: 5_000, content: "ok".into() },
+//!     );
+//! let call_log = executor.call_log_handle();  // clone before Arc wrapping
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use gglib_core::domain::agent::{ToolCall, ToolDefinition, ToolResult};
+use gglib_core::ports::ToolExecutorPort;
+use tokio::sync::Mutex;
+
+// =============================================================================
+// MockToolBehavior
+// =============================================================================
+
+/// Configurable response strategy for a single mock tool.
+#[derive(Clone)]
+#[allow(dead_code)] // Fail/Error are API surface for future tests
+pub enum MockToolBehavior {
+    /// Returns a successful result immediately.
+    Immediate {
+        /// Content returned to the LLM as the tool output.
+        content: String,
+    },
+    /// Sleeps for `millis` milliseconds before returning a successful result.
+    ///
+    /// Useful for exercising the per-tool timeout in [`AgentConfig`].
+    Delayed {
+        /// How long to sleep before returning, in milliseconds.
+        millis: u64,
+        /// Content returned to the LLM as the tool output.
+        content: String,
+    },
+    /// Returns a `ToolResult` with `success = false`.
+    ///
+    /// This is a domain-level failure — the loop feeds the message back to
+    /// the LLM so it can observe and react to the failure.
+    Fail {
+        /// Error description returned as the tool content.
+        message: String,
+    },
+    /// Returns `Err(anyhow::Error)`, simulating an infrastructure failure.
+    ///
+    /// The agent loop converts this into a `ToolResult { success: false }`.
+    Error {
+        /// Human-readable error description.
+        message: String,
+    },
+}
+
+// =============================================================================
+// CallLog handle — sharable snapshot accessor
+// =============================================================================
+
+/// A clonable handle to the shared call-log, so callers can capture it before
+/// the executor is wrapped in an `Arc<dyn ToolExecutorPort>`.
+///
+/// ```rust,ignore
+/// let executor = MockToolExecutorPort::new().with_tool(…);
+/// let log = executor.call_log_handle();
+/// let agent = AgentLoop::new(llm, Arc::new(executor));
+/// agent.run(…).await.unwrap();
+///
+/// let calls = log.snapshot().await;
+/// assert_eq!(calls.len(), 1);
+/// ```
+#[derive(Clone)]
+pub struct CallLogHandle(Arc<Mutex<Vec<(String, serde_json::Value)>>>);
+
+impl CallLogHandle {
+    /// Return a cloned snapshot of all `(tool_name, arguments)` pairs recorded
+    /// up to now.
+    pub async fn snapshot(&self) -> Vec<(String, serde_json::Value)> {
+        self.0.lock().await.clone()
+    }
+}
+
+// =============================================================================
+// MockToolExecutorPort
+// =============================================================================
+
+/// Mock [`ToolExecutorPort`] with configurable per-tool behaviour.
+///
+/// All invocations are appended to a shared [`CallLogHandle`] that can be
+/// captured before wrapping the executor in `Arc<dyn ToolExecutorPort>`.
+pub struct MockToolExecutorPort {
+    tools: Vec<ToolDefinition>,
+    behaviors: HashMap<String, MockToolBehavior>,
+    call_log: Arc<Mutex<Vec<(String, serde_json::Value)>>>,
+}
+
+impl MockToolExecutorPort {
+    /// Create an empty mock with no tools configured.
+    pub fn new() -> Self {
+        Self {
+            tools: Vec::new(),
+            behaviors: HashMap::new(),
+            call_log: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Register a tool with its associated behaviour (builder-style).
+    ///
+    /// Tools are advertised to the LLM in the order they are added.
+    pub fn with_tool(mut self, definition: ToolDefinition, behavior: MockToolBehavior) -> Self {
+        self.behaviors.insert(definition.name.clone(), behavior);
+        self.tools.push(definition);
+        self
+    }
+
+    /// Return a [`CallLogHandle`] that shares the internal call-log.
+    ///
+    /// Clone this **before** wrapping the executor in `Arc<dyn ToolExecutorPort>`
+    /// so you can inspect calls after the agent loop has run.
+    pub fn call_log_handle(&self) -> CallLogHandle {
+        CallLogHandle(Arc::clone(&self.call_log))
+    }
+}
+
+impl Default for MockToolExecutorPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolExecutorPort for MockToolExecutorPort {
+    async fn list_tools(&self) -> Vec<ToolDefinition> {
+        self.tools.clone()
+    }
+
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult> {
+        let start = Instant::now();
+
+        // Record the invocation.
+        self.call_log
+            .lock()
+            .await
+            .push((call.name.clone(), call.arguments.clone()));
+
+        let behavior = self
+            .behaviors
+            .get(&call.name)
+            .cloned()
+            .unwrap_or(MockToolBehavior::Immediate {
+                content: "ok".into(),
+            });
+
+        match behavior {
+            MockToolBehavior::Immediate { content } => Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                content,
+                success: true,
+                duration_ms: start.elapsed().as_millis() as u64,
+            }),
+            MockToolBehavior::Delayed { millis, content } => {
+                tokio::time::sleep(std::time::Duration::from_millis(millis)).await;
+                Ok(ToolResult {
+                    tool_call_id: call.id.clone(),
+                    content,
+                    success: true,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                })
+            }
+            MockToolBehavior::Fail { message } => Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                content: message,
+                success: false,
+                duration_ms: start.elapsed().as_millis() as u64,
+            }),
+            MockToolBehavior::Error { message } => Err(anyhow::anyhow!(message)),
+        }
+    }
+}

--- a/crates/gglib-agent/tests/common/mod.rs
+++ b/crates/gglib-agent/tests/common/mod.rs
@@ -1,0 +1,9 @@
+//! Common test infrastructure for `gglib-agent` integration tests.
+//!
+//! - [`mock_llm`] — configurable [`LlmCompletionPort`] that serves scripted
+//!   responses without any HTTP server.
+//! - [`mock_tools`] — configurable [`ToolExecutorPort`] with per-tool
+//!   behaviour (instant, delayed, fail, infra-error) and call recording.
+
+pub mod mock_llm;
+pub mod mock_tools;

--- a/crates/gglib-agent/tests/integration_agent_loop.rs
+++ b/crates/gglib-agent/tests/integration_agent_loop.rs
@@ -1,0 +1,464 @@
+//! Integration tests for the backend agentic loop.
+//!
+//! All tests are fully in-process: they drive [`AgentLoop`] directly through
+//! the [`AgentLoopPort`] interface using [`MockLlmPort`] and
+//! [`MockToolExecutorPort`] — no HTTP server, no llama-server process, no MCP
+//! daemon.  The suite completes in a few seconds.
+//!
+//! # Coverage
+//!
+//! | Test | Guard exercised |
+//! |------|----------------|
+//! | [`test_simple_tool_call_cycle`] | Basic LLM→tool→LLM round-trip |
+//! | [`test_parallel_tool_calls`] | Multiple tool calls in one iteration |
+//! | [`test_max_iterations_reached`] | [`AgentConfig::max_iterations`] limit |
+//! | [`test_tool_timeout`] | Per-tool timeout → `success = false` result |
+//! | [`test_loop_detection`] | Repeated tool-call batch → [`AgentError::LoopDetected`] |
+//! | [`test_context_budget_pruning`] | Oversized history → pruning → loop continues |
+
+mod common;
+
+use std::sync::Arc;
+
+use common::mock_llm::{MockLlmPort, MockLlmResponse};
+use common::mock_tools::{MockToolBehavior, MockToolExecutorPort};
+use gglib_agent::AgentLoop;
+use gglib_core::domain::agent::{
+    AgentConfig, AgentEvent, AgentMessage, ToolCall, ToolDefinition,
+};
+use gglib_core::ports::{AgentError, AgentLoopPort};
+use serde_json::json;
+use tokio::sync::mpsc;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Drain all events that were sent to `rx` before the channel was closed.
+///
+/// `AgentLoopPort::run` takes the `Sender` by value and drops it on return,
+/// so by the time we call this the channel is already closed; we just read
+/// what's buffered.
+async fn collect_events(mut rx: mpsc::Receiver<AgentEvent>) -> Vec<AgentEvent> {
+    let mut events = Vec::new();
+    while let Some(evt) = rx.recv().await {
+        events.push(evt);
+    }
+    events
+}
+
+/// Return `true` when `events` contains at least one [`AgentEvent::FinalAnswer`].
+fn has_final_answer(events: &[AgentEvent]) -> bool {
+    events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::FinalAnswer { .. }))
+}
+
+/// Return `true` when `events` contains at least one
+/// [`AgentEvent::ToolCallStart`] with the given tool name.
+fn has_tool_start(events: &[AgentEvent], name: &str) -> bool {
+    events.iter().any(|e| {
+        matches!(e, AgentEvent::ToolCallStart { tool_call, .. } if tool_call.name == name)
+    })
+}
+
+/// Return `true` when `events` contains at least one
+/// [`AgentEvent::ToolCallComplete`] whose result has the given `success` value.
+fn has_tool_complete_with_success(events: &[AgentEvent], success: bool) -> bool {
+    events.iter().any(|e| {
+        matches!(e, AgentEvent::ToolCallComplete { result, .. } if result.success == success)
+    })
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// **Simple tool-call cycle**: LLM requests one tool → tool executes → LLM
+/// produces the final answer.
+///
+/// Exercises the core happy path from the first iteration through to
+/// `FinalAnswer`.
+#[tokio::test]
+async fn test_simple_tool_call_cycle() {
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::tool_call("tc1", "search", json!({"q": "rust"})))
+            .push(MockLlmResponse::text("Here are the results.")),
+    );
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("search").with_description("Full-text search"),
+        MockToolBehavior::Immediate {
+            content: "result: async programming".into(),
+        },
+    );
+    let log = executor.call_log_handle();
+
+    let agent = AgentLoop::new(llm, Arc::new(executor));
+    let (tx, rx) = mpsc::channel(64);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "Find info about Rust".into(),
+            }],
+            AgentConfig::default(),
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    assert_eq!(result.unwrap(), "Here are the results.");
+
+    // Tool was called exactly once with the right name.
+    let calls = log.snapshot().await;
+    assert_eq!(calls.len(), 1, "expected exactly one tool invocation");
+    assert_eq!(calls[0].0, "search");
+
+    // Event stream contains the expected milestones.
+    assert!(has_tool_start(&events, "search"), "missing ToolCallStart");
+    assert!(
+        has_tool_complete_with_success(&events, true),
+        "missing successful ToolCallComplete"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::IterationComplete { iteration: 1, .. })),
+        "missing IterationComplete for iteration 1"
+    );
+    assert!(has_final_answer(&events), "missing FinalAnswer");
+}
+
+/// **Parallel tool calls**: LLM requests three tools in a single batch → all
+/// three execute (possibly concurrently) → LLM produces the final answer.
+///
+/// Verifies that the `execute_tools_parallel` helper dispatches all calls
+/// and that the agent loop correctly builds the follow-up conversation.
+#[tokio::test]
+async fn test_parallel_tool_calls() {
+    let batch = MockLlmResponse::tool_calls(vec![
+        ToolCall {
+            id: "tc1".into(),
+            name: "search".into(),
+            arguments: json!({"q": "Rust"}),
+        },
+        ToolCall {
+            id: "tc2".into(),
+            name: "search".into(),
+            arguments: json!({"q": "async"}),
+        },
+        ToolCall {
+            id: "tc3".into(),
+            name: "search".into(),
+            arguments: json!({"q": "tokio"}),
+        },
+    ]);
+
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(batch)
+            .push(MockLlmResponse::text("All done.")),
+    );
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("search"),
+        MockToolBehavior::Immediate {
+            content: "ok".into(),
+        },
+    );
+    let log = executor.call_log_handle();
+
+    let agent = AgentLoop::new(llm, Arc::new(executor));
+    let (tx, rx) = mpsc::channel(128);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "Search three topics".into(),
+            }],
+            AgentConfig {
+                max_parallel_tools: 3,
+                ..AgentConfig::default()
+            },
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    assert_eq!(result.unwrap(), "All done.");
+
+    // All three tool calls were executed.
+    let calls = log.snapshot().await;
+    assert_eq!(calls.len(), 3, "expected 3 tool invocations");
+
+    // Three ToolCallStart and three ToolCallComplete events.
+    let starts = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::ToolCallStart { .. }))
+        .count();
+    let completes = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::ToolCallComplete { .. }))
+        .count();
+    assert_eq!(starts, 3, "expected 3 ToolCallStart events");
+    assert_eq!(completes, 3, "expected 3 ToolCallComplete events");
+    assert!(has_final_answer(&events));
+}
+
+/// **Max iterations reached**: the LLM keeps requesting tool calls without
+/// ever producing a final answer.  The loop must terminate with
+/// [`AgentError::MaxIterationsReached`] after `max_iterations` iterations.
+#[tokio::test]
+async fn test_max_iterations_reached() {
+    // Provide more responses than max_iterations so the LLM never "runs out".
+    let llm = Arc::new(MockLlmPort::new().push_many(
+        (0..10).map(|i| MockLlmResponse::tool_call(format!("tc{i}"), "do_thing", json!({}))),
+    ));
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("do_thing"),
+        MockToolBehavior::Immediate {
+            content: "done".into(),
+        },
+    );
+
+    let agent = AgentLoop::new(llm, Arc::new(executor));
+    let (tx, rx) = mpsc::channel(128);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "go".into(),
+            }],
+            AgentConfig {
+                max_iterations: 3,
+                max_protocol_strikes: 100, // disable loop detection for this test
+                max_stagnation_steps: 100, // disable stagnation for this test
+                ..AgentConfig::default()
+            },
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // The loop must report the correct error.
+    assert!(
+        matches!(result, Err(AgentError::MaxIterationsReached(3))),
+        "expected MaxIterationsReached(3), got: {result:?}"
+    );
+
+    // The event stream should contain an Error event.
+    assert!(
+        events.iter().any(|e| matches!(e, AgentEvent::Error { .. })),
+        "expected at least one Error event in the stream"
+    );
+
+    // No FinalAnswer should have been emitted.
+    assert!(!has_final_answer(&events), "unexpected FinalAnswer");
+}
+
+/// **Tool timeout**: a slow tool exceeds the per-tool deadline.  The loop must
+/// continue by injecting a failed `ToolResult` into the conversation so the
+/// LLM can observe and react to the timeout.
+///
+/// Verifies that:
+/// - The timed-out tool produces a `ToolCallComplete` with `success = false`.
+/// - The loop does **not** terminate with an error — it makes another LLM call.
+/// - `FinalAnswer` is still emitted when the second LLM call returns text.
+#[tokio::test]
+async fn test_tool_timeout() {
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::tool_call(
+                "tc1",
+                "slow_tool",
+                json!({}),
+            ))
+            .push(MockLlmResponse::text("Timeout handled gracefully.")),
+    );
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("slow_tool"),
+        // 5 000 ms far exceeds the 50 ms deadline — timeout will fire first.
+        MockToolBehavior::Delayed {
+            millis: 5_000,
+            content: "this should never arrive".into(),
+        },
+    );
+
+    let agent = AgentLoop::new(llm, Arc::new(executor));
+    let (tx, rx) = mpsc::channel(64);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "run the slow tool".into(),
+            }],
+            AgentConfig {
+                tool_timeout_ms: 50, // 50 ms — fires long before the 5 s delay
+                ..AgentConfig::default()
+            },
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // The loop must recover: the second LLM call produces the final answer.
+    assert_eq!(
+        result.unwrap(),
+        "Timeout handled gracefully.",
+        "loop should complete successfully after timeout"
+    );
+
+    // The timed-out tool should appear as a failed completion.
+    assert!(
+        has_tool_complete_with_success(&events, false),
+        "expected a ToolCallComplete with success=false for the timed-out tool"
+    );
+
+    assert!(has_final_answer(&events), "missing FinalAnswer");
+}
+
+/// **Loop detection**: the model keeps invoking the same tool with the same
+/// arguments across multiple iterations.  After `max_protocol_strikes`
+/// repetitions the loop must terminate with [`AgentError::LoopDetected`].
+///
+/// The loop detector computes a signature over tool *names and argument hashes*
+/// (not call IDs), so using incrementing IDs does not prevent detection.
+#[tokio::test]
+async fn test_loop_detection() {
+    // Same name + same arguments = same batch signature every iteration.
+    let llm = Arc::new(MockLlmPort::new().push_many(
+        (0..10).map(|i| MockLlmResponse::tool_call(format!("tc{i}"), "do_thing", json!({}))),
+    ));
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("do_thing"),
+        MockToolBehavior::Immediate {
+            content: "done".into(),
+        },
+    );
+
+    let agent = AgentLoop::new(llm, Arc::new(executor));
+    let (tx, rx) = mpsc::channel(128);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "go".into(),
+            }],
+            AgentConfig {
+                max_iterations: 10,
+                max_protocol_strikes: 2,
+                max_stagnation_steps: 100,
+                ..AgentConfig::default()
+            },
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // Must terminate with LoopDetected.
+    assert!(
+        matches!(result, Err(AgentError::LoopDetected { .. })),
+        "expected LoopDetected, got: {result:?}"
+    );
+
+    // The loop emits IterationComplete events before detecting the loop.
+    // The detection is returned as a Rust Err — no Error event is emitted
+    // (only MaxIterationsReached emits an Error event before returning).
+    // At minimum, one IterationComplete should have been emitted.
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::IterationComplete { .. })),
+        "expected at least one IterationComplete event before loop detection"
+    );
+}
+
+/// **Context budget pruning**: when the accumulated message history exceeds
+/// `context_budget_chars`, the pruning pass must trim old tool messages so
+/// the loop can continue rather than aborting.
+///
+/// This test verifies the end-to-end behaviour: an oversized history is passed
+/// in, pruning runs silently during the first iteration, and the loop completes
+/// normally with a `FinalAnswer`.
+#[tokio::test]
+async fn test_context_budget_pruning() {
+    // Build a history that far exceeds a small budget.
+    // Pattern: System → User → [Assistant(tool_calls) + Tool] × 20 → User
+    let mut messages: Vec<AgentMessage> = vec![
+        AgentMessage::System {
+            content: "You are helpful.".into(),
+        },
+        AgentMessage::User {
+            content: "First question.".into(),
+        },
+    ];
+
+    for i in 0_u32..20 {
+        messages.push(AgentMessage::Assistant {
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: format!("old_tc{i}"),
+                name: "search".into(),
+                arguments: json!({}),
+            }]),
+        });
+        // 60 chars per result — 20 × 60 = 1 200 chars, well over the 500-char budget.
+        messages.push(AgentMessage::Tool {
+            tool_call_id: format!("old_tc{i}"),
+            content: format!("old tool result {i}: {}", "x".repeat(40)),
+        });
+    }
+
+    messages.push(AgentMessage::User {
+        content: "Final question after a long history.".into(),
+    });
+
+    // Single LLM response: no tool calls → FinalAnswer immediately.
+    let llm = Arc::new(
+        MockLlmPort::new().push(MockLlmResponse::text("Pruning worked — I can still answer.")),
+    );
+
+    // Executor with "search" registered (needed so LLM advertises it),
+    // but it won't be called in this test.
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("search"),
+        MockToolBehavior::Immediate {
+            content: "ok".into(),
+        },
+    );
+
+    let agent = AgentLoop::new(llm, Arc::new(executor));
+    let (tx, rx) = mpsc::channel(64);
+
+    let result = agent
+        .run(
+            messages,
+            AgentConfig {
+                context_budget_chars: 500,
+                ..AgentConfig::default()
+            },
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // Pruning must not abort the loop — it should complete successfully.
+    assert_eq!(
+        result.unwrap(),
+        "Pruning worked — I can still answer.",
+        "loop aborted unexpectedly after context pruning"
+    );
+
+    assert!(has_final_answer(&events), "missing FinalAnswer after pruning");
+}


### PR DESCRIPTION
## Parent epic: #247 — Backend agentic loop for CLI/headless
## Closes: #268

---

## What this PR does

Adds comprehensive in-process integration tests for `gglib-agent`, exercising every guard in the `LLM→tool→LLM` state machine through the public `AgentLoopPort` interface — no HTTP server, no llama-server process, no MCP daemon.

---

## New files

### `crates/gglib-agent/tests/common/mock_llm.rs`

`MockLlmPort` — a `LlmCompletionPort` implementation backed by a `VecDeque` of scripted response sequences.

```rust
let llm = MockLlmPort::new()
    .push(MockLlmResponse::tool_call("tc1", "search", json!({"q": "rust"})))
    .push(MockLlmResponse::text("Here are the results."));
```

### `crates/gglib-agent/tests/common/mock_tools.rs`

`MockToolExecutorPort` — a `ToolExecutorPort` implementation with per-tool `MockToolBehavior` (`Immediate` / `Delayed` / `Fail` / `Error`) and a `CallLogHandle` for post-test assertions.

```rust
let executor = MockToolExecutorPort::new()
    .with_tool(ToolDefinition::new("search"), MockToolBehavior::Immediate { content: "ok".into() });
let log = executor.call_log_handle();
// ... run loop ...
assert_eq!(log.snapshot().await.len(), 1);
```

### `crates/gglib-agent/tests/integration_agent_loop.rs`

| Test | Guard exercised |
|------|----------------|
| `test_simple_tool_call_cycle` | Core happy-path LLM→tool→LLM round-trip |
| `test_parallel_tool_calls` | 3 tools dispatched in one batch |
| `test_max_iterations_reached` | `AgentError::MaxIterationsReached(3)` |
| `test_tool_timeout` | Per-tool deadline (50 ms) → `success=false` → loop recovers |
| `test_loop_detection` | Repeated identical batch → `AgentError::LoopDetected` |
| `test_context_budget_pruning` | Oversized history pruned silently → loop completes |

---

## Acceptance criteria status

- [x] Mock LLM server supports multiple scripted responses
- [x] Mock tool executor allows configurable behavior per tool
- [x] Tests cover: simple cycle, parallel tools, max iterations, timeouts, loop detection, budget pruning
- [ ] SSE endpoint test verifies event stream format _(deferred — requires injecting `AgentLoopPort` into `AppState` or a mock llama-server; tracked as follow-up)_
- [x] All tests pass in CI (no external dependencies)
- [x] Tests are fast (~50 ms, not minutes)

---

## Test run

```
running 6 tests
test test_context_budget_pruning ... ok
test test_simple_tool_call_cycle ... ok
test test_parallel_tool_calls   ... ok
test test_max_iterations_reached ... ok
test test_loop_detection        ... ok
test test_tool_timeout          ... ok

test result: ok. 6 passed; 0 failed; finished in 0.05s
```
