### PR TITLE
fix(cli): route download registration through ModelRegistrarPort

### DIFF
--- a/crates/gglib-cli/src/bootstrap.rs
+++ b/crates/gglib-cli/src/bootstrap.rs
@@ -18,8 +18,8 @@ use async_trait::async_trait;
 use gglib_core::ModelRegistrar;
 use gglib_core::download::DownloadError;
 use gglib_core::ports::{
-    DownloadManagerConfig, DownloadManagerPort, GgufParserPort, ModelRepository,
-    NoopDownloadEmitter, NoopEmitter, ProcessRunner, Repos,
+    DownloadManagerConfig, DownloadManagerPort, GgufParserPort, ModelRegistrarPort,
+    ModelRepository, NoopDownloadEmitter, NoopEmitter, ProcessRunner, Repos,
 };
 use gglib_core::services::{AppCore, ModelVerificationService};
 use gglib_db::{CoreFactory, setup_database};
@@ -109,6 +109,11 @@ pub struct CliContext {
     pub llama_server_path: PathBuf,
     /// Base port for allocating llama-server instances (from CLI `--base-port`).
     pub base_port: u16,
+    /// Model registrar for download registration with full GGUF metadata.
+    ///
+    /// Shared with the download manager so both GUI and CLI download paths
+    /// use the identical registration logic.
+    pub model_registrar: Arc<dyn ModelRegistrarPort>,
     /// Shared HTTP client for LLM adapter calls.
     ///
     /// Constructed once at bootstrap and cloned into each agent session so that
@@ -162,7 +167,9 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
     let models_dir_resolution = resolve_models_dir(None)?;
     let download_config = DownloadManagerConfig::new(models_dir_resolution.path);
 
-    // Create the model registrar (composes over model repository + GGUF parser)
+    // Create the model registrar (composes over model repository + GGUF parser).
+    // Stored on CliContext AND injected into the download manager so CLI
+    // download registration uses the same code path as the GUI.
     let model_files_repo = Arc::new(gglib_db::repositories::ModelFilesRepository::new(
         pool.clone(),
     ));
@@ -184,7 +191,7 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
     // Build the download manager
     let downloads: Arc<dyn DownloadManagerPort> =
         Arc::new(build_download_manager(DownloadManagerDeps {
-            model_registrar,
+            model_registrar: model_registrar.clone(),
             download_repo,
             hf_client: hf_client.clone(),
             event_emitter,
@@ -210,6 +217,7 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
         downloads,
         gguf_parser,
         model_repo: repos.models,
+        model_registrar,
         llama_server_path: config.llama_server_path,
         base_port: config.base_port,
         http_client: reqwest::Client::new(),
@@ -224,6 +232,7 @@ pub fn bootstrap_with(
     runner: Arc<dyn ProcessRunner>,
     downloads: Arc<dyn DownloadManagerPort>,
     gguf_parser: Arc<dyn GgufParserPort>,
+    model_registrar: Arc<dyn ModelRegistrarPort>,
     llama_server_path: PathBuf,
 ) -> CliContext {
     let model_repo = repos.models.clone();
@@ -239,6 +248,7 @@ pub fn bootstrap_with(
         downloads,
         gguf_parser,
         model_repo,
+        model_registrar,
         llama_server_path,
         base_port: 9000,
         http_client: reqwest::Client::new(),

--- a/crates/gglib-cli/src/handlers/model/download/exec.rs
+++ b/crates/gglib-cli/src/handlers/model/download/exec.rs
@@ -76,8 +76,7 @@ pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
 /// Map a [`CliDownloadResult`] to the [`CompletedDownload`] DTO that
 /// [`ModelRegistrarPort::register_model`] expects.
 fn build_completed_download(result: &CliDownloadResult) -> Result<CompletedDownload> {
-    let quantization = Quantization::from_str(&result.quantization)
-        .unwrap_or_default(); // falls back to Quantization::Unknown
+    let quantization = Quantization::from_str(&result.quantization).unwrap_or_default(); // falls back to Quantization::Unknown
 
     let is_sharded = result.downloaded_paths.len() > 1;
 

--- a/crates/gglib-cli/src/handlers/model/download/exec.rs
+++ b/crates/gglib-cli/src/handlers/model/download/exec.rs
@@ -1,11 +1,14 @@
 //! Download handler.
 //!
-//! Downloads models from HuggingFace Hub and registers them in the database.
+//! Downloads models from HuggingFace Hub and registers them in the database
+//! via [`ModelRegistrarPort`], the same registration path used by the GUI.
+
+use std::str::FromStr;
 
 use anyhow::Result;
-use chrono::Utc;
-use gglib_core::domain::NewModel;
-use gglib_download::cli_exec::{self, CliDownloadRequest, list_quantizations};
+use gglib_core::download::Quantization;
+use gglib_core::ports::CompletedDownload;
+use gglib_download::cli_exec::{self, CliDownloadRequest, CliDownloadResult, list_quantizations};
 
 use crate::bootstrap::CliContext;
 use gglib_core::paths::resolve_models_dir;
@@ -43,32 +46,11 @@ pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
     // Execute download (this handles progress display)
     let result = cli_exec::download(request).await?;
 
-    // Create model name from repo_id
-    let model_name = result
-        .repo_id
-        .split('/')
-        .next_back()
-        .unwrap_or(&result.repo_id)
-        .to_string();
+    // Register via the same ModelRegistrarPort that the GUI uses,
+    // ensuring full GGUF metadata extraction and parity.
+    let completed = build_completed_download(&result)?;
 
-    // Build NewModel for database registration
-    let mut new_model = NewModel::new(
-        format!("{}-{}", model_name, result.quantization),
-        result.primary_path.clone(),
-        0.0, // Will be populated from GGUF metadata during add
-        Utc::now(),
-    );
-    new_model.hf_repo_id = Some(result.repo_id.clone());
-    new_model.hf_commit_sha = Some(result.commit_sha.clone());
-    new_model.hf_filename = result
-        .primary_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(String::from);
-    new_model.quantization = Some(result.quantization.clone());
-    new_model.download_date = Some(Utc::now());
-
-    match ctx.app.models().add(new_model).await {
+    match ctx.model_registrar.register_model(&completed).await {
         Ok(model) => {
             println!("✓ Model registered in database:");
             println!("  ID: {}", model.id);
@@ -89,4 +71,38 @@ pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Map a [`CliDownloadResult`] to the [`CompletedDownload`] DTO that
+/// [`ModelRegistrarPort::register_model`] expects.
+fn build_completed_download(result: &CliDownloadResult) -> Result<CompletedDownload> {
+    let quantization = Quantization::from_str(&result.quantization)
+        .unwrap_or_default(); // falls back to Quantization::Unknown
+
+    let is_sharded = result.downloaded_paths.len() > 1;
+
+    let total_bytes = result
+        .downloaded_paths
+        .iter()
+        .map(|p| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
+        .sum();
+
+    let file_paths = if is_sharded {
+        Some(result.downloaded_paths.clone())
+    } else {
+        None
+    };
+
+    Ok(CompletedDownload {
+        primary_path: result.primary_path.clone(),
+        all_paths: result.downloaded_paths.clone(),
+        quantization,
+        repo_id: result.repo_id.clone(),
+        commit_sha: result.commit_sha.clone(),
+        is_sharded,
+        total_bytes,
+        file_paths,
+        hf_tags: vec![],
+        hf_file_entries: vec![],
+    })
 }


### PR DESCRIPTION
## Summary

CLI model downloads now use the same `ModelRegistrarPort::register_model()` code path as the GUI, fixing the **0M parameters** badge bug.

### Problem

When downloading models via CLI (`gglib model download`), the handler in `exec.rs` hardcoded `param_count_b: 0.0` and called the raw `ModelService::add()` — a direct DB insert with no GGUF metadata parsing. This meant downloaded models showed "0M" in the GUI parameter badge, had no architecture info, no capabilities, no auto-tags, etc.

### Fix

- **`bootstrap.rs`**: Expose `model_registrar: Arc<dyn ModelRegistrarPort>` on `CliContext` (shared with the download manager).
- **`exec.rs`**: Replace manual `NewModel` construction with `CompletedDownload` DTO → `register_model()`, the identical path the GUI uses.
- Extract `build_completed_download()` helper for the `CliDownloadResult` → `CompletedDownload` mapping.
- `total_bytes` computed from `std::fs::metadata` (not hardcoded 0).
- `Quantization` parsed via `FromStr` with `Unknown` fallback.

### Guardrails

- ✅ `total_bytes` from actual file metadata
- ✅ Graceful `Quantization` parsing — falls back to `Unknown`
- ✅ Extracted helper function (`build_completed_download`)
- ✅ Full CLI/GUI registration parity

Closes #420