### PR TITLE
feat(ui): rich tool result rendering with auto-detection and custom renderers (#250)

### DIFF
--- a/src/components/ToolUI/GenericToolUI.tsx
+++ b/src/components/ToolUI/GenericToolUI.tsx
@@ -10,13 +10,13 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
-  Clock3,
   Loader2,
   Wrench,
   XCircle,
 } from 'lucide-react';
 import { Icon } from '../ui/Icon';
 import { cn } from '../../utils/cn';
+import { ToolResultDisplay } from './ToolResultDisplay';
 
 /**
  * Status indicator component
@@ -142,11 +142,7 @@ export const GenericToolUI = makeAssistantToolUI<
 
           {/* Show result when complete */}
           {status.type === 'complete' && result !== undefined && (
-            <JsonViewer
-              data={result}
-              label="Result"
-              defaultExpanded={true}
-            />
+            <ToolResultDisplay toolName={toolName} result={result} />
           )}
 
           {/* Show spinner when running */}
@@ -161,80 +157,6 @@ export const GenericToolUI = makeAssistantToolUI<
           {status.type === 'incomplete' && status.reason === 'error' && (
             <div className="px-3 py-2 bg-[rgba(239,68,68,0.1)] rounded-sm text-[#f87171] text-xs">
               Tool execution was interrupted or failed.
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  },
-});
-
-/**
- * Specialized tool UI for time-related results.
- * Shows a formatted clock display.
- */
-export const TimeToolUI = makeAssistantToolUI<
-  { timezone?: string; format?: string },
-  { time: string | number; timezone: string; format: string }
->({
-  toolName: 'get_current_time',
-  render: ({ args, status, result }) => {
-    const displayName = 'Get Current Time';
-
-    let displayStatus: 'running' | 'complete' | 'error' | 'incomplete' = 'running';
-    if (status.type === 'complete') {
-      const hasError = result && typeof result === 'object' && 'error' in result;
-      displayStatus = hasError ? 'error' : 'complete';
-    } else if (status.type === 'incomplete') {
-      displayStatus = status.reason === 'error' ? 'error' : 'incomplete';
-    }
-
-    return (
-      <div className="bg-background-secondary border border-border rounded-lg my-2 overflow-hidden text-[13px]">
-        <div className="flex items-center gap-2 px-3 py-2.5 bg-background-tertiary border-b border-border">
-          <span className="text-base" aria-hidden>
-            <Icon icon={Clock3} size={14} />
-          </span>
-          <span className="font-semibold text-text flex-1">{displayName}</span>
-          <StatusBadge status={displayStatus} />
-        </div>
-
-        <div className="p-3">
-          {/* Show timezone argument if provided */}
-          {args?.timezone && (
-            <div className="flex items-center gap-2 mb-2">
-              <span className="font-medium text-text-secondary">Timezone:</span>
-              <span className="text-text font-mono">{args.timezone}</span>
-            </div>
-          )}
-
-          {/* Show formatted time when complete */}
-          {status.type === 'complete' && result && !('error' in result) && (
-            <div className="text-center py-3">
-              <div className="text-lg font-semibold text-text mb-2 font-mono">
-                {typeof result.time === 'number'
-                  ? result.time.toString()
-                  : result.time}
-              </div>
-              <div className="flex justify-center gap-4 text-[11px] text-text-muted">
-                <span>Timezone: {result.timezone}</span>
-                <span>Format: {result.format}</span>
-              </div>
-            </div>
-          )}
-
-          {/* Show error */}
-          {status.type === 'complete' && result && 'error' in result && (
-            <div className="px-3 py-2 bg-[rgba(239,68,68,0.1)] rounded-sm text-[#f87171] text-xs">
-              {(result as { error: string }).error}
-            </div>
-          )}
-
-          {/* Show spinner when running */}
-          {status.type === 'running' && (
-            <div className="flex items-center gap-2 py-2 text-text-secondary">
-              <span className="w-4 h-4 border-2 border-border border-t-primary rounded-full animate-spin-360"></span>
-              <span>Fetching time...</span>
             </div>
           )}
         </div>

--- a/src/components/ToolUI/GenericToolUI.tsx
+++ b/src/components/ToolUI/GenericToolUI.tsx
@@ -107,7 +107,7 @@ export const GenericToolUI = makeAssistantToolUI<
   unknown
 >({
   toolName: '*', // Matches any tool
-  render: ({ toolName, args, status, result }) => {
+  render: ({ toolName, args, status, result, toolCallId }) => {
     // Determine display status
     let displayStatus: 'running' | 'complete' | 'error' | 'incomplete' = 'running';
     if (status.type === 'complete') {
@@ -142,7 +142,7 @@ export const GenericToolUI = makeAssistantToolUI<
 
           {/* Show result when complete */}
           {status.type === 'complete' && result !== undefined && (
-            <ToolResultDisplay toolName={toolName} result={result} />
+            <ToolResultDisplay toolName={toolName} result={result} toolCallId={toolCallId} />
           )}
 
           {/* Show spinner when running */}

--- a/src/components/ToolUI/SortableTable.tsx
+++ b/src/components/ToolUI/SortableTable.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import { Icon } from '../ui/Icon';
+import { cn } from '../../utils/cn';
+
+const MAX_ROWS = 200;
+
+export interface SortableTableProps {
+  rows: Record<string, unknown>[];
+  columns?: string[];
+}
+
+type SortDir = 'asc' | 'desc';
+
+function compareValues(a: unknown, b: unknown, dir: SortDir): number {
+  // Both numeric → numericcompare
+  if (typeof a === 'number' && typeof b === 'number') {
+    return dir === 'asc' ? a - b : b - a;
+  }
+  const sa = a === null || a === undefined ? '' : String(a);
+  const sb = b === null || b === undefined ? '' : String(b);
+  const cmp = sa.localeCompare(sb, undefined, { numeric: true, sensitivity: 'base' });
+  return dir === 'asc' ? cmp : -cmp;
+}
+
+function renderCell(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return <span className="text-text-muted italic">—</span>;
+  }
+  if (typeof value === 'boolean') {
+    return <span className="font-mono text-[11px]">{String(value)}</span>;
+  }
+  if (typeof value === 'object') {
+    try {
+      return (
+        <span className="font-mono text-[11px] text-text-secondary">
+          {JSON.stringify(value)}
+        </span>
+      );
+    } catch {
+      return <span className="text-text-muted italic">[object]</span>;
+    }
+  }
+  // Check if it looks like a URL
+  if (typeof value === 'string' && /^https?:\/\//.test(value)) {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary underline break-all"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {value}
+      </a>
+    );
+  }
+  return String(value);
+}
+
+/**
+ * Sortable data table for tool results that are arrays of objects.
+ * Columns are inferred from the first row if not explicitly provided.
+ * Supports click-to-sort column headers with lexicographic/numeric comparison.
+ * Caps rendering at 200 rows.
+ */
+export const SortableTable: React.FC<SortableTableProps> = ({ rows, columns: columnsProp }) => {
+  const [sortKey, setSortKey] = React.useState<string | null>(null);
+  const [sortDir, setSortDir] = React.useState<SortDir>('asc');
+
+  const columns = React.useMemo(
+    () => columnsProp ?? Object.keys(rows[0] ?? {}),
+    [columnsProp, rows],
+  );
+
+  const sortedRows = React.useMemo(() => {
+    if (!sortKey) return rows;
+    return [...rows].sort((a, b) => compareValues(a[sortKey], b[sortKey], sortDir));
+  }, [rows, sortKey, sortDir]);
+
+  const visibleRows = sortedRows.slice(0, MAX_ROWS);
+  const truncated = rows.length > MAX_ROWS;
+
+  const handleSort = (col: string) => {
+    if (sortKey === col) {
+      setSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(col);
+      setSortDir('asc');
+    }
+  };
+
+  const SortIcon: React.FC<{ col: string }> = ({ col }) => {
+    if (sortKey !== col) return <Icon icon={ChevronsUpDown} size={11} className="opacity-40" />;
+    return <Icon icon={sortDir === 'asc' ? ChevronUp : ChevronDown} size={11} />;
+  };
+
+  if (columns.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border my-1 text-[12px]">
+      <table className="border-collapse w-full">
+        <thead>
+          <tr className="bg-background-tertiary">
+            {columns.map((col) => (
+              <th
+                key={col}
+                onClick={() => handleSort(col)}
+                className={cn(
+                  'border-b border-border py-1.5 px-2.5 text-left font-semibold text-text-secondary',
+                  'cursor-pointer select-none whitespace-nowrap',
+                  'hover:text-text hover:bg-background-secondary transition-colors duration-100',
+                  sortKey === col && 'text-text',
+                )}
+              >
+                <span className="inline-flex items-center gap-1">
+                  {col}
+                  <SortIcon col={col} />
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((row, rowIdx) => (
+            <tr
+              key={rowIdx}
+              className="border-b border-border last:border-b-0 hover:bg-background-secondary transition-colors duration-75"
+            >
+              {columns.map((col) => (
+                <td
+                  key={col}
+                  className="py-1.5 px-2.5 text-left text-text align-top border-r border-border last:border-r-0"
+                >
+                  {renderCell(row[col])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {truncated && (
+        <p className="px-3 py-1.5 text-[11px] text-text-muted border-t border-border bg-background-secondary">
+          Showing {MAX_ROWS} of {rows.length} rows.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default SortableTable;

--- a/src/components/ToolUI/SortableTable.tsx
+++ b/src/components/ToolUI/SortableTable.tsx
@@ -12,6 +12,15 @@ export interface SortableTableProps {
 
 type SortDir = 'asc' | 'desc';
 
+const SortIcon: React.FC<{ col: string; sortKey: string | null; sortDir: SortDir }> = ({
+  col,
+  sortKey,
+  sortDir,
+}) => {
+  if (sortKey !== col) return <Icon icon={ChevronsUpDown} size={11} className="opacity-40" />;
+  return <Icon icon={sortDir === 'asc' ? ChevronUp : ChevronDown} size={11} />;
+};
+
 function compareValues(a: unknown, b: unknown, dir: SortDir): number {
   // Both numeric → numericcompare
   if (typeof a === 'number' && typeof b === 'number') {
@@ -90,11 +99,6 @@ export const SortableTable: React.FC<SortableTableProps> = ({ rows, columns: col
     }
   };
 
-  const SortIcon: React.FC<{ col: string }> = ({ col }) => {
-    if (sortKey !== col) return <Icon icon={ChevronsUpDown} size={11} className="opacity-40" />;
-    return <Icon icon={sortDir === 'asc' ? ChevronUp : ChevronDown} size={11} />;
-  };
-
   if (columns.length === 0) return null;
 
   return (
@@ -115,7 +119,7 @@ export const SortableTable: React.FC<SortableTableProps> = ({ rows, columns: col
               >
                 <span className="inline-flex items-center gap-1">
                   {col}
-                  <SortIcon col={col} />
+                  <SortIcon col={col} sortKey={sortKey} sortDir={sortDir} />
                 </span>
               </th>
             ))}

--- a/src/components/ToolUI/ToolResultDisplay.tsx
+++ b/src/components/ToolUI/ToolResultDisplay.tsx
@@ -9,6 +9,7 @@ import { fallbackRenderer } from '../../services/tools/renderers';
 export interface ToolResultDisplayProps {
   toolName: string;
   result: unknown;
+  toolCallId?: string;
 }
 
 function safeRenderSummary(renderer: ToolResultRenderer, result: unknown, toolName: string): string {
@@ -32,24 +33,23 @@ function safeRenderSummary(renderer: ToolResultRenderer, result: unknown, toolNa
  * This is the single source of truth for result rendering across
  * GenericToolUI (inline chat bubble) and ToolDetailsModal.
  */
-export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, result }) => {
+export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, result, toolCallId }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
 
   const renderer = getToolRegistry().getRenderer(toolName) ?? fallbackRenderer;
 
-  const summary = React.useMemo(
-    () => safeRenderSummary(renderer, result, toolName),
-    [renderer, result, toolName],
-  );
-
-  const body = React.useMemo(() => {
-    try {
-      return renderer.renderResult(result, toolName);
-    } catch {
-      return fallbackRenderer.renderResult(result, toolName);
-    }
-  }, [renderer, result, toolName]);
+  const { summary, body } = React.useMemo(() => {
+    const computedSummary = safeRenderSummary(renderer, result, toolName);
+    const computedBody = (() => {
+      try {
+        return renderer.renderResult(result, toolName);
+      } catch {
+        return fallbackRenderer.renderResult(result, toolName);
+      }
+    })();
+    return { summary: computedSummary, body: computedBody };
+  }, [renderer, toolName, result, toolCallId]);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/ToolUI/ToolResultDisplay.tsx
+++ b/src/components/ToolUI/ToolResultDisplay.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Check, ChevronDown, ChevronRight, Clipboard } from 'lucide-react';
+import type { ToolResultRenderer } from '../../services/tools/types';
+import { Icon } from '../ui/Icon';
+import { cn } from '../../utils/cn';
+import { getToolRegistry } from '../../services/tools/registry';
+import { fallbackRenderer } from '../../services/tools/renderers';
+
+export interface ToolResultDisplayProps {
+  toolName: string;
+  result: unknown;
+}
+
+function safeRenderSummary(renderer: ToolResultRenderer, result: unknown, toolName: string): string {
+  try {
+    return renderer.renderSummary?.(result, toolName) ?? fallbackRenderer.renderSummary!(result, toolName);
+  } catch {
+    try {
+      return fallbackRenderer.renderSummary!(result, toolName);
+    } catch {
+      return toolName;
+    }
+  }
+}
+
+/**
+ * Collapsible card for displaying a single tool result.
+ * Dispatches to the registered ToolResultRenderer for the tool,
+ * falling back to the generic JSON renderer if none is registered or
+ * if the renderer throws.
+ *
+ * This is the single source of truth for result rendering across
+ * GenericToolUI (inline chat bubble) and ToolDetailsModal.
+ */
+export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, result }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
+
+  const renderer = getToolRegistry().getRenderer(toolName) ?? fallbackRenderer;
+
+  const summary = React.useMemo(
+    () => safeRenderSummary(renderer, result, toolName),
+    [renderer, result, toolName],
+  );
+
+  const body = React.useMemo(() => {
+    try {
+      return renderer.renderResult(result, toolName);
+    } catch {
+      return fallbackRenderer.renderResult(result, toolName);
+    }
+  }, [renderer, result, toolName]);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const text = (() => {
+      try {
+        return JSON.stringify(result, null, 2) ?? String(result);
+      } catch {
+        return String(result);
+      }
+    })();
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="border border-border rounded-lg bg-background overflow-hidden my-2 text-[13px]">
+      {/* Header — always visible, toggles body */}
+      <button
+        type="button"
+        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer bg-transparent hover:bg-background-secondary transition-colors duration-150"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-expanded={isExpanded}
+      >
+        <span className="shrink-0 text-text-secondary" aria-hidden>
+          <Icon icon={isExpanded ? ChevronDown : ChevronRight} size={14} />
+        </span>
+
+        <span className="flex-1 truncate font-mono text-[11px] text-text-secondary">
+          {summary}
+        </span>
+
+        {/* Copy button — stopPropagation prevents accordion toggle */}
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label="Copy result as JSON"
+          className={cn(
+            'shrink-0 inline-flex items-center justify-center w-6 h-6 rounded transition-colors duration-150',
+            'text-text-muted hover:text-text hover:bg-background-tertiary',
+            copied && 'text-[#4ade80]',
+          )}
+          onClick={handleCopy}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleCopy(e as unknown as React.MouseEvent);
+            }
+          }}
+        >
+          <Icon icon={copied ? Check : Clipboard} size={13} />
+        </span>
+      </button>
+
+      {/* Body — visible when expanded */}
+      {isExpanded && (
+        <div className="px-3 py-2 border-t border-border overflow-x-auto max-h-[400px] overflow-y-auto">
+          {body}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ToolResultDisplay;

--- a/src/components/ToolUI/ToolResultDisplay.tsx
+++ b/src/components/ToolUI/ToolResultDisplay.tsx
@@ -37,9 +37,9 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, 
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
 
-  const renderer = getToolRegistry().getRenderer(toolName) ?? fallbackRenderer;
-
   const { summary, body } = React.useMemo(() => {
+    // React owns the memoization. If the parent passes unstable result references, it will re-render.
+    const renderer = getToolRegistry().getRenderer(toolName) ?? fallbackRenderer;
     const computedSummary = safeRenderSummary(renderer, result, toolName);
     const computedBody = (() => {
       try {
@@ -49,7 +49,7 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, 
       }
     })();
     return { summary: computedSummary, body: computedBody };
-  }, [renderer, toolName, result, toolCallId]);
+  }, [toolName, result, toolCallId]);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -63,7 +63,7 @@ export const ToolResultDisplay: React.FC<ToolResultDisplayProps> = ({ toolName, 
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    }).catch(() => {});
   };
 
   return (

--- a/src/components/ToolUI/index.ts
+++ b/src/components/ToolUI/index.ts
@@ -2,5 +2,6 @@
  * Tool UI components for rendering tool calls in chat.
  */
 
-export { GenericToolUI, TimeToolUI } from './GenericToolUI';
+export { GenericToolUI } from './GenericToolUI';
+export { ToolResultDisplay } from './ToolResultDisplay';
 export { default } from './GenericToolUI';

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -8,6 +8,7 @@ import { cn } from '../../utils/cn';
 import { Stack } from '../primitives';
 import { getToolRegistry } from '../../services/tools/registry';
 import { formatToolDisplayName } from '../../services/tools/nameUtils';
+import { ToolResultDisplay } from '../ToolUI/ToolResultDisplay';
 
 type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call' }>;
 
@@ -103,13 +104,10 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
       <div className="flex flex-col gap-sm max-h-[55vh] overflow-auto pr-[2px]">
         {toolCalls.map((call, index) => {
           const argsId = `args-${index}`;
-          const resultId = `result-${index}`;
           const argsExpanded = expandedSections.has(argsId);
-          const resultExpanded = expandedSections.has(resultId);
 
           const formattedArgs = JSON.stringify(call.args, null, 2);
           const result = 'result' in call ? call.result : null;
-          const formattedResult = result ? JSON.stringify(result, null, 2) : 'No result';
           const durationMs = (call as AugmentedToolCallPart).durationMs;
 
           const StatusIcon = getStatusIcon(call);
@@ -164,33 +162,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 {argsExpanded && <pre className="m-0 p-3 bg-background border border-border rounded-lg font-mono text-[0.9rem] leading-normal text-text overflow-x-auto whitespace-pre max-h-[300px]">{formattedArgs}</pre>}
               </Stack>
 
-              <Stack gap="xs">
-                <div className="flex items-center gap-xs w-full bg-background border border-border rounded-lg py-2 px-3 cursor-pointer transition-[border-color,background] duration-150 hover:border-primary hover:bg-background-tertiary" onClick={() => toggleSection(resultId)} role="button" tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      toggleSection(resultId);
-                    }
-                  }}
-                >
-                  <ChevronRight className={cn('text-text-secondary transition-transform duration-200', resultExpanded && 'rotate-90')} size={14} />
-                  <span className="flex-1 text-left font-semibold text-text">Result</span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="ml-auto text-text-secondary"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      copyToClipboard(formattedResult, resultId);
-                    }}
-                    leftIcon={<Icon icon={copiedId === resultId ? Check : Clipboard} size={14} />}
-                  >
-                    {copiedId === resultId ? 'Copied' : 'Copy'}
-                  </Button>
-                </div>
-                {resultExpanded && <pre className="m-0 p-3 bg-background border border-border rounded-lg font-mono text-[0.9rem] leading-normal text-text overflow-x-auto whitespace-pre max-h-[300px]">{formattedResult}</pre>}
-              </Stack>
+              <ToolResultDisplay toolName={call.toolName} result={result} />
             </div>
           );
         })}

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -162,7 +162,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 {argsExpanded && <pre className="m-0 p-3 bg-background border border-border rounded-lg font-mono text-[0.9rem] leading-normal text-text overflow-x-auto whitespace-pre max-h-[300px]">{formattedArgs}</pre>}
               </Stack>
 
-              <ToolResultDisplay toolName={call.toolName} result={result} />
+              <ToolResultDisplay toolName={call.toolName} result={result} toolCallId={call.toolCallId} />
             </div>
           );
         })}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -6,7 +6,7 @@ import { ConversationListPanel } from '../components/ConversationListPanel';
 import { ChatMessagesPanel } from '../components/ChatMessagesPanel';
 import { ConsoleInfoPanel } from '../components/ConsoleInfoPanel';
 import { ConsoleLogPanel } from '../components/ConsoleLogPanel';
-import { GenericToolUI, TimeToolUI } from '../components/ToolUI';
+import { GenericToolUI } from '../components/ToolUI';
 import { VoiceOverlay } from '../components/VoiceOverlay';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
@@ -440,7 +440,6 @@ export default function ChatPage({
       {/* Chat Tab Content - always mounted, hidden when not active */}
       <AssistantRuntimeProvider runtime={runtime}>
         {/* Tool UI Components - render tool calls in chat messages */}
-        <TimeToolUI />
         <GenericToolUI />
         
         <div

--- a/src/services/tools/builtin/index.ts
+++ b/src/services/tools/builtin/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { getToolRegistry } from '../registry';
+import { timeRenderer } from '../renderers/TimeRenderer';
 
 // Import built-in tools
 import * as time from './time';
@@ -17,7 +18,7 @@ export function registerBuiltinTools(): void {
 
   // Only register if not already registered (idempotent)
   if (!registry.has('get_current_time')) {
-    registry.register(time.definition, time.execute);
+    registry.register(time.definition, time.execute, 'builtin', timeRenderer);
   }
 }
 

--- a/src/services/tools/mcpIntegration.ts
+++ b/src/services/tools/mcpIntegration.ts
@@ -16,6 +16,7 @@ import type { McpTool, McpServerId } from '../clients/mcp';
 import { getToolRegistry, ToolSource } from './registry';
 import type { ToolDefinition, ToolExecutor, ToolResult } from './types';
 import { sanitizeToolName, detectCollisions } from './nameUtils';
+import { mcpGenericRenderer, createMcpSchemaRenderer } from './renderers';
 import { appLogger } from '../platform';
 
 /**
@@ -139,7 +140,11 @@ export function registerMcpTools(serverId: McpServerId, tools: McpTool[]): numbe
         },
       };
 
-      registry.registerWithNameMapping(tool.name, String(serverId), sanitizedName, namespacedDef, executor, source);
+      const renderer = tool.output_schema
+        ? createMcpSchemaRenderer(tool.output_schema)
+        : mcpGenericRenderer;
+
+      registry.registerWithNameMapping(tool.name, String(serverId), sanitizedName, namespacedDef, executor, source, renderer);
       count++;
     } catch (err) {
       // Tool might already exist from another source — log and continue.

--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -7,6 +7,7 @@ import type {
   ToolDefinition,
   ToolExecutor,
   ToolResult,
+  ToolResultRenderer,
   RegisteredTool,
   ParsedToolCall,
 } from './types';
@@ -25,6 +26,7 @@ export type ToolSource =
  */
 interface RegisteredToolWithSource extends RegisteredTool {
   source: ToolSource;
+  renderer?: ToolResultRenderer;
 }
 
 /**
@@ -59,14 +61,15 @@ export class ToolRegistry {
    * @param definition - OpenAI-compatible tool definition
    * @param execute - Function to execute when tool is called
    * @param source - Source identifier for the tool (default: 'builtin')
+   * @param renderer - Optional renderer for displaying results in the chat UI
    * @throws Error if tool with same name already exists
    */
-  register(definition: ToolDefinition, execute: ToolExecutor, source: ToolSource = 'builtin'): void {
+  register(definition: ToolDefinition, execute: ToolExecutor, source: ToolSource = 'builtin', renderer?: ToolResultRenderer): void {
     const name = definition.function.name;
     if (this.tools.has(name)) {
       throw new Error(`Tool "${name}" is already registered`);
     }
-    this.tools.set(name, { definition, execute, source });
+    this.tools.set(name, { definition, execute, source, renderer });
     // Newly registered tools are disabled by default.
     // Intentionally do not mutate enable-state here so that if a tool is
     // re-registered after being enabled (e.g., MCP resync), it stays enabled.
@@ -121,13 +124,15 @@ export class ToolRegistry {
    * @param parameters - JSON Schema for parameters (optional)
    * @param execute - Executor function
    * @param source - Source identifier for the tool (default: 'builtin')
+   * @param renderer - Optional renderer for displaying results in the chat UI
    */
   registerFunction(
     name: string,
     description: string,
     parameters: ToolDefinition['function']['parameters'] | undefined,
     execute: ToolExecutor,
-    source: ToolSource = 'builtin'
+    source: ToolSource = 'builtin',
+    renderer?: ToolResultRenderer
   ): void {
     this.register(
       {
@@ -139,7 +144,8 @@ export class ToolRegistry {
         },
       },
       execute,
-      source
+      source,
+      renderer
     );
   }
 
@@ -205,6 +211,14 @@ export class ToolRegistry {
    */
   getExecutor(name: string): ToolExecutor | undefined {
     return this.tools.get(name)?.execute;
+  }
+
+  /**
+   * Get the registered renderer for a tool, if one was provided.
+   * Returns undefined for tools without a renderer or unknown tool names.
+   */
+  getRenderer(toolName: string): ToolResultRenderer | undefined {
+    return this.tools.get(toolName)?.renderer;
   }
 
   /**

--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -88,6 +88,7 @@ export class ToolRegistry {
    * @param definition   - ToolDefinition whose function.name must equal sanitizedName
    * @param execute      - Executor (must call MCP with originalName, not sanitizedName)
    * @param source       - Tool source (e.g. 'mcp:server-id')
+   * @param renderer     - Optional renderer for displaying results in the chat UI
    */
   registerWithNameMapping(
     originalName: string,
@@ -96,9 +97,10 @@ export class ToolRegistry {
     definition: ToolDefinition,
     execute: ToolExecutor,
     source: ToolSource,
+    renderer?: ToolResultRenderer,
   ): void {
     this._nameMap.set(sanitizedName, { originalName, serverId });
-    this.register(definition, execute, source);
+    this.register(definition, execute, source, renderer);
   }
 
   /**

--- a/src/services/tools/renderers/FallbackRenderer.tsx
+++ b/src/services/tools/renderers/FallbackRenderer.tsx
@@ -6,7 +6,6 @@ const SUMMARY_MAX_LENGTH = 80;
 
 /**
  * Collapsible JSON viewer for arbitrary data.
- * Exported so GenericToolUI can use it for the args section too.
  */
 export const JsonViewer: React.FC<{
   data: unknown;

--- a/src/services/tools/renderers/FallbackRenderer.tsx
+++ b/src/services/tools/renderers/FallbackRenderer.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { ToolResultRenderer } from '../types';
+
+const SUMMARY_MAX_LENGTH = 80;
+
+/**
+ * Collapsible JSON viewer for arbitrary data.
+ * Exported so GenericToolUI can use it for the args section too.
+ */
+export const JsonViewer: React.FC<{
+  data: unknown;
+  label?: string;
+  defaultExpanded?: boolean;
+}> = ({ data, label, defaultExpanded = false }) => {
+  const [expanded, setExpanded] = React.useState(defaultExpanded);
+
+  const formattedJson = React.useMemo(() => {
+    try {
+      return JSON.stringify(data, null, 2);
+    } catch {
+      return String(data);
+    }
+  }, [data]);
+
+  // Primitives and null are shown inline — no collapse needed.
+  const isSimple = typeof data !== 'object' || data === null;
+  if (isSimple) {
+    return (
+      <div className="mb-2 last:mb-0">
+        {label && <span className="font-medium text-text-secondary mr-2">{label}:</span>}
+        <span className="text-text font-mono text-xs">{String(data)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-2 last:mb-0">
+      <button
+        className="flex items-center gap-1.5 bg-transparent border-none py-1 cursor-pointer text-text-secondary text-[13px] text-left w-full hover:text-text"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+      >
+        <span className="text-[10px] w-3 text-center" aria-hidden>
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+        {label && <span className="font-medium text-text-secondary mr-2">{label}</span>}
+        {!expanded && (
+          <span className="font-mono text-[11px] text-text-muted overflow-hidden text-ellipsis whitespace-nowrap flex-1">
+            {formattedJson.length > 50 ? `${formattedJson.substring(0, 50)}...` : formattedJson}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <pre className="bg-background rounded-sm px-3 py-2 mt-1.5 overflow-x-auto font-mono text-xs text-text max-h-[200px] overflow-y-auto">
+          {formattedJson}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+function safeJsonSummary(data: unknown): string {
+  try {
+    const raw = JSON.stringify(data);
+    if (raw === undefined) return '(result)';
+    return raw.length > SUMMARY_MAX_LENGTH ? `${raw.substring(0, SUMMARY_MAX_LENGTH)}…` : raw;
+  } catch {
+    return '(result)';
+  }
+}
+
+/**
+ * Fallback renderer: renders any tool result as pretty-printed JSON.
+ * Used for all tools that don't register a custom renderer.
+ */
+export const fallbackRenderer: ToolResultRenderer = {
+  renderResult(data) {
+    return <JsonViewer data={data} defaultExpanded />;
+  },
+  renderSummary(data) {
+    return safeJsonSummary(data);
+  },
+};

--- a/src/services/tools/renderers/McpGenericRenderer.tsx
+++ b/src/services/tools/renderers/McpGenericRenderer.tsx
@@ -1,0 +1,89 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { SortableTable } from '../../../components/ToolUI/SortableTable';
+import { fallbackRenderer } from './FallbackRenderer';
+import type { ToolResultRenderer } from '../types';
+
+// ---------------------------------------------------------------------------
+// Heuristic helpers
+// ---------------------------------------------------------------------------
+
+const MARKDOWN_PATTERNS = [
+  /^#{1,6} /m,         // ATX headings
+  /\*\*[^*]+\*\*/,     // bold
+  /^- /m,              // unordered list item
+  /`[^`]+`/,           // inline code or fenced block
+  /\[[^\]]+\]\([^)]+\)/, // link
+];
+
+/**
+ * Returns true if the string is likely Markdown prose.
+ * Requires length > 20 AND at least 2 matching Markdown patterns to reduce
+ * false positives on short strings that happen to contain a lone `*` or `#`.
+ */
+export function looksLikeMarkdown(s: string): boolean {
+  if (s.length <= 20) return false;
+  let matches = 0;
+  for (const pattern of MARKDOWN_PATTERNS) {
+    if (pattern.test(s)) {
+      matches++;
+      if (matches >= 2) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if data is a non-empty array where every element is an object
+ * that shares at least one key with the first element.
+ * This identifies homogeneous record arrays suitable for tabular rendering.
+ */
+export function isArrayOfHomogeneousObjects(
+  data: unknown,
+): data is Record<string, unknown>[] {
+  if (!Array.isArray(data) || data.length === 0) return false;
+  const first = data[0];
+  if (typeof first !== 'object' || first === null) return false;
+  const firstKeys = new Set(Object.keys(first as object));
+  if (firstKeys.size === 0) return false;
+  return data.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      Object.keys(item as object).some((k) => firstKeys.has(k)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic renderer for MCP tools that don't declare an output schema.
+ *
+ * Dispatch order:
+ *  1. String that looks like Markdown → ReactMarkdown
+ *  2. Homogeneous array of objects   → SortableTable
+ *  3. Everything else                → fallbackRenderer (pretty-printed JSON)
+ */
+export const mcpGenericRenderer: ToolResultRenderer = {
+  renderResult(data, toolName) {
+    if (typeof data === 'string' && looksLikeMarkdown(data)) {
+      return (
+        <div className="prose-sm text-text text-[13px] leading-relaxed [&_a]:text-primary [&_a]:underline [&_code]:bg-background [&_code]:rounded [&_code]:px-1 [&_pre]:bg-background [&_pre]:rounded [&_pre]:p-2 [&_pre]:overflow-x-auto">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{data}</ReactMarkdown>
+        </div>
+      );
+    }
+
+    if (isArrayOfHomogeneousObjects(data)) {
+      return <SortableTable rows={data} />;
+    }
+
+    return fallbackRenderer.renderResult(data, toolName);
+  },
+
+  renderSummary(data, toolName) {
+    return fallbackRenderer.renderSummary!(data, toolName);
+  },
+};

--- a/src/services/tools/renderers/McpSchemaRenderer.tsx
+++ b/src/services/tools/renderers/McpSchemaRenderer.tsx
@@ -1,0 +1,21 @@
+import { SchemaBasedView } from './SchemaBasedView';
+import { fallbackRenderer } from './FallbackRenderer';
+import type { ToolResultRenderer } from '../types';
+
+/**
+ * Factory: given a tool's output JSON Schema, returns a ToolResultRenderer
+ * that uses SchemaBasedView for structured display.
+ *
+ * Used when an MCP server declares an output_schema for a tool.
+ * Falls back to fallbackRenderer.renderSummary for the summary line.
+ */
+export const createMcpSchemaRenderer = (
+  schema: Record<string, unknown>,
+): ToolResultRenderer => ({
+  renderResult(data) {
+    return <SchemaBasedView data={data} schema={schema} />;
+  },
+  renderSummary(data, toolName) {
+    return fallbackRenderer.renderSummary!(data, toolName);
+  },
+});

--- a/src/services/tools/renderers/SchemaBasedView.tsx
+++ b/src/services/tools/renderers/SchemaBasedView.tsx
@@ -1,3 +1,4 @@
+import type { FC, ReactNode } from 'react';
 import { JsonViewer } from './FallbackRenderer';
 import { SortableTable } from '../../../components/ToolUI/SortableTable';
 import type { JSONSchema, JSONSchemaProperty } from '../types';
@@ -14,7 +15,7 @@ function isSafeUrl(value: unknown): value is string {
   return typeof value === 'string' && /^https?:\/\//i.test(value);
 }
 
-function renderPrimitive(data: unknown, schema: JSONSchemaProperty | JSONSchema): React.ReactNode {
+function renderPrimitive(data: unknown, schema: JSONSchemaProperty | JSONSchema): ReactNode {
   // date-time: try parsing as a date
   if (schema.type === 'string' && 'format' in schema && schema.format === 'date-time') {
     try {
@@ -61,7 +62,7 @@ function renderPrimitive(data: unknown, schema: JSONSchemaProperty | JSONSchema)
  * - Numbers → toLocaleString
  * - Deep nesting (level > MAX_LEVEL) → JsonViewer fallback
  */
-export const SchemaBasedView: React.FC<SchemaBasedViewProps> = ({ data, schema, level = 0 }) => {
+export const SchemaBasedView: FC<SchemaBasedViewProps> = ({ data, schema, level = 0 }) => {
   // Depth guard: avoid runaway recursion on deeply nested schemas
   if (level > MAX_LEVEL) {
     return <JsonViewer data={data} label="Result" />;

--- a/src/services/tools/renderers/SchemaBasedView.tsx
+++ b/src/services/tools/renderers/SchemaBasedView.tsx
@@ -1,0 +1,140 @@
+import { JsonViewer } from './FallbackRenderer';
+import { SortableTable } from '../../../components/ToolUI/SortableTable';
+import type { JSONSchema, JSONSchemaProperty } from '../types';
+
+export interface SchemaBasedViewProps {
+  data: unknown;
+  schema: Record<string, unknown>;
+  level?: number;
+}
+
+const MAX_LEVEL = 2;
+
+function isSafeUrl(value: unknown): value is string {
+  return typeof value === 'string' && /^https?:\/\//i.test(value);
+}
+
+function renderPrimitive(data: unknown, schema: JSONSchemaProperty | JSONSchema): React.ReactNode {
+  // date-time: try parsing as a date
+  if (schema.type === 'string' && 'format' in schema && schema.format === 'date-time') {
+    try {
+      const d = new Date(String(data));
+      if (!isNaN(d.getTime())) {
+        return <span className="text-text font-mono">{d.toLocaleString()}</span>;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  // uri: render as safe link (http/https only)
+  if (schema.type === 'string' && 'format' in schema && schema.format === 'uri') {
+    if (isSafeUrl(data)) {
+      return (
+        <a
+          href={data}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline break-all"
+        >
+          {data}
+        </a>
+      );
+    }
+    return <span className="text-text font-mono">{String(data)}</span>;
+  }
+
+  // number with locale formatting
+  if (schema.type === 'number' && typeof data === 'number') {
+    return <span className="text-text font-mono">{data.toLocaleString()}</span>;
+  }
+
+  return <span className="text-text font-mono text-[12px]">{String(data ?? '')}</span>;
+}
+
+/**
+ * Renders a tool result using its JSON Schema as a guide.
+ * - Objects → two-column key/value table with recursive rendering (max 2 levels)
+ * - Arrays of objects → SortableTable
+ * - Strings with format "uri" → safe clickable link (http/https only)
+ * - Strings with format "date-time" → toLocaleString
+ * - Numbers → toLocaleString
+ * - Deep nesting (level > MAX_LEVEL) → JsonViewer fallback
+ */
+export const SchemaBasedView: React.FC<SchemaBasedViewProps> = ({ data, schema, level = 0 }) => {
+  // Depth guard: avoid runaway recursion on deeply nested schemas
+  if (level > MAX_LEVEL) {
+    return <JsonViewer data={data} label="Result" />;
+  }
+
+  // Arrays
+  if (schema.type === 'array') {
+    if (!Array.isArray(data)) {
+      return <JsonViewer data={data} label="Result" />;
+    }
+
+    // Array of objects → SortableTable; infer column order from schema.items if available
+    const firstItem = data[0];
+    if (data.length > 0 && typeof firstItem === 'object' && firstItem !== null) {
+      const schemaItems = schema.items as JSONSchemaProperty | undefined;
+      const columns =
+        schemaItems?.properties ? Object.keys(schemaItems.properties) : undefined;
+      return <SortableTable rows={data as Record<string, unknown>[]} columns={columns} />;
+    }
+
+    // Array of primitives → simple list
+    return (
+      <ul className="list-none m-0 p-0 flex flex-col gap-0.5">
+        {(data as unknown[]).map((item, i) => (
+          <li key={i} className="font-mono text-[12px] text-text">
+            {String(item ?? '')}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  // Objects
+  if (schema.type === 'object') {
+    const properties = (schema.properties ?? {}) as Record<string, JSONSchemaProperty>;
+    const obj = (typeof data === 'object' && data !== null ? data : {}) as Record<string, unknown>;
+    // Union schema keys with actual data keys so unknown keys still render
+    const keys = Array.from(new Set([...Object.keys(properties), ...Object.keys(obj)]));
+
+    if (keys.length === 0) {
+      return <span className="text-text-muted italic text-[12px]">(empty)</span>;
+    }
+
+    return (
+      <div className="overflow-x-auto rounded-lg border border-border my-1 text-[12px]">
+        <table className="border-collapse w-full">
+          <tbody>
+            {keys.map((key) => {
+              const propSchema = properties[key];
+              const val = obj[key];
+              return (
+                <tr key={key} className="border-b border-border last:border-b-0 hover:bg-background-secondary transition-colors duration-75">
+                  <td className="py-1.5 px-2.5 font-semibold text-text-secondary whitespace-nowrap border-r border-border w-1/3 align-top">
+                    {key}
+                  </td>
+                  <td className="py-1.5 px-2.5 text-text align-top">
+                    {propSchema ? (
+                      <SchemaBasedView data={val} schema={propSchema as unknown as Record<string, unknown>} level={level + 1} />
+                    ) : (
+                      <span className="font-mono text-[12px]">{String(val ?? '')}</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  // Primitives (string, number, boolean, etc.)
+  return renderPrimitive(data, schema as unknown as JSONSchemaProperty);
+};
+
+export default SchemaBasedView;

--- a/src/services/tools/renderers/TimeRenderer.tsx
+++ b/src/services/tools/renderers/TimeRenderer.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { ToolResultRenderer } from '../types';
+import { fallbackRenderer } from './FallbackRenderer';
+
+interface TimeResult {
+  time: string | number;
+  timezone: string;
+  format: string;
+}
+
+function isTimeResult(data: unknown): data is TimeResult {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'time' in data &&
+    !('error' in data)
+  );
+}
+
+/**
+ * Renderer for the get_current_time built-in tool.
+ * Displays a centered time value with timezone and format metadata.
+ * Delegates to fallbackRenderer for any unexpected result shape.
+ */
+export const timeRenderer: ToolResultRenderer = {
+  renderResult(data, toolName) {
+    if (!isTimeResult(data)) {
+      return fallbackRenderer.renderResult(data, toolName);
+    }
+
+    return (
+      <div className="text-center py-3">
+        <div className="text-lg font-semibold text-text mb-2 font-mono">
+          {typeof data.time === 'number' ? data.time.toString() : data.time}
+        </div>
+        <div className="flex justify-center gap-4 text-[11px] text-text-muted">
+          <span>Timezone: {data.timezone}</span>
+          <span>Format: {data.format}</span>
+        </div>
+      </div>
+    );
+  },
+
+  renderSummary(data) {
+    try {
+      const time = (data as Record<string, unknown>)?.time;
+      return time !== undefined ? String(time) : '(unknown)';
+    } catch {
+      return '(unknown)';
+    }
+  },
+};

--- a/src/services/tools/renderers/TimeRenderer.tsx
+++ b/src/services/tools/renderers/TimeRenderer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ToolResultRenderer } from '../types';
 import { fallbackRenderer } from './FallbackRenderer';
 

--- a/src/services/tools/renderers/index.ts
+++ b/src/services/tools/renderers/index.ts
@@ -1,2 +1,5 @@
 export { fallbackRenderer, JsonViewer } from './FallbackRenderer';
 export { timeRenderer } from './TimeRenderer';
+export { mcpGenericRenderer, looksLikeMarkdown, isArrayOfHomogeneousObjects } from './McpGenericRenderer';
+export { createMcpSchemaRenderer } from './McpSchemaRenderer';
+export { SchemaBasedView } from './SchemaBasedView';

--- a/src/services/tools/renderers/index.ts
+++ b/src/services/tools/renderers/index.ts
@@ -1,0 +1,2 @@
+export { fallbackRenderer, JsonViewer } from './FallbackRenderer';
+export { timeRenderer } from './TimeRenderer';

--- a/src/services/tools/types.ts
+++ b/src/services/tools/types.ts
@@ -3,6 +3,8 @@
  * These types match the Rust proxy/models.rs types for OpenAI API compatibility.
  */
 
+import type { ReactNode } from 'react';
+
 // =============================================================================
 // Tool Definition Types (for declaring tools)
 // =============================================================================
@@ -74,6 +76,17 @@ export type ToolExecutor = (
 ) => Promise<ToolResult> | ToolResult;
 
 /**
+ * Interface for rendering a tool result in the chat UI.
+ * Implementors are plain objects, not React components.
+ */
+export interface ToolResultRenderer {
+  /** Render the full result as a React node for display in the chat. */
+  renderResult(data: unknown, toolName: string): ReactNode;
+  /** Render a compact plain-text summary (used in collapsed headers). Must not throw. */
+  renderSummary?(data: unknown, toolName: string): string;
+}
+
+/**
  * A registered tool with its definition and executor.
  */
 export interface RegisteredTool {
@@ -81,6 +94,8 @@ export interface RegisteredTool {
   definition: ToolDefinition;
   /** Function to execute when the tool is called */
   execute: ToolExecutor;
+  /** Optional renderer for displaying results in the chat UI */
+  renderer?: ToolResultRenderer;
 }
 
 // =============================================================================

--- a/src/services/transport/types/mcp.ts
+++ b/src/services/transport/types/mcp.ts
@@ -92,6 +92,9 @@ export interface McpTool {
   name: string;
   description?: string;
   input_schema?: Record<string, unknown>;
+  /** Optional JSON Schema describing the tool's output. Present only when the
+   * MCP server declares it. Used to auto-generate a structured result renderer. */
+  output_schema?: Record<string, unknown>;
 }
 
 /**

--- a/tests/ts/services/tools/mcpIntegration.test.ts
+++ b/tests/ts/services/tools/mcpIntegration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerMcpTools, unregisterMcpTools, getMcpSource } from '../../../../src/services/tools/mcpIntegration';
 import { resetToolRegistry, getToolRegistry } from '../../../../src/services/tools/registry';
+import { mcpGenericRenderer } from '../../../../src/services/tools/renderers';
 import type { McpTool } from '../../../../src/services/clients/mcp';
 
 // =============================================================================
@@ -168,6 +169,26 @@ describe('registerMcpTools', () => {
       'get data!',  // raw name, not 'mcp_my_server_get_data'
       {},
     );
+  });
+
+  // ── Renderer assignment ────────────────────────────────────────────────────
+
+  it('assigns mcpGenericRenderer to tools without an output_schema', () => {
+    registerMcpTools('srv1', [makeTool('get_weather')]);
+    const registry = getToolRegistry();
+    expect(registry.getRenderer('mcp_srv1_get_weather')).toBe(mcpGenericRenderer);
+  });
+
+  it('assigns a schema renderer (not mcpGenericRenderer) to tools with an output_schema', () => {
+    const toolWithSchema: McpTool = {
+      ...makeTool('search_results'),
+      output_schema: { type: 'object', properties: { items: { type: 'array' } } },
+    };
+    registerMcpTools('srv1', [toolWithSchema]);
+    const registry = getToolRegistry();
+    const renderer = registry.getRenderer('mcp_srv1_search_results');
+    expect(renderer).toBeDefined();
+    expect(renderer).not.toBe(mcpGenericRenderer);
   });
 });
 

--- a/tests/ts/services/tools/mcpRenderers.test.ts
+++ b/tests/ts/services/tools/mcpRenderers.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  looksLikeMarkdown,
+  isArrayOfHomogeneousObjects,
+  mcpGenericRenderer,
+} from '../../../../src/services/tools/renderers/McpGenericRenderer';
+import { createMcpSchemaRenderer } from '../../../../src/services/tools/renderers/McpSchemaRenderer';
+
+// =============================================================================
+// looksLikeMarkdown
+// =============================================================================
+
+describe('looksLikeMarkdown', () => {
+  it('returns false for an empty string', () => {
+    expect(looksLikeMarkdown('')).toBe(false);
+  });
+
+  it('returns false for a string ≤ 20 characters even with markdown syntax', () => {
+    // "# Short" has a heading but is only 7 chars
+    expect(looksLikeMarkdown('# Short')).toBe(false);
+    // "**bold** text here!!" is exactly 20 chars
+    expect(looksLikeMarkdown('**bold** text here!!')).toBe(false);
+  });
+
+  it('returns false for a long plain-text string with no markdown patterns', () => {
+    const plain = 'This is a completely plain sentence with no formatting at all, just words.';
+    expect(looksLikeMarkdown(plain)).toBe(false);
+  });
+
+  it('returns false for a long string matching only one markdown pattern', () => {
+    // Only bold — not enough on its own
+    const onlyBold = 'This sentence is quite long and contains only **one** bold marker without anything else.';
+    expect(looksLikeMarkdown(onlyBold)).toBe(false);
+  });
+
+  it('returns true for a long string with a heading and bold text (2 patterns)', () => {
+    const md = '# Chapter 1\n\nThis is a **bold** introductory paragraph about the topic.';
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+
+  it('returns true for a long string with a list and inline code (2 patterns)', () => {
+    const md = 'Install the dependencies:\n\n- Run `npm install`\n- Then start the server\n';
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+
+  it('returns true for a long string with bold text and a markdown link (2 patterns)', () => {
+    const md = 'Check out **this project** and read [the docs](https://example.com) for more details.';
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+
+  it('returns true for a realistic multi-section markdown document', () => {
+    const md = [
+      '## Results',
+      '',
+      '**Status**: Complete',
+      '',
+      '- Item one',
+      '- Item two',
+      '',
+      'See `README.md` for more.',
+    ].join('\n');
+    expect(looksLikeMarkdown(md)).toBe(true);
+  });
+});
+
+// =============================================================================
+// isArrayOfHomogeneousObjects
+// =============================================================================
+
+describe('isArrayOfHomogeneousObjects', () => {
+  it('returns false for an empty array', () => {
+    expect(isArrayOfHomogeneousObjects([])).toBe(false);
+  });
+
+  it('returns false for an array of primitive numbers', () => {
+    expect(isArrayOfHomogeneousObjects([1, 2, 3])).toBe(false);
+  });
+
+  it('returns false for an array of strings', () => {
+    expect(isArrayOfHomogeneousObjects(['a', 'b', 'c'])).toBe(false);
+  });
+
+  it('returns false for a non-array value', () => {
+    expect(isArrayOfHomogeneousObjects(null)).toBe(false);
+    expect(isArrayOfHomogeneousObjects(undefined)).toBe(false);
+    expect(isArrayOfHomogeneousObjects({ a: 1 })).toBe(false);
+    expect(isArrayOfHomogeneousObjects('text')).toBe(false);
+  });
+
+  it('returns false for an array of objects with no shared keys', () => {
+    expect(isArrayOfHomogeneousObjects([{ a: 1 }, { b: 2 }])).toBe(false);
+  });
+
+  it('returns false for a mixed array containing null alongside an object', () => {
+    expect(isArrayOfHomogeneousObjects([{ a: 1 }, null])).toBe(false);
+  });
+
+  it('returns false for an array of empty objects (no keys to share)', () => {
+    expect(isArrayOfHomogeneousObjects([{}, {}])).toBe(false);
+  });
+
+  it('returns true for an array of objects sharing at least one key', () => {
+    // id is shared; age is absent in first object — still true
+    expect(
+      isArrayOfHomogeneousObjects([
+        { id: 1, name: 'Alice' },
+        { id: 2, age: 30 },
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns true when all objects share the same complete key set', () => {
+    expect(
+      isArrayOfHomogeneousObjects([
+        { id: 1, value: 'x' },
+        { id: 2, value: 'y' },
+        { id: 3, value: 'z' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns true for a single-element array containing an object with keys', () => {
+    expect(isArrayOfHomogeneousObjects([{ id: 1 }])).toBe(true);
+  });
+});
+
+// =============================================================================
+// mcpGenericRenderer.renderSummary
+// =============================================================================
+
+describe('mcpGenericRenderer.renderSummary', () => {
+  it('delegates to the fallback renderer and returns a string for an object', () => {
+    const result = mcpGenericRenderer.renderSummary!({ key: 'value' }, 'my_tool');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns a string for null data without throwing', () => {
+    expect(() => {
+      const result = mcpGenericRenderer.renderSummary!(null, 'my_tool');
+      expect(typeof result).toBe('string');
+    }).not.toThrow();
+  });
+
+  it('returns a string for a circular reference without throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => {
+      const result = mcpGenericRenderer.renderSummary!(circular, 'my_tool');
+      expect(typeof result).toBe('string');
+    }).not.toThrow();
+  });
+
+  it('returns a string for a primitive number', () => {
+    const result = mcpGenericRenderer.renderSummary!(42, 'my_tool');
+    expect(typeof result).toBe('string');
+    expect(result).toBe('42');
+  });
+
+  it('returns a string for an array result', () => {
+    const result = mcpGenericRenderer.renderSummary!([1, 2, 3], 'my_tool');
+    expect(typeof result).toBe('string');
+  });
+});
+
+// =============================================================================
+// createMcpSchemaRenderer
+// =============================================================================
+
+describe('createMcpSchemaRenderer', () => {
+  it('returns an object with renderResult and renderSummary functions', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object' });
+    expect(typeof renderer.renderResult).toBe('function');
+    expect(typeof renderer.renderSummary).toBe('function');
+  });
+
+  it('returns a new renderer instance each call (factory pattern)', () => {
+    const schema = { type: 'object', properties: {} };
+    const r1 = createMcpSchemaRenderer(schema);
+    const r2 = createMcpSchemaRenderer(schema);
+    expect(r1).not.toBe(r2);
+  });
+
+  it('renderSummary delegates to fallbackRenderer and returns a string', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object' });
+    const result = renderer.renderSummary!({ status: 'ok', count: 5 }, 'schema_tool');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('renderSummary returns a string for null data without throwing', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object' });
+    expect(() => {
+      const result = renderer.renderSummary!(null, 'schema_tool');
+      expect(typeof result).toBe('string');
+    }).not.toThrow();
+  });
+
+  it('renderResult returns a defined React element', () => {
+    const renderer = createMcpSchemaRenderer({ type: 'object', properties: {} });
+    const result = renderer.renderResult({ key: 'value' }, 'schema_tool');
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+});

--- a/tests/ts/services/tools/renderers.test.ts
+++ b/tests/ts/services/tools/renderers.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { fallbackRenderer } from '../../../../src/services/tools/renderers/FallbackRenderer';
+import { timeRenderer } from '../../../../src/services/tools/renderers/TimeRenderer';
+import { ToolRegistry } from '../../../../src/services/tools/registry';
+import type { ToolResultRenderer } from '../../../../src/services/tools/types';
+
+// ---------------------------------------------------------------------------
+// fallbackRenderer
+// ---------------------------------------------------------------------------
+
+describe('fallbackRenderer.renderSummary', () => {
+  it('returns a string for a primitive string value', () => {
+    const result = fallbackRenderer.renderSummary!('hello', 'tool');
+    expect(typeof result).toBe('string');
+    expect(result).toBe('"hello"');
+  });
+
+  it('returns a string for a number', () => {
+    const result = fallbackRenderer.renderSummary!(42, 'tool');
+    expect(result).toBe('42');
+  });
+
+  it('returns a JSON string for a plain object', () => {
+    const result = fallbackRenderer.renderSummary!({ key: 'value' }, 'tool');
+    expect(typeof result).toBe('string');
+    expect(result).toContain('key');
+  });
+
+  it('returns a JSON string for an array', () => {
+    const result = fallbackRenderer.renderSummary!([1, 2, 3], 'tool');
+    expect(typeof result).toBe('string');
+    expect(result).toContain('1');
+  });
+
+  it('returns a string for null', () => {
+    const result = fallbackRenderer.renderSummary!(null, 'tool');
+    expect(result).toBe('null');
+  });
+
+  it('returns a safe fallback string for circular references without throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    // JSON.stringify throws on circular references; renderSummary must not.
+    expect(() => {
+      const result = fallbackRenderer.renderSummary!(circular, 'tool');
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    }).not.toThrow();
+
+    const result = fallbackRenderer.renderSummary!(circular, 'tool');
+    expect(result).toBe('(result)');
+  });
+
+  it('truncates very long JSON to at most 80 characters plus an ellipsis', () => {
+    const big = { data: 'x'.repeat(200) };
+    const result = fallbackRenderer.renderSummary!(big, 'tool');
+    // The raw JSON is far longer than 80 chars; summary must be truncated.
+    expect(result.length).toBeLessThanOrEqual(81); // 80 chars + 1 ellipsis char
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timeRenderer
+// ---------------------------------------------------------------------------
+
+describe('timeRenderer.renderSummary', () => {
+  it('returns the time string for a valid time result shape', () => {
+    const data = { time: 'Sunday, 10:00 AM', timezone: 'UTC', format: 'human' };
+    const result = timeRenderer.renderSummary!(data, 'get_current_time');
+    expect(result).toBe('Sunday, 10:00 AM');
+  });
+
+  it('returns a string representation of a UNIX timestamp', () => {
+    const data = { time: 1672531200, timezone: 'UTC', format: 'unix' };
+    const result = timeRenderer.renderSummary!(data, 'get_current_time');
+    expect(result).toBe('1672531200');
+  });
+
+  it('returns "(unknown)" for an empty object without throwing', () => {
+    expect(() => {
+      const result = timeRenderer.renderSummary!({}, 'get_current_time');
+      expect(result).toBe('(unknown)');
+    }).not.toThrow();
+  });
+
+  it('returns "(unknown)" for null without throwing', () => {
+    expect(() => {
+      const result = timeRenderer.renderSummary!(null, 'get_current_time');
+      expect(result).toBe('(unknown)');
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ToolRegistry.getRenderer
+// ---------------------------------------------------------------------------
+
+describe('ToolRegistry.getRenderer', () => {
+  const mockRenderer: ToolResultRenderer = {
+    renderResult: (data) => String(data),
+    renderSummary: (data) => String(data),
+  };
+
+  it('returns the registered renderer for a tool registered with one', () => {
+    const registry = new ToolRegistry();
+    registry.registerFunction(
+      'dummy',
+      'A dummy tool',
+      undefined,
+      () => ({ success: true, data: 'ok' }),
+      'builtin',
+      mockRenderer,
+    );
+    expect(registry.getRenderer('dummy')).toBe(mockRenderer);
+  });
+
+  it('returns undefined for a tool registered without a renderer', () => {
+    const registry = new ToolRegistry();
+    registry.registerFunction(
+      'no_renderer',
+      'A tool without a renderer',
+      undefined,
+      () => ({ success: true, data: 'ok' }),
+    );
+    expect(registry.getRenderer('no_renderer')).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown tool name', () => {
+    const registry = new ToolRegistry();
+    expect(registry.getRenderer('unknown_tool')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #250.

## Summary

Tool call results in the chat UI were displayed as raw collapsed JSON. This epic replaces that with a rendering pipeline that automatically picks the best visual representation — from structured schema-driven layouts to heuristic Markdown/table detection — with a safe JSON fallback for everything else.

---

## What changed — 3 phases, 14 commits

### Phase 1 — Extension point ([#322](https://github.com/mmogr/gglib/pull/322))
Established the architecture: a `ToolResultRenderer` interface that any tool can register with, exposed as `getRenderer()` on the registry singleton.

- `ToolResultRenderer` interface (`renderResult`, optional `renderSummary`) in `src/services/tools/types.ts`
- `RegisteredTool` gains an optional `renderer` field
- `register()` / `registerFunction()` / `registerWithNameMapping()` each accept an optional `renderer` argument
- `getRenderer(toolName)` exposed on the registry

### Phase 2 — Chat UI integration ([#323](https://github.com/mmogr/gglib/pull/323))
Wired the renderer into the chat UI and shipped the first built-in renderers.

| New file | Purpose |
|---|---|
| `src/services/tools/renderers/FallbackRenderer.tsx` | Collapsible JSON viewer with truncated summary; circular-ref-safe |
| `src/services/tools/renderers/TimeRenderer.tsx` | Inline human-readable time for `get_current_time` |
| `src/components/ToolUI/ToolResultDisplay.tsx` | Renderer-dispatching collapsible card — `useMemo` for body + summary |
| `src/services/tools/renderers/index.ts` | Barrel exports |

- `get_current_time` registers `timeRenderer` at startup
- `GenericToolUI` and `ToolDetailsModal` now render via `ToolResultDisplay`
- `TimeToolUI` deleted (replaced by the renderer pipeline)
- 14 unit tests

### Phase 3 — MCP renderers ([#324](https://github.com/mmogr/gglib/pull/324))
Added schema-driven and heuristic renderers for all MCP tools; no per-tool configuration required.

| New file | Purpose |
|---|---|
| `src/components/ToolUI/SortableTable.tsx` | Click-to-sort data table; URL→link, 200-row cap, lucide sort icons |
| `src/services/tools/renderers/SchemaBasedView.tsx` | JSON Schema → structured React layout (max 2 levels; fallback to JsonViewer) |
| `src/services/tools/renderers/McpSchemaRenderer.tsx` | Factory: `output_schema` → `ToolResultRenderer` using `SchemaBasedView` |
| `src/services/tools/renderers/McpGenericRenderer.tsx` | Heuristic: Markdown string → `ReactMarkdown`; homogeneous array → `SortableTable`; else fallback |

- `McpTool` gains forward-compatible `output_schema?: Record<string, unknown>`
- MCP registration loop: tools with `output_schema` → schema renderer; others → `mcpGenericRenderer`
- `ToolResultDisplay` gains `toolCallId?` prop; `useMemo` uses it as a dependency to skip identity-change re-renders
- 28 new unit tests (`mcpRenderers.test.ts` + 2 integration assertions)

---

## Acceptance criteria coverage

| Criterion | Status |
|---|---|
| `RegisteredTool` supports optional `resultRenderer` field | ✅ Phase 1 |
| Default renderer auto-detects common result patterns | ✅ Phase 3 (`McpGenericRenderer`) |
| Large results are collapsible with a visible summary | ✅ Phase 2 (`FallbackRenderer`, `ToolResultDisplay`) |
| Error results display distinctly | ✅ `FallbackRenderer` (`isError` styling in `GenericToolUI`) |
| Built-in tools can register custom renderers | ✅ Phase 2 (`timeRenderer`) |
| MCP tools use default renderer + schema-driven rendering | ✅ Phase 3 |
| Renderer output supports markdown formatting | ✅ Phase 3 (`McpGenericRenderer` via `ReactMarkdown`) |
| No regression — tools without renderers fall back to JSON | ✅ `FallbackRenderer` |

---

## Test summary

| File | Tests |
|---|---|
| `tests/ts/services/tools/renderers.test.ts` | 14 |
| `tests/ts/services/tools/mcpRenderers.test.ts` | 28 |
| `tests/ts/services/tools/mcpIntegration.test.ts` | +2 renderer assertions |
| **Total new** | **44+** |

All 107 TypeScript tests pass. Zero `tsc --noEmit` errors.