### PR TITLE
fix: sync built-in tools on app startup so ToolsPopover shows them immediately

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { initServerEvents, cleanupServerEvents } from "./services/serverEvents";
 import { initProxyEvents, cleanupProxyEvents } from "./services/proxyEvents";
 import { startProxy, stopProxy } from "./services/clients/servers";
 import { getSetupStatus } from "./services/transport/api/setup";
+import { syncBuiltinTools } from "./services/tools";
 
 /**
  * Inner app component that consumes ToastContext.
@@ -65,6 +66,11 @@ function AppContent() {
       cleanupServerEvents();
       cleanupProxyEvents();
     };
+  }, []);
+
+  // Sync built-in tool definitions from the backend into the tool registry
+  useEffect(() => {
+    syncBuiltinTools().catch(() => void 0);
   }, []);
 
   // Close modal when installation completes

--- a/src/hooks/useMcpServers.ts
+++ b/src/hooks/useMcpServers.ts
@@ -22,7 +22,7 @@ import type {
   UpdateMcpServer,
   McpServerId,
 } from "../services/clients/mcp";
-import { syncAllMcpTools, syncBuiltinTools } from "../services/tools";
+import { syncAllMcpTools } from "../services/tools";
 
 interface UseMcpServersResult {
   /** List of all MCP servers with their status */
@@ -88,11 +88,9 @@ export function useMcpServers(): UseMcpServersResult {
     }
   }, []);
 
-  // Initial load: list servers and sync built-in tools from backend
+  // Initial load: list servers
   useEffect(() => {
     refresh();
-    // Fire-and-forget; errors are logged inside syncBuiltinTools
-    syncBuiltinTools().catch(() => void 0);
   }, [refresh]);
 
   const addServer = useCallback(


### PR DESCRIPTION
## Problem

Fixes #337

Built-in tools (e.g. `get_current_time`) did not appear in the ToolsPopover on initial app load. They only appeared after navigating to **Settings → MCP Servers** and returning to the chat view.

### Root cause

`syncBuiltinTools()` was only called inside `useMcpServers`, which only mounts when the MCP settings panel is open. On the initial chat view the `ToolRegistry` was empty, so `ToolsPopover` showed nothing.

## Changes

### `src/hooks/useMcpServers.ts`
- Remove `syncBuiltinTools()` call and its import. Built-in tools are static at runtime — re-running this on every MCP panel mount was a redundant second call site.

### `src/App.tsx`
- Add a single `useEffect` in `AppContent` that calls `syncBuiltinTools()` on mount. This fires at app startup so built-in tools are always available in the ToolsPopover.

## Commits

1. `refactor: remove syncBuiltinTools from useMcpServers`
2. `fix: sync built-in tools from backend on app startup`