### PR TITLE
chore: add Run Frontend Tests task to VS Code Full CI Pipeline

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -64,6 +64,23 @@
 			}
 		},
 		{
+			"label": "🧪 Run Frontend Tests",
+			"type": "shell",
+			"command": "npm",
+			"args": [
+				"run",
+				"test:run"
+			],
+			"group": "test",
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": false,
+				"clear": true
+			}
+		},
+		{
 			"label": "🧪 Run Tests (Lib Only)",
 			"type": "shell",
 			"command": "cargo",
@@ -387,8 +404,7 @@
 				"🔍 Check Formatting",
 				"� Check Boundaries",
 				"�📎 Clippy (Strict)",
-				"🧪 Run All Tests",
-				"🚀 Build (Release)"
+				"🧪 Run All Tests",				"🧪 Run Frontend Tests",				"🚀 Build (Release)"
 			],
 			"dependsOrder": "sequence",
 			"group": "none",


### PR DESCRIPTION
## Summary

Adds a `🧪 Run Frontend Tests` VS Code task and wires it into the `🚢 Full CI Pipeline` task, so running the local CI pipeline now also runs the TypeScript/Vitest test suite alongside the Rust tests.

## Changes

- New task `🧪 Run Frontend Tests` — runs `npm run test:run`
- `🚢 Full CI Pipeline` `dependsOn` updated to include the new task

## Related

- Follow-on to #330 (split frontend tests into their own GitHub Actions job)