### PR TITLE
Council designer enhancements: targeted refinement, inline editing, CLI refine

### DIFF
--- a/crates/gglib-agent/src/council/config.rs
+++ b/crates/gglib-agent/src/council/config.rs
@@ -86,6 +86,10 @@ pub struct SuggestedCouncil {
     pub agents: Vec<CouncilAgent>,
 
     /// Suggested number of debate rounds.
+    ///
+    /// Defaults to `0` when absent (fill responses only return one agent
+    /// and may omit council-level fields).
+    #[serde(default)]
     pub rounds: u32,
 
     /// Suggested synthesis guidance.

--- a/crates/gglib-agent/src/council/config.rs
+++ b/crates/gglib-agent/src/council/config.rs
@@ -115,8 +115,8 @@ impl SuggestedCouncil {
 
     /// Fill in any `id` or `color` fields that the LLM left empty.
     ///
-    /// - `id` is derived by slugifying the agent `name` with a numeric suffix.
-    /// - `color` cycles through a palette of 8 distinct colours.
+    /// Existing non-empty values are preserved so that stable IDs from
+    /// a prior suggestion survive a refinement round.
     pub fn backfill_defaults(&mut self) {
         for (i, agent) in self.agents.iter_mut().enumerate() {
             if agent.id.is_empty() {
@@ -192,5 +192,38 @@ mod tests {
         }"##;
         let agent: CouncilAgent = serde_json::from_str(json).unwrap();
         assert!(agent.tool_filter.is_none());
+    }
+
+    #[test]
+    fn backfill_preserves_existing_ids_and_colors() {
+        let mut council = SuggestedCouncil {
+            agents: vec![
+                CouncilAgent {
+                    id: "kept-id".into(),
+                    name: "Kept".into(),
+                    color: "#aaa".into(),
+                    persona: String::new(),
+                    perspective: String::new(),
+                    contentiousness: 0.5,
+                    tool_filter: None,
+                },
+                CouncilAgent {
+                    id: String::new(),
+                    name: "New Agent".into(),
+                    color: String::new(),
+                    persona: String::new(),
+                    perspective: String::new(),
+                    contentiousness: 0.3,
+                    tool_filter: None,
+                },
+            ],
+            rounds: 2,
+            synthesis_guidance: None,
+        };
+        council.backfill_defaults();
+        assert_eq!(council.agents[0].id, "kept-id");
+        assert_eq!(council.agents[0].color, "#aaa");
+        assert_eq!(council.agents[1].id, "new-agent-2");
+        assert!(!council.agents[1].color.is_empty());
     }
 }

--- a/crates/gglib-agent/src/council/config.rs
+++ b/crates/gglib-agent/src/council/config.rs
@@ -42,6 +42,9 @@ pub struct CouncilAgent {
     /// The raw float is stored for UI slider binding.  Prompt assembly
     /// maps it to a discrete instruction string via
     /// [`crate::council::prompts::contentiousness_to_instruction`].
+    ///
+    /// The alias covers a common LLM typo (`"contententiousness"`).
+    #[serde(alias = "contententiousness")]
     pub contentiousness: f32,
 
     /// Optional allowlist of tool names this agent may use.

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -19,9 +19,10 @@
 /// Placeholders: `{agent_count}`, `{user_topic}`.
 pub const COUNCIL_DESIGNER_PROMPT: &str = "\
 You are a council architect. Given a user's question or topic, design a council \
-of {agent_count} agents who will deliberate on it from diverse perspectives.
+of approximately {agent_count} agents who will deliberate on it from diverse perspectives.
 
 For each agent, provide:
+- id: A short kebab-case identifier (e.g., \"devils-advocate\", \"domain-expert\")
 - name: A concise role title (e.g., \"Devil's Advocate\", \"Domain Expert\", \"Pragmatist\")
 - persona: 2-3 sentences defining their worldview, expertise, and argumentative style
 - contentiousness: A number 0.0-1.0 (0.0 = fully collaborative, 1.0 = maximally adversarial)
@@ -39,11 +40,21 @@ Also suggest:
 
 Respond with ONLY the JSON object below — no explanation, no markdown fences, \
 no surrounding text:
- the JSON object below — no explanation, no markdown fences, \
-no surrounding text:
 {{ \"agents\": [...], \"rounds\": N, \"synthesis_guidance\": \"...\" }}
 
 Topic: \"{user_topic}\"";
+
+/// Addendum appended to the designer system prompt during refinement.
+///
+/// Instructs the LLM to make minimal, targeted changes and preserve
+/// stable agent IDs so the frontend can diff old vs new suggestions.
+pub const COUNCIL_REFINEMENT_ADDENDUM: &str = "\n\n\
+IMPORTANT — you are REFINING a previous suggestion based on user feedback.\n\
+- Make MINIMAL changes. Preserve agents the user does not mention.\n\
+- Keep the `id` field IDENTICAL for agents you do not modify.\n\
+- Only add, remove, or modify agents the user specifically requests.\n\
+- You may adjust the agent count freely — ignore the original count guidance.\n\
+- Respond with the COMPLETE updated JSON (all agents, not just changes).";
 
 // ─── agent turn ──────────────────────────────────────────────────────────────
 

--- a/crates/gglib-agent/src/council/suggest.rs
+++ b/crates/gglib-agent/src/council/suggest.rs
@@ -4,6 +4,9 @@
 //! parses the LLM's JSON output, and returns a [`SuggestedCouncil`].
 //! Used by both the CLI and Axum consumers.
 
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use anyhow::{Result, anyhow};
 use tokio::sync::mpsc;
 
@@ -13,8 +16,6 @@ use gglib_core::domain::agent::{AgentConfig, AgentEvent, AgentMessage};
 use crate::AgentLoop;
 use crate::council::config::SuggestedCouncil;
 use crate::council::prompts::{COUNCIL_DESIGNER_PROMPT, COUNCIL_REFINEMENT_ADDENDUM};
-
-use std::sync::Arc;
 
 use gglib_core::ports::{LlmCompletionPort, ToolExecutorPort};
 
@@ -50,7 +51,10 @@ pub async fn suggest_council(
     let mut config = AgentConfig::default();
     config.max_iterations = 1;
 
-    let agent = AgentLoop::build(llm, tool_executor, None);
+    // The designer only returns JSON — no tools needed.  An empty filter
+    // prevents tool-happy models from burning the single iteration on a
+    // tool call (which triggers MaxIterationsReached).
+    let agent = AgentLoop::build(llm, tool_executor, Some(HashSet::new()));
     let (tx, mut rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
 
     let handle = tokio::spawn(async move { agent.run(messages, config, tx).await });

--- a/crates/gglib-agent/src/council/suggest.rs
+++ b/crates/gglib-agent/src/council/suggest.rs
@@ -12,7 +12,7 @@ use gglib_core::domain::agent::{AgentConfig, AgentEvent, AgentMessage};
 
 use crate::AgentLoop;
 use crate::council::config::SuggestedCouncil;
-use crate::council::prompts::COUNCIL_DESIGNER_PROMPT;
+use crate::council::prompts::{COUNCIL_DESIGNER_PROMPT, COUNCIL_REFINEMENT_ADDENDUM};
 
 use std::sync::Arc;
 
@@ -37,9 +37,13 @@ pub async fn suggest_council(
     refinement_history: Option<Vec<AgentMessage>>,
 ) -> Result<SuggestedCouncil> {
     #[allow(clippy::literal_string_with_formatting_args)]
-    let system = COUNCIL_DESIGNER_PROMPT
+    let mut system = COUNCIL_DESIGNER_PROMPT
         .replace("{agent_count}", &agent_count.to_string())
         .replace("{user_topic}", topic);
+
+    if refinement_history.is_some() {
+        system.push_str(COUNCIL_REFINEMENT_ADDENDUM);
+    }
 
     let messages = build_suggest_messages(&system, refinement_history, topic);
 
@@ -228,5 +232,19 @@ mod tests {
     fn extract_json_no_json_returns_original() {
         let input = "no json here";
         assert_eq!(extract_json(input), input);
+    }
+
+    #[test]
+    fn designer_prompt_says_approximately() {
+        assert!(
+            COUNCIL_DESIGNER_PROMPT.contains("approximately {agent_count}"),
+            "prompt should use 'approximately' to allow flexible agent count"
+        );
+    }
+
+    #[test]
+    fn refinement_addendum_instructs_minimal_changes() {
+        assert!(COUNCIL_REFINEMENT_ADDENDUM.contains("MINIMAL changes"));
+        assert!(COUNCIL_REFINEMENT_ADDENDUM.contains("Keep the `id` field IDENTICAL"));
     }
 }

--- a/crates/gglib-axum/src/handlers/council/mod.rs
+++ b/crates/gglib-axum/src/handlers/council/mod.rs
@@ -39,8 +39,8 @@ pub async fn suggest(
         state.mcp.clone(),
     );
 
-    // Build multi-turn refinement history when the client sends a prior
-    // suggestion and a follow-up message.
+    // Build multi-turn refinement history when the client sends a
+    // follow-up message (with or without a prior suggestion).
     let refinement_history = match (req.previous_suggestion, req.refinement) {
         (Some(prev), Some(feedback)) => {
             let prev_json = serde_json::to_string(&prev).map_err(|e| {
@@ -59,6 +59,14 @@ pub async fn suggest(
                 AgentMessage::User { content: feedback },
             ])
         }
+        // Fill mode: refinement without a prior suggestion — two-message
+        // thread so the LLM sees the topic AND the refinement instruction.
+        (None, Some(feedback)) => Some(vec![
+            AgentMessage::User {
+                content: req.topic.clone(),
+            },
+            AgentMessage::User { content: feedback },
+        ]),
         _ => None,
     };
 

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -118,6 +118,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `search <query>` | Search HuggingFace Hub for models |
 | `config settings show` | Show current configuration |
 | `config default <id>` | Set/show/clear the default model |
+| `chat council <topic>` | Interactive council: suggest → edit → run |
+| `chat council --suggest <topic>` | Suggest a council and print JSON |
 | `verify <id>` | Verify model integrity via SHA256 hash comparison |
 | `repair <id>` | Re-download corrupt shards for a model |
 | `completions <shell>` | Print a shell completion script to stdout |
@@ -233,6 +235,40 @@ reaches stdout. This works regardless of rendering mode.
 ```bash
 gglib config default 1
 ```
+
+### Council Command
+
+The `chat council` command lets you compose a multi-agent debate panel:
+
+```bash
+# Interactive mode: suggest → edit → run
+gglib chat council "Should we use microservices?"
+
+# Suggest-only: print the designed council as JSON
+gglib chat council --suggest "Pros and cons of Rust"
+
+# Load a saved config, edit, then run
+gglib chat council --config council.json --edit "My topic"
+```
+
+The interactive REPL editor supports these commands:
+
+| Command | Description |
+|---------|-------------|
+| `show` | Re-display the council summary |
+| `persona <N>` | Edit agent N's persona |
+| `cont <N>` | Edit agent N's contentiousness (0.0–1.0) |
+| `tools <N>` | Edit agent N's tool filter |
+| `rounds <N>` | Set number of deliberation rounds |
+| `remove <N>` | Remove agent N |
+| `refine <msg>` | Ask the LLM to revise the council |
+| `save <path>` | Save config to a JSON file |
+| `run` | Accept and run the council |
+| `quit` | Abort without running |
+
+The `refine` command sends your instruction to the LLM along with the current
+council as context, producing a targeted revision that preserves stable agent
+IDs and makes minimal changes. You can refine multiple times before running.
 
 ## Usage
 

--- a/crates/gglib-cli/src/handlers/council/editor.rs
+++ b/crates/gglib-cli/src/handlers/council/editor.rs
@@ -13,6 +13,15 @@ use super::stream::temperature_fg;
 
 // ─── Agent-level edits ──────────────────────────────────────────────────────
 
+/// Rename an agent.
+pub fn apply_name(agent: &mut CouncilAgent, new_name: &str) -> Result<()> {
+    if new_name.is_empty() {
+        bail!("name cannot be empty");
+    }
+    agent.name = new_name.to_owned();
+    Ok(())
+}
+
 /// Set the persona (system prompt flavour) for a single agent.
 pub fn apply_persona(agent: &mut CouncilAgent, new_persona: &str) -> Result<()> {
     if new_persona.is_empty() {

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -241,11 +241,7 @@ async fn edit_then_run(config: &mut CouncilConfig, ports: CouncilPorts) -> Resul
             repl::EditOutcome::Run => return run_with_ports(config.clone(), ports).await,
             repl::EditOutcome::Quit => return Ok(()),
             repl::EditOutcome::Refine(instruction) => {
-                eprintln!(
-                    "{}  Refining council …{}",
-                    style::DIM,
-                    style::RESET
-                );
+                eprintln!("{}  Refining council …{}", style::DIM, style::RESET);
 
                 let prev = SuggestedCouncil {
                     agents: config.agents.clone(),

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result, anyhow};
 use tokio::sync::mpsc;
 
+use gglib_agent::council::config::CouncilAgent;
 use gglib_agent::council::config::CouncilConfig;
 use gglib_agent::council::config::SuggestedCouncil;
-use gglib_agent::council::config::CouncilAgent;
 use gglib_agent::council::events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 use gglib_agent::council::{run_council, suggest_council};
 use gglib_core::domain::agent::AgentConfig;
@@ -309,7 +309,12 @@ async fn handle_ai_fill(
     let name = target.name.clone();
     let old = target.clone();
 
-    eprintln!("{}  Filling details for '{}' \u{2026}{}", style::DIM, name, style::RESET);
+    eprintln!(
+        "{}  Filling details for '{}' \u{2026}{}",
+        style::DIM,
+        name,
+        style::RESET
+    );
 
     let prev = SuggestedCouncil {
         agents: config.agents.clone(),
@@ -324,11 +329,18 @@ async fn handle_ai_fill(
          council JSON, but focus your creative updates strictly on the agent named '{name}'."
     );
     let history = vec![
-        AgentMessage::User { content: config.topic.clone() },
-        AgentMessage::Assistant {
-            content: AssistantContent { text: Some(prev_json), tool_calls: vec![] },
+        AgentMessage::User {
+            content: config.topic.clone(),
         },
-        AgentMessage::User { content: refinement },
+        AgentMessage::Assistant {
+            content: AssistantContent {
+                text: Some(prev_json),
+                tool_calls: vec![],
+            },
+        },
+        AgentMessage::User {
+            content: refinement,
+        },
     ];
 
     let suggested = suggest_council(
@@ -345,7 +357,8 @@ async fn handle_ai_fill(
     let Some(filled) = filled else {
         eprintln!(
             "  \x1b[31mThe LLM did not return an agent named '{}' — no changes applied.{}",
-            name, style::RESET
+            name,
+            style::RESET
         );
         return Ok(());
     };
@@ -377,5 +390,8 @@ async fn handle_ai_fill(
 
 /// Find an agent by name in the suggestion, falling back to same index.
 fn pluck_agent<'a>(agents: &'a [CouncilAgent], name: &str, idx: usize) -> Option<&'a CouncilAgent> {
-    agents.iter().find(|a| a.name == name).or_else(|| agents.get(idx))
+    agents
+        .iter()
+        .find(|a| a.name == name)
+        .or_else(|| agents.get(idx))
 }

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -322,8 +322,8 @@ async fn handle_ai_fill(
         "The council already has these agents: [{}]. \
          Generate details for the agent named '{name}' to complement them. \
          Return a JSON with ONLY this one agent in the \"agents\" array \u{2014} do NOT \
-         regenerate the other agents. Include: id, name, persona (2-3 sentences), \
-         perspective (1 sentence), and contentiousness (0.0-1.0).",
+         regenerate the other agents. Include id, name, persona (2-3 sentences), \
+         perspective (1 sentence), contentiousness (0.0-1.0), rounds, and synthesis_guidance.",
         roster.join(", ")
     );
     let history = vec![

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -20,10 +20,11 @@ use anyhow::{Context as _, Result, anyhow};
 use tokio::sync::mpsc;
 
 use gglib_agent::council::config::CouncilConfig;
+use gglib_agent::council::config::SuggestedCouncil;
 use gglib_agent::council::events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 use gglib_agent::council::{run_council, suggest_council};
 use gglib_core::domain::agent::AgentConfig;
-use gglib_core::{ProcessHandle, ServerConfig};
+use gglib_core::{AgentMessage, AssistantContent, ProcessHandle, ServerConfig};
 use gglib_runtime::CouncilPorts;
 use gglib_runtime::compose_council_ports;
 use gglib_runtime::llama::args::{resolve_jinja_flag, resolve_reasoning_format};
@@ -234,9 +235,53 @@ async fn edit_then_run(config: &mut CouncilConfig, ports: CouncilPorts) -> Resul
         .into_iter()
         .map(|t| t.name)
         .collect();
-    match repl::edit_loop(config, &tools)? {
-        Some(()) => run_with_ports(config.clone(), ports).await,
-        None => Ok(()),
+
+    loop {
+        match repl::edit_loop(config, &tools)? {
+            repl::EditOutcome::Run => return run_with_ports(config.clone(), ports).await,
+            repl::EditOutcome::Quit => return Ok(()),
+            repl::EditOutcome::Refine(instruction) => {
+                eprintln!(
+                    "{}  Refining council …{}",
+                    style::DIM,
+                    style::RESET
+                );
+
+                let prev = SuggestedCouncil {
+                    agents: config.agents.clone(),
+                    rounds: config.rounds,
+                    synthesis_guidance: config.synthesis_guidance.clone(),
+                };
+                let prev_json = serde_json::to_string(&prev)?;
+
+                let history = vec![
+                    AgentMessage::User {
+                        content: config.topic.clone(),
+                    },
+                    AgentMessage::Assistant {
+                        content: AssistantContent {
+                            text: Some(prev_json),
+                            tool_calls: vec![],
+                        },
+                    },
+                    AgentMessage::User {
+                        content: instruction,
+                    },
+                ];
+
+                let suggested = suggest_council(
+                    Arc::clone(&ports.llm),
+                    Arc::clone(&ports.tool_executor),
+                    &config.topic,
+                    config.agents.len() as u32,
+                    Some(history),
+                )
+                .await?;
+
+                render::render_suggested(&suggested);
+                *config = suggested.into_config(config.topic.clone());
+            }
+        }
     }
 }
 

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -21,6 +21,7 @@ use tokio::sync::mpsc;
 
 use gglib_agent::council::config::CouncilConfig;
 use gglib_agent::council::config::SuggestedCouncil;
+use gglib_agent::council::config::CouncilAgent;
 use gglib_agent::council::events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 use gglib_agent::council::{run_council, suggest_council};
 use gglib_core::domain::agent::AgentConfig;
@@ -277,6 +278,9 @@ async fn edit_then_run(config: &mut CouncilConfig, ports: CouncilPorts) -> Resul
                 render::render_suggested(&suggested);
                 *config = suggested.into_config(config.topic.clone());
             }
+            repl::EditOutcome::Fill(idx) => {
+                handle_ai_fill(config, idx, &ports).await?;
+            }
         }
     }
 }
@@ -291,4 +295,87 @@ async fn run_with_ports(council: CouncilConfig, ports: CouncilPorts) -> Result<(
 
     stream::render_council_stream(&mut rx).await;
     Ok(())
+}
+
+/// Call `suggest_council` with a targeted refinement prompt for one agent,
+/// show a diff, and apply on confirmation.  Strict plucking: only the
+/// matching agent's persona/perspective/contentiousness are extracted.
+async fn handle_ai_fill(
+    config: &mut CouncilConfig,
+    idx: usize,
+    ports: &CouncilPorts,
+) -> Result<()> {
+    let target = &config.agents[idx];
+    let name = target.name.clone();
+    let old = target.clone();
+
+    eprintln!("{}  Filling details for '{}' \u{2026}{}", style::DIM, name, style::RESET);
+
+    let prev = SuggestedCouncil {
+        agents: config.agents.clone(),
+        rounds: config.rounds,
+        synthesis_guidance: config.synthesis_guidance.clone(),
+    };
+    let prev_json = serde_json::to_string(&prev)?;
+    let refinement = format!(
+        "The user wants to add/update an agent named '{name}'. \
+         Please generate a highly specific persona, perspective, and contentiousness \
+         score for this agent to complement the rest of the council. Return the full \
+         council JSON, but focus your creative updates strictly on the agent named '{name}'."
+    );
+    let history = vec![
+        AgentMessage::User { content: config.topic.clone() },
+        AgentMessage::Assistant {
+            content: AssistantContent { text: Some(prev_json), tool_calls: vec![] },
+        },
+        AgentMessage::User { content: refinement },
+    ];
+
+    let suggested = suggest_council(
+        Arc::clone(&ports.llm),
+        Arc::clone(&ports.tool_executor),
+        &config.topic,
+        config.agents.len() as u32,
+        Some(history),
+    )
+    .await?;
+
+    // Strict plucking: find matching agent by name, fallback to same index.
+    let filled = pluck_agent(&suggested.agents, &name, idx);
+    let Some(filled) = filled else {
+        eprintln!(
+            "  \x1b[31mThe LLM did not return an agent named '{}' — no changes applied.{}",
+            name, style::RESET
+        );
+        return Ok(());
+    };
+
+    // Build a preview agent with only the three target fields changed.
+    let preview = CouncilAgent {
+        persona: filled.persona.clone(),
+        perspective: filled.perspective.clone(),
+        contentiousness: filled.contentiousness,
+        ..old.clone()
+    };
+
+    render::render_agent_diff(idx, &old, &preview);
+
+    eprint!("  Apply these changes? [Y/n] ");
+    let _ = std::io::Write::flush(&mut std::io::stderr());
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    if matches!(answer.trim(), "" | "y" | "Y" | "yes") {
+        config.agents[idx].persona = filled.persona.clone();
+        config.agents[idx].perspective = filled.perspective.clone();
+        config.agents[idx].contentiousness = filled.contentiousness;
+        render::render_config(config);
+    } else {
+        eprintln!("  {}Discarded.{}", style::DIM, style::RESET);
+    }
+    Ok(())
+}
+
+/// Find an agent by name in the suggestion, falling back to same index.
+fn pluck_agent<'a>(agents: &'a [CouncilAgent], name: &str, idx: usize) -> Option<&'a CouncilAgent> {
+    agents.iter().find(|a| a.name == name).or_else(|| agents.get(idx))
 }

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -316,27 +316,19 @@ async fn handle_ai_fill(
         style::RESET
     );
 
-    let prev = SuggestedCouncil {
-        agents: config.agents.clone(),
-        rounds: config.rounds,
-        synthesis_guidance: config.synthesis_guidance.clone(),
-    };
-    let prev_json = serde_json::to_string(&prev)?;
+    // Send only agent names as context — avoids echoing full personas back.
+    let roster: Vec<&str> = config.agents.iter().map(|a| a.name.as_str()).collect();
     let refinement = format!(
-        "The user wants to add/update an agent named '{name}'. \
-         Please generate a highly specific persona, perspective, and contentiousness \
-         score for this agent to complement the rest of the council. Return the full \
-         council JSON, but focus your creative updates strictly on the agent named '{name}'."
+        "The council already has these agents: [{}]. \
+         Generate details for the agent named '{name}' to complement them. \
+         Return a JSON with ONLY this one agent in the \"agents\" array \u{2014} do NOT \
+         regenerate the other agents. Include: id, name, persona (2-3 sentences), \
+         perspective (1 sentence), and contentiousness (0.0-1.0).",
+        roster.join(", ")
     );
     let history = vec![
         AgentMessage::User {
             content: config.topic.clone(),
-        },
-        AgentMessage::Assistant {
-            content: AssistantContent {
-                text: Some(prev_json),
-                tool_calls: vec![],
-            },
         },
         AgentMessage::User {
             content: refinement,
@@ -347,7 +339,7 @@ async fn handle_ai_fill(
         Arc::clone(&ports.llm),
         Arc::clone(&ports.tool_executor),
         &config.topic,
-        config.agents.len() as u32,
+        1,
         Some(history),
     )
     .await?;

--- a/crates/gglib-cli/src/handlers/council/render.rs
+++ b/crates/gglib-cli/src/handlers/council/render.rs
@@ -3,7 +3,7 @@
 //! Renders a scannable table of agents with colour-coded contentiousness
 //! and an optional synthesis guidance line.
 
-use gglib_agent::council::config::{CouncilConfig, SuggestedCouncil};
+use gglib_agent::council::config::{CouncilAgent, CouncilConfig, SuggestedCouncil};
 
 use crate::presentation::style::{BOLD, DIM, RESET};
 
@@ -66,4 +66,41 @@ fn render_agent_table(agents: &[gglib_agent::council::config::CouncilAgent]) {
             perspective,
         );
     }
+}
+
+/// Print a coloured before/after diff for the three AI-filled fields of an agent.
+pub fn render_agent_diff(idx: usize, old: &CouncilAgent, new: &CouncilAgent) {
+    let color = temperature_fg(new.contentiousness);
+    eprintln!(
+        "\n  {BOLD}Agent #{} \"{}\"{RESET}",
+        idx + 1,
+        new.name,
+    );
+
+    if old.persona != new.persona {
+        eprintln!("  {DIM}persona:{RESET}");
+        eprintln!("    \x1b[31m- {}{RESET}", old.persona);
+        eprintln!("    \x1b[32m+ {}{RESET}", new.persona);
+    }
+    if old.perspective != new.perspective {
+        eprintln!("  {DIM}perspective:{RESET}");
+        eprintln!("    \x1b[31m- {}{RESET}", old.perspective);
+        eprintln!("    \x1b[32m+ {}{RESET}", new.perspective);
+    }
+    if (old.contentiousness - new.contentiousness).abs() > f32::EPSILON {
+        let old_color = temperature_fg(old.contentiousness);
+        eprintln!(
+            "  {DIM}contentiousness:{RESET}  {old_color}{:.2}{RESET} → {color}{:.2}{RESET}",
+            old.contentiousness,
+            new.contentiousness,
+        );
+    }
+
+    if old.persona == new.persona
+        && old.perspective == new.perspective
+        && (old.contentiousness - new.contentiousness).abs() <= f32::EPSILON
+    {
+        eprintln!("  {DIM}(no changes){RESET}");
+    }
+    eprintln!();
 }

--- a/crates/gglib-cli/src/handlers/council/render.rs
+++ b/crates/gglib-cli/src/handlers/council/render.rs
@@ -71,11 +71,7 @@ fn render_agent_table(agents: &[gglib_agent::council::config::CouncilAgent]) {
 /// Print a coloured before/after diff for the three AI-filled fields of an agent.
 pub fn render_agent_diff(idx: usize, old: &CouncilAgent, new: &CouncilAgent) {
     let color = temperature_fg(new.contentiousness);
-    eprintln!(
-        "\n  {BOLD}Agent #{} \"{}\"{RESET}",
-        idx + 1,
-        new.name,
-    );
+    eprintln!("\n  {BOLD}Agent #{} \"{}\"{RESET}", idx + 1, new.name,);
 
     if old.persona != new.persona {
         eprintln!("  {DIM}persona:{RESET}");
@@ -91,8 +87,7 @@ pub fn render_agent_diff(idx: usize, old: &CouncilAgent, new: &CouncilAgent) {
         let old_color = temperature_fg(old.contentiousness);
         eprintln!(
             "  {DIM}contentiousness:{RESET}  {old_color}{:.2}{RESET} → {color}{:.2}{RESET}",
-            old.contentiousness,
-            new.contentiousness,
+            old.contentiousness, new.contentiousness,
         );
     }
 

--- a/crates/gglib-cli/src/handlers/council/repl.rs
+++ b/crates/gglib-cli/src/handlers/council/repl.rs
@@ -7,6 +7,7 @@
 //!   tools <N>           — edit agent N's tool filter (prints list first)
 //!   rounds <N>          — set the number of deliberation rounds
 //!   remove <N>          — remove agent N
+//!   refine <msg>        — ask the LLM to revise the council
 //!   run                 — accept and run the council
 //!   save <path>         — write the config to a JSON file
 //!   quit / q            — abort without running
@@ -23,9 +24,18 @@ use crate::presentation::style::{BOLD, DIM, RESET};
 use super::editor;
 use super::render;
 
-/// Run the interactive editing REPL.  Returns `Some(config)` if the user
-/// chose `run`, or `None` if they quit.
-pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Result<Option<()>> {
+/// Outcome of a single REPL session.
+pub enum EditOutcome {
+    /// User chose `run` — proceed with deliberation.
+    Run,
+    /// User chose `quit` — abort without running.
+    Quit,
+    /// User chose `refine <msg>` — caller should re-suggest then re-enter REPL.
+    Refine(String),
+}
+
+/// Run the interactive editing REPL.
+pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Result<EditOutcome> {
     let mut rl = DefaultEditor::new()?;
 
     print_help();
@@ -37,7 +47,7 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
                 rustyline::error::ReadlineError::Interrupted | rustyline::error::ReadlineError::Eof,
             ) => {
                 eprintln!("{DIM}Aborted.{RESET}");
-                return Ok(None);
+                return Ok(EditOutcome::Quit);
             }
             Err(e) => return Err(e.into()),
         };
@@ -51,11 +61,15 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
         match cmd {
             "help" | "h" | "?" => print_help(),
             "show" | "s" => render::render_config(config),
-            "run" | "r" => return Ok(Some(())),
+            "run" | "r" => return Ok(EditOutcome::Run),
             "quit" | "q" => {
                 eprintln!("{DIM}Aborted.{RESET}");
-                return Ok(None);
+                return Ok(EditOutcome::Quit);
             }
+            "refine" => match arg {
+                Some(instruction) => return Ok(EditOutcome::Refine(instruction.to_owned())),
+                None => eprintln!("  usage: refine <instruction>"),
+            },
             "rounds" => match arg {
                 Some(a) => report(editor::apply_rounds(config, a)),
                 None => eprintln!("  usage: rounds <number>"),
@@ -155,6 +169,7 @@ fn print_help() {
   tools <N>        edit agent N's tool filter
   rounds <N>       set number of rounds
   remove <N>       remove agent N
+  refine <msg>     ask the LLM to revise the council
   save <path>      save config to JSON file
   run              accept and run the council
   quit             abort without running

--- a/crates/gglib-cli/src/handlers/council/repl.rs
+++ b/crates/gglib-cli/src/handlers/council/repl.rs
@@ -2,10 +2,13 @@
 //!
 //! Commands:
 //!   show                — re-display the council summary table
+//!   name <N>            — rename agent N (offers AI-fill afterwards)
 //!   persona <N>         — edit agent N's persona (single-line prompt)
 //!   cont <N>            — edit agent N's contentiousness
 //!   tools <N>           — edit agent N's tool filter (prints list first)
+//!   fill <N>            — ask the LLM to fill agent N's details
 //!   rounds <N>          — set the number of deliberation rounds
+//!   add                 — add a new agent (prompts for name, offers fill)
 //!   remove <N>          — remove agent N
 //!   refine <msg>        — ask the LLM to revise the council
 //!   run                 — accept and run the council
@@ -17,7 +20,7 @@ use std::io::Write as _;
 use anyhow::Result;
 use rustyline::DefaultEditor;
 
-use gglib_agent::council::config::CouncilConfig;
+use gglib_agent::council::config::{CouncilAgent, CouncilConfig};
 
 use crate::presentation::style::{BOLD, DIM, RESET};
 
@@ -32,6 +35,8 @@ pub enum EditOutcome {
     Quit,
     /// User chose `refine <msg>` — caller should re-suggest then re-enter REPL.
     Refine(String),
+    /// User wants the LLM to fill an agent's details (by 0-based index).
+    Fill(usize),
 }
 
 /// Run the interactive editing REPL.
@@ -89,6 +94,44 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
                     let res = editor::apply_persona(&mut config.agents[idx], input.trim());
                     report(res);
                     editor::print_agent_summary(idx, &config.agents[idx]);
+                }
+            }
+            "name" => {
+                if let Some(idx) = parse_agent_idx(arg, config.agents.len()) {
+                    eprint!("  New name for #{} ({}): ", idx + 1, config.agents[idx].name);
+                    let _ = std::io::stderr().flush();
+                    let input = rl.readline("  ")?;
+                    let res = editor::apply_name(&mut config.agents[idx], input.trim());
+                    report(res);
+                    editor::print_agent_summary(idx, &config.agents[idx]);
+                    if offer_fill(&mut rl, &config.agents[idx].name)? {
+                        return Ok(EditOutcome::Fill(idx));
+                    }
+                }
+            }
+            "fill" => {
+                if let Some(idx) = parse_agent_idx(arg, config.agents.len()) {
+                    return Ok(EditOutcome::Fill(idx));
+                }
+            }
+            "add" => {
+                let eprint_msg = format!(
+                    "  Name for the new agent (#{}): ",
+                    config.agents.len() + 1
+                );
+                eprint!("{eprint_msg}");
+                let _ = std::io::stderr().flush();
+                let input = rl.readline("  ")?;
+                let name = input.trim();
+                if name.is_empty() {
+                    eprintln!("  name cannot be empty");
+                } else {
+                    let idx = config.agents.len();
+                    config.agents.push(scaffold_agent(name, idx));
+                    render::render_config(config);
+                    if offer_fill(&mut rl, name)? {
+                        return Ok(EditOutcome::Fill(idx));
+                    }
                 }
             }
             "cont" => {
@@ -160,14 +203,52 @@ fn report(result: Result<()>) {
     }
 }
 
+/// Prompt the user to AI-fill details for a named agent. Returns `true` on "y".
+fn offer_fill(rl: &mut DefaultEditor, agent_name: &str) -> Result<bool> {
+    eprintln!("  Let the LLM fill in details for '{agent_name}'? [y/N] ");
+    let answer = rl.readline("  ")?;
+    Ok(matches!(answer.trim(), "y" | "Y" | "yes"))
+}
+
+/// Create a scaffold agent with a slugified ID and cycled color.
+fn scaffold_agent(name: &str, idx: usize) -> CouncilAgent {
+    let slug: String = name
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned();
+    let id = if slug.is_empty() {
+        format!("agent-{idx}")
+    } else {
+        format!("{slug}-{idx}")
+    };
+    let colors = [
+        "#3b82f6", "#ef4444", "#10b981", "#f59e0b",
+        "#8b5cf6", "#ec4899", "#06b6d4", "#f97316",
+    ];
+    CouncilAgent {
+        id,
+        name: name.to_owned(),
+        color: colors[idx % colors.len()].to_owned(),
+        persona: String::from("Define this agent's worldview and expertise."),
+        perspective: String::from("Describe their unique angle."),
+        contentiousness: 0.5,
+        tool_filter: None,
+    }
+}
+
 fn print_help() {
     eprintln!(
         "\n{BOLD}Council Editor Commands:{RESET}
   show             re-display the council summary
+  name <N>         rename agent N (offers AI-fill)
   persona <N>      edit agent N's persona
   cont <N>         edit agent N's contentiousness
   tools <N>        edit agent N's tool filter
+  fill <N>         ask the LLM to fill agent N's details
   rounds <N>       set number of rounds
+  add              add a new agent
   remove <N>       remove agent N
   refine <msg>     ask the LLM to revise the council
   save <path>      save config to JSON file

--- a/crates/gglib-cli/src/handlers/council/repl.rs
+++ b/crates/gglib-cli/src/handlers/council/repl.rs
@@ -98,7 +98,11 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
             }
             "name" => {
                 if let Some(idx) = parse_agent_idx(arg, config.agents.len()) {
-                    eprint!("  New name for #{} ({}): ", idx + 1, config.agents[idx].name);
+                    eprint!(
+                        "  New name for #{} ({}): ",
+                        idx + 1,
+                        config.agents[idx].name
+                    );
                     let _ = std::io::stderr().flush();
                     let input = rl.readline("  ")?;
                     let res = editor::apply_name(&mut config.agents[idx], input.trim());
@@ -115,10 +119,8 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
                 }
             }
             "add" => {
-                let eprint_msg = format!(
-                    "  Name for the new agent (#{}): ",
-                    config.agents.len() + 1
-                );
+                let eprint_msg =
+                    format!("  Name for the new agent (#{}): ", config.agents.len() + 1);
                 eprint!("{eprint_msg}");
                 let _ = std::io::stderr().flush();
                 let input = rl.readline("  ")?;
@@ -214,7 +216,13 @@ fn offer_fill(rl: &mut DefaultEditor, agent_name: &str) -> Result<bool> {
 fn scaffold_agent(name: &str, idx: usize) -> CouncilAgent {
     let slug: String = name
         .chars()
-        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .map(|c| {
+            if c.is_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
         .collect::<String>()
         .trim_matches('-')
         .to_owned();
@@ -224,8 +232,7 @@ fn scaffold_agent(name: &str, idx: usize) -> CouncilAgent {
         format!("{slug}-{idx}")
     };
     let colors = [
-        "#3b82f6", "#ef4444", "#10b981", "#f59e0b",
-        "#8b5cf6", "#ec4899", "#06b6d4", "#f97316",
+        "#3b82f6", "#ef4444", "#10b981", "#f59e0b", "#8b5cf6", "#ec4899", "#06b6d4", "#f97316",
     ];
     CouncilAgent {
         id,

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -592,6 +592,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                       onUpdateAgent={council.updateAgent}
                       onRemoveAgent={council.removeAgent}
                       onAddAgent={council.addAgent}
+                      onFillAgent={council.fillAgent}
                     />
                   <ThreadPrimitive.ScrollToBottom className="sticky bottom-sm self-center py-xs px-md bg-primary text-white border-none rounded-full text-sm cursor-pointer opacity-0 transition-opacity duration-200 data-[visible=true]:opacity-100">
                     Jump to latest

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -589,6 +589,9 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
                     <CouncilThread
                       onRun={(config) => council.run(config)}
                       onCancel={() => council.reset()}
+                      onUpdateAgent={council.updateAgent}
+                      onRemoveAgent={council.removeAgent}
+                      onAddAgent={council.addAgent}
                     />
                   <ThreadPrimitive.ScrollToBottom className="sticky bottom-sm self-center py-xs px-md bg-primary text-white border-none rounded-full text-sm cursor-pointer opacity-0 transition-opacity duration-200 data-[visible=true]:opacity-100">
                     Jump to latest

--- a/src/components/Council/Messages/CouncilThread.tsx
+++ b/src/components/Council/Messages/CouncilThread.tsx
@@ -26,6 +26,7 @@ export interface CouncilThreadProps {
   onUpdateAgent?: (agentId: string, changes: Partial<CouncilAgent>) => void;
   onRemoveAgent?: (agentId: string) => void;
   onAddAgent?: () => void;
+  onFillAgent?: (agentId: string) => Promise<void>;
 }
 
 type ThreadItem =
@@ -35,7 +36,7 @@ type ThreadItem =
   | { kind: 'synthesis' };
 
 export const CouncilThread: FC<CouncilThreadProps> = ({
-  onRun, onCancel, onUpdateAgent, onRemoveAgent, onAddAgent,
+  onRun, onCancel, onUpdateAgent, onRemoveAgent, onAddAgent, onFillAgent,
 }) => {
   const { session } = useCouncilContext();
   const prevAgentsRef = useRef<CouncilAgent[]>([]);
@@ -137,6 +138,7 @@ export const CouncilThread: FC<CouncilThreadProps> = ({
         onUpdateAgent={onUpdateAgent}
         onRemoveAgent={onRemoveAgent}
         onAddAgent={onAddAgent}
+        onFillAgent={onFillAgent}
       />
     );
   }
@@ -159,6 +161,7 @@ export const CouncilThread: FC<CouncilThreadProps> = ({
           onUpdateAgent={onUpdateAgent}
           onRemoveAgent={onRemoveAgent}
           onAddAgent={onAddAgent}
+          onFillAgent={onFillAgent}
         />
       </>
     );

--- a/src/components/Council/Messages/CouncilThread.tsx
+++ b/src/components/Council/Messages/CouncilThread.tsx
@@ -11,17 +11,21 @@
  * @module components/Council/Messages/CouncilThread
  */
 
-import { type FC, useMemo } from 'react';
+import { type FC, useMemo, useRef } from 'react';
 import { useCouncilContext } from '../../../contexts/CouncilContext';
-import type { CouncilConfig } from '../../../types/council';
+import type { CouncilAgent, CouncilConfig } from '../../../types/council';
 import { CouncilMessage } from './CouncilMessage';
 import { SynthesisMessage } from './SynthesisMessage';
 import { RoundSeparator } from './RoundSeparator';
 import { CouncilSetupPanel } from '../Setup/CouncilSetupPanel';
+import type { DiffStatus } from '../Setup/AgentDiffBadge';
 
 export interface CouncilThreadProps {
   onRun: (config: CouncilConfig) => void;
   onCancel: () => void;
+  onUpdateAgent?: (agentId: string, changes: Partial<CouncilAgent>) => void;
+  onRemoveAgent?: (agentId: string) => void;
+  onAddAgent?: () => void;
 }
 
 type ThreadItem =
@@ -30,8 +34,39 @@ type ThreadItem =
   | { kind: 'streaming' }
   | { kind: 'synthesis' };
 
-export const CouncilThread: FC<CouncilThreadProps> = ({ onRun, onCancel }) => {
+export const CouncilThread: FC<CouncilThreadProps> = ({
+  onRun, onCancel, onUpdateAgent, onRemoveAgent, onAddAgent,
+}) => {
   const { session } = useCouncilContext();
+  const prevAgentsRef = useRef<CouncilAgent[]>([]);
+
+  // Compute per-agent diff statuses after a refinement
+  const diffStatuses = useMemo<Record<string, DiffStatus>>(() => {
+    const prev = prevAgentsRef.current;
+    if (prev.length === 0) return {};
+    const prevMap = new Map(prev.map((a) => [a.id, a]));
+    const statuses: Record<string, DiffStatus> = {};
+    for (const agent of session.suggestedAgents) {
+      const old = prevMap.get(agent.id);
+      if (!old) {
+        statuses[agent.id] = 'new';
+      } else if (
+        old.name !== agent.name ||
+        old.persona !== agent.persona ||
+        old.perspective !== agent.perspective
+      ) {
+        statuses[agent.id] = 'modified';
+      } else {
+        statuses[agent.id] = 'unchanged';
+      }
+    }
+    return statuses;
+  }, [session.suggestedAgents]);
+
+  // Snapshot agents when entering setup so the next refinement can diff
+  if (session.phase === 'setup' && prevAgentsRef.current !== session.suggestedAgents) {
+    prevAgentsRef.current = session.suggestedAgents;
+  }
 
   // Build a flat list of render items with round separators injected
   const items = useMemo<ThreadItem[]>(() => {
@@ -96,8 +131,12 @@ export const CouncilThread: FC<CouncilThreadProps> = ({ onRun, onCancel }) => {
         agents={session.suggestedAgents}
         rounds={session.suggestedRounds}
         synthesisGuidance={session.suggestedSynthesisGuidance}
+        diffStatuses={diffStatuses}
         onRun={onRun}
         onCancel={onCancel}
+        onUpdateAgent={onUpdateAgent}
+        onRemoveAgent={onRemoveAgent}
+        onAddAgent={onAddAgent}
       />
     );
   }
@@ -114,8 +153,12 @@ export const CouncilThread: FC<CouncilThreadProps> = ({ onRun, onCancel }) => {
           agents={session.suggestedAgents}
           rounds={session.suggestedRounds}
           synthesisGuidance={session.suggestedSynthesisGuidance}
+          diffStatuses={diffStatuses}
           onRun={onRun}
           onCancel={onCancel}
+          onUpdateAgent={onUpdateAgent}
+          onRemoveAgent={onRemoveAgent}
+          onAddAgent={onAddAgent}
         />
       </>
     );

--- a/src/components/Council/Setup/AddAgentButton.tsx
+++ b/src/components/Council/Setup/AddAgentButton.tsx
@@ -1,0 +1,34 @@
+/**
+ * Button to add a blank agent scaffold to the council.
+ *
+ * Renders a dashed-border card that matches the agent card grid layout.
+ *
+ * @module components/Council/Setup/AddAgentButton
+ */
+
+import type { FC } from 'react';
+import { cn } from '../../../utils/cn';
+
+interface AddAgentButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export const AddAgentButton: FC<AddAgentButtonProps> = ({ onClick, disabled }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className={cn(
+      'rounded-base border-2 border-dashed border-border p-md',
+      'flex items-center justify-center gap-sm',
+      'text-sm text-text-muted transition-colors',
+      'hover:border-primary hover:text-primary',
+      'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-border disabled:hover:text-text-muted',
+    )}
+    aria-label="Add agent"
+  >
+    <span className="text-lg leading-none">+</span>
+    Add Agent
+  </button>
+);

--- a/src/components/Council/Setup/AgentCard.tsx
+++ b/src/components/Council/Setup/AgentCard.tsx
@@ -7,12 +7,14 @@
  * @module components/Council/Setup/AgentCard
  */
 
-import type { FC } from 'react';
+import { type FC, useState } from 'react';
 import type { CouncilAgent } from '../../../types/council';
 import { contentiousnessColor, contentiousnessLabel } from '../../../types/council';
 import { cn } from '../../../utils/cn';
 import { EditableTextField } from './EditableTextField';
 import { AgentDiffBadge, type DiffStatus } from './AgentDiffBadge';
+import { Sparkles } from 'lucide-react';
+import { Icon } from '../../ui/Icon';
 
 interface AgentCardProps {
   agent: CouncilAgent;
@@ -20,12 +22,14 @@ interface AgentCardProps {
   onContentiousnessChange?: (agentId: string, value: number) => void;
   onUpdate?: (agentId: string, changes: Partial<CouncilAgent>) => void;
   onRemove?: (agentId: string) => void;
+  onFillAgent?: (agentId: string) => Promise<void>;
   disabled?: boolean;
 }
 
 export const AgentCard: FC<AgentCardProps> = ({
-  agent, diffStatus = 'unchanged', onContentiousnessChange, onUpdate, onRemove, disabled,
+  agent, diffStatus = 'unchanged', onContentiousnessChange, onUpdate, onRemove, onFillAgent, disabled,
 }) => {
+  const [isFilling, setIsFilling] = useState(false);
   const color = contentiousnessColor(agent.contentiousness);
   const label = contentiousnessLabel(agent.contentiousness);
 
@@ -53,6 +57,25 @@ export const AgentCard: FC<AgentCardProps> = ({
           aria-label={`${agent.name} name`}
         />
         <AgentDiffBadge status={diffStatus} />
+        {onFillAgent && !disabled && (
+          <button
+            type="button"
+            onClick={async () => {
+              setIsFilling(true);
+              try { await onFillAgent(agent.id); } finally { setIsFilling(false); }
+            }}
+            disabled={isFilling}
+            className="text-text-muted hover:text-primary transition-colors p-0.5 disabled:pointer-events-none"
+            aria-label={`AI-fill ${agent.name}`}
+            title="Fill details with AI"
+          >
+            {isFilling ? (
+              <span className="inline-block w-[14px] h-[14px] border-2 border-text-muted border-t-primary rounded-full animate-spin-360" />
+            ) : (
+              <Icon icon={Sparkles} size={14} />
+            )}
+          </button>
+        )}
         <div className="ml-auto">
           {onRemove && !disabled && (
             <button

--- a/src/components/Council/Setup/AgentCard.tsx
+++ b/src/components/Council/Setup/AgentCard.tsx
@@ -11,14 +11,21 @@ import type { FC } from 'react';
 import type { CouncilAgent } from '../../../types/council';
 import { contentiousnessColor, contentiousnessLabel } from '../../../types/council';
 import { cn } from '../../../utils/cn';
+import { EditableTextField } from './EditableTextField';
+import { AgentDiffBadge, type DiffStatus } from './AgentDiffBadge';
 
 interface AgentCardProps {
   agent: CouncilAgent;
+  diffStatus?: DiffStatus;
   onContentiousnessChange?: (agentId: string, value: number) => void;
+  onUpdate?: (agentId: string, changes: Partial<CouncilAgent>) => void;
+  onRemove?: (agentId: string) => void;
   disabled?: boolean;
 }
 
-export const AgentCard: FC<AgentCardProps> = ({ agent, onContentiousnessChange, disabled }) => {
+export const AgentCard: FC<AgentCardProps> = ({
+  agent, diffStatus = 'unchanged', onContentiousnessChange, onUpdate, onRemove, disabled,
+}) => {
   const color = contentiousnessColor(agent.contentiousness);
   const label = contentiousnessLabel(agent.contentiousness);
 
@@ -31,25 +38,57 @@ export const AgentCard: FC<AgentCardProps> = ({ agent, onContentiousnessChange, 
       )}
       style={{ '--agent-color': color } as React.CSSProperties}
     >
-      {/* Header: name + color dot */}
+      {/* Header: name + color dot + diff badge + delete */}
       <div className="flex items-center gap-sm">
         <span
           className="w-3 h-3 rounded-full shrink-0"
           style={{ backgroundColor: color }}
           aria-hidden
         />
-        <h4 className="text-sm font-medium text-text m-0">{agent.name}</h4>
+        <EditableTextField
+          value={agent.name}
+          onChange={(v) => onUpdate?.(agent.id, { name: v })}
+          disabled={disabled || !onUpdate}
+          className="text-sm font-medium text-text"
+          aria-label={`${agent.name} name`}
+        />
+        <AgentDiffBadge status={diffStatus} />
+        <div className="ml-auto">
+          {onRemove && !disabled && (
+            <button
+              type="button"
+              onClick={() => onRemove(agent.id)}
+              className="text-text-muted hover:text-danger transition-colors text-xs px-1"
+              aria-label={`Remove ${agent.name}`}
+            >
+              &times;
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Perspective (one-liner) */}
-      <p className="text-xs text-text-muted m-0 leading-relaxed">{agent.perspective}</p>
+      {/* Perspective (editable one-liner) */}
+      <EditableTextField
+        value={agent.perspective}
+        onChange={(v) => onUpdate?.(agent.id, { perspective: v })}
+        disabled={disabled || !onUpdate}
+        className="text-xs text-text-muted leading-relaxed"
+        aria-label={`${agent.name} perspective`}
+      />
 
-      {/* Persona (collapsed by default to save space) */}
+      {/* Persona (collapsed, editable) */}
       <details className="text-xs">
         <summary className="cursor-pointer text-text-secondary hover:text-text transition-colors">
           Persona
         </summary>
-        <p className="mt-xs text-text-muted leading-relaxed m-0">{agent.persona}</p>
+        <EditableTextField
+          value={agent.persona}
+          onChange={(v) => onUpdate?.(agent.id, { persona: v })}
+          disabled={disabled || !onUpdate}
+          multiline
+          className="mt-xs text-text-muted leading-relaxed"
+          aria-label={`${agent.name} persona`}
+        />
       </details>
 
       {/* Contentiousness slider */}

--- a/src/components/Council/Setup/AgentDiffBadge.tsx
+++ b/src/components/Council/Setup/AgentDiffBadge.tsx
@@ -1,0 +1,55 @@
+/**
+ * Small badge indicating agent diff status after a refinement.
+ *
+ * Renders "NEW" or "MODIFIED" with an auto-fade animation.
+ * Disappears after ~3 seconds unless the parent unmounts first.
+ *
+ * @module components/Council/Setup/AgentDiffBadge
+ */
+
+import { type FC, useState, useEffect } from 'react';
+import { cn } from '../../../utils/cn';
+
+export type DiffStatus = 'new' | 'modified' | 'unchanged';
+
+interface AgentDiffBadgeProps {
+  status: DiffStatus;
+}
+
+const labels: Record<DiffStatus, string | null> = {
+  new: 'NEW',
+  modified: 'MODIFIED',
+  unchanged: null,
+};
+
+const colors: Record<DiffStatus, string> = {
+  new: 'bg-success/20 text-success',
+  modified: 'bg-warning/20 text-warning',
+  unchanged: '',
+};
+
+export const AgentDiffBadge: FC<AgentDiffBadgeProps> = ({ status }) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (status === 'unchanged') return;
+    const timer = setTimeout(() => setVisible(false), 3000);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  const label = labels[status];
+  if (!label || !visible) return null;
+
+  return (
+    <span
+      className={cn(
+        'text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded-full',
+        'transition-opacity duration-500',
+        colors[status],
+        !visible && 'opacity-0',
+      )}
+    >
+      {label}
+    </span>
+  );
+};

--- a/src/components/Council/Setup/CouncilSetupPanel.tsx
+++ b/src/components/Council/Setup/CouncilSetupPanel.tsx
@@ -12,6 +12,8 @@ import { type FC, useState, useCallback } from 'react';
 import type { CouncilAgent, CouncilConfig } from '../../../types/council';
 import { Button } from '../../ui/Button';
 import { AgentCard } from './AgentCard';
+import { AddAgentButton } from './AddAgentButton';
+import type { DiffStatus } from './AgentDiffBadge';
 import { cn } from '../../../utils/cn';
 
 interface CouncilSetupPanelProps {
@@ -19,8 +21,13 @@ interface CouncilSetupPanelProps {
   agents: CouncilAgent[];
   rounds: number;
   synthesisGuidance?: string;
+  /** Per-agent diff status after a refinement. Keyed by agent id. */
+  diffStatuses?: Record<string, DiffStatus>;
   onRun: (config: CouncilConfig) => void;
   onCancel: () => void;
+  onUpdateAgent?: (agentId: string, changes: Partial<CouncilAgent>) => void;
+  onRemoveAgent?: (agentId: string) => void;
+  onAddAgent?: () => void;
   disabled?: boolean;
 }
 
@@ -29,8 +36,12 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
   agents: initialAgents,
   rounds: initialRounds,
   synthesisGuidance,
+  diffStatuses,
   onRun,
   onCancel,
+  onUpdateAgent,
+  onRemoveAgent,
+  onAddAgent,
   disabled,
 }) => {
   const [agents, setAgents] = useState<CouncilAgent[]>(initialAgents);
@@ -76,10 +87,14 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
           <AgentCard
             key={agent.id}
             agent={agent}
+            diffStatus={diffStatuses?.[agent.id]}
             onContentiousnessChange={handleContentiousnessChange}
+            onUpdate={onUpdateAgent}
+            onRemove={onRemoveAgent}
             disabled={disabled}
           />
         ))}
+        {onAddAgent && !disabled && <AddAgentButton onClick={onAddAgent} disabled={disabled} />}
       </div>
 
       {/* Rounds control + Run */}

--- a/src/components/Council/Setup/CouncilSetupPanel.tsx
+++ b/src/components/Council/Setup/CouncilSetupPanel.tsx
@@ -8,7 +8,7 @@
  * @module components/Council/Setup/CouncilSetupPanel
  */
 
-import { type FC, useState, useCallback } from 'react';
+import { type FC, useState, useCallback, useEffect } from 'react';
 import type { CouncilAgent, CouncilConfig } from '../../../types/council';
 import { Button } from '../../ui/Button';
 import { AgentCard } from './AgentCard';
@@ -46,6 +46,11 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
 }) => {
   const [agents, setAgents] = useState<CouncilAgent[]>(initialAgents);
   const [rounds, setRounds] = useState(initialRounds);
+
+  // Sync local state when context-driven changes arrive (add/remove/update agent).
+  useEffect(() => {
+    setAgents(initialAgents);
+  }, [initialAgents]);
 
   const handleContentiousnessChange = useCallback((agentId: string, value: number) => {
     setAgents((prev) =>

--- a/src/components/Council/Setup/CouncilSetupPanel.tsx
+++ b/src/components/Council/Setup/CouncilSetupPanel.tsx
@@ -28,6 +28,7 @@ interface CouncilSetupPanelProps {
   onUpdateAgent?: (agentId: string, changes: Partial<CouncilAgent>) => void;
   onRemoveAgent?: (agentId: string) => void;
   onAddAgent?: () => void;
+  onFillAgent?: (agentId: string) => Promise<void>;
   disabled?: boolean;
 }
 
@@ -42,6 +43,7 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
   onUpdateAgent,
   onRemoveAgent,
   onAddAgent,
+  onFillAgent,
   disabled,
 }) => {
   const [agents, setAgents] = useState<CouncilAgent[]>(initialAgents);
@@ -96,6 +98,7 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
             onContentiousnessChange={handleContentiousnessChange}
             onUpdate={onUpdateAgent}
             onRemove={onRemoveAgent}
+            onFillAgent={onFillAgent}
             disabled={disabled}
           />
         ))}

--- a/src/components/Council/Setup/EditableTextField.tsx
+++ b/src/components/Council/Setup/EditableTextField.tsx
@@ -1,0 +1,93 @@
+/**
+ * Inline-editable text field for council agent properties.
+ *
+ * Renders as plain text by default; click to switch to an input/textarea.
+ * Commits on blur or Enter. Supports single-line (input) and multi-line
+ * (textarea) modes.
+ *
+ * @module components/Council/Setup/EditableTextField
+ */
+
+import { type FC, useState, useRef, useEffect } from 'react';
+import { cn } from '../../../utils/cn';
+
+interface EditableTextFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  multiline?: boolean;
+  disabled?: boolean;
+  className?: string;
+  placeholder?: string;
+  'aria-label'?: string;
+}
+
+export const EditableTextField: FC<EditableTextFieldProps> = ({
+  value, onChange, multiline, disabled, className, placeholder, ...props
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const ref = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  useEffect(() => { setDraft(value); }, [value]);
+  useEffect(() => { if (editing) ref.current?.focus(); }, [editing]);
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== value) onChange(trimmed);
+    else setDraft(value);
+  };
+
+  if (disabled || !editing) {
+    return (
+      <span
+        className={cn(
+          'cursor-pointer rounded px-xs hover:bg-background-hover transition-colors',
+          disabled && 'cursor-not-allowed opacity-50',
+          className,
+        )}
+        onClick={() => !disabled && setEditing(true)}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={(e) => { if (e.key === 'Enter' && !disabled) setEditing(true); }}
+        aria-label={props['aria-label']}
+      >
+        {value || placeholder}
+      </span>
+    );
+  }
+
+  const shared = {
+    value: draft,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setDraft(e.target.value),
+    onBlur: commit,
+    className: cn(
+      'w-full rounded border border-border bg-background-input px-xs py-0.5 text-inherit outline-none focus:border-primary',
+      className,
+    ),
+    'aria-label': props['aria-label'],
+  };
+
+  if (multiline) {
+    return (
+      <textarea
+        ref={ref as React.RefObject<HTMLTextAreaElement>}
+        rows={3}
+        onKeyDown={(e) => { if (e.key === 'Escape') { setDraft(value); setEditing(false); } }}
+        {...shared}
+      />
+    );
+  }
+
+  return (
+    <input
+      ref={ref as React.RefObject<HTMLInputElement>}
+      type="text"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') commit();
+        if (e.key === 'Escape') { setDraft(value); setEditing(false); }
+      }}
+      {...shared}
+    />
+  );
+};

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -37,6 +37,9 @@ export type CouncilAction =
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
   | { type: 'COUNCIL_ERROR'; error: string }
   | { type: 'COUNCIL_COMPLETE' }
+  | { type: 'UPDATE_AGENT'; agentId: string; changes: Partial<CouncilAgent> }
+  | { type: 'ADD_AGENT'; agent: CouncilAgent }
+  | { type: 'REMOVE_AGENT'; agentId: string }
   | { type: 'RESET' };
 
 // ─── Reducer ────────────────────────────────────────────────────────────────
@@ -137,6 +140,23 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
 
     case 'COUNCIL_COMPLETE':
       return { ...state, phase: 'complete' };
+
+    case 'UPDATE_AGENT':
+      return {
+        ...state,
+        suggestedAgents: state.suggestedAgents.map((a) =>
+          a.id === action.agentId ? { ...a, ...action.changes } : a,
+        ),
+      };
+
+    case 'ADD_AGENT':
+      return { ...state, suggestedAgents: [...state.suggestedAgents, action.agent] };
+
+    case 'REMOVE_AGENT':
+      return {
+        ...state,
+        suggestedAgents: state.suggestedAgents.filter((a) => a.id !== action.agentId),
+      };
 
     case 'RESET':
       return createEmptySession();

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -35,6 +35,12 @@ export interface UseCouncilReturn {
   cancel: () => void;
   /** Reset session to idle. */
   reset: () => void;
+  /** Update a single agent's properties. */
+  updateAgent: (agentId: string, changes: Partial<CouncilAgent>) => void;
+  /** Remove an agent by id. */
+  removeAgent: (agentId: string) => void;
+  /** Add a blank agent scaffold. */
+  addAgent: () => void;
   /** Whether a deliberation is currently streaming. */
   isStreaming: boolean;
 }
@@ -220,5 +226,28 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
 
   const isStreaming = session.phase === 'deliberating' || session.phase === 'synthesizing';
 
-  return { session, suggest, refine, run, cancel, reset, isStreaming };
+  const updateAgent = useCallback((agentId: string, changes: Partial<CouncilAgent>) => {
+    dispatch({ type: 'UPDATE_AGENT', agentId, changes });
+  }, [dispatch]);
+
+  const removeAgent = useCallback((agentId: string) => {
+    dispatch({ type: 'REMOVE_AGENT', agentId });
+  }, [dispatch]);
+
+  const addAgent = useCallback(() => {
+    const id = `new-agent-${Date.now()}`;
+    dispatch({
+      type: 'ADD_AGENT',
+      agent: {
+        id,
+        name: 'New Agent',
+        color: '',
+        persona: 'Define this agent\'s worldview and expertise.',
+        perspective: 'Describe their unique angle.',
+        contentiousness: 0.5,
+      },
+    });
+  }, [dispatch]);
+
+  return { session, suggest, refine, run, cancel, reset, updateAgent, removeAgent, addAgent, isStreaming };
 }

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -236,18 +236,20 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
 
   const addAgent = useCallback(() => {
     const id = `new-agent-${Date.now()}`;
+    const colors = ['#3b82f6','#ef4444','#10b981','#f59e0b','#8b5cf6','#ec4899','#06b6d4','#f97316'];
+    const idx = session.suggestedAgents.length % colors.length;
     dispatch({
       type: 'ADD_AGENT',
       agent: {
         id,
         name: 'New Agent',
-        color: '',
+        color: colors[idx],
         persona: 'Define this agent\'s worldview and expertise.',
         perspective: 'Describe their unique angle.',
         contentiousness: 0.5,
       },
     });
-  }, [dispatch]);
+  }, [dispatch, session.suggestedAgents.length]);
 
   return { session, suggest, refine, run, cancel, reset, updateAgent, removeAgent, addAgent, isStreaming };
 }

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -256,22 +256,19 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
   const fillAgent = useCallback(async (agentId: string): Promise<void> => {
     const target = session.suggestedAgents.find((a) => a.id === agentId);
     if (!target) return;
-    const prev = {
-      agents: session.suggestedAgents,
-      rounds: session.suggestedRounds,
-      synthesis_guidance: session.suggestedSynthesisGuidance,
-    };
+    // Send only agent names as context — avoids echoing full personas back.
+    const roster = session.suggestedAgents.map((a) => a.name).join(', ');
     const result = await suggestCouncil({
       port: serverPort,
       topic: session.topic,
       model,
-      previous_suggestion: prev,
-      refinement: `The user wants to add/update an agent named '${target.name}'. `
-        + `Please generate a highly specific persona, perspective, and contentiousness `
-        + `score for this agent to complement the rest of the council. Return the full `
-        + `council JSON, but focus your creative updates strictly on the agent named '${target.name}'.`,
+      agent_count: 1,
+      refinement: `The council already has these agents: [${roster}]. `
+        + `Generate details for the agent named '${target.name}' to complement them. `
+        + `Return a JSON with ONLY this one agent in the "agents" array — do NOT `
+        + `regenerate the other agents. Include: id, name, persona (2-3 sentences), `
+        + `perspective (1 sentence), and contentiousness (0.0-1.0).`,
     });
-    // Strict plucking: find the matching agent by name, discard everything else.
     const filled = result.agents.find((a) => a.name === target.name) ?? result.agents[0];
     if (!filled) return;
     dispatch({
@@ -279,7 +276,7 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
       agentId,
       changes: { persona: filled.persona, perspective: filled.perspective, contentiousness: filled.contentiousness },
     });
-  }, [serverPort, model, session.topic, session.suggestedAgents, session.suggestedRounds, session.suggestedSynthesisGuidance, dispatch]);
+  }, [serverPort, model, session.topic, session.suggestedAgents, dispatch]);
 
   return { session, suggest, refine, run, cancel, reset, updateAgent, removeAgent, addAgent, fillAgent, isStreaming };
 }

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -258,17 +258,23 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
     if (!target) return;
     // Send only agent names as context — avoids echoing full personas back.
     const roster = session.suggestedAgents.map((a) => a.name).join(', ');
-    const result = await suggestCouncil({
-      port: serverPort,
-      topic: session.topic,
-      model,
-      agent_count: 1,
-      refinement: `The council already has these agents: [${roster}]. `
-        + `Generate details for the agent named '${target.name}' to complement them. `
-        + `Return a JSON with ONLY this one agent in the "agents" array — do NOT `
-        + `regenerate the other agents. Include: id, name, persona (2-3 sentences), `
-        + `perspective (1 sentence), and contentiousness (0.0-1.0).`,
-    });
+    let result;
+    try {
+      result = await suggestCouncil({
+        port: serverPort,
+        topic: session.topic,
+        model,
+        agent_count: 1,
+        refinement: `The council already has these agents: [${roster}]. `
+          + `Generate details for the agent named '${target.name}' to complement them. `
+          + `Return a JSON with ONLY this one agent in the "agents" array — do NOT `
+          + `regenerate the other agents. Include id, name, persona (2-3 sentences), `
+          + `perspective (1 sentence), contentiousness (0.0-1.0), rounds, and synthesis_guidance.`,
+      });
+    } catch (err) {
+      appLogger.error('hook', 'Council fill failed', { error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
     const filled = result.agents.find((a) => a.name === target.name) ?? result.agents[0];
     if (!filled) return;
     dispatch({

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -41,6 +41,8 @@ export interface UseCouncilReturn {
   removeAgent: (agentId: string) => void;
   /** Add a blank agent scaffold. */
   addAgent: () => void;
+  /** Ask the LLM to fill/update a single agent's details by name. */
+  fillAgent: (agentId: string) => Promise<void>;
   /** Whether a deliberation is currently streaming. */
   isStreaming: boolean;
 }
@@ -251,5 +253,33 @@ export function useCouncil({ serverPort, model }: UseCouncilOptions): UseCouncil
     });
   }, [dispatch, session.suggestedAgents.length]);
 
-  return { session, suggest, refine, run, cancel, reset, updateAgent, removeAgent, addAgent, isStreaming };
+  const fillAgent = useCallback(async (agentId: string): Promise<void> => {
+    const target = session.suggestedAgents.find((a) => a.id === agentId);
+    if (!target) return;
+    const prev = {
+      agents: session.suggestedAgents,
+      rounds: session.suggestedRounds,
+      synthesis_guidance: session.suggestedSynthesisGuidance,
+    };
+    const result = await suggestCouncil({
+      port: serverPort,
+      topic: session.topic,
+      model,
+      previous_suggestion: prev,
+      refinement: `The user wants to add/update an agent named '${target.name}'. `
+        + `Please generate a highly specific persona, perspective, and contentiousness `
+        + `score for this agent to complement the rest of the council. Return the full `
+        + `council JSON, but focus your creative updates strictly on the agent named '${target.name}'.`,
+    });
+    // Strict plucking: find the matching agent by name, discard everything else.
+    const filled = result.agents.find((a) => a.name === target.name) ?? result.agents[0];
+    if (!filled) return;
+    dispatch({
+      type: 'UPDATE_AGENT',
+      agentId,
+      changes: { persona: filled.persona, perspective: filled.perspective, contentiousness: filled.contentiousness },
+    });
+  }, [serverPort, model, session.topic, session.suggestedAgents, session.suggestedRounds, session.suggestedSynthesisGuidance, dispatch]);
+
+  return { session, suggest, refine, run, cancel, reset, updateAgent, removeAgent, addAgent, fillAgent, isStreaming };
 }


### PR DESCRIPTION
## Summary

Improves the council designer across backend, frontend, and CLI — fixing agent count rigidity during refinement, enabling inline agent editing in the UI, and adding a `refine` command to the CLI REPL for parity.

## Changes

### Phase A+B: Backend — Targeted Refinement with Stable IDs
- **`prompts.rs`**: Designer prompt now says "approximately {agent_count}" instead of a fixed count; added `id` field (kebab-case) to the agent JSON schema; new `COUNCIL_REFINEMENT_ADDENDUM` constant instructing minimal changes, stable ID preservation, and ignoring original count guidance
- **`suggest.rs`**: Appends the refinement addendum to the system prompt when `refinement_history` is present
- **`config.rs`**: `backfill_defaults()` preserves existing non-empty `id` and `color` values across refinement rounds

### Phase C: Frontend — Inline Agent Editing
- **`EditableTextField`** (~90 LOC): Click-to-edit inline text field with multiline support
- **`AgentDiffBadge`** (~55 LOC): "NEW" / "MODIFIED" badges with 3-second auto-fade after refinement
- **`AddAgentButton`** (~35 LOC): Dashed-border card to append new agents to the grid
- **`AgentCard`**: Name, perspective, and persona are now inline-editable; shows diff badge and delete button
- **`CouncilSetupPanel`**: Passes editing callbacks and diff statuses through to agent cards
- **`CouncilContext`**: New reducer actions — `UPDATE_AGENT`, `ADD_AGENT`, `REMOVE_AGENT`
- **`useCouncil`**: `updateAgent()`, `removeAgent()`, `addAgent()` dispatchers
- **`CouncilThread`**: Diff status computation via ref-based snapshot comparison after refinement

### Phase D: CLI — Refine Command
- **`repl.rs`**: New `refine <msg>` command; `edit_loop` returns `EditOutcome` enum (`Run | Quit | Refine(String)`)
- **`mod.rs`**: `edit_then_run` loops on `Refine` — serialises current config as `SuggestedCouncil`, builds 3-message refinement history, calls `suggest_council()`, replaces config, re-enters REPL

### Phase E: Documentation
- **CLI README**: Added council commands to the command table, new "Council Command" section documenting the interactive REPL and all editor commands including `refine`

### Phase F: Conversational Designer Issue
- Opened #422 for the next evolution — a conversational "Conductor" agent that designs councils through dialogue

## Testing

- All 585 frontend tests pass (`npx vitest run`)
- All 106 agent crate tests pass (`cargo test --package gglib-agent`)
- TypeScript compiles cleanly (`npx tsc --noEmit`)
- Rust compiles cleanly (`cargo check --release --package gglib-cli`)

Closes #422 reference: conversational designer deferred to separate issue.