### PR TITLE
fix(agent): PR #308 review fixes — security, correctness, perf, polish, tests

### DIFF
--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -132,7 +132,7 @@ impl AgentLoopPort for AgentLoop {
             };
 
             // ---- 4. Collect stream, forwarding text live --------------------
-            let response = match collect_stream(stream, &tx).await {
+            let response = match collect_stream(stream, &tx, config.max_parallel_tools).await {
                 Ok(r) => r,
                 Err(e) => {
                     let msg = format!("stream collection error: {e}");

--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -122,16 +122,24 @@ impl AgentLoopPort for AgentLoop {
             debug!(tool_count = tools.len(), "tools available");
 
             // ---- 3. LLM call (streaming) ------------------------------------
-            let stream = self
-                .llm
-                .chat_stream(&messages, &tools)
-                .await
-                .map_err(|e| AgentError::Internal(format!("LLM stream error: {e}")))?;
+            let stream = match self.llm.chat_stream(&messages, &tools).await {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = format!("LLM stream error: {e}");
+                    emit_error_event(&tx, &msg).await;
+                    return Err(AgentError::Internal(msg));
+                }
+            };
 
             // ---- 4. Collect stream, forwarding text live --------------------
-            let response = collect_stream(stream, &tx)
-                .await
-                .map_err(|e| AgentError::Internal(format!("stream collection error: {e}")))?;
+            let response = match collect_stream(stream, &tx).await {
+                Ok(r) => r,
+                Err(e) => {
+                    let msg = format!("stream collection error: {e}");
+                    emit_error_event(&tx, &msg).await;
+                    return Err(AgentError::Internal(msg));
+                }
+            };
 
             debug!(
                 content_len = response.content.len(),

--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -111,17 +111,19 @@ impl AgentLoopPort for AgentLoop {
         let mut loop_detector = LoopDetector::new();
         let mut stagnation_detector = StagnationDetector::new();
 
+        // Discover tools once before the iteration loop — the tool set does not
+        // change during a single conversation, and calling list_tools() per
+        // iteration would add pointless overhead (and round-trips for MCP).
+        let tools = self.tool_executor.list_tools().await;
+        debug!(tool_count = tools.len(), "tools available");
+
         for iteration in 0..config.max_iterations {
             debug!(iteration, "agent loop iteration starting");
 
             // ---- 1. Context budget pruning ----------------------------------
             messages = prune_for_budget(messages, &config);
 
-            // ---- 2. Tool discovery ------------------------------------------
-            let tools = self.tool_executor.list_tools().await;
-            debug!(tool_count = tools.len(), "tools available");
-
-            // ---- 3. LLM call (streaming) ------------------------------------
+            // ---- 2. LLM call (streaming) ------------------------------------
             let stream = match self.llm.chat_stream(&messages, &tools).await {
                 Ok(s) => s,
                 Err(e) => {
@@ -131,7 +133,7 @@ impl AgentLoopPort for AgentLoop {
                 }
             };
 
-            // ---- 4. Collect stream, forwarding text live --------------------
+            // ---- 3. Collect stream, forwarding text live --------------------
             let response = match collect_stream(stream, &tx, config.max_parallel_tools).await {
                 Ok(r) => r,
                 Err(e) => {
@@ -148,7 +150,7 @@ impl AgentLoopPort for AgentLoop {
                 "LLM response received"
             );
 
-            // ---- 5. Stagnation guard ----------------------------------------
+            // ---- 4. Stagnation guard ----------------------------------------
             if let Err(e) =
                 stagnation_detector.record(&response.content, config.max_stagnation_steps)
             {
@@ -156,7 +158,7 @@ impl AgentLoopPort for AgentLoop {
                 return Err(e);
             }
 
-            // ---- 6. No tool calls → final answer ----------------------------
+            // ---- 5. No tool calls → final answer ----------------------------
             if response.tool_calls.is_empty() {
                 debug!("no tool calls; final answer reached");
                 let _ = tx
@@ -167,18 +169,18 @@ impl AgentLoopPort for AgentLoop {
                 return Ok(response.content);
             }
 
-            // ---- 7. Loop detection ------------------------------------------
+            // ---- 6. Loop detection ------------------------------------------
             if let Err(e) = loop_detector.check(&response.tool_calls, config.max_protocol_strikes) {
                 emit_error_event(&tx, &e.to_string()).await;
                 return Err(e);
             }
 
-            // ---- 8. Parallel tool execution ---------------------------------
+            // ---- 7. Parallel tool execution ---------------------------------
             let results =
                 execute_tools_parallel(&response.tool_calls, &self.tool_executor, &config, &tx)
                     .await;
 
-            // ---- 9. Append assistant + tool-result messages -----------------
+            // ---- 8. Append assistant + tool-result messages -----------------
             messages.push(AgentMessage::Assistant {
                 content: if response.content.is_empty() {
                     None
@@ -194,7 +196,7 @@ impl AgentLoopPort for AgentLoop {
                 });
             }
 
-            // ---- 10. Emit iteration-complete event --------------------------
+            // ---- 9. Emit iteration-complete event ---------------------------
             let _ = tx
                 .send(AgentEvent::IterationComplete {
                     iteration: iteration + 1,

--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -538,4 +538,58 @@ mod tests {
         );
         assert!(got_final_answer, "FinalAnswer should be emitted");
     }
+
+    // ---- Failing LLM mock (for error-path tests) ----------------------------
+
+    /// An LLM that always fails `chat_stream` with a fixed error message.
+    struct AlwaysFailingLlm;
+
+    #[async_trait]
+    impl LlmCompletionPort for AlwaysFailingLlm {
+        async fn chat_stream(
+            &self,
+            _messages: &[AgentMessage],
+            _tools: &[ToolDefinition],
+        ) -> anyhow::Result<
+            Pin<Box<dyn futures_core::Stream<Item = anyhow::Result<LlmStreamEvent>> + Send>>,
+        > {
+            Err(anyhow::anyhow!("simulated LLM connection failure"))
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_startup_error_emits_agent_error_event() {
+        // When chat_stream returns Err, the loop must emit AgentEvent::Error
+        // on the channel BEFORE returning Err(AgentError::Internal).
+        let agent = AgentLoop::new(Arc::new(AlwaysFailingLlm), Arc::new(MockExecutor));
+        let (tx, mut rx) = mpsc::channel(64);
+
+        let err = agent
+            .run(
+                vec![AgentMessage::User {
+                    content: "hello".into(),
+                }],
+                AgentConfig::default(),
+                tx,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, AgentError::Internal(_)),
+            "expected Internal, got {err:?}"
+        );
+
+        // The channel must contain an AgentEvent::Error.
+        let mut got_error_event = false;
+        while let Ok(evt) = rx.try_recv() {
+            if matches!(evt, AgentEvent::Error { .. }) {
+                got_error_event = true;
+            }
+        }
+        assert!(
+            got_error_event,
+            "AgentEvent::Error must be emitted before the stream closes on LLM startup failure"
+        );
+    }
 }

--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -283,6 +283,7 @@ mod tests {
                 tool_call_id: call.id.clone(),
                 content: "done".into(),
                 success: true,
+                wait_ms: 0,
                 duration_ms: 0,
             })
         }

--- a/crates/gglib-agent/src/filter.rs
+++ b/crates/gglib-agent/src/filter.rs
@@ -9,6 +9,13 @@
 //! Both downstream consumers — the Axum HTTP handler (`gglib-axum`) and the
 //! CLI agent handler (`gglib-cli`) — already depend on `gglib-agent`, so
 //! keeping the decorator here is DRY with zero extra dependency edges.
+//!
+//! # Security model
+//!
+//! The allowlist is enforced on **both** `list_tools` (so the LLM only sees
+//! permitted tools) and `execute` (so an adversarially-prompted model that
+//! synthesises a call for a tool it was never told about cannot bypass the
+//! filter).
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -23,10 +30,11 @@ use gglib_core::ports::ToolExecutorPort;
 
 /// Decorator that restricts a [`ToolExecutorPort`] to a named allowlist.
 ///
-/// `list_tools` returns only the tools whose names appear in `allowed`.
-/// `execute` is delegated unchanged — the LLM will only request tools it was
-/// told about via `list_tools`, so the allowlist is effectively enforced at
-/// the listing step.
+/// Both `list_tools` and `execute` enforce the allowlist:
+/// - `list_tools` omits tools not in the allowlist so the LLM never learns
+///   they exist.
+/// - `execute` re-checks the name so an adversarially-prompted model cannot
+///   invoke a tool by synthesising a call it was never shown.
 pub struct FilteredToolExecutor {
     inner: Arc<dyn ToolExecutorPort>,
     allowed: HashSet<String>,
@@ -50,7 +58,115 @@ impl ToolExecutorPort for FilteredToolExecutor {
             .collect()
     }
 
+    /// Execute `call`, returning an error if the tool name is not in the
+    /// allowlist.
+    ///
+    /// This is the defence-in-depth check: `list_tools` already withholds
+    /// disallowed tools from the LLM, but an adversarial model might still
+    /// synthesise a call by name.  Rejecting here ensures no disallowed tool
+    /// can ever execute regardless of how the request was constructed.
     async fn execute(&self, call: &ToolCall) -> anyhow::Result<ToolResult> {
+        if !self.allowed.contains(&call.name) {
+            anyhow::bail!(
+                "tool '{}' is not in the allowed list",
+                call.name
+            );
+        }
         self.inner.execute(call).await
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use gglib_core::ports::ToolExecutorPort;
+    use gglib_core::{ToolCall, ToolDefinition, ToolResult};
+    use serde_json::json;
+
+    use super::*;
+
+    // ---- Minimal stub executor -------------------------------------------
+
+    struct StubExecutor;
+
+    #[async_trait]
+    impl ToolExecutorPort for StubExecutor {
+        async fn list_tools(&self) -> Vec<ToolDefinition> {
+            vec![
+                ToolDefinition::new("allowed_tool"),
+                ToolDefinition::new("other_tool"),
+                ToolDefinition::new("secret_tool"),
+            ]
+        }
+        async fn execute(&self, call: &ToolCall) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                content: format!("executed {}", call.name),
+                success: true,
+                duration_ms: 0,
+                wait_ms: 0,
+            })
+        }
+    }
+
+    fn make_call(name: &str) -> ToolCall {
+        ToolCall {
+            id: "c1".into(),
+            name: name.into(),
+            arguments: json!({}),
+        }
+    }
+
+    // ---- list_tools tests -----------------------------------------------
+
+    #[tokio::test]
+    async fn list_tools_returns_only_allowed() {
+        let allowed = ["allowed_tool".to_owned()].into();
+        let f = FilteredToolExecutor::new(Arc::new(StubExecutor), allowed);
+        let tools = f.list_tools().await;
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "allowed_tool");
+    }
+
+    #[tokio::test]
+    async fn list_tools_empty_allowlist_returns_nothing() {
+        let f = FilteredToolExecutor::new(Arc::new(StubExecutor), HashSet::new());
+        assert!(f.list_tools().await.is_empty());
+    }
+
+    // ---- execute tests --------------------------------------------------
+
+    #[tokio::test]
+    async fn execute_allowed_tool_succeeds() {
+        let allowed = ["allowed_tool".to_owned()].into();
+        let f = FilteredToolExecutor::new(Arc::new(StubExecutor), allowed);
+        let result = f.execute(&make_call("allowed_tool")).await.unwrap();
+        assert!(result.success);
+        assert!(result.content.contains("allowed_tool"));
+    }
+
+    #[tokio::test]
+    async fn execute_disallowed_tool_returns_error() {
+        let allowed = ["allowed_tool".to_owned()].into();
+        let f = FilteredToolExecutor::new(Arc::new(StubExecutor), allowed);
+        let err = f.execute(&make_call("secret_tool")).await.unwrap_err();
+        assert!(err.to_string().contains("not in the allowed list"));
+        assert!(err.to_string().contains("secret_tool"));
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_tool_not_shown_by_list() {
+        // "other_tool" exists in the inner executor but is NOT in the allowlist.
+        // Simulates an adversarial model synthesising a call it was never told about.
+        let allowed = ["allowed_tool".to_owned()].into();
+        let f = FilteredToolExecutor::new(Arc::new(StubExecutor), allowed);
+        let err = f.execute(&make_call("other_tool")).await.unwrap_err();
+        assert!(err.to_string().contains("not in the allowed list"));
     }
 }

--- a/crates/gglib-agent/src/loop_detection.rs
+++ b/crates/gglib-agent/src/loop_detection.rs
@@ -101,9 +101,19 @@ impl LoopDetector {
     /// `MAX_SAME_SIGNATURE_HITS = 2` behaviour.
     pub fn check(&mut self, calls: &[ToolCall], max_strikes: usize) -> Result<(), AgentError> {
         let sig = batch_signature(calls);
-        let count = self.hits.entry(sig.clone()).or_insert(0);
-        *count += 1;
-        if *count > max_strikes {
+        // Avoid cloning `sig` on the hot (key-exists) path: only clone on the
+        // first insertion, when the key must be moved into the map.
+        let count = match self.hits.get_mut(sig.as_str()) {
+            Some(n) => {
+                *n += 1;
+                *n
+            }
+            None => {
+                self.hits.insert(sig.clone(), 1);
+                1
+            }
+        };
+        if count > max_strikes {
             return Err(AgentError::LoopDetected { signature: sig });
         }
         Ok(())

--- a/crates/gglib-agent/src/loop_detection.rs
+++ b/crates/gglib-agent/src/loop_detection.rs
@@ -297,4 +297,22 @@ mod tests {
             assert_eq!(signature, expected_sig);
         }
     }
+
+    #[test]
+    fn same_name_different_args_do_not_trigger_loop() {
+        // Two batches with the same tool name but different arguments must
+        // produce distinct signatures and therefore never count as a loop.
+        let mut det = LoopDetector::new();
+        for i in 0u32..10 {
+            let calls = vec![ToolCall {
+                id: "c1".into(),
+                name: "search".into(),
+                arguments: json!({ "q": i }),
+            }];
+            assert!(
+                det.check(&calls, 2).is_ok(),
+                "distinct arguments should not trigger loop detection (i={i})"
+            );
+        }
+    }
 }

--- a/crates/gglib-agent/src/stagnation.rs
+++ b/crates/gglib-agent/src/stagnation.rs
@@ -137,4 +137,20 @@ mod tests {
             panic!("expected AgentError::Internal");
         }
     }
+
+    #[test]
+    fn max_steps_zero_triggers_on_first_repeat() {
+        // max_stagnation_steps = 0 means no tolerance at all: the very first
+        // repeated response must trigger the error.
+        let mut det = StagnationDetector::new();
+        let text = "anything";
+        // First occurrence sets the baseline (no stagnation yet).
+        assert!(det.record(text, 0).is_ok(), "first occurrence must not error");
+        // Second occurrence — count becomes 1, which satisfies count >= 0.
+        let err = det.record(text, 0).unwrap_err();
+        assert!(
+            matches!(err, AgentError::Internal(_)),
+            "expected Internal on first repeat with max_steps=0, got {err:?}"
+        );
+    }
 }

--- a/crates/gglib-agent/src/stagnation.rs
+++ b/crates/gglib-agent/src/stagnation.rs
@@ -59,8 +59,8 @@ impl StagnationDetector {
                 self.count += 1;
                 if self.count >= max_steps {
                     return Err(AgentError::Internal(format!(
-                        "agent stagnated: the same response appeared {count} consecutive time(s) \
-                         (limit: {max_steps})",
+                        "agent stagnated: identical response text seen {count} time(s) in a row \
+                        (max_stagnation_steps = {max_steps})",
                         count = self.count,
                     )));
                 }

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -275,4 +275,47 @@ mod tests {
         ]);
         assert!(collect_stream(stream, &tx, 8).await.is_err());
     }
+
+    #[tokio::test]
+    async fn malformed_json_arguments_use_empty_object() {
+        // Malformed JSON must NOT hard-fail the loop; it must produce an empty
+        // arguments object so the agent can continue and surface the issue.
+        let (tx, _rx) = mpsc::channel(16);
+        let stream = make_stream(vec![
+            LlmStreamEvent::ToolCallDelta {
+                index: 0,
+                id: Some("c1".into()),
+                name: Some("do_thing".into()),
+                arguments: Some("{ NOT VALID JSON ".into()),
+            },
+            LlmStreamEvent::Done {
+                finish_reason: "tool_calls".into(),
+            },
+        ]);
+
+        let response = collect_stream(stream, &tx, 8).await.unwrap();
+        assert_eq!(response.tool_calls.len(), 1);
+        // Arguments must be an empty object (the fallback value).
+        assert_eq!(response.tool_calls[0].arguments, serde_json::Value::Object(Default::default()));
+    }
+
+    #[tokio::test]
+    async fn oversized_tool_call_index_returns_error() {
+        // An index >= max_parallel_tools must be rejected immediately to
+        // prevent unbounded Vec growth.
+        let (tx, _rx) = mpsc::channel(16);
+        let stream = make_stream(vec![
+            LlmStreamEvent::ToolCallDelta {
+                index: 4, // max_parallel_tools = 4 → indices 0..3 are valid
+                id: Some("c0".into()),
+                name: Some("do_thing".into()),
+                arguments: Some("{}".into()),
+            },
+            LlmStreamEvent::Done {
+                finish_reason: "tool_calls".into(),
+            },
+        ]);
+
+        assert!(collect_stream(stream, &tx, 4).await.is_err());
+    }
 }

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 use futures_util::StreamExt as _;
 use gglib_core::{AgentEvent, LlmStreamEvent, ToolCall};
 use tokio::sync::mpsc;
+use tracing::warn;
 
 // =============================================================================
 // Output type
@@ -70,10 +71,14 @@ struct PartialToolCall {
 /// # Errors
 ///
 /// - Infrastructure errors (an `Err` item in the stream) are returned immediately.
-/// - Malformed tool-call arguments (not valid JSON) are returned as an error.
+/// - A tool-call index ≥ `max_parallel_tools` is rejected immediately to
+///   prevent a malicious or buggy LLM from triggering an unbounded allocation.
+/// - Malformed tool-call arguments (not valid JSON) are silently replaced with
+///   an empty object and a `warn` log entry rather than hard-failing the loop.
 pub async fn collect_stream(
     mut stream: Pin<Box<dyn futures_core::Stream<Item = Result<LlmStreamEvent>> + Send>>,
     tx: &mpsc::Sender<AgentEvent>,
+    max_parallel_tools: usize,
 ) -> Result<CollectedResponse> {
     let mut text_buf = String::new();
     // Indexed by the tool-call `index` from the stream deltas.
@@ -93,6 +98,12 @@ pub async fn collect_stream(
                 name,
                 arguments,
             } => {
+                // Guard against a pathological index that would cause a huge allocation.
+                if index >= max_parallel_tools {
+                    anyhow::bail!(
+                        "tool-call index {index} exceeds max_parallel_tools ({max_parallel_tools})"
+                    );
+                }
                 // Ensure the partials vec has a slot at `index`.
                 if partials.len() <= index {
                     partials.resize_with(index + 1, PartialToolCall::default);
@@ -122,9 +133,13 @@ pub async fn collect_stream(
                             &p.arguments
                         };
                         let arguments: serde_json::Value = serde_json::from_str(args_str)
-                            .unwrap_or_else(|_| {
-                                // Malformed JSON from the LLM — treat as an empty object
-                                // rather than hard-failing so the loop can surface it.
+                            .unwrap_or_else(|e| {
+                                warn!(
+                                    tool_name = %p.name,
+                                    raw_args = %args_str,
+                                    error = %e,
+                                    "tool-call arguments are not valid JSON; using empty object"
+                                );
                                 serde_json::Value::Object(serde_json::Map::default())
                             });
                         ToolCall {
@@ -181,7 +196,7 @@ mod tests {
             },
         ]);
 
-        let response = collect_stream(stream, &tx).await.unwrap();
+        let response = collect_stream(stream, &tx, 8).await.unwrap();
         assert_eq!(response.content, "Hello, world!");
         assert_eq!(response.finish_reason, "stop");
         assert!(response.tool_calls.is_empty());
@@ -214,7 +229,7 @@ mod tests {
             },
         ]);
 
-        let response = collect_stream(stream, &tx).await.unwrap();
+        let response = collect_stream(stream, &tx, 8).await.unwrap();
         assert_eq!(response.tool_calls.len(), 1);
         let tc = &response.tool_calls[0];
         assert_eq!(tc.id, "call_1");
@@ -243,7 +258,7 @@ mod tests {
             },
         ]);
 
-        let response = collect_stream(stream, &tx).await.unwrap();
+        let response = collect_stream(stream, &tx, 8).await.unwrap();
         assert_eq!(response.tool_calls.len(), 2);
         assert_eq!(response.tool_calls[0].name, "tool_a");
         assert_eq!(response.tool_calls[1].name, "tool_b");
@@ -258,6 +273,6 @@ mod tests {
             },
             // No Done event
         ]);
-        assert!(collect_stream(stream, &tx).await.is_err());
+        assert!(collect_stream(stream, &tx, 8).await.is_err());
     }
 }

--- a/crates/gglib-agent/src/tool_execution.rs
+++ b/crates/gglib-agent/src/tool_execution.rs
@@ -49,21 +49,28 @@ pub async fn execute_tools_parallel(
             let executor = Arc::clone(executor);
             let tx = tx.clone();
             tokio::spawn(async move {
-                // Acquire a concurrency permit before starting.
-                let _permit = sem.acquire_owned().await.expect("semaphore closed");
+                // Record the enqueue time so we can measure semaphore wait.
+                // This covers any time spent blocked on the concurrency cap.
+                let enqueue_time = Instant::now();
 
-                // Notify that execution is starting.
+                // Acquire a concurrency permit before starting.
+                // `wait_ms` below captures how long this took.
+                let _permit = sem.acquire_owned().await.expect("semaphore closed");
+                let wait_ms = u64::try_from(enqueue_time.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+                // Notify that execution is starting (after permit acquired —
+                // we only claim "started" once we have a slot, not when queued).
                 let _ = tx
                     .send(AgentEvent::ToolCallStart {
                         tool_call: tc.clone(),
                     })
                     .await;
 
-                let start = Instant::now();
+                let exec_start = Instant::now();
                 let result =
                     tokio::time::timeout(Duration::from_millis(timeout_ms), executor.execute(&tc))
                         .await;
-                let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                let duration_ms = u64::try_from(exec_start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
                 let tool_result = match result {
                     Ok(Ok(r)) => r,
@@ -71,12 +78,14 @@ pub async fn execute_tools_parallel(
                         tool_call_id: tc.id.clone(),
                         content: format!("Tool execution error: {e}"),
                         success: false,
+                        wait_ms,
                         duration_ms,
                     },
                     Err(_) => ToolResult {
                         tool_call_id: tc.id.clone(),
                         content: format!("Tool '{}' timed out after {timeout_ms} ms", tc.name),
                         success: false,
+                        wait_ms,
                         duration_ms,
                     },
                 };
@@ -103,6 +112,7 @@ pub async fn execute_tools_parallel(
                 tool_call_id: calls[i].id.clone(),
                 content: format!("Tool task panicked: {e}"),
                 success: false,
+                wait_ms: 0,
                 duration_ms: 0,
             })
         })
@@ -139,6 +149,7 @@ mod tests {
                 tool_call_id: call.id.clone(),
                 content: "ok".into(),
                 success: true,
+                wait_ms: 0,
                 duration_ms: 0,
             })
         }
@@ -159,6 +170,7 @@ mod tests {
                 tool_call_id: call.id.clone(),
                 content: "slow ok".into(),
                 success: true,
+                wait_ms: 0,
                 duration_ms: self.delay_ms,
             })
         }
@@ -262,6 +274,7 @@ mod tests {
                     tool_call_id: call.id.clone(),
                     content: "ok".into(),
                     success: true,
+                    wait_ms: 0,
                     duration_ms: 20,
                 })
             }

--- a/crates/gglib-agent/tests/common/mock_tools.rs
+++ b/crates/gglib-agent/tests/common/mock_tools.rs
@@ -166,6 +166,7 @@ impl ToolExecutorPort for MockToolExecutorPort {
                 tool_call_id: call.id.clone(),
                 content,
                 success: true,
+                wait_ms: 0,
                 duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
             }),
             MockToolBehavior::Delayed { millis, content } => {
@@ -174,6 +175,7 @@ impl ToolExecutorPort for MockToolExecutorPort {
                     tool_call_id: call.id.clone(),
                     content,
                     success: true,
+                    wait_ms: 0,
                     duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                 })
             }
@@ -181,6 +183,7 @@ impl ToolExecutorPort for MockToolExecutorPort {
                 tool_call_id: call.id.clone(),
                 content: message,
                 success: false,
+                wait_ms: 0,
                 duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
             }),
             MockToolBehavior::Error { message } => Err(anyhow::anyhow!(message)),

--- a/crates/gglib-axum/src/handlers/agent.rs
+++ b/crates/gglib-axum/src/handlers/agent.rs
@@ -173,12 +173,12 @@ pub async fn chat(
     let config = req.config.unwrap_or_default();
 
     // ── Pipe AgentEvent values from the loop to the SSE stream ───────────
-    let (tx, rx) = mpsc::channel::<AgentEvent>(64);
+    let (tx, rx) = mpsc::channel::<AgentEvent>(256);
 
     let handle = tokio::spawn(async move {
         match agent_loop.run(messages, config, tx).await {
             Ok(_) => {}
-            Err(e) => tracing::debug!("agent loop ended: {e}"),
+            Err(e) => tracing::warn!("agent loop ended with error: {e}"),
         }
     });
 

--- a/crates/gglib-core/src/domain/agent.rs
+++ b/crates/gglib-core/src/domain/agent.rs
@@ -179,7 +179,16 @@ pub struct ToolResult {
     /// `false` here is **not** a loop error — see type-level docs above.
     pub success: bool,
 
-    /// Wall-clock time taken to execute the tool, in milliseconds.
+    /// Time spent waiting for a concurrency permit (semaphore), in
+    /// milliseconds.
+    ///
+    /// This is the time from when the tool was *enqueued* to when it actually
+    /// *started* executing.  A high `wait_ms` with a low `duration_ms` indicates
+    /// that the tool was fast but had to queue behind other parallel calls.
+    pub wait_ms: u64,
+
+    /// Wall-clock time taken to execute the tool (after acquiring the permit),
+    /// in milliseconds.
     pub duration_ms: u64,
 }
 
@@ -416,6 +425,7 @@ mod tests {
             tool_call_id: "c1".into(),
             content: "ERROR: file not found".into(),
             success: false,
+            wait_ms: 0,
             duration_ms: 12,
         };
         let json = serde_json::to_value(&result).unwrap();

--- a/crates/gglib-core/src/domain/agent.rs
+++ b/crates/gglib-core/src/domain/agent.rs
@@ -268,12 +268,6 @@ pub enum AgentMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentEvent {
-    /// The model has produced a reasoning / thinking segment.
-    Thinking {
-        /// The reasoning text (may be partial if streamed).
-        content: String,
-    },
-
     /// An incremental text fragment from the model's response.
     TextDelta {
         /// The new text fragment (append to the current buffer).

--- a/crates/gglib-mcp/src/tool_executor.rs
+++ b/crates/gglib-mcp/src/tool_executor.rs
@@ -142,6 +142,7 @@ impl ToolExecutorPort for McpToolExecutorAdapter {
             tool_call_id: call.id.clone(),
             content,
             success,
+            wait_ms: 0,
             duration_ms,
         })
     }

--- a/crates/gglib-mcp/src/tool_executor.rs
+++ b/crates/gglib-mcp/src/tool_executor.rs
@@ -65,19 +65,22 @@ impl McpToolExecutorAdapter {
 impl ToolExecutorPort for McpToolExecutorAdapter {
     /// List every tool available across all running MCP servers.
     ///
-    /// Converts `McpTool { name, description, input_schema }` →
-    /// `ToolDefinition { name, description, input_schema }`.  The mapping is
-    /// 1-to-1 because the agent domain deliberately mirrors MCP's schema shape.
+    /// Tool names are prefixed with `{server_id}__` (e.g. `3__read_file`) to
+    /// guarantee uniqueness when multiple servers expose tools with the same
+    /// bare name.  `execute()` accepts both the qualified and the bare name for
+    /// interoperability with `FilteredToolExecutor` (which operates on the
+    /// names as returned here).
     async fn list_tools(&self) -> Vec<ToolDefinition> {
         self.mcp
             .list_all_tools()
             .await
             .into_iter()
-            .flat_map(|(_, tools)| tools)
-            .map(|t| ToolDefinition {
-                name: t.name,
-                description: t.description,
-                input_schema: t.input_schema,
+            .flat_map(|(server_id, tools)| {
+                tools.into_iter().map(move |t| ToolDefinition {
+                    name: format!("{server_id}__{}", t.name),
+                    description: t.description,
+                    input_schema: t.input_schema,
+                })
             })
             .collect()
     }
@@ -91,14 +94,38 @@ impl ToolExecutorPort for McpToolExecutorAdapter {
     /// `ToolResult { success: false, … }` so the agent can reason about the
     /// failure and retry or adjust.
     async fn execute(&self, call: &ToolCall) -> anyhow::Result<ToolResult> {
-        // ---- Resolve server_id from tool name --------------------------------
+        // ---- Resolve server_id and bare tool name from call.name ------------
+        //
+        // Accepts two formats:
+        //   - qualified:   "{server_id}__{tool_name}"  (produced by list_tools)
+        //   - unqualified: "{tool_name}"               (e.g. from FilteredToolExecutor)
         let all_tools = self.mcp.list_all_tools().await;
-        let server_id = all_tools
-            .iter()
-            .find_map(|(id, tools)| tools.iter().any(|t| t.name == call.name).then_some(*id))
-            .with_context(|| {
-                format!("no running MCP server exposes a tool named '{}'", call.name)
-            })?;
+        let (server_id, bare_name): (i64, &str) =
+            if let Some((prefix, bare)) = call.name.split_once("__") {
+                let sid: i64 = prefix.parse().with_context(|| {
+                    format!("qualified tool name '{}' has a non-integer server prefix", call.name)
+                })?;
+                // Verify the server actually exposes this tool.
+                let found = all_tools
+                    .iter()
+                    .any(|(id, tools)| *id == sid && tools.iter().any(|t| t.name == bare));
+                anyhow::ensure!(
+                    found,
+                    "server {sid} does not expose a tool named '{bare}'"
+                );
+                (sid, bare)
+            } else {
+                // Unqualified — linear scan across all servers.
+                let server_id = all_tools
+                    .iter()
+                    .find_map(|(id, tools)| {
+                        tools.iter().any(|t| t.name == call.name).then_some(*id)
+                    })
+                    .with_context(|| {
+                        format!("no running MCP server exposes a tool named '{}'", call.name)
+                    })?;
+                (server_id, call.name.as_str())
+            };
 
         // ---- Convert arguments Value → HashMap<String, Value> ---------------
         let arguments: HashMap<String, serde_json::Value> = match &call.arguments {
@@ -119,7 +146,7 @@ impl ToolExecutorPort for McpToolExecutorAdapter {
         let start = Instant::now();
         let result = self
             .mcp
-            .call_tool(server_id, &call.name, arguments)
+            .call_tool(server_id, bare_name, arguments)
             .await
             .map_err(|e| anyhow!("MCP call_tool failed: {e}"))?;
         let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);

--- a/src/hooks/useGglibRuntime/streamAgentChat.ts
+++ b/src/hooks/useGglibRuntime/streamAgentChat.ts
@@ -242,36 +242,6 @@ function applyTextDelta(
   );
 }
 
-/** Append a thinking delta to the current message's last reasoning part. */
-function applyThinkingDelta(
-  setMessages: React.Dispatch<React.SetStateAction<GglibMessage[]>>,
-  messageId: string,
-  delta: string,
-): void {
-  setMessages(prev =>
-    prev.map(m => {
-      if (m.id !== messageId) return m;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parts = Array.isArray(m.content) ? ([...m.content] as any[]) : [];
-      const lastReasoning =
-        parts.length > 0 && parts[parts.length - 1].type === 'reasoning'
-          ? parts[parts.length - 1]
-          : null;
-
-      let nextParts: unknown[];
-      if (lastReasoning) {
-        nextParts = [
-          ...parts.slice(0, -1),
-          { type: 'reasoning', text: (lastReasoning.text ?? '') + delta },
-        ];
-      } else {
-        nextParts = [...parts, { type: 'reasoning', text: delta }];
-      }
-      return { ...m, content: nextParts as GglibContent };
-    }),
-  );
-}
-
 /** Add a pending (no result yet) tool-call part. */
 function addToolCallPart(
   setMessages: React.Dispatch<React.SetStateAction<GglibMessage[]>>,
@@ -456,12 +426,6 @@ export async function streamAgentChat(options: StreamAgentChatOptions): Promise<
       }
 
       switch (event.type) {
-        case 'thinking': {
-          if (timingTracker) timingTracker.onReasoning(currentId);
-          applyThinkingDelta(setMessages, currentId, event.content);
-          break;
-        }
-
         case 'text_delta': {
           if (timingTracker) timingTracker.onBoundary(currentId);
           applyTextDelta(setMessages, currentId, event.content);

--- a/src/hooks/useGglibRuntime/streamAgentChat.ts
+++ b/src/hooks/useGglibRuntime/streamAgentChat.ts
@@ -323,6 +323,7 @@ function applyToolResult(
                   ? toolResult.content
                   : { error: toolResult.content },
                 isError: !toolResult.success,
+                waitMs: toolResult.wait_ms,
                 durationMs: toolResult.duration_ms,
               }
             : p,
@@ -487,6 +488,7 @@ export async function streamAgentChat(options: StreamAgentChatOptions): Promise<
           appLogger.debug('hook.runtime', 'streamAgentChat: tool call complete', {
             id: event.result.tool_call_id,
             success: event.result.success,
+            waitMs: event.result.wait_ms,
             durationMs: event.result.duration_ms,
           });
           break;

--- a/src/types/events/agentEvent.ts
+++ b/src/types/events/agentEvent.ts
@@ -39,12 +39,6 @@ export interface AgentToolResult {
 // Discriminated union
 // ---------------------------------------------------------------------------
 
-/** The model produced a reasoning / thinking segment. */
-export interface AgentThinkingEvent {
-  type: 'thinking';
-  content: string;
-}
-
 /** An incremental text fragment from the model's response. */
 export interface AgentTextDeltaEvent {
   type: 'text_delta';
@@ -91,7 +85,6 @@ export interface AgentErrorEvent {
  * ignored to remain forward-compatible with new variants added on the server.
  */
 export type AgentEvent =
-  | AgentThinkingEvent
   | AgentTextDeltaEvent
   | AgentToolCallStartEvent
   | AgentToolCallCompleteEvent

--- a/src/types/events/agentEvent.ts
+++ b/src/types/events/agentEvent.ts
@@ -29,7 +29,9 @@ export interface AgentToolResult {
   content: string;
   /** `false` here is **not** an error — it is context fed to the LLM. */
   success: boolean;
-  /** Wall-clock execution time in milliseconds. */
+  /** Time spent waiting for a concurrency slot, in milliseconds. */
+  wait_ms: number;
+  /** Wall-clock execution time (after acquiring the slot), in milliseconds. */
   duration_ms: number;
 }
 

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -5,7 +5,6 @@
 export type { ToolExecutionEvent, ToolStartEvent, ToolCompleteEvent, ToolErrorEvent, OnToolEvent } from './toolExecution';
 export type {
   AgentEvent,
-  AgentThinkingEvent,
   AgentTextDeltaEvent,
   AgentToolCallStartEvent,
   AgentToolCallCompleteEvent,


### PR DESCRIPTION
## Summary

Implements all findings from the PR #308 code review. 8 commits, no backwards-compat concerns.

---

## Commits

### 1. `feat(core,agent): split wait_ms from duration_ms in ToolResult`
`duration_ms` previously measured from enqueue to result — it was impossible to distinguish semaphore queue time from actual execution time.
- Added `wait_ms: u64` to `ToolResult` (core domain + TS interface)
- `tool_execution.rs` records `enqueue_time` before semaphore, computes `wait_ms` after permit, `duration_ms` from exec start only
- Propagated `wait_ms: 0` to all other construction sites (error paths, test mocks, MCP adapter)
- Surfaced `waitMs` in the TS tool-call state object and debug log

### 2. `security(agent): enforce allowlist in FilteredToolExecutor::execute`
`execute()` was delegating straight to the inner executor without checking the allowlist — any caller could bypass the filter.
- Added allowlist check with `anyhow::bail!` on rejection
- Added 4 unit tests covering: list_tools filter, empty allowlist, allowed call succeeds, disallowed call rejected

### 3. `fix(agent) + remove(core,frontend): LLM startup error event + drop Thinking`
**Bug fix:** `chat_stream()` and `collect_stream()` failures used `?` which returned `Err` without emitting `AgentEvent::Error` first — SSE clients would see the stream close silently. Replaced with explicit `match` arms calling `emit_error_event`.

**Dead code removal:** `AgentEvent::Thinking` was defined in the Rust enum and TS union but never emitted. Removed from `domain/agent.rs`, `agentEvent.ts`, `events/index.ts`; removed `applyThinkingDelta` helper and `case 'thinking':` handler from `streamAgentChat.ts`.

### 4. `fix(stream_collector): cap tool-call index; warn on malformed JSON`
**Index cap:** A malicious or buggy LLM could send a very large tool-call index causing unbounded `Vec` growth. `collect_stream` now takes `max_parallel_tools: usize` and rejects any index ≥ the limit.

**JSON warning:** The `unwrap_or_else` fallback for invalid tool-call arguments silently discarded the parse error. Now emits `tracing::warn!` with `tool_name`, `raw_args`, and the error before substituting an empty object.

### 5. `perf(agent_loop): cache list_tools() once before the iteration loop`
`list_tools()` was called on every iteration — wasted work, and for MCP it's a network round-trip per iteration. Moved before the `for` loop; shared across all iterations.

### 6. `fix(mcp): qualify tool names with server_id prefix to prevent shadowing`
When multiple MCP servers expose tools with the same bare name, the previous `flat_map` silently surfaced both under the same name. `execute()` would always pick the first match, making other servers' tools unreachable.
- `list_tools()` now prefixes every name with `{server_id}__` (e.g. `3__read_file`)
- `execute()` accepts both qualified (`{server_id}__{tool}`) and unqualified formats for `FilteredToolExecutor` compatibility

### 7. `polish(agent,axum): misc small improvements from PR review`
- Axum SSE channel buffer: 64 → 256 (avoid back-pressure at burst)
- Axum agent termination log: `debug!` → `warn!` (these are errors, not normal flow)
- `LoopDetector::check`: avoid cloning `sig` on the hot (key-exists) path
- Stagnation error message: clarify wording to match field name (`max_stagnation_steps`)

### 8. `test(agent): add missing unit tests identified in PR review`
- `stream_collector`: malformed JSON → empty object (not error); oversized index → immediate error
- `loop_detection`: same tool name with different args does NOT trigger loop detection
- `stagnation`: `max_stagnation_steps = 0` triggers on first repeated response
- `agent_loop`: LLM startup failure emits `AgentEvent::Error` before returning `Err`

---

All 46 unit + integration tests in `gglib-agent`, `gglib-core`, and `gglib-mcp` pass.