### PR TITLE
feat(agent): Council of Agents — Phase 1 backend foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "gglib-core",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/gglib-agent/Cargo.toml
+++ b/crates/gglib-agent/Cargo.toml
@@ -21,6 +21,7 @@ futures-core = { workspace = true }
 async-trait  = { workspace = true }
 anyhow       = { workspace = true }
 tracing      = { workspace = true }
+serde        = { workspace = true }
 serde_json   = { workspace = true }
 
 [lints]

--- a/crates/gglib-agent/src/council/config.rs
+++ b/crates/gglib-agent/src/council/config.rs
@@ -1,0 +1,152 @@
+//! Configuration types for the Council of Agents feature.
+//!
+//! A council is a group of agents with distinct personas who debate a topic
+//! across multiple rounds, then produce a synthesised answer.  These types
+//! describe the static configuration of a council run — who the agents are,
+//! how many rounds to run, and what the synthesis should prioritise.
+
+use serde::{Deserialize, Serialize};
+
+// ─── per-agent config ────────────────────────────────────────────────────────
+
+/// Describes a single agent participating in a council debate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CouncilAgent {
+    /// Unique opaque identifier (e.g. a short slug or UUID).
+    pub id: String,
+
+    /// Human-readable role title (e.g. "Devil's Advocate", "Pragmatist").
+    pub name: String,
+
+    /// CSS-compatible colour string for the agent's avatar and lane tint
+    /// (e.g. `"#ef4444"` or `"rgb(239,68,68)"`).
+    pub color: String,
+
+    /// 2-3 sentence persona definition.  Re-injected at the top of every
+    /// turn to anchor the model's identity.
+    pub persona: String,
+
+    /// What unique angle this agent brings, expressed as a single sentence.
+    pub perspective: String,
+
+    /// Behavioural contentiousness on a `[0.0, 1.0]` scale.
+    ///
+    /// - `0.0` – fully collaborative (seek common ground)
+    /// - `1.0` – maximally adversarial (devil's advocate)
+    ///
+    /// The raw float is stored for UI slider binding.  Prompt assembly
+    /// maps it to a discrete instruction string via
+    /// [`crate::council::prompts::contentiousness_to_instruction`].
+    pub contentiousness: f32,
+
+    /// Optional allowlist of tool names this agent may use.
+    ///
+    /// - `None` → agent may use **all** tools available to the session.
+    /// - `Some(vec![])` → agent may use **no** tools.
+    /// - `Some(vec!["web_search"])` → agent may only use `web_search`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_filter: Option<Vec<String>>,
+}
+
+// ─── council-level config ────────────────────────────────────────────────────
+
+/// Full configuration for a council deliberation run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CouncilConfig {
+    /// The agents that will participate in the debate.
+    pub agents: Vec<CouncilAgent>,
+
+    /// The user's question or topic that the council will deliberate on.
+    pub topic: String,
+
+    /// Number of debate rounds before synthesis.
+    pub rounds: u32,
+
+    /// Optional guidance injected into the synthesis prompt to steer the
+    /// final answer's focus (e.g. "prioritise actionable recommendations").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthesis_guidance: Option<String>,
+}
+
+// ─── suggested council (returned by /api/council/suggest) ────────────────────
+
+/// The LLM's suggested council composition, returned from the designer
+/// endpoint.  Every field is user-editable before the run begins.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestedCouncil {
+    /// Suggested agents.
+    pub agents: Vec<CouncilAgent>,
+
+    /// Suggested number of debate rounds.
+    pub rounds: u32,
+
+    /// Suggested synthesis guidance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthesis_guidance: Option<String>,
+}
+
+// ─── validation ──────────────────────────────────────────────────────────────
+
+/// Clamp `contentiousness` into `[0.0, 1.0]`.
+#[must_use]
+pub const fn clamp_contentiousness(value: f32) -> f32 {
+    if value < 0.0 {
+        0.0
+    } else if value > 1.0 {
+        1.0
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_within_range() {
+        assert!((clamp_contentiousness(0.5) - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn clamp_below_zero() {
+        assert!((clamp_contentiousness(-0.3) - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn clamp_above_one() {
+        assert!((clamp_contentiousness(1.7) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn round_trip_council_agent_json() {
+        let agent = CouncilAgent {
+            id: "skeptic-1".into(),
+            name: "Skeptic".into(),
+            color: "#ef4444".into(),
+            persona: "A rigorous critic who demands evidence.".into(),
+            perspective: "Challenges assumptions.".into(),
+            contentiousness: 0.8,
+            tool_filter: Some(vec!["web_search".into()]),
+        };
+        let json = serde_json::to_string(&agent).unwrap();
+        let back: CouncilAgent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, "skeptic-1");
+        assert!((back.contentiousness - 0.8).abs() < f32::EPSILON);
+        assert_eq!(back.tool_filter.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn council_agent_without_tool_filter() {
+        let json = r##"{
+            "id": "a",
+            "name": "A",
+            "color": "#000",
+            "persona": "p",
+            "perspective": "v",
+            "contentiousness": 0.5
+        }"##;
+        let agent: CouncilAgent = serde_json::from_str(json).unwrap();
+        assert!(agent.tool_filter.is_none());
+    }
+}

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -1,0 +1,206 @@
+//! SSE event types emitted during a council deliberation run.
+//!
+//! `CouncilEvent` is the **single source of truth** for the wire format
+//! shared by the Axum SSE handler, the CLI consumer, and the TypeScript
+//! frontend types (`src/types/council.ts`).
+//!
+//! Serialisation uses the same `{"type":"variant_name", ...}` envelope as
+//! [`gglib_core::AgentEvent`] so frontend event handlers stay consistent.
+
+use serde::{Deserialize, Serialize};
+
+use gglib_core::{ToolCall, ToolResult};
+
+/// Channel capacity for the council event sender.
+///
+/// Larger than the per-agent channel because council events include
+/// contributions from multiple agents plus orchestration bookkeeping.
+pub const COUNCIL_EVENT_CHANNEL_CAPACITY: usize = 8_192;
+
+/// A single event in a council deliberation stream.
+///
+/// Consumers receive these over SSE (web) or an `mpsc` channel (CLI).
+/// Each variant is independently useful — the frontend can render
+/// progressively as events arrive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CouncilEvent {
+    // ── agent turn lifecycle ─────────────────────────────────────────────
+    /// An agent is about to speak.  The frontend creates a new message
+    /// bubble with the agent's name, colour and round badge.
+    AgentTurnStart {
+        agent_id: String,
+        agent_name: String,
+        color: String,
+        round: u32,
+        contentiousness: f32,
+    },
+
+    /// Incremental text token from the current agent's response.
+    AgentTextDelta { agent_id: String, delta: String },
+
+    /// Incremental reasoning/thinking token (for models that expose `CoT`).
+    AgentReasoningDelta { agent_id: String, delta: String },
+
+    /// The current agent has started a tool call.
+    AgentToolCallStart {
+        agent_id: String,
+        tool_call: ToolCall,
+        display_name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        args_summary: Option<String>,
+    },
+
+    /// A tool call by the current agent has completed.
+    AgentToolCallComplete {
+        agent_id: String,
+        tool_name: String,
+        result: ToolResult,
+        display_name: String,
+        duration_display: String,
+    },
+
+    /// The current agent's turn is finished.
+    ///
+    /// `core_claim` is extracted from a `CORE CLAIM: ...` marker in the
+    /// response.  If the model omitted the marker, this is `None` — which
+    /// is perfectly normal and does not constitute an error.
+    AgentTurnComplete {
+        agent_id: String,
+        content: String,
+        round: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        core_claim: Option<String>,
+    },
+
+    // ── round bookkeeping ────────────────────────────────────────────────
+    /// Emitted between rounds.  The frontend renders a plain "Round N"
+    /// divider — no gradient, no tension metric (v1).
+    RoundSeparator { round: u32 },
+
+    // ── synthesis ────────────────────────────────────────────────────────
+    /// The synthesis phase has begun.
+    SynthesisStart,
+
+    /// Incremental text token from the synthesis.
+    SynthesisTextDelta { delta: String },
+
+    /// The synthesis is complete.
+    SynthesisComplete { content: String },
+
+    // ── terminal ─────────────────────────────────────────────────────────
+    /// An unrecoverable error during the council run.
+    CouncilError { message: String },
+
+    /// The entire council run has finished (all rounds + synthesis).
+    CouncilComplete,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_agent_turn_start() {
+        let event = CouncilEvent::AgentTurnStart {
+            agent_id: "s1".into(),
+            agent_name: "Skeptic".into(),
+            color: "#ef4444".into(),
+            round: 1,
+            contentiousness: 0.8,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "agent_turn_start");
+        assert_eq!(json["agent_name"], "Skeptic");
+        assert_eq!(json["round"], 1);
+    }
+
+    #[test]
+    fn serialize_agent_turn_complete_with_core_claim() {
+        let event = CouncilEvent::AgentTurnComplete {
+            agent_id: "s1".into(),
+            content: "Full response text.".into(),
+            round: 1,
+            core_claim: Some("Microservices are overkill.".into()),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "agent_turn_complete");
+        assert_eq!(json["core_claim"], "Microservices are overkill.");
+    }
+
+    #[test]
+    fn serialize_agent_turn_complete_without_core_claim() {
+        let event = CouncilEvent::AgentTurnComplete {
+            agent_id: "s1".into(),
+            content: "No marker in response.".into(),
+            round: 2,
+            core_claim: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "agent_turn_complete");
+        assert!(json.get("core_claim").is_none());
+    }
+
+    #[test]
+    fn serialize_round_separator() {
+        let event = CouncilEvent::RoundSeparator { round: 2 };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "round_separator");
+        assert_eq!(json["round"], 2);
+    }
+
+    #[test]
+    fn serialize_synthesis_complete() {
+        let event = CouncilEvent::SynthesisComplete {
+            content: "Final synthesis.".into(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "synthesis_complete");
+    }
+
+    #[test]
+    fn serialize_council_complete() {
+        let json = serde_json::to_value(&CouncilEvent::CouncilComplete).unwrap();
+        assert_eq!(json["type"], "council_complete");
+    }
+
+    #[test]
+    fn round_trip_all_variants() {
+        let events = vec![
+            CouncilEvent::AgentTurnStart {
+                agent_id: "a".into(),
+                agent_name: "A".into(),
+                color: "#000".into(),
+                round: 1,
+                contentiousness: 0.5,
+            },
+            CouncilEvent::AgentTextDelta {
+                agent_id: "a".into(),
+                delta: "hello".into(),
+            },
+            CouncilEvent::AgentReasoningDelta {
+                agent_id: "a".into(),
+                delta: "thinking...".into(),
+            },
+            CouncilEvent::RoundSeparator { round: 1 },
+            CouncilEvent::SynthesisStart,
+            CouncilEvent::SynthesisTextDelta {
+                delta: "synth".into(),
+            },
+            CouncilEvent::SynthesisComplete {
+                content: "done".into(),
+            },
+            CouncilEvent::CouncilError {
+                message: "oops".into(),
+            },
+            CouncilEvent::CouncilComplete,
+        ];
+        for event in &events {
+            let json = serde_json::to_string(event).unwrap();
+            let back: CouncilEvent = serde_json::from_str(&json).unwrap();
+            // Verify the round-trip doesn't panic; structural equality
+            // is covered by the per-variant tests above.
+            let _ = format!("{back:?}");
+        }
+    }
+}

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -1,0 +1,243 @@
+//! Per-agent context assembly for council debate turns.
+//!
+//! Builds the full `Vec<AgentMessage>` for a single agent turn by:
+//!
+//! 1. Constructing a system prompt with identity anchoring (agent name,
+//!    persona, contentiousness instruction — re-injected every turn).
+//! 2. Formatting the debate transcript from prior rounds as a labelled
+//!    `[Agent Name]: content` block.
+//! 3. Appending round-phase suffixes (debate-history cue, final-round cue).
+//! 4. Wrapping the topic as a `User` message.
+
+use gglib_core::AgentMessage;
+
+use super::config::CouncilAgent;
+use super::prompts::{
+    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX,
+    contentiousness_to_instruction,
+};
+use super::state::CouncilState;
+
+/// Build the message list for a single agent's turn in the council debate.
+///
+/// Returns `[System(prompt), User(topic)]` — a two-message conversation
+/// that the `AgentLoop` will extend with tool calls and responses during
+/// its own run.
+///
+/// # Arguments
+///
+/// - `agent` — the agent about to speak.
+/// - `topic` — the user's original question/topic.
+/// - `round` — zero-indexed current round.
+/// - `total_rounds` — total debate rounds (used for final-round detection).
+/// - `state` — accumulated contributions from prior turns/rounds.
+#[must_use]
+pub fn build_agent_messages(
+    agent: &CouncilAgent,
+    topic: &str,
+    round: u32,
+    total_rounds: u32,
+    state: &CouncilState,
+) -> Vec<AgentMessage> {
+    let system_prompt = build_agent_system_prompt(agent, topic, round, total_rounds, state);
+    vec![
+        AgentMessage::System {
+            content: system_prompt,
+        },
+        AgentMessage::User {
+            content: topic.to_owned(),
+        },
+    ]
+}
+
+/// Assemble the full system prompt for a single agent turn.
+///
+/// This is separated from [`build_agent_messages`] for testability.
+#[must_use]
+pub fn build_agent_system_prompt(
+    agent: &CouncilAgent,
+    topic: &str,
+    round: u32,
+    total_rounds: u32,
+    state: &CouncilState,
+) -> String {
+    let instruction = contentiousness_to_instruction(agent.contentiousness);
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let mut prompt = AGENT_TURN_SYSTEM_PROMPT
+        .replace("{agent_name}", &agent.name)
+        .replace("{agent_persona}", &agent.persona)
+        .replace("{topic}", topic)
+        .replace("{perspective}", &agent.perspective)
+        .replace("{contentiousness_instruction}", instruction);
+
+    // Inject debate history from prior rounds.
+    if round > 0 {
+        let transcript = format_transcript(state, round);
+        if !transcript.is_empty() {
+            prompt.push_str("\n\nDEBATE HISTORY:\n");
+            prompt.push_str(&transcript);
+            prompt.push_str(DEBATE_HISTORY_SUFFIX);
+        }
+    }
+
+    // Final-round cue.
+    let is_final = total_rounds > 0 && round == total_rounds - 1;
+    if is_final {
+        prompt.push_str(FINAL_ROUND_SUFFIX);
+    }
+
+    prompt
+}
+
+/// Format prior contributions as a labelled transcript block.
+///
+/// Output format:
+/// ```text
+/// === Round 1 ===
+/// [Skeptic]: Their argument text...
+/// [Pragmatist]: Their argument text...
+/// === Round 2 ===
+/// ...
+/// ```
+///
+/// Only includes rounds `0..round` (exclusive of the current round).
+#[must_use]
+fn format_transcript(state: &CouncilState, up_to_round: u32) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for r in 0..up_to_round {
+        let contributions = state.contributions_for_round(r);
+        if contributions.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "=== Round {} ===", r + 1);
+        for c in &contributions {
+            let _ = writeln!(out, "[{}]: {}", c.agent.name, c.content);
+        }
+    }
+    out
+}
+
+/// Format the full transcript for the synthesis prompt (all rounds).
+///
+/// Similar to [`format_transcript`] but includes agent perspectives and
+/// covers all completed rounds.
+#[must_use]
+pub fn format_synthesis_transcript(state: &CouncilState) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for (round, contributions) in state.rounds_with_contributions() {
+        let _ = writeln!(out, "=== Round {} ===", round + 1);
+        for c in &contributions {
+            let _ = writeln!(
+                out,
+                "[{} ({})]: {}",
+                c.agent.name, c.agent.perspective, c.content
+            );
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::council::config::CouncilAgent;
+    use crate::council::state::AgentContribution;
+
+    fn agent(id: &str, name: &str, contentiousness: f32) -> CouncilAgent {
+        CouncilAgent {
+            id: id.into(),
+            name: name.into(),
+            color: "#000".into(),
+            persona: format!("{name} is a test agent."),
+            perspective: format!("{name}'s angle"),
+            contentiousness,
+            tool_filter: None,
+        }
+    }
+
+    #[test]
+    fn round_0_no_history() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Test topic", 0, 3, &state);
+
+        assert!(prompt.contains("You are Skeptic."));
+        assert!(prompt.contains("Skeptic is a test agent."));
+        assert!(prompt.contains("rigorous critic"));
+        assert!(!prompt.contains("DEBATE HISTORY"));
+        assert!(!prompt.contains("FINAL ROUND"));
+    }
+
+    #[test]
+    fn round_1_includes_history() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "I disagree strongly.".into(),
+            core_claim: Some("Bad idea.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Let's find middle ground.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.advance_round();
+
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Test topic", 1, 3, &state);
+
+        assert!(prompt.contains("DEBATE HISTORY:"));
+        assert!(prompt.contains("=== Round 1 ==="));
+        assert!(prompt.contains("[Skeptic]: I disagree strongly."));
+        assert!(prompt.contains("[Pragmatist]: Let's find middle ground."));
+        assert!(prompt.contains("Respond to the strongest counterarguments"));
+        assert!(!prompt.contains("FINAL ROUND"));
+    }
+
+    #[test]
+    fn final_round_suffix_appended() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        assert!(prompt.contains("FINAL ROUND"));
+    }
+
+    #[test]
+    fn single_round_is_also_final() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 0, 1, &state);
+        assert!(prompt.contains("FINAL ROUND"));
+    }
+
+    #[test]
+    fn build_agent_messages_structure() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let msgs = build_agent_messages(&a, "My topic", 0, 2, &state);
+
+        assert_eq!(msgs.len(), 2);
+        assert!(
+            matches!(&msgs[0], AgentMessage::System { content } if content.contains("Skeptic"))
+        );
+        assert!(matches!(&msgs[1], AgentMessage::User { content } if content == "My topic"));
+    }
+
+    #[test]
+    fn synthesis_transcript_includes_perspectives() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Bad idea.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        let transcript = format_synthesis_transcript(&state);
+        assert!(transcript.contains("[Skeptic (Skeptic's angle)]: Bad idea."));
+    }
+}

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -1,0 +1,33 @@
+//! Council of Agents — multi-agent deliberation with structured debate.
+//!
+//! This module orchestrates multiple LLM-backed agents through rounds of
+//! debate on a user's topic, then produces a synthesised answer.  Each
+//! agent runs via the existing [`AgentLoop`](crate::AgentLoop) — this
+//! module adds orchestration, not a new loop implementation.
+//!
+//! # Module layout
+//!
+//! | File              | Responsibility                                      |
+//! |-------------------|-----------------------------------------------------|
+//! | `config.rs`       | `CouncilConfig`, `CouncilAgent`, `SuggestedCouncil` |
+//! | `events.rs`       | `CouncilEvent` SSE enum (wire format)               |
+//! | `prompts.rs`      | Prompt templates + contentiousness mapping          |
+//! | `state.rs`        | Round/contribution accumulator                      |
+//! | `history.rs`      | Per-turn context builder (identity + transcript)    |
+//! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
+//! | `orchestrator.rs` | Round×agent loop driver + synthesis dispatch         |
+
+pub mod config;
+pub mod events;
+pub mod history;
+pub mod orchestrator;
+pub mod prompts;
+pub mod state;
+pub mod stream_bridge;
+
+pub use config::{CouncilAgent, CouncilConfig, SuggestedCouncil};
+pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
+pub use orchestrator::run as run_council;
+pub use prompts::{contentiousness_tier_label, contentiousness_to_instruction};
+pub use state::{AgentContribution, CouncilState, extract_core_claim};
+pub use stream_bridge::{bridge_agent_events, emit_turn_complete};

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,0 +1,240 @@
+//! Round×agent orchestration loop for a council deliberation.
+//!
+//! ```text
+//! CouncilOrchestrator::run()
+//!   │
+//!   ├─ for each round 0..N
+//!   │   ├─ emit RoundSeparator (round > 0)
+//!   │   └─ for each agent
+//!   │       ├─ emit AgentTurnStart
+//!   │       ├─ build_agent_messages()          (history.rs)
+//!   │       ├─ AgentLoop::run()                (delegated, stagnation+loop guards active)
+//!   │       ├─ bridge_agent_events()           (stream_bridge.rs)
+//!   │       ├─ emit AgentTurnComplete          (with core claim extraction)
+//!   │       └─ state.push(contribution)
+//!   │
+//!   ├─ emit SynthesisStart
+//!   ├─ AgentLoop::run() with synthesis prompt
+//!   ├─ bridge synthesis events
+//!   ├─ emit SynthesisComplete
+//!   └─ emit CouncilComplete
+//! ```
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::CouncilConfig;
+use super::events::CouncilEvent;
+use super::history::{build_agent_messages, format_synthesis_transcript};
+use super::prompts::SYNTHESIS_PROMPT;
+use super::state::{AgentContribution, CouncilState, extract_core_claim};
+use super::stream_bridge::{bridge_agent_events, emit_turn_complete};
+
+/// Runs a full council deliberation: rounds → agent turns → synthesis.
+///
+/// This function is the only public entry point.  It owns the round×agent
+/// loop and delegates each agent turn to an [`AgentLoop`] via the existing
+/// port traits.  The caller provides a `council_tx` to receive streamed
+/// [`CouncilEvent`]s.
+///
+/// # Errors
+///
+/// Individual agent errors (stagnation, loop detection, max iterations) are
+/// handled gracefully — the contribution is recorded as-is and the council
+/// proceeds.  Only infrastructure-level failures (channel closure) cause an
+/// early return.
+pub async fn run(
+    config: CouncilConfig,
+    agent_config: AgentConfig,
+    llm: Arc<dyn LlmCompletionPort>,
+    tool_executor: Arc<dyn ToolExecutorPort>,
+    council_tx: mpsc::Sender<CouncilEvent>,
+) {
+    let mut state = CouncilState::new();
+
+    // ── debate rounds ────────────────────────────────────────────────────
+    for round in 0..config.rounds {
+        if round > 0 {
+            if send(&council_tx, CouncilEvent::RoundSeparator { round })
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+
+        for agent in &config.agents {
+            // Announce the turn.
+            let start = CouncilEvent::AgentTurnStart {
+                agent_id: agent.id.clone(),
+                agent_name: agent.name.clone(),
+                color: agent.color.clone(),
+                round,
+                contentiousness: agent.contentiousness,
+            };
+            if send(&council_tx, start).await.is_err() {
+                return;
+            }
+
+            // Build per-agent tool filter.
+            let filter = agent
+                .tool_filter
+                .as_ref()
+                .map(|names| names.iter().cloned().collect::<HashSet<String>>());
+
+            // Build the agent loop with per-agent tool restrictions.
+            let agent_loop = AgentLoop::build(Arc::clone(&llm), Arc::clone(&tool_executor), filter);
+
+            // Assemble context with identity anchoring + debate transcript.
+            let messages = build_agent_messages(agent, &config.topic, round, config.rounds, &state);
+
+            // Delegate to AgentLoop — stagnation + loop guards are active
+            // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).
+            let (agent_tx, agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+            let loop_handle = {
+                let agent_loop = Arc::clone(&agent_loop);
+                let cfg = agent_config.clone();
+                tokio::spawn(async move { agent_loop.run(messages, cfg, agent_tx).await })
+            };
+
+            // Bridge events from agent → council stream.
+            let answer = bridge_agent_events(agent, round, agent_rx, &council_tx).await;
+
+            // Await the agent loop completion (the channel is already drained).
+            match loop_handle.await {
+                Ok(Ok(_output)) => {
+                    debug!(agent_id = %agent.id, round, "agent turn completed normally");
+                }
+                Ok(Err(e)) => {
+                    // Stagnation, loop detection, max iterations — all graceful.
+                    warn!(agent_id = %agent.id, round, error = %e, "agent turn ended early");
+                }
+                Err(e) => {
+                    warn!(agent_id = %agent.id, round, error = %e, "agent task panicked");
+                }
+            }
+
+            // Record the contribution (use whatever content we got).
+            let content = answer.unwrap_or_default();
+            let core_claim = extract_core_claim(&content);
+            emit_turn_complete(agent, round, &content, &council_tx).await;
+
+            state.push(AgentContribution {
+                agent: agent.clone(),
+                content,
+                core_claim,
+                round,
+            });
+        }
+
+        state.advance_round();
+    }
+
+    // ── synthesis ────────────────────────────────────────────────────────
+    run_synthesis(&config, agent_config, &llm, &tool_executor, &state, &council_tx).await;
+}
+
+/// Synthesis pass: build the transcript, run a single-iteration agent loop,
+/// and emit `SynthesisStart` / `SynthesisTextDelta` / `SynthesisComplete` /
+/// `CouncilComplete`.
+async fn run_synthesis(
+    config: &CouncilConfig,
+    agent_config: AgentConfig,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    state: &CouncilState,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+) {
+    if send(council_tx, CouncilEvent::SynthesisStart)
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let transcript = format_synthesis_transcript(state);
+    let guidance = config
+        .synthesis_guidance
+        .as_deref()
+        .unwrap_or("Provide an actionable synthesis.");
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let synthesis_prompt = SYNTHESIS_PROMPT
+        .replace("{agent_count}", &config.agents.len().to_string())
+        .replace("{topic}", &config.topic)
+        .replace("{transcript}", &transcript)
+        .replace("{synthesis_guidance}", guidance);
+
+    let synth_messages = vec![
+        AgentMessage::System {
+            content: synthesis_prompt,
+        },
+        AgentMessage::User {
+            content: config.topic.clone(),
+        },
+    ];
+
+    let synth_loop = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), None);
+    let (synth_agent_tx, synth_agent_rx) =
+        mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    // Synthesis uses a restricted config — no tools needed, single iteration.
+    let mut synth_config = agent_config;
+    synth_config.max_iterations = 1;
+
+    let synth_handle = {
+        let synth_loop = Arc::clone(&synth_loop);
+        tokio::spawn(async move {
+            synth_loop
+                .run(synth_messages, synth_config, synth_agent_tx)
+                .await
+        })
+    };
+
+    // Bridge synthesis events — map TextDelta → SynthesisTextDelta.
+    let synth_content = bridge_synthesis_events(synth_agent_rx, council_tx).await;
+
+    let _ = synth_handle.await;
+
+    let content = synth_content.unwrap_or_default();
+    let _ = send(council_tx, CouncilEvent::SynthesisComplete { content }).await;
+    let _ = send(council_tx, CouncilEvent::CouncilComplete).await;
+}
+
+/// Bridge synthesis-phase events (only text deltas are relevant).
+async fn bridge_synthesis_events(
+    mut rx: mpsc::Receiver<AgentEvent>,
+    tx: &mpsc::Sender<CouncilEvent>,
+) -> Option<String> {
+    let mut content: Option<String> = None;
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::TextDelta { content: delta } => {
+                let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
+            }
+            AgentEvent::FinalAnswer { content: answer } => {
+                content = Some(answer);
+            }
+            _ => {}
+        }
+    }
+    content
+}
+
+/// Best-effort send helper — returns `Err` when the receiver is gone.
+async fn send(
+    tx: &mpsc::Sender<CouncilEvent>,
+    event: CouncilEvent,
+) -> Result<(), mpsc::error::SendError<CouncilEvent>> {
+    tx.send(event).await
+}

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -141,7 +141,15 @@ pub async fn run(
     }
 
     // ── synthesis ────────────────────────────────────────────────────────
-    run_synthesis(&config, agent_config, &llm, &tool_executor, &state, &council_tx).await;
+    run_synthesis(
+        &config,
+        agent_config,
+        &llm,
+        &tool_executor,
+        &state,
+        &council_tx,
+    )
+    .await;
 }
 
 /// Synthesis pass: build the transcript, run a single-iteration agent loop,

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -1,0 +1,205 @@
+//! Prompt templates and contentiousness mapping for council deliberations.
+//!
+//! All prompts are plain string constants with `{placeholder}` markers that
+//! callers fill via [`format!`].  The contentiousness float is mapped to a
+//! discrete behavioural instruction via [`contentiousness_to_instruction`] so
+//! that small models receive an unambiguous directive rather than a raw number.
+//!
+//! # Research references
+//!
+//! - `SocraSynth` (Stanford) — contentiousness parameter, Socratic method
+//! - MAD / Multi-Agent Debate — structured debate topologies
+//! - UT Austin — explicit stance-forcing to prevent summarisation collapse
+//! - Debate-to-Write — persona → debate → synthesis pipeline
+
+// ─── council designer ────────────────────────────────────────────────────────
+
+/// System prompt for the `/api/council/suggest` endpoint.
+///
+/// Placeholders: `{agent_count}`, `{user_topic}`.
+pub const COUNCIL_DESIGNER_PROMPT: &str = "\
+You are a council architect. Given a user's question or topic, design a council \
+of {agent_count} agents who will deliberate on it from diverse perspectives.
+
+For each agent, provide:
+- name: A concise role title (e.g., \"Devil's Advocate\", \"Domain Expert\", \"Pragmatist\")
+- persona: 2-3 sentences defining their worldview, expertise, and argumentative style
+- contentiousness: A number 0.0-1.0 (0.0 = fully collaborative, 1.0 = maximally adversarial)
+- perspective: One sentence describing what unique angle they bring
+
+Rules:
+- Agents MUST have genuinely different perspectives, not just different phrasings of agreement
+- At least one agent should be skeptical/adversarial (contentiousness >= 0.7)
+- At least one agent should be constructive/solution-oriented (contentiousness <= 0.4)
+- Personas should be specific enough that a small language model can consistently role-play them
+
+Also suggest:
+- rounds: How many debate rounds (typically 2-4; more for complex/controversial topics)
+- synthesis_guidance: A brief note on what the final synthesis should prioritize
+
+Respond in JSON: {{ \"agents\": [...], \"rounds\": N, \"synthesis_guidance\": \"...\" }}
+
+Topic: \"{user_topic}\"";
+
+// ─── agent turn ──────────────────────────────────────────────────────────────
+
+/// System prompt injected at the start of every agent turn.
+///
+/// Placeholders: `{agent_name}`, `{agent_persona}`, `{topic}`,
+/// `{perspective}`, `{contentiousness}`, `{contentiousness_instruction}`.
+///
+/// The debate history and final-round blocks are appended separately by
+/// [`crate::council::history::build_agent_system_prompt`].
+pub const AGENT_TURN_SYSTEM_PROMPT: &str = "\
+You are {agent_name}. {agent_persona}
+
+IDENTITY: You are participating in a structured council debate on the topic: \"{topic}\"
+YOUR ROLE: {agent_name} — {perspective}
+{contentiousness_instruction}
+
+RULES:
+- You MUST take a clear position consistent with your role. Do NOT summarize or present \"both sides.\"
+- Reference and respond to specific points from other agents when relevant.
+- If you have access to tools (web search, etc.), use them to find evidence supporting your position.
+- Be concise and substantive. Avoid filler and repetition.
+- If you genuinely cannot form a position on some aspect, say \"I lack sufficient information on [X]\" rather than guessing.
+- End your response with a single-sentence summary of your core claim on its own line, \
+prefixed with \"CORE CLAIM:\" (e.g., \"CORE CLAIM: Microservices add more operational cost \
+than they save for teams under 20 engineers.\"). If you cannot form a single claim, omit this line.";
+
+/// Appended to the system prompt when the agent has prior rounds to respond to.
+pub const DEBATE_HISTORY_SUFFIX: &str = "\n\n\
+Respond to the strongest counterarguments from previous rounds. \
+Strengthen, revise, or concede specific points.";
+
+/// Appended to the system prompt in the last debate round.
+pub const FINAL_ROUND_SUFFIX: &str = "\n\n\
+FINAL ROUND: This is the last debate round. Make your strongest, most refined argument. \
+Acknowledge valid points from others where appropriate, but maintain your position unless \
+genuinely convinced otherwise.";
+
+// ─── synthesis ───────────────────────────────────────────────────────────────
+
+/// System prompt for the post-debate synthesis pass.
+///
+/// Placeholders: `{agent_count}`, `{topic}`, `{transcript}`,
+/// `{synthesis_guidance}`.
+pub const SYNTHESIS_PROMPT: &str = "\
+You are the Council Synthesizer. You have observed a structured debate between \
+{agent_count} agents on the topic: \"{topic}\"
+
+Your task: Produce a comprehensive, balanced synthesis that:
+1. Identifies the key points of agreement across agents
+2. Maps the genuine disagreements and their strongest arguments on each side
+3. Highlights evidence or reasoning that was particularly compelling
+4. Provides a clear, actionable conclusion or recommendation
+5. Notes any unresolved questions or areas needing further investigation
+
+FULL DEBATE TRANSCRIPT:
+{transcript}
+
+{synthesis_guidance}
+
+Write the synthesis as a well-structured response. Do NOT simply list each agent's position. \
+Integrate and analyze the arguments to produce a genuinely higher-quality answer than any \
+single agent could provide alone.";
+
+// ─── contentiousness mapping ─────────────────────────────────────────────────
+
+/// Map a contentiousness float to a discrete behavioural instruction string.
+///
+/// Small models cannot interpret a raw float like `0.7`.  This function maps
+/// the `[0.0, 1.0]` range into one of five instruction tiers that give the
+/// model an unambiguous behavioural directive.
+#[must_use]
+pub fn contentiousness_to_instruction(value: f32) -> &'static str {
+    match value {
+        v if v < 0.2 => {
+            "You are highly collaborative. Build on others' ideas. \
+             Seek common ground. Only disagree when you have strong evidence."
+        }
+        v if v < 0.4 => {
+            "You are constructive but independent. Offer your own perspective. \
+             Agree when warranted, but push back on weak reasoning."
+        }
+        v if v < 0.6 => {
+            "You are balanced. Evaluate each argument on its merits. \
+             Challenge unsupported claims. Credit strong points from others."
+        }
+        v if v < 0.8 => {
+            "You are a rigorous critic. Actively look for flaws, assumptions, \
+             and gaps in others' arguments. Demand evidence for claims."
+        }
+        _ => {
+            "You are a devil's advocate. Systematically challenge every argument. \
+             Assume the opposing position. Force others to defend their reasoning \
+             under pressure."
+        }
+    }
+}
+
+/// Return the human-readable tier label for a contentiousness value.
+///
+/// Useful for UI display alongside the slider.
+#[must_use]
+pub fn contentiousness_tier_label(value: f32) -> &'static str {
+    match value {
+        v if v < 0.2 => "Collaborative",
+        v if v < 0.4 => "Constructive",
+        v if v < 0.6 => "Balanced",
+        v if v < 0.8 => "Adversarial",
+        _ => "Devil's Advocate",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contentiousness_boundaries() {
+        assert!(contentiousness_to_instruction(0.0).contains("collaborative"));
+        assert!(contentiousness_to_instruction(0.19).contains("collaborative"));
+        assert!(contentiousness_to_instruction(0.2).contains("constructive"));
+        assert!(contentiousness_to_instruction(0.4).contains("balanced"));
+        assert!(contentiousness_to_instruction(0.6).contains("rigorous critic"));
+        assert!(contentiousness_to_instruction(0.8).contains("devil's advocate"));
+        assert!(contentiousness_to_instruction(1.0).contains("devil's advocate"));
+    }
+
+    #[test]
+    fn tier_labels() {
+        assert_eq!(contentiousness_tier_label(0.0), "Collaborative");
+        assert_eq!(contentiousness_tier_label(0.3), "Constructive");
+        assert_eq!(contentiousness_tier_label(0.5), "Balanced");
+        assert_eq!(contentiousness_tier_label(0.7), "Adversarial");
+        assert_eq!(contentiousness_tier_label(0.9), "Devil's Advocate");
+    }
+
+    #[test]
+    fn designer_prompt_has_placeholders() {
+        assert!(COUNCIL_DESIGNER_PROMPT.contains("{agent_count}"));
+        assert!(COUNCIL_DESIGNER_PROMPT.contains("{user_topic}"));
+    }
+
+    #[test]
+    fn agent_turn_prompt_has_placeholders() {
+        assert!(AGENT_TURN_SYSTEM_PROMPT.contains("{agent_name}"));
+        assert!(AGENT_TURN_SYSTEM_PROMPT.contains("{agent_persona}"));
+        assert!(AGENT_TURN_SYSTEM_PROMPT.contains("{topic}"));
+        assert!(AGENT_TURN_SYSTEM_PROMPT.contains("{contentiousness_instruction}"));
+    }
+
+    #[test]
+    fn synthesis_prompt_has_placeholders() {
+        assert!(SYNTHESIS_PROMPT.contains("{agent_count}"));
+        assert!(SYNTHESIS_PROMPT.contains("{topic}"));
+        assert!(SYNTHESIS_PROMPT.contains("{transcript}"));
+        assert!(SYNTHESIS_PROMPT.contains("{synthesis_guidance}"));
+    }
+
+    #[test]
+    fn negative_contentiousness_treated_as_collaborative() {
+        assert!(contentiousness_to_instruction(-0.5).contains("collaborative"));
+    }
+}

--- a/crates/gglib-agent/src/council/state.rs
+++ b/crates/gglib-agent/src/council/state.rs
@@ -1,0 +1,220 @@
+//! Round and contribution state for a running council deliberation.
+//!
+//! [`CouncilState`] accumulates agent contributions as they complete,
+//! organised by round.  It is the single mutable data structure that the
+//! orchestrator writes to and that [`crate::council::history`] reads from
+//! when assembling per-agent context.
+
+use super::config::CouncilAgent;
+
+// ─── contribution ────────────────────────────────────────────────────────────
+
+/// A completed agent contribution within a single round.
+#[derive(Debug, Clone)]
+pub struct AgentContribution {
+    /// Agent metadata snapshot (id, name, perspective, etc.).
+    pub agent: CouncilAgent,
+    /// The full text produced by the agent during this turn.
+    pub content: String,
+    /// Extracted core claim, or `None` if the model omitted the marker.
+    pub core_claim: Option<String>,
+    /// Zero-indexed round number.
+    pub round: u32,
+}
+
+// ─── core claim extraction ───────────────────────────────────────────────────
+
+/// Marker prefix that agents are instructed to include in their response.
+const CORE_CLAIM_PREFIX: &str = "CORE CLAIM:";
+
+/// Fault-tolerant extraction of a `CORE CLAIM: ...` line from a response.
+///
+/// Scans from the **end** of the text (the prompt asks agents to place the
+/// claim at the bottom).  Returns `None` without error if the marker is
+/// absent — this is expected behaviour for small models that may ignore
+/// formatting instructions.
+#[must_use]
+pub fn extract_core_claim(content: &str) -> Option<String> {
+    content
+        .lines()
+        .rev()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix(CORE_CLAIM_PREFIX)
+                .map(|rest| rest.trim().to_owned())
+        })
+        .filter(|s| !s.is_empty())
+}
+
+// ─── state ───────────────────────────────────────────────────────────────────
+
+/// Accumulates contributions for an in-progress council run.
+///
+/// Written to by the orchestrator after each agent turn completes.
+/// Read by the history module to assemble transcript context.
+#[derive(Debug, Default)]
+pub struct CouncilState {
+    /// All contributions, in insertion order.
+    contributions: Vec<AgentContribution>,
+    /// Current round (zero-indexed).
+    current_round: u32,
+}
+
+impl CouncilState {
+    /// Create a new, empty state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a completed agent turn.
+    pub fn push(&mut self, contribution: AgentContribution) {
+        self.contributions.push(contribution);
+    }
+
+    /// Advance to the next round.
+    pub const fn advance_round(&mut self) {
+        self.current_round += 1;
+    }
+
+    /// Current round number (zero-indexed).
+    #[must_use]
+    pub const fn current_round(&self) -> u32 {
+        self.current_round
+    }
+
+    /// All contributions across all rounds, in insertion order.
+    #[must_use]
+    pub fn all_contributions(&self) -> &[AgentContribution] {
+        &self.contributions
+    }
+
+    /// Contributions for a specific round.
+    #[must_use]
+    pub fn contributions_for_round(&self, round: u32) -> Vec<&AgentContribution> {
+        self.contributions
+            .iter()
+            .filter(|c| c.round == round)
+            .collect()
+    }
+
+    /// All completed rounds (each round is a `Vec` of contributions).
+    ///
+    /// Rounds are returned in order `0..=current_round` but only those
+    /// that actually have at least one contribution.
+    #[must_use]
+    pub fn rounds_with_contributions(&self) -> Vec<(u32, Vec<&AgentContribution>)> {
+        let max = self
+            .contributions
+            .iter()
+            .map(|c| c.round)
+            .max()
+            .unwrap_or(0);
+        (0..=max)
+            .map(|r| (r, self.contributions_for_round(r)))
+            .filter(|(_, cs)| !cs.is_empty())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::council::config::CouncilAgent;
+
+    fn test_agent(id: &str) -> CouncilAgent {
+        CouncilAgent {
+            id: id.into(),
+            name: id.into(),
+            color: "#000".into(),
+            persona: "p".into(),
+            perspective: "v".into(),
+            contentiousness: 0.5,
+            tool_filter: None,
+        }
+    }
+
+    // ── extract_core_claim ───────────────────────────────────────────────
+
+    #[test]
+    fn extract_claim_at_end() {
+        let text = "Some argument.\nCORE CLAIM: Monoliths scale better.";
+        assert_eq!(
+            extract_core_claim(text).as_deref(),
+            Some("Monoliths scale better.")
+        );
+    }
+
+    #[test]
+    fn extract_claim_with_surrounding_whitespace() {
+        let text = "Argument.\n  CORE CLAIM:   Spaced claim.  \n";
+        assert_eq!(extract_core_claim(text).as_deref(), Some("Spaced claim."));
+    }
+
+    #[test]
+    fn missing_claim_returns_none() {
+        let text = "Just a regular response with no marker.";
+        assert!(extract_core_claim(text).is_none());
+    }
+
+    #[test]
+    fn empty_claim_returns_none() {
+        let text = "Text.\nCORE CLAIM:   \n";
+        assert!(extract_core_claim(text).is_none());
+    }
+
+    #[test]
+    fn claim_in_middle_still_found() {
+        let text = "Intro.\nCORE CLAIM: Middle claim.\nPost-text.";
+        assert_eq!(extract_core_claim(text).as_deref(), Some("Middle claim."));
+    }
+
+    // ── CouncilState ─────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_state() {
+        let state = CouncilState::new();
+        assert_eq!(state.current_round(), 0);
+        assert!(state.all_contributions().is_empty());
+        assert!(state.rounds_with_contributions().is_empty());
+    }
+
+    #[test]
+    fn push_and_round_tracking() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: test_agent("a"),
+            content: "Round 0 from a".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: test_agent("b"),
+            content: "Round 0 from b".into(),
+            core_claim: Some("Claim B.".into()),
+            round: 0,
+        });
+        assert_eq!(state.all_contributions().len(), 2);
+        assert_eq!(state.contributions_for_round(0).len(), 2);
+        assert_eq!(state.contributions_for_round(1).len(), 0);
+
+        state.advance_round();
+        assert_eq!(state.current_round(), 1);
+
+        state.push(AgentContribution {
+            agent: test_agent("a"),
+            content: "Round 1 from a".into(),
+            core_claim: None,
+            round: 1,
+        });
+        assert_eq!(state.contributions_for_round(1).len(), 1);
+
+        let rounds = state.rounds_with_contributions();
+        assert_eq!(rounds.len(), 2);
+        assert_eq!(rounds[0].0, 0);
+        assert_eq!(rounds[0].1.len(), 2);
+        assert_eq!(rounds[1].0, 1);
+        assert_eq!(rounds[1].1.len(), 1);
+    }
+}

--- a/crates/gglib-agent/src/council/stream_bridge.rs
+++ b/crates/gglib-agent/src/council/stream_bridge.rs
@@ -1,0 +1,313 @@
+//! Maps inner [`AgentEvent`]s to tagged [`CouncilEvent`] variants.
+//!
+//! The bridge sits between a delegated `AgentLoop` channel and the outer
+//! council event channel.  It tags every event with `agent_id` and `round`,
+//! converting the generic agent stream into the council-specific wire format.
+//!
+//! This module contains **no business logic** — it is a pure, lossless
+//! event transformer.
+
+use tokio::sync::mpsc;
+use tracing::debug;
+
+use gglib_core::AgentEvent;
+
+use super::config::CouncilAgent;
+use super::events::CouncilEvent;
+use super::state::extract_core_claim;
+
+/// Consume all events from an `AgentLoop` channel, map each to its
+/// [`CouncilEvent`] counterpart, and forward to the council sender.
+///
+/// Returns the final answer text (if one was emitted) so the orchestrator
+/// can record it as an [`AgentContribution`](super::state::AgentContribution).
+///
+/// # Behaviour on channel closure
+///
+/// When the inner `AgentLoop` finishes (or is terminated by stagnation /
+/// loop detection), it drops its `Sender`, which closes the channel.
+/// This function returns `None` if no `FinalAnswer` was received — the
+/// orchestrator treats this as a truncated contribution and moves on.
+pub async fn bridge_agent_events(
+    agent: &CouncilAgent,
+    round: u32,
+    mut agent_rx: mpsc::Receiver<AgentEvent>,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+) -> Option<String> {
+    let id = &agent.id;
+    let mut final_content: Option<String> = None;
+
+    while let Some(event) = agent_rx.recv().await {
+        let council_event = match event {
+            AgentEvent::TextDelta { content } => CouncilEvent::AgentTextDelta {
+                agent_id: id.clone(),
+                delta: content,
+            },
+
+            AgentEvent::ReasoningDelta { content } => CouncilEvent::AgentReasoningDelta {
+                agent_id: id.clone(),
+                delta: content,
+            },
+
+            AgentEvent::ToolCallStart {
+                tool_call,
+                display_name,
+                args_summary,
+            } => CouncilEvent::AgentToolCallStart {
+                agent_id: id.clone(),
+                tool_call,
+                display_name,
+                args_summary,
+            },
+
+            AgentEvent::ToolCallComplete {
+                tool_name,
+                result,
+                display_name,
+                duration_display,
+                ..
+            } => CouncilEvent::AgentToolCallComplete {
+                agent_id: id.clone(),
+                tool_name,
+                result,
+                display_name,
+                duration_display,
+            },
+
+            AgentEvent::FinalAnswer { content } => {
+                final_content = Some(content);
+                // Don't emit a council event here — the orchestrator emits
+                // `AgentTurnComplete` after recording the contribution.
+                continue;
+            }
+
+            // Iteration boundaries are internal to the agent loop; they
+            // don't map to a council-level concept.
+            AgentEvent::IterationComplete { .. } => continue,
+
+            // Agent-level errors are logged but don't terminate the council.
+            // The orchestrator handles the `None` return for final_content.
+            AgentEvent::Error { message } => {
+                debug!(agent_id = %id, round, %message, "agent error during council turn");
+                continue;
+            }
+        };
+
+        // Best-effort send — if the council receiver is dropped (e.g. client
+        // disconnected), we stop forwarding but still drain to completion.
+        if council_tx.send(council_event).await.is_err() {
+            debug!(agent_id = %id, round, "council channel closed, draining agent events");
+            break;
+        }
+    }
+
+    final_content
+}
+
+/// Emit the [`CouncilEvent::AgentTurnComplete`] event, extracting the
+/// core claim from the response content.
+///
+/// This is called by the orchestrator after `bridge_agent_events` returns,
+/// ensuring the complete content is available for core claim parsing.
+pub async fn emit_turn_complete(
+    agent: &CouncilAgent,
+    round: u32,
+    content: &str,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+) {
+    let core_claim = extract_core_claim(content);
+    let event = CouncilEvent::AgentTurnComplete {
+        agent_id: agent.id.clone(),
+        content: content.to_owned(),
+        round,
+        core_claim,
+    };
+    let _ = council_tx.send(event).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gglib_core::{ToolCall, ToolResult};
+
+    fn test_agent() -> CouncilAgent {
+        CouncilAgent {
+            id: "test-1".into(),
+            name: "Tester".into(),
+            color: "#fff".into(),
+            persona: "p".into(),
+            perspective: "v".into(),
+            contentiousness: 0.5,
+            tool_filter: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn text_deltas_forwarded_with_agent_id() {
+        let agent = test_agent();
+        let (agent_tx, agent_rx) = mpsc::channel(32);
+        let (council_tx, mut council_rx) = mpsc::channel(32);
+
+        agent_tx
+            .send(AgentEvent::TextDelta {
+                content: "hello".into(),
+            })
+            .await
+            .unwrap();
+        agent_tx
+            .send(AgentEvent::FinalAnswer {
+                content: "hello world".into(),
+            })
+            .await
+            .unwrap();
+        drop(agent_tx);
+
+        let answer = bridge_agent_events(&agent, 0, agent_rx, &council_tx).await;
+        assert_eq!(answer.as_deref(), Some("hello world"));
+
+        let event = council_rx.recv().await.unwrap();
+        assert!(matches!(
+            event,
+            CouncilEvent::AgentTextDelta { agent_id, delta }
+                if agent_id == "test-1" && delta == "hello"
+        ));
+    }
+
+    #[tokio::test]
+    async fn tool_events_forwarded() {
+        let agent = test_agent();
+        let (agent_tx, agent_rx) = mpsc::channel(32);
+        let (council_tx, mut council_rx) = mpsc::channel(32);
+
+        agent_tx
+            .send(AgentEvent::ToolCallStart {
+                tool_call: ToolCall {
+                    id: "c1".into(),
+                    name: "search".into(),
+                    arguments: serde_json::json!({}),
+                },
+                display_name: "Web Search".into(),
+                args_summary: Some("query".into()),
+            })
+            .await
+            .unwrap();
+        agent_tx
+            .send(AgentEvent::ToolCallComplete {
+                tool_name: "search".into(),
+                result: ToolResult {
+                    tool_call_id: "c1".into(),
+                    content: "results".into(),
+                    success: true,
+                },
+                wait_ms: 0,
+                execute_duration_ms: 100,
+                display_name: "Web Search".into(),
+                duration_display: "100ms".into(),
+            })
+            .await
+            .unwrap();
+        agent_tx
+            .send(AgentEvent::FinalAnswer {
+                content: "done".into(),
+            })
+            .await
+            .unwrap();
+        drop(agent_tx);
+
+        bridge_agent_events(&agent, 1, agent_rx, &council_tx).await;
+
+        let e1 = council_rx.recv().await.unwrap();
+        assert!(
+            matches!(e1, CouncilEvent::AgentToolCallStart { agent_id, .. } if agent_id == "test-1")
+        );
+
+        let e2 = council_rx.recv().await.unwrap();
+        assert!(
+            matches!(e2, CouncilEvent::AgentToolCallComplete { agent_id, .. } if agent_id == "test-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn iteration_and_error_events_skipped() {
+        let agent = test_agent();
+        let (agent_tx, agent_rx) = mpsc::channel(32);
+        let (council_tx, mut council_rx) = mpsc::channel(32);
+
+        agent_tx
+            .send(AgentEvent::IterationComplete {
+                iteration: 0,
+                tool_calls: 2,
+            })
+            .await
+            .unwrap();
+        agent_tx
+            .send(AgentEvent::Error {
+                message: "stagnation".into(),
+            })
+            .await
+            .unwrap();
+        agent_tx
+            .send(AgentEvent::FinalAnswer {
+                content: "recovered".into(),
+            })
+            .await
+            .unwrap();
+        drop(agent_tx);
+
+        let answer = bridge_agent_events(&agent, 0, agent_rx, &council_tx).await;
+        assert_eq!(answer.as_deref(), Some("recovered"));
+
+        // Channel should be empty — iteration/error events were skipped.
+        assert!(council_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn no_final_answer_returns_none() {
+        let agent = test_agent();
+        let (agent_tx, agent_rx) = mpsc::channel(32);
+        let (council_tx, _council_rx) = mpsc::channel(32);
+
+        agent_tx
+            .send(AgentEvent::TextDelta {
+                content: "partial".into(),
+            })
+            .await
+            .unwrap();
+        drop(agent_tx);
+
+        let answer = bridge_agent_events(&agent, 0, agent_rx, &council_tx).await;
+        assert!(answer.is_none());
+    }
+
+    #[tokio::test]
+    async fn emit_turn_complete_with_core_claim() {
+        let agent = test_agent();
+        let (council_tx, mut council_rx) = mpsc::channel(32);
+
+        emit_turn_complete(&agent, 1, "Analysis.\nCORE CLAIM: Test claim.", &council_tx).await;
+
+        let event = council_rx.recv().await.unwrap();
+        assert!(matches!(
+            event,
+            CouncilEvent::AgentTurnComplete { core_claim: Some(c), round: 1, .. }
+                if c == "Test claim."
+        ));
+    }
+
+    #[tokio::test]
+    async fn emit_turn_complete_without_core_claim() {
+        let agent = test_agent();
+        let (council_tx, mut council_rx) = mpsc::channel(32);
+
+        emit_turn_complete(&agent, 0, "No marker here.", &council_tx).await;
+
+        let event = council_rx.recv().await.unwrap();
+        assert!(matches!(
+            event,
+            CouncilEvent::AgentTurnComplete {
+                core_claim: None,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/gglib-agent/src/lib.rs
+++ b/crates/gglib-agent/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod agent_loop;
 pub(crate) mod context_pruning;
+pub mod council;
 pub(crate) mod fnv1a;
 pub(crate) mod loop_detection;
 pub(crate) mod stagnation;


### PR DESCRIPTION
## Summary

Replace the unused Deep Research feature with **Council of Agents** — a multi-agent deliberation system where multiple LLM-backed personas debate a topic through structured rounds, then produce a synthesised answer.

This PR delivers **Phase 1: Backend Foundation** — all core types, prompt templates, event wiring, and orchestration logic inside `crates/gglib-agent/src/council/`. No API routes, CLI commands, or frontend changes are included; those arrive in subsequent phases.

---

## What was added

| File | LOC (prod) | Responsibility |
|------|-----------|----------------|
| `config.rs` | 146 | `CouncilAgent`, `CouncilConfig`, `SuggestedCouncil` types with validation and `clamp_contentiousness()` |
| `events.rs` | 224 | `CouncilEvent` SSE wire enum — 12 variants, `serde(tag = "type")` tagged, single source of truth for all consumers |
| `prompts.rs` | 205 | 5 prompt constants + `contentiousness_to_instruction()` 5-tier mapping + `contentiousness_tier_label()` |
| `state.rs` | 226 | `CouncilState` round/contribution accumulator + `extract_core_claim()` fault-tolerant parser |
| `history.rs` | 237 | `build_agent_messages()` per-turn context builder (identity anchoring + debate transcript injection + round-phase suffixes) |
| `stream_bridge.rs` | 306 | `AgentEvent` → `CouncilEvent` mapper — tags with `agent_id`/`round`, filters internal events, extracts core claims |
| `orchestrator.rs` | 221 | Round×agent loop driver — delegates to existing `AgentLoop::run()`, synthesis pass, graceful error handling |
| `mod.rs` | 33 | Module declarations + re-exports |

**Modified files:** `Cargo.toml` (added `serde` dep), `lib.rs` (added `pub mod council`), `Cargo.lock`

---

## Key design decisions

- **Fault-tolerant core claim extraction**: `extract_core_claim()` scans from the end of the response for a `CORE CLAIM:` marker. Returns `None` on missing or empty — no retry, no error, no breakage.
- **Graceful agent error handling**: The orchestrator catches `StagnationDetected`, `LoopDetected`, and `MaxIterationsReached` from `AgentLoop` — logs a warning, records the partial contribution, and continues the council. One stuck agent never kills the deliberation.
- **Per-agent tool filters**: Each `CouncilAgent.tool_filter` is forwarded to `AgentLoop::build()` as a `HashSet`, giving fine-grained control over which tools each persona can access.
- **Synthesis phase**: Uses a single-iteration `AgentConfig` with no tools — the synthesiser sees the full debate transcript and produces a final answer.
- **All files < 200 LOC** production code (tests are separate and thorough).

---

## Test coverage

**70 tests pass** (37 new council tests + 33 existing crate tests), covering:
- Config validation and contentiousness clamping
- Event serialisation round-trips for all 12 variants
- Prompt tier mapping across all 5 contentiousness bands
- State accumulation, round tracking, and core claim extraction edge cases
- History context building with identity anchoring and transcript formatting
- Stream bridge event mapping, filtering, and channel-closure behaviour

---

## Multi-phase epic

This is **Phase 1 of a multi-phase effort** to ship Council of Agents:

- [x] **Phase 1** — Backend foundation (this PR)
- [ ] **Phase 2** — CLI integration + Axum/proxy SSE routes
- [ ] **Phase 3** — Remove legacy Deep Research code
- [ ] **Phase 4** — Frontend council UI
- [ ] **Phase 5** — Tauri bridge + GUI integration

Each phase ships as a separate PR into `main`.