### PR TITLE
fix: restore tool-call graphics after chat reload

### DIFF
--- a/src/components/ChatMessagesPanel/hooks/useChatPersistence.ts
+++ b/src/components/ChatMessagesPanel/hooks/useChatPersistence.ts
@@ -3,8 +3,7 @@ import type { ThreadRuntime, ThreadMessageLike } from '@assistant-ui/react';
 import { appLogger } from '../../../services/platform';
 import { getMessages, deleteMessage } from '../../../services/clients/chat';
 import type { ConversationSummary } from '../../../services/clients/chat';
-import { reconstructContent } from '../../../utils/messages';
-import type { SerializableContentPart } from '../../../utils/messages';
+import { buildLoadedMessage } from '../../../hooks/useChatPersistence/buildLoadedMessage';
 
 /**
  * Options for the useChatPersistence hook.
@@ -90,38 +89,9 @@ export function useChatPersistence({
 
         const initialMessages: ThreadMessageLike[] = [
           ...systemPromptMessage,
-          ...messages.map<ThreadMessageLike>((message) => {
-            // Restore metadata including research state for deep research messages
-            const metadata = message.metadata;
-            const isDeepResearch = metadata?.isDeepResearch === true;
-
-            // Reconstruct structured content from metadata if available
-            const storedParts = metadata?.contentParts as SerializableContentPart[] | undefined;
-            const content = reconstructContent(message.content, storedParts);
-            
-            return {
-              id: `db-${message.id}`,
-              role: message.role,
-              content,
-              createdAt: new Date(message.created_at),
-              // Include metadata with dbId for future updates and research state for rendering
-              metadata: isDeepResearch
-                ? {
-                    custom: {
-                      dbId: message.id,
-                      conversationId: message.conversation_id,
-                      isDeepResearch: true,
-                      researchState: metadata.researchState,
-                    },
-                  }
-                : {
-                    custom: {
-                      dbId: message.id,
-                      conversationId: message.conversation_id,
-                    },
-                  },
-            };
-          }),
+          ...messages.map<ThreadMessageLike>((message) =>
+            buildLoadedMessage(message, activeConversationId)
+          ),
         ];
 
         // Build position -> DB ID mapping for edit detection and delete counting
@@ -296,15 +266,9 @@ export function useMessageDelete({
 
       const reloadedMessages: ThreadMessageLike[] = [
         ...systemPromptMessage,
-        ...messages.map<ThreadMessageLike>((message) => {
-          const storedParts = message.metadata?.contentParts as SerializableContentPart[] | undefined;
-          return {
-            id: `db-${message.id}`,
-            role: message.role,
-            content: reconstructContent(message.content, storedParts),
-            createdAt: new Date(message.created_at),
-          };
-        }),
+        ...messages.map<ThreadMessageLike>((message) =>
+          buildLoadedMessage(message, activeConversationId)
+        ),
       ];
 
       // Rebuild position mapping

--- a/src/hooks/useChatPersistence/buildLoadedMessage.ts
+++ b/src/hooks/useChatPersistence/buildLoadedMessage.ts
@@ -1,0 +1,36 @@
+import type { ThreadMessageLike } from '@assistant-ui/react';
+import { reconstructContent } from '../../utils/messages';
+import type { SerializableContentPart } from '../../utils/messages';
+import type { ChatMessage } from '../../services/clients/chat';
+
+/**
+ * Convert a raw DB message into a ThreadMessageLike ready for the runtime.
+ *
+ * Restores structured content parts (tool-call, audio, file, image) stored in
+ * `metadata.contentParts` so they survive the DB round-trip. When no parts are
+ * stored the plain-text `content` column is used as-is (backward compat).
+ */
+export function buildLoadedMessage(
+  msg: ChatMessage,
+  conversationId: number,
+): ThreadMessageLike {
+  const storedParts = msg.metadata?.contentParts as SerializableContentPart[] | undefined;
+  const isDeepResearch = msg.metadata?.isDeepResearch === true;
+
+  const custom = isDeepResearch
+    ? {
+        dbId: msg.id,
+        conversationId,
+        isDeepResearch: true,
+        researchState: msg.metadata?.researchState,
+      }
+    : { dbId: msg.id, conversationId };
+
+  return {
+    id: `db-${msg.id}`,
+    role: msg.role as 'user' | 'assistant',
+    content: reconstructContent(msg.content, storedParts ?? null),
+    createdAt: new Date(msg.created_at),
+    metadata: { custom },
+  };
+}

--- a/src/hooks/useChatPersistence/buildSaveMetadata.ts
+++ b/src/hooks/useChatPersistence/buildSaveMetadata.ts
@@ -1,0 +1,18 @@
+import type { ThreadMessage, ThreadMessageLike } from '@assistant-ui/react';
+import { extractNonTextContentParts } from '../../utils/messages';
+import type { ChatMessageMetadata } from '../../services/clients/chat';
+
+/**
+ * Build the metadata payload for a DB save or update call.
+ *
+ * Extracts non-text content parts (tool-call, audio, file, image) from a
+ * runtime message and packages them as `metadata.contentParts` so they can
+ * be restored by buildLoadedMessage on next hydration.
+ *
+ * Returns null when the message contains no structured parts, keeping the
+ * metadata column null for plain text messages.
+ */
+export function buildSaveMetadata(m: ThreadMessageLike): ChatMessageMetadata | null {
+  const parts = extractNonTextContentParts(m as unknown as ThreadMessage);
+  return parts.length > 0 ? { contentParts: parts } : null;
+}

--- a/src/hooks/useChatPersistence/index.ts
+++ b/src/hooks/useChatPersistence/index.ts
@@ -1,73 +1,47 @@
 /**
  * Chat message persistence hook for ExternalStoreRuntime.
- * 
+ *
  * Handles hydration and persistence of messages to/from the database.
  * Works with external message state (not threadRuntime internals).
- * 
+ *
  * @module useChatPersistence
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { appLogger } from '../services/platform';
+import { appLogger } from '../../services/platform';
 import type { ThreadMessageLike } from '@assistant-ui/react';
-import { getMessages, saveMessage, updateMessage, deleteMessage } from '../services/clients/chat';
-import type { ChatMessage } from '../services/clients/chat';
-import { threadMessageToTranscriptMarkdown } from '../utils/messages';
-import type { ReasoningTimingTracker } from './useGglibRuntime/reasoningTiming';
+import { getMessages, saveMessage, updateMessage, deleteMessage } from '../../services/clients/chat';
+import type { ChatMessage } from '../../services/clients/chat';
+import { threadMessageToTranscriptMarkdown } from '../../utils/messages';
+import type { ReasoningTimingTracker } from '../useGglibRuntime/reasoningTiming';
+import { buildLoadedMessage } from './buildLoadedMessage';
+import { buildSaveMetadata } from './buildSaveMetadata';
 
-/**
- * Extract database ID from message metadata.
- */
 function getDbId(m: ThreadMessageLike): number | undefined {
   return (m.metadata as any)?.custom?.dbId;
 }
 
-/**
- * Create a stable digest for detecting message content changes.
- * Includes timingFinalized flag to trigger final persist after streaming.
- */
 function digestMessage(m: ThreadMessageLike): string {
   const timingFinalized = (m.metadata as any)?.custom?.timingFinalized;
   return JSON.stringify({ role: m.role, content: m.content, timingFinalized });
 }
 
-
-
 export interface UseChatPersistenceOptions {
-  /** Active conversation ID */
   activeConversationId: number | null;
-  /** System prompt for the active conversation */
   systemPrompt?: string | null;
-  /** Created timestamp for system message */
   conversationCreatedAt?: string;
-  /** Current messages array */
   messages: readonly ThreadMessageLike[];
-  /** Setter for messages array */
   setMessages: React.Dispatch<React.SetStateAction<ThreadMessageLike[]>>;
-  /** Callback to sync conversations list (silent refresh after saves) */
   syncConversations: (options?: { preferredId?: number | null; silent?: boolean }) => Promise<void>;
-  /** Error callback */
   setChatError: (error: string | null) => void;
-  /** Optional timing tracker for reasoning duration injection */
   timingTracker?: ReasoningTimingTracker;
 }
 
 export interface UseChatPersistenceResult {
-  /** Whether messages are currently being loaded from DB */
   isLoading: boolean;
-  /** Whether a persist operation is in progress */
   isPersisting: boolean;
 }
 
-/**
- * Hook that handles message persistence to/from the database.
- * 
- * Responsibilities:
- * - Hydrates messages from DB when conversation changes
- * - Persists new messages as they're created
- * - Updates existing messages when content changes (throttled)
- * - Tracks message IDs to prevent duplicate saves
- */
 export function useChatPersistence({
   activeConversationId,
   systemPrompt,
@@ -78,22 +52,11 @@ export function useChatPersistence({
   setChatError,
   timingTracker,
 }: UseChatPersistenceOptions): UseChatPersistenceResult {
-  // Track which message IDs have been persisted (runtime ID -> DB ID)
   const persistedByMessageId = useRef(new Map<string, number>());
-  
-  // Track last saved digest for each message (for update detection)
   const lastDigestByMessageId = useRef(new Map<string, string>());
-  
-  // Throttle timers for updates (per message ID)
   const updateTimers = useRef(new Map<string, number>());
-  
-  // Cleanup timers for delayed tracker clearing (per message ID)
   const cleanupTimers = useRef(new Map<string, number>());
-  
-  // Track messages currently being processed (prevents concurrent operations)
   const processingRef = useRef(new Set<string>());
-  
-  // Loading and persisting state
   const [isLoading, setIsLoading] = useState(false);
   const isPersistingRef = useRef(false);
 
@@ -105,7 +68,6 @@ export function useChatPersistence({
     updateTimers.current.clear();
     cleanupTimers.current.forEach((t) => window.clearTimeout(t));
     cleanupTimers.current.clear();
-    updateTimers.current.clear();
   }, [activeConversationId]);
 
   // Effect 1: Hydrate messages from DB when conversation changes
@@ -124,7 +86,6 @@ export function useChatPersistence({
         const dbMessages = await getMessages(activeConversationId);
         if (cancelled) return;
 
-        // Build system prompt message if exists
         const prompt = systemPrompt?.trim();
         const systemMessage: ThreadMessageLike[] = prompt
           ? [{
@@ -135,34 +96,21 @@ export function useChatPersistence({
             }]
           : [];
 
-        // Convert DB messages to ThreadMessageLike format
         const loadedMessages: ThreadMessageLike[] = [
           ...systemMessage,
-          ...dbMessages.map<ThreadMessageLike>((msg) => ({
-            id: `db-${msg.id}`,
-            role: msg.role as 'user' | 'assistant',
-            content: msg.content,
-            createdAt: new Date(msg.created_at),
-            metadata: {
-              custom: {
-                dbId: msg.id,
-                conversationId: activeConversationId,
-              },
-            },
-          })),
+          ...dbMessages.map<ThreadMessageLike>((msg) =>
+            buildLoadedMessage(msg, activeConversationId)
+          ),
         ];
 
-        // Track all loaded messages as persisted
+        // Seed caches so loaded messages don't trigger spurious saves
         dbMessages.forEach((msg) => {
           const runtimeId = `db-${msg.id}`;
+          const loaded = loadedMessages.find((m) => m.id === runtimeId)!;
           persistedByMessageId.current.set(runtimeId, msg.id);
-          lastDigestByMessageId.current.set(
-            runtimeId,
-            JSON.stringify({ role: msg.role, content: msg.content })
-          );
+          lastDigestByMessageId.current.set(runtimeId, digestMessage(loaded));
         });
 
-        // Set messages
         setMessages(loadedMessages);
       } catch (error) {
         if (!cancelled) {
@@ -190,20 +138,15 @@ export function useChatPersistence({
     const conversationId = activeConversationId;
     if (!conversationId) return;
 
-    // --- Detect and delete truncated messages ---
-    // When onEdit truncates the in-memory array, old messages remain in the DB.
-    // Compare current message IDs against persistedByMessageId to find orphans,
-    // then cascade-delete the first one (backend removes it and all subsequent).
-    const currentIds = new Set(messages.map(m => m.id));
+    // Detect and cascade-delete messages that were truncated by an edit
+    const currentIds = new Set(messages.map((m) => m.id));
     let firstOrphanDbId: number | null = null;
 
     for (const [runtimeId, dbId] of persistedByMessageId.current.entries()) {
       if (!currentIds.has(runtimeId)) {
-        // This persisted message is no longer in the current array
         if (firstOrphanDbId === null || dbId < firstOrphanDbId) {
           firstOrphanDbId = dbId;
         }
-        // Clean up tracking state for the removed message
         persistedByMessageId.current.delete(runtimeId);
         lastDigestByMessageId.current.delete(runtimeId);
         const timer = updateTimers.current.get(runtimeId);
@@ -220,8 +163,6 @@ export function useChatPersistence({
     }
 
     if (firstOrphanDbId !== null) {
-      // Cascade delete: backend removes this message and all with higher IDs
-      // in the same conversation
       const dbIdToDelete = firstOrphanDbId;
       (async () => {
         try {
@@ -236,38 +177,29 @@ export function useChatPersistence({
       })();
     }
 
-    // Process each message
     for (const m of messages) {
-      // Skip messages without IDs or system messages
       if (!m.id || m.role === 'system') continue;
 
-      // Skip assistant messages that are still streaming (not yet finalized).
-      // The agentic loop sets timingFinalized after streaming completes;
-      // without this guard, partial content is saved as a new DB row on every
-      // streaming update and then the completed content creates another row.
+      // Hold off on assistant messages until streaming + timing are finalised
       if (m.role === 'assistant' && !(m.metadata as any)?.custom?.timingFinalized) continue;
 
-      // Skip if already processing this message ID
       if (processingRef.current.has(m.id) || isPersistingRef.current) continue;
 
       const currentDigest = digestMessage(m);
       const existingDbId = getDbId(m) ?? persistedByMessageId.current.get(m.id);
 
-      // Case 1: New message - create in DB
+      // Case 1: New message — save to DB
       if (!existingDbId) {
-        // Check if message has any content
-        const text = threadMessageToTranscriptMarkdown(m as any, 
-          // Only inject durations for assistant messages when tracker available
+        const text = threadMessageToTranscriptMarkdown(
+          m as any,
           m.role === 'assistant' && timingTracker
             ? { getDurationForSegment: (msgId, idx) => timingTracker.getDurationSec(msgId, idx) }
-            : undefined
+            : undefined,
         );
         if (!text.trim()) continue;
-
-        // Check if already persisted via the ref (prevents double-save)
         if (persistedByMessageId.current.has(m.id)) continue;
 
-        const messageId = m.id; // Capture for closure
+        const messageId = m.id;
         processingRef.current.add(messageId);
         isPersistingRef.current = true;
 
@@ -276,16 +208,15 @@ export function useChatPersistence({
             const dbId = await saveMessage(
               conversationId,
               m.role as ChatMessage['role'],
-              text
+              text,
+              buildSaveMetadata(m),
             );
-
             persistedByMessageId.current.set(messageId, dbId);
             lastDigestByMessageId.current.set(messageId, currentDigest);
-
             await syncConversations({ silent: true });
           } catch (error) {
             appLogger.error('hook.persistence', 'Failed to persist new message', { error });
-            persistedByMessageId.current.delete(messageId); // Allow retry on next render
+            persistedByMessageId.current.delete(messageId);
           } finally {
             processingRef.current.delete(messageId);
             isPersistingRef.current = false;
@@ -294,39 +225,33 @@ export function useChatPersistence({
         continue;
       }
 
-      // Case 2: Existing message - check for updates
+      // Case 2: Existing message — update if content changed
       const prevDigest = lastDigestByMessageId.current.get(m.id);
       if (prevDigest !== currentDigest) {
         lastDigestByMessageId.current.set(m.id, currentDigest);
 
-        // Throttle updates per message ID (prevents update on every streaming token)
         const oldTimer = updateTimers.current.get(m.id);
         if (oldTimer) window.clearTimeout(oldTimer);
 
-        const messageId = m.id; // Capture for closure
+        const messageId = m.id;
         const timer = window.setTimeout(async () => {
           processingRef.current.add(messageId);
           isPersistingRef.current = true;
           try {
-            const text = threadMessageToTranscriptMarkdown(m as any,
-              // Only inject durations for assistant messages when tracker available
+            const text = threadMessageToTranscriptMarkdown(
+              m as any,
               m.role === 'assistant' && timingTracker
                 ? { getDurationForSegment: (msgId, idx) => timingTracker.getDurationSec(msgId, idx) }
-                : undefined
+                : undefined,
             );
             if (text.trim() && existingDbId) {
-              await updateMessage(existingDbId, text);
+              await updateMessage(existingDbId, text, buildSaveMetadata(m));
               await syncConversations({ silent: true });
-              
-              // Cleanup timing data after successful persist (prevent memory growth)
-              // Delay by 60s to allow UI to display final duration before clearing tracker
-              // Cancel any existing cleanup timer for this message (idempotent)
+
               const isFinalized = (m.metadata as any)?.custom?.timingFinalized;
               if (m.role === 'assistant' && isFinalized && timingTracker) {
                 const existingTimer = cleanupTimers.current.get(messageId);
-                if (existingTimer) {
-                  window.clearTimeout(existingTimer);
-                }
+                if (existingTimer) window.clearTimeout(existingTimer);
                 const timerId = window.setTimeout(() => {
                   timingTracker.clearMessage(messageId);
                   cleanupTimers.current.delete(messageId);
@@ -341,16 +266,12 @@ export function useChatPersistence({
             updateTimers.current.delete(messageId);
             isPersistingRef.current = false;
           }
-        }, 500); // 500ms throttle
+        }, 500);
 
         updateTimers.current.set(m.id, timer);
       }
     }
-  }, [
-    activeConversationId,
-    messages,
-    syncConversations,
-  ]);
+  }, [activeConversationId, messages, syncConversations]);
 
   return {
     isLoading,


### PR DESCRIPTION
Closes #335

## Problem

Tool-call graphics (badges, args, result) disappear when a chat is closed and reopened. During a live session the content parts array in React state is complete and renders correctly. On reload, messages were reconstructed from the DB with only plain text — all structured parts were silently lost.

Two root causes:

- **Save path** — `saveMessage()` and `updateMessage()` were called without a `metadata` argument, so `metadata.contentParts` was never written to the DB.
- **Load path** — The hydration effect set `content: msg.content` (the raw text string) instead of calling `reconstructContent()`, so even if parts had been saved they would not have been restored.

The utilities to fix both (`extractNonTextContentParts`, `reconstructContent`) already existed and were fully tested — they just weren't wired into the active persistence path.

## Changes

### New shared helpers (`src/hooks/useChatPersistence/`)

`useChatPersistence.ts` is converted to a module directory with two focused helper files:

| File | Responsibility |
|---|---|
| `buildLoadedMessage.ts` | DB `ChatMessage` → `ThreadMessageLike` with `reconstructContent()` applied (load-path fix) |
| `buildSaveMetadata.ts` | `ThreadMessageLike` → `ChatMessageMetadata \| null` via `extractNonTextContentParts()` (save-path fix) |

### `src/hooks/useChatPersistence/index.ts` (was `useChatPersistence.ts`)

- Hydration: `content: msg.content` → `buildLoadedMessage(msg, conversationId)`
- Save: `saveMessage(…, text)` → `saveMessage(…, text, buildSaveMetadata(m))`
- Update: `updateMessage(…, text)` → `updateMessage(…, text, buildSaveMetadata(m))`
- Digest seeding: uses `digestMessage(loadedMsg)` (consistent with runtime digest) instead of a manual `JSON.stringify({role, content})`, preventing spurious DB re-writes on every conversation open

### `src/components/ChatMessagesPanel/hooks/useChatPersistence.ts`

Replaces the two duplicated inline `ChatMessage → ThreadMessageLike` conversions (in `hydrate()` and `confirmDelete()`) with `buildLoadedMessage()`. Also fixes the `confirmDelete` path — tool-call parts are now correctly restored after a cascade delete.

## Commits

1. `feat: add buildLoadedMessage helper — restores tool-call parts on load`
2. `feat: add buildSaveMetadata helper — persists tool-call parts on save`
3. `refactor: convert useChatPersistence.ts to module directory` ← wires both helpers
4. `refactor: use buildLoadedMessage in component-level persistence hook` ← removes duplication

## Testing

- All 28 `contentParts.test.ts` unit tests pass
- 677/684 frontend tests pass; the 7 failures are pre-existing in `main` (`useServers` / `serverEvents.normalize`) and unrelated to this change
- TypeScript reports 0 errors (`tsc --noEmit` clean)
