### PR TITLE
fix: Windows setup wizard path separators and GPU backend detection

### DIFF
--- a/crates/gglib-core/src/paths/models.rs
+++ b/crates/gglib-core/src/paths/models.rs
@@ -9,7 +9,8 @@ use std::path::PathBuf;
 use super::error::PathError;
 use super::platform::normalize_user_path;
 
-/// Default relative location for downloaded models under the user's home directory.
+/// Default relative location for downloaded models on non-Windows platforms.
+#[cfg(not(target_os = "windows"))]
 pub const DEFAULT_MODELS_DIR_RELATIVE: &str = ".local/share/llama_models";
 
 /// How the models directory was derived.
@@ -19,7 +20,8 @@ pub enum ModelsDirSource {
     Explicit,
     /// The path came from environment variables / `.env`.
     EnvVar,
-    /// Fallback default (`~/.local/share/llama_models`).
+    /// Fallback default (`~/.local/share/llama_models` on Linux/macOS,
+    /// `%LOCALAPPDATA%\llama_models` on Windows).
     Default,
 }
 
@@ -34,10 +36,19 @@ pub struct ModelsDirResolution {
 
 /// Return the platform-specific default models directory.
 ///
-/// Defaults to `~/.local/share/llama_models`.
+/// - **Windows**: `%LOCALAPPDATA%\llama_models` (e.g. `C:\Users\name\AppData\Local\llama_models`)
+/// - **macOS / Linux**: `~/.local/share/llama_models`
 pub fn default_models_dir() -> Result<PathBuf, PathError> {
-    let home = dirs::home_dir().ok_or(PathError::NoHomeDir)?;
-    Ok(home.join(DEFAULT_MODELS_DIR_RELATIVE))
+    #[cfg(target_os = "windows")]
+    {
+        let local_app_data = dirs::data_local_dir().ok_or(PathError::NoDataDir)?;
+        Ok(local_app_data.join("llama_models"))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let home = dirs::home_dir().ok_or(PathError::NoHomeDir)?;
+        Ok(home.join(DEFAULT_MODELS_DIR_RELATIVE))
+    }
 }
 
 /// Resolve the models directory from an explicit override, env var, or default.
@@ -76,9 +87,28 @@ mod tests {
     use serial_test::serial;
 
     #[test]
-    fn test_default_models_dir_contains_relative() {
+    fn test_default_models_dir_platform_path() {
         let dir = default_models_dir().unwrap();
-        assert!(dir.to_string_lossy().contains(DEFAULT_MODELS_DIR_RELATIVE));
+        let path_str = dir.to_string_lossy();
+        // On Windows the path should be under %LOCALAPPDATA% and use native
+        // separators throughout — no forward-slash fragments.
+        #[cfg(target_os = "windows")]
+        {
+            assert!(
+                path_str.contains("llama_models"),
+                "Expected 'llama_models' in path: {path_str}"
+            );
+            assert!(
+                !path_str.contains('/'),
+                "Path must not contain forward slashes on Windows: {path_str}"
+            );
+        }
+        // On non-Windows the path should sit under ~/.local/share/llama_models.
+        #[cfg(not(target_os = "windows"))]
+        assert!(
+            path_str.contains(DEFAULT_MODELS_DIR_RELATIVE),
+            "Expected '{DEFAULT_MODELS_DIR_RELATIVE}' in path: {path_str}"
+        );
     }
 
     #[test]

--- a/crates/gglib-runtime/src/llama/download/mod.rs
+++ b/crates/gglib-runtime/src/llama/download/mod.rs
@@ -92,6 +92,30 @@ pub enum PrebuiltAvailability {
     },
 }
 
+/// Map a detected [`GpuInfo`] to the appropriate Windows x64 pre-built variant.
+///
+/// Extracted as a standalone function so it can be unit-tested with
+/// arbitrary [`GpuInfo`] values without triggering real hardware probes.
+#[cfg(feature = "prebuilt")]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn windows_availability_for_gpu(gpu: &gglib_core::utils::system::GpuInfo) -> PrebuiltAvailability {
+    if gpu.has_nvidia_gpu && gpu.cuda_version.is_some() {
+        PrebuiltAvailability::Available {
+            asset_pattern: "bin-win-cuda-12.4-x64.zip".to_string(),
+            description: "Windows x64 (CUDA 12.4)".to_string(),
+        }
+    } else if gpu.has_vulkan {
+        PrebuiltAvailability::Available {
+            asset_pattern: "bin-win-vulkan-x64.zip".to_string(),
+            description: "Windows x64 (Vulkan)".to_string(),
+        }
+    } else {
+        PrebuiltAvailability::NotAvailable {
+            reason: "No supported GPU backend detected (requires CUDA or Vulkan)".to_string(),
+        }
+    }
+}
+
 /// Check if pre-built llama.cpp binaries are available for the current platform.
 ///
 /// On Windows x64 the GPU is probed at runtime:
@@ -132,22 +156,7 @@ pub fn check_prebuilt_availability() -> PrebuiltAvailability {
         #[cfg(target_arch = "x86_64")]
         {
             let gpu = crate::system::gpu::detect_gpu_info();
-            if gpu.has_nvidia_gpu && gpu.cuda_version.is_some() {
-                PrebuiltAvailability::Available {
-                    asset_pattern: "bin-win-cuda-12.4-x64.zip".to_string(),
-                    description: "Windows x64 (CUDA 12.4)".to_string(),
-                }
-            } else if gpu.has_vulkan {
-                PrebuiltAvailability::Available {
-                    asset_pattern: "bin-win-vulkan-x64.zip".to_string(),
-                    description: "Windows x64 (Vulkan)".to_string(),
-                }
-            } else {
-                PrebuiltAvailability::NotAvailable {
-                    reason: "No supported GPU backend detected (requires CUDA or Vulkan)"
-                        .to_string(),
-                }
-            }
+            windows_availability_for_gpu(&gpu)
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -940,6 +949,114 @@ mod tests {
             PrebuiltAvailability::Available { .. } => {}
             PrebuiltAvailability::NotAvailable { .. } => {}
         }
+    }
+
+    // ---- windows_availability_for_gpu unit tests ----
+    // These run on all platforms because windows_availability_for_gpu is a pure
+    // function that takes a GpuInfo value — no Windows-only cfg guard needed.
+
+    #[test]
+    #[cfg(feature = "prebuilt")]
+    fn test_windows_gpu_cuda_selects_cuda_binary() {
+        use gglib_core::utils::system::GpuInfo;
+        let gpu = GpuInfo {
+            has_nvidia_gpu: true,
+            cuda_version: Some("12.4".to_string()),
+            has_metal: false,
+            has_vulkan: false,
+        };
+        let result = windows_availability_for_gpu(&gpu);
+        match result {
+            PrebuiltAvailability::Available {
+                asset_pattern,
+                description,
+            } => {
+                assert!(
+                    asset_pattern.contains("cuda"),
+                    "Expected CUDA asset, got: {asset_pattern}"
+                );
+                assert!(
+                    description.contains("CUDA"),
+                    "Expected CUDA description, got: {description}"
+                );
+            }
+            PrebuiltAvailability::NotAvailable { reason } => {
+                panic!("Expected Available for CUDA GPU, got NotAvailable: {reason}");
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "prebuilt")]
+    fn test_windows_gpu_vulkan_only_selects_vulkan_binary() {
+        use gglib_core::utils::system::GpuInfo;
+        let gpu = GpuInfo {
+            has_nvidia_gpu: false,
+            cuda_version: None,
+            has_metal: false,
+            has_vulkan: true,
+        };
+        let result = windows_availability_for_gpu(&gpu);
+        match result {
+            PrebuiltAvailability::Available {
+                asset_pattern,
+                description,
+            } => {
+                assert!(
+                    asset_pattern.contains("vulkan"),
+                    "Expected Vulkan asset, got: {asset_pattern}"
+                );
+                assert!(
+                    description.contains("Vulkan"),
+                    "Expected Vulkan description, got: {description}"
+                );
+            }
+            PrebuiltAvailability::NotAvailable { reason } => {
+                panic!("Expected Available for Vulkan GPU, got NotAvailable: {reason}");
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "prebuilt")]
+    fn test_windows_gpu_nvidia_without_cuda_falls_back_to_vulkan() {
+        use gglib_core::utils::system::GpuInfo;
+        // NVIDIA hardware present but CUDA toolkit not installed; Vulkan is available.
+        let gpu = GpuInfo {
+            has_nvidia_gpu: true,
+            cuda_version: None,
+            has_metal: false,
+            has_vulkan: true,
+        };
+        let result = windows_availability_for_gpu(&gpu);
+        match result {
+            PrebuiltAvailability::Available { asset_pattern, .. } => {
+                assert!(
+                    asset_pattern.contains("vulkan"),
+                    "Should prefer Vulkan when CUDA toolkit absent, got: {asset_pattern}"
+                );
+            }
+            PrebuiltAvailability::NotAvailable { reason } => {
+                panic!("Expected Available (Vulkan fallback), got NotAvailable: {reason}");
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "prebuilt")]
+    fn test_windows_gpu_no_gpu_returns_not_available() {
+        use gglib_core::utils::system::GpuInfo;
+        let gpu = GpuInfo {
+            has_nvidia_gpu: false,
+            cuda_version: None,
+            has_metal: false,
+            has_vulkan: false,
+        };
+        let result = windows_availability_for_gpu(&gpu);
+        assert!(
+            matches!(result, PrebuiltAvailability::NotAvailable { .. }),
+            "Expected NotAvailable when no GPU backends present"
+        );
     }
 
     /// Verify that `extract_binaries_tar_gz` correctly handles modern llama.cpp

--- a/crates/gglib-runtime/src/llama/download/mod.rs
+++ b/crates/gglib-runtime/src/llama/download/mod.rs
@@ -689,9 +689,12 @@ pub async fn download_prebuilt_binaries() -> Result<()> {
     let post_download_result = async {
         extract_binaries(&zip_path, &bin_dir)?;
 
-        // Windows: Also download CUDA runtime DLLs
+        // Windows + CUDA only: also download the CUDA runtime DLLs.
+        // Vulkan builds bundle everything they need inside the main zip.
         #[cfg(target_os = "windows")]
-        download_cuda_runtime(&client, &release, &bin_dir, &download_dir).await?;
+        if asset_pattern.contains("cuda") {
+            download_cuda_runtime(&client, &release, &bin_dir, &download_dir).await?;
+        }
 
         Ok::<_, anyhow::Error>(())
     }
@@ -781,9 +784,12 @@ pub async fn download_prebuilt_binaries_with_callback(
     let post_download_result = async {
         extract_binaries(&zip_path, &bin_dir)?;
 
-        // Windows: Also download CUDA runtime DLLs
+        // Windows + CUDA only: also download the CUDA runtime DLLs.
+        // Vulkan builds bundle everything they need inside the main zip.
         #[cfg(target_os = "windows")]
-        download_cuda_runtime(&client, &release, &bin_dir, &download_dir).await?;
+        if asset_pattern.contains("cuda") {
+            download_cuda_runtime(&client, &release, &bin_dir, &download_dir).await?;
+        }
 
         Ok::<_, anyhow::Error>(())
     }
@@ -862,9 +868,12 @@ pub async fn download_prebuilt_binaries_with_boxed_callback(
     let post_download_result = async {
         extract_binaries(&zip_path, &bin_dir)?;
 
-        // Windows: Also download CUDA runtime DLLs
+        // Windows + CUDA only: also download the CUDA runtime DLLs.
+        // Vulkan builds bundle everything they need inside the main zip.
         #[cfg(target_os = "windows")]
-        download_cuda_runtime(&client, &release, &bin_dir, &download_dir).await?;
+        if asset_pattern.contains("cuda") {
+            download_cuda_runtime(&client, &release, &bin_dir, &download_dir).await?;
+        }
 
         Ok::<_, anyhow::Error>(())
     }

--- a/crates/gglib-runtime/src/llama/download/mod.rs
+++ b/crates/gglib-runtime/src/llama/download/mod.rs
@@ -6,7 +6,7 @@
 //! Platform support:
 //! - macOS ARM64: Metal-enabled pre-built binaries
 //! - macOS x64: Metal-enabled pre-built binaries
-//! - Windows x64: CUDA-enabled pre-built binaries
+//! - Windows x64: CUDA or Vulkan pre-built binaries (selected at runtime via GPU detection)
 //! - Linux x64: CPU pre-built binaries (CUDA requires building from source)
 
 #[cfg(feature = "prebuilt")]
@@ -94,8 +94,13 @@ pub enum PrebuiltAvailability {
 
 /// Check if pre-built llama.cpp binaries are available for the current platform.
 ///
-/// Returns `Available` with asset pattern for macOS (Metal) and Windows (CUDA).
-/// Returns `NotAvailable` for Linux (no CUDA pre-built available).
+/// On Windows x64 the GPU is probed at runtime:
+/// - NVIDIA + CUDA → CUDA 12.4 binary
+/// - Vulkan runtime present → Vulkan binary
+/// - Neither → `NotAvailable`
+///
+/// Returns `Available` with asset pattern for macOS (Metal), Windows (CUDA/Vulkan),
+/// and Linux (CPU).
 #[cfg(feature = "prebuilt")]
 pub fn check_prebuilt_availability() -> PrebuiltAvailability {
     #[cfg(target_os = "macos")]
@@ -126,9 +131,22 @@ pub fn check_prebuilt_availability() -> PrebuiltAvailability {
     {
         #[cfg(target_arch = "x86_64")]
         {
-            PrebuiltAvailability::Available {
-                asset_pattern: "bin-win-cuda-12.4-x64.zip".to_string(),
-                description: "Windows x64 (CUDA 12.4)".to_string(),
+            let gpu = crate::system::gpu::detect_gpu_info();
+            if gpu.has_nvidia_gpu && gpu.cuda_version.is_some() {
+                PrebuiltAvailability::Available {
+                    asset_pattern: "bin-win-cuda-12.4-x64.zip".to_string(),
+                    description: "Windows x64 (CUDA 12.4)".to_string(),
+                }
+            } else if gpu.has_vulkan {
+                PrebuiltAvailability::Available {
+                    asset_pattern: "bin-win-vulkan-x64.zip".to_string(),
+                    description: "Windows x64 (Vulkan)".to_string(),
+                }
+            } else {
+                PrebuiltAvailability::NotAvailable {
+                    reason: "No supported GPU backend detected (requires CUDA or Vulkan)"
+                        .to_string(),
+                }
             }
         }
         #[cfg(not(target_arch = "x86_64"))]


### PR DESCRIPTION
## Summary

Fixes two bugs observed in the Windows GUI setup wizard.

---

### Bug 1 — Mixed path separators in models folder path

**Symptom:** The setup wizard showed a models folder path like `C:\Users\name\.local/share/llama_models` — backslashes from Windows up to the home directory, then forward slashes from the hardcoded Linux XDG string.

**Root cause:** `default_models_dir()` unconditionally joined `dirs::home_dir()` (which returns native backslash paths on Windows) with the string literal `".local/share/llama_models"` (which contains forward slashes). `PathBuf::join()` does not normalise embedded separators, producing a mixed-separator path.

**Fix:** `default_models_dir()` now branches on `target_os`:
- **Windows:** `dirs::data_local_dir().join("llama_models")` → `C:\Users\name\AppData\Local\llama_models`
- **macOS / Linux:** unchanged `~/.local/share/llama_models`

`DEFAULT_MODELS_DIR_RELATIVE` is scoped to non-Windows with `#[cfg(not(target_os = "windows"))]`.

---

### Bug 2 — CUDA binary always selected regardless of GPU

**Symptom:** The setup wizard reported "downloading Windows x64 (CUDA 12.4)" even on a system with a Vulkan-only GPU (AMD, non-CUDA NVIDIA, Intel).

**Root cause:** `check_prebuilt_availability()` was entirely compile-time `#[cfg]` — it always returned the CUDA 12.4 asset for Windows x64 with no runtime GPU check. The existing `detect_gpu_info()` function (which correctly probes `vulkan-1.dll`) was never consulted for binary selection.

**Fix:**
- `check_prebuilt_availability()` now calls `crate::system::gpu::detect_gpu_info()` at runtime on Windows x64 and selects:
  - NVIDIA GPU + CUDA present → `bin-win-cuda-12.4-x64.zip`
  - Vulkan runtime present → `bin-win-vulkan-x64.zip`
  - Neither → `NotAvailable` (no CPU fallback)
- All three download functions (`download_prebuilt_binaries`, `_with_callback`, `_with_boxed_callback`) now only call `download_cuda_runtime()` when the selected `asset_pattern` contains `"cuda"`, preventing a spurious/failing CUDA DLL download for Vulkan installs.

---

### Tests

- `test_default_models_dir_platform_path` — asserts no forward slashes on Windows, correct XDG path on Unix
- `test_windows_gpu_cuda_selects_cuda_binary` — NVIDIA + CUDA → CUDA asset
- `test_windows_gpu_vulkan_only_selects_vulkan_binary` — Vulkan only → Vulkan asset
- `test_windows_gpu_nvidia_without_cuda_falls_back_to_vulkan` — NVIDIA hardware, no CUDA toolkit, Vulkan available → Vulkan
- `test_windows_gpu_no_gpu_returns_not_available` — no backends → `NotAvailable`

All GPU selection tests run cross-platform by testing the extracted `windows_availability_for_gpu()` helper directly.

---

### Commits

1. `fix(paths): use platform-appropriate default models directory on Windows`
2. `fix(download): select CUDA or Vulkan llama.cpp binary based on runtime GPU detection`
3. `fix(download): skip CUDA runtime DLL download for Vulkan installs on Windows`
4. `test(download): add unit tests for Windows GPU binary selection`