### PR TITLE
feat(tools): Phase 1 – ToolResultRenderer interface and registry extension point (#273)

### DIFF
--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -7,6 +7,7 @@ import type {
   ToolDefinition,
   ToolExecutor,
   ToolResult,
+  ToolResultRenderer,
   RegisteredTool,
   ParsedToolCall,
 } from './types';
@@ -25,6 +26,7 @@ export type ToolSource =
  */
 interface RegisteredToolWithSource extends RegisteredTool {
   source: ToolSource;
+  renderer?: ToolResultRenderer;
 }
 
 /**
@@ -59,14 +61,15 @@ export class ToolRegistry {
    * @param definition - OpenAI-compatible tool definition
    * @param execute - Function to execute when tool is called
    * @param source - Source identifier for the tool (default: 'builtin')
+   * @param renderer - Optional renderer for displaying results in the chat UI
    * @throws Error if tool with same name already exists
    */
-  register(definition: ToolDefinition, execute: ToolExecutor, source: ToolSource = 'builtin'): void {
+  register(definition: ToolDefinition, execute: ToolExecutor, source: ToolSource = 'builtin', renderer?: ToolResultRenderer): void {
     const name = definition.function.name;
     if (this.tools.has(name)) {
       throw new Error(`Tool "${name}" is already registered`);
     }
-    this.tools.set(name, { definition, execute, source });
+    this.tools.set(name, { definition, execute, source, renderer });
     // Newly registered tools are disabled by default.
     // Intentionally do not mutate enable-state here so that if a tool is
     // re-registered after being enabled (e.g., MCP resync), it stays enabled.
@@ -121,13 +124,15 @@ export class ToolRegistry {
    * @param parameters - JSON Schema for parameters (optional)
    * @param execute - Executor function
    * @param source - Source identifier for the tool (default: 'builtin')
+   * @param renderer - Optional renderer for displaying results in the chat UI
    */
   registerFunction(
     name: string,
     description: string,
     parameters: ToolDefinition['function']['parameters'] | undefined,
     execute: ToolExecutor,
-    source: ToolSource = 'builtin'
+    source: ToolSource = 'builtin',
+    renderer?: ToolResultRenderer
   ): void {
     this.register(
       {
@@ -139,7 +144,8 @@ export class ToolRegistry {
         },
       },
       execute,
-      source
+      source,
+      renderer
     );
   }
 
@@ -205,6 +211,14 @@ export class ToolRegistry {
    */
   getExecutor(name: string): ToolExecutor | undefined {
     return this.tools.get(name)?.execute;
+  }
+
+  /**
+   * Get the registered renderer for a tool, if one was provided.
+   * Returns undefined for tools without a renderer or unknown tool names.
+   */
+  getRenderer(toolName: string): ToolResultRenderer | undefined {
+    return this.tools.get(toolName)?.renderer;
   }
 
   /**

--- a/src/services/tools/types.ts
+++ b/src/services/tools/types.ts
@@ -3,6 +3,8 @@
  * These types match the Rust proxy/models.rs types for OpenAI API compatibility.
  */
 
+import type { ReactNode } from 'react';
+
 // =============================================================================
 // Tool Definition Types (for declaring tools)
 // =============================================================================
@@ -74,6 +76,17 @@ export type ToolExecutor = (
 ) => Promise<ToolResult> | ToolResult;
 
 /**
+ * Interface for rendering a tool result in the chat UI.
+ * Implementors are plain objects, not React components.
+ */
+export interface ToolResultRenderer {
+  /** Render the full result as a React node for display in the chat. */
+  renderResult(data: unknown, toolName: string): ReactNode;
+  /** Render a compact plain-text summary (used in collapsed headers). Must not throw. */
+  renderSummary?(data: unknown, toolName: string): string;
+}
+
+/**
  * A registered tool with its definition and executor.
  */
 export interface RegisteredTool {
@@ -81,6 +94,8 @@ export interface RegisteredTool {
   definition: ToolDefinition;
   /** Function to execute when the tool is called */
   execute: ToolExecutor;
+  /** Optional renderer for displaying results in the chat UI */
+  renderer?: ToolResultRenderer;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Implements Phase 1 of #273 (sub-issue of #250).

Establishes the `ToolResultRenderer` extension point in the tool type system and registry, so any built-in or MCP tool can declare how its completed result is displayed in the chat UI.

## Changes

### `src/services/tools/types.ts`
- Add `import type { ReactNode } from 'react'`
- Define `ToolResultRenderer` interface:
  - `renderResult(data, toolName): ReactNode` — full result display
  - `renderSummary?(data, toolName): string` — compact plain-text summary for collapsed headers (must not throw)
- Add `renderer?: ToolResultRenderer` to `RegisteredTool`

### `src/services/tools/registry.ts`
- Import `ToolResultRenderer`
- `RegisteredToolWithSource` carries `renderer?`
- `register(definition, execute, source, renderer?)` — optional 4th param, stored in the map
- `registerFunction(name, desc, params, execute, source, renderer?)` — optional 6th param, passed through to `register()`
- New `getRenderer(toolName): ToolResultRenderer | undefined` method

## Testing

All 4 existing `ToolRegistry` tests pass unchanged — the new params are optional and additive.

## What's Next

- **Phase 3** (this branch): `FallbackRenderer` + `TimeRenderer` concrete implementations
- **Phase 4** (this branch): attach `timeRenderer` when registering `get_current_time`
- **Phase 5** (this branch): wire `getRenderer()` into `GenericToolUI` and `ToolDetailsModal`; delete `TimeToolUI`
- **#274**: `ToolResultDisplay` component with collapsible cards and copy-to-clipboard