### PR TITLE
feat(runtime): define BuildEvent and BuildPhase enums [Phase B]

### DIFF
--- a/crates/gglib-runtime/src/llama/build_events.rs
+++ b/crates/gglib-runtime/src/llama/build_events.rs
@@ -1,0 +1,106 @@
+//! Observable events for the llama.cpp source-build pipeline.
+//!
+//! [`BuildEvent`] is produced by the build-from-source pipeline and consumed by:
+//!
+//! | Consumer | Output                                                          |
+//! |----------|-----------------------------------------------------------------|
+//! | CLI      | `indicatif` spinner + progress bar                              |
+//! | Axum     | SSE stream at `GET /api/system/build-llama-from-source`         |
+//! | Tauri    | `llama-build-progress` event to WebView                         |
+//!
+//! The event type is **not** feature-gated: all three surfaces import [`BuildEvent`]
+//! and [`BuildPhase`] unconditionally. Only the pipeline that *produces* the events
+//! (in `build/` and `install/`) is gated behind `feature = "cli"`.
+
+use serde::Serialize;
+
+// =============================================================================
+// BuildPhase
+// =============================================================================
+
+/// A discrete stage within the llama.cpp source-build pipeline.
+///
+/// Phases execute in the order they are listed. [`BuildEvent::PhaseStarted`]
+/// and [`BuildEvent::PhaseCompleted`] bracket each stage so consumers can
+/// drive a multi-step progress indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildPhase {
+    /// Checking that cmake, git, and a suitable C++ compiler are present.
+    DependencyCheck,
+
+    /// Cloning the llama.cpp repository or pulling the latest commit.
+    CloneOrUpdateRepo,
+
+    /// Running `cmake` to configure the build system and detect acceleration.
+    Configure,
+
+    /// Running `cmake --build` to compile all translation units.
+    Compile,
+
+    /// Copying the built binaries to `~/.local/share/gglib/bin/`.
+    InstallBinaries,
+}
+
+// =============================================================================
+// BuildEvent
+// =============================================================================
+
+/// An observable event emitted by the llama.cpp source-build pipeline.
+///
+/// Events are the unit of SSE emission for the build pipeline. Every notable
+/// state change produces exactly one variant. Consumers decide how to render
+/// them: the CLI produces `indicatif` progress bars; Axum serialises to
+/// `data: <json>\n\n` frames; Tauri emits them to the WebView.
+///
+/// # Serde tag
+///
+/// `#[serde(tag = "type", rename_all = "snake_case")]` produces e.g.
+/// `{"type":"phase_started","phase":"configure"}`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BuildEvent {
+    /// A pipeline stage is beginning.
+    PhaseStarted {
+        /// The stage that is about to execute.
+        phase: BuildPhase,
+    },
+
+    /// A raw log line from cmake, the compiler, or git.
+    Log {
+        /// The unmodified output line from the subprocess.
+        message: String,
+    },
+
+    /// Compilation progress reported by cmake.
+    ///
+    /// Both `current` and `total` are file counts derived from cmake output
+    /// patterns such as `[ 50%]` (mapped to `50/100`) or `[150/300]`.
+    Progress {
+        /// Files compiled so far.
+        current: u64,
+        /// Total files to compile.
+        total: u64,
+    },
+
+    /// A pipeline stage has finished successfully.
+    PhaseCompleted {
+        /// The stage that just finished.
+        phase: BuildPhase,
+    },
+
+    /// The entire build-and-install pipeline completed successfully.
+    Completed {
+        /// The llama.cpp version or commit SHA that was built.
+        version: String,
+        /// Human-readable name of the GPU acceleration that was compiled in
+        /// (e.g. `"Metal"`, `"CUDA"`, `"CPU"`).
+        acceleration: String,
+    },
+
+    /// The pipeline terminated with an unrecoverable error.
+    Failed {
+        /// Human-readable description of the failure.
+        message: String,
+    },
+}

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -29,6 +29,7 @@
 pub mod args;
 #[cfg(feature = "cli")]
 mod build;
+pub mod build_events;
 mod config;
 mod deps;
 mod detect;
@@ -57,6 +58,9 @@ pub use server_availability::{LlamaServerError, LlamaServerResult, resolve_llama
 // Progress and prompt traits
 pub use progress::{NoopProgress, ProgressReporter};
 pub use prompt::{AutoConfirmPrompt, InstallPrompt, NonInteractivePrompt};
+
+// Build pipeline event types
+pub use build_events::{BuildEvent, BuildPhase};
 
 #[cfg(feature = "cli")]
 pub use progress::CliProgress;


### PR DESCRIPTION
Closes #369
Part of Epic #367

## What

Adds `crates/gglib-runtime/src/llama/build_events.rs` with the two foundational types that all subsequent build-pipeline phases depend on:

- **`BuildPhase`** — `DependencyCheck` | `CloneOrUpdateRepo` | `Configure` | `Compile` | `InstallBinaries` — one variant per step in the install-from-source flow.
- **`BuildEvent`** — `PhaseStarted` | `Log` | `Progress { current, total }` | `PhaseCompleted` | `Completed` | `Failed` — serde-tagged with `type` / `snake_case`, matching `AgentEvent` conventions.

Both are re-exported as `gglib_runtime::llama::{BuildEvent, BuildPhase}`.

## Architectural note vs. issue spec

The issue placed the types inside `llama/build/events.rs` (inside the `#[cfg(feature = "cli")]`-gated `build/` submodule). This PR places them at `llama/build_events.rs` — one level up, **not feature-gated**.

Rationale: `BuildEvent` must be importable by the Axum and Tauri surfaces when they consume the channel. Neither surface enables the `cli` feature. Keeping the *type definitions* unconditional while leaving the *pipeline that produces events* behind `cli` is the correct layer split and consistent with how `AgentEvent` is structured in `gglib-core`.

## Progress shape

`Progress { current: u64, total: u64 }` rather than `percent: u8` — cmake emits both `[ 50%]` (→ `50/100`) and `[150/300]`-style output. Preserving raw counts lets consumers compute percentage and avoids lossy conversion at the producer.

## Verification

```
cargo check -p gglib-runtime                   ✅
cargo check -p gglib-runtime --features cli    ✅
cargo clippy -p gglib-runtime -- -D warnings   ✅ (both feature sets)
cargo test --doc -p gglib-runtime              ✅
```