### PR TITLE
fix(ci): trigger release badges on CI completion instead of Release

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -2,7 +2,7 @@ name: Update Badges
 
 on:
   workflow_run:
-    workflows: ["CI", "Coverage", "Release"]
+    workflows: ["CI", "Coverage"]
     types: [completed]
     branches: [main]
 
@@ -717,11 +717,15 @@ jobs:
           commit_message: 'Update coverage badges [skip ci] ${{ github.event.workflow_run.head_sha }}'
 
   # =============================================================================
-  # RELEASE WORKFLOW: Update version badge and SCC metrics
+  # CI WORKFLOW (post-release): Update version badge and SCC metrics
+  # Since PR #356 converted Release to a workflow_call inside CI, the "Release"
+  # workflow_run event no longer fires. Trigger on CI instead (see issue #402).
+  # Serialised after update-test-badges to avoid concurrent pushes to badges.
   # =============================================================================
   update-release-badges:
     name: Update Release Badges
-    if: ${{ github.event.workflow_run.name == 'Release' }}
+    needs: [update-test-badges]
+    if: ${{ github.event.workflow_run.name == 'CI' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch (for source analysis)
@@ -1067,4 +1071,4 @@ jobs:
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'Update release badges [skip ci] ${{ github.event.workflow_run.head_sha }}'
+          commit_message: 'Update release badges (from CI) [skip ci] ${{ github.event.workflow_run.head_sha }}'


### PR DESCRIPTION
## Problem

The version badge on the main README has stopped updating despite new versions being released. The `update-release-badges` job in `badges.yml` was conditioned on `github.event.workflow_run.name == 'Release'`, but since PR #356 converted `release.yml` to a `workflow_call` invoked from `ci.yml`, the Release workflow no longer emits its own `workflow_run` event. The job has been dead code since.

**Regression introduced by:** #356 (`481c6d9`)
**Follow-up (did not address badges):** #358 (`abf4ad7`)
**Original workflow_run setup:** #103 (fixed #102), #75, #63

Fixes #402

## Fix

1. **Changed `update-release-badges` trigger** from `workflow_run.name == 'Release'` to `workflow_run.name == 'CI'` — since Release now runs as a nested job inside CI, the CI completion event is the correct trigger.
2. **Added `needs: [update-test-badges]`** to serialise the two CI-triggered badge jobs, preventing concurrent pushes to the `badges` branch.
3. **Removed `"Release"` from the `workflow_run` trigger list** since it can no longer fire as a standalone workflow run.

## Verification

| Scenario | Before | After |
|---|---|---|
| Push to main → CI completes | `update-release-badges` skipped (no "Release" event) | `update-release-badges` runs after `update-test-badges` |
| Coverage completes | `update-coverage-badges` runs | No change |
| Manual `workflow_dispatch` on release.yml | Would trigger badges (but rarely used) | No change (manual dispatch doesn't trigger `workflow_run`) |