### PR TITLE
fix(ui): prevent chat panels from becoming scroll containers

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -553,7 +553,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
   // Render
   // ─────────────────────────────────────────────────────────────────────────────
   return (
-    <div className="flex flex-col overflow-y-auto overflow-x-hidden relative flex-1 bg-surface md:h-full md:min-h-0">
+    <div className="flex flex-col overflow-hidden relative flex-1 bg-surface md:h-full md:min-h-0">
       {/* Header */}
       <div className="p-base border-b border-border bg-background shrink-0 flex flex-wrap justify-between items-center gap-md phone:flex-nowrap">
         <div className="flex items-center gap-sm min-w-0 basis-full phone:basis-auto phone:flex-1">

--- a/src/components/ConversationListPanel/ConversationListPanel.tsx
+++ b/src/components/ConversationListPanel/ConversationListPanel.tsx
@@ -63,7 +63,7 @@ const ConversationListPanel: FC<ConversationListPanelProps> = ({
     : conversations;
 
   return (
-    <div className="flex flex-col overflow-y-auto overflow-x-hidden border-b border-border relative flex-1 bg-surface md:h-full md:min-h-0 md:border-b-0 md:border-r">
+    <div className="flex flex-col overflow-hidden border-b border-border relative flex-1 bg-surface md:h-full md:min-h-0 md:border-b-0 md:border-r">
       <div className="p-base border-b border-border bg-background shrink-0">
         {/* View Tabs */}
         <div className="mb-md">


### PR DESCRIPTION
## Summary

Closes #398

When a conversation grew long enough, the panel root `<div>` in both `ChatMessagesPanel` and `ConversationListPanel` became the active scroll container instead of the inner `ThreadPrimitive.Viewport`. This caused the sticky header and composer/input bar to scroll off screen with the message list — the panel appeared to "dislodge".

## Root cause

Both panel roots had `overflow-y-auto overflow-x-hidden`. When the flex height chain was under-constrained at a given viewport size, those roots became scroll containers, pulling the header and composer out of their pinned positions.

## Fix

Replace `overflow-y-auto overflow-x-hidden` → `overflow-hidden` on the two panel root divs. The inner content zones (`flex-1 min-h-0 overflow-y-auto`) already provide all the scroll behaviour needed.

## Changed files

- `src/components/ChatMessagesPanel/ChatMessagesPanel.tsx` — panel root div
- `src/components/ConversationListPanel/ConversationListPanel.tsx` — panel root div

## Testing

1. Start the frontend dev server.
2. Open a chat and send enough messages to trigger scrolling.
3. Scroll through messages — verify the header stays pinned at top and the composer stays pinned at bottom.
4. Verify the left conversation list scrolls only within its list body, not the whole sidebar (model name + buttons stay visible).