### PR TITLE
feat: improve tool call display formatting with DRY backend-first rendering

### DIFF
--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -199,9 +199,11 @@ impl AgentLoop {
         config: &AgentConfig,
         iteration: usize,
         tx: &mpsc::Sender<AgentEvent>,
+        tools: &[ToolDefinition],
     ) {
         let results =
-            execute_tools_parallel(&response.tool_calls, &self.tool_executor, config, tx).await;
+            execute_tools_parallel(&response.tool_calls, &self.tool_executor, config, tx, tools)
+                .await;
 
         let tool_call_count = results.len();
         let tool_failures = results.iter().filter(|r| !r.success).count();
@@ -300,7 +302,7 @@ impl AgentLoopPort for AgentLoop {
                     .await;
             }
 
-            self.execute_tool_iteration(&mut messages, response, &config, iteration, &tx)
+            self.execute_tool_iteration(&mut messages, response, &config, iteration, &tx, &tools)
                 .await;
         }
 

--- a/crates/gglib-agent/src/tool_execution/mod.rs
+++ b/crates/gglib-agent/src/tool_execution/mod.rs
@@ -28,7 +28,7 @@ use gglib_core::domain::agent::tool_display::{
 };
 use gglib_core::format_duration_human;
 use gglib_core::ports::ToolExecutorPort;
-use gglib_core::{AgentConfig, AgentEvent, ToolCall, ToolResult};
+use gglib_core::{AgentConfig, AgentEvent, ToolCall, ToolDefinition, ToolResult};
 use tokio::sync::{Semaphore, mpsc};
 use tokio::task::JoinSet;
 use tracing::warn;
@@ -52,6 +52,7 @@ async fn execute_single_tool(
     sem: Arc<Semaphore>,
     tx: mpsc::Sender<AgentEvent>,
     timeout_ms: u64,
+    title: Option<String>,
 ) -> ToolResult {
     // Shared failure constructor — avoids repeating the struct literal with the
     // same `tool_call_id` and `success: false` across every error branch.
@@ -81,7 +82,7 @@ async fn execute_single_tool(
     // Notify that execution is starting (after permit acquired —
     // we only claim "started" once we have a slot, not when queued).
     let bare_name = strip_tool_prefix(&tc.name);
-    let display_name = format_tool_display_name(bare_name);
+    let display_name = title.unwrap_or_else(|| format_tool_display_name(bare_name));
     let args_summary = format_tool_args_summary(bare_name, &tc.arguments);
 
     let _ = tx
@@ -134,6 +135,7 @@ pub async fn execute_tools_parallel(
     executor: &Arc<dyn ToolExecutorPort>,
     config: &AgentConfig,
     tx: &mpsc::Sender<AgentEvent>,
+    tools: &[ToolDefinition],
 ) -> Vec<ToolResult> {
     let semaphore = Arc::new(Semaphore::new(config.max_parallel_tools));
     let timeout_ms = config.tool_timeout_ms;
@@ -149,8 +151,12 @@ pub async fn execute_tools_parallel(
         let permit = Arc::clone(&semaphore);
         let executor = Arc::clone(executor);
         let tx = tx.clone();
+        let title = tools
+            .iter()
+            .find(|d| d.name == tc.name)
+            .and_then(|d| d.title.clone());
         set.spawn(async move {
-            let result = execute_single_tool(tc, executor, permit, tx, timeout_ms).await;
+            let result = execute_single_tool(tc, executor, permit, tx, timeout_ms, title).await;
             (i, result)
         });
     }

--- a/crates/gglib-agent/src/tool_execution/mod.rs
+++ b/crates/gglib-agent/src/tool_execution/mod.rs
@@ -23,6 +23,10 @@ mod tests;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use gglib_core::domain::agent::tool_display::{
+    format_tool_args_summary, format_tool_display_name, strip_tool_prefix,
+};
+use gglib_core::format_duration_human;
 use gglib_core::ports::ToolExecutorPort;
 use gglib_core::{AgentConfig, AgentEvent, ToolCall, ToolResult};
 use tokio::sync::{Semaphore, mpsc};
@@ -76,9 +80,15 @@ async fn execute_single_tool(
 
     // Notify that execution is starting (after permit acquired —
     // we only claim "started" once we have a slot, not when queued).
+    let bare_name = strip_tool_prefix(&tc.name);
+    let display_name = format_tool_display_name(bare_name);
+    let args_summary = format_tool_args_summary(bare_name, &tc.arguments);
+
     let _ = tx
         .send(AgentEvent::ToolCallStart {
             tool_call: tc.clone(),
+            display_name: display_name.clone(),
+            args_summary,
         })
         .await;
 
@@ -96,12 +106,15 @@ async fn execute_single_tool(
     };
 
     // Notify that execution is complete.
+    let duration_display = format_duration_human(duration_ms);
     let _ = tx
         .send(AgentEvent::ToolCallComplete {
             tool_name: tc.name.clone(),
             result: tool_result.clone(),
             wait_ms,
             execute_duration_ms: duration_ms,
+            display_name,
+            duration_display,
         })
         .await;
 

--- a/crates/gglib-agent/src/tool_execution/tests.rs
+++ b/crates/gglib-agent/src/tool_execution/tests.rs
@@ -63,7 +63,8 @@ async fn all_tools_return_results_in_order() {
     let executor: Arc<dyn ToolExecutorPort> = Arc::new(OkExecutor);
     let calls: Vec<ToolCall> = (0..3).map(|i| call(&format!("c{i}"), "t")).collect();
 
-    let results = execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx, &[]).await;
+    let results =
+        execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx, &[]).await;
 
     assert_eq!(results.len(), 3);
     for (i, r) in results.iter().enumerate() {
@@ -169,7 +170,8 @@ async fn executor_error_produces_failure_result() {
     let executor: Arc<dyn ToolExecutorPort> = Arc::new(ErrorExecutor);
     let calls = vec![call("err1", "broken_tool")];
 
-    let results = execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx, &[]).await;
+    let results =
+        execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx, &[]).await;
 
     assert_eq!(results.len(), 1);
     assert!(!results[0].success, "result should indicate failure");

--- a/crates/gglib-agent/src/tool_execution/tests.rs
+++ b/crates/gglib-agent/src/tool_execution/tests.rs
@@ -63,7 +63,7 @@ async fn all_tools_return_results_in_order() {
     let executor: Arc<dyn ToolExecutorPort> = Arc::new(OkExecutor);
     let calls: Vec<ToolCall> = (0..3).map(|i| call(&format!("c{i}"), "t")).collect();
 
-    let results = execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx).await;
+    let results = execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx, &[]).await;
 
     assert_eq!(results.len(), 3);
     for (i, r) in results.iter().enumerate() {
@@ -86,7 +86,7 @@ async fn timeout_produces_failure_result() {
     let mut config = AgentConfig::default();
     config.tool_timeout_ms = 10;
 
-    let results = execute_tools_parallel(&calls, &executor, &config, &tx).await;
+    let results = execute_tools_parallel(&calls, &executor, &config, &tx, &[]).await;
 
     assert_eq!(results.len(), 1);
     assert!(!results[0].success);
@@ -140,7 +140,7 @@ async fn concurrency_limited_by_semaphore() {
     let mut config = AgentConfig::default();
     config.max_parallel_tools = 3;
 
-    execute_tools_parallel(&calls, &tracker, &config, &tx).await;
+    execute_tools_parallel(&calls, &tracker, &config, &tx, &[]).await;
 
     let observed_peak = peak.load(Ordering::SeqCst);
     assert!(
@@ -169,7 +169,7 @@ async fn executor_error_produces_failure_result() {
     let executor: Arc<dyn ToolExecutorPort> = Arc::new(ErrorExecutor);
     let calls = vec![call("err1", "broken_tool")];
 
-    let results = execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx).await;
+    let results = execute_tools_parallel(&calls, &executor, &AgentConfig::default(), &tx, &[]).await;
 
     assert_eq!(results.len(), 1);
     assert!(!results[0].success, "result should indicate failure");

--- a/crates/gglib-cli/src/handlers/agent_chat/drain.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/drain.rs
@@ -1,0 +1,137 @@
+//! Async event-stream consumer for the agentic chat loop.
+//!
+//! [`drain_event_stream`] pulls [`AgentEvent`]s from a
+//! [`tokio::sync::mpsc::Receiver`], classifies inline thinking tokens via
+//! [`ThinkingAccumulator`], and renders each event through the
+//! [`super::renderer`] and [`super::thinking_dispatch`] modules.
+//!
+//! Extracted from `renderer.rs` to separate the stateful async orchestration
+//! (spinner lifecycle, thinking accumulator, Rich/Raw mode selection) from
+//! the stateless per-event formatting in [`super::renderer::render_event`].
+
+use std::io::{self, IsTerminal, Write as _};
+
+use gglib_core::domain::agent::AgentEvent;
+use gglib_core::domain::thinking::ThinkingAccumulator;
+use tokio::sync::mpsc;
+
+use super::markdown::render_markdown;
+use super::renderer::render_event;
+use super::thinking_dispatch::{
+    RenderContext, close_thinking, dispatch_thinking_event, suspend_or_run,
+};
+
+/// Drain `rx` until the channel closes or a [`AgentEvent::FinalAnswer`]
+/// arrives, rendering each event.
+///
+/// Returns `true` only when the turn completed with a [`AgentEvent::FinalAnswer`]
+/// event.  Returns `false` when the channel closes without one (e.g. the loop
+/// hit max iterations or stagnated).  Cancellation (Ctrl+C) is handled by the
+/// caller via `tokio::select!`; this function has no side effects beyond
+/// rendering.
+///
+/// When stdout is a TTY and `quiet` is `false`, tokens are buffered and
+/// rendered through [`termimad`] on completion (Rich mode).  An
+/// [`indicatif`] spinner runs on stderr while buffering.  In all other
+/// cases tokens stream to stdout as they arrive (Raw mode).
+///
+/// A [`ThinkingAccumulator`] intercepts `TextDelta` events so that inline
+/// `<think>` tags are reclassified: reasoning goes to stderr, content to
+/// stdout.
+///
+/// The caller **must** gate any history update on the return value: history
+/// from a failed or incomplete turn must not replace the previous context.
+pub async fn drain_event_stream(
+    rx: &mut mpsc::Receiver<AgentEvent>,
+    verbose: bool,
+    quiet: bool,
+) -> bool {
+    let rich = !quiet && io::stdout().is_terminal();
+    let stderr_tty = io::stderr().is_terminal();
+    let mut acc = ThinkingAccumulator::new();
+    let mut ctx = RenderContext::new(rich, stderr_tty, quiet);
+    let mut had_text = false;
+
+    while let Some(event) = rx.recv().await {
+        match &event {
+            // ── Content tokens ───────────────────────────────────────
+            AgentEvent::TextDelta { content } => {
+                had_text = true;
+                for te in acc.push(content) {
+                    dispatch_thinking_event(te, &mut ctx);
+                }
+            }
+
+            // ── Structured reasoning (already classified by the model) ─
+            AgentEvent::ReasoningDelta { content } => {
+                if !quiet {
+                    use gglib_core::domain::thinking::ThinkingEvent;
+                    dispatch_thinking_event(
+                        ThinkingEvent::ThinkingDelta(content.clone()),
+                        &mut ctx,
+                    );
+                }
+            }
+
+            // ── Turn complete ────────────────────────────────────────
+            AgentEvent::FinalAnswer { content } => {
+                close_thinking(&mut ctx);
+
+                // Flush any pending thinking accumulator state.
+                for te in acc.flush() {
+                    dispatch_thinking_event(te, &mut ctx);
+                }
+                close_thinking(&mut ctx);
+
+                // Stop spinner before rendering.
+                if let Some(sp) = ctx.spinner.take() {
+                    sp.finish_and_clear();
+                }
+
+                // Render the final output.
+                if rich {
+                    let text = if ctx.buf.is_empty() {
+                        content.as_str()
+                    } else {
+                        &ctx.buf
+                    };
+                    if !text.is_empty() {
+                        render_markdown(text);
+                    }
+                } else {
+                    // Raw mode: defensive fallback for non-streaming responses.
+                    if !had_text && !content.is_empty() {
+                        print!("{content}");
+                        let _ = io::stdout().flush();
+                    }
+                    println!();
+                }
+
+                debug_assert!(
+                    rx.try_recv().is_err(),
+                    "events after FinalAnswer violate agent protocol"
+                );
+                return true;
+            }
+
+            // ── Tool / progress / error events ───────────────────────
+            _ => {
+                close_thinking(&mut ctx);
+                suspend_or_run(ctx.spinner.as_ref(), || {
+                    render_event(&event, verbose, quiet, had_text);
+                });
+            }
+        }
+    }
+
+    // Channel closed without a FinalAnswer — the loop ended with an error
+    // (max iterations, stagnation, etc.).
+    close_thinking(&mut ctx);
+    if let Some(sp) = ctx.spinner.take() {
+        sp.finish_and_clear();
+    }
+    if rich && !ctx.buf.is_empty() {
+        render_markdown(&ctx.buf);
+    }
+    false
+}

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -4,12 +4,14 @@
 //! independently readable:
 //! - [`config`]   — resolves LLM port + MCP tools, composes an [`gglib_core::ports::AgentLoopPort`]
 //! - [`renderer`] — maps [`gglib_core::AgentEvent`] variants to terminal output
+//! - [`drain`]    — async event-stream consumer (spinner, thinking accumulator)
 //! - [`repl`]     — async REPL loop with `rustyline` + `spawn_blocking` input
 //! - [`tool_format`] — tool-result summary formatters
 //! - [`markdown`] — Markdown normalisation + termimad rendering
 //! - [`thinking_dispatch`] — `RenderContext`, thinking-event dispatch, spinner coordination
 
 pub mod config;
+pub mod drain;
 mod markdown;
 pub mod persistence;
 pub mod renderer;

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -77,9 +77,7 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
                     Some(summary) => eprintln!(
                         "\n  {DIM}⚙{RESET}  {BOLD}{display_name}{RESET}  {DIM}{summary}{RESET} …"
                     ),
-                    None => eprintln!(
-                        "\n  {DIM}⚙{RESET}  {BOLD}{display_name}{RESET} …"
-                    ),
+                    None => eprintln!("\n  {DIM}⚙{RESET}  {BOLD}{display_name}{RESET} …"),
                 }
             }
         }

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -16,31 +16,19 @@
 //! In **Raw** mode tokens stream to stdout as they arrive — identical to the
 //! pre-`termimad` behaviour.  This keeps piped output clean and predictable.
 //!
-//! ## Inline thinking fallback
-//!
-//! A [`ThinkingAccumulator`] intercepts `TextDelta` events so that models
-//! emitting inline `<think>` tags (when `--reasoning-format none` or no
-//! format was specified) have their reasoning content redirected to stderr
-//! and only the answer text reaches stdout.
-//!
 //! ## Module decomposition
 //!
 //! | Module | Contents |
 //! |--------|----------|
+//! | [`super::drain`] | Async event-stream consumer (spinner, thinking accumulator) |
 //! | [`super::tool_format`] | Tool-result summary formatters |
 //! | [`super::markdown`] | Markdown normalisation + termimad rendering |
 //! | [`super::thinking_dispatch`] | `RenderContext`, thinking-event dispatch, spinner coordination |
 
-use std::io::{self, IsTerminal, Write as _};
+use std::io::{self, Write as _};
 
 use gglib_core::domain::agent::AgentEvent;
-use gglib_core::domain::thinking::ThinkingAccumulator;
-use tokio::sync::mpsc;
 
-use super::markdown::render_markdown;
-use super::thinking_dispatch::{
-    RenderContext, close_thinking, dispatch_thinking_event, suspend_or_run,
-};
 use super::tool_format::format_tool_result;
 
 // =============================================================================
@@ -121,121 +109,6 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
             eprintln!("\n  ❌  {message}");
         }
     }
-}
-
-/// Drain `rx` until the channel closes or a [`AgentEvent::FinalAnswer`]
-/// arrives, rendering each event.
-///
-/// Returns `true` only when the turn completed with a [`AgentEvent::FinalAnswer`]
-/// event.  Returns `false` when the channel closes without one (e.g. the loop
-/// hit max iterations or stagnated).  Cancellation (Ctrl+C) is handled by the
-/// caller via `tokio::select!`; this function has no side effects beyond
-/// rendering.
-///
-/// When stdout is a TTY and `quiet` is `false`, tokens are buffered and
-/// rendered through [`termimad`] on completion (Rich mode).  An
-/// [`indicatif`] spinner runs on stderr while buffering.  In all other
-/// cases tokens stream to stdout as they arrive (Raw mode).
-///
-/// A [`ThinkingAccumulator`] intercepts `TextDelta` events so that inline
-/// `<think>` tags are reclassified: reasoning goes to stderr, content to
-/// stdout.
-///
-/// The caller **must** gate any history update on the return value: history
-/// from a failed or incomplete turn must not replace the previous context.
-pub async fn drain_event_stream(
-    rx: &mut mpsc::Receiver<AgentEvent>,
-    verbose: bool,
-    quiet: bool,
-) -> bool {
-    let rich = !quiet && io::stdout().is_terminal();
-    let stderr_tty = io::stderr().is_terminal();
-    let mut acc = ThinkingAccumulator::new();
-    let mut ctx = RenderContext::new(rich, stderr_tty, quiet);
-    let mut had_text = false;
-
-    while let Some(event) = rx.recv().await {
-        match &event {
-            // ── Content tokens ───────────────────────────────────────
-            AgentEvent::TextDelta { content } => {
-                had_text = true;
-                for te in acc.push(content) {
-                    dispatch_thinking_event(te, &mut ctx);
-                }
-            }
-
-            // ── Structured reasoning (already classified by the model) ─
-            AgentEvent::ReasoningDelta { content } => {
-                if !quiet {
-                    use gglib_core::domain::thinking::ThinkingEvent;
-                    dispatch_thinking_event(
-                        ThinkingEvent::ThinkingDelta(content.clone()),
-                        &mut ctx,
-                    );
-                }
-            }
-
-            // ── Turn complete ────────────────────────────────────────
-            AgentEvent::FinalAnswer { content } => {
-                close_thinking(&mut ctx);
-
-                // Flush any pending thinking accumulator state.
-                for te in acc.flush() {
-                    dispatch_thinking_event(te, &mut ctx);
-                }
-                close_thinking(&mut ctx);
-
-                // Stop spinner before rendering.
-                if let Some(sp) = ctx.spinner.take() {
-                    sp.finish_and_clear();
-                }
-
-                // Render the final output.
-                if rich {
-                    let text = if ctx.buf.is_empty() {
-                        content.as_str()
-                    } else {
-                        &ctx.buf
-                    };
-                    if !text.is_empty() {
-                        render_markdown(text);
-                    }
-                } else {
-                    // Raw mode: defensive fallback for non-streaming responses.
-                    if !had_text && !content.is_empty() {
-                        print!("{content}");
-                        let _ = io::stdout().flush();
-                    }
-                    println!();
-                }
-
-                debug_assert!(
-                    rx.try_recv().is_err(),
-                    "events after FinalAnswer violate agent protocol"
-                );
-                return true;
-            }
-
-            // ── Tool / progress / error events ───────────────────────
-            _ => {
-                close_thinking(&mut ctx);
-                suspend_or_run(ctx.spinner.as_ref(), || {
-                    render_event(&event, verbose, quiet, had_text);
-                });
-            }
-        }
-    }
-
-    // Channel closed without a FinalAnswer — the loop ended with an error
-    // (max iterations, stagnation, etc.).
-    close_thinking(&mut ctx);
-    if let Some(sp) = ctx.spinner.take() {
-        sp.finish_and_clear();
-    }
-    if rich && !ctx.buf.is_empty() {
-        render_markdown(&ctx.buf);
-    }
-    false
 }
 
 // =============================================================================

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -29,6 +29,8 @@ use std::io::{self, Write as _};
 
 use gglib_core::domain::agent::AgentEvent;
 
+use crate::presentation::style::{BOLD, DANGER, DIM, RESET, SUCCESS};
+
 use super::tool_format::format_tool_result;
 
 // =============================================================================
@@ -72,8 +74,12 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
         } => {
             if !quiet {
                 match args_summary {
-                    Some(summary) => eprintln!("\n  ⚙   {display_name}  {summary} …"),
-                    None => eprintln!("\n  ⚙   {display_name} …"),
+                    Some(summary) => eprintln!(
+                        "\n  {DIM}⚙{RESET}  {BOLD}{display_name}{RESET}  {DIM}{summary}{RESET} …"
+                    ),
+                    None => eprintln!(
+                        "\n  {DIM}⚙{RESET}  {BOLD}{display_name}{RESET} …"
+                    ),
                 }
             }
         }
@@ -86,9 +92,15 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
             ..
         } => {
             if !quiet {
-                let icon = if result.success { "✓" } else { "✗" };
+                let (icon, icon_color) = if result.success {
+                    ("✓", SUCCESS)
+                } else {
+                    ("✗", DANGER)
+                };
                 let summary = format_tool_result(tool_name, result);
-                eprintln!("  {icon}  {duration_display}  {display_name}  {summary}");
+                eprintln!(
+                    "  {icon_color}{icon}{RESET}  {BOLD}{display_name}{RESET}  {DIM}{duration_display}{RESET}  {summary}"
+                );
             }
         }
 

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -65,22 +65,30 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
             let _ = io::stdout().flush();
         }
 
-        AgentEvent::ToolCallStart { tool_call } => {
+        AgentEvent::ToolCallStart {
+            display_name,
+            args_summary,
+            ..
+        } => {
             if !quiet {
-                eprintln!("\n  ⚙   {} …", tool_call.name);
+                match args_summary {
+                    Some(summary) => eprintln!("\n  ⚙   {display_name}  {summary} …"),
+                    None => eprintln!("\n  ⚙   {display_name} …"),
+                }
             }
         }
 
         AgentEvent::ToolCallComplete {
             tool_name,
+            display_name,
+            duration_display,
             result,
-            execute_duration_ms,
             ..
         } => {
             if !quiet {
                 let icon = if result.success { "✓" } else { "✗" };
                 let summary = format_tool_result(tool_name, result);
-                eprintln!("  {icon}  {execute_duration_ms}ms  {summary}");
+                eprintln!("  {icon}  {duration_display}  {display_name}  {summary}");
             }
         }
 
@@ -176,6 +184,8 @@ mod tests {
             },
             wait_ms: 0,
             execute_duration_ms: 5,
+            display_name: "Some Tool".into(),
+            duration_display: "5ms".into(),
         });
     }
 
@@ -191,6 +201,8 @@ mod tests {
             },
             wait_ms: 0,
             execute_duration_ms: 10,
+            display_name: "Read File".into(),
+            duration_display: "10ms".into(),
         });
     }
 
@@ -205,6 +217,8 @@ mod tests {
             },
             wait_ms: 0,
             execute_duration_ms: 3,
+            display_name: "List Directory".into(),
+            duration_display: "3ms".into(),
         });
     }
 
@@ -219,6 +233,8 @@ mod tests {
             },
             wait_ms: 0,
             execute_duration_ms: 20,
+            display_name: "Grep Search".into(),
+            duration_display: "20ms".into(),
         });
     }
 
@@ -233,6 +249,8 @@ mod tests {
             },
             wait_ms: 0,
             execute_duration_ms: 15,
+            display_name: "Grep Search".into(),
+            duration_display: "15ms".into(),
         });
     }
 
@@ -247,6 +265,8 @@ mod tests {
             },
             wait_ms: 0,
             execute_duration_ms: 1,
+            display_name: "Read File".into(),
+            duration_display: "1ms".into(),
         });
     }
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -40,7 +40,7 @@ use gglib_core::ports::AgentLoopPort;
 use crate::handlers::inference::chat::ChatArgs;
 
 use super::persistence::Conversation;
-use super::renderer::drain_event_stream;
+use super::drain::drain_event_stream;
 
 // =============================================================================
 // Help text

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -39,8 +39,8 @@ use gglib_core::ports::AgentLoopPort;
 
 use crate::handlers::inference::chat::ChatArgs;
 
-use super::persistence::Conversation;
 use super::drain::drain_event_stream;
+use super::persistence::Conversation;
 
 // =============================================================================
 // Help text

--- a/crates/gglib-cli/src/handlers/agent_chat/thinking_dispatch.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/thinking_dispatch.rs
@@ -110,9 +110,17 @@ fn suspend_eprint(spinner: Option<&ProgressBar>, text: &str) {
 }
 
 /// Open a "Thinking" banner on stderr if not already in thinking mode.
+///
+/// The spinner is stopped before printing the banner so that its 80 ms
+/// steady-tick does not interleave with per-token `eprint!` calls,
+/// which would produce garbled output like `word⠴ Receiving…`.
+/// The spinner is recreated automatically on the next `ContentDelta`.
 fn open_thinking(ctx: &mut RenderContext) {
     if !ctx.in_thinking && ctx.stderr_tty {
-        suspend_or_run(ctx.spinner.as_ref(), style::print_thinking_banner);
+        if let Some(sp) = ctx.spinner.take() {
+            sp.finish_and_clear();
+        }
+        style::print_thinking_banner();
         ctx.in_thinking = true;
     }
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/tool_format.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/tool_format.rs
@@ -76,10 +76,7 @@ fn format_get_current_time(content: &str) -> String {
     // The tool returns JSON like {"timezone":"UTC","datetime":"2025-01-15T10:30:00Z","unix_timestamp":...}
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(content) {
         if let Some(dt) = v.get("datetime").and_then(|d| d.as_str()) {
-            let tz = v
-                .get("timezone")
-                .and_then(|t| t.as_str())
-                .unwrap_or("");
+            let tz = v.get("timezone").and_then(|t| t.as_str()).unwrap_or("");
             if tz.is_empty() {
                 return dt.to_string();
             }

--- a/crates/gglib-cli/src/handlers/agent_chat/tool_format.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/tool_format.rs
@@ -74,14 +74,14 @@ fn format_grep_search(content: &str) -> String {
 /// `get_current_time` → extract the readable time value from result JSON.
 fn format_get_current_time(content: &str) -> String {
     // The tool returns JSON like {"timezone":"UTC","datetime":"2025-01-15T10:30:00Z","unix_timestamp":...}
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(content) {
-        if let Some(dt) = v.get("datetime").and_then(|d| d.as_str()) {
-            let tz = v.get("timezone").and_then(|t| t.as_str()).unwrap_or("");
-            if tz.is_empty() {
-                return dt.to_string();
-            }
-            return format!("{dt} ({tz})");
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(content)
+        && let Some(dt) = v.get("datetime").and_then(|d| d.as_str())
+    {
+        let tz = v.get("timezone").and_then(|t| t.as_str()).unwrap_or("");
+        if tz.is_empty() {
+            return dt.to_string();
         }
+        return format!("{dt} ({tz})");
     }
     // Fallback: content is already human-readable or unexpected format.
     truncate_string(content, 80)

--- a/crates/gglib-cli/src/handlers/agent_chat/tool_format.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/tool_format.rs
@@ -13,13 +13,14 @@ use crate::presentation::tables::truncate_string;
 /// falls back to the standard 80-char preview.
 pub(super) fn format_tool_result(tool_name: &str, result: &ToolResult) -> String {
     if !result.success {
-        return truncate_string(&result.content, 80);
+        return truncate_string(&result.content, 120);
     }
 
     match tool_name {
         "builtin:read_file" => format_read_file(&result.content),
         "builtin:list_directory" => format_list_directory(&result.content),
         "builtin:grep_search" => format_grep_search(&result.content),
+        "builtin:get_current_time" => format_get_current_time(&result.content),
         _ => truncate_string(&result.content, 80),
     }
 }
@@ -68,4 +69,23 @@ fn format_grep_search(content: &str) -> String {
     } else {
         format!("{match_count} matches  {preview}")
     }
+}
+
+/// `get_current_time` → extract the readable time value from result JSON.
+fn format_get_current_time(content: &str) -> String {
+    // The tool returns JSON like {"timezone":"UTC","datetime":"2025-01-15T10:30:00Z","unix_timestamp":...}
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(content) {
+        if let Some(dt) = v.get("datetime").and_then(|d| d.as_str()) {
+            let tz = v
+                .get("timezone")
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+            if tz.is_empty() {
+                return dt.to_string();
+            }
+            return format!("{dt} ({tz})");
+        }
+    }
+    // Fallback: content is already human-readable or unexpected format.
+    truncate_string(content, 80)
 }

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -18,7 +18,7 @@ use gglib_core::domain::agent::{AgentConfig, AgentEvent, AgentMessage};
 use crate::bootstrap::CliContext;
 use crate::handlers::agent_chat::config::{AgentSessionParams, compose};
 use crate::handlers::agent_chat::persistence::Conversation;
-use crate::handlers::agent_chat::renderer::drain_event_stream;
+use crate::handlers::agent_chat::drain::drain_event_stream;
 use crate::handlers::agent_chat::repl::run_repl_with_history;
 use crate::shared_args::SamplingArgs;
 

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -17,8 +17,8 @@ use gglib_core::domain::agent::{AgentConfig, AgentEvent, AgentMessage};
 
 use crate::bootstrap::CliContext;
 use crate::handlers::agent_chat::config::{AgentSessionParams, compose};
-use crate::handlers::agent_chat::persistence::Conversation;
 use crate::handlers::agent_chat::drain::drain_event_stream;
+use crate::handlers::agent_chat::persistence::Conversation;
 use crate::handlers::agent_chat::repl::run_repl_with_history;
 use crate::shared_args::SamplingArgs;
 

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -42,6 +42,10 @@ pub enum AgentEvent {
     ToolCallStart {
         /// The tool call that is about to be dispatched.
         tool_call: ToolCall,
+        /// Human-readable tool name (prefix stripped, title-cased).
+        display_name: String,
+        /// One-line argument summary (e.g. file path, search pattern).
+        args_summary: Option<String>,
     },
 
     /// A tool execution has completed (success or failure).
@@ -55,6 +59,10 @@ pub enum AgentEvent {
         /// Wall-clock time taken to execute the tool after acquiring the permit,
         /// in milliseconds.
         execute_duration_ms: u64,
+        /// Human-readable tool name (prefix stripped, title-cased).
+        display_name: String,
+        /// Human-readable duration (e.g. "125ms", "1.5s").
+        duration_display: String,
     },
 
     /// One full LLM→tool-execution cycle has completed.
@@ -184,6 +192,8 @@ mod tests {
                 name: "search".into(),
                 arguments: serde_json::json!({"q": "rust"}),
             },
+            display_name: "Search".into(),
+            args_summary: None,
         };
         let json = serde_json::to_value(&evt).unwrap();
         assert_eq!(json["type"], "tool_call_start");

--- a/crates/gglib-core/src/domain/agent/mod.rs
+++ b/crates/gglib-core/src/domain/agent/mod.rs
@@ -30,6 +30,7 @@ pub mod config;
 pub mod events;
 pub mod messages;
 mod messages_serde;
+pub mod tool_display;
 pub mod tool_types;
 
 // Re-export everything so callers continue to use `gglib_core::AgentConfig` etc.

--- a/crates/gglib-core/src/domain/agent/tool_display.rs
+++ b/crates/gglib-core/src/domain/agent/tool_display.rs
@@ -1,0 +1,278 @@
+//! Shared tool display formatting — single source of truth for all surfaces.
+//!
+//! These pure functions convert raw tool names and arguments into
+//! human-readable display strings.  The agentic loop populates
+//! [`AgentEvent`] payloads with pre-formatted fields computed here,
+//! so CLI, WebUI (Axum SSE), and GUI (Tauri) all render identical labels
+//! without duplicating formatting logic.
+//!
+//! [`AgentEvent`]: super::events::AgentEvent
+
+/// Strip the routing prefix from a qualified tool name.
+///
+/// Tool names carry a `"builtin:"` or `"{server_id}:"` prefix for
+/// O(1) dispatch routing in `CombinedToolExecutor`.  This function
+/// removes that prefix for display purposes only.
+///
+/// ```
+/// use gglib_core::domain::agent::tool_display::strip_tool_prefix;
+///
+/// assert_eq!(strip_tool_prefix("builtin:read_file"), "read_file");
+/// assert_eq!(strip_tool_prefix("3:some_tool"), "some_tool");
+/// assert_eq!(strip_tool_prefix("plain_name"), "plain_name");
+/// ```
+pub fn strip_tool_prefix(name: &str) -> &str {
+    match name.find(':') {
+        Some(pos) => &name[pos + 1..],
+        None => name,
+    }
+}
+
+/// Convert a raw tool name into a human-readable "Title Case" label.
+///
+/// Splits on hyphens, underscores, dots, and whitespace, then title-cases
+/// each word.  This replaces the frontend `formatToolDisplayName` function
+/// and is the single Rust source of truth used by all surfaces.
+///
+/// ```
+/// use gglib_core::domain::agent::tool_display::format_tool_display_name;
+///
+/// assert_eq!(format_tool_display_name("read_file"), "Read File");
+/// assert_eq!(format_tool_display_name("get-weather"), "Get Weather");
+/// assert_eq!(format_tool_display_name("file.read"), "File Read");
+/// assert_eq!(format_tool_display_name("get_current_time"), "Get Current Time");
+/// assert_eq!(format_tool_display_name("Already Good"), "Already Good");
+/// ```
+pub fn format_tool_display_name(raw: &str) -> String {
+    raw.split(|c: char| c == '-' || c == '_' || c == '.' || c.is_whitespace())
+        .filter(|w| !w.is_empty())
+        .map(title_case_word)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Extract a one-line argument summary from a tool call's `arguments` JSON.
+///
+/// Known builtins get tool-specific summaries (e.g. `read_file → path`).
+/// Unknown tools show the first string-valued key, truncated to 60 chars.
+/// Returns `None` when no meaningful summary can be extracted.
+///
+/// ```
+/// use gglib_core::domain::agent::tool_display::format_tool_args_summary;
+/// use serde_json::json;
+///
+/// let args = json!({"path": "/src/main.rs", "line_range": [1, 50]});
+/// assert_eq!(
+///     format_tool_args_summary("read_file", &args),
+///     Some("/src/main.rs".to_string()),
+/// );
+///
+/// let args = json!({"pattern": "TODO", "path": "/src"});
+/// assert_eq!(
+///     format_tool_args_summary("grep_search", &args),
+///     Some("\"TODO\" in /src".to_string()),
+/// );
+/// ```
+pub fn format_tool_args_summary(
+    bare_name: &str,
+    arguments: &serde_json::Value,
+) -> Option<String> {
+    let obj = arguments.as_object()?;
+
+    match bare_name {
+        "read_file" => obj
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(|s| truncate(s, 60).to_string()),
+
+        "list_directory" => obj
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(|s| truncate(s, 60).to_string()),
+
+        "grep_search" => {
+            let pattern = obj.get("pattern").and_then(|v| v.as_str())?;
+            let path = obj
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or(".");
+            Some(format!("\"{}\" in {}", truncate(pattern, 30), truncate(path, 30)))
+        }
+
+        "get_current_time" => obj
+            .get("timezone")
+            .and_then(|v| v.as_str())
+            .map(|tz| tz.to_string()),
+
+        // Generic fallback: show the first string-valued argument.
+        _ => obj
+            .values()
+            .find_map(|v| v.as_str())
+            .map(|s| truncate(s, 60).to_string()),
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Title-case a single word (first char uppercase, rest lowercase).
+fn title_case_word(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        Some(c) => {
+            let upper: String = c.to_uppercase().collect();
+            upper + &chars.as_str().to_owned()
+        }
+        None => String::new(),
+    }
+}
+
+/// Truncate a string to `max_len` characters, appending `…` if truncated.
+fn truncate(s: &str, max_len: usize) -> &str {
+    if s.len() <= max_len {
+        s
+    } else {
+        // Find a valid char boundary at or before max_len.
+        let end = s.floor_char_boundary(max_len);
+        &s[..end]
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── strip_tool_prefix ────────────────────────────────────────────
+
+    #[test]
+    fn strip_builtin_prefix() {
+        assert_eq!(strip_tool_prefix("builtin:read_file"), "read_file");
+    }
+
+    #[test]
+    fn strip_numeric_server_prefix() {
+        assert_eq!(strip_tool_prefix("3:some_tool"), "some_tool");
+    }
+
+    #[test]
+    fn strip_no_prefix() {
+        assert_eq!(strip_tool_prefix("plain_name"), "plain_name");
+    }
+
+    // ── format_tool_display_name ─────────────────────────────────────
+
+    #[test]
+    fn display_name_underscore() {
+        assert_eq!(format_tool_display_name("read_file"), "Read File");
+    }
+
+    #[test]
+    fn display_name_hyphen() {
+        assert_eq!(format_tool_display_name("get-weather"), "Get Weather");
+    }
+
+    #[test]
+    fn display_name_dot() {
+        assert_eq!(format_tool_display_name("file.read"), "File Read");
+    }
+
+    #[test]
+    fn display_name_mixed_separators() {
+        assert_eq!(
+            format_tool_display_name("my-tool_name.here"),
+            "My Tool Name Here"
+        );
+    }
+
+    #[test]
+    fn display_name_consecutive_separators() {
+        assert_eq!(format_tool_display_name("a..b"), "A B");
+        assert_eq!(format_tool_display_name("a--b"), "A B");
+    }
+
+    #[test]
+    fn display_name_single_word() {
+        assert_eq!(format_tool_display_name("weather"), "Weather");
+    }
+
+    #[test]
+    fn display_name_already_title_case() {
+        assert_eq!(format_tool_display_name("Get Weather"), "Get Weather");
+    }
+
+    // ── format_tool_args_summary ─────────────────────────────────────
+
+    #[test]
+    fn args_summary_read_file() {
+        let args = json!({"path": "/src/main.rs"});
+        assert_eq!(
+            format_tool_args_summary("read_file", &args),
+            Some("/src/main.rs".into())
+        );
+    }
+
+    #[test]
+    fn args_summary_grep_search() {
+        let args = json!({"pattern": "TODO", "path": "/src"});
+        assert_eq!(
+            format_tool_args_summary("grep_search", &args),
+            Some("\"TODO\" in /src".into())
+        );
+    }
+
+    #[test]
+    fn args_summary_grep_search_no_path() {
+        let args = json!({"pattern": "TODO"});
+        assert_eq!(
+            format_tool_args_summary("grep_search", &args),
+            Some("\"TODO\" in .".into())
+        );
+    }
+
+    #[test]
+    fn args_summary_list_directory() {
+        let args = json!({"path": "/src"});
+        assert_eq!(
+            format_tool_args_summary("list_directory", &args),
+            Some("/src".into())
+        );
+    }
+
+    #[test]
+    fn args_summary_get_current_time() {
+        let args = json!({"timezone": "UTC"});
+        assert_eq!(
+            format_tool_args_summary("get_current_time", &args),
+            Some("UTC".into())
+        );
+    }
+
+    #[test]
+    fn args_summary_generic_fallback() {
+        let args = json!({"query": "rust async"});
+        assert_eq!(
+            format_tool_args_summary("custom_search", &args),
+            Some("rust async".into())
+        );
+    }
+
+    #[test]
+    fn args_summary_no_string_values() {
+        let args = json!({"count": 5});
+        assert_eq!(format_tool_args_summary("some_tool", &args), None);
+    }
+
+    #[test]
+    fn args_summary_null_args() {
+        assert_eq!(
+            format_tool_args_summary("some_tool", &serde_json::Value::Null),
+            None
+        );
+    }
+}

--- a/crates/gglib-core/src/domain/agent/tool_display.rs
+++ b/crates/gglib-core/src/domain/agent/tool_display.rs
@@ -3,7 +3,7 @@
 //! These pure functions convert raw tool names and arguments into
 //! human-readable display strings.  The agentic loop populates
 //! [`AgentEvent`] payloads with pre-formatted fields computed here,
-//! so CLI, WebUI (Axum SSE), and GUI (Tauri) all render identical labels
+//! so CLI, `WebUI` (Axum SSE), and GUI (Tauri) all render identical labels
 //! without duplicating formatting logic.
 //!
 //! [`AgentEvent`]: super::events::AgentEvent
@@ -22,10 +22,7 @@
 /// assert_eq!(strip_tool_prefix("plain_name"), "plain_name");
 /// ```
 pub fn strip_tool_prefix(name: &str) -> &str {
-    match name.find(':') {
-        Some(pos) => &name[pos + 1..],
-        None => name,
-    }
+    name.find(':').map_or(name, |pos| &name[pos + 1..])
 }
 
 /// Convert a raw tool name into a human-readable "Title Case" label.
@@ -100,7 +97,7 @@ pub fn format_tool_args_summary(bare_name: &str, arguments: &serde_json::Value) 
         "get_current_time" => obj
             .get("timezone")
             .and_then(|v| v.as_str())
-            .map(|tz| tz.to_string()),
+            .map(std::string::ToString::to_string),
 
         // Generic fallback: show the first string-valued argument.
         _ => obj
@@ -117,13 +114,10 @@ pub fn format_tool_args_summary(bare_name: &str, arguments: &serde_json::Value) 
 /// Title-case a single word (first char uppercase, rest lowercase).
 fn title_case_word(word: &str) -> String {
     let mut chars = word.chars();
-    match chars.next() {
-        Some(c) => {
-            let upper: String = c.to_uppercase().collect();
-            upper + &chars.as_str().to_owned()
-        }
-        None => String::new(),
-    }
+    chars.next().map_or_else(String::new, |c| {
+        let upper: String = c.to_uppercase().collect();
+        upper + chars.as_str()
+    })
 }
 
 /// Truncate a string to `max_len` characters, appending `…` if truncated.

--- a/crates/gglib-core/src/domain/agent/tool_display.rs
+++ b/crates/gglib-core/src/domain/agent/tool_display.rs
@@ -73,10 +73,7 @@ pub fn format_tool_display_name(raw: &str) -> String {
 ///     Some("\"TODO\" in /src".to_string()),
 /// );
 /// ```
-pub fn format_tool_args_summary(
-    bare_name: &str,
-    arguments: &serde_json::Value,
-) -> Option<String> {
+pub fn format_tool_args_summary(bare_name: &str, arguments: &serde_json::Value) -> Option<String> {
     let obj = arguments.as_object()?;
 
     match bare_name {
@@ -92,11 +89,12 @@ pub fn format_tool_args_summary(
 
         "grep_search" => {
             let pattern = obj.get("pattern").and_then(|v| v.as_str())?;
-            let path = obj
-                .get("path")
-                .and_then(|v| v.as_str())
-                .unwrap_or(".");
-            Some(format!("\"{}\" in {}", truncate(pattern, 30), truncate(path, 30)))
+            let path = obj.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+            Some(format!(
+                "\"{}\" in {}",
+                truncate(pattern, 30),
+                truncate(path, 30)
+            ))
         }
 
         "get_current_time" => obj

--- a/crates/gglib-core/src/domain/agent/tool_types.rs
+++ b/crates/gglib-core/src/domain/agent/tool_types.rs
@@ -28,6 +28,13 @@ pub struct ToolDefinition {
     /// JSON Schema object describing the tool's input parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_schema: Option<serde_json::Value>,
+
+    /// Human-readable display title from MCP `annotations.title`.
+    ///
+    /// When present, surfaces prefer this over the heuristic
+    /// `format_tool_display_name()`.  Not serialized to the LLM.
+    #[serde(skip)]
+    pub title: Option<String>,
 }
 
 impl ToolDefinition {
@@ -38,6 +45,7 @@ impl ToolDefinition {
             name: name.into(),
             description: None,
             input_schema: None,
+            title: None,
         }
     }
 

--- a/crates/gglib-core/src/domain/mcp/types.rs
+++ b/crates/gglib-core/src/domain/mcp/types.rs
@@ -341,6 +341,10 @@ pub struct McpTool {
     /// JSON Schema for input parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_schema: Option<serde_json::Value>,
+
+    /// Human-readable display title from MCP `annotations.title` (spec 2025-03-26).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 impl McpTool {
@@ -350,6 +354,7 @@ impl McpTool {
             name: name.into(),
             description: None,
             input_schema: None,
+            title: None,
         }
     }
 

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -47,7 +47,7 @@ pub use settings::{
 };
 
 // Re-export timing utility
-pub use utils::timing::elapsed_ms;
+pub use utils::timing::{elapsed_ms, format_duration_human};
 
 // Re-export path utilities
 #[cfg(not(target_os = "windows"))]

--- a/crates/gglib-core/src/utils/timing.rs
+++ b/crates/gglib-core/src/utils/timing.rs
@@ -26,7 +26,10 @@ pub fn format_duration_human(ms: u64) -> String {
     if ms < 1_000 {
         format!("{ms}ms")
     } else if ms < 60_000 {
-        format!("{:.1}s", ms as f64 / 1_000.0)
+#[allow(clippy::cast_precision_loss)] // ms values are ≤60k here; no precision issue
+        {
+            format!("{:.1}s", ms as f64 / 1_000.0)
+        }
     } else {
         let mins = ms / 60_000;
         let secs = (ms % 60_000) / 1_000;

--- a/crates/gglib-core/src/utils/timing.rs
+++ b/crates/gglib-core/src/utils/timing.rs
@@ -1,4 +1,4 @@
-//! Timing utility shared across crates that measure tool execution latency.
+//! Timing utilities shared across crates.
 
 use std::time::Instant;
 
@@ -9,6 +9,29 @@ use std::time::Instant;
 #[inline]
 pub fn elapsed_ms(start: Instant) -> u64 {
     u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Format a millisecond duration into a compact human-readable string.
+///
+/// ```
+/// use gglib_core::utils::timing::format_duration_human;
+///
+/// assert_eq!(format_duration_human(0), "0ms");
+/// assert_eq!(format_duration_human(125), "125ms");
+/// assert_eq!(format_duration_human(1500), "1.5s");
+/// assert_eq!(format_duration_human(60_000), "1m 0s");
+/// assert_eq!(format_duration_human(135_000), "2m 15s");
+/// ```
+pub fn format_duration_human(ms: u64) -> String {
+    if ms < 1_000 {
+        format!("{ms}ms")
+    } else if ms < 60_000 {
+        format!("{:.1}s", ms as f64 / 1_000.0)
+    } else {
+        let mins = ms / 60_000;
+        let secs = (ms % 60_000) / 1_000;
+        format!("{mins}m {secs}s")
+    }
 }
 
 #[cfg(test)]
@@ -23,5 +46,25 @@ mod tests {
             ms < 1000,
             "elapsed_ms should be near zero for an immediate call"
         );
+    }
+
+    #[test]
+    fn duration_human_milliseconds() {
+        assert_eq!(format_duration_human(0), "0ms");
+        assert_eq!(format_duration_human(125), "125ms");
+        assert_eq!(format_duration_human(999), "999ms");
+    }
+
+    #[test]
+    fn duration_human_seconds() {
+        assert_eq!(format_duration_human(1_000), "1.0s");
+        assert_eq!(format_duration_human(1_500), "1.5s");
+        assert_eq!(format_duration_human(59_999), "60.0s");
+    }
+
+    #[test]
+    fn duration_human_minutes() {
+        assert_eq!(format_duration_human(60_000), "1m 0s");
+        assert_eq!(format_duration_human(135_000), "2m 15s");
     }
 }

--- a/crates/gglib-core/src/utils/timing.rs
+++ b/crates/gglib-core/src/utils/timing.rs
@@ -26,7 +26,7 @@ pub fn format_duration_human(ms: u64) -> String {
     if ms < 1_000 {
         format!("{ms}ms")
     } else if ms < 60_000 {
-#[allow(clippy::cast_precision_loss)] // ms values are ≤60k here; no precision issue
+        #[allow(clippy::cast_precision_loss)] // ms values are ≤60k here; no precision issue
         {
             format!("{:.1}s", ms as f64 / 1_000.0)
         }

--- a/crates/gglib-gui/src/mcp.rs
+++ b/crates/gglib-gui/src/mcp.rs
@@ -30,6 +30,7 @@ impl<'a> McpOps<'a> {
             name: tool.name.clone(),
             description: tool.description.clone(),
             input_schema: tool.input_schema.clone(),
+            title: tool.title.clone(),
         }
     }
 

--- a/crates/gglib-gui/src/types.rs
+++ b/crates/gglib-gui/src/types.rs
@@ -439,6 +439,9 @@ pub struct McpToolInfo {
     pub name: String,
     pub description: Option<String>,
     pub input_schema: Option<serde_json::Value>,
+    /// Human-readable display title from MCP `annotations.title`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 /// Request to call an MCP tool.

--- a/crates/gglib-mcp/src/builtin/mod.rs
+++ b/crates/gglib-mcp/src/builtin/mod.rs
@@ -179,6 +179,7 @@ impl ToolExecutorPort for BuiltinToolExecutorAdapter {
                 name: format!("{BUILTIN_PREFIX}{}", t.name),
                 description: t.description,
                 input_schema: t.input_schema,
+                title: None,
             })
             .collect()
     }

--- a/crates/gglib-mcp/src/client.rs
+++ b/crates/gglib-mcp/src/client.rs
@@ -116,6 +116,10 @@ struct McpToolSchema {
     description: Option<String>,
     #[serde(default, rename = "inputSchema")]
     input_schema: Option<Value>,
+    /// Raw MCP annotations object (spec 2025-03-26).
+    /// We extract `title` from this during conversion to `McpTool`.
+    #[serde(default)]
+    annotations: Option<Value>,
 }
 
 /// Client for communicating with an MCP server via stdio.
@@ -255,10 +259,19 @@ impl McpClient {
 
         Ok(mcp_tools
             .into_iter()
-            .map(|t| McpTool {
-                name: t.name,
-                description: t.description,
-                input_schema: t.input_schema,
+            .map(|t| {
+                let title = t
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.get("title"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                McpTool {
+                    name: t.name,
+                    description: t.description,
+                    input_schema: t.input_schema,
+                    title,
+                }
             })
             .collect())
     }

--- a/crates/gglib-mcp/src/tool_executor.rs
+++ b/crates/gglib-mcp/src/tool_executor.rs
@@ -286,9 +286,6 @@ mod tests {
     #[test]
     fn extract_object_falls_back_to_json() {
         let v = serde_json::json!({"unexpected": "shape"});
-        assert_eq!(
-            extract_mcp_content_text(&v),
-            r#"{"unexpected":"shape"}"#
-        );
+        assert_eq!(extract_mcp_content_text(&v), r#"{"unexpected":"shape"}"#);
     }
 }

--- a/crates/gglib-mcp/src/tool_executor.rs
+++ b/crates/gglib-mcp/src/tool_executor.rs
@@ -82,6 +82,7 @@ impl ToolExecutorPort for McpToolExecutorAdapter {
                     name: format!("{server_id}:{}", t.name),
                     description: t.description,
                     input_schema: t.input_schema,
+                    title: t.title,
                 })
             })
             .collect()

--- a/crates/gglib-mcp/src/tool_executor.rs
+++ b/crates/gglib-mcp/src/tool_executor.rs
@@ -145,10 +145,10 @@ impl ToolExecutorPort for McpToolExecutorAdapter {
 
         // ---- Convert McpToolResult → ToolResult ------------------------------
         let (content, success) = if result.success {
-            let text = result.data.as_ref().map_or_else(
-                || "null".to_owned(),
-                |v| v.as_str().map_or_else(|| v.to_string(), str::to_owned),
-            );
+            let text = result
+                .data
+                .as_ref()
+                .map_or_else(|| "null".to_owned(), extract_mcp_content_text);
             (text, true)
         } else {
             let text = result
@@ -166,11 +166,46 @@ impl ToolExecutorPort for McpToolExecutorAdapter {
 }
 
 // =============================================================================
+// Helpers
+// =============================================================================
+
+/// Extract human-readable text from an MCP `content` array.
+///
+/// MCP `tools/call` responses return a `content` field that is a JSON array
+/// of items like `[{"type":"text","text":"..."}]`.  This function concatenates
+/// the `text` fields from all text-typed items, joining multiple items with
+/// `\n`.  Non-text items (e.g. images) are skipped.
+///
+/// Falls back to `v.to_string()` when `v` is neither an array nor a string.
+fn extract_mcp_content_text(v: &serde_json::Value) -> String {
+    // Fast path: already a plain string (some servers return un-wrapped text).
+    if let Some(s) = v.as_str() {
+        return s.to_owned();
+    }
+
+    // Standard MCP path: array of content items.
+    if let Some(arr) = v.as_array() {
+        let texts: Vec<&str> = arr
+            .iter()
+            .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+            .collect();
+        if !texts.is_empty() {
+            return texts.join("\n");
+        }
+        // Array with no text items — fall through to to_string().
+    }
+
+    // Safety net for unexpected shapes.
+    v.to_string()
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     #[test]
     fn qualified_name_splits_on_colon_separator() {
         // execute() uses split_once(':') to parse the qualified form
@@ -206,6 +241,53 @@ mod tests {
         assert!(
             name.split_once(':').is_none(),
             "unqualified name must not contain a colon — execute() will reject it"
+        );
+    }
+
+    // ---- extract_mcp_content_text -------------------------------------------
+
+    #[test]
+    fn extract_single_text_item() {
+        let v = serde_json::json!([{"type": "text", "text": "hello world"}]);
+        assert_eq!(extract_mcp_content_text(&v), "hello world");
+    }
+
+    #[test]
+    fn extract_multiple_text_items() {
+        let v = serde_json::json!([
+            {"type": "text", "text": "line 1"},
+            {"type": "text", "text": "line 2"},
+        ]);
+        assert_eq!(extract_mcp_content_text(&v), "line 1\nline 2");
+    }
+
+    #[test]
+    fn extract_skips_non_text_items() {
+        let v = serde_json::json!([
+            {"type": "image", "data": "base64..."},
+            {"type": "text", "text": "caption"},
+        ]);
+        assert_eq!(extract_mcp_content_text(&v), "caption");
+    }
+
+    #[test]
+    fn extract_plain_string_value() {
+        let v = serde_json::json!("already a string");
+        assert_eq!(extract_mcp_content_text(&v), "already a string");
+    }
+
+    #[test]
+    fn extract_empty_array_falls_back() {
+        let v = serde_json::json!([]);
+        assert_eq!(extract_mcp_content_text(&v), "[]");
+    }
+
+    #[test]
+    fn extract_object_falls_back_to_json() {
+        let v = serde_json::json!({"unexpected": "shape"});
+        assert_eq!(
+            extract_mcp_content_text(&v),
+            r#"{"unexpected":"shape"}"#
         );
     }
 }

--- a/crates/gglib-proxy/src/mcp/handlers.rs
+++ b/crates/gglib-proxy/src/mcp/handlers.rs
@@ -172,6 +172,7 @@ async fn handle_tools_list(mcp: &gglib_mcp::McpService, id: Value) -> Response {
                 name: format!("{server_name}__{}", tool.name),
                 description: tool.description,
                 input_schema: tool.input_schema,
+                title: tool.title,
             }
         })
         .collect();

--- a/crates/gglib-proxy/src/mcp/types.rs
+++ b/crates/gglib-proxy/src/mcp/types.rs
@@ -181,6 +181,9 @@ pub struct McpToolSpec {
     /// JSON Schema describing the tool's input parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_schema: Option<Value>,
+    /// Human-readable display title from MCP `annotations.title`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 /// Result of the `tools/list` method.

--- a/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
+++ b/src/components/ToolExecutionProgress/ToolExecutionProgress.tsx
@@ -33,6 +33,8 @@ type AugmentedToolCallPart = ToolCallPart & {
   durationMs?: number;
   /** True when the tool result represents an error condition. */
   isError?: boolean;
+  /** Pre-computed display name from the backend (e.g. "Read File"). */
+  displayName?: string;
 };
 
 type ToolRowState = 'running' | 'complete' | 'error';
@@ -40,6 +42,7 @@ type ToolRowState = 'running' | 'complete' | 'error';
 interface ToolRowData {
   toolCallId: string;
   toolName: string;
+  displayLabel: string;
   state: ToolRowState;
   durationMs?: number;
   /** First 80 chars of the error message, for inline display. */
@@ -76,9 +79,10 @@ function formatDuration(ms: number): string {
 function classifyPart(part: ToolCallPart): ToolRowData {
   const augmented = part as AugmentedToolCallPart;
   const durationMs = augmented.durationMs;
+  const displayLabel = augmented.displayName ?? formatToolName(part.toolName);
 
   if (!('result' in part)) {
-    return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'running' };
+    return { toolCallId: part.toolCallId, toolName: part.toolName, displayLabel, state: 'running' };
   }
 
   if (augmented.isError === true) {
@@ -90,13 +94,14 @@ function classifyPart(part: ToolCallPart): ToolRowData {
     return {
       toolCallId: part.toolCallId,
       toolName: part.toolName,
+      displayLabel,
       state: 'error',
       durationMs,
       errorSummary,
     };
   }
 
-  return { toolCallId: part.toolCallId, toolName: part.toolName, state: 'complete', durationMs };
+  return { toolCallId: part.toolCallId, toolName: part.toolName, displayLabel, state: 'complete', durationMs };
 }
 
 // =============================================================================
@@ -125,7 +130,7 @@ const ToolRow: React.FC<{ row: ToolRowData }> = ({ row }) => (
       <Icon icon={XCircle} size={13} className="flex-shrink-0" />
     )}
 
-    <span className="font-medium truncate">{formatToolName(row.toolName)}</span>
+    <span className="font-medium truncate">{row.displayLabel}</span>
 
     {row.state === 'error' && row.errorSummary && (
       <span className="ml-1 text-text-muted truncate max-w-[160px]">
@@ -185,10 +190,10 @@ const ToolExecutionProgress: React.FC = () => {
 
       if (row.state === 'complete') {
         const dur = row.durationMs !== undefined ? ` in ${formatDuration(row.durationMs)}` : '';
-        out.push(`Tool ${formatToolName(row.toolName)} complete${dur}.`);
+        out.push(`Tool ${row.displayLabel} complete${dur}.`);
       } else {
         const err = row.errorSummary ? `: ${row.errorSummary}` : '';
-        out.push(`Tool ${formatToolName(row.toolName)} failed${err}.`);
+        out.push(`Tool ${row.displayLabel} failed${err}.`);
       }
     }
     return out;

--- a/src/components/ToolUI/GenericToolUI.tsx
+++ b/src/components/ToolUI/GenericToolUI.tsx
@@ -17,6 +17,7 @@ import {
 import { Icon } from '../ui/Icon';
 import { cn } from '../../utils/cn';
 import { ToolResultDisplay } from './ToolResultDisplay';
+import { formatToolDisplayName } from '../../services/tools/nameUtils';
 
 /**
  * Status indicator component
@@ -118,11 +119,9 @@ export const GenericToolUI = makeAssistantToolUI<
       displayStatus = status.reason === 'error' ? 'error' : 'incomplete';
     }
 
-    // Format tool name for display (e.g., get_current_time -> Get Current Time)
-    const displayName = toolName
-      .split('_')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    // Format tool name for display (e.g., get_current_time -> Get Current Time).
+    // Uses the shared nameUtils formatter to match the backend's display_name.
+    const displayName = formatToolDisplayName(toolName);
 
     return (
       <div className="bg-background-secondary border border-border rounded-lg my-2 overflow-hidden text-[13px]">

--- a/src/components/ToolUsageBadge/ToolDetailsModal.tsx
+++ b/src/components/ToolUsageBadge/ToolDetailsModal.tsx
@@ -20,6 +20,8 @@ type ToolCallPart = Extract<ThreadMessage['content'][number], { type: 'tool-call
 type AugmentedToolCallPart = ToolCallPart & {
   /** Elapsed wall-clock time in milliseconds (present once the tool has settled). */
   durationMs?: number;
+  /** Pre-computed display name from the backend (e.g. "Read File"). */
+  displayName?: string;
 };
 
 interface ToolDetailsModalProps {
@@ -66,11 +68,12 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
     });
   };
 
-  const formatToolName = (name: string): string => {
-    // Resolve sanitized registry key to the original raw MCP tool name so that
-    // tools with dots, spaces, or other special characters display correctly.
-    // Falls back to the name itself for built-in tools with no mapping.
-    const raw = getToolRegistry().getOriginalName(name) ?? name;
+  const formatToolName = (call: ToolCallPart): string => {
+    // Prefer the backend-provided display name stamped on the part.
+    const augmented = call as AugmentedToolCallPart;
+    if (augmented.displayName) return augmented.displayName;
+    // Fallback: resolve via registry + local formatter.
+    const raw = getToolRegistry().getOriginalName(call.toolName) ?? call.toolName;
     return formatToolDisplayName(raw);
   };
 
@@ -123,7 +126,7 @@ const ToolDetailsModal: React.FC<ToolDetailsModalProps> = ({ toolCalls, isOpen =
                 )}>
                   <Icon icon={StatusIcon} size={16} className={StatusIcon === Loader2 ? 'animate-spin' : ''} />
                 </span>
-                <span className="font-semibold text-text">{formatToolName(call.toolName)}</span>
+                <span className="font-semibold text-text">{formatToolName(call)}</span>
                 <span className="text-[0.85rem] text-text-secondary font-mono">({call.toolName})</span>
                 {durationMs !== undefined && (
                   <span className="ml-auto text-[0.8rem] text-text-muted font-mono">

--- a/src/hooks/useGglibRuntime/agentMessageState.ts
+++ b/src/hooks/useGglibRuntime/agentMessageState.ts
@@ -151,6 +151,7 @@ export function addToolCallPart(
   toolCallId: string,
   toolName: string,
   toolArgs: unknown,
+  displayName?: string,
 ): void {
   setMessages(prev =>
     prev.map(m => {
@@ -167,6 +168,7 @@ export function addToolCallPart(
             toolCallId,
             toolName,
             args: typeof toolArgs === 'object' ? toolArgs : {},
+            ...(displayName ? { displayName } : {}),
           },
         ] as GglibContent,
       };

--- a/src/hooks/useGglibRuntime/streamAgentChat.ts
+++ b/src/hooks/useGglibRuntime/streamAgentChat.ts
@@ -294,7 +294,7 @@ export function dispatchAgentEvent(event: AgentEvent, state: DispatchState, deps
         return false;
       }
       if (timingTracker) timingTracker.onBoundary(state.currentId);
-      addToolCallPart(setMessages, state.currentId, event.tool_call.id, event.tool_call.name, event.tool_call.arguments);
+      addToolCallPart(setMessages, state.currentId, event.tool_call.id, event.tool_call.name, event.tool_call.arguments, event.display_name);
       appLogger.debug('hook.runtime', 'streamAgentChat: tool call started', { tool: event.tool_call.name });
       return false;
     }

--- a/src/services/transport/types/mcp.ts
+++ b/src/services/transport/types/mcp.ts
@@ -95,6 +95,8 @@ export interface McpTool {
   /** Optional JSON Schema describing the tool's output. Present only when the
    * MCP server declares it. Used to auto-generate a structured result renderer. */
   output_schema?: Record<string, unknown>;
+  /** Human-readable display title from MCP annotations.title (spec 2025-03-26). */
+  title?: string;
 }
 
 /**

--- a/src/types/events/agentEvent.ts
+++ b/src/types/events/agentEvent.ts
@@ -45,16 +45,26 @@ export interface AgentTextDeltaEvent {
 export interface AgentToolCallStartEvent {
   type: 'tool_call_start';
   tool_call: AgentToolCall;
+  /** Human-readable title-cased tool name (e.g. "Read File"). */
+  display_name: string;
+  /** Optional one-line argument summary (e.g. a file path). */
+  args_summary?: string;
 }
 
 /** A tool execution has completed (success or failure). */
 export interface AgentToolCallCompleteEvent {
   type: 'tool_call_complete';
+  /** Raw tool name including any prefix (e.g. "builtin:read_file"). */
+  tool_name: string;
   result: AgentToolResult;
   /** Time spent waiting for a concurrency slot, in milliseconds. */
   wait_ms: number;
   /** Wall-clock execution time (after acquiring the slot), in milliseconds. */
   execute_duration_ms: number;
+  /** Human-readable title-cased tool name (e.g. "Read File"). */
+  display_name: string;
+  /** Pre-formatted duration string (e.g. "125ms", "1.8s"). */
+  duration_display: string;
 }
 
 /** One full LLM → tool-execution cycle has completed. */

--- a/tests/ts/hooks/useGglibRuntime/agentMessageState.test.ts
+++ b/tests/ts/hooks/useGglibRuntime/agentMessageState.test.ts
@@ -205,9 +205,12 @@ describe('applyToolResult', () => {
     };
     const event: AgentToolCallCompleteEvent = {
       type: 'tool_call_complete',
+      tool_name: 'search',
       result: { tool_call_id: 'tc-1', content: 'found it', success: true },
       wait_ms: 10,
       execute_duration_ms: 50,
+      display_name: 'Search',
+      duration_display: '50ms',
     };
     const msgs = applyUpdate([initial], (set) =>
       applyToolResult(set, MSG_ID, event),
@@ -229,9 +232,12 @@ describe('applyToolResult', () => {
     };
     const event: AgentToolCallCompleteEvent = {
       type: 'tool_call_complete',
+      tool_name: 'fn',
       result: { tool_call_id: 'tc-2', content: 'timeout', success: false },
       wait_ms: 0,
       execute_duration_ms: 30000,
+      display_name: 'Fn',
+      duration_display: '30.0s',
     };
     const msgs = applyUpdate([initial], (set) =>
       applyToolResult(set, MSG_ID, event),
@@ -252,9 +258,12 @@ describe('applyToolResult', () => {
     };
     const event: AgentToolCallCompleteEvent = {
       type: 'tool_call_complete',
+      tool_name: 'fn',
       result: { tool_call_id: 'tc-B', content: 'ok', success: true },
       wait_ms: 0,
       execute_duration_ms: 5,
+      display_name: 'Fn',
+      duration_display: '5ms',
     };
     const msgs = applyUpdate([initial], (set) =>
       applyToolResult(set, MSG_ID, event),

--- a/tests/ts/hooks/useGglibRuntime/dispatchAgentEvent.test.ts
+++ b/tests/ts/hooks/useGglibRuntime/dispatchAgentEvent.test.ts
@@ -142,6 +142,7 @@ describe('dispatchAgentEvent — tool_call_start', () => {
       {
         type: 'tool_call_start',
         tool_call: { id: 'tc-1', name: 'search', arguments: { q: 'test' } },
+        display_name: 'Search',
       },
       state,
       deps,
@@ -155,6 +156,7 @@ describe('dispatchAgentEvent — tool_call_start', () => {
       toolCallId: 'tc-1',
       toolName: 'search',
       args: { q: 'test' },
+      displayName: 'Search',
     });
   });
 });
@@ -179,9 +181,12 @@ describe('dispatchAgentEvent — tool_call_complete', () => {
     const done = dispatchAgentEvent(
       {
         type: 'tool_call_complete',
+        tool_name: 'search',
         result: { tool_call_id: 'tc-1', content: 'found it', success: true },
         wait_ms: 5,
         execute_duration_ms: 50,
+        display_name: 'Search',
+        duration_display: '50ms',
       },
       state,
       deps,


### PR DESCRIPTION
## Summary

Improves CLI tool call rendering to match GUI quality, with **true DRY parity** — the Rust backend becomes the single source of truth for tool display formatting. Pre-formatted display strings are attached to `AgentEvent` payloads so all three surfaces (CLI, Axum WebUI, Tauri GUI) receive identical, ready-to-render labels. The frontend strips its duplicate formatting code and becomes a thin renderer.

## Before → After (CLI)

```
# Before
  ⚙   builtin:read_file …
  ✓  1850ms  4 lines  /some/preview

# After
  ⚙  Read File  src/main.rs …
  ✓  Read File  1.8s  4 lines  /some/preview
```

Tool names are title-cased, arguments are summarized inline, durations are human-readable, and output is ANSI-colored (green ✓ / red ✗, bold tool names, dim metadata).

## Changes

### Phase 0: Modularity prep
- **Extract `drain_event_stream()`** from `renderer.rs` into new `drain.rs` — separates stateful async orchestration from stateless per-event formatting
- **Create `tool_display.rs`** in `gglib-core::domain::agent` — single source of truth for tool name formatting

### Phase 1: Shared formatting utilities (`gglib-core`)
- `strip_tool_prefix()` — strips `builtin:` / `{server_id}:` prefix at display layer only (prefix is architecturally required for O(1) dispatch routing)
- `format_tool_display_name()` — title-cased labels (replaces frontend `formatToolDisplayName`)
- `format_tool_args_summary()` — one-line argument summaries for known builtins
- `format_duration_human()` — `125ms`, `1.8s`, `2m 15s`

### Phase 2: Wire format changes (`AgentEvent`)
- Add `display_name`, `args_summary` to `ToolCallStart` variant
- Add `display_name`, `duration_display` to `ToolCallComplete` variant
- Populate new fields at emit sites in `tool_execution/mod.rs`
- Update all Rust test fixtures with new required fields

### Phase 3: CLI renderer improvements
- ANSI color: dim ⚙ icon, bold tool name, dim args summary, green/red status icons
- Add `get_current_time` formatter to `tool_format.rs`
- Increase failed tool result truncation from 80 → 120 chars

### Phase 4: Frontend parity (TypeScript)
- Add `display_name`, `args_summary`, `tool_name`, `duration_display` to TS event types
- Fix latent bug: `tool_name` was missing from `AgentToolCallCompleteEvent`
- Pass `display_name` through `addToolCallPart` to tool-call content parts
- `ToolExecutionProgress` / `ToolDetailsModal`: prefer backend `displayName`, fallback to local formatter
- `GenericToolUI`: use shared `formatToolDisplayName` instead of inline split/map/join
- Update all TS test fixtures with new required fields

## Test Results
- **Rust**: 924 tests pass, 0 failures (`cargo test --workspace`)
- **TypeScript**: 611 tests pass, 0 failures (`vitest run`)
- **Doc-tests**: All pass (`cargo test --doc`)

## Files Changed

**New files:**
- `crates/gglib-core/src/domain/agent/tool_display.rs` — formatting functions + comprehensive tests
- `crates/gglib-cli/src/handlers/agent_chat/drain.rs` — extracted event stream consumer

**Modified Rust:**
- `crates/gglib-core/src/domain/agent/events.rs` — new display fields on event variants
- `crates/gglib-core/src/utils/timing.rs` — `format_duration_human()`
- `crates/gglib-agent/src/tool_execution/mod.rs` — populate display fields at emit sites
- `crates/gglib-cli/src/handlers/agent_chat/renderer.rs` — ANSI colors, use display fields
- `crates/gglib-cli/src/handlers/agent_chat/tool_format.rs` — `get_current_time` formatter

**Modified TypeScript:**
- `src/types/events/agentEvent.ts` — new display fields + bug fix
- `src/hooks/useGglibRuntime/agentMessageState.ts` — pass displayName through
- `src/hooks/useGglibRuntime/streamAgentChat.ts` — pass display_name to addToolCallPart
- `src/components/ToolUI/GenericToolUI.tsx` — use shared formatter
- `src/components/ToolExecutionProgress/ToolExecutionProgress.tsx` — prefer backend displayName
- `src/components/ToolUsageBadge/ToolDetailsModal.tsx` — prefer backend displayName
