### PR TITLE
fix(runtime): make `gpu` pub(crate) to fix Windows release CI E0603 (#351)

### DIFF
--- a/crates/gglib-runtime/src/system/mod.rs
+++ b/crates/gglib-runtime/src/system/mod.rs
@@ -6,7 +6,7 @@
 
 mod commands;
 mod deps;
-mod gpu;
+pub(crate) mod gpu;
 
 use gglib_core::ports::SystemProbePort;
 use gglib_core::utils::system::{Dependency, DependencyStatus, GpuInfo, SystemMemoryInfo};


### PR DESCRIPTION
## Summary

Fixes #351.

The Windows release CI jobs (`Build x86_64-pc-windows-msvc` and `Build GUI x86_64-pc-windows-msvc`) have been failing since #348 with:

```
error[E0603]: module `gpu` is private
   --> crates\gglib-runtime\src\llama\download\mod.rs:158:38
```

## Root cause

`#348` added a Windows-`#[cfg]`-gated call to `crate::system::gpu::detect_gpu_info()` in `llama/download/mod.rs`, but the `gpu` submodule in `system/mod.rs` was declared `mod gpu;` (private). Rust's cross-module path resolution requires each segment of `crate::system::gpu` to be visible at the call site. The bug was invisible on macOS/Linux CI because the offending code only compiles on Windows.

## Fix

One-line change in `crates/gglib-runtime/src/system/mod.rs`:

```diff
-mod gpu;
+pub(crate) mod gpu;
```

`pub(crate)` makes the module reachable from anywhere within `gglib-runtime` without leaking it as a public API item (safe since `system` itself is already `pub mod` in `lib.rs`).