### PR TITLE
feat: Streaming BuildEvent pipeline for llama.cpp source builds (Epic #367)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,448 @@
+# Contributing to gglib
+
+This document is the definitive engineering guide for contributors. Read it before opening a pull request.
+
+---
+
+## Table of Contents
+
+1. [Core Philosophy](#core-philosophy)
+2. [Architecture Overview](#architecture-overview)
+3. [GUI Parity Principle](#gui-parity-principle)
+4. [Concurrency Model](#concurrency-model)
+5. [Subprocess Invocation](#subprocess-invocation)
+6. [Crate Boundaries](#crate-boundaries)
+7. [Documentation Standards](#documentation-standards)
+6. [Badges Pipeline](#badges-pipeline)
+7. [Development Workflow](#development-workflow)
+8. [CI Pipeline](#ci-pipeline)
+9. [Pull Request Checklist](#pull-request-checklist)
+
+---
+
+## Core Philosophy
+
+**Small, focused, low-complexity files.** If a module is growing, that is a signal to decompose it, not to add more to it. Functions should do one thing. Files should have one responsibility.
+
+**DRY without ceremony.** When the same logic appears twice, extract it. When extraction requires a new abstraction, make sure that abstraction earns its existence — it should simplify the call sites, not complicate them.
+
+**No backwards compatibility obligation.** If an existing signature, struct layout, or module boundary is in the way of a cleaner design, refactor it. Callers are in the same workspace; update them. There is no public API contract to preserve here.
+
+**Minimum viable surface area.** Do not add configuration knobs, trait objects, or generic parameters for hypothetical future requirements. The right abstraction is the one that solves the problem at hand with the fewest moving parts.
+
+---
+
+## Architecture Overview
+
+The workspace is organized into layers. Dependencies flow strictly inward.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Surfaces (one per interface)                                │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │  gglib-cli   │  │  gglib-axum  │  │  gglib-tauri │      │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘      │
+│         │                 │                  │               │
+├─────────▼─────────────────▼──────────────────▼──────────────┤
+│  Shared Backend                                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │ gglib-runtime│  │  gglib-agent │  │  gglib-gui   │      │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘      │
+│         │                 │                  │               │
+├─────────▼─────────────────▼──────────────────▼──────────────┤
+│  Domain & Infrastructure                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │  gglib-core  │  │   gglib-db   │  │  gglib-hf    │      │
+│  └──────────────┘  └──────────────┘  └──────────────┘      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**`gglib-core`** is the pure domain layer: types, traits, error definitions, and path utilities. It has no adapter dependencies and must not acquire any. This is enforced in CI.
+
+**`gglib-runtime`** orchestrates processes (llama.cpp, llama-server). It owns the build and install pipelines.
+
+**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) adapt the shared backend to their output medium. They contain no business logic. Any feature added to one surface must be achievable on all three — see the [GUI Parity Principle](#gui-parity-principle).
+
+---
+
+## GUI Parity Principle
+
+Every capability offered through one interface must be reachable through all three. Downloads, builds, agent loops, and model management all follow the same pattern:
+
+1. **Core logic in a runtime or domain crate** — emits typed events over a `tokio::sync::mpsc::Sender<T>` channel. It has no knowledge of the terminal, HTTP, or Tauri.
+2. **Surface adapters consume the channel** — the CLI renders events as an `indicatif` progress bar; the Axum layer streams them as SSE; the Tauri layer emits them as Tauri events to the WebView.
+
+Concrete examples of established patterns:
+
+| Domain | Event type | CLI consumer | Axum consumer | Tauri consumer |
+|---|---|---|---|---|
+| Agent loop | `AgentEvent` | spinner + streaming print | SSE at `/api/agent/stream` | `agent-event` Tauri event |
+| llama install | `LlamaProgressEvent` | progress bar | SSE at `/api/llama/install` | `llama-install-progress` |
+| llama build | `BuildEvent` | spinner + progress bar | SSE at `/api/system/build-llama-from-source` | `llama-build-progress` |
+
+When adding a new long-running operation:
+
+- Define the event enum in the relevant runtime or domain crate.
+- The function signature takes `tx: tokio::sync::mpsc::Sender<YourEvent>` as a parameter.
+- Wire the CLI adapter in its own function. Wire the Axum handler. Wire the Tauri command.
+- All three ship in the same PR.
+
+**Tauri commands are OS integration only.** Product features are served over HTTP (Axum). The CI enforces that `#[tauri::command]` functions live only in a small set of approved files (`util.rs`, `llama.rs`, `app_logs.rs`, `research_logs.rs`). A new product feature does not get a Tauri command — it gets an Axum route that the WebView calls over HTTP, just like the browser-based UI does.
+
+**Frontend transport is unified.** The frontend client modules must not branch on `isTauriApp`. If you find yourself writing `if (isTauriApp()) { invoke(...) } else { fetch(...) }` in a service module, that is an architectural violation. The transport abstraction layer handles that distinction.
+
+---
+
+## Concurrency Model
+
+The codebase uses Tokio for the async runtime. Understanding the boundary between async Tokio tasks and OS threads is critical.
+
+### Subprocess I/O: use `std::thread::spawn`
+
+Reading from a subprocess's stdout or stderr is blocking I/O. This must happen on an OS thread, not a Tokio task.
+
+```rust
+// Correct: OS thread reads from subprocess, sends over async channel
+let (tx, rx) = tokio::sync::mpsc::channel::<BuildEvent>(64);
+
+let tx_thread = tx.clone();
+std::thread::spawn(move || {
+    let reader = BufReader::new(child.stdout.take().unwrap());
+    for line in reader.lines().map_while(Result::ok) {
+        // blocking_send is safe and correct from a std::thread context
+        if tx_thread.blocking_send(BuildEvent::Log { message: line }).is_err() {
+            break; // receiver dropped, stop reading
+        }
+    }
+});
+
+// Caller drives the Tokio side
+while let Some(event) = rx.recv().await {
+    // render, forward, emit...
+}
+```
+
+`blocking_send` is safe to call from a `std::thread` because it is not running on the Tokio executor — there is no risk of stalling async task scheduling. The panic risk from `blocking_send` exists only inside a `tokio::spawn(async { ... })` future, which is why subprocess readers get their own OS threads.
+
+### Do not read subprocess output on the Tokio executor
+
+The following is incorrect:
+
+```rust
+// Wrong: blocks the Tokio executor thread
+tokio::spawn(async move {
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+    while let Some(line) = lines.next_line().await { ... }
+});
+```
+
+Use `tokio::process::Command` with async I/O, or use `std::thread::spawn` with blocking reads. Choose based on what the rest of the function's call chain expects.
+
+### Channel capacity
+
+All event channels are created with a bounded capacity of 64. This provides backpressure if a consumer falls behind. Do not use unbounded channels for subprocess output.
+
+---
+
+## Subprocess Invocation
+
+When constructing a `std::process::Command` or `tokio::process::Command`, be defensive about the environment it inherits.
+
+### Merging environment variables
+
+Do not blindly set environment variables that may already exist in the caller's environment. For example, if a build step requires `-Wno-missing-noreturn`, do not do this:
+
+```rust
+// Wrong: silently discards any CXXFLAGS the user or parent process set
+cmd.env("CXXFLAGS", "-Wno-missing-noreturn");
+```
+
+Instead, read the existing value and append:
+
+```rust
+// Correct: preserves upstream flags
+let existing = std::env::var("CXXFLAGS").unwrap_or_default();
+let merged = format!("{existing} -Wno-missing-noreturn").trim().to_owned();
+cmd.env("CXXFLAGS", merged);
+```
+
+The same principle applies to `CFLAGS`, `LDFLAGS`, `CMAKE_ARGS`, and any other flag-aggregating variables. One `.env()` call per variable.
+
+### Capturing output
+
+Subprocesses that produce output must always be spawned with `Stdio::piped()`. Never use `.status()` or `.output()` on a long-running subprocess that would print to the terminal — those methods either inherit the TTY or block until exit, neither of which is compatible with the streaming event model.
+
+```rust
+let mut child = Command::new("cmake")
+    .args(&["--build", "."])
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()?;
+```
+
+---
+
+## Crate Boundaries
+
+The CI runs `scripts/check_boundaries.sh` on every push and pull request. Violations fail the build.
+
+**`gglib-core`** — Pure domain types, error types, and path resolution utilities. No I/O, no async runtime, no adapter crates.
+
+**`gglib-db`** — May depend on `gglib-core` and `sqlx`. Nothing else.
+
+**`gglib-runtime`**, **`gglib-agent`**, **`gglib-download`**, **`gglib-hf`** — May depend on `gglib-core`, `gglib-db`, and peer library crates in the same layer. Must not depend on any surface crate.
+
+**`gglib-gui`** — Backend bridge used by both `gglib-axum` and `gglib-tauri`. No surface-specific code.
+
+**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) — May depend on anything in lower layers. Must not depend on each other.
+
+If your change requires adding a dependency from a lower layer to a higher layer, reconsider the design. The dependency should flow in the opposite direction via the channel/event pattern described above.
+
+### Feature flags in `gglib-runtime`
+
+`gglib-runtime` uses feature flags to gate compilation of heavy subsystems:
+
+| Feature | Includes | Use in |
+|---|---|---|
+| *(default)* | Inference and server management | `gglib-axum`, `gglib-gui` |
+| `prebuilt` | Pre-built binary download support | `gglib-tauri`, `gglib-gui` |
+| `cli` | Source build pipeline (`build/`, `install/`) — implies `prebuilt` | `gglib-cli`, any crate that drives source builds |
+
+When adding a new flag-gated import in a surface crate, ensure its `Cargo.toml` declares the correct `features = [...]` value. A missing feature flag will produce a confusing "function not found" compile error rather than a clear feature gate message.
+
+---
+
+## Documentation Standards
+
+This codebase has three distinct documentation surfaces. Each has a defined purpose and a defined location. Understanding the split prevents duplication and keeps the right audience reading the right thing.
+
+### Surface 1: Crate READMEs (shields.io badges + ASCII architecture diagrams)
+
+Each crate's `README.md` serves two narrow purposes:
+
+1. **Badges** — metrics surfaced as shields.io endpoint badges (tests, coverage, LOC, complexity) that read from the `badges` branch (see [Badges Pipeline](#badges-pipeline) below).
+2. **Architecture ASCII diagrams** — a text diagram showing where the crate sits in the layer model and an internal structure diagram. These are written and maintained by hand.
+
+Crate READMEs are **not** the place for API documentation, usage examples, or explanatory prose about how individual types work — that belongs in Rustdoc.
+
+### Surface 2: Module-level Rustdoc (`//!`)
+
+Every public module should open with a `//!` block that explains:
+
+- What the module is responsible for.
+- What it is **not** responsible for (prevents scope creep in future changes).
+- If it is part of a streaming pipeline, a table showing which consumers read from its channel.
+
+```rust
+//! Download progress events for the pre-built binary pipeline.
+//!
+//! [`DownloadEvent`] is produced by [`download_prebuilt_binaries`] and consumed by:
+//!
+//! | Consumer    | Output                                          |
+//! |-------------|--------------------------------------------------|
+//! | CLI         | `indicatif` progress bar                        |
+//! | Axum        | SSE stream at `GET /api/llama/install`           |
+//! | Tauri       | `llama-install-progress` event to WebView        |
+```
+
+This is the canonical location for architectural explanation of a module. When you add a new module, write the `//!` block first — it forces you to be clear about what the module owns before you write a single line of implementation.
+
+### Surface 3: Item-level Rustdoc (`///`)
+
+All `pub` types, enums, variants, traits, and functions must have a `///` doc comment. One sentence is enough for simple items; use longer descriptions only when the behaviour is non-obvious.
+
+```rust
+/// The build completed successfully.
+Complete { version: String, acceleration: String },
+```
+
+### The `cargo test --doc` gate
+
+CI runs `cargo test --doc --verbose` on every PR. This compiles all `///` example blocks as Rust code — a dangling import or wrong type in a doc-test will fail CI. When you add a triple-backtick Rust example, make sure it compiles. If an example requires external infrastructure, mark it `no_run`:
+
+````rust
+/// ```no_run
+/// let events = open_event_stream().await?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+````
+
+Private helper functions, unit-test modules (`#[cfg(test)]`), and generated code do not require doc comments.
+
+### Cargo docs deployment
+
+`cargo doc` is deployed to GitHub Pages automatically when a release is published, via `.github/workflows/docs.yml`. It runs:
+
+```bash
+cargo doc --workspace --no-deps --document-private-items --exclude gglib-app
+```
+
+The published site redirects to `gglib_core/index.html`, which is the primary API reference. You can preview locally with `make doc` (opens the browser). Do not add a docs deployment step manually — the release workflow handles it.
+
+---
+
+## Badges Pipeline
+
+Badges in crate READMEs are **not** static images. They are shields.io endpoint badges that read JSON files from a dedicated `badges` branch. Do not author or edit badge JSON files manually.
+
+### How the pipeline works
+
+```
+CI run (ci.yml)
+  └─ uploads artifacts: test-results, boundary-status.json, ts-test-results.json
+        │
+        ▼
+badges.yml (triggers after ci.yml completes)
+  └─ downloads CI artifacts
+  └─ generates badge JSON files (tests, boundaries, TS tests)
+  └─ commits JSON to the 'badges' branch
+
+coverage.yml (runs on push to main)
+  └─ generates lcov.info via cargo-llvm-cov
+  └─ triggers badges.yml (coverage variant)
+  └─ per-crate and per-module coverage JSONs pushed to 'badges' branch
+```
+
+Shields.io resolves badge URLs like:
+```
+https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-tests.json
+```
+
+### Module badge tables in READMEs
+
+Crate READMEs contain per-module badge tables delimited by HTML comment markers:
+
+```html
+<!-- module-table:start -->
+| Module | Tests | Coverage | LOC | Complexity |
+|--------|-------|----------|-----|------------|
+| ...    | ...   | ...      | ... | ...        |
+<!-- module-table:end -->
+```
+
+`scripts/generate_module_tables.sh` regenerates these tables by discovering the actual `.rs` files and subdirectories in each crate and wiring up the corresponding badge URLs. Run it after adding or removing modules:
+
+```bash
+./scripts/generate_module_tables.sh           # update all tables in-place
+./scripts/generate_module_tables.sh --check   # CI mode: exit 1 if any table is out of date
+./scripts/generate_module_tables.sh --dry-run # preview changes without writing
+```
+
+The `--check` mode is not currently a CI gate but is intended to become one. Keep tables current when you add modules.
+
+### Adding a badge to a new crate README
+
+Badge URLs follow the pattern `gglib-{crate-name}-{metric}.json` on the `badges` branch. For a new crate `gglib-foo`:
+
+```markdown
+![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-foo-tests.json)
+![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-foo-coverage.json)
+![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-foo-loc.json)
+![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-foo-complexity.json)
+```
+
+The badge JSON files will appear on the `badges` branch automatically after the first CI run that includes the new crate. Until then, the badges render as "unknown" — that is expected.
+
+To pre-generate badge structure for a new crate or update module tables, use `scripts/generate_submodule_readmes.sh`. This script updates existing README files with the standard badge block and module table markers; it does not create new README files.
+
+```bash
+./scripts/generate_submodule_readmes.sh           # update all existing READMEs
+./scripts/generate_submodule_readmes.sh --dry-run # preview changes
+```
+
+---
+
+## Development Workflow
+
+### Prerequisites
+
+- Rust 1.91.0 (managed via `rust-toolchain.toml` — `rustup` will install it automatically)
+- Node.js 20+
+- Platform system libraries (see `scripts/check-deps.sh` for a live dependency check)
+
+Run `make setup` for a one-command first-time setup on macOS. On Linux, review `scripts/check-deps.sh` first to install system packages.
+
+### Common commands
+
+```bash
+# Compile-check without producing artefacts (fastest feedback loop)
+make check
+
+# Run all tests
+make test
+
+# Format code (must be clean before commit)
+make fmt
+
+# Run Clippy — treat all warnings as errors
+make lint
+
+# Build and open Rustdoc locally
+make doc
+
+# Run all pre-commit checks in sequence: fmt + lint + check + test
+make pre-commit
+```
+
+### Working on the frontend
+
+```bash
+npm install
+npm run dev          # Start Vite dev server
+npm run test:run     # Run Vitest suite
+npm run build        # Production build (required before integration tests)
+```
+
+### Testing with feature flags
+
+Some crates have conditional compilation gated on feature flags. A plain `cargo test` will use default features. To test a specific feature combination:
+
+```bash
+cargo test -p gglib-runtime --features cli
+cargo doc  -p gglib-runtime --features cli
+```
+
+### Lockfile discipline
+
+The Cargo lockfile (`Cargo.lock`) is committed and must stay consistent. CI runs `cargo metadata --locked` as an early gate. After editing any `Cargo.toml`, run `cargo generate-lockfile` and commit the result.
+
+---
+
+## CI Pipeline
+
+Every PR must pass the following gates in order. They are not advisory.
+
+| Gate | Command | What it enforces |
+|---|---|---|
+| **Format** | `cargo fmt --all -- --check` | Consistent code style |
+| **Boundaries** | `./scripts/check_boundaries.sh` | Layer dependency rules |
+| **Architecture** | `./scripts/check-tauri-commands.sh`, `check-frontend-ipc.sh`, `check_transport_branching.sh` | Tauri policy; no IPC in product routes; no frontend transport branching |
+| **Clippy** | `cargo clippy --all-targets --all-features -- -D warnings` | No warnings, ever |
+| **Rust tests** | `cargo test` (aggregate + per-crate) | Correctness |
+| **Doc tests** | `cargo test --doc --verbose` | Doc examples compile and run |
+| **Frontend tests** | `npm run test:run` | TypeScript correctness |
+| **Cross-OS check** | `cargo check` on Linux/macOS/Windows | No platform-specific breakage |
+
+After each successful CI run, `badges.yml` downloads the test/boundary/coverage artifacts and pushes updated badge JSON files to the `badges` branch. Shields.io badges in crate READMEs resolve from there.
+
+Coverage is measured on every push to `main` with `cargo-llvm-cov` and feeds into the same badge pipeline.
+
+Docs are deployed to GitHub Pages automatically when a release is published, via `docs.yml`.
+
+---
+
+## Pull Request Checklist
+
+Before requesting review, confirm each item:
+
+- [ ] `make pre-commit` passes locally (`fmt` + `lint` + `check` + `test`).
+- [ ] `cargo test --doc` passes.
+- [ ] Any new public type or enum has `///` doc comments on all items.
+- [ ] Any architectural change is documented in `//!` module-level Rustdoc. ASCII architecture diagrams belong in crate READMEs; prose API documentation does not.
+- [ ] If a new module was added, `./scripts/generate_module_tables.sh` has been run and the updated badge table is committed.
+- [ ] Subprocess I/O is captured with `Stdio::piped()` and read on an OS thread, not a Tokio task.
+- [ ] Environment variable merging uses read-then-append, not a bare `.env()` that overwrites.
+- [ ] Any feature gated behind `#[cfg(feature = "...")]` is declared correctly in all consuming `Cargo.toml` files.
+- [ ] If the change adds a new long-running operation, all three surfaces (CLI, Axum, Tauri) are wired up.
+- [ ] `Cargo.lock` is up to date and committed.
+- [ ] No new dependency has been introduced from a higher layer to a lower layer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -224,9 +224,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1123,9 +1123,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "der"
@@ -1294,17 +1294,17 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.25.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9c2e7f1d22d0f2ce07626d259b8a55f4a47cb0938d4006dd8ae037f17d585e"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser 0.36.0",
  "foldhash 0.2.0",
- "html5ever 0.36.1",
+ "html5ever 0.38.0",
  "precomputed-hash",
- "selectors 0.35.0",
- "tendril",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "3.0.6"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
 dependencies = [
  "cc",
  "memchr",
@@ -3325,12 +3325,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever 0.36.1",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -3702,9 +3702,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -3832,7 +3832,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3841,9 +3841,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3857,10 +3879,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4004,9 +4028,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -4090,17 +4114,17 @@ dependencies = [
  "phf_codegen 0.11.3",
  "string_cache 0.8.9",
  "string_cache_codegen 0.5.4",
- "tendril",
+ "tendril 0.4.3",
 ]
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.5.0",
  "web_atoms",
 ]
 
@@ -4215,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4295,7 +4319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
@@ -4309,7 +4333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -4329,7 +4353,7 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -4338,7 +4362,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -4441,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -4498,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -4508,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -5131,9 +5155,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -5239,7 +5263,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -5880,9 +5904,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6057,9 +6081,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser 0.36.0",
@@ -6183,9 +6207,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -6419,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -6925,9 +6949,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.6"
+version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d52c379e63da659a483a958110bbde891695a0ecb53e48cc7786d5eda7bb"
+checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
@@ -6974,9 +6998,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -7285,6 +7309,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7385,9 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7515,7 +7549,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -7542,9 +7576,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -7575,30 +7609,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
@@ -7885,9 +7919,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -7990,9 +8024,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8139,9 +8173,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8152,23 +8186,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8176,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8189,9 +8219,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -8258,9 +8288,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8985,6 +9015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9090,9 +9129,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24eda84b5d488f99344e54b807138896cee8df0b2d16c793f1f6b80e6d8df1f"
+checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -9188,18 +9227,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-app"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-axum"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1995,14 +1995,14 @@ dependencies = [
 
 [[package]]
 name = "gglib-build-info"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "vergen-gix",
 ]
 
 [[package]]
 name = "gglib-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-db"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-download"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-gguf"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "gglib-core",
  "memmap2",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-gui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "dirs",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-hf"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "gglib-core",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-proxy"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-runtime"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-tauri"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-voice"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5335,7 +5335,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -5356,7 +5356,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5785,9 +5785,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -6094,7 +6094,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "gglib-mcp",
  "gglib-runtime",
  "hf-hub",
+ "indicatif 0.18.4",
  "reqwest 0.13.2",
  "rustyline",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 # Shared package metadata for all workspace crates
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "GPLv3"
 repository = "https://github.com/mmogr/gglib"

--- a/crates/gglib-axum/Cargo.toml
+++ b/crates/gglib-axum/Cargo.toml
@@ -18,7 +18,7 @@ gglib-gguf = { path = "../gglib-gguf" }  # GGUF_BOOTSTRAP_EXCEPTION: Parser inje
 gglib-gui = { path = "../gglib-gui" }
 gglib-hf = { path = "../gglib-hf" }
 gglib-mcp = { path = "../gglib-mcp" }
-gglib-runtime = { path = "../gglib-runtime" }
+gglib-runtime = { path = "../gglib-runtime", features = ["cli"] }
 gglib-voice = { path = "../gglib-voice" }  # Composition root: constructs VoiceService and injects into GuiDeps
 
 # Shared deps

--- a/crates/gglib-axum/src/handlers/setup.rs
+++ b/crates/gglib-axum/src/handlers/setup.rs
@@ -13,7 +13,9 @@ use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_core::paths::{llama_cli_path, llama_cpp_dir, llama_server_path};
 use gglib_gui::setup::SetupStatus;
-use gglib_runtime::llama::{Acceleration, BuildEvent, detect_optimal_acceleration, run_llama_source_build};
+use gglib_runtime::llama::{
+    Acceleration, BuildEvent, detect_optimal_acceleration, run_llama_source_build,
+};
 
 /// Get the full system setup status for the first-run wizard.
 pub async fn status(State(state): State<AppState>) -> Result<Json<SetupStatus>, HttpError> {
@@ -120,21 +122,33 @@ pub async fn build_llama_from_source(
         let llama_dir = match llama_cpp_dir() {
             Ok(p) => p,
             Err(e) => {
-                let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                let _ = tx
+                    .send(BuildEvent::Failed {
+                        message: e.to_string(),
+                    })
+                    .await;
                 return;
             }
         };
         let server_path = match llama_server_path() {
             Ok(p) => p,
             Err(e) => {
-                let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                let _ = tx
+                    .send(BuildEvent::Failed {
+                        message: e.to_string(),
+                    })
+                    .await;
                 return;
             }
         };
         let cli_path = match llama_cli_path() {
             Ok(p) => p,
             Err(e) => {
-                let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                let _ = tx
+                    .send(BuildEvent::Failed {
+                        message: e.to_string(),
+                    })
+                    .await;
                 return;
             }
         };
@@ -147,17 +161,24 @@ pub async fn build_llama_from_source(
             _ => match detect_optimal_acceleration() {
                 Ok(a) => a,
                 Err(e) => {
-                    let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                    let _ = tx
+                        .send(BuildEvent::Failed {
+                            message: e.to_string(),
+                        })
+                        .await;
                     return;
                 }
             },
         };
 
         if let Err(e) =
-            run_llama_source_build(acceleration, llama_dir, server_path, cli_path, tx.clone())
-                .await
+            run_llama_source_build(acceleration, llama_dir, server_path, cli_path, tx.clone()).await
         {
-            let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+            let _ = tx
+                .send(BuildEvent::Failed {
+                    message: e.to_string(),
+                })
+                .await;
         }
     });
 

--- a/crates/gglib-axum/src/handlers/setup.rs
+++ b/crates/gglib-axum/src/handlers/setup.rs
@@ -7,11 +7,13 @@ use axum::extract::State;
 use axum::response::sse::{Event, Sse};
 use futures_util::StreamExt;
 use futures_util::stream::Stream;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::HttpError;
 use crate::state::AppState;
+use gglib_core::paths::{llama_cli_path, llama_cpp_dir, llama_server_path};
 use gglib_gui::setup::SetupStatus;
+use gglib_runtime::llama::{Acceleration, BuildEvent, detect_optimal_acceleration, run_llama_source_build};
 
 /// Get the full system setup status for the first-run wizard.
 pub async fn status(State(state): State<AppState>) -> Result<Json<SetupStatus>, HttpError> {
@@ -89,4 +91,94 @@ enum LlamaProgressEvent {
     Error {
         message: String,
     },
+}
+
+/// Optional request body for [`build_llama_from_source`].
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildLlamaRequest {
+    /// Acceleration backend override. If omitted, auto-detection is used.
+    /// Valid values: `"metal"`, `"cuda"`, `"vulkan"`, `"cpu"`.
+    pub acceleration: Option<String>,
+}
+
+/// Build llama.cpp from source with SSE progress streaming.
+///
+/// Returns a server-sent event stream. Named event types:
+/// - `phase_started`: `{ "type": "phase_started", "phase": "<phase>" }`
+/// - `progress`: `{ "type": "progress", "current": <n>, "total": <n> }`
+/// - `log`: `{ "type": "log", "message": "<text>" }`
+/// - `phase_completed`: `{ "type": "phase_completed", "phase": "<phase>" }`
+/// - `completed`: `{ "type": "completed", "version": "<ver>", "acceleration": "<accel>" }`
+/// - `failed`: `{ "type": "failed", "message": "<error>" }`
+pub async fn build_llama_from_source(
+    Json(req): Json<BuildLlamaRequest>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<BuildEvent>(64);
+
+    tokio::spawn(async move {
+        let llama_dir = match llama_cpp_dir() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                return;
+            }
+        };
+        let server_path = match llama_server_path() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                return;
+            }
+        };
+        let cli_path = match llama_cli_path() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                return;
+            }
+        };
+
+        let acceleration = match req.acceleration.as_deref() {
+            Some("metal") => Acceleration::Metal,
+            Some("cuda") => Acceleration::Cuda,
+            Some("vulkan") => Acceleration::Vulkan,
+            Some("cpu") => Acceleration::Cpu,
+            _ => match detect_optimal_acceleration() {
+                Ok(a) => a,
+                Err(e) => {
+                    let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+                    return;
+                }
+            },
+        };
+
+        if let Err(e) =
+            run_llama_source_build(acceleration, llama_dir, server_path, cli_path, tx.clone())
+                .await
+        {
+            let _ = tx.send(BuildEvent::Failed { message: e.to_string() }).await;
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(build_event_to_sse);
+
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(std::time::Duration::from_secs(30))
+            .text("ping"),
+    )
+}
+
+fn build_event_to_sse(event: BuildEvent) -> Result<Event, Infallible> {
+    let event_type = match &event {
+        BuildEvent::PhaseStarted { .. } => "phase_started",
+        BuildEvent::Log { .. } => "log",
+        BuildEvent::Progress { .. } => "progress",
+        BuildEvent::PhaseCompleted { .. } => "phase_completed",
+        BuildEvent::Completed { .. } => "completed",
+        BuildEvent::Failed { .. } => "failed",
+    };
+    let data = serde_json::to_string(&event).unwrap_or_default();
+    Ok(Event::default().event(event_type).data(data))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -89,6 +89,10 @@ pub(crate) fn api_routes() -> Router<AppState> {
             "/system/install-llama",
             post(handlers::setup::install_llama),
         )
+        .route(
+            "/system/build-llama-from-source",
+            post(handlers::setup::build_llama_from_source),
+        )
         .route("/system/setup-python", post(handlers::setup::setup_python))
         .route(
             "/system/models-directory",

--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { workspace = true }
 
 # CLI-specific dependencies
 clap = { version = "4.0", features = ["derive", "env"] }
+indicatif = { workspace = true }
 chrono = { workspace = true }
 hf-hub = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/gglib-cli/src/handlers/llama.rs
+++ b/crates/gglib-cli/src/handlers/llama.rs
@@ -11,8 +11,7 @@ use crate::llama_commands::LlamaCommand;
 /// Dispatch a `llama` sub-command to the appropriate `gglib_runtime` handler.
 pub async fn dispatch(command: LlamaCommand) -> Result<()> {
     use gglib_runtime::llama::{
-        handle_check_updates, handle_install, handle_rebuild, handle_status, handle_uninstall,
-        handle_update,
+        handle_check_updates, handle_status, handle_uninstall, handle_update,
     };
 
     match command {
@@ -23,7 +22,7 @@ pub async fn dispatch(command: LlamaCommand) -> Result<()> {
             force,
             build,
         } => {
-            handle_install(cuda, metal, vulkan, force, build).await?;
+            super::llama_install::handle_install(cuda, metal, vulkan, force, build).await?;
         }
         LlamaCommand::CheckUpdates => {
             handle_check_updates().await?;
@@ -39,7 +38,7 @@ pub async fn dispatch(command: LlamaCommand) -> Result<()> {
             metal,
             vulkan,
         } => {
-            handle_rebuild(cuda, metal, vulkan).await?;
+            super::llama_install::handle_install(cuda, metal, vulkan, true, true).await?;
         }
         LlamaCommand::Uninstall { force } => {
             handle_uninstall(force).await?;

--- a/crates/gglib-cli/src/handlers/llama_install.rs
+++ b/crates/gglib-cli/src/handlers/llama_install.rs
@@ -1,0 +1,273 @@
+//! llama.cpp source-build installation — CLI surface adapter.
+//!
+//! Wraps [`run_llama_source_build`] with CLI concerns: dependency checks,
+//! the interactive Y/n prompt, and `indicatif` progress rendering.
+//! Surface-agnostic build logic lives in `gglib-runtime::llama`.
+
+use anyhow::{Result, bail};
+use indicatif::{ProgressBar, ProgressStyle};
+use std::io::{self, Write};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+use gglib_core::paths::{
+    gglib_data_dir, is_prebuilt_binary, llama_cli_path, llama_cpp_dir, llama_server_path,
+};
+use gglib_runtime::llama::{
+    Acceleration, BuildEvent, BuildPhase, check_dependencies, check_disk_space,
+    check_prebuilt_availability, detect_optimal_acceleration, download_prebuilt_binaries,
+    run_llama_source_build, PrebuiltAvailability,
+};
+
+fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
+    r.map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+/// Handle the install command.
+///
+/// Installation method is determined by context:
+/// - `--build` flag: Always build from source
+/// - Running from source repo: Build from source (existing behavior)
+/// - Pre-built binary + macOS/Windows: Download pre-built binaries
+/// - Pre-built binary + Linux: Build from source (CUDA requires compilation)
+pub async fn handle_install(
+    cuda: bool,
+    metal: bool,
+    vulkan: bool,
+    force: bool,
+    build_from_source: bool,
+) -> Result<()> {
+    // Check if already installed
+    let server_path = path_err(llama_server_path())?;
+    let cli_path = path_err(llama_cli_path())?;
+    if server_path.exists() && cli_path.exists() && !force {
+        let install_dir = server_path
+            .parent()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| server_path.display().to_string());
+        println!(
+            "llama-server and llama-cli are already installed in: {}",
+            install_dir
+        );
+        println!("Use --force to rebuild or refresh binaries.");
+        return Ok(());
+    }
+
+    // Determine installation method
+    let should_build = build_from_source
+        || !is_prebuilt_binary() // Running from source repo
+        || cuda
+        || metal
+        || vulkan // User specified acceleration flags
+        || matches!(
+            check_prebuilt_availability(),
+            PrebuiltAvailability::NotAvailable { .. }
+        );
+
+    if !should_build {
+        // Try downloading pre-built binaries
+        println!("Attempting to download pre-built llama.cpp binaries...");
+        match download_prebuilt_binaries().await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                println!();
+                println!("⚠️  Failed to download pre-built binaries: {}", e);
+                println!("Falling back to building from source...");
+                println!();
+            }
+        }
+    }
+
+    // Build from source
+    build_from_source_impl(cuda, metal, vulkan, force).await
+}
+
+/// CLI-only wrapper for the source-build pipeline.
+///
+/// Performs dependency checks and the interactive Y/n prompt (CLI concerns), then
+/// delegates the actual build work to [`run_llama_source_build`].
+async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bool) -> Result<()> {
+    // Step 1: Check dependencies.
+    check_dependencies()?;
+    println!();
+
+    // Step 2: Determine acceleration.
+    let acceleration = determine_acceleration(cuda, metal, vulkan)?;
+    println!("Selected acceleration: {}", acceleration.display_name());
+    println!();
+
+    // Step 3: Interactive pre-flight prompt.
+    if !force {
+        print_preflight_info(&acceleration)?;
+        print!("Continue? [Y/n]: ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if input.trim().eq_ignore_ascii_case("n") {
+            println!("Installation cancelled.");
+            return Ok(());
+        }
+    }
+
+    // Steps 4-7: delegate to the pure streaming core.
+    let llama_dir = path_err(llama_cpp_dir())?;
+    let server_path = path_err(llama_server_path())?;
+    let cli_path = path_err(llama_cli_path())?;
+    let (tx, rx) = mpsc::channel::<BuildEvent>(64);
+    let build = tokio::spawn(run_llama_source_build(
+        acceleration,
+        llama_dir,
+        server_path,
+        cli_path,
+        tx,
+    ));
+    consume_build_events_cli(rx).await;
+    build.await??;
+
+    Ok(())
+}
+
+fn determine_acceleration(cuda: bool, metal: bool, vulkan: bool) -> Result<Acceleration> {
+    let flags_set = [cuda, metal, vulkan].iter().filter(|&&x| x).count();
+
+    if flags_set > 1 {
+        bail!("Only one acceleration flag can be specified");
+    }
+
+    if metal {
+        #[cfg(not(target_os = "macos"))]
+        bail!("Metal acceleration is only available on macOS");
+
+        #[cfg(target_os = "macos")]
+        Ok(Acceleration::Metal)
+    } else if cuda {
+        Ok(Acceleration::Cuda)
+    } else if vulkan {
+        Ok(Acceleration::Vulkan)
+    } else {
+        // Auto-detect
+        detect_optimal_acceleration()
+    }
+}
+
+fn print_preflight_info(acceleration: &Acceleration) -> Result<()> {
+    println!("Pre-flight check:");
+    println!("✓ Build dependencies installed");
+
+    // Check disk space
+    if check_disk_space(800)? {
+        println!("✓ Disk space available");
+    }
+
+    println!("✓ Detected: {}", acceleration.display_name());
+    println!();
+    println!("This will:");
+    println!("  1. Clone llama.cpp repository (~150 MB)");
+    println!(
+        "  2. Configure with CMake ({} enabled)",
+        acceleration.display_name()
+    );
+    println!("  3. Compile llama-server and llama-cli (~3-5 minutes)");
+
+    let gglib_dir = path_err(gglib_data_dir())?;
+    println!("  4. Install to {}", gglib_dir.join("bin").display());
+    println!();
+
+    Ok(())
+}
+
+/// Consumes [`BuildEvent`] values from the build pipeline channel and renders
+/// them as `indicatif` spinners and progress bars.
+///
+/// A single `Option<ProgressBar>` tracks the active indicator. Phases are
+/// strictly sequential so there is never more than one active bar at a time.
+async fn consume_build_events_cli(mut rx: mpsc::Receiver<BuildEvent>) {
+    let spinner_style = ProgressStyle::default_spinner()
+        .template("{spinner:.green} [{elapsed_precise}] {msg}")
+        .expect("valid spinner template");
+
+    let bar_style = ProgressStyle::default_bar()
+        .template(
+            "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({percent}%) {msg}",
+        )
+        .expect("valid bar template")
+        .progress_chars("#>-");
+
+    let mut active: Option<ProgressBar> = None;
+
+    while let Some(event) = rx.recv().await {
+        match event {
+            BuildEvent::PhaseStarted { phase } => {
+                // Clean up any previous indicator before starting a new one.
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+                let pb = match phase {
+                    BuildPhase::Compile => {
+                        // Length unknown until the first Progress event.
+                        let pb = ProgressBar::new(0);
+                        pb.set_style(bar_style.clone());
+                        pb.set_message("Compiling...");
+                        pb
+                    }
+                    BuildPhase::DependencyCheck => {
+                        // CLI performs its own dep-check output before the channel
+                        // opens, so no indicatif bar is needed here.
+                        continue;
+                    }
+                    _ => {
+                        let msg = match phase {
+                            BuildPhase::CloneOrUpdateRepo => "Cloning llama.cpp repository...",
+                            BuildPhase::Configure => "Configuring with CMake...",
+                            BuildPhase::InstallBinaries => "Installing binaries...",
+                            _ => unreachable!(),
+                        };
+                        let pb = ProgressBar::new_spinner();
+                        pb.set_style(spinner_style.clone());
+                        pb.set_message(msg);
+                        pb.enable_steady_tick(Duration::from_millis(100));
+                        pb
+                    }
+                };
+                active = Some(pb);
+            }
+            BuildEvent::PhaseCompleted { .. } => {
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+            }
+            BuildEvent::Progress { current, total } => {
+                if let Some(pb) = &active {
+                    pb.set_length(total);
+                    pb.set_position(current);
+                }
+            }
+            BuildEvent::Log { message } => {
+                if let Some(pb) = &active {
+                    pb.println(&message);
+                } else {
+                    println!("{}", message);
+                }
+            }
+            BuildEvent::Completed {
+                version,
+                acceleration,
+            } => {
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+                println!();
+                println!("✓ llama.cpp installed successfully!");
+                println!("  Version:       {}", version);
+                println!("  Acceleration:  {}", acceleration);
+                println!("You can now use 'gglib serve', 'gglib proxy', and 'gglib chat'.");
+            }
+            BuildEvent::Failed { message } => {
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+                eprintln!("✗ Build failed: {}", message);
+            }
+        }
+    }
+}

--- a/crates/gglib-cli/src/handlers/llama_install.rs
+++ b/crates/gglib-cli/src/handlers/llama_install.rs
@@ -14,9 +14,9 @@ use gglib_core::paths::{
     gglib_data_dir, is_prebuilt_binary, llama_cli_path, llama_cpp_dir, llama_server_path,
 };
 use gglib_runtime::llama::{
-    Acceleration, BuildEvent, BuildPhase, check_dependencies, check_disk_space,
-    check_prebuilt_availability, detect_optimal_acceleration, download_prebuilt_binaries,
-    run_llama_source_build, PrebuiltAvailability,
+    Acceleration, BuildEvent, BuildPhase, PrebuiltAvailability, check_dependencies,
+    check_disk_space, check_prebuilt_availability, detect_optimal_acceleration,
+    download_prebuilt_binaries, run_llama_source_build,
 };
 
 fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {

--- a/crates/gglib-cli/src/handlers/mod.rs
+++ b/crates/gglib-cli/src/handlers/mod.rs
@@ -26,6 +26,7 @@ pub mod download;
 pub mod gui;
 pub mod list;
 pub mod llama;
+pub mod llama_install;
 pub mod paths;
 pub mod question;
 pub mod remove;

--- a/crates/gglib-runtime/Cargo.toml
+++ b/crates/gglib-runtime/Cargo.toml
@@ -50,7 +50,7 @@ zip = { version = "7.1", default-features = false, features = ["aes-crypto", "bz
 flate2 = "1"
 tar = "0.4"
 
-# CLI progress (used by cli feature)
+# CLI progress (used by cli feature and prebuilt download)
 indicatif = { workspace = true }
 
 # Unix signal handling

--- a/crates/gglib-runtime/src/llama/build/README.md
+++ b/crates/gglib-runtime/src/llama/build/README.md
@@ -21,10 +21,6 @@ Handles compiling llama.cpp from source with appropriate acceleration flags.
 3. Progress bar shows compilation status
 4. Validate built binaries
 
-## Note
-
-`CXXFLAGS="-O2"` is set to work around a GCC 15.2.1 segfault bug during optimization passes.
-
 <!-- module-docs:end -->
 
 <details>

--- a/crates/gglib-runtime/src/llama/build/mod.rs
+++ b/crates/gglib-runtime/src/llama/build/mod.rs
@@ -4,6 +4,13 @@
 //! `tokio::sync::mpsc::Sender<BuildEvent>` so that callers can render progress
 //! without this module knowing anything about terminals, HTTP, or Tauri.
 //!
+//! ## I/O Model
+//!
+//! All subprocess output is routed through the `tokio::sync::mpsc::Sender<BuildEvent>`
+//! channel supplied by the caller. The build functions do not write to the terminal
+//! directly; the caller is responsible for adapting the event stream to its preferred
+//! output (CLI spinner, SSE frames, Tauri events, etc.).
+//!
 //! ## Threading model
 //!
 //! The subprocess reader threads are spawned with [`std::thread::spawn`] and call

--- a/crates/gglib-runtime/src/llama/build/mod.rs
+++ b/crates/gglib-runtime/src/llama/build/mod.rs
@@ -97,7 +97,10 @@ fn configure_cmake(
 
     // Merge into any CXXFLAGS/CFLAGS already set by the caller's environment.
     // -O1: GCC 15.2.1 ICE workaround. -Wno-missing-noreturn: suppress upstream warning flood.
-    cmd.env("CXXFLAGS", merge_flags("CXXFLAGS", "-O1 -Wno-missing-noreturn"));
+    cmd.env(
+        "CXXFLAGS",
+        merge_flags("CXXFLAGS", "-O1 -Wno-missing-noreturn"),
+    );
     cmd.env("CFLAGS", merge_flags("CFLAGS", "-O1"));
 
     // Compiler selection priority (platform-specific):

--- a/crates/gglib-runtime/src/llama/build/mod.rs
+++ b/crates/gglib-runtime/src/llama/build/mod.rs
@@ -1,4 +1,16 @@
-//! Build orchestration for llama.cpp with progress tracking.
+//! Build orchestration for llama.cpp.
+//!
+//! [`build_llama_cpp`] emits [`BuildEvent`] values over a
+//! `tokio::sync::mpsc::Sender<BuildEvent>` so that callers can render progress
+//! without this module knowing anything about terminals, HTTP, or Tauri.
+//!
+//! ## Threading model
+//!
+//! The subprocess reader threads are spawned with [`std::thread::spawn`] and call
+//! `tx.blocking_send()`. This is safe because the threads are OS threads, not
+//! Tokio tasks — there is no risk of blocking the async executor.
+//!
+//! ## Compiler flags
 //!
 //! `CXXFLAGS` is merged (read-then-append) during both the cmake configure and build
 //! phases to carry two flags:
@@ -7,8 +19,6 @@
 //!   higher optimisation passes on `chat.cpp` and related files.
 //! - `-Wno-missing-noreturn` — suppresses the warning flood from `common/jinja/runtime.h`,
 //!   whose virtual `throw`-only methods AppleClang flags as candidates for `[[noreturn]]`.
-//!   Because many translation units include the header and jobs run in parallel, the warning
-//!   fires hundreds of times and corrupts `indicatif` progress-bar output.
 //!
 //! `CFLAGS` receives only `-O1`; `-Wmissing-noreturn` is a C++-only diagnostic.
 //! Any `CXXFLAGS`/`CFLAGS` already present in the caller's environment are preserved
@@ -21,46 +31,44 @@ use super::detect::select_cuda_compiler_for_build;
 
 use anyhow::{Context, Result, bail};
 
-use indicatif::{ProgressBar, ProgressStyle};
+use super::build_events::{BuildEvent, BuildPhase};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::sync::mpsc;
+use std::sync::mpsc as std_mpsc;
 use std::thread;
+use tokio::sync::mpsc;
 
-/// Build llama.cpp with the specified acceleration
-pub fn build_llama_cpp(llama_dir: &Path, acceleration: Acceleration) -> Result<()> {
-    println!();
-    println!(
-        "Building llama.cpp with {} support...",
-        acceleration.display_name()
-    );
-    println!();
-
+/// Build llama.cpp from source, emitting [`BuildEvent`] values over `tx`.
+///
+/// Callers supply a sender so that progress can be rendered by any surface
+/// (CLI progress bar, Axum SSE, Tauri event) without this function knowing
+/// which interface is consuming the stream.
+pub fn build_llama_cpp(
+    llama_dir: &Path,
+    acceleration: Acceleration,
+    tx: &mpsc::Sender<BuildEvent>,
+) -> Result<()> {
     let build_dir = llama_dir.join("build");
     std::fs::create_dir_all(&build_dir).context("Failed to create build directory")?;
 
-    // Step 1: CMake Configure
-    configure_cmake(llama_dir, &build_dir, acceleration)?;
-
-    // Step 2: Build
-    build_project(&build_dir, acceleration)?;
-
-    println!();
-    println!("✓ Build completed successfully");
+    configure_cmake(llama_dir, &build_dir, acceleration, tx)?;
+    build_project(&build_dir, acceleration, tx)?;
 
     Ok(())
 }
 
-/// Run `CMake` configuration
-fn configure_cmake(llama_dir: &Path, build_dir: &Path, acceleration: Acceleration) -> Result<()> {
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} [{elapsed_precise}] {msg}")
-            .unwrap(),
-    );
-    pb.set_message("Configuring with CMake...");
+/// Run `CMake` configuration, emitting a [`BuildEvent::PhaseStarted`] at the start
+/// and [`BuildEvent::Log`] for each non-empty subprocess output line.
+fn configure_cmake(
+    llama_dir: &Path,
+    build_dir: &Path,
+    acceleration: Acceleration,
+    tx: &mpsc::Sender<BuildEvent>,
+) -> Result<()> {
+    let _ = tx.blocking_send(BuildEvent::PhaseStarted {
+        phase: BuildPhase::Configure,
+    });
 
     let mut args = vec![
         "-S",
@@ -114,15 +122,22 @@ fn configure_cmake(llama_dir: &Path, build_dir: &Path, acceleration: Acceleratio
                 if compiler.contains("clang") {
                     cmd.env("CC", "clang");
                     cmd.env("CXX", "clang++");
-                    pb.println("Using clang/clang++ for CUDA build (best compatibility)");
+                    let _ = tx.blocking_send(BuildEvent::Log {
+                        message: "Using clang/clang++ for CUDA build (best compatibility)"
+                            .to_string(),
+                    });
                 } else if compiler == "gcc-12" {
                     cmd.env("CC", "gcc-12");
                     cmd.env("CXX", "g++-12");
-                    pb.println("Using gcc-12/g++-12 for CUDA compatibility");
+                    let _ = tx.blocking_send(BuildEvent::Log {
+                        message: "Using gcc-12/g++-12 for CUDA compatibility".to_string(),
+                    });
                 } else if compiler == "gcc-11" {
                     cmd.env("CC", "gcc-11");
                     cmd.env("CXX", "g++-11");
-                    pb.println("Using gcc-11/g++-11 for CUDA compatibility");
+                    let _ = tx.blocking_send(BuildEvent::Log {
+                        message: "Using gcc-11/g++-11 for CUDA compatibility".to_string(),
+                    });
                 }
                 // If "gcc" (system default), don't set explicitly
             } else {
@@ -152,7 +167,9 @@ fn configure_cmake(llama_dir: &Path, build_dir: &Path, acceleration: Acceleratio
     // For CUDA builds, set CUDA paths explicitly
     let cuda_args = if matches!(acceleration, Acceleration::Cuda) {
         if let Some(cuda_path) = get_cuda_path() {
-            pb.println(format!("Using CUDA installation at: {}", cuda_path));
+            let _ = tx.blocking_send(BuildEvent::Log {
+                message: format!("Using CUDA installation at: {}", cuda_path),
+            });
 
             // Set environment variables for FindCUDAToolkit
             cmd.env("CUDAToolkit_ROOT", &cuda_path);
@@ -182,18 +199,17 @@ fn configure_cmake(llama_dir: &Path, build_dir: &Path, acceleration: Acceleratio
         .spawn()
         .context("Failed to run CMake")?;
 
-    // Capture and display output
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
 
-    let (tx, rx) = mpsc::channel();
-    let tx2 = tx.clone();
+    let (line_tx, line_rx) = std_mpsc::channel();
+    let line_tx2 = line_tx.clone();
 
     // Read stdout
     thread::spawn(move || {
         let reader = BufReader::new(stdout);
         for line in reader.lines().map_while(Result::ok) {
-            let _ = tx.send(line);
+            let _ = line_tx.send(line);
         }
     });
 
@@ -201,52 +217,49 @@ fn configure_cmake(llama_dir: &Path, build_dir: &Path, acceleration: Acceleratio
     thread::spawn(move || {
         let reader = BufReader::new(stderr);
         for line in reader.lines().map_while(Result::ok) {
-            let _ = tx2.send(line);
+            let _ = line_tx2.send(line);
         }
     });
 
-    // Update spinner with output
-    while let Ok(line) = rx.recv_timeout(std::time::Duration::from_millis(100)) {
+    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(100)) {
         if !line.trim().is_empty() {
-            pb.println(&line);
+            let _ = tx.blocking_send(BuildEvent::Log { message: line });
         }
-        pb.tick();
     }
 
     let status = child.wait().context("Failed to wait for CMake")?;
 
     // Drain any remaining output in the channel before finishing
     // This prevents losing error messages due to race conditions
-    while let Ok(line) = rx.recv_timeout(std::time::Duration::from_millis(50)) {
+    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(50)) {
         if !line.trim().is_empty() {
-            pb.println(&line);
+            let _ = tx.blocking_send(BuildEvent::Log { message: line });
         }
     }
 
-    pb.finish_and_clear();
+    let _ = tx.blocking_send(BuildEvent::PhaseCompleted {
+        phase: BuildPhase::Configure,
+    });
 
     if !status.success() {
         bail!("CMake configuration failed");
     }
 
-    println!("✓ CMake configuration complete");
     Ok(())
 }
 
-/// Build the project with progress tracking
-fn build_project(build_dir: &Path, acceleration: Acceleration) -> Result<()> {
-    println!();
+/// Run `cmake --build`, emitting [`BuildEvent::Progress`] and [`BuildEvent::Log`]
+/// events as compilation proceeds.
+fn build_project(
+    build_dir: &Path,
+    acceleration: Acceleration,
+    tx: &mpsc::Sender<BuildEvent>,
+) -> Result<()> {
+    let _ = tx.blocking_send(BuildEvent::PhaseStarted {
+        phase: BuildPhase::Compile,
+    });
 
     let num_cores = build_parallelism(acceleration);
-    println!("Building with {} parallel jobs...", num_cores);
-
-    let pb = ProgressBar::new(100);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({percent}%) {msg}")
-            .unwrap()
-            .progress_chars("#>-")
-    );
 
     // Merge into any CXXFLAGS/CFLAGS already set by the caller's environment.
     // -O1: GCC 15.2.1 ICE workaround. -Wno-missing-noreturn: suppress upstream warning flood.
@@ -272,14 +285,14 @@ fn build_project(build_dir: &Path, acceleration: Acceleration) -> Result<()> {
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
 
-    let (tx, rx) = mpsc::channel();
-    let tx2 = tx.clone();
+    let (line_tx, line_rx) = std_mpsc::channel();
+    let line_tx2 = line_tx.clone();
 
     // Read stdout
     thread::spawn(move || {
         let reader = BufReader::new(stdout);
         for line in reader.lines().map_while(Result::ok) {
-            let _ = tx.send(line);
+            let _ = line_tx.send(line);
         }
     });
 
@@ -287,7 +300,7 @@ fn build_project(build_dir: &Path, acceleration: Acceleration) -> Result<()> {
     thread::spawn(move || {
         let reader = BufReader::new(stderr);
         for line in reader.lines().map_while(Result::ok) {
-            let _ = tx2.send(line);
+            let _ = line_tx2.send(line);
         }
     });
 
@@ -295,16 +308,16 @@ fn build_project(build_dir: &Path, acceleration: Acceleration) -> Result<()> {
     let mut total_files = 100; // Default estimate
 
     // Process output and update progress
-    while let Ok(line) = rx.recv_timeout(std::time::Duration::from_millis(100)) {
-        pb.tick();
-
+    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(100)) {
         // Parse build progress from output
         // Look for patterns like "[ 50%]" or "[150/200]"
         if let Some(progress) = parse_build_progress(&line, &mut total_files)
             && progress > last_progress
         {
-            pb.set_length(total_files as u64);
-            pb.set_position(progress as u64);
+            let _ = tx.blocking_send(BuildEvent::Progress {
+                current: progress as u64,
+                total: total_files as u64,
+            });
             last_progress = progress;
         }
 
@@ -318,27 +331,28 @@ fn build_project(build_dir: &Path, acceleration: Acceleration) -> Result<()> {
             || line_lower.contains("undefined reference")
             || line_lower.contains("cannot find")
         {
-            pb.println(&line);
+            let _ = tx.blocking_send(BuildEvent::Log { message: line });
         }
     }
 
     let status = child.wait().context("Failed to wait for build")?;
 
     // Drain any remaining output after process exits
-    while let Ok(line) = rx.recv_timeout(std::time::Duration::from_millis(100)) {
+    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(100)) {
         let line_lower = line.to_ascii_lowercase();
         if line_lower.contains("error") || line_lower.contains("fatal") {
-            eprintln!("{}", line);
+            let _ = tx.blocking_send(BuildEvent::Log { message: line });
         }
     }
 
-    pb.finish_and_clear();
+    let _ = tx.blocking_send(BuildEvent::PhaseCompleted {
+        phase: BuildPhase::Compile,
+    });
 
     if !status.success() {
         bail!("Build failed (exit code: {})", status.code().unwrap_or(-1));
     }
 
-    println!("✓ Compilation complete");
     Ok(())
 }
 

--- a/crates/gglib-runtime/src/llama/build/mod.rs
+++ b/crates/gglib-runtime/src/llama/build/mod.rs
@@ -83,10 +83,6 @@ fn configure_cmake(
         "-B",
         build_dir.to_str().unwrap(),
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_CXX_FLAGS=-O1 -g0", // Use -O1 to work around GCC 15.2.1 ICE
-        "-DCMAKE_C_FLAGS=-O1 -g0",   // Use -O1 to work around GCC 15.2.1 ICE
-        "-DCMAKE_CXX_FLAGS_RELEASE=-O1 -DNDEBUG", // Override Release flags
-        "-DCMAKE_C_FLAGS_RELEASE=-O1 -DNDEBUG", // Override Release flags
         "-DGGML_METAL_EMBED_LIBRARY=ON",
         "-DLLAMA_BUILD_SERVER=ON",
         "-DLLAMA_BUILD_EXAMPLES=OFF", // Skip examples to avoid GCC bug in some files
@@ -228,21 +224,13 @@ fn configure_cmake(
         }
     });
 
-    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+    while let Ok(line) = line_rx.recv() {
         if !line.trim().is_empty() {
             let _ = tx.blocking_send(BuildEvent::Log { message: line });
         }
     }
 
     let status = child.wait().context("Failed to wait for CMake")?;
-
-    // Drain any remaining output in the channel before finishing
-    // This prevents losing error messages due to race conditions
-    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(50)) {
-        if !line.trim().is_empty() {
-            let _ = tx.blocking_send(BuildEvent::Log { message: line });
-        }
-    }
 
     let _ = tx.blocking_send(BuildEvent::PhaseCompleted {
         phase: BuildPhase::Configure,
@@ -315,7 +303,7 @@ fn build_project(
     let mut total_files = 100; // Default estimate
 
     // Process output and update progress
-    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+    while let Ok(line) = line_rx.recv() {
         // Parse build progress from output
         // Look for patterns like "[ 50%]" or "[150/200]"
         if let Some(progress) = parse_build_progress(&line, &mut total_files)
@@ -343,14 +331,6 @@ fn build_project(
     }
 
     let status = child.wait().context("Failed to wait for build")?;
-
-    // Drain any remaining output after process exits
-    while let Ok(line) = line_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-        let line_lower = line.to_ascii_lowercase();
-        if line_lower.contains("error") || line_lower.contains("fatal") {
-            let _ = tx.blocking_send(BuildEvent::Log { message: line });
-        }
-    }
 
     let _ = tx.blocking_send(BuildEvent::PhaseCompleted {
         phase: BuildPhase::Compile,
@@ -390,8 +370,7 @@ fn build_parallelism(acceleration: Acceleration) -> usize {
     }
 }
 
-/// Parse build progress from `CMake` output
-/// Merges `extra` flags into an environment variable, preserving any value
+/// Merges `extra` into the named environment variable, preserving any value
 /// already set by the caller's environment. Returns the combined string with
 /// a single space separator; leading/trailing whitespace is trimmed.
 fn merge_flags(var: &str, extra: &str) -> String {

--- a/crates/gglib-runtime/src/llama/build/mod.rs
+++ b/crates/gglib-runtime/src/llama/build/mod.rs
@@ -1,8 +1,18 @@
 //! Build orchestration for llama.cpp with progress tracking.
 //!
-//! Note: CXXFLAGS="-O2" is set during cmake configure and build to work around
-//! GCC 15.2.1 segfault bug during optimization passes (particularly -O3).
-//! This is a known compiler issue affecting chat.cpp and other files.
+//! `CXXFLAGS` is merged (read-then-append) during both the cmake configure and build
+//! phases to carry two flags:
+//!
+//! - `-O1` — works around a GCC 15.2.1 ICE (internal compiler error) that fires during
+//!   higher optimisation passes on `chat.cpp` and related files.
+//! - `-Wno-missing-noreturn` — suppresses the warning flood from `common/jinja/runtime.h`,
+//!   whose virtual `throw`-only methods AppleClang flags as candidates for `[[noreturn]]`.
+//!   Because many translation units include the header and jobs run in parallel, the warning
+//!   fires hundreds of times and corrupts `indicatif` progress-bar output.
+//!
+//! `CFLAGS` receives only `-O1`; `-Wmissing-noreturn` is a C++-only diagnostic.
+//! Any `CXXFLAGS`/`CFLAGS` already present in the caller's environment are preserved
+//! (see [`merge_flags`]).
 
 use super::detect::{Acceleration, get_cuda_path, get_num_cores, validate_cuda_gcc_compatibility};
 
@@ -74,9 +84,10 @@ fn configure_cmake(llama_dir: &Path, build_dir: &Path, acceleration: Acceleratio
 
     let mut cmd = Command::new("cmake");
 
-    // Work around GCC 15.2.1 segfault bug by reducing optimization level
-    cmd.env("CXXFLAGS", "-O1");
-    cmd.env("CFLAGS", "-O1");
+    // Merge into any CXXFLAGS/CFLAGS already set by the caller's environment.
+    // -O1: GCC 15.2.1 ICE workaround. -Wno-missing-noreturn: suppress upstream warning flood.
+    cmd.env("CXXFLAGS", merge_flags("CXXFLAGS", "-O1 -Wno-missing-noreturn"));
+    cmd.env("CFLAGS", merge_flags("CFLAGS", "-O1"));
 
     // Compiler selection priority (platform-specific):
     // Linux CUDA builds: Clang (best) > GCC 12/11 (compatible) > system GCC
@@ -237,9 +248,14 @@ fn build_project(build_dir: &Path, acceleration: Acceleration) -> Result<()> {
             .progress_chars("#>-")
     );
 
+    // Merge into any CXXFLAGS/CFLAGS already set by the caller's environment.
+    // -O1: GCC 15.2.1 ICE workaround. -Wno-missing-noreturn: suppress upstream warning flood.
+    let cxxflags = merge_flags("CXXFLAGS", "-O1 -Wno-missing-noreturn");
+    let cflags = merge_flags("CFLAGS", "-O1");
+
     let mut child = Command::new("cmake")
-        .env("CXXFLAGS", "-O1") // Work around GCC 15.2.1 segfault bug
-        .env("CFLAGS", "-O1") // Work around GCC 15.2.1 segfault bug
+        .env("CXXFLAGS", cxxflags)
+        .env("CFLAGS", cflags)
         .args([
             "--build",
             build_dir.to_str().unwrap(),
@@ -354,6 +370,14 @@ fn build_parallelism(acceleration: Acceleration) -> usize {
 }
 
 /// Parse build progress from `CMake` output
+/// Merges `extra` flags into an environment variable, preserving any value
+/// already set by the caller's environment. Returns the combined string with
+/// a single space separator; leading/trailing whitespace is trimmed.
+fn merge_flags(var: &str, extra: &str) -> String {
+    let existing = std::env::var(var).unwrap_or_default();
+    format!("{existing} {extra}").trim().to_owned()
+}
+
 fn parse_build_progress(line: &str, total_files: &mut usize) -> Option<usize> {
     // Match "[ 50%]" pattern
     if let Some(start) = line.find('[')

--- a/crates/gglib-runtime/src/llama/build_events.rs
+++ b/crates/gglib-runtime/src/llama/build_events.rs
@@ -1,12 +1,16 @@
 //! Observable events for the llama.cpp source-build pipeline.
 //!
-//! [`BuildEvent`] is produced by the build-from-source pipeline and consumed by:
+//! [`BuildEvent`] is produced by the build-from-source pipeline and consumed by three
+//! surfaces, each adapting the event stream to its own output medium:
 //!
-//! | Consumer | Output                                                          |
-//! |----------|-----------------------------------------------------------------|
-//! | CLI      | `indicatif` spinner + progress bar                              |
-//! | Axum     | SSE stream at `GET /api/system/build-llama-from-source`         |
-//! | Tauri    | `llama-build-progress` event to WebView                         |
+//! | Consumer    | Crate        | Output                                                                    |
+//! |-------------|--------------|--------------------------------------------------------------------------|
+//! | CLI         | `gglib-cli`  | `indicatif` spinner + progress bar via `consume_build_events_cli`         |
+//! | REST / SSE  | `gglib-axum` | Server-Sent Events at `POST /api/system/build-llama-from-source`          |
+//! | Desktop GUI | `gglib-tauri`| Tauri event `llama-build-progress` emitted to the WebView                 |
+//!
+//! The sender end is a `tokio::sync::mpsc::Sender<BuildEvent>` with capacity 64.
+//! When the sender is dropped the consumer loop terminates naturally.
 //!
 //! The event type is **not** feature-gated: all three surfaces import [`BuildEvent`]
 //! and [`BuildPhase`] unconditionally. Only the pipeline that *produces* the events

--- a/crates/gglib-runtime/src/llama/build_events.rs
+++ b/crates/gglib-runtime/src/llama/build_events.rs
@@ -1,0 +1,106 @@
+//! Observable events for the llama.cpp source-build pipeline.
+//!
+//! [`BuildEvent`] is produced by the build-from-source pipeline and consumed by:
+//!
+//! | Consumer | Output                                                          |
+//! |----------|-----------------------------------------------------------------|
+//! | CLI      | `indicatif` spinner + progress bar                              |
+//! | Axum     | SSE stream at `GET /api/system/build-llama-from-source`         |
+//! | Tauri    | `llama-build-progress` event to WebView                         |
+//!
+//! The event type is **not** feature-gated: all three surfaces import [`BuildEvent`]
+//! and [`BuildPhase`] unconditionally. Only the pipeline that *produces* the events
+//! (in `build/` and `install/`) is gated behind `feature = "cli"`.
+
+use serde::Serialize;
+
+// =============================================================================
+// BuildPhase
+// =============================================================================
+
+/// A discrete stage within the llama.cpp source-build pipeline.
+///
+/// Phases execute in the order they are listed. [`BuildEvent::PhaseStarted`]
+/// and [`BuildEvent::PhaseCompleted`] bracket each stage so consumers can
+/// drive a multi-step progress indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildPhase {
+    /// Checking that cmake, git, and a suitable C++ compiler are present.
+    DependencyCheck,
+
+    /// Cloning the llama.cpp repository or pulling the latest commit.
+    CloneOrUpdateRepo,
+
+    /// Running `cmake` to configure the build system and detect acceleration.
+    Configure,
+
+    /// Running `cmake --build` to compile all translation units.
+    Compile,
+
+    /// Copying the built binaries to `~/.local/share/gglib/bin/`.
+    InstallBinaries,
+}
+
+// =============================================================================
+// BuildEvent
+// =============================================================================
+
+/// An observable event emitted by the llama.cpp source-build pipeline.
+///
+/// Events are the unit of SSE emission for the build pipeline. Every notable
+/// state change produces exactly one variant. Consumers decide how to render
+/// them: the CLI produces `indicatif` progress bars; Axum serialises to
+/// `data: <json>\n\n` frames; Tauri emits them to the WebView.
+///
+/// # Serde tag
+///
+/// `#[serde(tag = "type", rename_all = "snake_case")]` produces e.g.
+/// `{"type":"phase_started","phase":"configure"}`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BuildEvent {
+    /// A pipeline stage is beginning.
+    PhaseStarted {
+        /// The stage that is about to execute.
+        phase: BuildPhase,
+    },
+
+    /// A raw log line from cmake, the compiler, or git.
+    Log {
+        /// The unmodified output line from the subprocess.
+        message: String,
+    },
+
+    /// Compilation progress reported by cmake.
+    ///
+    /// Both `current` and `total` are file counts derived from cmake output
+    /// patterns such as `[ 50%]` (mapped to `50/100`) or `[150/300]`.
+    Progress {
+        /// Files compiled so far.
+        current: u64,
+        /// Total files to compile.
+        total: u64,
+    },
+
+    /// A pipeline stage has finished successfully.
+    PhaseCompleted {
+        /// The stage that just finished.
+        phase: BuildPhase,
+    },
+
+    /// The entire build-and-install pipeline completed successfully.
+    Completed {
+        /// The llama.cpp version or commit SHA that was built.
+        version: String,
+        /// Human-readable name of the GPU acceleration that was compiled in
+        /// (e.g. `"Metal"`, `"CUDA"`, `"CPU"`).
+        acceleration: String,
+    },
+
+    /// The pipeline terminated with an unrecoverable error.
+    Failed {
+        /// Human-readable description of the failure.
+        message: String,
+    },
+}

--- a/crates/gglib-runtime/src/llama/ensure.rs
+++ b/crates/gglib-runtime/src/llama/ensure.rs
@@ -1,11 +1,14 @@
 use anyhow::Result;
-use gglib_core::paths::{is_prebuilt_binary, llama_cli_path, llama_server_path};
+use gglib_core::paths::{is_prebuilt_binary, llama_cli_path, llama_cpp_dir, llama_server_path};
 use std::io::{self, Write};
+use tokio::sync::mpsc;
 
+use super::build_events::BuildEvent;
+use super::detect::detect_optimal_acceleration;
 use super::download::{
     PrebuiltAvailability, check_prebuilt_availability, download_prebuilt_binaries,
 };
-use super::install::handle_install;
+use super::install::run_llama_source_build;
 
 // Helper to convert PathError to anyhow::Error
 fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
@@ -65,8 +68,8 @@ async fn ensure_for_source_build() -> Result<()> {
     println!("Building llama.cpp from source (auto-detecting hardware)...");
     println!();
 
-    // Call the install handler - force build from source since we're in source build mode
-    handle_install(false, false, false, false, true).await?;
+    // Run source build - acceleration is auto-detected
+    install_from_source().await?;
 
     Ok(())
 }
@@ -106,7 +109,7 @@ async fn ensure_for_prebuilt_binary() -> Result<()> {
                     println!();
 
                     // Fall back to building from source
-                    handle_install(false, false, false, false, true).await
+                    install_from_source().await
                 }
             }
         }
@@ -135,9 +138,48 @@ async fn ensure_for_prebuilt_binary() -> Result<()> {
             println!("Building llama.cpp from source (auto-detecting hardware)...");
             println!();
 
-            handle_install(false, false, false, false, true).await
+            install_from_source().await
         }
     }
+}
+
+/// Runs a source build and streams events as simple text output.
+///
+/// Used by the ensure flow which handles its own user prompts; indicatif
+/// is intentionally omitted here so this remains surface-agnostic.
+async fn install_from_source() -> Result<()> {
+    let acceleration = detect_optimal_acceleration()?;
+    let llama_dir = path_err(llama_cpp_dir())?;
+    let server_path = path_err(llama_server_path())?;
+    let cli_path = path_err(llama_cli_path())?;
+
+    let (tx, mut rx) = mpsc::channel::<BuildEvent>(64);
+    let build = tokio::spawn(run_llama_source_build(
+        acceleration,
+        llama_dir,
+        server_path,
+        cli_path,
+        tx,
+    ));
+
+    while let Some(event) = rx.recv().await {
+        match event {
+            BuildEvent::PhaseStarted { phase } => println!("→ {:?}", phase),
+            BuildEvent::Log { message } => println!("  {}", message),
+            BuildEvent::Progress { current, total } => {
+                println!("  [{}/{}] Compiling...", current, total);
+            }
+            BuildEvent::PhaseCompleted { .. } => {}
+            BuildEvent::Completed { version, .. } => {
+                println!("✓ Build complete ({})", version);
+            }
+            BuildEvent::Failed { message } => {
+                eprintln!("✗ Build failed: {}", message);
+            }
+        }
+    }
+
+    build.await?
 }
 
 /// Print required build tools for building from source.

--- a/crates/gglib-runtime/src/llama/install/mod.rs
+++ b/crates/gglib-runtime/src/llama/install/mod.rs
@@ -1,7 +1,25 @@
-//! Installation command for llama.cpp.
+//! Source-build installation pipeline for llama.cpp.
+//!
+//! The primary streaming entry point is [`run_llama_source_build`], which emits
+//! [`BuildEvent`] values into a `Sender<BuildEvent>` channel. CLI-only concerns
+//! (dependency checks, user prompts) remain in [`build_from_source_impl`].
+//!
+//! ## Consumer table
+//!
+//! | Consumer | Output                                                             |
+//! |----------|--------------------------------------------------------------------|           
+//! | CLI      | `indicatif` progress bar (Phase E, via `consume_build_events_cli`) |
+//! | Axum     | SSE stream at `POST /api/system/build-llama-from-source`           |
+//! | Tauri    | `llama-build-progress` event to WebView                            |
+//!
+//! ## Threading model
+//!
+//! [`clone_llama_cpp`] and [`build_llama_cpp`] call `blocking_send` directly in their
+//! function bodies and must run via [`tokio::task::spawn_blocking`] from async contexts.
+//! [`run_llama_source_build`] handles this wrapping automatically.
 
 use super::build::build_llama_cpp;
-use super::build_events::BuildEvent;
+use super::build_events::{BuildEvent, BuildPhase};
 use super::config::BuildConfig;
 use super::deps::check_dependencies;
 use super::detect::{Acceleration, detect_optimal_acceleration};
@@ -14,9 +32,11 @@ use gglib_core::paths::{
     llama_server_path,
 };
 use gglib_core::utils::process::cmd;
-use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::thread;
 use tokio::sync::mpsc;
 
 // Helper to convert PathError to anyhow::Error
@@ -78,18 +98,107 @@ pub async fn handle_install(
     build_from_source_impl(cuda, metal, vulkan, force).await
 }
 
-/// Build llama.cpp from source (the original installation logic)
+/// Core streaming build pipeline for llama.cpp from source.
+///
+/// Clones or reuses the repository, configures, compiles, installs binaries, and saves
+/// the build configuration. All progress is emitted as [`BuildEvent`] values on `tx`.
+///
+/// This function has no CLI concerns (no user prompts, no dependency checks). Callers
+/// must perform pre-flight validation before calling this.
+///
+/// # Threading
+///
+/// Blocking subprocess work ([`clone_llama_cpp`], [`build_llama_cpp`]) runs inside
+/// [`tokio::task::spawn_blocking`] so the Tokio executor is never blocked and
+/// `blocking_send` calls are always on OS threads.
+pub async fn run_llama_source_build(
+    acceleration: Acceleration,
+    llama_dir: PathBuf,
+    server_path: PathBuf,
+    cli_path: PathBuf,
+    tx: mpsc::Sender<BuildEvent>,
+) -> Result<()> {
+    // Step 1: Clone or reuse repository.
+    let (version, commit_sha) = if llama_dir.exists() {
+        let _ = tx
+            .send(BuildEvent::Log {
+                message: "Using existing llama.cpp repository.".to_string(),
+            })
+            .await;
+        get_repo_info(&llama_dir)?
+    } else {
+        let tx_clone = tx.clone();
+        let dir = llama_dir.clone();
+        tokio::task::spawn_blocking(move || clone_llama_cpp(&dir, &tx_clone)).await??
+    };
+
+    // Step 2: Configure and compile.
+    {
+        let tx_clone = tx.clone();
+        let dir = llama_dir.clone();
+        tokio::task::spawn_blocking(move || build_llama_cpp(&dir, acceleration, &tx_clone))
+            .await??;
+    }
+
+    // Step 3: Install binaries.
+    {
+        let tx_clone = tx.clone();
+        let dir = llama_dir.clone();
+        let sp = server_path.clone();
+        let cp = cli_path.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _ = tx_clone.blocking_send(BuildEvent::PhaseStarted {
+                phase: BuildPhase::InstallBinaries,
+            });
+            install_binary(&dir, "llama-server", &sp)?;
+            install_binary(&dir, "llama-cli", &cp)?;
+            let _ = tx_clone.blocking_send(BuildEvent::PhaseCompleted {
+                phase: BuildPhase::InstallBinaries,
+            });
+            Ok(())
+        })
+        .await??;
+    }
+
+    // Step 4: Persist build configuration.
+    let config = BuildConfig::new(version.clone(), commit_sha, acceleration);
+    let config_path = path_err(llama_config_path())?;
+    config.save(&config_path)?;
+
+    // Step 5: Signal successful completion.
+    let _ = tx
+        .send(BuildEvent::Completed {
+            version,
+            acceleration: acceleration.display_name().to_string(),
+        })
+        .await;
+
+    Ok(())
+}
+
+/// Consumes [`BuildEvent`] values from the build pipeline channel.
+///
+/// Phase E will replace this stub with full `indicatif` progress-bar rendering.
+async fn consume_build_events_cli(mut rx: mpsc::Receiver<BuildEvent>) {
+    // Phase E stub: drain events until the indicatif renderer is implemented.
+    while rx.recv().await.is_some() {}
+}
+
+/// CLI-only wrapper for the source-build pipeline.
+///
+/// Performs dependency checks and the interactive Y/n prompt (CLI concerns), then
+/// delegates the actual build work to [`run_llama_source_build`].
 async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bool) -> Result<()> {
-    // Step 1: Check dependencies
+    // Step 1: Check dependencies.
     check_dependencies()?;
     println!();
 
-    // Step 2: Determine acceleration
+    // Step 2: Determine acceleration.
     let acceleration = determine_acceleration(cuda, metal, vulkan)?;
     println!("Selected acceleration: {}", acceleration.display_name());
     println!();
 
-    // Step 3: Pre-flight check
+    // Step 3: Interactive pre-flight prompt.
     if !force {
         print_preflight_info(&acceleration)?;
         print!("Continue? [Y/n]: ");
@@ -102,37 +211,24 @@ async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bo
         }
     }
 
-    // Step 4: Clone or update repository
+    // Steps 4-7: delegate to the pure streaming core.
     let llama_dir = path_err(llama_cpp_dir())?;
-    let (version, commit_sha) = if llama_dir.exists() {
-        println!("Using existing llama.cpp repository...");
-        get_repo_info(&llama_dir)?
-    } else {
-        clone_llama_cpp(&llama_dir)?
-    };
-
-    // Step 5: Build llama.cpp
-    let (build_tx, _build_rx) = mpsc::channel::<BuildEvent>(64);
-    build_llama_cpp(&llama_dir, acceleration, &build_tx)?;
-
-    // Step 6: Install binary
     let server_path = path_err(llama_server_path())?;
     let cli_path = path_err(llama_cli_path())?;
-    install_binary(&llama_dir, "llama-server", &server_path)?;
-    install_binary(&llama_dir, "llama-cli", &cli_path)?;
-
-    // Step 7: Save configuration
-    let config = BuildConfig::new(version.clone(), commit_sha, acceleration);
-    let config_path = path_err(llama_config_path())?;
-    config.save(&config_path)?;
+    let (tx, rx) = mpsc::channel::<BuildEvent>(64);
+    let build = tokio::spawn(run_llama_source_build(
+        acceleration,
+        llama_dir,
+        server_path,
+        cli_path,
+        tx,
+    ));
+    // Phase E will replace this stub with full indicatif rendering.
+    consume_build_events_cli(rx).await;
+    build.await??;
 
     println!();
     println!("✓ llama.cpp installed successfully!");
-    println!("  Server: {}", server_path.display());
-    println!("  CLI: {}", cli_path.display());
-    println!("  Version: {}", version);
-    println!("  Acceleration: {}", acceleration.display_name());
-    println!();
     println!("You can now use 'gglib serve', 'gglib proxy', and 'gglib chat'.");
 
     Ok(())
@@ -191,41 +287,62 @@ fn print_preflight_info(acceleration: &Acceleration) -> Result<()> {
     Ok(())
 }
 
-/// Clone the llama.cpp repository
-fn clone_llama_cpp(llama_dir: &std::path::Path) -> Result<(String, String)> {
-    println!("Cloning llama.cpp repository...");
-    println!();
+/// Clone the llama.cpp repository, routing subprocess output through `tx`.
+///
+/// Git progress lines containing `\r` (animated carriage-return output) are filtered
+/// out to avoid corrupting SSE streams. Only clean, newline-terminated informational
+/// lines are emitted as [`BuildEvent::Log`].
+fn clone_llama_cpp(llama_dir: &Path, tx: &mpsc::Sender<BuildEvent>) -> Result<(String, String)> {
+    let _ = tx.blocking_send(BuildEvent::PhaseStarted {
+        phase: BuildPhase::CloneOrUpdateRepo,
+    });
 
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} [{elapsed_precise}] {msg}")
-            .unwrap(),
-    );
-    pb.set_message("Cloning from GitHub...");
-
-    // Ensure parent directory exists
     if let Some(parent) = llama_dir.parent() {
         fs::create_dir_all(parent).context("Failed to create parent directory")?;
     }
 
-    let status = cmd("git")
+    let mut child = cmd("git")
         .args([
             "clone",
             "--depth=1",
             "https://github.com/ggerganov/llama.cpp",
             llama_dir.to_str().unwrap(),
         ])
-        .status()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .context("Failed to run git clone")?;
 
-    pb.finish_and_clear();
+    let stderr = child.stderr.take().unwrap();
 
+    // Git writes all progress to stderr. Read on an OS thread (blocking I/O).
+    // Carriage-return progress lines (e.g. "Receiving objects: 45%\r") are
+    // filtered: BufRead::lines() keeps \r as trailing content; any line
+    // containing \r is dropped to avoid corrupting SSE streams.
+    let tx_reader = tx.clone();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            if line.trim().is_empty() || line.contains('\r') {
+                continue;
+            }
+            if tx_reader
+                .blocking_send(BuildEvent::Log { message: line })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    let status = child.wait().context("Failed to wait for git clone")?;
     if !status.success() {
         bail!("Failed to clone llama.cpp repository");
     }
 
-    println!("✓ Repository cloned");
+    let _ = tx.blocking_send(BuildEvent::PhaseCompleted {
+        phase: BuildPhase::CloneOrUpdateRepo,
+    });
 
     get_repo_info(llama_dir)
 }

--- a/crates/gglib-runtime/src/llama/install/mod.rs
+++ b/crates/gglib-runtime/src/llama/install/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! | Consumer | Output                                                             |
 //! |----------|--------------------------------------------------------------------|           
-//! | CLI      | `indicatif` progress bar (Phase E, via `consume_build_events_cli`) |
+//! | CLI      | `indicatif` spinner + progress bar (via `consume_build_events_cli`) |
 //! | Axum     | SSE stream at `POST /api/system/build-llama-from-source`           |
 //! | Tauri    | `llama-build-progress` event to WebView                            |
 //!
@@ -176,12 +176,98 @@ pub async fn run_llama_source_build(
     Ok(())
 }
 
-/// Consumes [`BuildEvent`] values from the build pipeline channel.
+/// Consumes [`BuildEvent`] values from the build pipeline channel and renders
+/// them as `indicatif` spinners and progress bars.
 ///
-/// Phase E will replace this stub with full `indicatif` progress-bar rendering.
+/// A single `Option<ProgressBar>` tracks the active indicator. Phases are
+/// strictly sequential so there is never more than one active bar at a time.
 async fn consume_build_events_cli(mut rx: mpsc::Receiver<BuildEvent>) {
-    // Phase E stub: drain events until the indicatif renderer is implemented.
-    while rx.recv().await.is_some() {}
+    use indicatif::{ProgressBar, ProgressStyle};
+    use std::time::Duration;
+
+    let spinner_style = ProgressStyle::default_spinner()
+        .template("{spinner:.green} [{elapsed_precise}] {msg}")
+        .expect("valid spinner template");
+
+    let bar_style = ProgressStyle::default_bar()
+        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({percent}%) {msg}")
+        .expect("valid bar template")
+        .progress_chars("#>-");
+
+    let mut active: Option<ProgressBar> = None;
+
+    while let Some(event) = rx.recv().await {
+        match event {
+            BuildEvent::PhaseStarted { phase } => {
+                // Clean up any previous indicator before starting a new one.
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+                let pb = match phase {
+                    BuildPhase::Compile => {
+                        // Length unknown until the first Progress event.
+                        let pb = ProgressBar::new(0);
+                        pb.set_style(bar_style.clone());
+                        pb.set_message("Compiling...");
+                        pb
+                    }
+                    BuildPhase::DependencyCheck => {
+                        // CLI performs its own dep-check output before the channel
+                        // opens, so no indicatif bar is needed here.
+                        continue;
+                    }
+                    _ => {
+                        let msg = match phase {
+                            BuildPhase::CloneOrUpdateRepo => "Cloning llama.cpp repository...",
+                            BuildPhase::Configure => "Configuring with CMake...",
+                            BuildPhase::InstallBinaries => "Installing binaries...",
+                            _ => unreachable!(),
+                        };
+                        let pb = ProgressBar::new_spinner();
+                        pb.set_style(spinner_style.clone());
+                        pb.set_message(msg);
+                        pb.enable_steady_tick(Duration::from_millis(100));
+                        pb
+                    }
+                };
+                active = Some(pb);
+            }
+            BuildEvent::PhaseCompleted { .. } => {
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+            }
+            BuildEvent::Progress { current, total } => {
+                if let Some(pb) = &active {
+                    pb.set_length(total);
+                    pb.set_position(current);
+                }
+            }
+            BuildEvent::Log { message } => {
+                if let Some(pb) = &active {
+                    pb.println(&message);
+                } else {
+                    println!("{}", message);
+                }
+            }
+            BuildEvent::Completed { version, acceleration } => {
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+                println!();
+                println!("✓ llama.cpp installed successfully!");
+                println!("  Version:       {}", version);
+                println!("  Acceleration:  {}", acceleration);
+                println!("You can now use 'gglib serve', 'gglib proxy', and 'gglib chat'.");
+            }
+            BuildEvent::Failed { message } => {
+                if let Some(pb) = active.take() {
+                    pb.finish_and_clear();
+                }
+                eprintln!("✗ Build failed: {}", message);
+            }
+        }
+    }
 }
 
 /// CLI-only wrapper for the source-build pipeline.
@@ -223,13 +309,8 @@ async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bo
         cli_path,
         tx,
     ));
-    // Phase E will replace this stub with full indicatif rendering.
     consume_build_events_cli(rx).await;
     build.await??;
-
-    println!();
-    println!("✓ llama.cpp installed successfully!");
-    println!("You can now use 'gglib serve', 'gglib proxy', and 'gglib chat'.");
 
     Ok(())
 }
@@ -380,9 +461,6 @@ pub(super) fn install_binary(
     binary_name: &str,
     destination: &std::path::Path,
 ) -> Result<()> {
-    println!();
-    println!("Installing {} binary...", binary_name);
-
     let binary_src_root = llama_dir.join("build");
 
     #[cfg(target_os = "windows")]
@@ -410,8 +488,6 @@ pub(super) fn install_binary(
         perms.set_mode(0o755);
         fs::set_permissions(destination, perms)?;
     }
-
-    println!("✓ {} installed to: {}", binary_name, destination.display());
 
     Ok(())
 }

--- a/crates/gglib-runtime/src/llama/install/mod.rs
+++ b/crates/gglib-runtime/src/llama/install/mod.rs
@@ -1,16 +1,17 @@
 //! Source-build installation pipeline for llama.cpp.
 //!
 //! The primary streaming entry point is [`run_llama_source_build`], which emits
-//! [`BuildEvent`] values into a `Sender<BuildEvent>` channel. CLI-only concerns
-//! (dependency checks, user prompts) remain in [`build_from_source_impl`].
+//! [`BuildEvent`] values into a `Sender<BuildEvent>` channel. CLI surface concerns
+//! (dependency checks, user prompts, progress rendering) live in
+//! `gglib-cli::handlers::llama_install`.
 //!
 //! ## Consumer table
 //!
-//! | Consumer | Output                                                             |
-//! |----------|--------------------------------------------------------------------|           
-//! | CLI      | `indicatif` spinner + progress bar (via `consume_build_events_cli`) |
-//! | Axum     | SSE stream at `POST /api/system/build-llama-from-source`           |
-//! | Tauri    | `llama-build-progress` event to WebView                            |
+//! | Consumer | Crate        | Output                                                          |
+//! |----------|--------------|-----------------------------------------------------------------|
+//! | CLI      | `gglib-cli`  | `indicatif` spinner + progress bar in `handlers::llama_install` |
+//! | Axum     | `gglib-axum` | SSE stream at `POST /api/system/build-llama-from-source`        |
+//! | Tauri    | `gglib-tauri`| `llama-build-progress` event to WebView                         |
 //!
 //! ## Threading model
 //!
@@ -21,19 +22,12 @@
 use super::build::build_llama_cpp;
 use super::build_events::{BuildEvent, BuildPhase};
 use super::config::BuildConfig;
-use super::deps::check_dependencies;
-use super::detect::{Acceleration, detect_optimal_acceleration};
-use super::download::{
-    PrebuiltAvailability, check_prebuilt_availability, download_prebuilt_binaries,
-};
+use super::detect::Acceleration;
 use anyhow::{Context, Result, bail};
-use gglib_core::paths::{
-    gglib_data_dir, is_prebuilt_binary, llama_cli_path, llama_config_path, llama_cpp_dir,
-    llama_server_path,
-};
+use gglib_core::paths::llama_config_path;
 use gglib_core::utils::process::cmd;
 use std::fs;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::thread;
@@ -42,60 +36,6 @@ use tokio::sync::mpsc;
 // Helper to convert PathError to anyhow::Error
 fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
     r.map_err(|e| anyhow::anyhow!("{}", e))
-}
-
-/// Handle the install command
-///
-/// Installation method is determined by context:
-/// - `--build` flag: Always build from source
-/// - Running from source repo: Build from source (existing behavior)
-/// - Pre-built binary + macOS/Windows: Download pre-built binaries
-/// - Pre-built binary + Linux: Build from source (CUDA requires compilation)
-pub async fn handle_install(
-    cuda: bool,
-    metal: bool,
-    vulkan: bool,
-    force: bool,
-    build_from_source: bool,
-) -> Result<()> {
-    // Check if already installed
-    let server_path = path_err(llama_server_path())?;
-    let cli_path = path_err(llama_cli_path())?;
-    if server_path.exists() && cli_path.exists() && !force {
-        let install_dir = server_path
-            .parent()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| server_path.display().to_string());
-        println!(
-            "llama-server and llama-cli are already installed in: {}",
-            install_dir
-        );
-        println!("Use --force to rebuild or refresh binaries.");
-        return Ok(());
-    }
-
-    // Determine installation method
-    let should_build = build_from_source
-        || !is_prebuilt_binary()  // Running from source repo
-        || cuda || metal || vulkan  // User specified acceleration flags
-        || matches!(check_prebuilt_availability(), PrebuiltAvailability::NotAvailable { .. });
-
-    if !should_build {
-        // Try downloading pre-built binaries
-        println!("Attempting to download pre-built llama.cpp binaries...");
-        match download_prebuilt_binaries().await {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                println!();
-                println!("⚠️  Failed to download pre-built binaries: {}", e);
-                println!("Falling back to building from source...");
-                println!();
-            }
-        }
-    }
-
-    // Build from source
-    build_from_source_impl(cuda, metal, vulkan, force).await
 }
 
 /// Core streaming build pipeline for llama.cpp from source.
@@ -172,198 +112,6 @@ pub async fn run_llama_source_build(
             acceleration: acceleration.display_name().to_string(),
         })
         .await;
-
-    Ok(())
-}
-
-/// Consumes [`BuildEvent`] values from the build pipeline channel and renders
-/// them as `indicatif` spinners and progress bars.
-///
-/// A single `Option<ProgressBar>` tracks the active indicator. Phases are
-/// strictly sequential so there is never more than one active bar at a time.
-async fn consume_build_events_cli(mut rx: mpsc::Receiver<BuildEvent>) {
-    use indicatif::{ProgressBar, ProgressStyle};
-    use std::time::Duration;
-
-    let spinner_style = ProgressStyle::default_spinner()
-        .template("{spinner:.green} [{elapsed_precise}] {msg}")
-        .expect("valid spinner template");
-
-    let bar_style = ProgressStyle::default_bar()
-        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({percent}%) {msg}")
-        .expect("valid bar template")
-        .progress_chars("#>-");
-
-    let mut active: Option<ProgressBar> = None;
-
-    while let Some(event) = rx.recv().await {
-        match event {
-            BuildEvent::PhaseStarted { phase } => {
-                // Clean up any previous indicator before starting a new one.
-                if let Some(pb) = active.take() {
-                    pb.finish_and_clear();
-                }
-                let pb = match phase {
-                    BuildPhase::Compile => {
-                        // Length unknown until the first Progress event.
-                        let pb = ProgressBar::new(0);
-                        pb.set_style(bar_style.clone());
-                        pb.set_message("Compiling...");
-                        pb
-                    }
-                    BuildPhase::DependencyCheck => {
-                        // CLI performs its own dep-check output before the channel
-                        // opens, so no indicatif bar is needed here.
-                        continue;
-                    }
-                    _ => {
-                        let msg = match phase {
-                            BuildPhase::CloneOrUpdateRepo => "Cloning llama.cpp repository...",
-                            BuildPhase::Configure => "Configuring with CMake...",
-                            BuildPhase::InstallBinaries => "Installing binaries...",
-                            _ => unreachable!(),
-                        };
-                        let pb = ProgressBar::new_spinner();
-                        pb.set_style(spinner_style.clone());
-                        pb.set_message(msg);
-                        pb.enable_steady_tick(Duration::from_millis(100));
-                        pb
-                    }
-                };
-                active = Some(pb);
-            }
-            BuildEvent::PhaseCompleted { .. } => {
-                if let Some(pb) = active.take() {
-                    pb.finish_and_clear();
-                }
-            }
-            BuildEvent::Progress { current, total } => {
-                if let Some(pb) = &active {
-                    pb.set_length(total);
-                    pb.set_position(current);
-                }
-            }
-            BuildEvent::Log { message } => {
-                if let Some(pb) = &active {
-                    pb.println(&message);
-                } else {
-                    println!("{}", message);
-                }
-            }
-            BuildEvent::Completed { version, acceleration } => {
-                if let Some(pb) = active.take() {
-                    pb.finish_and_clear();
-                }
-                println!();
-                println!("✓ llama.cpp installed successfully!");
-                println!("  Version:       {}", version);
-                println!("  Acceleration:  {}", acceleration);
-                println!("You can now use 'gglib serve', 'gglib proxy', and 'gglib chat'.");
-            }
-            BuildEvent::Failed { message } => {
-                if let Some(pb) = active.take() {
-                    pb.finish_and_clear();
-                }
-                eprintln!("✗ Build failed: {}", message);
-            }
-        }
-    }
-}
-
-/// CLI-only wrapper for the source-build pipeline.
-///
-/// Performs dependency checks and the interactive Y/n prompt (CLI concerns), then
-/// delegates the actual build work to [`run_llama_source_build`].
-async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bool) -> Result<()> {
-    // Step 1: Check dependencies.
-    check_dependencies()?;
-    println!();
-
-    // Step 2: Determine acceleration.
-    let acceleration = determine_acceleration(cuda, metal, vulkan)?;
-    println!("Selected acceleration: {}", acceleration.display_name());
-    println!();
-
-    // Step 3: Interactive pre-flight prompt.
-    if !force {
-        print_preflight_info(&acceleration)?;
-        print!("Continue? [Y/n]: ");
-        io::stdout().flush()?;
-        let mut input = String::new();
-        io::stdin().read_line(&mut input)?;
-        if input.trim().eq_ignore_ascii_case("n") {
-            println!("Installation cancelled.");
-            return Ok(());
-        }
-    }
-
-    // Steps 4-7: delegate to the pure streaming core.
-    let llama_dir = path_err(llama_cpp_dir())?;
-    let server_path = path_err(llama_server_path())?;
-    let cli_path = path_err(llama_cli_path())?;
-    let (tx, rx) = mpsc::channel::<BuildEvent>(64);
-    let build = tokio::spawn(run_llama_source_build(
-        acceleration,
-        llama_dir,
-        server_path,
-        cli_path,
-        tx,
-    ));
-    consume_build_events_cli(rx).await;
-    build.await??;
-
-    Ok(())
-}
-
-/// Determine which acceleration to use
-fn determine_acceleration(cuda: bool, metal: bool, vulkan: bool) -> Result<Acceleration> {
-    let flags_set = [cuda, metal, vulkan].iter().filter(|&&x| x).count();
-
-    if flags_set > 1 {
-        bail!("Only one acceleration flag can be specified");
-    }
-
-    if metal {
-        #[cfg(not(target_os = "macos"))]
-        bail!("Metal acceleration is only available on macOS");
-
-        #[cfg(target_os = "macos")]
-        Ok(Acceleration::Metal)
-    } else if cuda {
-        Ok(Acceleration::Cuda)
-    } else if vulkan {
-        Ok(Acceleration::Vulkan)
-    } else {
-        // Auto-detect
-        detect_optimal_acceleration()
-    }
-}
-
-/// Print pre-flight information
-fn print_preflight_info(acceleration: &Acceleration) -> Result<()> {
-    use super::deps::check_disk_space;
-
-    println!("Pre-flight check:");
-    println!("✓ Build dependencies installed");
-
-    // Check disk space
-    if check_disk_space(800)? {
-        println!("✓ Disk space available");
-    }
-
-    println!("✓ Detected: {}", acceleration.display_name());
-    println!();
-    println!("This will:");
-    println!("  1. Clone llama.cpp repository (~150 MB)");
-    println!(
-        "  2. Configure with CMake ({} enabled)",
-        acceleration.display_name()
-    );
-    println!("  3. Compile llama-server and llama-cli (~3-5 minutes)");
-
-    let gglib_dir = path_err(gglib_data_dir())?;
-    println!("  4. Install to {}", gglib_dir.join("bin").display());
-    println!();
 
     Ok(())
 }

--- a/crates/gglib-runtime/src/llama/install/mod.rs
+++ b/crates/gglib-runtime/src/llama/install/mod.rs
@@ -1,6 +1,7 @@
 //! Installation command for llama.cpp.
 
 use super::build::build_llama_cpp;
+use super::build_events::BuildEvent;
 use super::config::BuildConfig;
 use super::deps::check_dependencies;
 use super::detect::{Acceleration, detect_optimal_acceleration};
@@ -16,6 +17,7 @@ use gglib_core::utils::process::cmd;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
 use std::io::{self, Write};
+use tokio::sync::mpsc;
 
 // Helper to convert PathError to anyhow::Error
 fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
@@ -110,7 +112,8 @@ async fn build_from_source_impl(cuda: bool, metal: bool, vulkan: bool, force: bo
     };
 
     // Step 5: Build llama.cpp
-    build_llama_cpp(&llama_dir, acceleration)?;
+    let (build_tx, _build_rx) = mpsc::channel::<BuildEvent>(64);
+    build_llama_cpp(&llama_dir, acceleration, &build_tx)?;
 
     // Step 6: Install binary
     let server_path = path_err(llama_server_path())?;

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -79,6 +79,8 @@ pub use validate::{handle_status, validate_llama_binary, validate_llama_cli_bina
 #[cfg(feature = "cli")]
 pub use install::handle_install;
 #[cfg(feature = "cli")]
+pub use install::run_llama_source_build;
+#[cfg(feature = "cli")]
 pub use uninstall::{handle_rebuild, handle_uninstall};
 #[cfg(feature = "cli")]
 pub use update::{handle_check_updates, handle_update};

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -29,6 +29,7 @@
 pub mod args;
 #[cfg(feature = "cli")]
 mod build;
+pub mod build_events;
 mod config;
 mod deps;
 mod detect;
@@ -57,6 +58,9 @@ pub use server_availability::{LlamaServerError, LlamaServerResult, resolve_llama
 // Progress and prompt traits
 pub use progress::{NoopProgress, ProgressReporter};
 pub use prompt::{AutoConfirmPrompt, InstallPrompt, NonInteractivePrompt};
+
+// Build pipeline event types
+pub use build_events::{BuildEvent, BuildPhase};
 
 #[cfg(feature = "cli")]
 pub use progress::CliProgress;

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -63,6 +63,9 @@ pub use prompt::{AutoConfirmPrompt, InstallPrompt, NonInteractivePrompt};
 pub use build_events::{BuildEvent, BuildPhase};
 
 #[cfg(feature = "cli")]
+pub use deps::{check_dependencies, check_disk_space};
+
+#[cfg(feature = "cli")]
 pub use progress::CliProgress;
 
 #[cfg(feature = "cli")]
@@ -77,11 +80,9 @@ pub use validate::{handle_status, validate_llama_binary, validate_llama_cli_bina
 
 // Installation (CLI only)
 #[cfg(feature = "cli")]
-pub use install::handle_install;
-#[cfg(feature = "cli")]
 pub use install::run_llama_source_build;
 #[cfg(feature = "cli")]
-pub use uninstall::{handle_rebuild, handle_uninstall};
+pub use uninstall::handle_uninstall;
 #[cfg(feature = "cli")]
 pub use update::{handle_check_updates, handle_update};
 

--- a/crates/gglib-runtime/src/llama/uninstall.rs
+++ b/crates/gglib-runtime/src/llama/uninstall.rs
@@ -4,18 +4,6 @@ use anyhow::Result;
 use gglib_core::paths::gglib_data_dir;
 use std::io::{self, Write};
 
-use super::handle_install;
-
-/// Handle the rebuild command.
-///
-/// Rebuilds llama.cpp from source with the specified acceleration options.
-/// This always forces a fresh build, ignoring any cached binaries.
-pub async fn handle_rebuild(cuda: bool, metal: bool, vulkan: bool) -> Result<()> {
-    // Rebuild always builds from source (that's the point of rebuild)
-    // force=true, build=true
-    handle_install(cuda, metal, vulkan, true, true).await
-}
-
 /// Handle the uninstall command.
 ///
 /// Removes the llama.cpp installation including binaries and configuration.

--- a/crates/gglib-runtime/src/llama/update.rs
+++ b/crates/gglib-runtime/src/llama/update.rs
@@ -1,6 +1,7 @@
 //! Update command for llama.cpp.
 
 use super::build::build_llama_cpp;
+use super::build_events::BuildEvent;
 use super::config::BuildConfig;
 use super::detect::{Acceleration, detect_optimal_acceleration};
 use super::install::install_binary;
@@ -8,6 +9,7 @@ use anyhow::{Context, Result, bail};
 use gglib_core::paths::{llama_cli_path, llama_config_path, llama_cpp_dir, llama_server_path};
 use gglib_core::utils::process::cmd;
 use std::io::{self, Write};
+use tokio::sync::mpsc;
 
 // Helper to convert PathError to anyhow::Error
 fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
@@ -212,7 +214,8 @@ pub async fn handle_update() -> Result<()> {
     let commit_sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
     // Rebuild
-    build_llama_cpp(&llama_dir, acceleration)?;
+    let (build_tx, _build_rx) = mpsc::channel::<BuildEvent>(64);
+    build_llama_cpp(&llama_dir, acceleration, &build_tx)?;
 
     // Install binaries
     install_binary(&llama_dir, "llama-server", &binary_path)?;

--- a/crates/gglib-tauri/src/events.rs
+++ b/crates/gglib-tauri/src/events.rs
@@ -25,6 +25,10 @@ pub mod names {
     // Llama installation events
     pub const LLAMA_INSTALL_PROGRESS: &str = "llama-install-progress";
 
+    /// Emitted during a llama.cpp source build (cmake + make).
+    /// Payload is a serialised [`BuildEvent`](gglib_runtime::llama::BuildEvent).
+    pub const LLAMA_BUILD_PROGRESS: &str = "llama-build-progress";
+
     // Menu action events (menu -> frontend)
     pub const MENU_ADD_MODEL_FILE: &str = "menu:add-model-file";
     pub const MENU_SHOW_DOWNLOADS: &str = "menu:show-downloads";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gglib-gui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Modern GUI for GGLib GGUF Model Manager",
   "author": "mmogr",
   "license": "GPLv3",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ gglib-core.workspace = true
 gglib-download.workspace = true
 gglib-mcp.workspace = true
 gglib-db.workspace = true
-gglib-runtime = { workspace = true, features = ["prebuilt"] }
+gglib-runtime = { workspace = true, features = ["cli"] }
 gglib-tauri.workspace = true
 gglib-axum.workspace = true
 gglib-gui.workspace = true

--- a/src-tauri/src/commands/llama.rs
+++ b/src-tauri/src/commands/llama.rs
@@ -1,10 +1,12 @@
 //! llama.cpp installation and status commands.
 
 use crate::app::events::{emit_or_log, names};
+use gglib_core::paths::{llama_cli_path, llama_cpp_dir, llama_server_path};
 use gglib_download::ProgressThrottle;
 use gglib_runtime::llama::{
-    PrebuiltAvailability, check_llama_installed, check_prebuilt_availability,
-    download_prebuilt_binaries_with_boxed_callback,
+    BuildEvent, PrebuiltAvailability, check_llama_installed, check_prebuilt_availability,
+    detect_optimal_acceleration, download_prebuilt_binaries_with_boxed_callback,
+    run_llama_source_build,
 };
 use std::sync::{Arc, Mutex};
 use tauri::AppHandle;
@@ -24,6 +26,45 @@ pub struct LlamaInstallEvent {
     pub total: u64,
     pub percentage: f64,
     pub message: String,
+}
+
+/// Trigger a llama.cpp source build and stream progress as Tauri events.
+///
+/// Emits `llama-build-progress` events to the frontend throughout the build.
+/// Each event payload is a serialised [`BuildEvent`]:
+///
+/// | Variant          | JSON shape                                              |
+/// |------------------|---------------------------------------------------------|
+/// | `PhaseStarted`   | `{ "type": "phase_started", "phase": "..." }`          |
+/// | `Log`            | `{ "type": "log", "message": "..." }`                  |
+/// | `Progress`       | `{ "type": "progress", "current": N, "total": N }`     |
+/// | `PhaseCompleted` | `{ "type": "phase_completed", "phase": "..." }`        |
+/// | `Completed`      | `{ "type": "completed", "version": "...", "acceleration": "..." }` |
+/// | `Failed`         | `{ "type": "failed", "message": "..." }`               |
+///
+/// Returns an error string if path resolution, acceleration detection, or the
+/// build itself fails.
+#[tauri::command]
+pub async fn build_llama_from_source(app: AppHandle) -> Result<(), String> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<BuildEvent>(64);
+
+    let llama_dir = llama_cpp_dir().map_err(|e| e.to_string())?;
+    let server_path = llama_server_path().map_err(|e| e.to_string())?;
+    let cli_path = llama_cli_path().map_err(|e| e.to_string())?;
+    let acceleration = detect_optimal_acceleration().map_err(|e| e.to_string())?;
+
+    let build_handle = tokio::spawn(async move {
+        run_llama_source_build(acceleration, llama_dir, server_path, cli_path, tx).await
+    });
+
+    while let Some(event) = rx.recv().await {
+        emit_or_log(&app, names::LLAMA_BUILD_PROGRESS, event);
+    }
+
+    build_handle
+        .await
+        .map_err(|e| format!("Build task panicked: {e}"))?
+        .map_err(|e| e.to_string())
 }
 
 /// Check if llama.cpp is installed.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -219,6 +219,7 @@ fn main() {
             // OS integration: llama.cpp binary management
             commands::llama::check_llama_status,
             commands::llama::install_llama,
+            commands::llama::build_llama_from_source,
             // Research logs: file persistence for debugging
             commands::research_logs::init_research_logs,
             commands::research_logs::append_research_log,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "GGLib GUI",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.gglib.gui",
   "build": {
     "beforeBuildCommand": "npm run build:tauri",


### PR DESCRIPTION
Closes #367

## Problem

The `gglib llama install --build` pipeline wrote cmake/make subprocess output directly to the terminal alongside an `indicatif` progress bar, causing a race condition that garbled output. There was also no way to surface build progress to the WebUI or Tauri GUI — pre-built downloads had SSE/event support, source builds did not.

## Solution

Introduce a `BuildEvent` enum and route all subprocess output through a `tokio::sync::mpsc::Sender<BuildEvent>`. Three consumer adapters plug into the same stream — the same pattern used by the agent streaming pipeline.

```
run_llama_source_build(..., tx: Sender<BuildEvent>)
    ├── CLI adapter      → indicatif spinner (gglib-cli)
    ├── Axum SSE handler → POST /api/system/build-llama-from-source
    └── Tauri command    → emit "llama-build-progress" events
```

## Phases

| # | Phase | Change |
|---|-------|--------|
| A | #368 | Suppress cmake `-Wmissing-noreturn` flood via `CXXFLAGS` env merge (`merge_flags`) |
| B | #369 | Define `BuildEvent` / `BuildPhase` enums in `build/events.rs` |
| C | #380 | Thread `Sender<BuildEvent>` through `configure_cmake` and `build_project`; remove direct terminal writes from both functions |
| D | #381 | Fix git clone TTY leak; extract `run_llama_source_build` as the single streaming entry point |
| E | #382 | CLI adapter: `consume_build_events_cli` drives indicatif from the event stream |
| F | #383 | Axum SSE: `POST /api/system/build-llama-from-source` streams `BuildEvent` as SSE |
| G | #384 | Tauri command `build_llama_from_source` emitting `llama-build-progress` |
| H | #385 | Rustdoc for `BuildEvent`, `BuildPhase`, and `build/mod.rs` |
| — | review | Fix code-review violations: `recv_timeout` → `recv()`, remove hardcoded cmake flag overrides, move `indicatif` rendering to `gglib-cli` |
