### PR TITLE
fix: prevent md:grid from overriding hidden on inactive tab panels

### DIFF
--- a/src/components/TwoPanelLayout.tsx
+++ b/src/components/TwoPanelLayout.tsx
@@ -11,6 +11,12 @@ interface TwoPanelLayoutProps {
   className?: string;
   leftClassName?: string;
   rightClassName?: string;
+  /**
+   * When true, hides the layout at all breakpoints.
+   * Uses both `hidden` and `md:hidden` so tailwind-merge can remove
+   * the responsive `md:grid` base class, preventing cascade conflicts.
+   */
+  isHidden?: boolean;
 }
 
 /**
@@ -18,11 +24,12 @@ interface TwoPanelLayoutProps {
  * Stacks vertically on mobile, switches to a side-by-side grid at md:.
  */
 const TwoPanelLayout = forwardRef<HTMLDivElement, TwoPanelLayoutProps>(
-  ({ leftWidth, onResizeStart, onKeyboardResize, left, right, className, leftClassName, rightClassName }, ref) => (
+  ({ leftWidth, onResizeStart, onKeyboardResize, left, right, className, leftClassName, rightClassName, isHidden }, ref) => (
     <div
       ref={ref}
       className={cn(
         'flex flex-col md:grid md:grid-cols-2 md:gap-0 md:h-full md:overflow-hidden',
+        isHidden && 'hidden md:hidden',
         className,
       )}
       style={{ gridTemplateColumns: `${leftWidth}% ${100 - leftWidth}%` }}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -30,7 +30,6 @@ import {
   DEFAULT_TITLE_GENERATION_PROMPT,
 } from '../services/clients/chat';
 import type { ConversationSummary } from '../services/clients/chat';
-import { cn } from '../utils/cn';
 
 const DEFAULT_CONVERSATION_TITLE = 'New Chat';
 
@@ -395,10 +394,8 @@ export default function ChatPage({
         
         <TwoPanelLayout
           ref={activeTab === 'chat' ? layoutRef : undefined}
-          className={cn(
-            "flex-1 min-h-0",
-            activeTab !== 'chat' && "hidden"
-          )}
+          isHidden={activeTab !== 'chat'}
+          className="flex-1 min-h-0"
           leftWidth={leftPanelWidth}
           onResizeStart={handlePointerDown}
           onKeyboardResize={handleKeyboardResize}
@@ -453,10 +450,8 @@ export default function ChatPage({
       {/* Console Tab Content - always mounted, hidden when not active */}
       <TwoPanelLayout
         ref={activeTab === 'console' ? layoutRef : undefined}
-        className={cn(
-          "flex-1 min-h-0",
-          activeTab !== 'console' && "hidden"
-        )}
+        isHidden={activeTab !== 'console'}
+        className="flex-1 min-h-0"
         leftWidth={leftPanelWidth}
         onResizeStart={handlePointerDown}
         onKeyboardResize={handleKeyboardResize}


### PR DESCRIPTION
## Summary

Fixes #364 — both the Chat and Console tab panels were rendering visibly at the same time on desktop viewports (≥768px).

## Root Cause

`TwoPanelLayout` applies `md:grid` as a persistent base class. `ChatPage` was hiding the inactive panel by injecting `"hidden"` via `cn()` (tailwind-merge). tailwind-merge correctly removes `flex` when `hidden` is added (same unprefixed variant group), but `md:grid` is in the `md:` variant group — a different group — so it survived the merge. At desktop widths the browser CSS cascade resolves in favour of the responsive `md:grid` rule (emitted after `.hidden`), causing `display: grid` to win, and both panels to appear.

## Fix

### `TwoPanelLayout` — new `isHidden` prop (Commit 1)

Adds `isHidden?: boolean` to `TwoPanelLayoutProps`. When true, `'hidden md:hidden'` is passed into `cn()` alongside the base classes. tailwind-merge now sees a competing `md:`-prefixed display utility (`md:hidden`) that conflicts with `md:grid` — it removes `md:grid`, fully hiding the element at all breakpoints.

The prop is named `isHidden` (not the native HTML `hidden`) to avoid DOM attribute ambiguity and TypeScript interface collisions.

### `ChatPage` — use `isHidden` prop (Commit 2)

Both `TwoPanelLayout` instances (chat tab and console tab) now use `isHidden={activeTab !== '...'}` instead of the raw `className` approach. The unused `cn` import is removed.

## Layout Impact Verified

The two `TwoPanelLayout`s are siblings in a **`flex flex-col`** container, not columns in a shared grid. When one becomes `display: none`, it exits the flex layout entirely and the active `flex-1` panel expands to full width and height. The active panel's internal `md:grid-cols-2` (sidebar + content) is completely unaffected. No half-screen issue.

## Changes

| File | Change |
|------|--------|
| `src/components/TwoPanelLayout.tsx` | Add `isHidden?: boolean` prop; append `'hidden md:hidden'` when true |
| `src/pages/ChatPage.tsx` | Use `isHidden` prop on both panels; remove unused `cn` import |