### PR TITLE
fix: setup wizard completion text squished due to Tailwind v4 spacing token conflict

### DIFF
--- a/src/components/SetupWizard/SetupWizard.tsx
+++ b/src/components/SetupWizard/SetupWizard.tsx
@@ -639,7 +639,7 @@ const CompleteStep: FC<{ status: SetupStatus; onFinish: () => void }> = ({ statu
         <Icon icon={CheckCircle2} size={32} className="text-success" />
       </div>
       <h2 className="text-xl font-semibold text-text mb-2">You&apos;re all set!</h2>
-      <p className="text-text-secondary leading-relaxed max-w-md mx-auto">
+      <p className="text-text-secondary leading-relaxed max-w-[28rem] mx-auto">
         Your system is configured and ready to run local AI models. You can
         re-run this wizard anytime from Settings.
       </p>

--- a/src/components/primitives/EmptyState.tsx
+++ b/src/components/primitives/EmptyState.tsx
@@ -34,7 +34,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
           {title}
         </h3>
         {description && (
-          <p className="text-sm text-text-muted max-w-md">
+          <p className="text-sm text-text-muted max-w-[28rem]">
             {description}
           </p>
         )}


### PR DESCRIPTION
## Summary

Fixes #313

The setup wizard "You're all set!" screen was rendering the description paragraph with one word per line instead of flowing prose text.

## Root Cause

Tailwind v4 maps `--spacing-*` custom properties to **all** size utilities, including `max-w-{key}`. The project's `variables.css` sets `--spacing-md: 0.75rem`, which caused `max-w-md` to resolve to `max-width: 0.75rem` (12px) rather than the expected Tailwind default of 28rem. With only 12px of available width, each word was forced onto its own line.

## Changes

- `src/components/SetupWizard/SetupWizard.tsx`: `max-w-md` → `max-w-[28rem]` on the `CompleteStep` paragraph
- `src/components/primitives/EmptyState.tsx`: `max-w-md` → `max-w-[28rem]` on the description paragraph

Using an explicit arbitrary value bypasses the custom spacing token and restores the intended max-width.
