### PR TITLE
feat(tauri): Phase G — Tauri command for llama.cpp source build with event emission

### DIFF
--- a/crates/gglib-tauri/src/events.rs
+++ b/crates/gglib-tauri/src/events.rs
@@ -25,6 +25,10 @@ pub mod names {
     // Llama installation events
     pub const LLAMA_INSTALL_PROGRESS: &str = "llama-install-progress";
 
+    /// Emitted during a llama.cpp source build (cmake + make).
+    /// Payload is a serialised [`BuildEvent`](gglib_runtime::llama::BuildEvent).
+    pub const LLAMA_BUILD_PROGRESS: &str = "llama-build-progress";
+
     // Menu action events (menu -> frontend)
     pub const MENU_ADD_MODEL_FILE: &str = "menu:add-model-file";
     pub const MENU_SHOW_DOWNLOADS: &str = "menu:show-downloads";

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ gglib-core.workspace = true
 gglib-download.workspace = true
 gglib-mcp.workspace = true
 gglib-db.workspace = true
-gglib-runtime = { workspace = true, features = ["prebuilt"] }
+gglib-runtime = { workspace = true, features = ["cli"] }
 gglib-tauri.workspace = true
 gglib-axum.workspace = true
 gglib-gui.workspace = true

--- a/src-tauri/src/commands/llama.rs
+++ b/src-tauri/src/commands/llama.rs
@@ -1,10 +1,12 @@
 //! llama.cpp installation and status commands.
 
 use crate::app::events::{emit_or_log, names};
+use gglib_core::paths::{llama_cli_path, llama_cpp_dir, llama_server_path};
 use gglib_download::ProgressThrottle;
 use gglib_runtime::llama::{
-    PrebuiltAvailability, check_llama_installed, check_prebuilt_availability,
-    download_prebuilt_binaries_with_boxed_callback,
+    BuildEvent, PrebuiltAvailability, check_llama_installed, check_prebuilt_availability,
+    detect_optimal_acceleration, download_prebuilt_binaries_with_boxed_callback,
+    run_llama_source_build,
 };
 use std::sync::{Arc, Mutex};
 use tauri::AppHandle;
@@ -24,6 +26,45 @@ pub struct LlamaInstallEvent {
     pub total: u64,
     pub percentage: f64,
     pub message: String,
+}
+
+/// Trigger a llama.cpp source build and stream progress as Tauri events.
+///
+/// Emits `llama-build-progress` events to the frontend throughout the build.
+/// Each event payload is a serialised [`BuildEvent`]:
+///
+/// | Variant          | JSON shape                                              |
+/// |------------------|---------------------------------------------------------|
+/// | `PhaseStarted`   | `{ "type": "phase_started", "phase": "..." }`          |
+/// | `Log`            | `{ "type": "log", "message": "..." }`                  |
+/// | `Progress`       | `{ "type": "progress", "current": N, "total": N }`     |
+/// | `PhaseCompleted` | `{ "type": "phase_completed", "phase": "..." }`        |
+/// | `Completed`      | `{ "type": "completed", "version": "...", "acceleration": "..." }` |
+/// | `Failed`         | `{ "type": "failed", "message": "..." }`               |
+///
+/// Returns an error string if path resolution, acceleration detection, or the
+/// build itself fails.
+#[tauri::command]
+pub async fn build_llama_from_source(app: AppHandle) -> Result<(), String> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<BuildEvent>(64);
+
+    let llama_dir = llama_cpp_dir().map_err(|e| e.to_string())?;
+    let server_path = llama_server_path().map_err(|e| e.to_string())?;
+    let cli_path = llama_cli_path().map_err(|e| e.to_string())?;
+    let acceleration = detect_optimal_acceleration().map_err(|e| e.to_string())?;
+
+    let build_handle = tokio::spawn(async move {
+        run_llama_source_build(acceleration, llama_dir, server_path, cli_path, tx).await
+    });
+
+    while let Some(event) = rx.recv().await {
+        emit_or_log(&app, names::LLAMA_BUILD_PROGRESS, event);
+    }
+
+    build_handle
+        .await
+        .map_err(|e| format!("Build task panicked: {e}"))?
+        .map_err(|e| e.to_string())
 }
 
 /// Check if llama.cpp is installed.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -219,6 +219,7 @@ fn main() {
             // OS integration: llama.cpp binary management
             commands::llama::check_llama_status,
             commands::llama::install_llama,
+            commands::llama::build_llama_from_source,
             // Research logs: file persistence for debugging
             commands::research_logs::init_research_logs,
             commands::research_logs::append_research_log,


### PR DESCRIPTION
Part of Epic #367 — Streaming BuildEvent Pipeline for llama.cpp.

Closes #384.

## What

Adds a `build_llama_from_source` Tauri command so the native desktop frontend can trigger a llama.cpp source build and receive streaming progress as `llama-build-progress` events.

## Changes

| File | Change |
|---|---|
| `crates/gglib-tauri/src/events.rs` | Added `LLAMA_BUILD_PROGRESS = "llama-build-progress"` constant to `pub mod names` |
| `src-tauri/Cargo.toml` | Upgraded `gglib-runtime` feature from `"prebuilt"` to `"cli"` (`cli` implies `prebuilt`; unlocks the `#[cfg(feature = "cli")]`-gated `run_llama_source_build` re-export) |
| `src-tauri/src/commands/llama.rs` | Added `#[tauri::command] pub async fn build_llama_from_source(app: AppHandle)` — resolves paths, detects acceleration, spawns the build on a Tokio task, drains the `BuildEvent` channel, and emits each event via `emit_or_log` |
| `src-tauri/src/main.rs` | Registered `commands::llama::build_llama_from_source` in `tauri::generate_handler![]` |

## Pattern

Follows the established `install_llama` pattern exactly: call the runtime function directly (not through `GuiBackend`), consume the typed event receiver, and forward each event to the frontend via `emit_or_log`. Channel capacity is 64, matching all other event channels in the codebase.

## Verification

- `cargo check -p gglib-app` — clean (zero warnings, zero errors)
- `build_llama_from_source` lives in `llama.rs`, which is already in the approved Tauri command file list enforced by `check-tauri-commands.sh`
- No new dependencies introduced across layer boundaries