### PR TITLE
feat(tools/mcp): Phase 3 – MCP tool result rendering with schema-based views and heuristic fallback (#275)

### DIFF
--- a/src/components/ToolUI/GenericToolUI.tsx
+++ b/src/components/ToolUI/GenericToolUI.tsx
@@ -107,7 +107,7 @@ export const GenericToolUI = makeAssistantToolUI<
   unknown
 >({
   toolName: '*', // Matches any tool
-  render: ({ toolName, args, status, result }) => {
+  render: ({ toolName, args, status, result, toolCallId }) => {
     // Determine display status
     let displayStatus: 'running' | 'complete' | 'error' | 'incomplete' = 'running';
     if (status.type === 'complete') {
@@ -142,7 +142,7 @@ export const GenericToolUI = makeAssistantToolUI<
 
           {/* Show result when complete */}
           {status.type === 'complete' && result !== undefined && (
-            <ToolResultDisplay toolName={toolName} result={result} />
+            <ToolResultDisplay toolName={toolName} result={result} toolCallId={toolCallId} />
           )}
 
           {/* Show spinner when running */}

--- a/src/components/ToolUI/SortableTable.tsx
+++ b/src/components/ToolUI/SortableTable.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import { Icon } from '../ui/Icon';
+import { cn } from '../../utils/cn';
+
+const MAX_ROWS = 200;
+
+export interface SortableTableProps {
+  rows: Record<string, unknown>[];
+  columns?: string[];
+}
+
+type SortDir = 'asc' | 'desc';
+
+function compareValues(a: unknown, b: unknown, dir: SortDir): number {
+  // Both numeric → numericcompare
+  if (typeof a === 'number' && typeof b === 'number') {
+    return dir === 'asc' ? a - b : b - a;
+  }
+  const sa = a === null || a === undefined ? '' : String(a);
+  const sb = b === null || b === undefined ? '' : String(b);
+  const cmp = sa.localeCompare(sb, undefined, { numeric: true, sensitivity: 'base' });
+  return dir === 'asc' ? cmp : -cmp;
+}
+
+function renderCell(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return <span className="text-text-muted italic">—</span>;
+  }
+  if (typeof value === 'boolean') {
+    return <span className="font-mono text-[11px]">{String(value)}</span>;
+  }
+  if (typeof value === 'object') {
+    try {
+      return (
+        <span className="font-mono text-[11px] text-text-secondary">
+          {JSON.stringify(value)}
+        </span>
+      );
+    } catch {
+      return <span className="text-text-muted italic">[object]</span>;
+    }
+  }
+  // Check if it looks like a URL
+  if (typeof value === 'string' && /^https?:\/\//.test(value)) {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary underline break-all"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {value}
+      </a>
+    );
+  }
+  return String(value);
+}
+
+/**
+ * Sortable data table for tool results that are arrays of objects.
+ * Columns are inferred from the first row if not explicitly provided.
+ * Supports click-to-sort column headers with lexicographic/numeric comparison.
+ * Caps rendering at 200 rows.
+ */
+export const SortableTable: React.FC<SortableTableProps> = ({ rows, columns: columnsProp }) => {
+  const [sortKey, setSortKey] = React.useState<string | null>(null);
+  const [sortDir, setSortDir] = React.useState<SortDir>('asc');
+
+  const columns = React.useMemo(
+    () => columnsProp ?? Object.keys(rows[0] ?? {}),
+    [columnsProp, rows],
+  );
+
+  const sortedRows = React.useMemo(() => {
+    if (!sortKey) return rows;
+    return [...rows].sort((a, b) => compareValues(a[sortKey], b[sortKey], sortDir));
+  }, [rows, sortKey, sortDir]);
+
+  const visibleRows = sortedRows.slice(0, MAX_ROWS);
+  const truncated = rows.length > MAX_ROWS;
+
+  const handleSort = (col: string) => {
+    if (sortKey === col) {
+      setSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(col);
+      setSortDir('asc');
+    }
+  };
+
+  const SortIcon: React.FC<{ col: string }> = ({ col }) => {
+    if (sortKey !== col) return <Icon icon={ChevronsUpDown} size={11} className="opacity-40" />;
+    return <Icon icon={sortDir === 'asc' ? ChevronUp : ChevronDown} size={11} />;
+  };
+
+  if (columns.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border my-1 text-[12px]">
+      <table className="border-collapse w-full">
+        <thead>
+          <tr className="bg-background-tertiary">
+            {columns.map((col) => (
+              <th
+                key={col}
+                onClick={() => handleSort(col)}
+                className={cn(
+                  'border-b border-border py-1.5 px-2.5 text-left font-semibold text-text-secondary',
+                  'cursor-pointer select-none whitespace-nowrap',
+                  'hover:text-text hover:bg-background-secondary transition-colors duration-100',
+                  sortKey === col && 'text-text',
+                )}
+              >
+                <span className="inline-flex items-center gap-1">
+                  {col}
+                  <SortIcon col={col} />
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((row, rowIdx) => (
+            <tr
+              key={rowIdx}
+              className="border-b border-border last:border-b-0 hover:bg-background-secondary transition-colors duration-75"
+            >
+              {columns.map((col) => (
+                <td
+                  key={col}
+                  className="py-1.5 px-2.5 text-left text-text align-top border-r border-border last:border-r-0"
+                >
+                  {renderCell(row[col])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {truncated && (
+        <p className="px-3 py-1.5 text-[11px] text-text-muted border-t border-border bg-background-secondary">
+          Showing {MAX_ROWS} of {rows.length} rows.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default SortableTable;

--- a/src/components/ToolUI/ToolResultDisplay.tsx
+++ b/src/components/ToolUI/ToolResultDisplay.tsx
@@ -9,6 +9,7 @@ import { fallbackRenderer } from '../../services/tools/renderers';
 export interface ToolResultDisplayProps {
   toolName: string;
   result: unknown;
+  toolCallId?: string;
 }
 
 function safeRenderSummary(renderer: ToolResultRenderer, result: unknown, toolName: string): string {
@@ -32,24 +33,23 @@ function safeRenderSummary(renderer: ToolResultRenderer, result: unknown, toolNa
  * This is the single source of truth for result rendering across
  * GenericToolUI (inline chat bubble) and ToolDetailsModal.
  */
-export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, result }) => {
+export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, result, toolCallId }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
 
   const renderer = getToolRegistry().getRenderer(toolName) ?? fallbackRenderer;
 
-  const summary = React.useMemo(
-    () => safeRenderSummary(renderer, result, toolName),
-    [renderer, result, toolName],
-  );
-
-  const body = React.useMemo(() => {
-    try {
-      return renderer.renderResult(result, toolName);
-    } catch {
-      return fallbackRenderer.renderResult(result, toolName);
-    }
-  }, [renderer, result, toolName]);
+  const { summary, body } = React.useMemo(() => {
+    const computedSummary = safeRenderSummary(renderer, result, toolName);
+    const computedBody = (() => {
+      try {
+        return renderer.renderResult(result, toolName);
+      } catch {
+        return fallbackRenderer.renderResult(result, toolName);
+      }
+    })();
+    return { summary: computedSummary, body: computedBody };
+  }, [renderer, toolName, result, toolCallId]);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -162,7 +162,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 {argsExpanded && <pre className="m-0 p-3 bg-background border border-border rounded-lg font-mono text-[0.9rem] leading-normal text-text overflow-x-auto whitespace-pre max-h-[300px]">{formattedArgs}</pre>}
               </Stack>
 
-              <ToolResultDisplay toolName={call.toolName} result={result} />
+              <ToolResultDisplay toolName={call.toolName} result={result} toolCallId={call.toolCallId} />
             </div>
           );
         })}

--- a/src/services/tools/mcpIntegration.ts
+++ b/src/services/tools/mcpIntegration.ts
@@ -16,6 +16,7 @@ import type { McpTool, McpServerId } from '../clients/mcp';
 import { getToolRegistry, ToolSource } from './registry';
 import type { ToolDefinition, ToolExecutor, ToolResult } from './types';
 import { sanitizeToolName, detectCollisions } from './nameUtils';
+import { mcpGenericRenderer, createMcpSchemaRenderer } from './renderers';
 import { appLogger } from '../platform';
 
 /**
@@ -139,7 +140,11 @@ export function registerMcpTools(serverId: McpServerId, tools: McpTool[]): numbe
         },
       };
 
-      registry.registerWithNameMapping(tool.name, String(serverId), sanitizedName, namespacedDef, executor, source);
+      const renderer = tool.output_schema
+        ? createMcpSchemaRenderer(tool.output_schema)
+        : mcpGenericRenderer;
+
+      registry.registerWithNameMapping(tool.name, String(serverId), sanitizedName, namespacedDef, executor, source, renderer);
       count++;
     } catch (err) {
       // Tool might already exist from another source — log and continue.

--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -88,6 +88,7 @@ export class ToolRegistry {
    * @param definition   - ToolDefinition whose function.name must equal sanitizedName
    * @param execute      - Executor (must call MCP with originalName, not sanitizedName)
    * @param source       - Tool source (e.g. 'mcp:server-id')
+   * @param renderer     - Optional renderer for displaying results in the chat UI
    */
   registerWithNameMapping(
     originalName: string,
@@ -96,9 +97,10 @@ export class ToolRegistry {
     definition: ToolDefinition,
     execute: ToolExecutor,
     source: ToolSource,
+    renderer?: ToolResultRenderer,
   ): void {
     this._nameMap.set(sanitizedName, { originalName, serverId });
-    this.register(definition, execute, source);
+    this.register(definition, execute, source, renderer);
   }
 
   /**

--- a/src/services/tools/renderers/McpGenericRenderer.tsx
+++ b/src/services/tools/renderers/McpGenericRenderer.tsx
@@ -1,0 +1,89 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { SortableTable } from '../../../components/ToolUI/SortableTable';
+import { fallbackRenderer } from './FallbackRenderer';
+import type { ToolResultRenderer } from '../types';
+
+// ---------------------------------------------------------------------------
+// Heuristic helpers
+// ---------------------------------------------------------------------------
+
+const MARKDOWN_PATTERNS = [
+  /^#{1,6} /m,         // ATX headings
+  /\*\*[^*]+\*\*/,     // bold
+  /^- /m,              // unordered list item
+  /`[^`]+`/,           // inline code or fenced block
+  /\[[^\]]+\]\([^)]+\)/, // link
+];
+
+/**
+ * Returns true if the string is likely Markdown prose.
+ * Requires length > 20 AND at least 2 matching Markdown patterns to reduce
+ * false positives on short strings that happen to contain a lone `*` or `#`.
+ */
+export function looksLikeMarkdown(s: string): boolean {
+  if (s.length <= 20) return false;
+  let matches = 0;
+  for (const pattern of MARKDOWN_PATTERNS) {
+    if (pattern.test(s)) {
+      matches++;
+      if (matches >= 2) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if data is a non-empty array where every element is an object
+ * that shares at least one key with the first element.
+ * This identifies homogeneous record arrays suitable for tabular rendering.
+ */
+export function isArrayOfHomogeneousObjects(
+  data: unknown,
+): data is Record<string, unknown>[] {
+  if (!Array.isArray(data) || data.length === 0) return false;
+  const first = data[0];
+  if (typeof first !== 'object' || first === null) return false;
+  const firstKeys = new Set(Object.keys(first as object));
+  if (firstKeys.size === 0) return false;
+  return data.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      Object.keys(item as object).some((k) => firstKeys.has(k)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic renderer for MCP tools that don't declare an output schema.
+ *
+ * Dispatch order:
+ *  1. String that looks like Markdown → ReactMarkdown
+ *  2. Homogeneous array of objects   → SortableTable
+ *  3. Everything else                → fallbackRenderer (pretty-printed JSON)
+ */
+export const mcpGenericRenderer: ToolResultRenderer = {
+  renderResult(data, toolName) {
+    if (typeof data === 'string' && looksLikeMarkdown(data)) {
+      return (
+        <div className="prose-sm text-text text-[13px] leading-relaxed [&_a]:text-primary [&_a]:underline [&_code]:bg-background [&_code]:rounded [&_code]:px-1 [&_pre]:bg-background [&_pre]:rounded [&_pre]:p-2 [&_pre]:overflow-x-auto">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{data}</ReactMarkdown>
+        </div>
+      );
+    }
+
+    if (isArrayOfHomogeneousObjects(data)) {
+      return <SortableTable rows={data} />;
+    }
+
+    return fallbackRenderer.renderResult(data, toolName);
+  },
+
+  renderSummary(data, toolName) {
+    return fallbackRenderer.renderSummary!(data, toolName);
+  },
+};

--- a/src/services/tools/renderers/McpSchemaRenderer.tsx
+++ b/src/services/tools/renderers/McpSchemaRenderer.tsx
@@ -1,0 +1,21 @@
+import { SchemaBasedView } from './SchemaBasedView';
+import { fallbackRenderer } from './FallbackRenderer';
+import type { ToolResultRenderer } from '../types';
+
+/**
+ * Factory: given a tool's output JSON Schema, returns a ToolResultRenderer
+ * that uses SchemaBasedView for structured display.
+ *
+ * Used when an MCP server declares an output_schema for a tool.
+ * Falls back to fallbackRenderer.renderSummary for the summary line.
+ */
+export const createMcpSchemaRenderer = (
+  schema: Record<string, unknown>,
+): ToolResultRenderer => ({
+  renderResult(data) {
+    return <SchemaBasedView data={data} schema={schema} />;
+  },
+  renderSummary(data, toolName) {
+    return fallbackRenderer.renderSummary!(data, toolName);
+  },
+});

--- a/src/services/tools/renderers/SchemaBasedView.tsx
+++ b/src/services/tools/renderers/SchemaBasedView.tsx
@@ -1,0 +1,140 @@
+import { JsonViewer } from './FallbackRenderer';
+import { SortableTable } from '../../../components/ToolUI/SortableTable';
+import type { JSONSchema, JSONSchemaProperty } from '../types';
+
+export interface SchemaBasedViewProps {
+  data: unknown;
+  schema: Record<string, unknown>;
+  level?: number;
+}
+
+const MAX_LEVEL = 2;
+
+function isSafeUrl(value: unknown): value is string {
+  return typeof value === 'string' && /^https?:\/\//i.test(value);
+}
+
+function renderPrimitive(data: unknown, schema: JSONSchemaProperty | JSONSchema): React.ReactNode {
+  // date-time: try parsing as a date
+  if (schema.type === 'string' && 'format' in schema && schema.format === 'date-time') {
+    try {
+      const d = new Date(String(data));
+      if (!isNaN(d.getTime())) {
+        return <span className="text-text font-mono">{d.toLocaleString()}</span>;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  // uri: render as safe link (http/https only)
+  if (schema.type === 'string' && 'format' in schema && schema.format === 'uri') {
+    if (isSafeUrl(data)) {
+      return (
+        <a
+          href={data}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline break-all"
+        >
+          {data}
+        </a>
+      );
+    }
+    return <span className="text-text font-mono">{String(data)}</span>;
+  }
+
+  // number with locale formatting
+  if (schema.type === 'number' && typeof data === 'number') {
+    return <span className="text-text font-mono">{data.toLocaleString()}</span>;
+  }
+
+  return <span className="text-text font-mono text-[12px]">{String(data ?? '')}</span>;
+}
+
+/**
+ * Renders a tool result using its JSON Schema as a guide.
+ * - Objects → two-column key/value table with recursive rendering (max 2 levels)
+ * - Arrays of objects → SortableTable
+ * - Strings with format "uri" → safe clickable link (http/https only)
+ * - Strings with format "date-time" → toLocaleString
+ * - Numbers → toLocaleString
+ * - Deep nesting (level > MAX_LEVEL) → JsonViewer fallback
+ */
+export const SchemaBasedView: React.FC<SchemaBasedViewProps> = ({ data, schema, level = 0 }) => {
+  // Depth guard: avoid runaway recursion on deeply nested schemas
+  if (level > MAX_LEVEL) {
+    return <JsonViewer data={data} label="Result" />;
+  }
+
+  // Arrays
+  if (schema.type === 'array') {
+    if (!Array.isArray(data)) {
+      return <JsonViewer data={data} label="Result" />;
+    }
+
+    // Array of objects → SortableTable; infer column order from schema.items if available
+    const firstItem = data[0];
+    if (data.length > 0 && typeof firstItem === 'object' && firstItem !== null) {
+      const schemaItems = schema.items as JSONSchemaProperty | undefined;
+      const columns =
+        schemaItems?.properties ? Object.keys(schemaItems.properties) : undefined;
+      return <SortableTable rows={data as Record<string, unknown>[]} columns={columns} />;
+    }
+
+    // Array of primitives → simple list
+    return (
+      <ul className="list-none m-0 p-0 flex flex-col gap-0.5">
+        {(data as unknown[]).map((item, i) => (
+          <li key={i} className="font-mono text-[12px] text-text">
+            {String(item ?? '')}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  // Objects
+  if (schema.type === 'object') {
+    const properties = (schema.properties ?? {}) as Record<string, JSONSchemaProperty>;
+    const obj = (typeof data === 'object' && data !== null ? data : {}) as Record<string, unknown>;
+    // Union schema keys with actual data keys so unknown keys still render
+    const keys = Array.from(new Set([...Object.keys(properties), ...Object.keys(obj)]));
+
+    if (keys.length === 0) {
+      return <span className="text-text-muted italic text-[12px]">(empty)</span>;
+    }
+
+    return (
+      <div className="overflow-x-auto rounded-lg border border-border my-1 text-[12px]">
+        <table className="border-collapse w-full">
+          <tbody>
+            {keys.map((key) => {
+              const propSchema = properties[key];
+              const val = obj[key];
+              return (
+                <tr key={key} className="border-b border-border last:border-b-0 hover:bg-background-secondary transition-colors duration-75">
+                  <td className="py-1.5 px-2.5 font-semibold text-text-secondary whitespace-nowrap border-r border-border w-1/3 align-top">
+                    {key}
+                  </td>
+                  <td className="py-1.5 px-2.5 text-text align-top">
+                    {propSchema ? (
+                      <SchemaBasedView data={val} schema={propSchema as unknown as Record<string, unknown>} level={level + 1} />
+                    ) : (
+                      <span className="font-mono text-[12px]">{String(val ?? '')}</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  // Primitives (string, number, boolean, etc.)
+  return renderPrimitive(data, schema as unknown as JSONSchemaProperty);
+};
+
+export default SchemaBasedView;

--- a/src/services/tools/renderers/index.ts
+++ b/src/services/tools/renderers/index.ts
@@ -1,2 +1,5 @@
 export { fallbackRenderer, JsonViewer } from './FallbackRenderer';
 export { timeRenderer } from './TimeRenderer';
+export { mcpGenericRenderer, looksLikeMarkdown, isArrayOfHomogeneousObjects } from './McpGenericRenderer';
+export { createMcpSchemaRenderer } from './McpSchemaRenderer';
+export { SchemaBasedView } from './SchemaBasedView';

--- a/src/services/transport/types/mcp.ts
+++ b/src/services/transport/types/mcp.ts
@@ -92,6 +92,9 @@ export interface McpTool {
   name: string;
   description?: string;
   input_schema?: Record<string, unknown>;
+  /** Optional JSON Schema describing the tool's output. Present only when the
+   * MCP server declares it. Used to auto-generate a structured result renderer. */
+  output_schema?: Record<string, unknown>;
 }
 
 /**

--- a/tests/ts/services/tools/mcpIntegration.test.ts
+++ b/tests/ts/services/tools/mcpIntegration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerMcpTools, unregisterMcpTools, getMcpSource } from '../../../../src/services/tools/mcpIntegration';
 import { resetToolRegistry, getToolRegistry } from '../../../../src/services/tools/registry';
+import { mcpGenericRenderer } from '../../../../src/services/tools/renderers';
 import type { McpTool } from '../../../../src/services/clients/mcp';
 
 // =============================================================================
@@ -168,6 +169,26 @@ describe('registerMcpTools', () => {
       'get data!',  // raw name, not 'mcp_my_server_get_data'
       {},
     );
+  });
+
+  // ── Renderer assignment ────────────────────────────────────────────────────
+
+  it('assigns mcpGenericRenderer to tools without an output_schema', () => {
+    registerMcpTools('srv1', [makeTool('get_weather')]);
+    const registry = getToolRegistry();
+    expect(registry.getRenderer('mcp_srv1_get_weather')).toBe(mcpGenericRenderer);
+  });
+
+  it('assigns a schema renderer (not mcpGenericRenderer) to tools with an output_schema', () => {
+    const toolWithSchema: McpTool = {
+      ...makeTool('search_results'),
+      output_schema: { type: 'object', properties: { items: { type: 'array' } } },
+    };
+    registerMcpTools('srv1', [toolWithSchema]);
+    const registry = getToolRegistry();
+    const renderer = registry.getRenderer('mcp_srv1_search_results');
+    expect(renderer).toBeDefined();
+    expect(renderer).not.toBe(mcpGenericRenderer);
   });
 });
 

--- a/tests/ts/services/tools/mcpRenderers.test.ts
+++ b/tests/ts/services/tools/mcpRenderers.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  looksLikeMarkdown,
+  isArrayOfHomogeneousObjects,
+  mcpGenericRenderer,
+} from '../../../../src/services/tools/renderers/McpGenericRenderer';
+import { createMcpSchemaRenderer } from '../../../../src/services/tools/renderers/McpSchemaRenderer';
+
+// =============================================================================
+// looksLikeMarkdown
+// =============================================================================
+
+describe('looksLikeMarkdown', () => {
+  it('returns false for an empty string', () => {
+    expect(looksLikeMarkdown('')).toBe(false);
+  });
+
+  it('returns false for a string ≤ 20 characters even with markdown syntax', () => {
+    // "# Short" has a heading but is only 7 chars
+    expect(looksLikeMarkdown('# Short')).toBe(false);
+    // "**bold** text here!!" is exactly 20 chars
+    expect(looksLikeMarkdown('**bold** text here!!')).toBe(false);
+  });
+
+  it('returns false for a long plain-text string with no markdown patterns', () => {
+    const plain = 'This is a completely plain sentence with no formatting at all, just words.';
+    expect(looksLikeMarkdown(plain)).toBe(false);
+  });
+
+  it('returns false for a long string matching only one markdown pattern', () => {
+    // Only bold — not enough on its own
+    const onlyBold = 'This sentence is quite long and contains only **one** bold marker without anything else.';
+    expect(looksLikeMarkdown(onlyBold)).toBe(false);
+  });
+
+  it('returns true for a long string with a heading and bold text (2 patterns)', () => {
+    const md = '# Chapter 1\n\nThis is a **bold** introductory paragraph about the topic.';
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+
+  it('returns true for a long string with a list and inline code (2 patterns)', () => {
+    const md = 'Install the dependencies:\n\n- Run `npm install`\n- Then start the server\n';
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+
+  it('returns true for a long string with bold text and a markdown link (2 patterns)', () => {
+    const md = 'Check out **this project** and read [the docs](https://example.com) for more details.';
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+
+  it('returns true for a realistic multi-section markdown document', () => {
+    const md = [
+      '## Results',
+      '',
+      '**Status**: Complete',
+      '',
+      '- Item one',
+      '- Item two',
+      '',
+      'See `README.md` for more.',
+    ].join('\n');
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+});
+
+// =============================================================================
+// isArrayOfHomogeneousObjects
+// =============================================================================
+
+describe('isArrayOfHomogeneousObjects', () => {
+  it('returns false for an empty array', () => {
+    expect(isArrayOfHomogeneousObjects([])).toBe(false);
+  });
+
+  it('returns false for an array of primitive numbers', () => {
+    expect(isArrayOfHomogeneousObjects([1, 2, 3])).toBe(false);
+  });
+
+  it('returns false for an array of strings', () => {
+    expect(isArrayOfHomogeneousObjects(['a', 'b', 'c'])).toBe(false);
+  });
+
+  it('returns false for a non-array value', () => {
+    expect(isArrayOfHomogeneousObjects(null)).toBe(false);
+    expect(isArrayOfHomogeneousObjects(undefined)).toBe(false);
+    expect(isArrayOfHomogeneousObjects({ a: 1 })).toBe(false);
+    expect(isArrayOfHomogeneousObjects('text')).toBe(false);
+  });
+
+  it('returns false for an array of objects with no shared keys', () => {
+    expect(isArrayOfHomogeneousObjects([{ a: 1 }, { b: 2 }])).toBe(false);
+  });
+
+  it('returns false for a mixed array containing null alongside an object', () => {
+    expect(isArrayOfHomogeneousObjects([{ a: 1 }, null])).toBe(false);
+  });
+
+  it('returns false for an array of empty objects (no keys to share)', () => {
+    expect(isArrayOfHomogeneousObjects([{}, {}])).toBe(false);
+  });
+
+  it('returns true for an array of objects sharing at least one key', () => {
+    // id is shared; age is absent in first object — still true
+    expect(
+      isArrayOfHomogeneousObjects([
+        { id: 1, name: 'Alice' },
+        { id: 2, age: 30 },
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns true when all objects share the same complete key set', () => {
+    expect(
+      isArrayOfHomogeneousObjects([
+        { id: 1, value: 'x' },
+        { id: 2, value: 'y' },
+        { id: 3, value: 'z' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns true for a single-element array containing an object with keys', () => {
+    expect(isArrayOfHomogeneousObjects([{ id: 1 }])).toBe(true);
+  });
+});
+
+// =============================================================================
+// mcpGenericRenderer.renderSummary
+// =============================================================================
+
+describe('mcpGenericRenderer.renderSummary', () => {
+  it('delegates to the fallback renderer and returns a string for an object', () => {
+    const result = mcpGenericRenderer.renderSummary!({ key: 'value' }, 'my_tool');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns a string for null data without throwing', () => {
+    expect(() => {
+      const result = mcpGenericRenderer.renderSummary!(null, 'my_tool');
+      expect(typeof result).toBe('string');
+    }).not.toThrow();
+  });
+
+  it('returns a string for a circular reference without throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => {
+      const result = mcpGenericRenderer.renderSummary!(circular, 'my_tool');
+      expect(typeof result).toBe('string');
+    }).not.toThrow();
+  });
+
+  it('returns a string for a primitive number', () => {
+    const result = mcpGenericRenderer.renderSummary!(42, 'my_tool');
+    expect(typeof result).toBe('string');
+    expect(result).toBe('42');
+  });
+
+  it('returns a string for an array result', () => {
+    const result = mcpGenericRenderer.renderSummary!([1, 2, 3], 'my_tool');
+    expect(typeof result).toBe('string');
+  });
+});
+
+// =============================================================================
+// createMcpSchemaRenderer
+// =============================================================================
+
+describe('createMcpSchemaRenderer', () => {
+  it('returns an object with renderResult and renderSummary functions', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object' });
+    expect(typeof renderer.renderResult).toBe('function');
+    expect(typeof renderer.renderSummary).toBe('function');
+  });
+
+  it('returns a new renderer instance each call (factory pattern)', () => {
+    const schema = { type: 'object', properties: {} };
+    const r1 = createMcpSchemaRenderer(schema);
+    const r2 = createMcpSchemaRenderer(schema);
+    expect(r1).not.toBe(r2);
+  });
+
+  it('renderSummary delegates to fallbackRenderer and returns a string', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object' });
+    const result = renderer.renderSummary!({ status: 'ok', count: 5 }, 'schema_tool');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('renderSummary returns a string for null data without throwing', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object' });
+    expect(() => {
+      const result = renderer.renderSummary!(null, 'schema_tool');
+      expect(typeof result).toBe('string');
+    }).not.toThrow();
+  });
+
+  it('renderResult returns a defined React element', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object', properties: {} });
+    const result = renderer.renderResult({ key: 'value' }, 'schema_tool');
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #275. Sub-issue of #250.

## Overview

This PR completes Phase 3 of the Rich Tool Result Rendering epic. It adds two complementary rendering strategies for MCP tool results:

1. **Heuristic renderer** (`McpGenericRenderer`) — automatically detects Markdown and homogeneous record arrays, rendering them with `ReactMarkdown` or `SortableTable` respectively, falling back to the collapsible JSON viewer.
2. **Schema-based renderer** (`McpSchemaRenderer` + `SchemaBasedView`) — uses a tool's declared `output_schema` to drive a structured, type-aware layout (object → key/value table, array of objects → `SortableTable`, date-time → localised string, URI → safe anchor).

Both renderers are wired into the MCP registration loop so every tool gets the best available renderer at registration time — no manual configuration required.

---

## Commits

| SHA | Description |
|-----|-------------|
| `3b254dc` | **Phase A** — Add `output_schema?` to `McpTool`; `renderer?` optional 7th arg to `registerWithNameMapping` |
| `9dda5df` | **Phase B1** — New `SortableTable` component: sortable columns, URL detection, 200-row cap, lucide sort icons |
| `cf16e7d` | **Phase B2** — `SchemaBasedView`, `McpSchemaRenderer`, `McpGenericRenderer`; barrel exports updated |
| `08bb933` | **Phase C** — `mcpIntegration.ts` registration loop: dispatch to schema or generic renderer per tool |
| `9701567` | **Phase D** — Merge dual `useMemo` in `ToolResultDisplay` into one; thread `toolCallId?` prop through `GenericToolUI` and `ToolDetailsModal` |
| `edbdccf` | **Phase E** — 28 unit tests across `mcpRenderers.test.ts` + 2 new integration assertions in `mcpIntegration.test.ts` |

---

## Key design decisions

### Heuristic detection (`looksLikeMarkdown`)
Requires **length > 20 AND ≥ 2 matching patterns** from: ATX headings, bold, unordered list, inline-code, markdown link. This avoids false positives on short strings or sentences that happen to contain a lone `*`.

### Homogeneous-objects detection (`isArrayOfHomogeneousObjects`)
An array qualifies if it is non-empty, every element is a non-null object, and every element shares at least one key with the first element. The "at least one shared key" rule handles real-world APIs that return objects with a mandatory `id` field plus optional type-specific fields.

### Schema dispatch depth
`SchemaBasedView` recurses at most **2 levels** - beyond that it falls back to the collapsible `JsonViewer`. This keeps the UI readable for deeply-nested schemas while still providing meaningful structure for the common `{ type: 'object', properties: { … } }` shape.

### URL safety
Both `SchemaBasedView` and `SortableTable` only render `<a>` tags for values that start with `http://` or `https://`, preventing `javascript:` injection.

### `toolCallId` in `useMemo` deps
`ToolResultDisplay` uses `toolCallId` as a memoisation dependency so the body only re-renders when the *logical call* changes, not just when a parent re-renders with a new object identity for `result`.

---

## Test coverage

- **`looksLikeMarkdown`** — 8 cases: empty, ≤20 chars, long plain, single-pattern, heading+bold, list+code, bold+link, full document
- **`isArrayOfHomogeneousObjects`** — 10 cases: empty array, primitives, strings, non-arrays, no-shared-keys, mixed-null, empty objects, partial share, full share, single-element
- **`mcpGenericRenderer.renderSummary`** — delegates to fallback; safe for null, circular refs, numbers, arrays
- **`createMcpSchemaRenderer`** — factory pattern; `renderResult` returns defined React element; `renderSummary` returns string
- **`mcpIntegration`** — two new assertions: tool without `output_schema` → `mcpGenericRenderer`; tool with `output_schema` → schema renderer (not `mcpGenericRenderer`)

All **107 tests** pass across 6 test files.