### PR TITLE
feat: auto-skip setup wizard when system is already configured

### DIFF
--- a/crates/gglib-gui/src/setup.rs
+++ b/crates/gglib-gui/src/setup.rs
@@ -147,7 +147,11 @@ impl<'a> SetupOps<'a> {
         // cargo/package manager) through a redundant wizard — llama.cpp and
         // the models directory are already configured by the build/install
         // process, so there is nothing for the wizard to do.
-        if !setup_completed && llama_installed && models_directory.exists && models_directory.writable {
+        if !setup_completed
+            && llama_installed
+            && models_directory.exists
+            && models_directory.writable
+        {
             setup_completed = true;
             let update = gglib_core::settings::SettingsUpdate {
                 setup_completed: Some(Some(true)),

--- a/crates/gglib-gui/src/setup.rs
+++ b/crates/gglib-gui/src/setup.rs
@@ -80,7 +80,7 @@ impl<'a> SetupOps<'a> {
             .get()
             .await
             .map_err(|e| GuiError::Internal(format!("Failed to get settings: {e}")))?;
-        let setup_completed = settings.setup_completed.unwrap_or(false);
+        let mut setup_completed = settings.setup_completed.unwrap_or(false);
 
         // Check llama installation
         let llama_installed = gglib_runtime::llama::check_llama_installed();
@@ -141,6 +141,22 @@ impl<'a> SetupOps<'a> {
         } else {
             None
         };
+
+        // Auto-complete setup if the system is already functional.
+        // This avoids forcing users who build from source (or install via
+        // cargo/package manager) through a redundant wizard — llama.cpp and
+        // the models directory are already configured by the build/install
+        // process, so there is nothing for the wizard to do.
+        if !setup_completed && llama_installed && models_directory.exists && models_directory.writable {
+            setup_completed = true;
+            let update = gglib_core::settings::SettingsUpdate {
+                setup_completed: Some(Some(true)),
+                ..Default::default()
+            };
+            // Best-effort persist — a failure here must not block the user
+            // from reaching the app.
+            let _ = self.deps.settings().update(update).await;
+        }
 
         Ok(SetupStatus {
             setup_completed,


### PR DESCRIPTION
## Summary

Fixes #315

Users who build from source (`make setup`) or install via `cargo install` were forced through a 5-step setup wizard on every fresh install, even though their system was already fully configured. The wizard had nothing meaningful to offer — llama.cpp and the models directory were already set up by the build/install process.

## Root Cause

`setup_completed` defaults to `false` in the DB (it's `Option<bool>` defaulting to `None`). `make setup` and `cargo install` never touch the DB, so on first launch the flag is always `false` and the wizard always appears.

## Change

In `SetupOps::get_status()` ([crates/gglib-gui/src/setup.rs](crates/gglib-gui/src/setup.rs)), after computing all status fields, the system is checked for functional readiness:

```rust
if !setup_completed && llama_installed && models_directory.exists && models_directory.writable {
    setup_completed = true;
    let update = gglib_core::settings::SettingsUpdate {
        setup_completed: Some(Some(true)),
        ..Default::default()
    };
    let _ = self.deps.settings().update(update).await; // best-effort persist
}
```

The condition requires all three: `llama_installed`, `models_directory.exists`, and `models_directory.writable` — meaning the system is genuinely usable, not just partially configured.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Built from source / `cargo install` (llama installed, models dir exists) | Wizard appears | Wizard skipped ✓ |
| Pre-built binary, first launch, no llama | Wizard appears | Wizard appears ✓ |
| Existing DB with `setup_completed: true` | App loads normally | App loads normally ✓ |
| "Re-run from Settings" | Works | Works ✓ |

No frontend changes required — `App.tsx` already reads `status.setupCompleted` from the API response.
