### PR TITLE
feat: skeleton loading UIs to replace text-based loading states (closes #198)

### DIFF
--- a/src/components/ConversationListPanel/ConversationListSkeleton.tsx
+++ b/src/components/ConversationListPanel/ConversationListSkeleton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Skeleton, Stack } from '../primitives';
+
+/**
+ * Skeleton placeholder for a single conversation list item.
+ * Mirrors the ConversationListPanel button: title line + relative timestamp.
+ */
+const SkeletonItem: React.FC = () => (
+  <div className="py-md px-base border border-border rounded-base">
+    <Stack gap="xs">
+      <Skeleton variant="text" width="70%" />
+      <Skeleton variant="text" width="35%" height="0.75em" />
+    </Stack>
+  </div>
+);
+
+/**
+ * Full-panel skeleton for the conversation list.
+ * Replaces the "Loading conversations…" text while conversations are being fetched.
+ * Rendered inside the flex-1 overflow container of ConversationListPanel.
+ */
+export const ConversationListSkeleton: React.FC = () => (
+  <div className="flex flex-col gap-sm" aria-hidden="true">
+    {Array.from({ length: 5 }, (_, i) => (
+      <SkeletonItem key={i} />
+    ))}
+  </div>
+);

--- a/src/components/HuggingFaceBrowser/ModelCardSkeleton.tsx
+++ b/src/components/HuggingFaceBrowser/ModelCardSkeleton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Skeleton, Stack, Row } from '../primitives';
+
+/**
+ * Skeleton placeholder for a single HuggingFace model card.
+ * Mirrors the ModelCard layout: model name + id line on the left,
+ * parameter badge + stats on the right.
+ */
+export const ModelCardSkeleton: React.FC = () => (
+  <div
+    className="bg-surface-elevated border border-border rounded-xl overflow-hidden"
+    aria-hidden="true"
+  >
+    <div className="px-4 py-[0.9rem]">
+      <Row gap="base" align="start" justify="between">
+        <Stack gap="xs" className="flex-1 min-w-0">
+          {/* Model name */}
+          <Skeleton variant="text" width="55%" height="1.1em" />
+          {/* Model ID (mono, smaller) */}
+          <Skeleton variant="text" width="75%" height="0.8em" />
+        </Stack>
+        {/* Right: param count badge + downloads + likes */}
+        <Row gap="sm" className="shrink-0">
+          <Skeleton width="36px" height="1.5em" />
+          <Skeleton width="48px" height="0.875em" />
+          <Skeleton width="40px" height="0.875em" />
+        </Row>
+      </Row>
+    </div>
+  </div>
+);

--- a/src/components/ModelInspectorPanel/ModelInspectorSkeleton.tsx
+++ b/src/components/ModelInspectorPanel/ModelInspectorSkeleton.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Skeleton, Stack, Row } from '../primitives';
+
+// Mirrors the panelContainer constant in ModelInspectorPanel.tsx
+const panelClass =
+  'flex flex-col h-full min-h-0 overflow-y-auto overflow-x-hidden relative flex-1 bg-surface';
+
+/**
+ * Full-panel skeleton for the ModelInspectorPanel.
+ * Shown when models are being initially fetched (loading && !model).
+ * Mirrors: header (name + circle action buttons) + metadata rows + tags + action buttons.
+ */
+export const ModelInspectorSkeleton: React.FC = () => (
+  <div className={panelClass} aria-hidden="true">
+    {/* Header — mirrors "p-base border-b" bar with model name + icon buttons */}
+    <div className="p-base border-b border-border bg-background shrink-0">
+      <Row gap="base" justify="between" align="center">
+        <Skeleton width="45%" height="1.5rem" />
+        <Row gap="xs">
+          <Skeleton
+            variant="circle"
+            width="var(--button-height-base)"
+            height="var(--button-height-base)"
+          />
+          <Skeleton
+            variant="circle"
+            width="var(--button-height-base)"
+            height="var(--button-height-base)"
+          />
+          <Skeleton
+            variant="circle"
+            width="var(--button-height-base)"
+            height="var(--button-height-base)"
+          />
+        </Row>
+      </Row>
+    </div>
+
+    {/* Content — mirrors ModelMetadataGrid + tags + InspectorActions */}
+    <div className="flex-1 min-h-0 p-base">
+      <Stack gap="xl">
+        {/* Model Information section */}
+        <Stack gap="md">
+          {/* Section heading */}
+          <Skeleton width="130px" height="0.7em" />
+          {/* label: value rows */}
+          {Array.from({ length: 4 }, (_, i) => (
+            <Row key={i} gap="base" justify="between" align="start">
+              <Skeleton width="80px" height="0.875em" className="shrink-0" />
+              <Skeleton width="45%" height="0.875em" />
+            </Row>
+          ))}
+        </Stack>
+
+        {/* Tags section */}
+        <Stack gap="sm">
+          <Skeleton width="50px" height="0.7em" />
+          <Row gap="sm" wrap>
+            <Skeleton width="56px" height="1.5rem" className="rounded-full" />
+            <Skeleton width="48px" height="1.5rem" className="rounded-full" />
+            <Skeleton width="64px" height="1.5rem" className="rounded-full" />
+          </Row>
+        </Stack>
+
+        {/* Action buttons */}
+        <Row gap="base">
+          <Skeleton width="100px" height="var(--button-height-base)" />
+          <Skeleton width="90px" height="var(--button-height-base)" />
+        </Row>
+      </Stack>
+    </div>
+  </div>
+);

--- a/src/components/ModelLibraryPanel/ModelListSkeleton.tsx
+++ b/src/components/ModelLibraryPanel/ModelListSkeleton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Skeleton, Stack, Row } from '../primitives';
+
+/**
+ * Skeleton placeholder for a single model list row.
+ * Mirrors the ModelsListContent row: name line + param/arch/quant badges.
+ */
+const SkeletonRow: React.FC = () => (
+  <div className="py-md px-base border-b border-border w-full">
+    <Stack gap="sm">
+      <Skeleton variant="text" width="55%" />
+      <Row gap="md" align="center">
+        <Skeleton width="40px" height="0.75em" />
+        <Skeleton width="60px" height="0.75em" />
+        <Skeleton width="36px" height="0.75em" />
+      </Row>
+    </Stack>
+  </div>
+);
+
+/**
+ * Full-panel skeleton for the model library list.
+ * Replaces the "Loading models..." text while the model list is being fetched.
+ */
+export const ModelListSkeleton: React.FC = () => (
+  <div aria-hidden="true">
+    {Array.from({ length: 6 }, (_, i) => (
+      <SkeletonRow key={i} />
+    ))}
+  </div>
+);

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+import { Stack } from './Stack';
+
+export interface SkeletonProps {
+  /** Visual shape of the skeleton block. Defaults to 'rect'. */
+  variant?: 'text' | 'rect' | 'circle';
+  /** CSS width value, e.g. '60%' or '120px'. Defaults vary by variant. */
+  width?: string;
+  /** CSS height value, e.g. '1em' or '32px'. Defaults vary by variant. */
+  height?: string;
+  className?: string;
+  /** Render N stacked skeleton items with gap-sm between them. */
+  count?: number;
+}
+
+const SHIMMER_BG = {
+  background:
+    'linear-gradient(90deg, var(--color-surface-elevated) 25%, var(--color-surface-hover) 50%, var(--color-surface-elevated) 75%)',
+  backgroundSize: '200% 100%',
+} as const;
+
+const variantClasses: Record<NonNullable<SkeletonProps['variant']>, string> = {
+  text: 'rounded-sm',
+  rect: 'rounded-base',
+  circle: 'rounded-full shrink-0',
+};
+
+const variantDefaults: Record<
+  NonNullable<SkeletonProps['variant']>,
+  { width: string; height: string }
+> = {
+  text: { width: '100%', height: '1em' },
+  rect: { width: '100%', height: '1rem' },
+  circle: { width: '2rem', height: '2rem' },
+};
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  variant = 'rect',
+  width,
+  height,
+  className,
+  count = 1,
+}) => {
+  const defaults = variantDefaults[variant];
+  const w = width ?? defaults.width;
+  const h = height ?? defaults.height;
+  const itemClass = cn('animate-shimmer', variantClasses[variant], className);
+  const itemStyle = { ...SHIMMER_BG, width: w, height: h };
+
+  if (count > 1) {
+    return (
+      <div aria-hidden="true">
+        <Stack gap="sm">
+          {Array.from({ length: count }, (_, i) => (
+            <div key={i} className={itemClass} style={itemStyle} />
+          ))}
+        </Stack>
+      </div>
+    );
+  }
+
+  return <div aria-hidden="true" className={itemClass} style={itemStyle} />;
+};
+
+Skeleton.displayName = 'Skeleton';

--- a/src/components/primitives/index.ts
+++ b/src/components/primitives/index.ts
@@ -3,3 +3,5 @@ export { Stack } from './Stack';
 export { Row } from './Row';
 export { Label } from './Label';
 export { EmptyState } from './EmptyState';
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton';

--- a/src/pages/ChatPageSkeleton.tsx
+++ b/src/pages/ChatPageSkeleton.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Skeleton, Stack, Row } from '../components/primitives';
+import { ConversationListSkeleton } from '../components/ConversationListPanel/ConversationListSkeleton';
+
+/**
+ * Full-page skeleton for the ChatPage Suspense fallback.
+ * Mirrors the two-column layout: conversation list panel (~30%) + message area (~70%).
+ * The left column header approximates the real ConversationListPanel header
+ * (tabs + model name + search input).
+ */
+export const ChatPageSkeleton: React.FC = () => (
+  <Row gap="none" align="stretch" className="flex-1 min-h-0 bg-background">
+    {/* Left panel — conversation list (~30% matches default leftPanelWidth) */}
+    <div
+      className="flex flex-col h-full min-h-0 shrink-0 border-r border-border overflow-hidden"
+      style={{ width: '30%' }}
+    >
+      {/* Header: tabs + model name + search */}
+      <div className="p-base border-b border-border bg-background shrink-0">
+        <Stack gap="sm">
+          <Row gap="sm">
+            <Skeleton width="50%" height="var(--button-height-sm)" />
+            <Skeleton width="50%" height="var(--button-height-sm)" />
+          </Row>
+          <Skeleton variant="text" width="65%" height="1.2em" />
+          <Skeleton width="100%" height="var(--input-height-sm)" />
+        </Stack>
+      </div>
+
+      {/* Conversation items */}
+      <div className="flex-1 overflow-y-auto p-xs">
+        <ConversationListSkeleton />
+      </div>
+    </div>
+
+    {/* Right panel — alternating message bubbles (user left, assistant right) */}
+    <Stack gap="lg" className="flex-1 h-full min-h-0 p-xl overflow-hidden">
+      <Skeleton width="65%" height="56px" className="self-start" />
+      <Skeleton width="75%" height="72px" className="self-end" />
+      <Skeleton width="60%" height="56px" className="self-start" />
+      <Skeleton width="70%" height="72px" className="self-end" />
+    </Stack>
+  </Row>
+);

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -153,6 +153,7 @@
   --animate-blink: blink 1s ease-in-out infinite;
   --animate-spin-360: spin-360 0.8s linear infinite;
   --animate-research-pulse: research-pulse 1.5s ease-in-out infinite;
+  --animate-shimmer: shimmer 1.5s linear infinite;
 }
 
 /* ---------- Z-Index Utilities ---------- */
@@ -283,6 +284,15 @@
   }
   50% {
     opacity: 1;
+  }
+}
+
+@keyframes shimmer {
+  from {
+    background-position: -200% 0;
+  }
+  to {
+    background-position: 200% 0;
   }
 }
 


### PR DESCRIPTION
Closes #198

## Summary

Replaces all text-based loading states (`"Loading models..."`, `"Loading conversations…"`, etc.) with polished shimmer skeleton UIs that mirror the real content layout, eliminating layout shift and making the app feel faster.

This PR covers **Phase 1 (foundation)** and **Phase 2 (co-located templates)**. Phase 3 (wiring the skeletons into the live loading states) follows in a separate PR once this is reviewed.

---

## Changes

### Phase 1 — Foundation

**`src/styles/tailwind.css`**
- Added `@keyframes shimmer`: background-position sweep (`-200% 0` → `200% 0`) with **`linear` easing** for a smooth, continuous wave (not ease-in-out, which causes jarring acceleration)
- Registered `--animate-shimmer: shimmer 1.5s linear infinite` in `@theme inline`
- All colours use `var(--color-surface-elevated)` / `var(--color-surface-hover)` — zero hardcoded hex

**`src/components/primitives/Skeleton.tsx`** *(new)*
- Props: `variant` (`text | rect | circle`), `width`, `height`, `className`, `count`
- `aria-hidden="true"` on every root element — screen readers skip purely visual placeholders
- Shimmer via `animate-shimmer` class + `style={{ background: gradient, backgroundSize: '200% 100%' }}`
- `count > 1` wraps N copies in the existing `Stack` primitive
- Exported from `primitives/index.ts`

### Phase 2 — Co-located Skeleton Templates

Each template lives beside the feature it mirrors (no central `skeletons/` directory). All use `Stack`/`Row` primitives — no raw flex div soup.

| File | Mirrors | Details |
|---|---|---|
| `src/components/ModelLibraryPanel/ModelListSkeleton.tsx` | `ModelsListContent` rows | 6 rows: `py-md px-base border-b` + name line (55%) + 3 badge rects |
| `src/components/ConversationListPanel/ConversationListSkeleton.tsx` | Conversation list items | 5 items: `border rounded-base` + title (70%) + timestamp (35%) |
| `src/pages/ChatPageSkeleton.tsx` | ChatPage two-column layout | Left 30% (header approx + `ConversationListSkeleton`) + right 70% (4 alternating message rects) |
| `src/components/HuggingFaceBrowser/ModelCardSkeleton.tsx` | HF `ModelCard` | `rounded-xl` card: name + id line + param badge + stats |
| `src/components/ModelInspectorPanel/ModelInspectorSkeleton.tsx` | `ModelInspectorPanel` | Header (name + 3 circle buttons) + 4 metadata rows + 3 tag pills + 2 action rects |

---

## Design decisions

- **`linear` easing**: `ease-in-out` makes the wave visibly speed up/slow down on each loop — `linear` gives the continuous, even flow of a real shimmer
- **Co-location over centralisation**: each skeleton template lives in the same directory as the feature it belongs to, keeping the codebase feature-isolated and DRY
- **`aria-hidden="true"`**: skeletons are purely visual; parent containers will use `aria-busy` in Phase 3 if needed
- **`Skeleton` in `primitives/`** (not `ui/`): it is a layout-level primitive, consistent with `Card`, `Stack`, `Row`

---

## Verification

`tsc --noEmit` exits clean (`EXIT:0`) with all 7 commits.