### PR TITLE
feat(toast): improve toast notification UX (#200)

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { AlertTriangle, CheckCircle2, Info, X, XCircle } from 'lucide-react';
 import { Icon } from '../ui/Icon';
 import { cn } from '../../utils/cn';
+import { useToastTimer } from '../../hooks/useToastTimer';
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
@@ -19,28 +20,23 @@ interface ToastItemProps {
 }
 
 const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
-  const [isExiting, setIsExiting] = useState(false);
+  const handleExpire = useCallback(() => onDismiss(toast.id), [toast.id, onDismiss]);
+  const { isExiting, setIsExiting, pause, resume } = useToastTimer(toast.duration ?? 4000, handleExpire);
 
+  // When the context marks this toast for graceful removal, trigger exit animation.
   useEffect(() => {
-    const duration = toast.duration ?? 4000;
-    const exitTimer = setTimeout(() => {
+    if (toast.isDismissing) {
+      pause();
       setIsExiting(true);
-    }, duration - 300); // Start exit animation before removal
+      const t = setTimeout(() => onDismiss(toast.id), 300);
+      return () => clearTimeout(t);
+    }
+  }, [toast.isDismissing, toast.id, onDismiss, pause, setIsExiting]);
 
-    const removeTimer = setTimeout(() => {
-      onDismiss(toast.id);
-    }, duration);
-
-    return () => {
-      clearTimeout(exitTimer);
-      clearTimeout(removeTimer);
-    };
-  }, [toast.id, toast.duration, onDismiss]);
-
-  const handleClick = useCallback(() => {
+  const handleDismiss = useCallback(() => {
     setIsExiting(true);
     setTimeout(() => onDismiss(toast.id), 300);
-  }, [toast.id, onDismiss]);
+  }, [toast.id, onDismiss, setIsExiting]);
 
   const icon = {
     success: CheckCircle2,
@@ -52,16 +48,20 @@ const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
   return (
     <div
       className={cn(
-        'flex items-center gap-sm px-md py-sm rounded-base bg-surface border border-border shadow-[0_8px_24px_rgba(0,0,0,0.22)] text-sm cursor-pointer pointer-events-auto animate-toast-enter transition-[transform,opacity] duration-300 ease-out hover:-translate-x-1',
+        'flex items-center gap-sm px-md py-sm rounded-base bg-surface border border-border shadow-[0_8px_24px_rgba(0,0,0,0.22)] text-sm pointer-events-auto animate-toast-enter transition-[transform,opacity] duration-300 ease-out hover:-translate-x-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
         toast.type === 'success' && 'border-[#10b981] bg-[linear-gradient(135deg,rgba(16,185,129,0.08)_0%,var(--color-surface)_100%)]',
         toast.type === 'error' && 'border-[#ef4444] bg-[linear-gradient(135deg,rgba(239,68,68,0.08)_0%,var(--color-surface)_100%)]',
         toast.type === 'info' && 'border-primary bg-[linear-gradient(135deg,rgba(99,102,241,0.12)_0%,var(--color-surface)_100%)]',
         toast.type === 'warning' && 'border-[#f59e0b] bg-[linear-gradient(135deg,rgba(245,158,11,0.12)_0%,var(--color-surface)_100%)]',
         isExiting && 'animate-toast-exit',
       )}
-      onClick={handleClick}
-      role="alert"
-      aria-live="polite"
+      role={toast.type === 'error' || toast.type === 'warning' ? 'alert' : 'status'}
+      tabIndex={0}
+      onMouseEnter={pause}
+      onMouseLeave={resume}
+      onFocus={pause}
+      onBlur={resume}
+      onKeyDown={(e) => e.key === 'Escape' && handleDismiss()}
     >
       <span className={cn(
         'text-base font-bold shrink-0 w-5 h-5 flex items-center justify-center',
@@ -76,10 +76,7 @@ const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
       <button
         className="bg-transparent border-none text-text-muted text-lg cursor-pointer p-0 leading-none opacity-70 transition-opacity duration-200 ease-out shrink-0 hover:opacity-100"
         aria-label="Dismiss notification"
-        onClick={(event) => {
-          event.stopPropagation();
-          handleClick();
-        }}
+        onClick={handleDismiss}
       >
         <Icon icon={X} size={14} />
       </button>

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -10,6 +10,7 @@ export interface ToastData {
   message: string;
   type: ToastType;
   duration?: number;
+  isDismissing?: boolean;
 }
 
 interface ToastItemProps {

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, FC, ReactNode, useCallback, useContext, useState } from 'react';
 import type { ToastData, ToastType } from '../components/Toast';
 
+const MAX_TOASTS = 5;
 let toastIdCounter = 0;
 
 /**
@@ -28,13 +29,12 @@ export const ToastProvider: FC<ToastProviderProps> = ({ children }) => {
 
   const showToast = useCallback((message: string, type: ToastType = 'info', duration?: number) => {
     const id = `toast-${++toastIdCounter}`;
-    const newToast: ToastData = {
-      id,
-      message,
-      type,
-      duration,
-    };
-    setToasts((prev) => [...prev, newToast]);
+    const newToast: ToastData = { id, message, type, duration };
+    setToasts((prev) => {
+      if (prev.length < MAX_TOASTS) return [...prev, newToast];
+      const [oldest, ...rest] = prev;
+      return [{ ...oldest, isDismissing: true }, ...rest, newToast];
+    });
   }, []);
 
   const dismissToast = useCallback((id: string) => {

--- a/src/hooks/useToastTimer.ts
+++ b/src/hooks/useToastTimer.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+
+const EXIT_ANIMATION_MS = 300;
+
+/**
+ * Manages a toast auto-dismiss timer with pause/resume support.
+ *
+ * - Starts counting down from `duration` on mount.
+ * - `pause()` freezes the countdown (e.g. on hover or focus).
+ * - `resume()` continues from where it left off.
+ * - `isExiting` becomes true 300ms before expiry so the exit animation plays.
+ */
+export function useToastTimer(duration: number, onExpire: () => void) {
+  const [isExiting, setIsExiting] = useState(false);
+
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  const remainingRef = useRef(duration);
+  const startedAtRef = useRef<number | null>(null);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const removeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimers = () => {
+    if (exitTimerRef.current !== null) clearTimeout(exitTimerRef.current);
+    if (removeTimerRef.current !== null) clearTimeout(removeTimerRef.current);
+  };
+
+  const start = (ms: number) => {
+    clearTimers();
+    remainingRef.current = ms;
+    startedAtRef.current = Date.now();
+    exitTimerRef.current = setTimeout(() => setIsExiting(true), ms - EXIT_ANIMATION_MS);
+    removeTimerRef.current = setTimeout(() => onExpireRef.current(), ms);
+  };
+
+  const pause = () => {
+    if (startedAtRef.current === null) return;
+    const elapsed = Date.now() - startedAtRef.current;
+    remainingRef.current = Math.max(EXIT_ANIMATION_MS, remainingRef.current - elapsed);
+    startedAtRef.current = null;
+    clearTimers();
+  };
+
+  const resume = () => {
+    if (startedAtRef.current !== null) return; // already running
+    start(remainingRef.current);
+  };
+
+  useEffect(() => {
+    start(duration);
+    return clearTimers;
+    // Intentionally only runs on mount; duration changes are not expected.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { isExiting, setIsExiting, pause, resume };
+}

--- a/tests/ts/components/Toast.test.tsx
+++ b/tests/ts/components/Toast.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ToastProvider, useToastContext } from '../../../src/contexts/ToastContext';
+import { ToastContainer } from '../../../src/components/Toast';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Renders the toast system with a control component that exposes showToast. */
+function renderToastSystem() {
+  let showToast!: ReturnType<typeof useToastContext>['showToast'];
+
+  const Controls = () => {
+    showToast = useToastContext().showToast;
+    return null;
+  };
+
+  const { toasts: _toasts, ...rest } = { toasts: [] as ReturnType<typeof useToastContext>['toasts'] };
+
+  const Wrapper = () => {
+    const ctx = useToastContext();
+    return (
+      <>
+        <Controls />
+        <ToastContainer toasts={ctx.toasts} onDismiss={ctx.dismissToast} />
+      </>
+    );
+  };
+
+  const result = render(
+    <ToastProvider>
+      <Wrapper />
+    </ToastProvider>
+  );
+
+  return { ...result, getShowToast: () => showToast };
+}
+
+// ---------------------------------------------------------------------------
+// Stack limit
+// ---------------------------------------------------------------------------
+
+describe('ToastContext — stack limit', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('allows up to MAX_TOASTS (5) toasts without dropping any', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => {
+      for (let i = 1; i <= 5; i++) getShowToast()(`Toast ${i}`, 'info');
+    });
+    expect(screen.getAllByRole('status')).toHaveLength(5);
+  });
+
+  it('marks the oldest toast as isDismissing when a 6th is added', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => {
+      for (let i = 1; i <= 5; i++) getShowToast()(`Toast ${i}`, 'info');
+    });
+
+    // All 5 should be present
+    const before = screen.getAllByText(/^Toast \d$/);
+    expect(before).toHaveLength(5);
+
+    // Adding a 6th should trigger exit on the oldest (Toast 1)
+    act(() => {
+      getShowToast()('Toast 6', 'info');
+    });
+
+    // After the exit animation (300ms) the oldest should be gone
+    act(() => vi.advanceTimersByTime(400));
+
+    expect(screen.queryByText('Toast 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Toast 6')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hover pause
+// ---------------------------------------------------------------------------
+
+describe('ToastItem — hover pauses auto-dismiss', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does not dismiss while hovered', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()('Hover me', 'info', 1000));
+
+    const toast = screen.getByText('Hover me').closest('[role="status"]')!;
+    fireEvent.mouseEnter(toast);
+
+    // Advance well past the natural duration — toast should still be there
+    act(() => vi.advanceTimersByTime(3000));
+    expect(screen.getByText('Hover me')).toBeInTheDocument();
+  });
+
+  it('dismisses after remaining duration on mouse leave', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()('Hover then leave', 'info', 1000));
+
+    const toast = screen.getByText('Hover then leave').closest('[role="status"]')!;
+
+    // Hover for 400ms then leave — 600ms remaining
+    fireEvent.mouseEnter(toast);
+    act(() => vi.advanceTimersByTime(400));
+    fireEvent.mouseLeave(toast);
+
+    // Should still be present just after leave
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByText('Hover then leave')).toBeInTheDocument();
+
+    // Should be gone after the remaining ~600ms + animation
+    act(() => vi.advanceTimersByTime(800));
+    expect(screen.queryByText('Hover then leave')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard — Escape dismissal
+// ---------------------------------------------------------------------------
+
+describe('ToastItem — keyboard', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('dismisses on Escape key press', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()('Press Escape', 'info'));
+
+    const toast = screen.getByText('Press Escape').closest('[role="status"]')!;
+    fireEvent.keyDown(toast, { key: 'Escape' });
+
+    // Exit animation plays for 300ms then it's removed
+    act(() => vi.advanceTimersByTime(400));
+    expect(screen.queryByText('Press Escape')).not.toBeInTheDocument();
+  });
+
+  it('does not dismiss on other key presses', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()('Other key', 'info', 10000));
+
+    const toast = screen.getByText('Other key').closest('[role="status"]')!;
+    fireEvent.keyDown(toast, { key: 'Enter' });
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(screen.getByText('Other key')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ARIA roles
+// ---------------------------------------------------------------------------
+
+describe('ToastItem — ARIA roles', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it.each([
+    ['error', 'alert'],
+    ['warning', 'alert'],
+    ['success', 'status'],
+    ['info', 'status'],
+  ] as const)('%s toast has role="%s"', (type, expectedRole) => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()(`A ${type} message`, type as 'error' | 'warning' | 'success' | 'info'));
+    expect(screen.getByRole(expectedRole)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Click target — only close button dismisses
+// ---------------------------------------------------------------------------
+
+describe('ToastItem — click target', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does not dismiss when clicking the toast body', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()('Body click', 'info', 10000));
+
+    const messageSpan = screen.getByText('Body click');
+    fireEvent.click(messageSpan);
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(screen.getByText('Body click')).toBeInTheDocument();
+  });
+
+  it('dismisses when clicking the close button', () => {
+    const { getShowToast } = renderToastSystem();
+    act(() => getShowToast()('Close button', 'info'));
+
+    const closeBtn = screen.getByRole('button', { name: /dismiss notification/i });
+    fireEvent.click(closeBtn);
+
+    act(() => vi.advanceTimersByTime(400));
+    expect(screen.queryByText('Close button')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #200

## Summary

Four targeted UX improvements to the global toast notification system, with no changes to any consumer code.

### Changes

**`src/contexts/ToastContext.tsx`**
- Added `MAX_TOASTS = 5` constant
- When the cap is reached, `showToast` marks the oldest toast `isDismissing: true` instead of forcibly removing it — the component then plays its own exit animation before being removed from state

**`src/components/Toast/Toast.tsx`**
- Added `isDismissing?: boolean` to `ToastData`
- `ToastItem` now reacts to `isDismissing` via a `useEffect` that triggers the exit animation gracefully
- Replaced whole-toast `onClick` dismiss with close-button-only dismiss (removed `cursor-pointer`; removed `onClick` on the outer div)
- Dynamic `role`: `error`/`warning` → `"alert"` (assertive), `success`/`info` → `"status"` (polite)
- Removed conflicting `aria-live="polite"` from individual items (the roles carry correct implicit live region semantics)
- Added `tabIndex={0}` + `onKeyDown` (Escape) for keyboard dismissal
- Added `focus-visible:ring-2 focus-visible:outline-none` for visible focus styles
- Wired `onMouseEnter`/`onMouseLeave`/`onFocus`/`onBlur` to pause/resume the dismiss timer

**`src/hooks/useToastTimer.ts`** *(new)*
- Encapsulates all timer logic: countdown, pause/resume, and exit animation trigger
- Uses `onExpireRef` to keep callback fresh without re-running the mount effect
- Tracks `remainingMs` with ref math for accurate pause/resume across arbitrary hover durations

**`tests/ts/components/Toast.test.tsx`** *(new)*
- 12 tests covering: stack limit, graceful oldest-eviction, hover pause, resume after leave, Escape key dismiss, non-Escape no-op, ARIA roles per type, body-click no-op, close-button dismiss

## Acceptance criteria

- [x] Toast auto-dismiss pauses on hover and resumes on mouse leave
- [x] Maximum 5 visible toasts; oldest dismissed gracefully when cap exceeded
- [x] Toasts have appropriate ARIA roles (`alert` / `status`)
- [x] Toasts are keyboard-dismissible (Escape on focused toast)
- [x] Whole-toast click-to-dismiss removed; only close button dismisses
- [x] No visual regression in toast appearance or animations