### PR TITLE
feat(runtime): thread Sender<BuildEvent> through git clone and run_llama_source_build (Phase D)

### DIFF
--- a/crates/gglib-runtime/src/llama/install/mod.rs
+++ b/crates/gglib-runtime/src/llama/install/mod.rs
@@ -1,7 +1,25 @@
-//! Installation command for llama.cpp.
+//! Source-build installation pipeline for llama.cpp.
+//!
+//! The primary streaming entry point is [`run_llama_source_build`], which emits
+//! [`BuildEvent`] values into a `Sender<BuildEvent>` channel. CLI-only concerns
+//! (dependency checks, user prompts) remain in [`build_from_source_impl`].
+//!
+//! ## Consumer table
+//!
+//! | Consumer | Output                                                             |
+//! |----------|--------------------------------------------------------------------|           
+//! | CLI      | `indicatif` progress bar (Phase E, via `consume_build_events_cli`) |
+//! | Axum     | SSE stream at `POST /api/system/build-llama-from-source`           |
+//! | Tauri    | `llama-build-progress` event to WebView                            |
+//!
+//! ## Threading model
+//!
+//! [`clone_llama_cpp`] and [`build_llama_cpp`] call `blocking_send` directly in their
+//! function bodies and must run via [`tokio::task::spawn_blocking`] from async contexts.
+//! [`run_llama_source_build`] handles this wrapping automatically.
 
 use super::build::build_llama_cpp;
-use super::build_events::BuildEvent;
+use super::build_events::{BuildEvent, BuildPhase};
 use super::config::BuildConfig;
 use super::deps::check_dependencies;
 use super::detect::{Acceleration, detect_optimal_acceleration};
@@ -14,9 +32,11 @@ use gglib_core::paths::{
     llama_server_path,
 };
 use gglib_core::utils::process::cmd;
-use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::thread;
 use tokio::sync::mpsc;
 
 // Helper to convert PathError to anyhow::Error
@@ -78,18 +98,107 @@ pub async fn handle_install(
     build_from_source_impl(cuda, metal, vulkan, force).await
 }
 
-/// Build llama.cpp from source (the original installation logic)
+/// Core streaming build pipeline for llama.cpp from source.
+///
+/// Clones or reuses the repository, configures, compiles, installs binaries, and saves
+/// the build configuration. All progress is emitted as [`BuildEvent`] values on `tx`.
+///
+/// This function has no CLI concerns (no user prompts, no dependency checks). Callers
+/// must perform pre-flight validation before calling this.
+///
+/// # Threading
+///
+/// Blocking subprocess work ([`clone_llama_cpp`], [`build_llama_cpp`]) runs inside
+/// [`tokio::task::spawn_blocking`] so the Tokio executor is never blocked and
+/// `blocking_send` calls are always on OS threads.
+pub async fn run_llama_source_build(
+    acceleration: Acceleration,
+    llama_dir: PathBuf,
+    server_path: PathBuf,
+    cli_path: PathBuf,
+    tx: mpsc::Sender<BuildEvent>,
+) -> Result<()> {
+    // Step 1: Clone or reuse repository.
+    let (version, commit_sha) = if llama_dir.exists() {
+        let _ = tx
+            .send(BuildEvent::Log {
+                message: "Using existing llama.cpp repository.".to_string(),
+            })
+            .await;
+        get_repo_info(&llama_dir)?
+    } else {
+        let tx_clone = tx.clone();
+        let dir = llama_dir.clone();
+        tokio::task::spawn_blocking(move || clone_llama_cpp(&dir, &tx_clone)).await??
+    };
+
+    // Step 2: Configure and compile.
+    {
+        let tx_clone = tx.clone();
+        let dir = llama_dir.clone();
+        tokio::task::spawn_blocking(move || build_llama_cpp(&dir, acceleration, &tx_clone))
+            .await??;
+    }
+
+    // Step 3: Install binaries.
+    {
+        let tx_clone = tx.clone();
+        let dir = llama_dir.clone();
+        let sp = server_path.clone();
+        let cp = cli_path.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _ = tx_clone.blocking_send(BuildEvent::PhaseStarted {
+                phase: BuildPhase::InstallBinaries,
+            });
+            install_binary(&dir, "llama-server", &sp)?;
+            install_binary(&dir, "llama-cli", &cp)?;
+            let _ = tx_clone.blocking_send(BuildEvent::PhaseCompleted {
+                phase: BuildPhase::InstallBinaries,
+            });
+            Ok(())
+        })
+        .await??;
+    }
+
+    // Step 4: Persist build configuration.
+    let config = BuildConfig::new(version.clone(), commit_sha, acceleration);
+    let config_path = path_err(llama_config_path())?;
+    config.save(&config_path)?;
+
+    // Step 5: Signal successful completion.
+    let _ = tx
+        .send(BuildEvent::Completed {
+            version,
+            acceleration: acceleration.display_name().to_string(),
+        })
+        .await;
+
+    Ok(())
+}
+
+/// Consumes [`BuildEvent`] values from the build pipeline channel.
+///
+/// Phase E will replace this stub with full `indicatif` progress-bar rendering.
+async fn consume_build_events_cli(mut rx: mpsc::Receiver<BuildEvent>) {
+    // Phase E stub: drain events until the indicatif renderer is implemented.
+    while rx.recv().await.is_some() {}
+}
+
+/// CLI-only wrapper for the source-build pipeline.
+///
+/// Performs dependency checks and the interactive Y/n prompt (CLI concerns), then
+/// delegates the actual build work to [`run_llama_source_build`].
 async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bool) -> Result<()> {
-    // Step 1: Check dependencies
+    // Step 1: Check dependencies.
     check_dependencies()?;
     println!();
 
-    // Step 2: Determine acceleration
+    // Step 2: Determine acceleration.
     let acceleration = determine_acceleration(cuda, metal, vulkan)?;
     println!("Selected acceleration: {}", acceleration.display_name());
     println!();
 
-    // Step 3: Pre-flight check
+    // Step 3: Interactive pre-flight prompt.
     if !force {
         print_preflight_info(&acceleration)?;
         print!("Continue? [Y/n]: ");
@@ -102,37 +211,24 @@ async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bo
         }
     }
 
-    // Step 4: Clone or update repository
+    // Steps 4-7: delegate to the pure streaming core.
     let llama_dir = path_err(llama_cpp_dir())?;
-    let (version, commit_sha) = if llama_dir.exists() {
-        println!("Using existing llama.cpp repository...");
-        get_repo_info(&llama_dir)?
-    } else {
-        clone_llama_cpp(&llama_dir)?
-    };
-
-    // Step 5: Build llama.cpp
-    let (build_tx, _build_rx) = mpsc::channel::<BuildEvent>(64);
-    build_llama_cpp(&llama_dir, acceleration, &build_tx)?;
-
-    // Step 6: Install binary
     let server_path = path_err(llama_server_path())?;
     let cli_path = path_err(llama_cli_path())?;
-    install_binary(&llama_dir, "llama-server", &server_path)?;
-    install_binary(&llama_dir, "llama-cli", &cli_path)?;
-
-    // Step 7: Save configuration
-    let config = BuildConfig::new(version.clone(), commit_sha, acceleration);
-    let config_path = path_err(llama_config_path())?;
-    config.save(&config_path)?;
+    let (tx, rx) = mpsc::channel::<BuildEvent>(64);
+    let build = tokio::spawn(run_llama_source_build(
+        acceleration,
+        llama_dir,
+        server_path,
+        cli_path,
+        tx,
+    ));
+    // Phase E will replace this stub with full indicatif rendering.
+    consume_build_events_cli(rx).await;
+    build.await??;
 
     println!();
     println!("✓ llama.cpp installed successfully!");
-    println!("  Server: {}", server_path.display());
-    println!("  CLI: {}", cli_path.display());
-    println!("  Version: {}", version);
-    println!("  Acceleration: {}", acceleration.display_name());
-    println!();
     println!("You can now use 'gglib serve', 'gglib proxy', and 'gglib chat'.");
 
     Ok(())
@@ -191,41 +287,62 @@ fn print_preflight_info(acceleration: &Acceleration) -> Result<()> {
     Ok(())
 }
 
-/// Clone the llama.cpp repository
-fn clone_llama_cpp(llama_dir: &std::path::Path) -> Result<(String, String)> {
-    println!("Cloning llama.cpp repository...");
-    println!();
+/// Clone the llama.cpp repository, routing subprocess output through `tx`.
+///
+/// Git progress lines containing `\r` (animated carriage-return output) are filtered
+/// out to avoid corrupting SSE streams. Only clean, newline-terminated informational
+/// lines are emitted as [`BuildEvent::Log`].
+fn clone_llama_cpp(llama_dir: &Path, tx: &mpsc::Sender<BuildEvent>) -> Result<(String, String)> {
+    let _ = tx.blocking_send(BuildEvent::PhaseStarted {
+        phase: BuildPhase::CloneOrUpdateRepo,
+    });
 
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} [{elapsed_precise}] {msg}")
-            .unwrap(),
-    );
-    pb.set_message("Cloning from GitHub...");
-
-    // Ensure parent directory exists
     if let Some(parent) = llama_dir.parent() {
         fs::create_dir_all(parent).context("Failed to create parent directory")?;
     }
 
-    let status = cmd("git")
+    let mut child = cmd("git")
         .args([
             "clone",
             "--depth=1",
             "https://github.com/ggerganov/llama.cpp",
             llama_dir.to_str().unwrap(),
         ])
-        .status()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .context("Failed to run git clone")?;
 
-    pb.finish_and_clear();
+    let stderr = child.stderr.take().unwrap();
 
+    // Git writes all progress to stderr. Read on an OS thread (blocking I/O).
+    // Carriage-return progress lines (e.g. "Receiving objects: 45%\r") are
+    // filtered: BufRead::lines() keeps \r as trailing content; any line
+    // containing \r is dropped to avoid corrupting SSE streams.
+    let tx_reader = tx.clone();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            if line.trim().is_empty() || line.contains('\r') {
+                continue;
+            }
+            if tx_reader
+                .blocking_send(BuildEvent::Log { message: line })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let status = child.wait().context("Failed to wait for git clone")?;
     if !status.success() {
         bail!("Failed to clone llama.cpp repository");
     }
 
-    println!("✓ Repository cloned");
+    let _ = tx.blocking_send(BuildEvent::PhaseCompleted {
+        phase: BuildPhase::CloneOrUpdateRepo,
+    });
 
     get_repo_info(llama_dir)
 }

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -79,6 +79,8 @@ pub use validate::{handle_status, validate_llama_binary, validate_llama_cli_bina
 #[cfg(feature = "cli")]
 pub use install::handle_install;
 #[cfg(feature = "cli")]
+pub use install::run_llama_source_build;
+#[cfg(feature = "cli")]
 pub use uninstall::{handle_rebuild, handle_uninstall};
 #[cfg(feature = "cli")]
 pub use update::{handle_check_updates, handle_update};


### PR DESCRIPTION
Closes #381. Part of Epic #367.

## What changed

### `crates/gglib-runtime/src/llama/install/mod.rs`

**`clone_llama_cpp`** — refactored to fix the TTY leak:
- Removed `ProgressBar`, the `.status()` call, and all `println!` output.
- Now accepts `tx: &mpsc::Sender<BuildEvent>` and emits `PhaseStarted { CloneOrUpdateRepo }` / `PhaseCompleted { CloneOrUpdateRepo }`.
- Subprocess spawned with `Stdio::piped()` on both stdout and stderr.
- `std::thread::spawn` reads stderr (where git writes all progress). Lines that are empty or contain `\r` (git's animated carriage-return progress) are filtered out to avoid corrupting SSE streams.

**`run_llama_source_build`** — new `pub async fn`, the streaming core for all three surfaces (CLI / Axum / Tauri):
- No CLI concerns: no prompts, no dependency checks.
- Wraps `clone_llama_cpp` and `build_llama_cpp` in `tokio::task::spawn_blocking` so `blocking_send` calls are always on OS threads — compliant with the concurrency model in CONTRIBUTING.md.
- Emits `PhaseStarted` / `PhaseCompleted { InstallBinaries }`, saves `BuildConfig`, and emits `BuildEvent::Completed` on success.
- Re-exported from `gglib_runtime::llama` under `#[cfg(feature = "cli")]`.

**`consume_build_events_cli`** — stub that silently drains `rx`. Phase E will replace this with `indicatif` rendering.

**`build_from_source_impl`** — retains all interactive CLI concerns (dep check, acceleration detection, Y/n prompt). Delegates steps 4–7 to `run_llama_source_build` via channel + `tokio::spawn`.

**Module `//!` doc** — updated with responsibility description, consumer table (CLI/Axum/Tauri), and threading model note.

### `crates/gglib-runtime/src/llama/mod.rs`

Added `pub use install::run_llama_source_build;` in the `#[cfg(feature = "cli")]` block.

## Verification

- `cargo check --features cli -p gglib-runtime` ✅
- `cargo check --workspace --all-features` ✅
- `cargo test -p gglib-runtime --features cli` ✅ (90/90 tests pass)
- `cargo clippy --features cli -p gglib-runtime -- -D warnings` ✅ (zero warnings)