### PR TITLE
fix(runtime): gate detect helpers behind correct cfg attributes

### DIFF
--- a/crates/gglib-runtime/src/llama/detect/cuda.rs
+++ b/crates/gglib-runtime/src/llama/detect/cuda.rs
@@ -22,11 +22,14 @@
 
 #[cfg(target_os = "linux")]
 use anyhow::Context;
+#[cfg(feature = "cli")]
 use anyhow::Result;
 #[cfg(target_os = "linux")]
 use tracing::warn;
 
-use super::tools::{command_exists, command_stdout, parse_version_tuple};
+use super::tools::command_exists;
+#[cfg(target_os = "linux")]
+use super::tools::{command_stdout, parse_version_tuple};
 
 // ============================================================================
 // CUDA toolkit detection
@@ -81,6 +84,7 @@ fn get_gcc_version_tuple() -> Option<(u32, u32)> {
 /// 3. `/usr/local/cuda-*` (versioned installs, newest first)
 /// 4. `/usr/local/cuda` (generic symlink)
 /// 5. Windows standard locations
+#[cfg(feature = "cli")]
 pub fn get_cuda_path() -> Option<String> {
     if let Ok(cuda_path) = std::env::var("CUDA_PATH")
         && std::path::Path::new(&cuda_path).exists()
@@ -206,6 +210,7 @@ fn get_specific_gcc_version(gcc_cmd: &str) -> Result<String> {
 /// Returns `Ok(())` if the combination is supported, or an `Err` with
 /// a detailed message including remediation steps. Validation is only
 /// performed on Linux; other platforms return `Ok(())` unconditionally.
+#[cfg(feature = "cli")]
 pub fn validate_cuda_gcc_compatibility() -> Result<()> {
     #[cfg(not(target_os = "linux"))]
     {

--- a/crates/gglib-runtime/src/llama/detect/mod.rs
+++ b/crates/gglib-runtime/src/llama/detect/mod.rs
@@ -31,7 +31,9 @@ mod vulkan;
 // Re-export submodule public API
 #[cfg(target_os = "linux")]
 pub use cuda::select_cuda_compiler_for_build;
+#[cfg(feature = "cli")]
 pub use cuda::{get_cuda_path, validate_cuda_gcc_compatibility};
+#[cfg(feature = "cli")]
 pub use tools::{get_num_cores, has_cmake, has_cpp_compiler, has_git};
 pub use vulkan::{MissingPackage, VulkanStatus, vulkan_status};
 

--- a/crates/gglib-runtime/src/llama/detect/tools.rs
+++ b/crates/gglib-runtime/src/llama/detect/tools.rs
@@ -13,6 +13,7 @@
 //! DRY. The helpers here provide a small, typed API on top of
 //! [`gglib_core::utils::process::cmd`].
 
+#[cfg(any(feature = "cli", test))]
 use anyhow::Result;
 use gglib_core::utils::process::cmd;
 
@@ -61,6 +62,7 @@ pub fn command_exists(program: &str) -> bool {
 ///
 /// Extracts only the leading numeric portion of each component, so
 /// `"12.0-rc1"` successfully parses as `(12, 0)`.
+#[cfg(any(target_os = "linux", test))]
 pub fn parse_version_tuple(version_str: &str) -> Option<(u32, u32)> {
     let parts: Vec<&str> = version_str.split('.').collect();
     if parts.len() >= 2 {
@@ -81,6 +83,7 @@ pub fn parse_version_tuple(version_str: &str) -> Option<(u32, u32)> {
 // ============================================================================
 
 /// Check if git is installed, returning its version string on success.
+#[cfg(any(feature = "cli", test))]
 pub fn has_git() -> Result<Option<String>> {
     match command_stdout("git", &["--version"]) {
         Some(v) => {
@@ -92,6 +95,7 @@ pub fn has_git() -> Result<Option<String>> {
 }
 
 /// Check if cmake is installed, returning its version string on success.
+#[cfg(any(feature = "cli", test))]
 pub fn has_cmake() -> Result<Option<String>> {
     match command_stdout("cmake", &["--version"]) {
         Some(v) => {
@@ -113,6 +117,7 @@ pub fn has_cmake() -> Result<Option<String>> {
 /// - **Windows**: `cl`, `g++`, `clang++`
 /// - **macOS**: `clang++`, `g++`
 /// - **Linux**: `g++`, `clang++`
+#[cfg(any(feature = "cli", test))]
 pub fn has_cpp_compiler() -> Result<Option<String>> {
     let compilers = if cfg!(target_os = "windows") {
         vec!["cl", "g++", "clang++"]
@@ -133,6 +138,7 @@ pub fn has_cpp_compiler() -> Result<Option<String>> {
 }
 
 /// Get the number of CPU cores available for parallel compilation.
+#[cfg(any(feature = "cli", test))]
 pub fn get_num_cores() -> usize {
     num_cpus::get()
 }


### PR DESCRIPTION
## Problem

On macOS, `cargo build -p gglib-runtime` (and the release/cli build via `make setup`) emitted lint warnings for symbols in the `llama/detect` subsystem that were compiled unconditionally but are only reachable on Linux or when the `cli` feature is enabled.

The two warnings visible in `make setup` output:
```
warning: unused imports: `command_stdout` and `parse_version_tuple`
  --> crates/gglib-runtime/src/llama/detect/cuda.rs:29:36

warning: function `parse_version_tuple` is never used
  --> crates/gglib-runtime/src/llama/detect/tools.rs:64:8
```

And 8 further warnings surfaced when building `gglib-runtime` in isolation (without the `cli` feature), all from the same root cause.

## Root cause

The CUDA detect submodule was introduced during Linux development. Several helpers are only meaningful on Linux (`command_stdout`, `parse_version_tuple` in CUDA context) or only reachable when a source build is triggered (`get_cuda_path`, `validate_cuda_gcc_compatibility`, `has_git`, `has_cmake`, `has_cpp_compiler`, `get_num_cores` — all consumed exclusively by `build/mod.rs` and `deps.rs`, which are both `#[cfg(feature = "cli")]`). Their imports and `pub use` re-exports in `detect/mod.rs` lacked matching `cfg` gates.

## Changes

| File | Change |
|------|--------|
| `detect/cuda.rs` | Split monolithic import; gate `command_stdout` + `parse_version_tuple` on `target_os = "linux"`. Gate `get_cuda_path`, `validate_cuda_gcc_compatibility`, and `use anyhow::Result` on `feature = "cli"`. |
| `detect/tools.rs` | Gate `parse_version_tuple` on `any(target_os = "linux", test)`. Gate `has_git`, `has_cmake`, `has_cpp_compiler`, `get_num_cores`, and `use anyhow::Result` on `any(feature = "cli", test)`. |
| `detect/mod.rs` | Add `#[cfg(feature = "cli")]` to the two `pub use` re-export lines that were unconditional. |

All `test` variants preserve existing unit tests on all platforms.

## Verification

```
# Without cli feature (previously 10 warnings → now 0)
cargo build -p gglib-runtime

# With cli feature (previously clean → still 0)
cargo build -p gglib-runtime --features gglib-runtime/cli
```