### PR TITLE
Phase 0: Extract round.rs and synthesis.rs from orchestrator

### DIFF
--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -53,6 +53,16 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `stream_collector` | Consumes `LlmStreamEvent` stream, forwards text live |
 | `tool_execution` | Parallel tool dispatch with semaphore + timeout |
 | `util` | Shared internal utilities |
+| `council/config` | `CouncilConfig`, `CouncilAgent`, `SuggestedCouncil` |
+| `council/events` | `CouncilEvent` SSE enum (wire format) |
+| `council/prompts` | Prompt templates + contentiousness mapping |
+| `council/state` | Round/contribution accumulator |
+| `council/history` | Per-turn context builder (identity + transcript) |
+| `council/stream_bridge` | `AgentEvent` → `CouncilEvent` mapper |
+| `council/round` | Sequential round execution (per-agent turn driver) |
+| `council/synthesis` | Synthesis pass (transcript → unified answer) |
+| `council/orchestrator` | Slim coordinator (rounds → synthesis sequencing) |
+| `council/suggest` | `suggest_council()` — shared suggest orchestration |
 <!-- MODULE_TABLE_END -->
 
 <details>

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -15,7 +15,9 @@
 //! | `state.rs`        | Round/contribution accumulator                      |
 //! | `history.rs`      | Per-turn context builder (identity + transcript)    |
 //! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
-//! | `orchestrator.rs` | Round×agent loop driver + synthesis dispatch         |
+//! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
+//! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
+//! | `orchestrator.rs` | Slim coordinator (rounds → synthesis sequencing)    |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -23,9 +25,11 @@ pub mod events;
 pub mod history;
 pub mod orchestrator;
 pub mod prompts;
+mod round;
 pub mod state;
 pub mod stream_bridge;
 pub mod suggest;
+mod synthesis;
 
 pub use config::{CouncilAgent, CouncilConfig, SuggestedCouncil};
 pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,58 +1,44 @@
-//! Round×agent orchestration loop for a council deliberation.
+//! Top-level coordinator for a council deliberation.
+//!
+//! This module is intentionally slim — it sequences the high-level phases
+//! (debate rounds → synthesis) and delegates all per-agent and per-phase
+//! logic to dedicated sub-modules:
 //!
 //! ```text
-//! CouncilOrchestrator::run()
+//! orchestrator::run()
 //!   │
 //!   ├─ for each round 0..N
 //!   │   ├─ emit RoundSeparator (round > 0)
-//!   │   └─ for each agent
-//!   │       ├─ emit AgentTurnStart
-//!   │       ├─ build_agent_messages()          (history.rs)
-//!   │       ├─ AgentLoop::run()                (delegated, stagnation+loop guards active)
-//!   │       ├─ bridge_agent_events()           (stream_bridge.rs)
-//!   │       ├─ emit AgentTurnComplete          (with core claim extraction)
-//!   │       └─ state.push(contribution)
+//!   │   └─ round::run_sequential_round()      (round.rs)
 //!   │
-//!   ├─ emit SynthesisStart
-//!   ├─ AgentLoop::run() with synthesis prompt
-//!   ├─ bridge synthesis events
-//!   ├─ emit SynthesisComplete
-//!   └─ emit CouncilComplete
+//!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
 
-use gglib_core::{
-    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
-    ToolExecutorPort,
-};
-
-use crate::AgentLoop;
+use gglib_core::{AgentConfig, LlmCompletionPort, ToolExecutorPort};
 
 use super::config::CouncilConfig;
 use super::events::CouncilEvent;
-use super::history::{build_agent_messages, format_synthesis_transcript};
-use super::prompts::SYNTHESIS_PROMPT;
-use super::state::{AgentContribution, CouncilState, extract_core_claim};
-use super::stream_bridge::{bridge_agent_events, emit_turn_complete};
+use super::round::{RoundContext, run_sequential_round};
+use super::state::CouncilState;
+use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: rounds → agent turns → synthesis.
+/// Runs a full council deliberation: debate rounds → synthesis.
 ///
-/// This function is the only public entry point.  It owns the round×agent
-/// loop and delegates each agent turn to an [`AgentLoop`] via the existing
-/// port traits.  The caller provides a `council_tx` to receive streamed
-/// [`CouncilEvent`]s.
+/// This function is the only public entry point.  It coordinates the
+/// high-level phase sequence and delegates per-agent turn execution to
+/// [`round::run_sequential_round`] and the synthesis pass to
+/// [`synthesis::run_synthesis`].
 ///
 /// # Errors
 ///
 /// Individual agent errors (stagnation, loop detection, max iterations) are
-/// handled gracefully — the contribution is recorded as-is and the council
-/// proceeds.  Only infrastructure-level failures (channel closure) cause an
-/// early return.
+/// handled gracefully inside `round.rs` — the contribution is recorded
+/// as-is and the council proceeds.  Only infrastructure-level failures
+/// (channel closure) cause an early return.
 pub async fn run(
     config: CouncilConfig,
     agent_config: AgentConfig,
@@ -62,10 +48,19 @@ pub async fn run(
 ) {
     let mut state = CouncilState::new();
 
+    let ctx = RoundContext {
+        config: &config,
+        agent_config: &agent_config,
+        llm: &llm,
+        tool_executor: &tool_executor,
+        council_tx: &council_tx,
+    };
+
     // ── debate rounds ────────────────────────────────────────────────────
     for round in 0..config.rounds {
         if round > 0 {
-            if send(&council_tx, CouncilEvent::RoundSeparator { round })
+            if council_tx
+                .send(CouncilEvent::RoundSeparator { round })
                 .await
                 .is_err()
             {
@@ -73,68 +68,8 @@ pub async fn run(
             }
         }
 
-        for agent in &config.agents {
-            // Announce the turn.
-            let start = CouncilEvent::AgentTurnStart {
-                agent_id: agent.id.clone(),
-                agent_name: agent.name.clone(),
-                color: agent.color.clone(),
-                round,
-                contentiousness: agent.contentiousness,
-            };
-            if send(&council_tx, start).await.is_err() {
-                return;
-            }
-
-            // Build per-agent tool filter.
-            let filter = agent
-                .tool_filter
-                .as_ref()
-                .map(|names| names.iter().cloned().collect::<HashSet<String>>());
-
-            // Build the agent loop with per-agent tool restrictions.
-            let agent_loop = AgentLoop::build(Arc::clone(&llm), Arc::clone(&tool_executor), filter);
-
-            // Assemble context with identity anchoring + debate transcript.
-            let messages = build_agent_messages(agent, &config.topic, round, config.rounds, &state);
-
-            // Delegate to AgentLoop — stagnation + loop guards are active
-            // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).
-            let (agent_tx, agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
-            let loop_handle = {
-                let agent_loop = Arc::clone(&agent_loop);
-                let cfg = agent_config.clone();
-                tokio::spawn(async move { agent_loop.run(messages, cfg, agent_tx).await })
-            };
-
-            // Bridge events from agent → council stream.
-            let answer = bridge_agent_events(agent, round, agent_rx, &council_tx).await;
-
-            // Await the agent loop completion (the channel is already drained).
-            match loop_handle.await {
-                Ok(Ok(_output)) => {
-                    debug!(agent_id = %agent.id, round, "agent turn completed normally");
-                }
-                Ok(Err(e)) => {
-                    // Stagnation, loop detection, max iterations — all graceful.
-                    warn!(agent_id = %agent.id, round, error = %e, "agent turn ended early");
-                }
-                Err(e) => {
-                    warn!(agent_id = %agent.id, round, error = %e, "agent task panicked");
-                }
-            }
-
-            // Record the contribution (use whatever content we got).
-            let content = answer.unwrap_or_default();
-            let core_claim = extract_core_claim(&content);
-            emit_turn_complete(agent, round, &content, &council_tx).await;
-
-            state.push(AgentContribution {
-                agent: agent.clone(),
-                content,
-                core_claim,
-                round,
-            });
+        if run_sequential_round(round, &ctx, &mut state).await.is_err() {
+            return;
         }
 
         state.advance_round();
@@ -150,99 +85,4 @@ pub async fn run(
         &council_tx,
     )
     .await;
-}
-
-/// Synthesis pass: build the transcript, run a single-iteration agent loop,
-/// and emit `SynthesisStart` / `SynthesisTextDelta` / `SynthesisComplete` /
-/// `CouncilComplete`.
-async fn run_synthesis(
-    config: &CouncilConfig,
-    agent_config: AgentConfig,
-    llm: &Arc<dyn LlmCompletionPort>,
-    tool_executor: &Arc<dyn ToolExecutorPort>,
-    state: &CouncilState,
-    council_tx: &mpsc::Sender<CouncilEvent>,
-) {
-    if send(council_tx, CouncilEvent::SynthesisStart)
-        .await
-        .is_err()
-    {
-        return;
-    }
-
-    let transcript = format_synthesis_transcript(state);
-    let guidance = config
-        .synthesis_guidance
-        .as_deref()
-        .unwrap_or("Provide an actionable synthesis.");
-
-    #[allow(clippy::literal_string_with_formatting_args)]
-    let synthesis_prompt = SYNTHESIS_PROMPT
-        .replace("{agent_count}", &config.agents.len().to_string())
-        .replace("{topic}", &config.topic)
-        .replace("{transcript}", &transcript)
-        .replace("{synthesis_guidance}", guidance);
-
-    let synth_messages = vec![
-        AgentMessage::System {
-            content: synthesis_prompt,
-        },
-        AgentMessage::User {
-            content: config.topic.clone(),
-        },
-    ];
-
-    let synth_loop = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), None);
-    let (synth_agent_tx, synth_agent_rx) =
-        mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
-
-    // Synthesis uses a restricted config — no tools needed, single iteration.
-    let mut synth_config = agent_config;
-    synth_config.max_iterations = 1;
-
-    let synth_handle = {
-        let synth_loop = Arc::clone(&synth_loop);
-        tokio::spawn(async move {
-            synth_loop
-                .run(synth_messages, synth_config, synth_agent_tx)
-                .await
-        })
-    };
-
-    // Bridge synthesis events — map TextDelta → SynthesisTextDelta.
-    let synth_content = bridge_synthesis_events(synth_agent_rx, council_tx).await;
-
-    let _ = synth_handle.await;
-
-    let content = synth_content.unwrap_or_default();
-    let _ = send(council_tx, CouncilEvent::SynthesisComplete { content }).await;
-    let _ = send(council_tx, CouncilEvent::CouncilComplete).await;
-}
-
-/// Bridge synthesis-phase events (only text deltas are relevant).
-async fn bridge_synthesis_events(
-    mut rx: mpsc::Receiver<AgentEvent>,
-    tx: &mpsc::Sender<CouncilEvent>,
-) -> Option<String> {
-    let mut content: Option<String> = None;
-    while let Some(event) = rx.recv().await {
-        match event {
-            AgentEvent::TextDelta { content: delta } => {
-                let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
-            }
-            AgentEvent::FinalAnswer { content: answer } => {
-                content = Some(answer);
-            }
-            _ => {}
-        }
-    }
-    content
-}
-
-/// Best-effort send helper — returns `Err` when the receiver is gone.
-async fn send(
-    tx: &mpsc::Sender<CouncilEvent>,
-    event: CouncilEvent,
-) -> Result<(), mpsc::error::SendError<CouncilEvent>> {
-    tx.send(event).await
 }

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -1,0 +1,143 @@
+//! Sequential round execution for a council deliberation.
+//!
+//! Each round iterates over agents in declaration order, delegating each
+//! turn to an [`AgentLoop`](crate::AgentLoop) and recording the resulting
+//! [`AgentContribution`] in the shared [`CouncilState`].
+//!
+//! This module owns:
+//! - per-agent tool filter construction
+//! - agent loop spawning + error handling
+//! - contribution recording (content + core claim extraction)
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, LlmCompletionPort, ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::{CouncilAgent, CouncilConfig};
+use super::events::CouncilEvent;
+use super::history::build_agent_messages;
+use super::state::{AgentContribution, CouncilState, extract_core_claim};
+use super::stream_bridge::{bridge_agent_events, emit_turn_complete};
+
+/// Shared, immutable context threaded through every agent turn in a round.
+///
+/// Bundles the dependencies that every turn needs so individual functions
+/// stay below the clippy `too_many_arguments` threshold.
+pub(super) struct RoundContext<'a> {
+    pub config: &'a CouncilConfig,
+    pub agent_config: &'a AgentConfig,
+    pub llm: &'a Arc<dyn LlmCompletionPort>,
+    pub tool_executor: &'a Arc<dyn ToolExecutorPort>,
+    pub council_tx: &'a mpsc::Sender<CouncilEvent>,
+}
+
+/// Execute a single debate round sequentially: each agent speaks in
+/// declaration order, receiving the full debate transcript up to this point.
+///
+/// Returns `Err(())` if the council channel is closed (caller should stop).
+pub(super) async fn run_sequential_round(
+    round: u32,
+    ctx: &RoundContext<'_>,
+    state: &mut CouncilState,
+) -> Result<(), ()> {
+    for agent in &ctx.config.agents {
+        run_agent_turn(agent, round, ctx, state).await?;
+    }
+    Ok(())
+}
+
+/// Execute a single agent's turn within a round.
+///
+/// Steps:
+/// 1. Emit `AgentTurnStart`
+/// 2. Build identity-anchored messages with debate transcript
+/// 3. Spawn `AgentLoop::run()` with per-agent tool filter
+/// 4. Bridge events from agent → council stream
+/// 5. Record contribution (content + core claim)
+///
+/// Returns `Err(())` if the council channel is closed.
+async fn run_agent_turn(
+    agent: &CouncilAgent,
+    round: u32,
+    ctx: &RoundContext<'_>,
+    state: &mut CouncilState,
+) -> Result<(), ()> {
+    // Announce the turn.
+    let start = CouncilEvent::AgentTurnStart {
+        agent_id: agent.id.clone(),
+        agent_name: agent.name.clone(),
+        color: agent.color.clone(),
+        round,
+        contentiousness: agent.contentiousness,
+    };
+    if ctx.council_tx.send(start).await.is_err() {
+        return Err(());
+    }
+
+    // Build per-agent tool filter.
+    let filter = agent
+        .tool_filter
+        .as_ref()
+        .map(|names| names.iter().cloned().collect::<HashSet<String>>());
+
+    // Build the agent loop with per-agent tool restrictions.
+    let agent_loop =
+        AgentLoop::build(Arc::clone(ctx.llm), Arc::clone(ctx.tool_executor), filter);
+
+    // Assemble context with identity anchoring + debate transcript.
+    let messages = build_agent_messages(
+        agent,
+        &ctx.config.topic,
+        round,
+        ctx.config.rounds,
+        state,
+    );
+
+    // Delegate to AgentLoop — stagnation + loop guards are active
+    // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).
+    let (agent_tx, agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+    let loop_handle = {
+        let agent_loop = Arc::clone(&agent_loop);
+        let cfg = ctx.agent_config.clone();
+        tokio::spawn(async move { agent_loop.run(messages, cfg, agent_tx).await })
+    };
+
+    // Bridge events from agent → council stream.
+    let answer = bridge_agent_events(agent, round, agent_rx, ctx.council_tx).await;
+
+    // Await the agent loop completion (the channel is already drained).
+    match loop_handle.await {
+        Ok(Ok(_output)) => {
+            debug!(agent_id = %agent.id, round, "agent turn completed normally");
+        }
+        Ok(Err(e)) => {
+            // Stagnation, loop detection, max iterations — all graceful.
+            warn!(agent_id = %agent.id, round, error = %e, "agent turn ended early");
+        }
+        Err(e) => {
+            warn!(agent_id = %agent.id, round, error = %e, "agent task panicked");
+        }
+    }
+
+    // Record the contribution (use whatever content we got).
+    let content = answer.unwrap_or_default();
+    let core_claim = extract_core_claim(&content);
+    emit_turn_complete(agent, round, &content, ctx.council_tx).await;
+
+    state.push(AgentContribution {
+        agent: agent.clone(),
+        content,
+        core_claim,
+        round,
+    });
+
+    Ok(())
+}

--- a/crates/gglib-agent/src/council/synthesis.rs
+++ b/crates/gglib-agent/src/council/synthesis.rs
@@ -1,0 +1,125 @@
+//! Synthesis pass for a council deliberation.
+//!
+//! After all debate rounds complete, the synthesiser builds a full debate
+//! transcript and runs a single-iteration [`AgentLoop`](crate::AgentLoop)
+//! to produce a unified answer that integrates all agent positions.
+//!
+//! This module owns:
+//! - transcript → synthesis prompt assembly
+//! - synthesis event bridging (`TextDelta` → `SynthesisTextDelta`)
+//! - `SynthesisComplete` / `CouncilComplete` emission
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::CouncilConfig;
+use super::events::CouncilEvent;
+use super::history::format_synthesis_transcript;
+use super::prompts::SYNTHESIS_PROMPT;
+use super::state::CouncilState;
+
+/// Run the synthesis phase: build the transcript, call a single-iteration
+/// [`AgentLoop`], and emit `SynthesisStart` / `SynthesisTextDelta` /
+/// `SynthesisComplete` / `CouncilComplete`.
+///
+/// The synthesis agent has no tool restrictions and runs for exactly one
+/// iteration — it produces a prose answer, never tool calls.
+pub(super) async fn run_synthesis(
+    config: &CouncilConfig,
+    agent_config: AgentConfig,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    state: &CouncilState,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+) {
+    if send(council_tx, CouncilEvent::SynthesisStart)
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let transcript = format_synthesis_transcript(state);
+    let guidance = config
+        .synthesis_guidance
+        .as_deref()
+        .unwrap_or("Provide an actionable synthesis.");
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let synthesis_prompt = SYNTHESIS_PROMPT
+        .replace("{agent_count}", &config.agents.len().to_string())
+        .replace("{topic}", &config.topic)
+        .replace("{transcript}", &transcript)
+        .replace("{synthesis_guidance}", guidance);
+
+    let synth_messages = vec![
+        AgentMessage::System {
+            content: synthesis_prompt,
+        },
+        AgentMessage::User {
+            content: config.topic.clone(),
+        },
+    ];
+
+    let synth_loop = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), None);
+    let (synth_agent_tx, synth_agent_rx) =
+        mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    // Synthesis uses a restricted config — no tools needed, single iteration.
+    let mut synth_config = agent_config;
+    synth_config.max_iterations = 1;
+
+    let synth_handle = {
+        let synth_loop = Arc::clone(&synth_loop);
+        tokio::spawn(async move {
+            synth_loop
+                .run(synth_messages, synth_config, synth_agent_tx)
+                .await
+        })
+    };
+
+    // Bridge synthesis events — map TextDelta → SynthesisTextDelta.
+    let synth_content = bridge_synthesis_events(synth_agent_rx, council_tx).await;
+
+    let _ = synth_handle.await;
+
+    let content = synth_content.unwrap_or_default();
+    let _ = send(council_tx, CouncilEvent::SynthesisComplete { content }).await;
+    let _ = send(council_tx, CouncilEvent::CouncilComplete).await;
+}
+
+/// Bridge synthesis-phase events (only text deltas are relevant).
+async fn bridge_synthesis_events(
+    mut rx: mpsc::Receiver<AgentEvent>,
+    tx: &mpsc::Sender<CouncilEvent>,
+) -> Option<String> {
+    let mut content: Option<String> = None;
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::TextDelta { content: delta } => {
+                let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
+            }
+            AgentEvent::FinalAnswer { content: answer } => {
+                content = Some(answer);
+            }
+            _ => {}
+        }
+    }
+    content
+}
+
+/// Best-effort send helper — returns `Err` when the receiver is gone.
+async fn send(
+    tx: &mpsc::Sender<CouncilEvent>,
+    event: CouncilEvent,
+) -> Result<(), mpsc::error::SendError<CouncilEvent>> {
+    tx.send(event).await
+}


### PR DESCRIPTION
## Phase 0 — Infrastructure Refactor

Pure structural extraction with no behaviour changes. Splits the monolithic `orchestrator.rs` into focused sub-modules to prepare for Phases 1–4.

### Changes

**New files:**
- `council/round.rs` — `RoundContext` struct, `run_sequential_round()`, `run_agent_turn()`
- `council/synthesis.rs` — `run_synthesis()`, `bridge_synthesis_events()`, `send()`

**Modified files:**
- `council/orchestrator.rs` — reduced to slim coordinator (~65 lines), delegates to `round` and `synthesis`
- `council/mod.rs` — added `mod round;` / `mod synthesis;`, updated module layout table
- `gglib-agent/README.md` — added council sub-module rows to MODULE_TABLE

### Verification

- Full workspace compiles cleanly
- All `gglib-agent` tests pass
- Clippy clean with `-D warnings`