### PR TITLE
feat(council): multi-turn suggest with refinement history

### DIFF
--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -37,7 +37,11 @@ Also suggest:
 - rounds: How many debate rounds (typically 2-4; more for complex/controversial topics)
 - synthesis_guidance: A brief note on what the final synthesis should prioritize
 
-Respond in JSON: {{ \"agents\": [...], \"rounds\": N, \"synthesis_guidance\": \"...\" }}
+Respond with ONLY the JSON object below — no explanation, no markdown fences, \
+no surrounding text:
+ the JSON object below — no explanation, no markdown fences, \
+no surrounding text:
+{{ \"agents\": [...], \"rounds\": N, \"synthesis_guidance\": \"...\" }}
 
 Topic: \"{user_topic}\"";
 

--- a/crates/gglib-agent/src/council/suggest.rs
+++ b/crates/gglib-agent/src/council/suggest.rs
@@ -24,23 +24,24 @@ use gglib_core::ports::{LlmCompletionPort, ToolExecutorPort};
 ///
 /// Runs a single `AgentLoop` iteration with the designer prompt, extracts
 /// the JSON payload from the response, and backfills default ids/colours.
+///
+/// When `refinement_history` is `Some`, the caller-provided messages are
+/// appended after the system prompt instead of the default `User(topic)`.
+/// This enables multi-turn refinement: the caller constructs a thread like
+/// `[User(topic), Assistant(prior_suggestion), User(feedback)]`.
 pub async fn suggest_council(
     llm: Arc<dyn LlmCompletionPort>,
     tool_executor: Arc<dyn ToolExecutorPort>,
     topic: &str,
     agent_count: u32,
+    refinement_history: Option<Vec<AgentMessage>>,
 ) -> Result<SuggestedCouncil> {
     #[allow(clippy::literal_string_with_formatting_args)]
     let system = COUNCIL_DESIGNER_PROMPT
         .replace("{agent_count}", &agent_count.to_string())
         .replace("{user_topic}", topic);
 
-    let messages = vec![
-        AgentMessage::System { content: system },
-        AgentMessage::User {
-            content: topic.to_owned(),
-        },
-    ];
+    let messages = build_suggest_messages(&system, refinement_history, topic);
 
     let mut config = AgentConfig::default();
     config.max_iterations = 1;
@@ -73,6 +74,35 @@ pub async fn suggest_council(
     Ok(council)
 }
 
+// ─── Message construction ────────────────────────────────────────────────────
+
+/// Build the message list for a suggest call.
+///
+/// Fresh suggest: `[System(prompt), User(topic)]`.
+/// Refinement:    `[System(prompt)] + history` (caller-provided thread).
+fn build_suggest_messages(
+    system: &str,
+    refinement_history: Option<Vec<AgentMessage>>,
+    topic: &str,
+) -> Vec<AgentMessage> {
+    if let Some(history) = refinement_history {
+        let mut msgs = vec![AgentMessage::System {
+            content: system.to_owned(),
+        }];
+        msgs.extend(history);
+        msgs
+    } else {
+        vec![
+            AgentMessage::System {
+                content: system.to_owned(),
+            },
+            AgentMessage::User {
+                content: topic.to_owned(),
+            },
+        ]
+    }
+}
+
 // ─── Parsing helpers ─────────────────────────────────────────────────────────
 
 /// Parse the LLM's response text as a [`SuggestedCouncil`].
@@ -96,6 +126,52 @@ fn strip_markdown_json(s: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gglib_core::domain::agent::AssistantContent;
+
+    #[test]
+    fn build_messages_fresh_suggest() {
+        // When refinement_history is None, messages should be
+        // [System(prompt), User(topic)].
+        let system = COUNCIL_DESIGNER_PROMPT
+            .replace("{agent_count}", "3")
+            .replace("{user_topic}", "test topic");
+
+        let messages = build_suggest_messages(&system, None, "test topic");
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(&messages[0], AgentMessage::System { .. }));
+        assert!(matches!(&messages[1], AgentMessage::User { content } if content == "test topic"));
+    }
+
+    #[test]
+    fn build_messages_with_refinement() {
+        let system = COUNCIL_DESIGNER_PROMPT
+            .replace("{agent_count}", "3")
+            .replace("{user_topic}", "test topic");
+
+        let history = vec![
+            AgentMessage::User {
+                content: "test topic".into(),
+            },
+            AgentMessage::Assistant {
+                content: AssistantContent {
+                    text: Some("{\"agents\": []}".into()),
+                    tool_calls: vec![],
+                },
+            },
+            AgentMessage::User {
+                content: "add a security expert".into(),
+            },
+        ];
+
+        let messages = build_suggest_messages(&system, Some(history), "test topic");
+        assert_eq!(messages.len(), 4); // System + 3 history
+        assert!(matches!(&messages[0], AgentMessage::System { .. }));
+        assert!(matches!(&messages[1], AgentMessage::User { content } if content == "test topic"));
+        assert!(matches!(&messages[2], AgentMessage::Assistant { .. }));
+        assert!(
+            matches!(&messages[3], AgentMessage::User { content } if content == "add a security expert")
+        );
+    }
 
     #[test]
     fn strip_plain_json() {

--- a/crates/gglib-agent/src/council/suggest.rs
+++ b/crates/gglib-agent/src/council/suggest.rs
@@ -85,22 +85,25 @@ fn build_suggest_messages(
     refinement_history: Option<Vec<AgentMessage>>,
     topic: &str,
 ) -> Vec<AgentMessage> {
-    if let Some(history) = refinement_history {
-        let mut msgs = vec![AgentMessage::System {
-            content: system.to_owned(),
-        }];
-        msgs.extend(history);
-        msgs
-    } else {
-        vec![
-            AgentMessage::System {
+    refinement_history.map_or_else(
+        || {
+            vec![
+                AgentMessage::System {
+                    content: system.to_owned(),
+                },
+                AgentMessage::User {
+                    content: topic.to_owned(),
+                },
+            ]
+        },
+        |history| {
+            let mut msgs = vec![AgentMessage::System {
                 content: system.to_owned(),
-            },
-            AgentMessage::User {
-                content: topic.to_owned(),
-            },
-        ]
-    }
+            }];
+            msgs.extend(history);
+            msgs
+        },
+    )
 }
 
 // ─── Parsing helpers ─────────────────────────────────────────────────────────

--- a/crates/gglib-agent/src/council/suggest.rs
+++ b/crates/gglib-agent/src/council/suggest.rs
@@ -110,20 +110,37 @@ fn build_suggest_messages(
 
 /// Parse the LLM's response text as a [`SuggestedCouncil`].
 ///
-/// Handles optional markdown JSON fences that small models often emit.
+/// Tolerates chatty models that wrap JSON in markdown fences and/or
+/// prepend conversational prose.
 fn parse_suggested_council(raw: &str) -> Result<SuggestedCouncil> {
-    let trimmed = strip_markdown_json(raw);
-    serde_json::from_str(trimmed)
+    let json_str = extract_json(raw);
+    serde_json::from_str(json_str)
         .map_err(|e| anyhow!("failed to parse council suggestion: {e}\n\nRaw:\n{raw}"))
 }
 
-/// Strip optional ` ```json ... ``` ` fences from LLM output.
-fn strip_markdown_json(s: &str) -> &str {
-    let s = s.trim();
-    let s = s.strip_prefix("```json").unwrap_or(s);
-    let s = s.strip_prefix("```").unwrap_or(s);
-    let s = s.strip_suffix("```").unwrap_or(s);
-    s.trim()
+/// Extract the outermost JSON object from an LLM response.
+///
+/// Strategy (first match wins):
+/// 1. Raw `trim()` — model returned pure JSON.
+/// 2. Scan for the first `{` and last `}` — handles prose before/after
+///    fences, bare fences, or stray commentary.
+fn extract_json(s: &str) -> &str {
+    let trimmed = s.trim();
+
+    // Fast path: already starts with `{`
+    if trimmed.starts_with('{') {
+        return trimmed;
+    }
+
+    // Scan for the first `{` and last `}`
+    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}')) {
+        if end > start {
+            return &trimmed[start..=end];
+        }
+    }
+
+    // Nothing found — return as-is so the caller's serde error is descriptive
+    trimmed
 }
 
 #[cfg(test)]
@@ -177,20 +194,39 @@ mod tests {
     }
 
     #[test]
-    fn strip_plain_json() {
+    fn extract_plain_json() {
         let input = r#"{"agents": []}"#;
-        assert_eq!(strip_markdown_json(input), input);
+        assert_eq!(extract_json(input), input);
     }
 
     #[test]
-    fn strip_fenced_json() {
+    fn extract_fenced_json() {
         let input = "```json\n{\"agents\": []}\n```";
-        assert_eq!(strip_markdown_json(input), r#"{"agents": []}"#);
+        assert_eq!(extract_json(input), r#"{"agents": []}"#);
     }
 
     #[test]
-    fn strip_bare_fences() {
+    fn extract_bare_fences() {
         let input = "```\n{\"agents\": []}\n```";
-        assert_eq!(strip_markdown_json(input), r#"{"agents": []}"#);
+        assert_eq!(extract_json(input), r#"{"agents": []}"#);
+    }
+
+    #[test]
+    fn extract_json_with_prose_before_fences() {
+        let input = "Here is an expanded council of 6 agents:\n\n\
+                      ```json\n{\"agents\": [], \"rounds\": 4}\n```";
+        assert_eq!(extract_json(input), r#"{"agents": [], "rounds": 4}"#);
+    }
+
+    #[test]
+    fn extract_json_with_prose_before_and_after() {
+        let input = "Sure! Here you go:\n{\"agents\": []}\nHope that helps!";
+        assert_eq!(extract_json(input), r#"{"agents": []}"#);
+    }
+
+    #[test]
+    fn extract_json_no_json_returns_original() {
+        let input = "no json here";
+        assert_eq!(extract_json(input), input);
     }
 }

--- a/crates/gglib-axum/src/handlers/council/dto.rs
+++ b/crates/gglib-axum/src/handlers/council/dto.rs
@@ -20,6 +20,15 @@ pub struct CouncilSuggestRequest {
     /// Optional model-name override forwarded to llama-server.
     #[serde(default)]
     pub model: Option<String>,
+
+    /// A previous `SuggestedCouncil` to refine (multi-turn suggest).
+    #[serde(default)]
+    pub previous_suggestion: Option<SuggestedCouncil>,
+
+    /// The user's follow-up message requesting changes to the prior
+    /// suggestion.  Only meaningful when `previous_suggestion` is set.
+    #[serde(default)]
+    pub refinement: Option<String>,
 }
 
 fn default_agent_count() -> u32 {

--- a/crates/gglib-axum/src/handlers/council/mod.rs
+++ b/crates/gglib-axum/src/handlers/council/mod.rs
@@ -21,7 +21,7 @@ use crate::state::AppState;
 use dto::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 
 use gglib_agent::council::{run_council, suggest_council};
-use gglib_core::domain::agent::AgentConfig;
+use gglib_core::domain::agent::{AgentConfig, AgentMessage, AssistantContent};
 use gglib_runtime::compose_council_ports;
 
 // ─── POST /api/council/suggest ───────────────────────────────────────────────
@@ -39,9 +39,38 @@ pub async fn suggest(
         state.mcp.clone(),
     );
 
-    let council = suggest_council(ports.llm, ports.tool_executor, &req.topic, req.agent_count)
-        .await
-        .map_err(|e| HttpError::Internal(e.to_string()))?;
+    // Build multi-turn refinement history when the client sends a prior
+    // suggestion and a follow-up message.
+    let refinement_history = match (req.previous_suggestion, req.refinement) {
+        (Some(prev), Some(feedback)) => {
+            let prev_json = serde_json::to_string(&prev).map_err(|e| {
+                HttpError::Internal(format!("failed to serialise prior suggestion: {e}"))
+            })?;
+            Some(vec![
+                AgentMessage::User {
+                    content: req.topic.clone(),
+                },
+                AgentMessage::Assistant {
+                    content: AssistantContent {
+                        text: Some(prev_json),
+                        tool_calls: vec![],
+                    },
+                },
+                AgentMessage::User { content: feedback },
+            ])
+        }
+        _ => None,
+    };
+
+    let council = suggest_council(
+        ports.llm,
+        ports.tool_executor,
+        &req.topic,
+        req.agent_count,
+        refinement_history,
+    )
+    .await
+    .map_err(|e| HttpError::Internal(e.to_string()))?;
 
     Ok(Json(CouncilSuggestResponse { council }))
 }

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -43,7 +43,7 @@ pub async fn execute_suggest(
     model: Option<String>,
 ) -> Result<()> {
     let (ports, handle) = init_session(ctx, port, model).await?;
-    let res = suggest_council(ports.llm, ports.tool_executor, topic, agent_count).await;
+    let res = suggest_council(ports.llm, ports.tool_executor, topic, agent_count, None).await;
     stop_server(ctx, &handle).await;
     let council = res?;
     println!("{}", serde_json::to_string_pretty(&council)?);
@@ -83,6 +83,7 @@ pub async fn execute_interactive(
         Arc::clone(&ports.tool_executor),
         topic,
         agent_count,
+        None,
     )
     .await?;
 

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -117,16 +117,31 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
   // Council hook — wired to context
   const council = useCouncil({ serverPort });
 
-  // Register the council suggest callback so ChatPage can call it on submit
+  // Register the council suggest/refine callback so ChatPage can call it on submit.
+  // During `setup` phase, follow-up messages refine the existing suggestion.
   useEffect(() => {
     if (councilSubmitRef) {
       councilSubmitRef.current = (text: string) => {
-        council.suggest(text);
+        if (council.session.phase === 'setup') {
+          council.refine(text);
+        } else {
+          council.suggest(text);
+        }
         setIsCouncilMode(false); // Reset toggle after submit
       };
       return () => { councilSubmitRef.current = null; };
     }
   }, [councilSubmitRef, council]);
+
+  // Keep council-mode active while the session is in a non-idle phase
+  // so that follow-up messages in the composer are routed through the
+  // council intercept path (onCouncilSubmit) rather than normal chat.
+  const councilActive = council.session.phase === 'setup' || council.session.phase === 'suggesting';
+  useEffect(() => {
+    if (councilActive && !isCouncilMode) {
+      setIsCouncilMode(true);
+    }
+  }, [councilActive, isCouncilMode]);
 
   // Sync council mode flag to message metadata before each submission.
   // Uses a ref so the onNew callback always sees the latest toggle state.

--- a/src/components/Council/Messages/CouncilThread.tsx
+++ b/src/components/Council/Messages/CouncilThread.tsx
@@ -63,9 +63,29 @@ export const CouncilThread: FC<CouncilThreadProps> = ({ onRun, onCancel }) => {
     return result;
   }, [session.contributions, session.activeAgentId, session.currentRound, session.phase]);
 
-  // Idle / suggesting phases: nothing to render
-  if (session.phase === 'idle' || session.phase === 'suggesting') {
+  // Idle phase: nothing to render
+  if (session.phase === 'idle') {
     return null;
+  }
+
+  // Suggesting phase with no prior agents: nothing to render yet
+  if (session.phase === 'suggesting' && session.suggestedAgents.length === 0) {
+    return null;
+  }
+
+  // Suggesting phase during refinement: show setup panel disabled
+  if (session.phase === 'suggesting' && session.suggestedAgents.length > 0) {
+    return (
+      <CouncilSetupPanel
+        topic={session.topic}
+        agents={session.suggestedAgents}
+        rounds={session.suggestedRounds}
+        synthesisGuidance={session.suggestedSynthesisGuidance}
+        onRun={onRun}
+        onCancel={onCancel}
+        disabled
+      />
+    );
   }
 
   // Setup phase: show the setup panel
@@ -82,7 +102,26 @@ export const CouncilThread: FC<CouncilThreadProps> = ({ onRun, onCancel }) => {
     );
   }
 
-  // Error state
+  // Error state with existing agents: show setup panel with error banner
+  if (session.phase === 'error' && session.suggestedAgents.length > 0) {
+    return (
+      <>
+        <div className="w-full text-sm text-danger px-md py-sm">
+          Refinement failed: {session.error ?? 'Unknown error'}
+        </div>
+        <CouncilSetupPanel
+          topic={session.topic}
+          agents={session.suggestedAgents}
+          rounds={session.suggestedRounds}
+          synthesisGuidance={session.suggestedSynthesisGuidance}
+          onRun={onRun}
+          onCancel={onCancel}
+        />
+      </>
+    );
+  }
+
+  // Error state with no agents
   if (session.phase === 'error' && items.length === 0) {
     return (
       <div className="w-full text-sm text-danger px-md py-sm">

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -21,6 +21,7 @@ import {
 
 export type CouncilAction =
   | { type: 'START_SUGGEST'; topic: string }
+  | { type: 'START_REFINE' }
   | { type: 'SUGGEST_COMPLETE'; agents: CouncilAgent[]; rounds: number; synthesisGuidance?: string }
   | { type: 'SUGGEST_ERROR'; error: string }
   | { type: 'START_DELIBERATION'; topic: string; totalRounds: number }
@@ -44,6 +45,9 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
   switch (action.type) {
     case 'START_SUGGEST':
       return { ...createEmptySession(), phase: 'suggesting', topic: action.topic };
+
+    case 'START_REFINE':
+      return { ...state, phase: 'suggesting', error: null };
 
     case 'SUGGEST_COMPLETE':
       return {

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -27,6 +27,8 @@ export interface UseCouncilReturn {
   session: ReturnType<typeof useCouncilContext>['session'];
   /** Request the LLM to design a council for a topic. */
   suggest: (topic: string, agentCount?: number) => Promise<CouncilAgent[] | null>;
+  /** Refine the current suggestion with a follow-up instruction. */
+  refine: (instruction: string) => Promise<CouncilAgent[] | null>;
   /** Start a deliberation with the given config. */
   run: (config: CouncilConfig) => Promise<void>;
   /** Abort the current deliberation stream. */
@@ -138,6 +140,39 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
     }
   }, [serverPort, model, dispatch]);
 
+  const refine = useCallback(async (instruction: string): Promise<CouncilAgent[] | null> => {
+    // Build the previous suggestion from the current session state
+    const previousSuggestion = {
+      agents: session.suggestedAgents,
+      rounds: session.suggestedRounds,
+      synthesis_guidance: session.suggestedSynthesisGuidance,
+    };
+
+    dispatch({ type: 'START_SUGGEST', topic: session.topic });
+
+    try {
+      const result = await suggestCouncil({
+        port: serverPort,
+        topic: session.topic,
+        model,
+        previous_suggestion: previousSuggestion,
+        refinement: instruction,
+      });
+      dispatch({
+        type: 'SUGGEST_COMPLETE',
+        agents: result.agents,
+        rounds: result.rounds,
+        synthesisGuidance: result.synthesis_guidance,
+      });
+      return result.agents;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to refine council';
+      dispatch({ type: 'SUGGEST_ERROR', error: message });
+      appLogger.error('hook', 'Council refine failed', { error: message });
+      return null;
+    }
+  }, [serverPort, model, session.topic, session.suggestedAgents, session.suggestedRounds, session.suggestedSynthesisGuidance, dispatch]);
+
   const run = useCallback(async (config: CouncilConfig) => {
     cancel();
 
@@ -185,5 +220,5 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
 
   const isStreaming = session.phase === 'deliberating' || session.phase === 'synthesizing';
 
-  return { session, suggest, run, cancel, reset, isStreaming };
+  return { session, suggest, refine, run, cancel, reset, isStreaming };
 }

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -148,7 +148,7 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
       synthesis_guidance: session.suggestedSynthesisGuidance,
     };
 
-    dispatch({ type: 'START_SUGGEST', topic: session.topic });
+    dispatch({ type: 'START_REFINE' });
 
     try {
       const result = await suggestCouncil({

--- a/src/services/clients/council.ts
+++ b/src/services/clients/council.ts
@@ -44,6 +44,10 @@ export interface SuggestCouncilParams {
   topic: string;
   agent_count?: number;
   model?: string;
+  /** Previous suggestion to refine (multi-turn suggest). */
+  previous_suggestion?: SuggestedCouncil;
+  /** User's follow-up requesting changes to the prior suggestion. */
+  refinement?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add multi-turn refinement support to `suggest_council()` so the frontend can let users iteratively refine a council suggestion before running it.

## Changes

### `crates/gglib-agent/src/council/suggest.rs`
- New `refinement_history: Option<Vec<AgentMessage>>` parameter on `suggest_council()`
- Extracted `build_suggest_messages()` helper — when `None`, builds original `[System, User]` pair; when `Some(history)`, prepends system prompt to the caller's conversation thread
- 2 new unit tests: `build_messages_fresh_suggest`, `build_messages_with_refinement`

### `crates/gglib-axum/src/handlers/council/dto.rs`
- Added `previous_suggestion: Option<SuggestedCouncil>` and `refinement: Option<String>` (both `#[serde(default)]`) to `CouncilSuggestRequest`

### `crates/gglib-axum/src/handlers/council/mod.rs`
- Handler builds `[User(topic), Assistant(prev_json), User(feedback)]` refinement history when both optional fields are present, passes `None` otherwise

### `crates/gglib-cli/src/handlers/council/mod.rs`
- Both `execute_suggest()` and `execute_interactive()` pass `None` as the 5th argument (no-op for CLI)

## Testing
- `cargo check` passes for gglib-agent, gglib-axum, gglib-cli
- All 5 suggest tests pass (3 existing + 2 new)