### PR TITLE
fix(ci): use always() on release job to break skip propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
   release:
     name: Release
     needs: [ci-success]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && needs.ci-success.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Problem

The `release` job in `ci.yml` was being silently skipped on every push to `main` — before its `if` expression was ever evaluated. This caused v0.5.11 to have no release despite CI passing.

**Root cause:** skip-taint propagation through the `ci-success` job.

```
cli-cross-os (matrix)    → SKIPPED  (only runs on pull_request)
  ↓
ci-success (if: always()) → SUCCESS  (runs itself, but does not clear the taint)
  ↓
release (custom if:)     → SKIPPED  (runner never allocated, runner_id: null)
```

`if: always()` on `ci-success` allows it to run despite the skipped matrix dependency, but does **not** clear the skip signal for downstream jobs. `release` has a custom non-`always()` condition, so GitHub's scheduler skips it without evaluating the expression.

## Fix

Add `always()` to the `release` job to break the transitive skip propagation, while explicitly guarding with `needs.ci-success.result == 'success'` to preserve the CI-gate that `always()` would otherwise bypass.

```yaml
# Before
if: github.event_name == 'push' && github.ref == 'refs/heads/main'

# After
if: always() && needs.ci-success.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
```

## Follow-up

After this merges, trigger `workflow_dispatch` on `release.yml` to backfill the missing v0.5.11 release.
