### PR TITLE
ci: surface release workflow as commit checks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,3 +323,19 @@ jobs:
             exit 1
           fi
           echo "All CI jobs passed successfully"
+
+  release:
+    name: Release
+    needs: [ci-success]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      pages: write
+      id-token: write
+      deployments: write
+    uses: ./.github/workflows/release.yml
+    with:
+      test_run: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
+  workflow_call:
+    inputs:
+      test_run:
+        description: 'Test run (skip actual release)'
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       test_run:
@@ -24,7 +27,7 @@ jobs:
   check-version:
     name: Check Version Change
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     outputs:
       version-changed: ${{ steps.version-check.outputs.changed }}
       new-version: ${{ steps.version-check.outputs.version }}
@@ -82,7 +85,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: check-version
-    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
     outputs:
       version: ${{ needs.check-version.outputs.new-version }}
     steps:
@@ -122,7 +125,7 @@ jobs:
     name: Deploy Documentation
     runs-on: ubuntu-latest
     needs: [check-version, create-release]
-    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && needs.check-version.outputs.is-prerelease != 'true' && inputs.test_run != true
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.check-version.outputs.version-changed == 'true' && needs.check-version.outputs.is-test-version != 'true' && needs.check-version.outputs.is-prerelease != 'true' && inputs.test_run != true
     # Allow one concurrent deployment
     concurrency:
       group: "pages"
@@ -265,7 +268,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     needs: [check-version]
-    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.check-version.outputs.version-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -400,7 +403,7 @@ jobs:
     name: Build GUI ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     needs: [check-version]
-    if: (github.event_name == 'push' || github.event_name == 'workflow_run') && needs.check-version.outputs.version-changed == 'true'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.check-version.outputs.version-changed == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The release workflow was triggered via `workflow_run` (fires after CI completes). Runs launched by `workflow_run` are not associated with any commit SHA, so they never appear in the commit's **Checks** section — they only show up in the Actions tab in the background.

## Solution

Convert `release.yml` to a reusable workflow (`workflow_call`) and call it directly from `ci.yml` as a final job. Because the call happens within the same CI workflow run, all release steps (Check Version, Create Release, Build, Build GUI, Deploy Docs) are now visible as check entries on the merge commit.

## Changes

### `.github/workflows/release.yml`
- **Replaced** `workflow_run` trigger with `workflow_call` (exposes the same `test_run` input as `workflow_dispatch`). `workflow_run` is removed entirely to prevent a spurious second release attempt — when CI (now containing the release jobs) completes, `workflow_run` would fire again and attempt a duplicate release.
- **Fixed `check-version` `if:` condition** — the old `workflow_run` conclusion-gate (`github.event.workflow_run.conclusion == 'success'`) is removed. The CI-success gate is now structural (`needs: [ci-success]` in `ci.yml`). Condition updated to `push || workflow_dispatch`. Note: when called via `workflow_call`, `github.event_name` inside the called workflow inherits the **caller's** event name (`push`), not `workflow_call`.
- **Fixed `create-release`, `deploy-docs`, `build`, `build-gui` `if:` conditions** — replaced `workflow_run` with `workflow_dispatch` so manual dispatch still activates these jobs.

### `.github/workflows/ci.yml`
- **Added `release` job** at the end:
  ```yaml
  release:
    name: Release
    needs: [ci-success]
    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
    permissions: { contents: write, issues: write, pull-requests: write, pages: write, id-token: write, deployments: write }
    uses: ./.github/workflows/release.yml
    with:
      test_run: false
    secrets: inherit
  ```
  - `needs: [ci-success]` — release only runs after all CI jobs pass
  - `github.ref == 'refs/heads/main'` — prevents accidental releases from feature branch pushes
  - `secrets: inherit` — no new secrets required

## Verification

| Scenario | Expected |
|---|---|
| PR merges to `main` | Release jobs appear in commit Checks tab |
| Push to feature branch | `release` job skipped (branch guard) |
| PR open/update | `release` job not in PR checks (`push` guard) |
| `workflow_dispatch` on `release.yml` | Works as before |
| No version change in `Cargo.toml` | `check-version` detects tag exists, skips downstream jobs |