### PR TITLE
feat: CLI conversation history listing and resume

### DIFF
--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -112,7 +112,7 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `chat <id> --continue <N>` | Resume a previous conversation by ID |
 | `question <text>` | Ask a question (with optional piped context) |
 | `question --agent <text>` | Agentic question with filesystem tools |
-| `history` | List past conversations with message counts |
+| `chat history` | List past conversations with message counts |
 | `proxy` | Start the OpenAI-compatible proxy |
 | `download <repo>` | Download a model from HuggingFace |
 | `search <query>` | Search HuggingFace Hub for models |

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -109,8 +109,10 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `remove <id>` | Remove a model from the library |
 | `serve <id>` | Start llama-server for a model |
 | `chat <id>` | Start interactive llama-cli chat |
+| `chat <id> --continue <N>` | Resume a previous conversation by ID |
 | `question <text>` | Ask a question (with optional piped context) |
 | `question --agent <text>` | Agentic question with filesystem tools |
+| `history` | List past conversations with message counts |
 | `proxy` | Start the OpenAI-compatible proxy |
 | `download <repo>` | Download a model from HuggingFace |
 | `search <query>` | Search HuggingFace Hub for models |

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -66,7 +66,8 @@ pub enum Commands {
     /// Chat with a model interactively
     #[command(display_order = 11)]
     Chat {
-        /// Name or ID of the model to chat with
+        /// Name or ID of the model to chat with (optional when resuming with --continue)
+        #[arg(default_value = "")]
         identifier: String,
         #[command(flatten)]
         context: ContextArgs,

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -99,6 +99,9 @@ pub enum Commands {
         /// Model name forwarded to llama-server (uses server default when omitted)
         #[arg(long)]
         model: Option<String>,
+        /// Resume a previous conversation by ID (use `gglib history` to find IDs)
+        #[arg(long = "continue", alias = "c")]
+        continue_id: Option<i64>,
     },
 
     /// Ask a question with optional context from stdin or file

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -37,6 +37,14 @@ pub enum Commands {
         command: McpCommand,
     },
 
+    /// List past conversations (use `--continue <ID>` with chat to resume)
+    #[command(display_order = 4)]
+    History {
+        /// Maximum number of conversations to show
+        #[arg(short = 'n', long, default_value = "20")]
+        limit: usize,
+    },
+
     // ── Inference ────────────────────────────────────────────────────────
     /// Serve a GGUF model with llama-server
     #[command(display_order = 10)]

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -12,6 +12,17 @@ use crate::mcp_commands::McpCommand;
 use crate::model_commands::ModelCommand;
 use crate::shared_args::{ContextArgs, SamplingArgs};
 
+/// Subcommands available under `gglib chat`.
+#[derive(Subcommand)]
+pub enum ChatCommand {
+    /// List past conversations (use `--continue <ID>` to resume one)
+    History {
+        /// Maximum number of conversations to show
+        #[arg(short = 'n', long, default_value = "20")]
+        limit: usize,
+    },
+}
+
 /// Top-level commands for the GGUF library management tool.
 #[derive(Subcommand)]
 pub enum Commands {
@@ -37,14 +48,6 @@ pub enum Commands {
         command: McpCommand,
     },
 
-    /// List past conversations (use `--continue <ID>` with chat to resume)
-    #[command(display_order = 4)]
-    History {
-        /// Maximum number of conversations to show
-        #[arg(short = 'n', long, default_value = "20")]
-        limit: usize,
-    },
-
     // ── Inference ────────────────────────────────────────────────────────
     /// Serve a GGUF model with llama-server
     #[command(display_order = 10)]
@@ -63,8 +66,8 @@ pub enum Commands {
         sampling: SamplingArgs,
     },
 
-    /// Chat with a model interactively
-    #[command(display_order = 11)]
+    /// Chat with a model interactively, or manage chat history
+    #[command(display_order = 11, subcommand_negates_reqs = true)]
     Chat {
         /// Name or ID of the model to chat with (optional when resuming with --continue)
         #[arg(default_value = "")]
@@ -100,9 +103,12 @@ pub enum Commands {
         /// Model name forwarded to llama-server (uses server default when omitted)
         #[arg(long)]
         model: Option<String>,
-        /// Resume a previous conversation by ID (use `gglib history` to find IDs)
+        /// Resume a previous conversation by ID (use `gglib chat history` to find IDs)
         #[arg(long = "continue", alias = "c")]
         continue_id: Option<i64>,
+        /// Subcommand (e.g. `history`)
+        #[command(subcommand)]
+        command: Option<ChatCommand>,
     },
 
     /// Ask a question with optional context from stdin or file

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -36,6 +36,9 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
         }
 
         // ── Inference (top-level for ergonomic access) ──────────────────────
+        Commands::History { limit } => {
+            handlers::history::execute(ctx, limit).await?;
+        }
         Commands::Serve {
             id,
             context,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -60,6 +60,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             tool_timeout_ms,
             max_parallel,
             model,
+            continue_id,
         } => {
             let args = handlers::inference::chat::ChatArgs {
                 identifier,
@@ -74,6 +75,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 max_parallel,
                 verbose, // global flag forwarded here
                 model,
+                continue_id,
             };
             handlers::inference::chat::execute(ctx, args).await?;
         }

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -36,9 +36,6 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
         }
 
         // ── Inference (top-level for ergonomic access) ──────────────────────
-        Commands::History { limit } => {
-            handlers::history::execute(ctx, limit).await?;
-        }
         Commands::Serve {
             id,
             context,
@@ -61,23 +58,33 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             max_parallel,
             model,
             continue_id,
+            command,
         } => {
-            let args = handlers::inference::chat::ChatArgs {
-                identifier,
-                context,
-                system_prompt,
-                sampling,
-                no_tools,
-                port,
-                max_iterations,
-                tools,
-                tool_timeout_ms,
-                max_parallel,
-                verbose, // global flag forwarded here
-                model,
-                continue_id,
-            };
-            handlers::inference::chat::execute(ctx, args).await?;
+            // Subcommand takes priority (e.g. `gglib chat history`)
+            if let Some(sub) = command {
+                match sub {
+                    crate::commands::ChatCommand::History { limit } => {
+                        handlers::history::execute(ctx, limit).await?;
+                    }
+                }
+            } else {
+                let args = handlers::inference::chat::ChatArgs {
+                    identifier,
+                    context,
+                    system_prompt,
+                    sampling,
+                    no_tools,
+                    port,
+                    max_iterations,
+                    tools,
+                    tool_timeout_ms,
+                    max_parallel,
+                    verbose, // global flag forwarded here
+                    model,
+                    continue_id,
+                };
+                handlers::inference::chat::execute(ctx, args).await?;
+            }
         }
         Commands::Question {
             question,

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -203,7 +203,11 @@ async fn resolve_port(
         eprintln!("  llama-server ready on port {}", handle.port);
 
         // Context size
-        print_context_line(params.ctx_size.as_deref(), context_size, model.context_length);
+        print_context_line(
+            params.ctx_size.as_deref(),
+            context_size,
+            model.context_length,
+        );
 
         // Sampling overrides
         if let Some(ref s) = banner.sampling {

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -43,6 +43,20 @@ pub struct AgentSessionParams {
     pub model_name: Option<String>,
 }
 
+/// Display metadata for the server-startup info banner.
+///
+/// Callers populate this with whatever session context they have so that
+/// `resolve_port` can render a richer startup message.
+#[derive(Debug, Clone, Default)]
+pub struct BannerInfo {
+    /// Suppress the banner entirely (e.g. `gglib q -Q`).
+    pub quiet: bool,
+    /// Sampling overrides to display (only non-default values are shown).
+    pub sampling: Option<InferenceConfig>,
+    /// Character count of prior conversation history being loaded (resume only).
+    pub prior_history_chars: Option<usize>,
+}
+
 impl From<&ChatArgs> for AgentSessionParams {
     fn from(args: &ChatArgs) -> Self {
         // When --no-tools is set, use a sentinel allowlist that matches nothing
@@ -80,9 +94,10 @@ pub async fn compose(
     params: &AgentSessionParams,
     sandbox_root: Option<PathBuf>,
     sampling: Option<InferenceConfig>,
+    banner: &BannerInfo,
 ) -> Result<(Arc<dyn AgentLoopPort>, Option<ProcessHandle>)> {
     // 1. Resolve the LLM port — reuse or auto-start.
-    let (port, maybe_handle) = resolve_port(ctx, params).await?;
+    let (port, maybe_handle) = resolve_port(ctx, params, banner).await?;
 
     // 2. Initialise MCP servers (CLI bootstrap intentionally skips this).
     //    A failure is logged as a warning rather than aborting the session:
@@ -125,6 +140,7 @@ pub async fn compose(
 async fn resolve_port(
     ctx: &CliContext,
     params: &AgentSessionParams,
+    banner: &BannerInfo,
 ) -> Result<(u16, Option<ProcessHandle>)> {
     if let Some(port) = params.port {
         tracing::debug!("reusing user-supplied llama-server on port {port}");
@@ -169,11 +185,13 @@ async fn resolve_port(
         server_config = server_config.with_reasoning_format(format);
     }
 
-    style::print_info_banner("Info", "\u{2139}\u{fe0f}");
-    eprintln!(
-        "  Starting llama-server for '{}' (this may take a moment) \u{2026}",
-        model.name
-    );
+    if !banner.quiet {
+        style::print_info_banner("Info", "\u{2139}\u{fe0f}");
+        eprintln!(
+            "  Starting llama-server for '{}' (this may take a moment) \u{2026}",
+            model.name
+        );
+    }
 
     let handle = ctx
         .runner
@@ -181,8 +199,69 @@ async fn resolve_port(
         .await
         .context("failed to start llama-server")?;
 
-    eprintln!("  llama-server ready on port {}", handle.port);
-    style::print_banner_close();
+    if !banner.quiet {
+        eprintln!("  llama-server ready on port {}", handle.port);
+
+        // Context size
+        print_context_line(params.ctx_size.as_deref(), context_size, model.context_length);
+
+        // Sampling overrides
+        if let Some(ref s) = banner.sampling {
+            print_sampling_lines(s);
+        }
+
+        // Conversation history usage (resume only)
+        if let Some(chars) = banner.prior_history_chars {
+            let budget = 180_000usize; // AgentConfig default
+            let pct = (chars * 100).checked_div(budget).unwrap_or(0);
+            eprintln!("  History: ~{chars} chars loaded (~{pct}% of context budget)");
+        }
+
+        style::print_banner_close();
+    }
 
     Ok((handle.port, Some(handle)))
+}
+
+/// Print the resolved context-size line in the info banner.
+fn print_context_line(
+    raw_flag: Option<&str>,
+    parsed_numeric: Option<u64>,
+    model_context_length: Option<u64>,
+) {
+    match (raw_flag, parsed_numeric) {
+        // User passed a numeric value like "8192"
+        (_, Some(n)) => {
+            eprintln!("  Context: {n}");
+        }
+        // User passed "max" — resolve from model metadata
+        (Some(flag), None) if flag.eq_ignore_ascii_case("max") => {
+            if let Some(model_ctx) = model_context_length {
+                eprintln!("  Context: {model_ctx} (model max)");
+            } else {
+                eprintln!("  Context: max (model default)");
+            }
+        }
+        // Not specified — server default
+        _ => {}
+    }
+}
+
+/// Print non-default sampling parameter lines in the info banner.
+fn print_sampling_lines(s: &InferenceConfig) {
+    if let Some(v) = s.temperature {
+        eprintln!("  Temperature: {v}");
+    }
+    if let Some(v) = s.top_p {
+        eprintln!("  Top-p: {v}");
+    }
+    if let Some(v) = s.top_k {
+        eprintln!("  Top-k: {v}");
+    }
+    if let Some(v) = s.max_tokens {
+        eprintln!("  Max tokens: {v}");
+    }
+    if let Some(v) = s.repeat_penalty {
+        eprintln!("  Repeat penalty: {v}");
+    }
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -153,8 +153,19 @@ async fn resume_conversation<'a>(
     }
 
     // Convert persisted messages to agent messages
-    let prior_messages: Vec<AgentMessage> =
+    let mut prior_messages: Vec<AgentMessage> =
         db_messages.iter().map(|m| m.to_agent_message()).collect();
+
+    // The system prompt is stored on the conversation record (not as a
+    // message row), so prepend it if present.
+    if let Some(ref prompt) = merged.system_prompt {
+        prior_messages.insert(
+            0,
+            AgentMessage::System {
+                content: prompt.clone(),
+            },
+        );
+    }
 
     let persistence = Conversation::resume(history, conv_id, msg_count).await;
 

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -19,7 +19,7 @@ pub mod repl;
 mod thinking_dispatch;
 mod tool_format;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use gglib_core::domain::agent::AgentMessage;
 use gglib_core::domain::chat::ConversationSettings;

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -49,8 +49,7 @@ pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
         new_conversation(ctx, args).await
     };
 
-    let result =
-        repl::run_repl_with_prior(agent, args, persistence, prior_messages).await;
+    let result = repl::run_repl_with_prior(agent, args, persistence, prior_messages).await;
 
     if let Some(ref handle) = maybe_handle
         && let Err(e) = ctx.runner.stop(handle).await
@@ -123,18 +122,10 @@ async fn resume_conversation<'a>(
 }
 
 /// Print the last user/assistant exchange as a memory jogger when resuming.
-fn print_memory_jogger(
-    db_messages: &[gglib_core::domain::chat::Message],
-    title: &str,
-) {
+fn print_memory_jogger(db_messages: &[gglib_core::domain::chat::Message], title: &str) {
     use gglib_core::domain::chat::MessageRole;
 
-    println!(
-        "\n{}Resuming: {}{}\n",
-        style::INFO,
-        title,
-        style::RESET,
-    );
+    println!("\n{}Resuming: {}{}\n", style::INFO, title, style::RESET,);
 
     // Find last user message and last assistant message
     let last_user = db_messages
@@ -160,10 +151,7 @@ fn print_memory_jogger(
         } else {
             asst_msg.content.clone()
         };
-        println!(
-            "{}  Assistant: {}{}",
-            style::DIM, content, style::RESET
-        );
+        println!("{}  Assistant: {}{}", style::DIM, content, style::RESET);
     }
     println!();
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -21,8 +21,11 @@ mod tool_format;
 
 use anyhow::Result;
 
+use gglib_core::domain::agent::AgentMessage;
+
 use crate::bootstrap::CliContext;
 use crate::handlers::inference::chat::ChatArgs;
+use crate::presentation::style;
 use crate::shared_args::ConversationSettingsBuilder;
 
 use self::persistence::Conversation;
@@ -30,6 +33,7 @@ use self::persistence::Conversation;
 /// Entry point: start the interactive agentic REPL.
 ///
 /// Manages the server lifecycle (auto-start / stop) around the REPL session.
+/// When `args.continue_id` is set, loads a previous conversation and resumes.
 pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
     let inference_config = args.sampling.clone().into_inference_config();
     let sampling = if inference_config == Default::default() {
@@ -39,14 +43,35 @@ pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
     };
     let (agent, maybe_handle) = config::compose(ctx, &args.into(), None, sampling).await?;
 
-    // Build ConversationSettings from CLI args for resume support.
+    let (persistence, prior_messages) = if let Some(conv_id) = args.continue_id {
+        resume_conversation(ctx, args, conv_id).await?
+    } else {
+        new_conversation(ctx, args).await
+    };
+
+    let result =
+        repl::run_repl_with_prior(agent, args, persistence, prior_messages).await;
+
+    if let Some(ref handle) = maybe_handle
+        && let Err(e) = ctx.runner.stop(handle).await
+    {
+        tracing::warn!("failed to stop llama-server after agent chat: {e}");
+    }
+
+    result
+}
+
+/// Create a new conversation for a fresh session.
+async fn new_conversation<'a>(
+    ctx: &'a CliContext,
+    args: &ChatArgs,
+) -> (Option<Conversation<'a>>, Vec<AgentMessage>) {
     let settings = ConversationSettingsBuilder::new(&args.sampling, &args.context)
         .model_name(&args.identifier)
         .tools(args.tools.clone(), args.no_tools)
         .agent_params(args.max_iterations, args.tool_timeout_ms, args.max_parallel)
         .build();
 
-    // Create a conversation for persistence (best-effort).
     let persistence = match Conversation::create(
         ctx.app.chat_history(),
         args.system_prompt.clone(),
@@ -62,13 +87,83 @@ pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
         }
     };
 
-    let result = repl::run_repl(agent, args, persistence).await;
+    (persistence, Vec::new())
+}
 
-    if let Some(ref handle) = maybe_handle
-        && let Err(e) = ctx.runner.stop(handle).await
-    {
-        tracing::warn!("failed to stop llama-server after agent chat: {e}");
+/// Load a previous conversation and prepare for resume.
+async fn resume_conversation<'a>(
+    ctx: &'a CliContext,
+    _args: &ChatArgs,
+    conv_id: i64,
+) -> Result<(Option<Conversation<'a>>, Vec<AgentMessage>)> {
+    let history = ctx.app.chat_history();
+
+    let conv = history
+        .get_conversation(conv_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("conversation {conv_id} not found"))?;
+
+    let db_messages = history.get_messages(conv_id).await?;
+    let msg_count = db_messages.len();
+
+    if msg_count == 0 {
+        println!("Conversation #{conv_id} has no messages — starting fresh.");
+    } else {
+        // Memory jogger: show the last user+assistant exchange
+        print_memory_jogger(&db_messages, &conv.title);
     }
 
-    result
+    // Convert persisted messages to agent messages
+    let prior_messages: Vec<AgentMessage> =
+        db_messages.iter().map(|m| m.to_agent_message()).collect();
+
+    let persistence = Conversation::resume(history, conv_id, msg_count).await;
+
+    Ok((Some(persistence), prior_messages))
+}
+
+/// Print the last user/assistant exchange as a memory jogger when resuming.
+fn print_memory_jogger(
+    db_messages: &[gglib_core::domain::chat::Message],
+    title: &str,
+) {
+    use gglib_core::domain::chat::MessageRole;
+
+    println!(
+        "\n{}Resuming: {}{}\n",
+        style::INFO,
+        title,
+        style::RESET,
+    );
+
+    // Find last user message and last assistant message
+    let last_user = db_messages
+        .iter()
+        .rev()
+        .find(|m| m.role == MessageRole::User);
+    let last_assistant = db_messages
+        .iter()
+        .rev()
+        .find(|m| m.role == MessageRole::Assistant);
+
+    if let Some(user_msg) = last_user {
+        let content = if user_msg.content.len() > 200 {
+            format!("{}…", &user_msg.content[..200])
+        } else {
+            user_msg.content.clone()
+        };
+        println!("{}  You: {}{}", style::DIM, content, style::RESET);
+    }
+    if let Some(asst_msg) = last_assistant {
+        let content = if asst_msg.content.len() > 200 {
+            format!("{}…", &asst_msg.content[..200])
+        } else {
+            asst_msg.content.clone()
+        };
+        println!(
+            "{}  Assistant: {}{}",
+            style::DIM, content, style::RESET
+        );
+    }
+    println!();
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -19,9 +19,10 @@ pub mod repl;
 mod thinking_dispatch;
 mod tool_format;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use gglib_core::domain::agent::AgentMessage;
+use gglib_core::domain::chat::ConversationSettings;
 
 use crate::bootstrap::CliContext;
 use crate::handlers::inference::chat::ChatArgs;
@@ -33,23 +34,36 @@ use self::persistence::Conversation;
 /// Entry point: start the interactive agentic REPL.
 ///
 /// Manages the server lifecycle (auto-start / stop) around the REPL session.
-/// When `args.continue_id` is set, loads a previous conversation and resumes.
+/// When `args.continue_id` is set, loads a previous conversation and resumes
+/// with the original session parameters (saved settings fill in any CLI args
+/// the user didn't explicitly provide).
 pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
+    // 1. If resuming, load the conversation first and merge saved settings
+    //    into args so the agent is composed with the correct parameters.
+    let mut args = args.clone();
+    let (persistence, prior_messages) = if let Some(conv_id) = args.continue_id {
+        let (merged_args, conv, prior) = resume_conversation(ctx, &args, conv_id).await?;
+        args = merged_args;
+        (Some(conv), prior)
+    } else {
+        if args.identifier.is_empty() {
+            bail!("model identifier is required (use --continue <ID> to resume a session)");
+        }
+        let (conv, prior) = new_conversation(ctx, &args).await;
+        (conv, prior)
+    };
+
+    // 2. Compose the agent with the (possibly merged) args.
     let inference_config = args.sampling.clone().into_inference_config();
     let sampling = if inference_config == Default::default() {
         None
     } else {
         Some(inference_config)
     };
-    let (agent, maybe_handle) = config::compose(ctx, &args.into(), None, sampling).await?;
+    let params = config::AgentSessionParams::from(&args);
+    let (agent, maybe_handle) = config::compose(ctx, &params, None, sampling).await?;
 
-    let (persistence, prior_messages) = if let Some(conv_id) = args.continue_id {
-        resume_conversation(ctx, args, conv_id).await?
-    } else {
-        new_conversation(ctx, args).await
-    };
-
-    let result = repl::run_repl_with_prior(agent, args, persistence, prior_messages).await;
+    let result = repl::run_repl_with_prior(agent, &args, persistence, prior_messages).await;
 
     if let Some(ref handle) = maybe_handle
         && let Err(e) = ctx.runner.stop(handle).await
@@ -89,12 +103,20 @@ async fn new_conversation<'a>(
     (persistence, Vec::new())
 }
 
-/// Load a previous conversation and prepare for resume.
+/// Load a previous conversation, merge its saved settings into args, and prepare for resume.
+///
+/// Settings restoration follows the principle: **saved settings are defaults,
+/// explicit CLI flags override**. For example:
+/// ```text
+/// gglib chat other-model --continue 42 --temperature 0.9
+/// ```
+/// uses `other-model` and temperature `0.9` from the CLI, but restores
+/// everything else (system prompt, top_p, tools, etc.) from conversation 42.
 async fn resume_conversation<'a>(
     ctx: &'a CliContext,
-    _args: &ChatArgs,
+    args: &ChatArgs,
     conv_id: i64,
-) -> Result<(Option<Conversation<'a>>, Vec<AgentMessage>)> {
+) -> Result<(ChatArgs, Conversation<'a>, Vec<AgentMessage>)> {
     let history = ctx.app.chat_history();
 
     let conv = history
@@ -108,8 +130,16 @@ async fn resume_conversation<'a>(
     if msg_count == 0 {
         println!("Conversation #{conv_id} has no messages — starting fresh.");
     } else {
-        // Memory jogger: show the last user+assistant exchange
         print_memory_jogger(&db_messages, &conv.title);
+    }
+
+    // Merge saved settings into a copy of the current args.
+    let merged = apply_saved_settings(args, &conv.system_prompt, &conv.settings);
+
+    if merged.identifier.is_empty() {
+        bail!(
+            "cannot resume conversation #{conv_id}: no model name was saved and none was provided on the CLI"
+        );
     }
 
     // Convert persisted messages to agent messages
@@ -118,7 +148,83 @@ async fn resume_conversation<'a>(
 
     let persistence = Conversation::resume(history, conv_id, msg_count).await;
 
-    Ok((Some(persistence), prior_messages))
+    Ok((merged, persistence, prior_messages))
+}
+
+/// Merge saved [`ConversationSettings`] into [`ChatArgs`].
+///
+/// CLI-provided values always win; saved settings fill in blanks.
+fn apply_saved_settings(
+    args: &ChatArgs,
+    saved_system_prompt: &Option<String>,
+    saved_settings: &Option<ConversationSettings>,
+) -> ChatArgs {
+    let mut merged = args.clone();
+
+    // Restore system prompt if the user didn't supply one on the CLI.
+    if merged.system_prompt.is_none() {
+        merged.system_prompt.clone_from(saved_system_prompt);
+    }
+
+    let Some(saved) = saved_settings else {
+        return merged;
+    };
+
+    // Model identifier: CLI wins if non-empty, otherwise use saved.
+    if merged.identifier.is_empty()
+        && let Some(ref name) = saved.model_name
+    {
+        merged.identifier = name.clone();
+    }
+
+    // Sampling parameters — only fill if CLI left them as None.
+    if merged.sampling.temperature.is_none() {
+        merged.sampling.temperature = saved.temperature;
+    }
+    if merged.sampling.top_p.is_none() {
+        merged.sampling.top_p = saved.top_p;
+    }
+    if merged.sampling.top_k.is_none() {
+        merged.sampling.top_k = saved.top_k;
+    }
+    if merged.sampling.max_tokens.is_none() {
+        merged.sampling.max_tokens = saved.max_tokens;
+    }
+    if merged.sampling.repeat_penalty.is_none() {
+        merged.sampling.repeat_penalty = saved.repeat_penalty;
+    }
+
+    // Context args
+    if merged.context.ctx_size.is_none() {
+        merged.context.ctx_size.clone_from(&saved.ctx_size);
+    }
+    if !merged.context.mlock {
+        merged.context.mlock = saved.mlock.unwrap_or(false);
+    }
+
+    // Tools — only restore if the user didn't provide any on the CLI.
+    if merged.tools.is_empty() {
+        merged.tools.clone_from(&saved.tools);
+    }
+    if !merged.no_tools {
+        merged.no_tools = saved.no_tools.unwrap_or(false);
+    }
+
+    // Agent loop params — fill if the user didn't override.
+    if let Some(saved_max) = saved.max_iterations {
+        // 25 is the clap default — treat it as "not set by user".
+        if merged.max_iterations == 25 {
+            merged.max_iterations = saved_max;
+        }
+    }
+    if merged.tool_timeout_ms.is_none() {
+        merged.tool_timeout_ms = saved.tool_timeout_ms;
+    }
+    if merged.max_parallel.is_none() {
+        merged.max_parallel = saved.max_parallel;
+    }
+
+    merged
 }
 
 /// Print the last user/assistant exchange as a memory jogger when resuming.

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -23,6 +23,7 @@ use anyhow::Result;
 
 use crate::bootstrap::CliContext;
 use crate::handlers::inference::chat::ChatArgs;
+use crate::shared_args::ConversationSettingsBuilder;
 
 use self::persistence::Conversation;
 
@@ -38,15 +39,28 @@ pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
     };
     let (agent, maybe_handle) = config::compose(ctx, &args.into(), None, sampling).await?;
 
+    // Build ConversationSettings from CLI args for resume support.
+    let settings = ConversationSettingsBuilder::new(&args.sampling, &args.context)
+        .model_name(&args.identifier)
+        .tools(args.tools.clone(), args.no_tools)
+        .agent_params(args.max_iterations, args.tool_timeout_ms, args.max_parallel)
+        .build();
+
     // Create a conversation for persistence (best-effort).
-    let persistence =
-        match Conversation::create(ctx.app.chat_history(), args.system_prompt.clone()).await {
-            Ok(conv) => Some(conv),
-            Err(e) => {
-                tracing::warn!("failed to create agent conversation: {e}");
-                None
-            }
-        };
+    let persistence = match Conversation::create(
+        ctx.app.chat_history(),
+        args.system_prompt.clone(),
+        None,
+        Some(settings),
+    )
+    .await
+    {
+        Ok(conv) => Some(conv),
+        Err(e) => {
+            tracing::warn!("failed to create agent conversation: {e}");
+            None
+        }
+    };
 
     let result = repl::run_repl(agent, args, persistence).await;
 

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -60,8 +60,18 @@ pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
     } else {
         Some(inference_config)
     };
+    let prior_chars: usize = prior_messages.iter().map(|m| m.char_count()).sum();
+    let banner = config::BannerInfo {
+        quiet: false,
+        sampling: sampling.clone(),
+        prior_history_chars: if prior_chars > 0 {
+            Some(prior_chars)
+        } else {
+            None
+        },
+    };
     let params = config::AgentSessionParams::from(&args);
-    let (agent, maybe_handle) = config::compose(ctx, &params, None, sampling).await?;
+    let (agent, maybe_handle) = config::compose(ctx, &params, None, sampling, &banner).await?;
 
     let result = repl::run_repl_with_prior(agent, &args, persistence, prior_messages).await;
 

--- a/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
@@ -59,10 +59,18 @@ impl<'a> Conversation<'a> {
 
     /// Persist any messages added since the last call.
     ///
+    /// System messages are **not** persisted — the system prompt lives on the
+    /// `chat_conversations` row (`system_prompt` column) and is the canonical
+    /// source for both CLI and GUI resume.  Persisting it as a message row
+    /// would cause duplicates when the GUI hydrates from both sources.
+    ///
     /// Errors are logged as warnings and swallowed — persistence must never
     /// break the interactive session.
     pub async fn save_new(&mut self, messages: &[AgentMessage]) {
         for msg in messages.iter().skip(self.saved) {
+            if matches!(msg, AgentMessage::System { .. }) {
+                continue;
+            }
             let new_msg = to_new_message(msg, self.id);
             if let Err(e) = self.service.save_message(new_msg).await {
                 tracing::warn!("failed to persist agent message: {e}");

--- a/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
@@ -42,6 +42,21 @@ impl<'a> Conversation<'a> {
         })
     }
 
+    /// Resume an existing conversation for continued persistence.
+    ///
+    /// Loads the existing message count so [`save_new`] only persists the delta.
+    pub async fn resume(
+        service: &'a ChatHistoryService,
+        id: i64,
+        existing_message_count: usize,
+    ) -> Conversation<'a> {
+        Conversation {
+            service,
+            id,
+            saved: existing_message_count,
+        }
+    }
+
     /// Persist any messages added since the last call.
     ///
     /// Errors are logged as warnings and swallowed — persistence must never

--- a/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::Local;
 
 use gglib_core::domain::agent::AgentMessage;
-use gglib_core::domain::chat::{MessageRole, NewMessage};
+use gglib_core::domain::chat::{ConversationSettings, MessageRole, NewConversation, NewMessage};
 use gglib_core::services::ChatHistoryService;
 
 /// Tracks a persisted conversation and the number of messages already saved,
@@ -23,10 +23,17 @@ impl<'a> Conversation<'a> {
     pub async fn create(
         service: &'a ChatHistoryService,
         system_prompt: Option<String>,
+        model_id: Option<i64>,
+        settings: Option<ConversationSettings>,
     ) -> Result<Conversation<'a>> {
         let title = format!("Agent session {}", Local::now().format("%Y-%m-%d %H:%M"));
         let id = service
-            .create_conversation(title, None, system_prompt)
+            .create_conversation_with_settings(NewConversation {
+                title,
+                model_id,
+                system_prompt,
+                settings,
+            })
             .await?;
         Ok(Conversation {
             service,

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -129,7 +129,7 @@ pub async fn run_repl_with_history(
     println!("Agentic chat ready. Type /help for help, /quit to exit.");
     if let Some(ref conv) = persistence {
         println!(
-            "{}Session #{} — resume later with: gglib chat <model> --continue {}{}",
+            "{}Session #{} — resume later with: gglib chat --continue {}{}",
             crate::presentation::style::DIM,
             conv.id,
             conv.id,
@@ -194,7 +194,7 @@ pub async fn run_repl_with_history(
 
     if let Some(ref conv) = persistence {
         println!(
-            "{}Session #{} saved. Resume with: gglib chat <model> --continue {}{}",
+            "{}Session #{} saved. Resume with: gglib chat --continue {}{}",
             crate::presentation::style::DIM,
             conv.id,
             conv.id,

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -67,6 +67,21 @@ pub async fn run_repl(
     args: &ChatArgs,
     persistence: Option<Conversation<'_>>,
 ) -> Result<()> {
+    run_repl_with_prior(agent_loop, args, persistence, Vec::new()).await
+}
+
+/// Run the interactive agent REPL with optional prior messages from a resumed
+/// conversation.
+///
+/// When `prior_messages` is non-empty, the REPL begins with those messages
+/// already in the history (no system prompt is prepended — it is already
+/// in the prior messages). When empty, behaves identically to [`run_repl`].
+pub async fn run_repl_with_prior(
+    agent_loop: Arc<dyn AgentLoopPort>,
+    args: &ChatArgs,
+    persistence: Option<Conversation<'_>>,
+    prior_messages: Vec<AgentMessage>,
+) -> Result<()> {
     let config = AgentConfig::from_user_params(
         Some(args.max_iterations),
         args.max_parallel,
@@ -74,13 +89,18 @@ pub async fn run_repl(
     )
     .map_err(|e| anyhow::anyhow!("invalid agent config: {e}"))?;
 
-    // Conversation history shared across turns.
-    let mut messages: Vec<AgentMessage> = Vec::new();
-    if let Some(ref system) = args.system_prompt {
-        messages.push(AgentMessage::System {
-            content: system.clone(),
-        });
-    }
+    let messages = if prior_messages.is_empty() {
+        // Fresh session: optionally prepend system prompt.
+        let mut msgs = Vec::new();
+        if let Some(ref system) = args.system_prompt {
+            msgs.push(AgentMessage::System {
+                content: system.clone(),
+            });
+        }
+        msgs
+    } else {
+        prior_messages
+    };
 
     run_repl_with_history(agent_loop, messages, config, args.verbose, persistence).await
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -127,6 +127,15 @@ pub async fn run_repl_with_history(
         })?));
 
     println!("Agentic chat ready. Type /help for help, /quit to exit.");
+    if let Some(ref conv) = persistence {
+        println!(
+            "{}Session #{} — resume later with: gglib chat <model> --continue {}{}",
+            crate::presentation::style::DIM,
+            conv.id,
+            conv.id,
+            crate::presentation::style::RESET,
+        );
+    }
 
     // ── REPL outer loop ──────────────────────────────────────────────────────
     loop {
@@ -181,6 +190,16 @@ pub async fn run_repl_with_history(
         if let Some(ref mut conv) = persistence {
             conv.save_new(&messages).await;
         }
+    }
+
+    if let Some(ref conv) = persistence {
+        println!(
+            "{}Session #{} saved. Resume with: gglib chat <model> --continue {}{}",
+            crate::presentation::style::DIM,
+            conv.id,
+            conv.id,
+            crate::presentation::style::RESET,
+        );
     }
 
     Ok(())

--- a/crates/gglib-cli/src/handlers/history.rs
+++ b/crates/gglib-cli/src/handlers/history.rs
@@ -52,9 +52,7 @@ pub async fn execute(ctx: &CliContext, limit: usize) -> Result<()> {
         );
     }
 
-    println!(
-        "\nResume with: gglib chat <model> --continue <ID>"
-    );
+    println!("\nResume with: gglib chat <model> --continue <ID>");
 
     Ok(())
 }

--- a/crates/gglib-cli/src/handlers/history.rs
+++ b/crates/gglib-cli/src/handlers/history.rs
@@ -1,0 +1,60 @@
+//! History command handler.
+//!
+//! Lists past chat conversations with message counts and relative timestamps.
+
+use anyhow::Result;
+
+use crate::bootstrap::CliContext;
+use crate::presentation::{format_relative_time, print_separator, truncate_string};
+
+/// Execute the history command.
+///
+/// Retrieves and displays past conversations with message counts
+/// and relative timestamps for quick browsing.
+pub async fn execute(ctx: &CliContext, limit: usize) -> Result<()> {
+    let conversations = ctx.app.chat_history().list_conversations().await?;
+
+    if conversations.is_empty() {
+        println!("No conversations found.");
+        println!("Start one with: gglib chat <model>");
+        return Ok(());
+    }
+
+    let conversations: Vec<_> = conversations.into_iter().take(limit).collect();
+
+    // Fetch message counts in parallel (repo already has get_message_count)
+    let mut rows = Vec::with_capacity(conversations.len());
+    for conv in &conversations {
+        let count = ctx.app.chat_history().get_message_count(conv.id).await?;
+        rows.push((conv, count));
+    }
+
+    println!(
+        "{:<5} {:<35} {:<6} {:<15} {:<15}",
+        "ID", "Title", "Msgs", "Model", "Updated"
+    );
+    print_separator(80);
+
+    for (conv, msg_count) in &rows {
+        let model_label = conv
+            .settings
+            .as_ref()
+            .and_then(|s| s.model_name.as_deref())
+            .unwrap_or("--");
+
+        println!(
+            "{:<5} {:<35} {:<6} {:<15} {:<15}",
+            conv.id,
+            truncate_string(&conv.title, 34),
+            msg_count,
+            truncate_string(model_label, 14),
+            format_relative_time(&conv.updated_at),
+        );
+    }
+
+    println!(
+        "\nResume with: gglib chat <model> --continue <ID>"
+    );
+
+    Ok(())
+}

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -144,7 +144,22 @@ pub async fn execute(
     let mut persistence = None;
     if completed && let Some(ref history) = history {
         let system_prompt = format!("{}\n\nWorking directory: {}", SYSTEM_PROMPT, cwd.display());
-        match Conversation::create(ctx.app.chat_history(), Some(system_prompt)).await {
+        let settings = crate::shared_args::ConversationSettingsBuilder::new(
+            &SamplingArgs::default(),
+            &crate::shared_args::ContextArgs::default(),
+        )
+        .model_name(params.model_identifier.clone())
+        .tools(tools.clone(), false)
+        .agent_params(max_iterations, tool_timeout_ms, max_parallel)
+        .build();
+        match Conversation::create(
+            ctx.app.chat_history(),
+            Some(system_prompt),
+            None,
+            Some(settings),
+        )
+        .await
+        {
             Ok(mut conv) => {
                 conv.save_new(history).await;
                 persistence = Some(conv);

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -92,7 +92,18 @@ pub async fn execute(
         Some(inference_config)
     };
 
-    let (agent, maybe_handle) = compose(ctx, &params, Some(cwd.clone()), sampling_override).await?;
+    let (agent, maybe_handle) = compose(
+        ctx,
+        &params,
+        Some(cwd.clone()),
+        sampling_override.clone(),
+        &crate::handlers::agent_chat::config::BannerInfo {
+            quiet,
+            sampling: sampling_override,
+            prior_history_chars: None,
+        },
+    )
+    .await?;
 
     let config = AgentConfig::from_user_params(Some(max_iterations), max_parallel, tool_timeout_ms)
         .map_err(|e| anyhow!("invalid agent config: {e}"))?;

--- a/crates/gglib-cli/src/handlers/inference/chat.rs
+++ b/crates/gglib-cli/src/handlers/inference/chat.rs
@@ -25,6 +25,8 @@ pub struct ChatArgs {
     pub verbose: bool,
     /// Optional model-name override for llama-server routing.
     pub model: Option<String>,
+    /// Resume a previous conversation by ID.
+    pub continue_id: Option<i64>,
 }
 
 /// Execute the chat command — always routes to the agentic REPL.

--- a/crates/gglib-cli/src/handlers/mod.rs
+++ b/crates/gglib-cli/src/handlers/mod.rs
@@ -16,6 +16,7 @@
 pub mod agent_chat;
 pub mod config;
 pub mod gui;
+pub mod history;
 pub mod inference;
 pub mod mcp_cli;
 pub mod model;

--- a/crates/gglib-cli/src/presentation/mod.rs
+++ b/crates/gglib-cli/src/presentation/mod.rs
@@ -16,4 +16,4 @@ pub mod tables;
 
 // Re-export commonly used items
 pub use model_display::{DisplayStyle, ModelSummaryOpts, display_model_summary};
-pub use tables::{format_optional, print_separator, truncate_string};
+pub use tables::{format_optional, format_relative_time, print_separator, truncate_string};

--- a/crates/gglib-cli/src/presentation/tables.rs
+++ b/crates/gglib-cli/src/presentation/tables.rs
@@ -117,7 +117,10 @@ mod tests {
 
     #[test]
     fn relative_time_just_now() {
-        let now = Utc::now().naive_utc().format("%Y-%m-%d %H:%M:%S").to_string();
+        let now = Utc::now()
+            .naive_utc()
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
         assert_eq!(format_relative_time(&now), "just now");
     }
 

--- a/crates/gglib-cli/src/presentation/tables.rs
+++ b/crates/gglib-cli/src/presentation/tables.rs
@@ -1,5 +1,51 @@
 //! Table formatting utilities for CLI output.
 
+use chrono::{NaiveDateTime, Utc};
+
+/// Format a SQLite datetime string as a human-readable relative time.
+///
+/// Returns strings like "just now", "5 min ago", "3 hours ago", "2 days ago",
+/// or the original date if more than 30 days old.
+///
+/// Falls back to the raw string on parse failure.
+pub fn format_relative_time(datetime_str: &str) -> String {
+    let Ok(dt) = NaiveDateTime::parse_from_str(datetime_str, "%Y-%m-%d %H:%M:%S") else {
+        return datetime_str.to_string();
+    };
+    let now = Utc::now().naive_utc();
+    let delta = now.signed_duration_since(dt);
+    let secs = delta.num_seconds();
+
+    if secs < 0 {
+        return datetime_str.to_string();
+    }
+
+    match secs {
+        0..=59 => "just now".to_string(),
+        60..=3599 => {
+            let m = secs / 60;
+            format!("{m} min ago")
+        }
+        3600..=86399 => {
+            let h = secs / 3600;
+            if h == 1 {
+                "1 hour ago".to_string()
+            } else {
+                format!("{h} hours ago")
+            }
+        }
+        86400..=2_591_999 => {
+            let d = secs / 86400;
+            if d == 1 {
+                "yesterday".to_string()
+            } else {
+                format!("{d} days ago")
+            }
+        }
+        _ => dt.format("%Y-%m-%d").to_string(),
+    }
+}
+
 /// Truncates a string to at most `max_len` characters, appending `\u{2026}` (…)
 /// if the string is longer.
 ///
@@ -45,7 +91,7 @@ pub fn format_optional<T: std::fmt::Display>(value: &Option<T>, default: &str) -
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_string;
+    use super::*;
 
     #[test]
     fn truncate_short_string_unchanged() {
@@ -67,5 +113,45 @@ mod tests {
     #[test]
     fn truncate_empty_string() {
         assert_eq!(truncate_string("", 10), "");
+    }
+
+    #[test]
+    fn relative_time_just_now() {
+        let now = Utc::now().naive_utc().format("%Y-%m-%d %H:%M:%S").to_string();
+        assert_eq!(format_relative_time(&now), "just now");
+    }
+
+    #[test]
+    fn relative_time_minutes_ago() {
+        let ts = (Utc::now().naive_utc() - chrono::Duration::minutes(5))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        assert_eq!(format_relative_time(&ts), "5 min ago");
+    }
+
+    #[test]
+    fn relative_time_hours_ago() {
+        let ts = (Utc::now().naive_utc() - chrono::Duration::hours(3))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        assert_eq!(format_relative_time(&ts), "3 hours ago");
+    }
+
+    #[test]
+    fn relative_time_yesterday() {
+        let ts = (Utc::now().naive_utc() - chrono::Duration::days(1))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        assert_eq!(format_relative_time(&ts), "yesterday");
+    }
+
+    #[test]
+    fn relative_time_old_shows_date() {
+        assert_eq!(format_relative_time("2020-01-15 10:30:00"), "2020-01-15");
+    }
+
+    #[test]
+    fn relative_time_bad_parse_returns_raw() {
+        assert_eq!(format_relative_time("not-a-date"), "not-a-date");
     }
 }

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -52,3 +52,62 @@ impl SamplingArgs {
         }
     }
 }
+
+/// Builder for [`ConversationSettings`](gglib_core::domain::chat::ConversationSettings)
+/// from CLI argument groups.
+///
+/// A single conversion point used by both `chat` and `q` handlers (DRY).
+pub struct ConversationSettingsBuilder {
+    settings: gglib_core::domain::chat::ConversationSettings,
+}
+
+impl ConversationSettingsBuilder {
+    /// Start building settings from sampling and context args.
+    pub fn new(sampling: &SamplingArgs, context: &ContextArgs) -> Self {
+        Self {
+            settings: gglib_core::domain::chat::ConversationSettings {
+                temperature: sampling.temperature,
+                top_p: sampling.top_p,
+                top_k: sampling.top_k,
+                max_tokens: sampling.max_tokens,
+                repeat_penalty: sampling.repeat_penalty,
+                ctx_size: context.ctx_size.clone(),
+                mlock: if context.mlock { Some(true) } else { None },
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Set the model name used for this session.
+    pub fn model_name(mut self, name: impl Into<String>) -> Self {
+        self.settings.model_name = Some(name.into());
+        self
+    }
+
+    /// Set tool-related configuration.
+    pub fn tools(mut self, tools: Vec<String>, no_tools: bool) -> Self {
+        self.settings.tools = tools;
+        if no_tools {
+            self.settings.no_tools = Some(true);
+        }
+        self
+    }
+
+    /// Set agent loop parameters.
+    pub fn agent_params(
+        mut self,
+        max_iterations: usize,
+        tool_timeout_ms: Option<u64>,
+        max_parallel: Option<usize>,
+    ) -> Self {
+        self.settings.max_iterations = Some(max_iterations);
+        self.settings.tool_timeout_ms = tool_timeout_ms;
+        self.settings.max_parallel = max_parallel;
+        self
+    }
+
+    /// Consume the builder and return the finished settings.
+    pub fn build(self) -> gglib_core::domain::chat::ConversationSettings {
+        self.settings
+    }
+}

--- a/crates/gglib-core/src/domain/chat.rs
+++ b/crates/gglib-core/src/domain/chat.rs
@@ -2,6 +2,9 @@
 //!
 //! These types represent chat conversations and messages in the domain model,
 //! independent of any infrastructure concerns.
+//!
+//! [`ConversationSettings`] captures CLI/GUI session parameters (sampling,
+//! context, tools) so conversations can be faithfully resumed.
 
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +15,9 @@ pub struct Conversation {
     pub title: String,
     pub model_id: Option<i64>,
     pub system_prompt: Option<String>,
+    /// Session parameters captured at creation for resume.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ConversationSettings>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -76,6 +82,8 @@ pub struct NewConversation {
     pub title: String,
     pub model_id: Option<i64>,
     pub system_prompt: Option<String>,
+    /// Session parameters to persist for resume.
+    pub settings: Option<ConversationSettings>,
 }
 
 /// Data for creating a new message.
@@ -94,4 +102,53 @@ pub struct ConversationUpdate {
     pub title: Option<String>,
     /// Use `Some(Some(prompt))` to set, `Some(None)` to clear, `None` to leave unchanged.
     pub system_prompt: Option<Option<String>>,
+    /// Use `Some(Some(settings))` to set, `Some(None)` to clear, `None` to leave unchanged.
+    pub settings: Option<Option<ConversationSettings>>,
+}
+
+/// Session parameters captured at conversation creation for resume.
+///
+/// Stores sampling, context, and tool configuration so a CLI or GUI session
+/// can be faithfully restored. Serialized as a JSON column in the database.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ConversationSettings {
+    /// Model name or identifier used for this session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    /// Sampling temperature (0.0–2.0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Nucleus sampling threshold (0.0–1.0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    /// Top-K sampling limit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<i32>,
+    /// Maximum tokens per response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Repetition penalty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repeat_penalty: Option<f32>,
+    /// Context window size (numeric or "max").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ctx_size: Option<String>,
+    /// Whether memory locking was enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mlock: Option<bool>,
+    /// Tool allowlist (empty = all tools).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+    /// Per-tool timeout in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_timeout_ms: Option<u64>,
+    /// Maximum parallel tool calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_parallel: Option<usize>,
+    /// Maximum agent loop iterations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_iterations: Option<usize>,
+    /// Whether tools were disabled entirely.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_tools: Option<bool>,
 }

--- a/crates/gglib-core/src/domain/chat.rs
+++ b/crates/gglib-core/src/domain/chat.rs
@@ -8,6 +8,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::agent::messages::AgentMessage;
+use super::agent::messages::AssistantContent;
+use super::agent::tool_types::ToolCall;
+
 /// A chat conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Conversation {
@@ -33,6 +37,55 @@ pub struct Message {
     /// Optional JSON metadata for deep research state, tool usage, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+}
+
+impl Message {
+    /// Convert a persisted message back into an [`AgentMessage`] for resume.
+    ///
+    /// Tool call metadata is faithfully restored from the JSON `"tool_calls"` key
+    /// (assistant messages) or `"tool_call_id"` key (tool messages).
+    #[must_use]
+    pub fn to_agent_message(&self) -> AgentMessage {
+        match self.role {
+            MessageRole::System => AgentMessage::System {
+                content: self.content.clone(),
+            },
+            MessageRole::User => AgentMessage::User {
+                content: self.content.clone(),
+            },
+            MessageRole::Assistant => {
+                let tool_calls: Vec<ToolCall> = self
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("tool_calls"))
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_default();
+                AgentMessage::Assistant {
+                    content: AssistantContent {
+                        text: if self.content.is_empty() {
+                            None
+                        } else {
+                            Some(self.content.clone())
+                        },
+                        tool_calls,
+                    },
+                }
+            }
+            MessageRole::Tool => {
+                let tool_call_id = self
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("tool_call_id"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                AgentMessage::Tool {
+                    tool_call_id,
+                    content: self.content.clone(),
+                }
+            }
+        }
+    }
 }
 
 /// The role of a message sender.

--- a/crates/gglib-core/src/services/chat_history.rs
+++ b/crates/gglib-core/src/services/chat_history.rs
@@ -35,8 +35,17 @@ impl ChatHistoryService {
                 title,
                 model_id,
                 system_prompt,
+                settings: None,
             })
             .await
+    }
+
+    /// Create a new conversation with session settings for resume.
+    pub async fn create_conversation_with_settings(
+        &self,
+        conv: NewConversation,
+    ) -> Result<i64, ChatHistoryError> {
+        self.repo.create_conversation(conv).await
     }
 
     /// List all conversations, ordered by most recently updated.
@@ -65,6 +74,7 @@ impl ChatHistoryService {
                 ConversationUpdate {
                     title: new_title,
                     system_prompt,
+                    settings: None,
                 },
             )
             .await

--- a/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
@@ -112,12 +112,14 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
             return Ok(());
         }
 
-        let row = sqlx::query("SELECT title, system_prompt, settings FROM chat_conversations WHERE id = ?")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| ChatHistoryError::Database(e.to_string()))?
-            .ok_or(ChatHistoryError::ConversationNotFound(id))?;
+        let row = sqlx::query(
+            "SELECT title, system_prompt, settings FROM chat_conversations WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ChatHistoryError::Database(e.to_string()))?
+        .ok_or(ChatHistoryError::ConversationNotFound(id))?;
 
         let current_title: String = row.get("title");
         let current_prompt: Option<String> = row.get("system_prompt");

--- a/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
@@ -28,12 +28,18 @@ impl SqliteChatHistoryRepository {
 #[async_trait]
 impl ChatHistoryRepository for SqliteChatHistoryRepository {
     async fn create_conversation(&self, conv: NewConversation) -> Result<i64, ChatHistoryError> {
+        let settings_str = conv
+            .settings
+            .as_ref()
+            .and_then(|s| serde_json::to_string(s).ok());
+
         let result = sqlx::query(
-            "INSERT INTO chat_conversations (title, model_id, system_prompt) VALUES (?, ?, ?)",
+            "INSERT INTO chat_conversations (title, model_id, system_prompt, settings) VALUES (?, ?, ?, ?)",
         )
         .bind(&conv.title)
         .bind(conv.model_id)
         .bind(conv.system_prompt)
+        .bind(&settings_str)
         .execute(&self.pool)
         .await
         .map_err(|e| ChatHistoryError::Database(e.to_string()))?;
@@ -43,7 +49,7 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
 
     async fn list_conversations(&self) -> Result<Vec<Conversation>, ChatHistoryError> {
         let rows = sqlx::query(
-            "SELECT id, title, model_id, system_prompt, created_at, updated_at 
+            "SELECT id, title, model_id, system_prompt, settings, created_at, updated_at 
              FROM chat_conversations 
              ORDER BY updated_at DESC",
         )
@@ -53,13 +59,18 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
 
         let conversations = rows
             .iter()
-            .map(|row| Conversation {
-                id: row.get("id"),
-                title: row.get("title"),
-                model_id: row.get("model_id"),
-                system_prompt: row.get("system_prompt"),
-                created_at: row.get("created_at"),
-                updated_at: row.get("updated_at"),
+            .map(|row| {
+                let settings_str: Option<String> = row.get("settings");
+                let settings = settings_str.and_then(|s| serde_json::from_str(&s).ok());
+                Conversation {
+                    id: row.get("id"),
+                    title: row.get("title"),
+                    model_id: row.get("model_id"),
+                    system_prompt: row.get("system_prompt"),
+                    settings,
+                    created_at: row.get("created_at"),
+                    updated_at: row.get("updated_at"),
+                }
             })
             .collect();
 
@@ -68,7 +79,7 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
 
     async fn get_conversation(&self, id: i64) -> Result<Option<Conversation>, ChatHistoryError> {
         let row = sqlx::query(
-            "SELECT id, title, model_id, system_prompt, created_at, updated_at 
+            "SELECT id, title, model_id, system_prompt, settings, created_at, updated_at 
              FROM chat_conversations 
              WHERE id = ?",
         )
@@ -77,13 +88,18 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
         .await
         .map_err(|e| ChatHistoryError::Database(e.to_string()))?;
 
-        Ok(row.map(|r| Conversation {
-            id: r.get("id"),
-            title: r.get("title"),
-            model_id: r.get("model_id"),
-            system_prompt: r.get("system_prompt"),
-            created_at: r.get("created_at"),
-            updated_at: r.get("updated_at"),
+        Ok(row.map(|r| {
+            let settings_str: Option<String> = r.get("settings");
+            let settings = settings_str.and_then(|s| serde_json::from_str(&s).ok());
+            Conversation {
+                id: r.get("id"),
+                title: r.get("title"),
+                model_id: r.get("model_id"),
+                system_prompt: r.get("system_prompt"),
+                settings,
+                created_at: r.get("created_at"),
+                updated_at: r.get("updated_at"),
+            }
         }))
     }
 
@@ -92,11 +108,11 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
         id: i64,
         update: ConversationUpdate,
     ) -> Result<(), ChatHistoryError> {
-        if update.title.is_none() && update.system_prompt.is_none() {
+        if update.title.is_none() && update.system_prompt.is_none() && update.settings.is_none() {
             return Ok(());
         }
 
-        let row = sqlx::query("SELECT title, system_prompt FROM chat_conversations WHERE id = ?")
+        let row = sqlx::query("SELECT title, system_prompt, settings FROM chat_conversations WHERE id = ?")
             .bind(id)
             .fetch_optional(&self.pool)
             .await
@@ -105,15 +121,22 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
 
         let current_title: String = row.get("title");
         let current_prompt: Option<String> = row.get("system_prompt");
+        let current_settings: Option<String> = row.get("settings");
 
         let next_title = update.title.unwrap_or(current_title);
         let next_prompt = update.system_prompt.unwrap_or(current_prompt);
+        let next_settings = match update.settings {
+            Some(Some(s)) => serde_json::to_string(&s).ok(),
+            Some(None) => None,
+            None => current_settings,
+        };
 
         sqlx::query(
-            "UPDATE chat_conversations SET title = ?, system_prompt = ?, updated_at = datetime('now') WHERE id = ?",
+            "UPDATE chat_conversations SET title = ?, system_prompt = ?, settings = ?, updated_at = datetime('now') WHERE id = ?",
         )
         .bind(next_title)
         .bind(next_prompt)
+        .bind(next_settings)
         .bind(id)
         .execute(&self.pool)
         .await

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -230,6 +230,12 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
         .await;
     // Ignore error if column already exists
 
+    // Migration: Add settings column for session parameter persistence.
+    let _ = sqlx::query(r#"ALTER TABLE chat_conversations ADD COLUMN settings TEXT"#)
+        .execute(pool)
+        .await;
+    // Ignore error if column already exists
+
     // Create MCP servers table
     sqlx::query(
         r#"

--- a/src/hooks/useChatPersistence/buildLoadedMessage.ts
+++ b/src/hooks/useChatPersistence/buildLoadedMessage.ts
@@ -38,13 +38,18 @@ export function foldToolMessages(messages: ChatMessage[]): ChatMessage[] {
   }
 
   // Nothing to fold — fast path.
-  if (toolResultByCallId.size === 0) return messages;
+  // Always strip system and tool rows: system prompt is sourced from the
+  // conversation record, and tool content is embedded in assistant messages.
+  if (toolResultByCallId.size === 0) {
+    return messages.filter((m) => m.role !== 'tool' && m.role !== 'system');
+  }
 
   const result: ChatMessage[] = [];
 
   for (const msg of messages) {
-    // Strip tool rows — their content is now embedded in the assistant.
-    if (msg.role === 'tool') continue;
+    // Strip tool and system rows — tool content is embedded in assistants,
+    // and system prompt is sourced from the conversation record.
+    if (msg.role === 'tool' || msg.role === 'system') continue;
 
     // Enrich assistant messages that have tool_calls metadata.
     if (

--- a/src/hooks/useGglibRuntime/wireMessages.ts
+++ b/src/hooks/useGglibRuntime/wireMessages.ts
@@ -64,10 +64,15 @@ export function convertToWireMessages(messages: GglibMessage[]): AgentWireMessag
 
     } else if (msg.role === 'assistant') {
       const parts = extractParts(msg.content);
-      const text = parts
-        .filter((p): p is TextPart => p.type === 'text')
-        .map(p => p.text)
-        .join('');
+      // Content may be a plain string (DB-loaded messages without structured
+      // contentParts) or an array of parts (GUI-created messages).  Handle
+      // both so we never lose the assistant's text.
+      const text = !Array.isArray(msg.content)
+        ? (msg.content as string) ?? ''
+        : parts
+            .filter((p): p is TextPart => p.type === 'text')
+            .map(p => p.text)
+            .join('');
       // Only include tool-call parts that have both required string fields AND
       // a result. An assistant message with tool_calls but no corresponding
       // tool-result entries is structurally invalid in the OpenAI wire format.

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -297,6 +297,7 @@ export default function ChatPage({
         title,
         model_id: null,
         system_prompt: systemPrompt,
+        settings: null,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };

--- a/src/services/transport/types/chat.ts
+++ b/src/services/transport/types/chat.ts
@@ -10,6 +10,26 @@ import type { ConversationId, MessageId, ModelId } from './ids';
 // ============================================================================
 
 /**
+ * Persisted session parameters for a conversation.
+ * Mirrors the Rust `ConversationSettings` domain type.
+ */
+export interface ConversationSettings {
+  model_name?: string | null;
+  temperature?: number | null;
+  top_p?: number | null;
+  top_k?: number | null;
+  max_tokens?: number | null;
+  repeat_penalty?: number | null;
+  ctx_size?: number | null;
+  mlock?: boolean | null;
+  tools?: string[] | null;
+  tool_timeout_ms?: number | null;
+  max_parallel?: number | null;
+  max_iterations?: number | null;
+  no_tools?: boolean | null;
+}
+
+/**
  * Summary of a conversation for listing.
  */
 export interface ConversationSummary {
@@ -17,6 +37,7 @@ export interface ConversationSummary {
   title: string;
   model_id: ModelId | null;
   system_prompt: string | null;
+  settings: ConversationSettings | null;
   created_at: string;
   updated_at: string;
 }

--- a/tests/integration_chat_parity.rs
+++ b/tests/integration_chat_parity.rs
@@ -21,6 +21,7 @@ async fn test_create_and_list_conversation() {
             title: "Test Chat".to_string(),
             model_id: None,
             system_prompt: Some("You are a helpful assistant.".to_string()),
+            settings: None,
         })
         .await
         .expect("Failed to create conversation");
@@ -61,6 +62,7 @@ async fn test_save_and_list_messages() {
             title: "Message Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .expect("Failed to create conversation");
@@ -126,6 +128,7 @@ async fn test_update_conversation() {
             title: "Original Title".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .expect("Failed to create conversation");
@@ -136,6 +139,7 @@ async fn test_update_conversation() {
         gglib_core::domain::chat::ConversationUpdate {
             title: Some("Updated Title".to_string()),
             system_prompt: None,
+            settings: None,
         },
     )
     .await
@@ -165,6 +169,7 @@ async fn test_delete_conversation_cascades() {
             title: "To Delete".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .expect("Failed to create conversation");

--- a/tests/ts/hooks/useGglibRuntime/wireMessages.test.ts
+++ b/tests/ts/hooks/useGglibRuntime/wireMessages.test.ts
@@ -124,6 +124,15 @@ describe('convertToWireMessages — assistant text', () => {
     ]);
     expect(wire[0]).toMatchObject({ role: 'assistant', content: 'Part A Part B' });
   });
+
+  it('preserves plain string content (DB-loaded messages)', () => {
+    // DB-loaded messages may arrive with content as a plain string instead
+    // of an array of parts.  convertToWireMessages must not lose the text.
+    const wire = convertToWireMessages([assistantMsg('Hello from DB')]);
+    expect(wire).toEqual<AgentWireMessage[]>([
+      { role: 'assistant', content: 'Hello from DB' },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/services/test_chat_history.rs
+++ b/tests/unit/services/test_chat_history.rs
@@ -19,6 +19,7 @@ async fn test_create_conversation() {
             title: "Test Chat".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -38,6 +39,7 @@ async fn test_create_conversation_with_system_prompt() {
             title: "Chat with Prompt".to_string(),
             model_id: None,
             system_prompt: Some(system_prompt.clone()),
+            settings: None,
         })
         .await
         .unwrap();
@@ -57,6 +59,7 @@ async fn test_list_conversations() {
         title: "First".to_string(),
         model_id: None,
         system_prompt: None,
+        settings: None,
     })
     .await
     .unwrap();
@@ -65,6 +68,7 @@ async fn test_list_conversations() {
         title: "Second".to_string(),
         model_id: None,
         system_prompt: None,
+        settings: None,
     })
     .await
     .unwrap();
@@ -73,6 +77,7 @@ async fn test_list_conversations() {
         title: "Third".to_string(),
         model_id: None,
         system_prompt: None,
+        settings: None,
     })
     .await
     .unwrap();
@@ -107,6 +112,7 @@ async fn test_get_conversation_by_id() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: Some("Prompt".to_string()),
+            settings: None,
         })
         .await
         .unwrap();
@@ -142,6 +148,7 @@ async fn test_save_user_message() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -175,6 +182,7 @@ async fn test_save_assistant_message() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -206,6 +214,7 @@ async fn test_save_system_message() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -234,6 +243,7 @@ async fn test_get_messages_ordering() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -285,6 +295,7 @@ async fn test_get_messages_empty() {
             title: "Empty".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -304,6 +315,7 @@ async fn test_update_conversation_title() {
             title: "Original".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -313,6 +325,7 @@ async fn test_update_conversation_title() {
         ConversationUpdate {
             title: Some("Updated".to_string()),
             system_prompt: None,
+            settings: None,
         },
     )
     .await
@@ -333,6 +346,7 @@ async fn test_update_conversation_system_prompt() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -342,6 +356,7 @@ async fn test_update_conversation_system_prompt() {
         ConversationUpdate {
             title: None,
             system_prompt: Some(Some("New prompt".to_string())),
+            settings: None,
         },
     )
     .await
@@ -362,6 +377,7 @@ async fn test_clear_system_prompt() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: Some("Initial prompt".to_string()),
+            settings: None,
         })
         .await
         .unwrap();
@@ -371,6 +387,7 @@ async fn test_clear_system_prompt() {
         ConversationUpdate {
             title: None,
             system_prompt: Some(None), // Clear the prompt
+            settings: None,
         },
     )
     .await
@@ -391,6 +408,7 @@ async fn test_delete_conversation() {
             title: "To Delete".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -412,6 +430,7 @@ async fn test_delete_conversation_cascades_messages() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -444,6 +463,7 @@ async fn test_conversation_count() {
         title: "First".to_string(),
         model_id: None,
         system_prompt: None,
+        settings: None,
     })
     .await
     .unwrap();
@@ -454,6 +474,7 @@ async fn test_conversation_count() {
         title: "Second".to_string(),
         model_id: None,
         system_prompt: None,
+        settings: None,
     })
     .await
     .unwrap();
@@ -472,6 +493,7 @@ async fn test_message_count() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -512,6 +534,7 @@ async fn test_update_message_content() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -545,6 +568,7 @@ async fn test_delete_message_and_subsequent() {
             title: "Test".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -597,6 +621,7 @@ async fn test_multiple_conversations_isolation() {
             title: "Conv 1".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();
@@ -606,6 +631,7 @@ async fn test_multiple_conversations_isolation() {
             title: "Conv 2".to_string(),
             model_id: None,
             system_prompt: None,
+            settings: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Add the ability to list past CLI conversations and resume them, bringing CLI parity with the GUI's conversation persistence.

## Changes

### Phase 1: Persist Session Parameters
- **`ConversationSettings`** domain type in `gglib-core` — captures sampling (temperature, top_p, top_k, etc.), context (ctx_size, mlock), and agent params (tools, max_iterations, tool_timeout_ms, max_parallel)
- **DB migration** — adds `settings TEXT` column to `chat_conversations`
- **Repository** — serializes/deserializes settings as JSON
- **`ConversationSettingsBuilder`** — DRY conversion from CLI args, used by both `chat` and `q` handlers
- **Frontend types** — `ConversationSettings` interface + `settings` field on `ConversationSummary`

### Phase 2: History Command
- **`gglib history`** — lists past conversations with ID, title, message count, model name, and relative timestamp
- **`format_relative_time()`** — converts SQLite datetime to "5 min ago", "yesterday", etc. (with tests)
- `-n/--limit` flag to control max rows shown (default: 20)

### Phase 3: Resume (`--continue`)
- **`--continue <ID>`** flag on `gglib chat` — loads conversation messages and resumes the REPL
- **`Message::to_agent_message()`** — domain-layer conversion from persisted messages back to `AgentMessage` variants (restores tool call metadata faithfully)
- **`Conversation::resume()`** — resumes persistence tracking from existing message count
- **Memory jogger** — prints last user/assistant exchange in DIM style when resuming
- **`run_repl_with_prior()`** — REPL entry point accepting pre-loaded history

### Phase 4: Quality of Life
- Session ID printed at REPL start and exit with resume hint

### Phase 5: Documentation
- Updated CLI README commands table with `history` and `--continue`

## Testing
- All existing tests pass (0 failures across workspace)
- New unit tests for `format_relative_time` (6 cases)
- Clean clippy, clean boundary checks

## Architecture Compliance
- Domain types in `gglib-core` (shared by all surface crates)
- No business logic in surface crates
- GUI parity maintained (frontend types updated)
- DRY: single `ConversationSettingsBuilder` used by both `chat` and `q`
