### PR TITLE
fix: restore real-time resize drag — replace mouse events with pointer events (#341)

### DIFF
--- a/src/hooks/usePanelResize.ts
+++ b/src/hooks/usePanelResize.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UsePanelResizeConfig {
+  initial: number;
+  min: number;
+  max: number;
+}
+
+export interface UsePanelResizeResult {
+  leftPanelWidth: number;
+  layoutRef: React.RefObject<HTMLDivElement | null>;
+  handlePointerDown: (e: React.PointerEvent) => void;
+  handleKeyboardResize: (delta: number) => void;
+}
+
+const KEYBOARD_STEP = 2;
+
+/**
+ * Manages drag-to-resize state for a two-panel layout.
+ * Uses the Pointer Events API (pointermove/pointerup) throughout to avoid
+ * the browser implicit pointer-capture issue that suppresses mousemove events
+ * while a pointerdown target has capture.
+ */
+export function usePanelResize({ initial, min, max }: UsePanelResizeConfig): UsePanelResizeResult {
+  const [leftPanelWidth, setLeftPanelWidth] = useState(initial);
+  const layoutRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef(false);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    // Release implicit pointer capture so pointermove events bubble to document.
+    (e.currentTarget as Element).releasePointerCapture(e.pointerId);
+    isDraggingRef.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  const handleKeyboardResize = useCallback((delta: number) => {
+    setLeftPanelWidth(prev => Math.max(min, Math.min(max, prev + delta)));
+  }, [min, max]);
+
+  useEffect(() => {
+    let rafId: number | null = null;
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (!isDraggingRef.current || !layoutRef.current) return;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+
+      rafId = requestAnimationFrame(() => {
+        if (!layoutRef.current) return;
+        const rect = layoutRef.current.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const percentage = (x / rect.width) * 100;
+        setLeftPanelWidth(Math.max(min, Math.min(max, percentage)));
+      });
+    };
+
+    const handlePointerUp = () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      isDraggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [min, max]);
+
+  return { leftPanelWidth, layoutRef, handlePointerDown, handleKeyboardResize };
+}
+
+export { KEYBOARD_STEP };

--- a/src/hooks/usePanelResize.ts
+++ b/src/hooks/usePanelResize.ts
@@ -13,8 +13,6 @@ export interface UsePanelResizeResult {
   handleKeyboardResize: (delta: number) => void;
 }
 
-const KEYBOARD_STEP = 2;
-
 /**
  * Manages drag-to-resize state for a two-panel layout.
  * Uses the Pointer Events API (pointermove/pointerup) throughout to avoid
@@ -74,5 +72,3 @@ export function usePanelResize({ initial, min, max }: UsePanelResizeConfig): Use
 
   return { leftPanelWidth, layoutRef, handlePointerDown, handleKeyboardResize };
 }
-
-export { KEYBOARD_STEP };

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { usePanelResize } from '../hooks/usePanelResize';
 import { type ChatPageTabId } from './chatTabs';
 import { appLogger } from '../services/platform';
 import { AssistantRuntimeProvider } from '@assistant-ui/react';
@@ -72,9 +73,7 @@ export default function ChatPage({
   const persistedMessageIds = useRef<Set<string>>(new Set());
   
   // Panel width for resize
-  const [leftPanelWidth, setLeftPanelWidth] = useState(35);
-  const layoutRef = useRef<HTMLDivElement>(null);
-  const isDraggingRef = useRef(false);
+  const { leftPanelWidth, layoutRef, handlePointerDown, handleKeyboardResize } = usePanelResize({ initial: 35, min: 20, max: 50 });
 
   // Toast notifications
   const { showToast } = useToastContext();
@@ -259,59 +258,6 @@ export default function ChatPage({
     setChatError,
     timingTracker,
   });
-
-  // Handle resize
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  }, []);
-
-  const handleKeyboardResize = useCallback((delta: number) => {
-    setLeftPanelWidth(prev => Math.max(20, Math.min(50, prev + delta)));
-  }, []);
-
-  useEffect(() => {
-    let rafId: number | null = null;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!isDraggingRef.current || !layoutRef.current) return;
-
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-
-      rafId = requestAnimationFrame(() => {
-        if (!layoutRef.current) return;
-        const rect = layoutRef.current.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const percentage = (x / rect.width) * 100;
-        const newLeftWidth = Math.max(20, Math.min(50, percentage));
-        setLeftPanelWidth(newLeftWidth);
-      });
-    };
-
-    const handleMouseUp = () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-      isDraggingRef.current = false;
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, []);
 
   // Conversation handlers
   const handleDeleteConversation = async (conversationId: number) => {

--- a/src/pages/modelControlCenter/useMccLayout.ts
+++ b/src/pages/modelControlCenter/useMccLayout.ts
@@ -1,64 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePanelResize, UsePanelResizeResult } from '../../hooks/usePanelResize';
 
-export interface UseMccLayoutResult {
-  leftPanelWidth: number;
-  layoutRef: React.RefObject<HTMLDivElement | null>;
-  handlePointerDown: (e: React.PointerEvent) => void;
-  handleKeyboardResize: (delta: number) => void;
-}
-
-const MIN_WIDTH = 25;
-const MAX_WIDTH = 60;
+export type UseMccLayoutResult = UsePanelResizeResult;
 
 export function useMccLayout(): UseMccLayoutResult {
-  const [leftPanelWidth, setLeftPanelWidth] = useState(45);
-  const layoutRef = useRef<HTMLDivElement>(null);
-  const isDraggingRef = useRef(false);
-
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  }, []);
-
-  const handleKeyboardResize = useCallback((delta: number) => {
-    setLeftPanelWidth(prev => Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, prev + delta)));
-  }, []);
-
-  useEffect(() => {
-    let rafId: number | null = null;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!isDraggingRef.current || !layoutRef.current) return;
-      if (rafId !== null) cancelAnimationFrame(rafId);
-
-      rafId = requestAnimationFrame(() => {
-        if (!layoutRef.current) return;
-        const rect = layoutRef.current.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const percentage = (x / rect.width) * 100;
-        const newLeftWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, percentage));
-        setLeftPanelWidth(newLeftWidth);
-      });
-    };
-
-    const handleMouseUp = () => {
-      if (rafId !== null) cancelAnimationFrame(rafId);
-      isDraggingRef.current = false;
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      if (rafId !== null) cancelAnimationFrame(rafId);
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, []);
-
-  return { leftPanelWidth, layoutRef, handlePointerDown, handleKeyboardResize };
+  return usePanelResize({ initial: 45, min: 25, max: 60 });
 }


### PR DESCRIPTION
## Summary

Fixes #341 — the resize handle between panels wouldn't track the mouse during drag, only jumping to the correct position on mouse-up.

## Root Cause

Regression introduced by PR #338, commit [`c1d4b8e`](https://github.com/mmogr/gglib/commit/c1d4b8e) ("Fix inconsistent responsive breakpoints — mobile-first refactor").

That commit migrated the drag-start handler from `onMouseDown` → `onPointerDown` but left the document-level tracking listeners unchanged as `mousemove`/`mouseup`. This created a **pointer/mouse event API mismatch**:

1. `pointerdown` fires on the handle
2. Browser implicitly sets **pointer capture** on the element
3. While captured, `mousemove` events are suppressed at the document level
4. The `mousemove` listener never fires during the drag → divider doesn't move
5. On mouse-up, capture is released and a final event fires → divider jumps to destination

Before `c1d4b8e`, the code consistently used `onMouseDown` + `mousemove`/`mouseup`. The fix is to consistently use the Pointer Events API throughout.

## Changes

### `src/hooks/usePanelResize.ts` _(new)_
Shared hook that correctly uses `pointermove`/`pointerup` throughout, and calls `releasePointerCapture` in `handlePointerDown` for belt-and-suspenders robustness. Accepts `{ initial, min, max }` config for reuse.

### `src/pages/modelControlCenter/useMccLayout.ts` _(simplified)_
Replaced ~60 lines of buggy inline resize logic with a single `usePanelResize({ initial: 45, min: 25, max: 60 })` call. Exported interface is preserved via a type alias.

### `src/pages/ChatPage.tsx` _(simplified)_
Removed ~50 lines of duplicate inline resize logic, replaced with `usePanelResize({ initial: 35, min: 20, max: 50 })`.

### `ResizeHandle.tsx` / `TwoPanelLayout.tsx`
No changes needed — the bug and its duplication were entirely in the drag state management layer.

## Commits

| Commit | Description |
|--------|-------------|
| `8ea30f7` | `fix(hooks): introduce usePanelResize with correct pointermove/pointerup events` |
| `1f1b76e` | `refactor(mcc): delegate resize logic to usePanelResize` |
| `7fdd22b` | `refactor(chat): delegate resize logic to usePanelResize` |

## Testing

- [ ] Drag resize handle on Chat page — divider tracks mouse live
- [ ] Drag resize handle on Model Control Center page — same
- [ ] Keyboard resize (focus handle → ArrowLeft/ArrowRight) works
- [ ] Releasing drag restores cursor and `userSelect`
- [ ] Frontend tests pass