### PR TITLE
fix: auto-detect reasoning format from model tags in GUI server start

### DIFF
--- a/crates/gglib-gui/src/servers.rs
+++ b/crates/gglib-gui/src/servers.rs
@@ -15,6 +15,7 @@ use tracing::{debug, warn};
 use gglib_core::domain::Model;
 use gglib_core::events::{AppEvent, ServerSummary};
 use gglib_core::ports::{ProcessHandle, ServerConfig, ServerHealthStatus};
+use gglib_runtime::llama::args::resolve_reasoning_format;
 
 use crate::deps::GuiDeps;
 use crate::error::GuiError;
@@ -185,6 +186,17 @@ impl<'a> ServerOps<'a> {
             && format != "none"
         {
             config = config.with_reasoning_format(format.clone());
+        } else if request.reasoning_format.is_none() {
+            // Auto-detect reasoning format from model tags when frontend doesn't specify
+            let reasoning = resolve_reasoning_format(None, &model.tags);
+            if let Some(format) = reasoning.format {
+                debug!(
+                    format = %format,
+                    source = ?reasoning.source,
+                    "Auto-detected reasoning format from model tags"
+                );
+                config = config.with_reasoning_format(format);
+            }
         }
 
         if let Some(ref params) = request.inference_params {

--- a/src/services/transport/mappers.ts
+++ b/src/services/transport/mappers.ts
@@ -87,7 +87,7 @@ export function toStartServerRequest(config: ServeConfig): StartServerRequest {
     port: config.port,
     mlock: config.mlock ?? false,
     jinja: config.jinja,
-    // reasoning_format is auto-detected from model tags on backend
+    // reasoning_format is auto-detected from model tags on backend when omitted
     reasoningFormat: undefined,
     inferenceParams,
   };


### PR DESCRIPTION
## Summary

Fixes #425 — GUI server start now auto-detects reasoning format from model tags, matching CLI behavior.

## Problem

When starting a llama-server through the GUI, `--reasoning-format` was never set for reasoning models (Qwen3.5, DeepSeek-R1, QwQ, etc.). This caused `<think>...</think>` chain-of-thought blocks to flow as regular `content` tokens instead of being parsed into `reasoning_content`, resulting in thousands of lines of internal monologue appearing in council deliberation output.

The CLI handlers correctly call `resolve_reasoning_format(None, &model.tags)`, but the GUI's `build_config()` only passed the format through when explicitly set by the frontend — which always sends `undefined`.

## Changes

- **`crates/gglib-gui/src/servers.rs`**: When `reasoning_format` is not explicitly set in the request, `build_config()` now calls `resolve_reasoning_format()` with the model's tags to auto-detect. Logs the detection result for observability.
- **`src/services/transport/mappers.ts`**: Updated comment to clarify the backend auto-detection behavior.

## Testing

- `cargo check --package gglib-gui` passes
- Manual verification: reasoning models with the `"reasoning"` tag (set during GGUF import) will now get `--reasoning-format deepseek` automatically