### PR TITLE
feat(frontend): Council of Agents UI scaffold

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -37,6 +37,8 @@ import { cn } from '../../utils/cn';
 import { DEFAULT_SYSTEM_PROMPT } from '../../hooks/useGglibRuntime';
 import { ToolSupportIndicator } from '../ToolSupportIndicator';
 import { getToolRegistry } from '../../services/tools';
+import { CouncilProvider } from '../../contexts/CouncilContext';
+import { CouncilThread } from '../Council/Messages/CouncilThread';
 
 
 interface ChatMessagesPanelProps {
@@ -506,6 +508,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
             <MessageActionsContext.Provider value={messageActionsValue}>
               <ThinkingTimingProvider value={{ timingTracker, currentStreamingAssistantMessageId, tick }}>
               <VoiceProvider value={voiceContextValue}>
+              <CouncilProvider>
                 <ThreadPrimitive.Root
                   key={activeConversationId ?? 'thread-root'}
                   className="flex flex-col h-full min-h-0"
@@ -513,6 +516,10 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                   <ThreadPrimitive.Viewport className="flex-1 overflow-y-auto p-md flex flex-col gap-md scroll-smooth" autoScroll>
                     <ThreadPrimitive.Messages
                       components={messageComponents}
+                    />
+                    <CouncilThread
+                      onRun={() => {/* wired in council mode integration */}}
+                      onCancel={() => {/* wired in council mode integration */}}
                     />
                   <ThreadPrimitive.ScrollToBottom className="sticky bottom-sm self-center py-xs px-md bg-primary text-white border-none rounded-full text-sm cursor-pointer opacity-0 transition-opacity duration-200 data-[visible=true]:opacity-100">
                     Jump to latest
@@ -557,6 +564,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                   </ComposerPrimitive.Root>
                 </div>
               </ThreadPrimitive.Root>
+              </CouncilProvider>
               </VoiceProvider>
               </ThinkingTimingProvider>
             </MessageActionsContext.Provider>

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -37,8 +37,10 @@ import { cn } from '../../utils/cn';
 import { DEFAULT_SYSTEM_PROMPT } from '../../hooks/useGglibRuntime';
 import { ToolSupportIndicator } from '../ToolSupportIndicator';
 import { getToolRegistry } from '../../services/tools';
-import { CouncilProvider } from '../../contexts/CouncilContext';
 import { CouncilThread } from '../Council/Messages/CouncilThread';
+import { CouncilToggle } from '../Council/Composer/CouncilToggle';
+import { useCouncil } from '../../hooks/useCouncil';
+import type { GglibMessageCustom } from '../../types/messages';
 
 
 interface ChatMessagesPanelProps {
@@ -68,6 +70,10 @@ interface ChatMessagesPanelProps {
   supportsToolCalls?: boolean | null;
   /** Detected tool-calling format, e.g. "hermes" or "llama3". */
   toolFormat?: string | null;
+  /** Ref for council submit callback (filled by this component). */
+  councilSubmitRef?: React.MutableRefObject<((text: string) => void) | null>;
+  /** Set one-shot metadata on the next user message. */
+  setNextMessageMeta?: (meta: Partial<GglibMessageCustom>) => void;
 }
 
 const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
@@ -91,10 +97,39 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
   voice,
   supportsToolCalls,
   toolFormat,
+  councilSubmitRef,
+  setNextMessageMeta,
 }) => {
   const threadRuntime = useThreadRuntime({ optional: true });
   const threadState = useThread({ optional: true });
   const isThreadRunning = threadState?.isRunning ?? false;
+
+  // Council mode toggle state
+  const [isCouncilMode, setIsCouncilMode] = useState(false);
+  const isCouncilModeRef = useRef(isCouncilMode);
+  isCouncilModeRef.current = isCouncilMode;
+
+  // Council hook — wired to context
+  const council = useCouncil({ serverPort });
+
+  // Register the council suggest callback so ChatPage can call it on submit
+  useEffect(() => {
+    if (councilSubmitRef) {
+      councilSubmitRef.current = (text: string) => {
+        council.suggest(text);
+        setIsCouncilMode(false); // Reset toggle after submit
+      };
+      return () => { councilSubmitRef.current = null; };
+    }
+  }, [councilSubmitRef, council]);
+
+  // Sync council mode flag to message metadata before each submission.
+  // Uses a ref so the onNew callback always sees the latest toggle state.
+  useEffect(() => {
+    if (setNextMessageMeta) {
+      setNextMessageMeta(isCouncilMode ? { isCouncilMode: true } : {});
+    }
+  }, [isCouncilMode, setNextMessageMeta]);
 
   // Shared ticker for live timer updates (only runs while streaming)
   // Note: Updating tick triggers provider re-render, but messageComponents is stable
@@ -508,7 +543,6 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
             <MessageActionsContext.Provider value={messageActionsValue}>
               <ThinkingTimingProvider value={{ timingTracker, currentStreamingAssistantMessageId, tick }}>
               <VoiceProvider value={voiceContextValue}>
-              <CouncilProvider>
                 <ThreadPrimitive.Root
                   key={activeConversationId ?? 'thread-root'}
                   className="flex flex-col h-full min-h-0"
@@ -518,8 +552,8 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                       components={messageComponents}
                     />
                     <CouncilThread
-                      onRun={() => {/* wired in council mode integration */}}
-                      onCancel={() => {/* wired in council mode integration */}}
+                      onRun={(config) => council.run(config)}
+                      onCancel={() => council.reset()}
                     />
                   <ThreadPrimitive.ScrollToBottom className="sticky bottom-sm self-center py-xs px-md bg-primary text-white border-none rounded-full text-sm cursor-pointer opacity-0 transition-opacity duration-200 data-[visible=true]:opacity-100">
                     Jump to latest
@@ -530,15 +564,25 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                   {isThreadRunning && (
                     <div className="text-sm text-primary mb-sm animate-research-pulse">Assistant is thinking…</div>
                   )}
+                  {council.session.phase === 'suggesting' && (
+                    <div className="text-sm text-primary mb-sm animate-pulse">Designing council…</div>
+                  )}
                   <ComposerPrimitive.Root className="flex gap-sm items-end">
                     <ComposerPrimitive.Input
                       className="flex-1 py-sm px-md border border-border rounded-base bg-surface text-text text-sm font-[inherit] resize-none min-h-[40px] max-h-[150px] focus:outline-none focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
                       placeholder={
                         isServerConnected
-                          ? 'Type your message. Shift + Enter for newline'
+                          ? isCouncilMode
+                            ? 'Describe the topic for the Council of Agents…'
+                            : 'Type your message. Shift + Enter for newline'
                           : 'Server not connected'
                       }
                       disabled={!isServerConnected}
+                    />
+                    <CouncilToggle
+                      active={isCouncilMode}
+                      onToggle={() => setIsCouncilMode((prev) => !prev)}
+                      disabled={!isServerConnected || council.isStreaming}
                     />
                     <div className="flex gap-sm shrink-0">
                       {isThreadRunning && (
@@ -547,6 +591,16 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                           size="sm"
                           onClick={() => threadRuntime?.cancelRun()}
                           title="Stop generation"
+                        >
+                          Stop
+                        </Button>
+                      )}
+                      {council.isStreaming && (
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => council.cancel()}
+                          title="Stop council"
                         >
                           Stop
                         </Button>
@@ -564,7 +618,6 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                   </ComposerPrimitive.Root>
                 </div>
               </ThreadPrimitive.Root>
-              </CouncilProvider>
               </VoiceProvider>
               </ThinkingTimingProvider>
             </MessageActionsContext.Provider>

--- a/src/components/Council/Composer/CouncilToggle.tsx
+++ b/src/components/Council/Composer/CouncilToggle.tsx
@@ -1,0 +1,39 @@
+/**
+ * Council mode toggle for the chat composer.
+ *
+ * When active, the next message submission routes to `suggestCouncil()`
+ * instead of the standard agentic chat flow.
+ *
+ * @module components/Council/Composer/CouncilToggle
+ */
+
+import type { FC } from 'react';
+import { Users } from 'lucide-react';
+import { cn } from '../../../utils/cn';
+import { Icon } from '../../ui/Icon';
+
+export interface CouncilToggleProps {
+  active: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}
+
+export const CouncilToggle: FC<CouncilToggleProps> = ({ active, onToggle, disabled }) => (
+  <button
+    type="button"
+    onClick={onToggle}
+    disabled={disabled}
+    title={active ? 'Council mode ON — click to disable' : 'Enable Council of Agents'}
+    aria-pressed={active}
+    className={cn(
+      'flex items-center justify-center w-8 h-8 rounded-base border transition-all duration-150',
+      'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+      'disabled:opacity-50 disabled:cursor-not-allowed',
+      active
+        ? 'bg-primary/15 border-primary/40 text-primary'
+        : 'bg-transparent border-border text-text-muted hover:bg-background-hover hover:text-text',
+    )}
+  >
+    <Icon icon={Users} size={16} />
+  </button>
+);

--- a/src/components/Council/Messages/CouncilMessage.tsx
+++ b/src/components/Council/Messages/CouncilMessage.tsx
@@ -1,0 +1,142 @@
+/**
+ * Renders a single agent's turn in the council deliberation.
+ *
+ * Ambient tinting via `--agent-color` CSS custom property. Subtle left
+ * border + faint background via `color-mix()`. Streaming-aware: shows
+ * either the completed contribution text or live `activeText`.
+ *
+ * @module components/Council/Messages/CouncilMessage
+ */
+
+import type { FC } from 'react';
+import { Wrench, CheckCircle, XCircle } from 'lucide-react';
+import type { AgentContribution, AgentToolCall } from '../../../types/council';
+import { contentiousnessColor } from '../../../types/council';
+import { cn } from '../../../utils/cn';
+import { Icon } from '../../ui/Icon';
+import MarkdownMessageContent from '../../ChatMessagesPanel/components/MarkdownMessageContent';
+
+// ─── Tool call display (lightweight, no registry dependency) ────────────────
+
+const ToolCallBadge: FC<{ call: AgentToolCall }> = ({ call }) => {
+  const done = call.result !== undefined;
+  const isError = call.result?.isError ?? false;
+
+  return (
+    <div className="flex items-center gap-xs text-xs text-text-secondary py-[2px]">
+      <Icon
+        icon={done ? (isError ? XCircle : CheckCircle) : Wrench}
+        size={12}
+        className={cn(
+          done && !isError && 'text-success',
+          done && isError && 'text-danger',
+          !done && 'text-text-muted animate-pulse',
+        )}
+      />
+      <span className="font-medium">{call.displayName}</span>
+      {call.argsSummary && (
+        <span className="text-text-muted truncate max-w-[180px]">{call.argsSummary}</span>
+      )}
+      {call.durationDisplay && (
+        <span className="text-text-muted">({call.durationDisplay})</span>
+      )}
+    </div>
+  );
+};
+
+// ─── Core claim pill ────────────────────────────────────────────────────────
+
+const CoreClaimPill: FC<{ claim: string }> = ({ claim }) => (
+  <div className="mt-sm pt-sm border-t border-[color-mix(in_srgb,var(--agent-color)_15%,var(--color-border))]">
+    <span className="inline-flex items-center gap-xs text-xs px-sm py-[2px] rounded-full bg-[color-mix(in_srgb,var(--agent-color)_12%,var(--color-surface))] text-text-secondary">
+      <span className="font-medium">Claim:</span>
+      <span className="italic">{claim}</span>
+    </span>
+  </div>
+);
+
+// ─── Main message ───────────────────────────────────────────────────────────
+
+export interface CouncilMessageProps {
+  /** Completed contribution (for finished turns). */
+  contribution?: AgentContribution;
+  /** Live-streaming state (for the active turn). */
+  streaming?: {
+    agentId: string;
+    agentName: string;
+    color: string;
+    contentiousness: number;
+    text: string;
+    reasoning: string;
+    toolCalls: AgentToolCall[];
+  };
+}
+
+export const CouncilMessage: FC<CouncilMessageProps> = ({ contribution, streaming }) => {
+  const source = contribution ?? streaming;
+  if (!source) return null;
+
+  const color = contentiousnessColor(source.contentiousness);
+  const text = contribution?.content ?? streaming?.text ?? '';
+  const reasoning = streaming?.reasoning ?? '';
+  const toolCalls = streaming?.toolCalls ?? [];
+  const coreClaim = contribution?.coreClaim;
+  const isStreaming = !!streaming;
+
+  return (
+    <div
+      className={cn(
+        'rounded-base border-l-[3px] p-md transition-colors duration-200',
+        'bg-[color-mix(in_srgb,var(--agent-color)_6%,var(--color-surface))]',
+        'border-[color-mix(in_srgb,var(--agent-color)_40%,transparent)]',
+      )}
+      style={{ '--agent-color': color } as React.CSSProperties}
+    >
+      {/* Agent header */}
+      <div className="flex items-center gap-sm mb-sm">
+        <span
+          className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
+          style={{ backgroundColor: color }}
+          aria-hidden
+        >
+          {source.agentName.charAt(0).toUpperCase()}
+        </span>
+        <span className="text-sm font-semibold text-text">{source.agentName}</span>
+        {contribution && (
+          <span className="text-xs text-text-muted">Round {contribution.round + 1}</span>
+        )}
+      </div>
+
+      {/* Reasoning (collapsible, only while streaming) */}
+      {reasoning && (
+        <details className="mb-sm text-xs" open={isStreaming}>
+          <summary className="cursor-pointer text-text-secondary hover:text-text transition-colors">
+            Reasoning
+          </summary>
+          <div className="mt-xs text-text-muted whitespace-pre-wrap leading-relaxed">
+            {reasoning}
+          </div>
+        </details>
+      )}
+
+      {/* Tool calls */}
+      {toolCalls.length > 0 && (
+        <div className="mb-sm flex flex-col gap-[2px]">
+          {toolCalls.map((tc, i) => (
+            <ToolCallBadge key={`${tc.toolName}-${i}`} call={tc} />
+          ))}
+        </div>
+      )}
+
+      {/* Main content */}
+      {text ? (
+        <MarkdownMessageContent text={text} />
+      ) : isStreaming ? (
+        <span className="text-sm text-text-muted animate-pulse">Speaking…</span>
+      ) : null}
+
+      {/* Core claim pill */}
+      {coreClaim && <CoreClaimPill claim={coreClaim} />}
+    </div>
+  );
+};

--- a/src/components/Council/Messages/CouncilThread.tsx
+++ b/src/components/Council/Messages/CouncilThread.tsx
@@ -1,0 +1,147 @@
+/**
+ * Renders the full council deliberation thread.
+ *
+ * Maps completed contributions with round separators injected between
+ * round boundaries, appends the live-streaming agent turn (if any),
+ * and renders the synthesis at the end.
+ *
+ * Designed to be placed inside the chat viewport alongside (or instead
+ * of) the regular message thread.
+ *
+ * @module components/Council/Messages/CouncilThread
+ */
+
+import { type FC, useMemo } from 'react';
+import { useCouncilContext } from '../../../contexts/CouncilContext';
+import type { CouncilConfig } from '../../../types/council';
+import { CouncilMessage } from './CouncilMessage';
+import { SynthesisMessage } from './SynthesisMessage';
+import { RoundSeparator } from './RoundSeparator';
+import { CouncilSetupPanel } from '../Setup/CouncilSetupPanel';
+
+export interface CouncilThreadProps {
+  onRun: (config: CouncilConfig) => void;
+  onCancel: () => void;
+}
+
+type ThreadItem =
+  | { kind: 'round'; round: number }
+  | { kind: 'contribution'; index: number }
+  | { kind: 'streaming' }
+  | { kind: 'synthesis' };
+
+export const CouncilThread: FC<CouncilThreadProps> = ({ onRun, onCancel }) => {
+  const { session } = useCouncilContext();
+
+  // Build a flat list of render items with round separators injected
+  const items = useMemo<ThreadItem[]>(() => {
+    const result: ThreadItem[] = [];
+    let lastRound = -1;
+
+    for (let i = 0; i < session.contributions.length; i++) {
+      const c = session.contributions[i];
+      if (c.round !== lastRound) {
+        result.push({ kind: 'round', round: c.round });
+        lastRound = c.round;
+      }
+      result.push({ kind: 'contribution', index: i });
+    }
+
+    // Active streaming turn
+    if (session.activeAgentId) {
+      if (session.currentRound !== lastRound) {
+        result.push({ kind: 'round', round: session.currentRound });
+      }
+      result.push({ kind: 'streaming' });
+    }
+
+    // Synthesis (streaming or complete)
+    if (session.phase === 'synthesizing' || session.phase === 'complete') {
+      result.push({ kind: 'synthesis' });
+    }
+
+    return result;
+  }, [session.contributions, session.activeAgentId, session.currentRound, session.phase]);
+
+  // Idle / suggesting phases: nothing to render
+  if (session.phase === 'idle' || session.phase === 'suggesting') {
+    return null;
+  }
+
+  // Setup phase: show the setup panel
+  if (session.phase === 'setup') {
+    return (
+      <CouncilSetupPanel
+        topic={session.topic}
+        agents={session.suggestedAgents}
+        rounds={session.suggestedRounds}
+        synthesisGuidance={session.suggestedSynthesisGuidance}
+        onRun={onRun}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  // Error state
+  if (session.phase === 'error' && items.length === 0) {
+    return (
+      <div className="text-sm text-danger px-md py-sm">
+        Council error: {session.error ?? 'Unknown error'}
+      </div>
+    );
+  }
+
+  // Deliberating / synthesizing / complete
+  return (
+    <div className="flex flex-col gap-md">
+      {items.map((item) => {
+        switch (item.kind) {
+          case 'round':
+            return <RoundSeparator key={`round-${item.round}`} round={item.round} />;
+
+          case 'contribution': {
+            const c = session.contributions[item.index];
+            return (
+              <CouncilMessage
+                key={`contrib-${c.agentId}-${c.round}`}
+                contribution={c}
+              />
+            );
+          }
+
+          case 'streaming':
+            return (
+              <CouncilMessage
+                key="streaming"
+                streaming={{
+                  agentId: session.activeAgentId!,
+                  agentName: session.activeAgentName,
+                  color: session.activeAgentColor,
+                  contentiousness: session.activeAgentContentiousness,
+                  text: session.activeAgentText,
+                  reasoning: session.activeAgentReasoning,
+                  toolCalls: session.activeToolCalls,
+                }}
+              />
+            );
+
+          case 'synthesis':
+            return (
+              <SynthesisMessage
+                key="synthesis"
+                text={session.synthesisText}
+                isStreaming={session.phase === 'synthesizing'}
+              />
+            );
+        }
+      })}
+
+      {/* Trailing error after partial progress */}
+      {session.phase === 'error' && session.error && (
+        <div className="text-sm text-danger px-md py-sm rounded-base border border-danger/20 bg-danger/5">
+          {session.error}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Council/Messages/RoundSeparator.tsx
+++ b/src/components/Council/Messages/RoundSeparator.tsx
@@ -1,0 +1,24 @@
+/**
+ * Lightweight horizontal divider with "Round N" label.
+ *
+ * Purely presentational — no state, no side-effects.
+ *
+ * @module components/Council/Messages/RoundSeparator
+ */
+
+import type { FC } from 'react';
+
+export interface RoundSeparatorProps {
+  /** Zero-based round index (displayed as round + 1). */
+  round: number;
+}
+
+export const RoundSeparator: FC<RoundSeparatorProps> = ({ round }) => (
+  <div className="flex items-center gap-md py-sm" role="separator">
+    <div className="flex-1 h-px bg-border" />
+    <span className="text-xs font-medium text-text-muted whitespace-nowrap">
+      Round {round + 1}
+    </span>
+    <div className="flex-1 h-px bg-border" />
+  </div>
+);

--- a/src/components/Council/Messages/SynthesisMessage.tsx
+++ b/src/components/Council/Messages/SynthesisMessage.tsx
@@ -1,0 +1,44 @@
+/**
+ * Renders the council synthesis — the final consensus output.
+ *
+ * Visually distinct from agent turns: no temperature tinting, uses a
+ * neutral/primary accent with subtle elevation to signal authority.
+ *
+ * @module components/Council/Messages/SynthesisMessage
+ */
+
+import type { FC } from 'react';
+import { Sparkles } from 'lucide-react';
+import { cn } from '../../../utils/cn';
+import { Icon } from '../../ui/Icon';
+import MarkdownMessageContent from '../../ChatMessagesPanel/components/MarkdownMessageContent';
+
+export interface SynthesisMessageProps {
+  text: string;
+  isStreaming?: boolean;
+}
+
+export const SynthesisMessage: FC<SynthesisMessageProps> = ({ text, isStreaming }) => (
+  <div
+    className={cn(
+      'rounded-base border p-md transition-colors duration-200',
+      'border-primary/30 bg-primary/[0.04]',
+      'shadow-[0_0_8px_0_var(--color-primary,#6366f1)_inset,0_0_0_1px_var(--color-primary,#6366f1)_inset] shadow-primary/[0.06]',
+    )}
+  >
+    {/* Badge */}
+    <div className="flex items-center gap-sm mb-sm">
+      <span className="w-6 h-6 rounded-full flex items-center justify-center bg-primary/20 shrink-0">
+        <Icon icon={Sparkles} size={14} className="text-primary" />
+      </span>
+      <span className="text-sm font-semibold text-primary">Council Synthesis</span>
+    </div>
+
+    {/* Content */}
+    {text ? (
+      <MarkdownMessageContent text={text} />
+    ) : isStreaming ? (
+      <span className="text-sm text-text-muted animate-pulse">Synthesizing consensus…</span>
+    ) : null}
+  </div>
+);

--- a/src/components/Council/Setup/AgentCard.tsx
+++ b/src/components/Council/Setup/AgentCard.tsx
@@ -1,0 +1,80 @@
+/**
+ * Single agent card for council setup.
+ *
+ * Displays agent persona, perspective, and a contentiousness slider.
+ * Injects `--agent-color` CSS custom property for ambient tinting.
+ *
+ * @module components/Council/Setup/AgentCard
+ */
+
+import type { FC } from 'react';
+import type { CouncilAgent } from '../../../types/council';
+import { contentiousnessColor, contentiousnessLabel } from '../../../types/council';
+import { cn } from '../../../utils/cn';
+
+interface AgentCardProps {
+  agent: CouncilAgent;
+  onContentiousnessChange?: (agentId: string, value: number) => void;
+  disabled?: boolean;
+}
+
+export const AgentCard: FC<AgentCardProps> = ({ agent, onContentiousnessChange, disabled }) => {
+  const color = contentiousnessColor(agent.contentiousness);
+  const label = contentiousnessLabel(agent.contentiousness);
+
+  return (
+    <div
+      className={cn(
+        'rounded-base border p-md flex flex-col gap-sm transition-colors duration-200',
+        'bg-[color-mix(in_srgb,var(--agent-color)_8%,var(--color-surface))]',
+        'border-[color-mix(in_srgb,var(--agent-color)_25%,var(--color-border))]',
+      )}
+      style={{ '--agent-color': color } as React.CSSProperties}
+    >
+      {/* Header: name + color dot */}
+      <div className="flex items-center gap-sm">
+        <span
+          className="w-3 h-3 rounded-full shrink-0"
+          style={{ backgroundColor: color }}
+          aria-hidden
+        />
+        <h4 className="text-sm font-medium text-text m-0">{agent.name}</h4>
+      </div>
+
+      {/* Perspective (one-liner) */}
+      <p className="text-xs text-text-muted m-0 leading-relaxed">{agent.perspective}</p>
+
+      {/* Persona (collapsed by default to save space) */}
+      <details className="text-xs">
+        <summary className="cursor-pointer text-text-secondary hover:text-text transition-colors">
+          Persona
+        </summary>
+        <p className="mt-xs text-text-muted leading-relaxed m-0">{agent.persona}</p>
+      </details>
+
+      {/* Contentiousness slider */}
+      <div className="flex flex-col gap-xs mt-xs">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-text-secondary">Contentiousness</span>
+          <span
+            className="text-xs font-medium px-xs rounded"
+            style={{ color }}
+          >
+            {label} ({agent.contentiousness.toFixed(1)})
+          </span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.1}
+          value={agent.contentiousness}
+          onChange={(e) => onContentiousnessChange?.(agent.id, parseFloat(e.target.value))}
+          disabled={disabled}
+          className="w-full accent-[var(--agent-color)] h-1.5 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={`${agent.name} contentiousness`}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/Council/Setup/CouncilSetupPanel.tsx
+++ b/src/components/Council/Setup/CouncilSetupPanel.tsx
@@ -1,0 +1,105 @@
+/**
+ * Council setup panel — displayed inline in the chat column before
+ * deliberation starts.
+ *
+ * Renders the suggested agent cards with editable contentiousness,
+ * a topic display, and the "Run Council" action.
+ *
+ * @module components/Council/Setup/CouncilSetupPanel
+ */
+
+import { type FC, useState, useCallback } from 'react';
+import type { CouncilAgent, CouncilConfig } from '../../../types/council';
+import { Button } from '../../ui/Button';
+import { AgentCard } from './AgentCard';
+import { cn } from '../../../utils/cn';
+
+interface CouncilSetupPanelProps {
+  topic: string;
+  agents: CouncilAgent[];
+  rounds: number;
+  synthesisGuidance?: string;
+  onRun: (config: CouncilConfig) => void;
+  onCancel: () => void;
+  disabled?: boolean;
+}
+
+export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
+  topic,
+  agents: initialAgents,
+  rounds: initialRounds,
+  synthesisGuidance,
+  onRun,
+  onCancel,
+  disabled,
+}) => {
+  const [agents, setAgents] = useState<CouncilAgent[]>(initialAgents);
+  const [rounds, setRounds] = useState(initialRounds);
+
+  const handleContentiousnessChange = useCallback((agentId: string, value: number) => {
+    setAgents((prev) =>
+      prev.map((a) => (a.id === agentId ? { ...a, contentiousness: value } : a)),
+    );
+  }, []);
+
+  const handleRun = useCallback(() => {
+    onRun({ agents, topic, rounds, synthesis_guidance: synthesisGuidance });
+  }, [agents, topic, rounds, synthesisGuidance, onRun]);
+
+  return (
+    <div className={cn(
+      'flex flex-col gap-md p-md rounded-base',
+      'border border-border bg-surface',
+      'max-w-2xl w-full mx-auto',
+    )}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-text m-0">Council Setup</h3>
+          <p className="text-xs text-text-muted m-0 mt-xs">
+            {agents.length} agents &middot; {rounds} round{rounds !== 1 ? 's' : ''}
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onCancel} disabled={disabled}>
+          Cancel
+        </Button>
+      </div>
+
+      {/* Topic */}
+      <div className="px-sm py-xs bg-background rounded-base">
+        <p className="text-sm text-text m-0 leading-relaxed">&ldquo;{topic}&rdquo;</p>
+      </div>
+
+      {/* Agent cards grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-sm">
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={agent}
+            onContentiousnessChange={handleContentiousnessChange}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+
+      {/* Rounds control + Run */}
+      <div className="flex items-center justify-between pt-sm border-t border-border">
+        <label className="flex items-center gap-sm text-sm text-text-secondary">
+          Rounds
+          <input
+            type="number"
+            min={1}
+            max={10}
+            value={rounds}
+            onChange={(e) => setRounds(Math.max(1, Math.min(10, parseInt(e.target.value) || 1)))}
+            disabled={disabled}
+            className="w-16 py-xs px-sm border border-border rounded-base bg-surface text-text text-sm text-center focus:outline-none focus:border-primary disabled:opacity-50"
+          />
+        </label>
+        <Button variant="primary" size="sm" onClick={handleRun} disabled={disabled || agents.length === 0}>
+          Run Council
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -1,0 +1,173 @@
+/**
+ * Council session context.
+ *
+ * Holds the current `CouncilSession` state and exposes dispatch actions
+ * to the component tree. The heavy lifting (SSE streaming, API calls)
+ * belongs in `useCouncil` — this context is a thin state container.
+ *
+ * @module contexts/CouncilContext
+ */
+
+import { createContext, useContext, useReducer, type Dispatch, type ReactNode } from 'react';
+import {
+  createEmptySession,
+  type CouncilSession,
+  type CouncilAgent,
+  type AgentContribution,
+  type AgentToolCall,
+} from '../types/council';
+
+// ─── Actions ────────────────────────────────────────────────────────────────
+
+export type CouncilAction =
+  | { type: 'START_SUGGEST'; topic: string }
+  | { type: 'SUGGEST_COMPLETE'; agents: CouncilAgent[]; rounds: number; synthesisGuidance?: string }
+  | { type: 'SUGGEST_ERROR'; error: string }
+  | { type: 'START_DELIBERATION'; topic: string; totalRounds: number }
+  | { type: 'AGENT_TURN_START'; agentId: string; agentName: string; color: string; round: number; contentiousness: number }
+  | { type: 'AGENT_TEXT_DELTA'; agentId: string; delta: string }
+  | { type: 'AGENT_REASONING_DELTA'; agentId: string; delta: string }
+  | { type: 'AGENT_TOOL_CALL_START'; toolCall: AgentToolCall }
+  | { type: 'AGENT_TOOL_CALL_COMPLETE'; agentId: string; toolName: string; result: { content: string; isError: boolean }; displayName: string; durationDisplay: string }
+  | { type: 'AGENT_TURN_COMPLETE'; contribution: AgentContribution }
+  | { type: 'ROUND_SEPARATOR'; round: number }
+  | { type: 'SYNTHESIS_START' }
+  | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
+  | { type: 'SYNTHESIS_COMPLETE'; content: string }
+  | { type: 'COUNCIL_ERROR'; error: string }
+  | { type: 'COUNCIL_COMPLETE' }
+  | { type: 'RESET' };
+
+// ─── Reducer ────────────────────────────────────────────────────────────────
+
+export function councilReducer(state: CouncilSession, action: CouncilAction): CouncilSession {
+  switch (action.type) {
+    case 'START_SUGGEST':
+      return { ...createEmptySession(), phase: 'suggesting', topic: action.topic };
+
+    case 'SUGGEST_COMPLETE':
+      return {
+        ...state,
+        phase: 'setup',
+        suggestedAgents: action.agents,
+        suggestedRounds: action.rounds,
+        suggestedSynthesisGuidance: action.synthesisGuidance,
+      };
+
+    case 'SUGGEST_ERROR':
+      return { ...state, phase: 'error', error: action.error };
+
+    case 'START_DELIBERATION':
+      return {
+        ...state,
+        phase: 'deliberating',
+        topic: action.topic,
+        totalRounds: action.totalRounds,
+        currentRound: 0,
+        contributions: [],
+        synthesisText: '',
+        error: null,
+      };
+
+    case 'AGENT_TURN_START':
+      return {
+        ...state,
+        activeAgentId: action.agentId,
+        activeAgentName: action.agentName,
+        activeAgentColor: action.color,
+        activeAgentContentiousness: action.contentiousness,
+        activeAgentText: '',
+        activeAgentReasoning: '',
+        activeToolCalls: [],
+        currentRound: action.round,
+      };
+
+    case 'AGENT_TEXT_DELTA':
+      if (state.activeAgentId !== action.agentId) return state;
+      return { ...state, activeAgentText: state.activeAgentText + action.delta };
+
+    case 'AGENT_REASONING_DELTA':
+      if (state.activeAgentId !== action.agentId) return state;
+      return { ...state, activeAgentReasoning: state.activeAgentReasoning + action.delta };
+
+    case 'AGENT_TOOL_CALL_START':
+      return { ...state, activeToolCalls: [...state.activeToolCalls, action.toolCall] };
+
+    case 'AGENT_TOOL_CALL_COMPLETE':
+      return {
+        ...state,
+        activeToolCalls: state.activeToolCalls.map((tc) =>
+          tc.toolName === action.toolName && tc.agentId === action.agentId
+            ? { ...tc, result: action.result, displayName: action.displayName, durationDisplay: action.durationDisplay }
+            : tc,
+        ),
+      };
+
+    case 'AGENT_TURN_COMPLETE':
+      return {
+        ...state,
+        activeAgentId: null,
+        activeAgentName: '',
+        activeAgentColor: '',
+        activeAgentContentiousness: 0,
+        activeAgentText: '',
+        activeAgentReasoning: '',
+        activeToolCalls: [],
+        contributions: [...state.contributions, action.contribution],
+      };
+
+    case 'ROUND_SEPARATOR':
+      return { ...state, currentRound: action.round };
+
+    case 'SYNTHESIS_START':
+      return { ...state, phase: 'synthesizing', synthesisText: '' };
+
+    case 'SYNTHESIS_TEXT_DELTA':
+      return { ...state, synthesisText: state.synthesisText + action.delta };
+
+    case 'SYNTHESIS_COMPLETE':
+      return { ...state, synthesisText: action.content };
+
+    case 'COUNCIL_ERROR':
+      return { ...state, phase: 'error', error: action.error };
+
+    case 'COUNCIL_COMPLETE':
+      return { ...state, phase: 'complete' };
+
+    case 'RESET':
+      return createEmptySession();
+
+    default:
+      return state;
+  }
+}
+
+// ─── Context ────────────────────────────────────────────────────────────────
+
+interface CouncilContextValue {
+  session: CouncilSession;
+  dispatch: Dispatch<CouncilAction>;
+}
+
+const CouncilContext = createContext<CouncilContextValue | null>(null);
+
+export function CouncilProvider({ children }: { children: ReactNode }) {
+  const [session, dispatch] = useReducer(councilReducer, undefined, createEmptySession);
+
+  return (
+    <CouncilContext.Provider value={{ session, dispatch }}>
+      {children}
+    </CouncilContext.Provider>
+  );
+}
+
+/**
+ * Access council session state and dispatch.
+ *
+ * Must be used within a `<CouncilProvider>`.
+ */
+export function useCouncilContext(): CouncilContextValue {
+  const ctx = useContext(CouncilContext);
+  if (!ctx) throw new Error('useCouncilContext must be used within <CouncilProvider>');
+  return ctx;
+}

--- a/src/hooks/useCouncil/index.ts
+++ b/src/hooks/useCouncil/index.ts
@@ -1,0 +1,1 @@
+export { useCouncil, type UseCouncilOptions, type UseCouncilReturn } from './useCouncil';

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -1,0 +1,189 @@
+/**
+ * Council orchestration hook.
+ *
+ * Bridges the `runCouncil` / `suggestCouncil` client functions to the
+ * `CouncilContext` reducer. Manages AbortController lifecycle so the
+ * user can cancel a deliberation mid-stream.
+ *
+ * All UI rendering logic belongs in components — this hook is strictly
+ * state orchestration + SSE event dispatch.
+ *
+ * @module hooks/useCouncil
+ */
+
+import { useCallback, useRef } from 'react';
+import { useCouncilContext, type CouncilAction } from '../../contexts/CouncilContext';
+import { suggestCouncil, runCouncil } from '../../services/clients/council';
+import type { CouncilConfig, CouncilEvent, CouncilAgent } from '../../types/council';
+import { appLogger } from '../../services/platform';
+
+export interface UseCouncilOptions {
+  serverPort: number;
+  model?: string;
+}
+
+export interface UseCouncilReturn {
+  /** Current session state (from context). */
+  session: ReturnType<typeof useCouncilContext>['session'];
+  /** Request the LLM to design a council for a topic. */
+  suggest: (topic: string, agentCount?: number) => Promise<CouncilAgent[] | null>;
+  /** Start a deliberation with the given config. */
+  run: (config: CouncilConfig) => Promise<void>;
+  /** Abort the current deliberation stream. */
+  cancel: () => void;
+  /** Reset session to idle. */
+  reset: () => void;
+  /** Whether a deliberation is currently streaming. */
+  isStreaming: boolean;
+}
+
+/** Map a raw SSE JSON object to a typed CouncilAction dispatch. */
+function eventToAction(event: CouncilEvent): CouncilAction | null {
+  switch (event.type) {
+    case 'agent_turn_start':
+      return {
+        type: 'AGENT_TURN_START',
+        agentId: event.agent_id,
+        agentName: event.agent_name,
+        color: event.color,
+        round: event.round,
+        contentiousness: event.contentiousness,
+      };
+    case 'agent_text_delta':
+      return { type: 'AGENT_TEXT_DELTA', agentId: event.agent_id, delta: event.delta };
+    case 'agent_reasoning_delta':
+      return { type: 'AGENT_REASONING_DELTA', agentId: event.agent_id, delta: event.delta };
+    case 'agent_tool_call_start':
+      return {
+        type: 'AGENT_TOOL_CALL_START',
+        toolCall: {
+          agentId: event.agent_id,
+          toolName: event.tool_call.name,
+          displayName: event.display_name,
+          argsSummary: event.args_summary,
+        },
+      };
+    case 'agent_tool_call_complete':
+      return {
+        type: 'AGENT_TOOL_CALL_COMPLETE',
+        agentId: event.agent_id,
+        toolName: event.tool_name,
+        result: { content: event.result.content, isError: event.result.is_error },
+        displayName: event.display_name,
+        durationDisplay: event.duration_display,
+      };
+    case 'agent_turn_complete':
+      return {
+        type: 'AGENT_TURN_COMPLETE',
+        contribution: {
+          agentId: event.agent_id,
+          agentName: '',        // Filled from context by reducer if needed
+          color: '',            // Filled from the turn-start event's state
+          contentiousness: 0,
+          content: event.content,
+          coreClaim: event.core_claim,
+          round: event.round,
+        },
+      };
+    case 'round_separator':
+      return { type: 'ROUND_SEPARATOR', round: event.round };
+    case 'synthesis_start':
+      return { type: 'SYNTHESIS_START' };
+    case 'synthesis_text_delta':
+      return { type: 'SYNTHESIS_TEXT_DELTA', delta: event.delta };
+    case 'synthesis_complete':
+      return { type: 'SYNTHESIS_COMPLETE', content: event.content };
+    case 'council_error':
+      return { type: 'COUNCIL_ERROR', error: event.message };
+    case 'council_complete':
+      return { type: 'COUNCIL_COMPLETE' };
+    default:
+      return null;
+  }
+}
+
+export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncilReturn {
+  const { session, dispatch } = useCouncilContext();
+  const abortRef = useRef<AbortController | null>(null);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    cancel();
+    dispatch({ type: 'RESET' });
+  }, [cancel, dispatch]);
+
+  const suggest = useCallback(async (topic: string, agentCount = 3): Promise<CouncilAgent[] | null> => {
+    dispatch({ type: 'START_SUGGEST', topic });
+
+    try {
+      const result = await suggestCouncil(
+        { port: serverPort, topic, agent_count: agentCount, model },
+      );
+      dispatch({
+        type: 'SUGGEST_COMPLETE',
+        agents: result.agents,
+        rounds: result.rounds,
+        synthesisGuidance: result.synthesis_guidance,
+      });
+      return result.agents;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to suggest council';
+      dispatch({ type: 'SUGGEST_ERROR', error: message });
+      appLogger.error('hook', 'Council suggest failed', { error: message });
+      return null;
+    }
+  }, [serverPort, model, dispatch]);
+
+  const run = useCallback(async (config: CouncilConfig) => {
+    cancel();
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    dispatch({ type: 'START_DELIBERATION', topic: config.topic, totalRounds: config.rounds });
+
+    // Build a lookup so we can enrich AGENT_TURN_COMPLETE with metadata
+    const agentMap = new Map(config.agents.map((a) => [a.id, a]));
+
+    try {
+      await runCouncil(
+        { port: serverPort, council: config, model },
+        (raw) => {
+          const event = raw as unknown as CouncilEvent;
+          const action = eventToAction(event);
+          if (!action) return;
+
+          // Enrich agent_turn_complete with name/color/contentiousness from config
+          if (action.type === 'AGENT_TURN_COMPLETE') {
+            const agent = agentMap.get(action.contribution.agentId);
+            if (agent) {
+              action.contribution.agentName = agent.name;
+              action.contribution.color = agent.color;
+              action.contribution.contentiousness = agent.contentiousness;
+            }
+          }
+
+          dispatch(action);
+        },
+        controller.signal,
+      );
+    } catch (err) {
+      if (controller.signal.aborted) return; // User-initiated cancel
+      const message = err instanceof Error ? err.message : 'Council deliberation failed';
+      dispatch({ type: 'COUNCIL_ERROR', error: message });
+      appLogger.error('hook', 'Council run failed', { error: message });
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    }
+  }, [serverPort, model, cancel, dispatch]);
+
+  const isStreaming = session.phase === 'deliberating' || session.phase === 'synthesizing';
+
+  return { session, suggest, run, cancel, reset, isStreaming };
+}

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -33,6 +33,8 @@ export interface UseGglibRuntimeOptions {
    * - `null` / `undefined` → unknown; treated as supported (permissive fallback)
    */
   supportsToolCalls?: boolean | null;
+  /** Called instead of the standard chat flow when isCouncilMode is set. */
+  onCouncilSubmit?: (text: string) => void;
 }
 
 export interface UseGglibRuntimeReturn {
@@ -59,6 +61,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
     maxToolIterations,
     onError,
     supportsToolCalls,
+    onCouncilSubmit,
   } = options;
 
   // Message state managed externally
@@ -185,6 +188,16 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
       // Drain any one-shot metadata (e.g. isVoice) queued for this message
       const extraMeta = nextMessageMetaRef.current;
       nextMessageMetaRef.current = {};
+
+      // Council mode intercept: route to council suggest instead of chat
+      if (extraMeta.isCouncilMode && onCouncilSubmit) {
+        const text = msg.content
+          .map((p) => ('text' in p && typeof p.text === 'string' ? p.text : ''))
+          .join('')
+          .trim();
+        if (text) onCouncilSubmit(text);
+        return;
+      }
 
       const userMessage = mkUserMessage(msg.content as GglibContent, {
         conversationId,

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -19,6 +19,7 @@ import { useSettings } from '../hooks/useSettings';
 import { useVoiceModeContext } from '../contexts/VoiceModeContext';
 import { useToastContext } from '../contexts/ToastContext';
 import { useConfirmContext } from '../contexts/ConfirmContext';
+import { CouncilProvider } from '../contexts/CouncilContext';
 import { useServerState } from '../services/serverEvents';
 import { getServerToolSupport } from '../services/clients/servers';
 import {
@@ -103,6 +104,9 @@ export default function ChatPage({
     return () => { cancelled = true; };
   }, [modelId]);
 
+  // Council mode: ref filled by ChatMessagesPanel with the suggest() callback
+  const councilSubmitRef = useRef<((text: string) => void) | null>(null);
+
   // Runtime - now with external message state
   const { runtime, messages, setMessages, isRunning, timingTracker, currentStreamingAssistantMessageId, setNextMessageMeta } = useGglibRuntime({
     conversationId: activeConversationId ?? undefined,
@@ -110,6 +114,7 @@ export default function ChatPage({
     onError: (error) => setChatError(error.message),
     maxToolIterations,
     supportsToolCalls,
+    onCouncilSubmit: (text) => councilSubmitRef.current?.(text),
   });
 
   // Server state from registry - derives isServerRunning reactively
@@ -393,6 +398,7 @@ export default function ChatPage({
         {/* Tool UI Components - render tool calls in chat messages */}
         <GenericToolUI />
         
+        <CouncilProvider>
         <TwoPanelLayout
           ref={activeTab === 'chat' ? layoutRef : undefined}
           isHidden={activeTab !== 'chat'}
@@ -440,9 +446,12 @@ export default function ChatPage({
               voice={voice ?? undefined}
               supportsToolCalls={supportsToolCalls}
               toolFormat={toolFormat}
+              councilSubmitRef={councilSubmitRef}
+              setNextMessageMeta={setNextMessageMeta}
             />
           }
         />
+        </CouncilProvider>
 
         {/* Voice overlay (floating controls when voice mode is active) */}
         <VoiceOverlay voice={voice} onTranscript={handleVoiceTranscript} />

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -1,0 +1,241 @@
+/**
+ * Council of Agents — frontend domain types.
+ *
+ * Mirrors the Rust `council::events::CouncilEvent` discriminated union
+ * and defines UI-layer state for the council session lifecycle.
+ *
+ * Wire types (`CouncilAgent`, `CouncilConfig`, `SuggestedCouncil`) live in
+ * `services/clients/council.ts` alongside the HTTP/SSE client.
+ *
+ * @module types/council
+ */
+
+// Re-export wire types so consumers have a single import path.
+export type {
+  CouncilAgent,
+  CouncilConfig,
+  SuggestedCouncil,
+} from '../services/clients/council';
+
+// Import locally for use within this file.
+import type { CouncilAgent } from '../services/clients/council';
+
+// ─── SSE Event discriminated union ──────────────────────────────────────────
+
+/**
+ * Mirrors `council::events::CouncilEvent` (Rust).
+ *
+ * The `type` field is `serde(tag = "type", rename_all = "snake_case")` on the
+ * Rust side, so every JSON event carries `"type": "agent_turn_start"` etc.
+ */
+export type CouncilEvent =
+  | AgentTurnStartEvent
+  | AgentTextDeltaEvent
+  | AgentReasoningDeltaEvent
+  | AgentToolCallStartEvent
+  | AgentToolCallCompleteEvent
+  | AgentTurnCompleteEvent
+  | RoundSeparatorEvent
+  | SynthesisStartEvent
+  | SynthesisTextDeltaEvent
+  | SynthesisCompleteEvent
+  | CouncilErrorEvent
+  | CouncilCompleteEvent;
+
+export interface AgentTurnStartEvent {
+  type: 'agent_turn_start';
+  agent_id: string;
+  agent_name: string;
+  color: string;
+  round: number;
+  contentiousness: number;
+}
+
+export interface AgentTextDeltaEvent {
+  type: 'agent_text_delta';
+  agent_id: string;
+  delta: string;
+}
+
+export interface AgentReasoningDeltaEvent {
+  type: 'agent_reasoning_delta';
+  agent_id: string;
+  delta: string;
+}
+
+export interface AgentToolCallStartEvent {
+  type: 'agent_tool_call_start';
+  agent_id: string;
+  tool_call: { name: string; arguments: string };
+  display_name: string;
+  args_summary?: string;
+}
+
+export interface AgentToolCallCompleteEvent {
+  type: 'agent_tool_call_complete';
+  agent_id: string;
+  tool_name: string;
+  result: { content: string; is_error: boolean };
+  display_name: string;
+  duration_display: string;
+}
+
+export interface AgentTurnCompleteEvent {
+  type: 'agent_turn_complete';
+  agent_id: string;
+  content: string;
+  round: number;
+  core_claim?: string;
+}
+
+export interface RoundSeparatorEvent {
+  type: 'round_separator';
+  round: number;
+}
+
+export interface SynthesisStartEvent {
+  type: 'synthesis_start';
+}
+
+export interface SynthesisTextDeltaEvent {
+  type: 'synthesis_text_delta';
+  delta: string;
+}
+
+export interface SynthesisCompleteEvent {
+  type: 'synthesis_complete';
+  content: string;
+}
+
+export interface CouncilErrorEvent {
+  type: 'council_error';
+  message: string;
+}
+
+export interface CouncilCompleteEvent {
+  type: 'council_complete';
+}
+
+// ─── UI session state ───────────────────────────────────────────────────────
+
+/** Completed contribution from a single agent turn. */
+export interface AgentContribution {
+  agentId: string;
+  agentName: string;
+  color: string;
+  contentiousness: number;
+  content: string;
+  coreClaim?: string;
+  round: number;
+}
+
+/** Tool call in progress or completed. */
+export interface AgentToolCall {
+  agentId: string;
+  toolName: string;
+  displayName: string;
+  argsSummary?: string;
+  result?: { content: string; isError: boolean };
+  durationDisplay?: string;
+}
+
+/** Session lifecycle phases. */
+export type CouncilPhase =
+  | 'idle'
+  | 'suggesting'
+  | 'setup'
+  | 'deliberating'
+  | 'synthesizing'
+  | 'complete'
+  | 'error';
+
+/** Accumulated state for a single council session. */
+export interface CouncilSession {
+  phase: CouncilPhase;
+  topic: string;
+  /** Agents returned by the suggestion step. */
+  suggestedAgents: CouncilAgent[];
+  /** Recommended rounds from suggestion. */
+  suggestedRounds: number;
+  /** Optional synthesis guidance from suggestion. */
+  suggestedSynthesisGuidance?: string;
+  currentRound: number;
+  totalRounds: number;
+  /** Agent currently speaking (streaming). */
+  activeAgentId: string | null;
+  /** Name of the currently speaking agent. */
+  activeAgentName: string;
+  /** Hex color of the currently speaking agent. */
+  activeAgentColor: string;
+  /** Contentiousness of the currently speaking agent. */
+  activeAgentContentiousness: number;
+  /** Text accumulated for the active agent's current turn. */
+  activeAgentText: string;
+  /** Reasoning text accumulated for the active agent's current turn. */
+  activeAgentReasoning: string;
+  /** Active tool calls for the current agent turn. */
+  activeToolCalls: AgentToolCall[];
+  /** All completed contributions across rounds. */
+  contributions: AgentContribution[];
+  /** Synthesis text (streamed incrementally). */
+  synthesisText: string;
+  /** Error message if phase === 'error'. */
+  error: string | null;
+}
+
+// ─── Contentiousness → colour mapping ───────────────────────────────────────
+
+/**
+ * Maps contentiousness float [0.0, 1.0] to a hex colour for ambient UI tinting.
+ *
+ * Tiers match the Rust `prompts.rs` behavioural descriptions and the CLI
+ * ANSI-256 palette in `council.rs`:
+ *
+ * | Range     | Label           | Hex       |
+ * |-----------|-----------------|-----------|
+ * | 0.0–0.2   | Collaborative   | `#2d8d8d` |
+ * | 0.2–0.4   | Constructive    | `#00af5f` |
+ * | 0.4–0.6   | Balanced        | `#b2b2b2` |
+ * | 0.6–0.8   | Adversarial     | `#ffaf00` |
+ * | 0.8–1.0   | Devil's Advocate| `#ff0000` |
+ */
+export function contentiousnessColor(c: number): string {
+  if (c < 0.2) return '#2d8d8d';
+  if (c < 0.4) return '#00af5f';
+  if (c < 0.6) return '#b2b2b2';
+  if (c < 0.8) return '#ffaf00';
+  return '#ff0000';
+}
+
+/** Human-readable label for the contentiousness tier. */
+export function contentiousnessLabel(c: number): string {
+  if (c < 0.2) return 'Collaborative';
+  if (c < 0.4) return 'Constructive';
+  if (c < 0.6) return 'Balanced';
+  if (c < 0.8) return 'Adversarial';
+  return "Devil's Advocate";
+}
+
+// ─── Factory ────────────────────────────────────────────────────────────────
+
+/** Create a fresh idle session. */
+export function createEmptySession(): CouncilSession {
+  return {
+    phase: 'idle',
+    topic: '',
+    suggestedAgents: [],
+    suggestedRounds: 3,
+    currentRound: 0,
+    totalRounds: 0,
+    activeAgentId: null,
+    activeAgentName: '',
+    activeAgentColor: '',
+    activeAgentContentiousness: 0,
+    activeAgentText: '',
+    activeAgentReasoning: '',
+    activeToolCalls: [],
+    contributions: [],
+    synthesisText: '',
+    error: null,
+  };
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -70,6 +70,8 @@ export type GglibMessageCustom = {
   timingFinalized?: boolean;
   /** Thinking duration in seconds (restored from metadata on load). */
   thinkingDurationSeconds?: number | null;
+  /** Whether this message should trigger council mode instead of normal chat. */
+  isCouncilMode?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Complete React frontend scaffold for the Council of Agents feature — types, state management, SSE hook, setup UI, message rendering, and composer wiring.

**15 files changed, 1,271 insertions(+), 1 deletion(−)**

## What's included

### Types & State (Phase 4 Part 1)
- `src/types/council.ts` — `CouncilEvent` discriminated union (12 variants), `CouncilSession` state shape, color/label utilities
- `src/contexts/CouncilContext.tsx` — 17-variant `CouncilAction`, `councilReducer`, `CouncilProvider`

### SSE Hook & Setup UI (Phase 4 Part 2)
- `src/hooks/useCouncil/useCouncil.ts` — `suggest()`, `run()`, `cancel()`, `reset()` with SSE streaming via `eventToAction()` mapper
- `src/components/Council/Setup/AgentCard.tsx` — Agent card with ambient CSS custom-property tinting
- `src/components/Council/Setup/CouncilSetupPanel.tsx` — Responsive agent grid with Run/Cancel

### Message Rendering (Phase 4 Part 3)
- `src/components/Council/Messages/CouncilMessage.tsx` — Agent turn with colored left-border, avatar, tool-call badges, `core_claim` pill
- `src/components/Council/Messages/SynthesisMessage.tsx` — Primary accent with inset glow, Sparkles badge
- `src/components/Council/Messages/RoundSeparator.tsx` — Lightweight HR with centered round label
- `src/components/Council/Messages/CouncilThread.tsx` — Orchestrates contributions, round separators, streaming, and synthesis

### Toggle & Submission Wiring (Phase 4 Part 4)
- `src/components/Council/Composer/CouncilToggle.tsx` — Toggle button with `Users` icon, `aria-pressed`
- `src/types/messages.ts` — `isCouncilMode` flag on `GglibMessageCustom`
- `src/hooks/useGglibRuntime/useGglibRuntime.ts` — `onCouncilSubmit` option; council intercept in `onNew`
- `src/pages/ChatPage.tsx` — `councilSubmitRef`, `CouncilProvider` lifted to wrap layout
- `src/components/ChatMessagesPanel/ChatMessagesPanel.tsx` — `useCouncil` wiring, `CouncilToggle` in composer, council Stop button, status indicator

## Flow

1. User toggles Council mode (👥 button in composer)
2. Types message and sends → `onNew` intercepts via `isCouncilMode` metadata
3. Routes to `council.suggest(topic)` → SSE stream → `CouncilSetupPanel` renders suggested agents
4. User reviews/adjusts agents, clicks Run → `council.run(config)` → SSE stream
5. `CouncilThread` renders agent contributions with round separators and streaming
6. Final synthesis displayed with `SynthesisMessage`

## Verification

- `tsc --noEmit` — clean
- `cargo clippy` — clean (no backend changes)