### PR TITLE
docs(runtime): Phase H — Rustdoc for BuildEvent, BuildPhase, and build/mod.rs

### DIFF
--- a/crates/gglib-runtime/src/llama/build/mod.rs
+++ b/crates/gglib-runtime/src/llama/build/mod.rs
@@ -4,6 +4,13 @@
 //! `tokio::sync::mpsc::Sender<BuildEvent>` so that callers can render progress
 //! without this module knowing anything about terminals, HTTP, or Tauri.
 //!
+//! ## I/O Model
+//!
+//! All subprocess output is routed through the `tokio::sync::mpsc::Sender<BuildEvent>`
+//! channel supplied by the caller. The build functions do not write to the terminal
+//! directly; the caller is responsible for adapting the event stream to its preferred
+//! output (CLI spinner, SSE frames, Tauri events, etc.).
+//!
 //! ## Threading model
 //!
 //! The subprocess reader threads are spawned with [`std::thread::spawn`] and call

--- a/crates/gglib-runtime/src/llama/build_events.rs
+++ b/crates/gglib-runtime/src/llama/build_events.rs
@@ -1,12 +1,16 @@
 //! Observable events for the llama.cpp source-build pipeline.
 //!
-//! [`BuildEvent`] is produced by the build-from-source pipeline and consumed by:
+//! [`BuildEvent`] is produced by the build-from-source pipeline and consumed by three
+//! surfaces, each adapting the event stream to its own output medium:
 //!
-//! | Consumer | Output                                                          |
-//! |----------|-----------------------------------------------------------------|
-//! | CLI      | `indicatif` spinner + progress bar                              |
-//! | Axum     | SSE stream at `GET /api/system/build-llama-from-source`         |
-//! | Tauri    | `llama-build-progress` event to WebView                         |
+//! | Consumer    | Crate        | Output                                                                    |
+//! |-------------|--------------|--------------------------------------------------------------------------|
+//! | CLI         | `gglib-cli`  | `indicatif` spinner + progress bar via `consume_build_events_cli`         |
+//! | REST / SSE  | `gglib-axum` | Server-Sent Events at `POST /api/system/build-llama-from-source`          |
+//! | Desktop GUI | `gglib-tauri`| Tauri event `llama-build-progress` emitted to the WebView                 |
+//!
+//! The sender end is a `tokio::sync::mpsc::Sender<BuildEvent>` with capacity 64.
+//! When the sender is dropped the consumer loop terminates naturally.
 //!
 //! The event type is **not** feature-gated: all three surfaces import [`BuildEvent`]
 //! and [`BuildPhase`] unconditionally. Only the pipeline that *produces* the events


### PR DESCRIPTION
Part of Epic #367 — Streaming BuildEvent Pipeline for llama.cpp.

Closes #385.

## What

Enriches the module-level `//!` documentation on the two key files introduced by the streaming pipeline. No code changes — docs only.

## Changes

| File | Change |
|---|---|
| `crates/gglib-runtime/src/llama/build_events.rs` | Updated `//!` consumer table: added Module column (`gglib-cli`, `gglib-axum`, `gglib-tauri`), corrected HTTP method `GET` → `POST`, added `consume_build_events_cli` function reference for the CLI row, added sender capacity (64) and drop-termination note |
| `crates/gglib-runtime/src/llama/build/mod.rs` | Added `## I/O Model` section to the `//!` block, documenting that all subprocess output routes through the `Sender<BuildEvent>` channel rather than being written to the terminal directly |

Per-variant `///` docs on `BuildEvent` and `BuildPhase` were already complete and correct in the existing code — no changes needed there.

## Verification

```
cargo doc --features cli -p gglib-runtime   # 0 new warnings introduced
cargo test --doc -p gglib-runtime --features cli  # test result: ok. 0 failed
```

No README files were modified.