### PR TITLE
fix(ci): add missing system deps and CMake pin to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,24 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install system dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libasound2-dev \
+            pkg-config
+
+      - name: Pin CMake 3.30 (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.30.8'
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -336,6 +354,12 @@ jobs:
         run: |
           npm install
           npm run build
+
+      - name: Set Windows linker args (sherpa-onnx ETW symbols)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          echo "RUSTFLAGS=$env:RUSTFLAGS -C link-arg=Advapi32.lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }} -p gglib-cli
@@ -417,6 +441,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pin CMake 3.30 (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.30.8'
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -461,6 +491,12 @@ jobs:
             libssl-dev \
             libasound2-dev \
             pkg-config
+
+      - name: Set Windows linker args (sherpa-onnx ETW symbols)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          echo "RUSTFLAGS=$env:RUSTFLAGS -C link-arg=Advapi32.lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build Tauri app
         run: |


### PR DESCRIPTION
## Problem

The v0.5.5 release is missing **Windows binaries** (CLI + GUI) and the **Linux CLI binary** because the release workflow's `build` job was missing system dependency installation steps that the CI workflow already had.

### Root cause

When `gglib-voice` was added (PR #166), it brought in `sherpa-rs`/`cpal`/`rodio` which require native audio libraries. The CI workflow was updated to install these deps, but the release workflow's `build` job was never updated.

### Failures in the v0.5.5 release run

1. **Linux CLI build**: `alsa-sys` crate failed because `libasound2-dev` was not installed
2. **Windows CLI build**: `sherpa-rs-sys` CMake build failed due to CMake 3.31 compatibility issue (`string REPLACE` error in `show-info.cmake`)
3. **Windows GUI build**: Cancelled after the CLI build failed

### Fix

- **Linux `build` job**: Add `Install system dependencies` step with `libasound2-dev` and related packages (matching what CI and the `build-gui` job already have)
- **Windows `build` + `build-gui` jobs**: Pin CMake to 3.30.x via `lukka/get-cmake` action to work around the sherpa-rs-sys CMake 3.31 incompatibility (the CI workflow sidesteps this by using `windows-2022` which ships CMake 3.25)
- **Windows `build` + `build-gui` jobs**: Add `Advapi32.lib` linker args for sherpa-onnx ETW symbols (matching what the CI workflow already sets)