### PR TITLE
feat(council): Phase 1 — Judge + Adaptive Early Stopping

### DIFF
--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -61,7 +61,8 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `council/stream_bridge` | `AgentEvent` → `CouncilEvent` mapper |
 | `council/round` | Sequential round execution (per-agent turn driver) |
 | `council/synthesis` | Synthesis pass (transcript → unified answer) |
-| `council/orchestrator` | Slim coordinator (rounds → synthesis sequencing) |
+| `council/judge` | Post-round judge evaluation + adaptive early stopping |
+| `council/orchestrator` | Slim coordinator (rounds → judge → synthesis) |
 | `council/suggest` | `suggest_council()` — shared suggest orchestration |
 <!-- MODULE_TABLE_END -->
 

--- a/crates/gglib-agent/src/council/config.rs
+++ b/crates/gglib-agent/src/council/config.rs
@@ -74,6 +74,37 @@ pub struct CouncilConfig {
     /// final answer's focus (e.g. "prioritise actionable recommendations").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub synthesis_guidance: Option<String>,
+
+    /// Optional judge configuration for adaptive early stopping.
+    ///
+    /// When present, a neutral judge agent evaluates the debate after each
+    /// round and may terminate early if consensus is detected.  When
+    /// absent, the council always runs the full `rounds` count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge: Option<JudgeConfig>,
+}
+
+// ─── judge config ────────────────────────────────────────────────────────────
+
+/// Configuration for the optional post-round judge.
+///
+/// The judge is a neutral LLM pass that evaluates the debate transcript
+/// after each round, summarises the current state, and decides whether
+/// consensus has been reached (triggering early stopping).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JudgeConfig {
+    /// Minimum number of rounds before the judge may stop the debate.
+    ///
+    /// Prevents premature consensus on the very first round.
+    /// Defaults to `1` (allow stopping after round 1, i.e. at least 2
+    /// rounds of debate if the first round yields consensus).
+    #[serde(default = "default_min_rounds_before_stop")]
+    pub min_rounds_before_stop: u32,
+}
+
+/// Default: allow early stopping after at least 1 completed round.
+const fn default_min_rounds_before_stop() -> u32 {
+    1
 }
 
 // ─── suggested council (returned by /api/council/suggest) ────────────────────
@@ -95,6 +126,10 @@ pub struct SuggestedCouncil {
     /// Suggested synthesis guidance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub synthesis_guidance: Option<String>,
+
+    /// Suggested judge configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge: Option<JudgeConfig>,
 }
 
 /// Default agent colours, cycled when the LLM omits `color`.
@@ -117,6 +152,7 @@ impl SuggestedCouncil {
             topic,
             rounds: self.rounds,
             synthesis_guidance: self.synthesis_guidance,
+            judge: self.judge,
         }
     }
 
@@ -226,6 +262,7 @@ mod tests {
             ],
             rounds: 2,
             synthesis_guidance: None,
+            judge: None,
         };
         council.backfill_defaults();
         assert_eq!(council.agents[0].id, "kept-id");

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -81,6 +81,24 @@ pub enum CouncilEvent {
     /// divider — no gradient, no tension metric (v1).
     RoundSeparator { round: u32 },
 
+    // ── judge ────────────────────────────────────────────────────────────
+    /// The judge evaluation phase has begun for this round.
+    JudgeStart { round: u32 },
+
+    /// Incremental text token from the judge agent.
+    JudgeTextDelta { delta: String },
+
+    /// The judge has completed its evaluation.
+    ///
+    /// `summary` is the judge's narrative assessment.
+    /// `consensus_reached` indicates whether the judge determined
+    /// that the agents have converged on a shared position.
+    JudgeSummary {
+        round: u32,
+        summary: String,
+        consensus_reached: bool,
+    },
+
     // ── synthesis ────────────────────────────────────────────────────────
     /// The synthesis phase has begun.  The frontend renders a
     /// "Synthesising…" placeholder.
@@ -187,6 +205,15 @@ mod tests {
                 delta: "thinking...".into(),
             },
             CouncilEvent::RoundSeparator { round: 1 },
+            CouncilEvent::JudgeStart { round: 1 },
+            CouncilEvent::JudgeTextDelta {
+                delta: "evaluating".into(),
+            },
+            CouncilEvent::JudgeSummary {
+                round: 1,
+                summary: "Agents are converging.".into(),
+                consensus_reached: true,
+            },
             CouncilEvent::SynthesisStart,
             CouncilEvent::SynthesisTextDelta {
                 delta: "synth".into(),

--- a/crates/gglib-agent/src/council/judge.rs
+++ b/crates/gglib-agent/src/council/judge.rs
@@ -1,0 +1,371 @@
+//! Post-round judge evaluation with adaptive early stopping.
+//!
+//! After each debate round, an optional neutral judge agent evaluates the
+//! transcript, produces a narrative summary, and determines whether the
+//! agents have reached consensus.  If consensus is detected and the
+//! minimum-rounds threshold has been met, the orchestrator skips remaining
+//! rounds and proceeds directly to synthesis.
+//!
+//! # Robust marker parsing
+//!
+//! The judge's output must contain a `CONSENSUS_REACHED: true/false` line.
+//! [`parse_judge_verdict`] uses case-insensitive, whitespace-tolerant
+//! matching to handle common LLM quirks:
+//! - Markdown bold/backtick wrapping (`**CONSENSUS_REACHED:** true`)
+//! - Leading prose / conversational filler
+//! - Extra spacing around the colon
+//! - Varying casing (`consensus_reached`, `Consensus_Reached`, etc.)
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::JudgeConfig;
+use super::events::CouncilEvent;
+use super::history::format_synthesis_transcript;
+use super::prompts::JUDGE_PROMPT;
+use super::state::CouncilState;
+
+/// The judge's parsed verdict after evaluating a round.
+#[derive(Debug, Clone)]
+pub(super) struct JudgeVerdict {
+    /// The judge's narrative summary of the debate state.
+    pub summary: String,
+    /// Whether the judge determined consensus has been reached.
+    pub consensus_reached: bool,
+}
+
+/// Run the judge evaluation for the given round.
+///
+/// Emits `JudgeStart`, streams `JudgeTextDelta` tokens, then emits
+/// `JudgeSummary` with the parsed verdict.
+///
+/// Returns `None` if the channel is closed or the judge produces no
+/// output (the orchestrator should treat this as "no consensus").
+pub(super) async fn run_judge(
+    round: u32,
+    total_rounds: u32,
+    _judge_config: &JudgeConfig,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    state: &CouncilState,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+    topic: &str,
+) -> Option<JudgeVerdict> {
+    // Announce the judge phase.
+    if council_tx
+        .send(CouncilEvent::JudgeStart { round })
+        .await
+        .is_err()
+    {
+        return None;
+    }
+
+    let transcript = format_synthesis_transcript(state);
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let system = JUDGE_PROMPT
+        .replace("{topic}", topic)
+        .replace("{round}", &(round + 1).to_string())
+        .replace("{total_rounds}", &total_rounds.to_string())
+        .replace("{transcript}", &transcript);
+
+    let messages = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: format!("Evaluate the debate state after round {}.", round + 1),
+        },
+    ];
+
+    // Judge gets no tools — pure evaluation.
+    let agent = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), Some(HashSet::new()));
+    let mut config = AgentConfig::default();
+    config.max_iterations = 1;
+
+    let (agent_tx, mut agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    let handle = {
+        let agent = Arc::clone(&agent);
+        tokio::spawn(async move { agent.run(messages, config, agent_tx).await })
+    };
+
+    // Bridge agent events → judge events.
+    let mut content: Option<String> = None;
+    while let Some(event) = agent_rx.recv().await {
+        match event {
+            AgentEvent::TextDelta { content: delta } => {
+                let _ = council_tx
+                    .send(CouncilEvent::JudgeTextDelta { delta })
+                    .await;
+            }
+            AgentEvent::FinalAnswer { content: answer } => {
+                content = Some(answer);
+            }
+            _ => {}
+        }
+    }
+
+    let _ = handle.await;
+
+    let raw = content.unwrap_or_default();
+    if raw.is_empty() {
+        warn!(round, "judge produced no output");
+        return None;
+    }
+
+    let verdict = parse_judge_verdict(&raw, round);
+
+    let _ = council_tx
+        .send(CouncilEvent::JudgeSummary {
+            round,
+            summary: verdict.summary.clone(),
+            consensus_reached: verdict.consensus_reached,
+        })
+        .await;
+
+    Some(verdict)
+}
+
+/// Robust, case-insensitive extraction of the `CONSENSUS_REACHED` marker.
+///
+/// Handles common LLM output variations:
+/// - `CONSENSUS_REACHED: true` (canonical)
+/// - `**CONSENSUS_REACHED:** false` (markdown bold)
+/// - `` `CONSENSUS_REACHED`: true `` (markdown backtick)
+/// - `consensus_reached : True` (extra spacing, mixed case)
+/// - `Consensus_Reached: FALSE` (title case)
+///
+/// The summary is everything *before* the marker line.  If the marker is
+/// absent, defaults to `consensus_reached = false`.
+fn parse_judge_verdict(raw: &str, round: u32) -> JudgeVerdict {
+    // Scan lines from the end — the prompt asks for the marker at the bottom.
+    let mut consensus_reached = false;
+    let mut marker_line_idx: Option<usize> = None;
+
+    let lines: Vec<&str> = raw.lines().collect();
+    for (i, line) in lines.iter().enumerate().rev() {
+        if let Some(value) = extract_consensus_value(line) {
+            consensus_reached = value;
+            marker_line_idx = Some(i);
+            break;
+        }
+    }
+
+    if marker_line_idx.is_none() {
+        debug!(round, "judge output missing CONSENSUS_REACHED marker, defaulting to false");
+    }
+
+    // Summary = everything before the marker line (or the full text if no marker).
+    let summary = match marker_line_idx {
+        Some(idx) => lines[..idx]
+            .iter()
+            .copied()
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_owned(),
+        None => raw.trim().to_owned(),
+    };
+
+    JudgeVerdict {
+        summary,
+        consensus_reached,
+    }
+}
+
+/// Try to extract a boolean value from a line containing `CONSENSUS_REACHED`.
+///
+/// Strips markdown formatting (`**`, `` ` ``), normalises whitespace, and
+/// performs case-insensitive matching.  Returns `None` if the line does not
+/// contain the marker.
+fn extract_consensus_value(line: &str) -> Option<bool> {
+    // Strip common markdown wrappers.
+    let cleaned: String = line
+        .chars()
+        .filter(|c| *c != '*' && *c != '`')
+        .collect();
+
+    let lower = cleaned.to_lowercase();
+
+    // Look for "consensus_reached" anywhere in the line.
+    let idx = lower.find("consensus_reached")?;
+
+    // Everything after the marker keyword.
+    let after = &lower[idx + "consensus_reached".len()..];
+
+    // Strip optional colon and whitespace.
+    let after = after.trim_start();
+    let after = after.strip_prefix(':').unwrap_or(after);
+    let after = after.trim();
+
+    // Parse the boolean value.
+    if after.starts_with("true") || after.starts_with("yes") {
+        Some(true)
+    } else if after.starts_with("false") || after.starts_with("no") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Whether the judge should allow early stopping at this round.
+///
+/// Returns `true` if the completed round count meets the minimum threshold
+/// configured in [`JudgeConfig`].
+pub(super) fn may_stop_early(judge_config: &JudgeConfig, completed_rounds: u32) -> bool {
+    completed_rounds >= judge_config.min_rounds_before_stop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_judge_verdict ──────────────────────────────────────────────
+
+    #[test]
+    fn canonical_true() {
+        let raw = "The agents agree on the core approach.\nCONSENSUS_REACHED: true";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(v.consensus_reached);
+        assert_eq!(v.summary, "The agents agree on the core approach.");
+    }
+
+    #[test]
+    fn canonical_false() {
+        let raw = "Significant disagreement remains.\nCONSENSUS_REACHED: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert_eq!(v.summary, "Significant disagreement remains.");
+    }
+
+    #[test]
+    fn markdown_bold_wrapping() {
+        let raw = "Summary here.\n**CONSENSUS_REACHED:** true";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(v.consensus_reached);
+        assert_eq!(v.summary, "Summary here.");
+    }
+
+    #[test]
+    fn markdown_backtick_wrapping() {
+        let raw = "Summary.\n`CONSENSUS_REACHED`: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+    }
+
+    #[test]
+    fn mixed_case() {
+        let raw = "Debate ongoing.\nConsensus_Reached: True";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(v.consensus_reached);
+    }
+
+    #[test]
+    fn extra_spacing() {
+        let raw = "Still debating.\nconsensus_reached :  false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+    }
+
+    #[test]
+    fn conversational_filler_before_marker() {
+        let raw = "Here is my verdict:\n\nThe agents remain divided on implementation.\n\nCONSENSUS_REACHED: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert!(v.summary.contains("Here is my verdict:"));
+        assert!(v.summary.contains("remain divided"));
+    }
+
+    #[test]
+    fn missing_marker_defaults_to_false() {
+        let raw = "The debate is interesting but I cannot decide.";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert_eq!(v.summary, raw);
+    }
+
+    #[test]
+    fn yes_no_alternatives() {
+        let raw = "All agree.\nCONSENSUS_REACHED: yes";
+        assert!(parse_judge_verdict(raw, 0).consensus_reached);
+
+        let raw = "No agreement.\nCONSENSUS_REACHED: no";
+        assert!(!parse_judge_verdict(raw, 0).consensus_reached);
+    }
+
+    #[test]
+    fn marker_in_middle_of_text() {
+        // Some models might put text after the marker — the parser should
+        // still find the last occurrence scanning from the bottom.
+        let raw = "Round 1 summary.\nCONSENSUS_REACHED: true\nExtra text here.";
+        let v = parse_judge_verdict(raw, 0);
+        // The scanner finds the marker line and uses text before it as summary.
+        // Because we scan from the end, the last CONSENSUS_REACHED line wins.
+        // In this case there's only one, but "Extra text here." is after it.
+        assert!(v.consensus_reached);
+    }
+
+    #[test]
+    fn multiline_summary_preserved() {
+        let raw = "Point 1.\nPoint 2.\nPoint 3.\n\nCONSENSUS_REACHED: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert!(v.summary.contains("Point 1."));
+        assert!(v.summary.contains("Point 3."));
+    }
+
+    // ── may_stop_early ───────────────────────────────────────────────────
+
+    #[test]
+    fn stop_early_respects_minimum() {
+        let cfg = JudgeConfig {
+            min_rounds_before_stop: 2,
+        };
+        assert!(!may_stop_early(&cfg, 0));
+        assert!(!may_stop_early(&cfg, 1));
+        assert!(may_stop_early(&cfg, 2));
+        assert!(may_stop_early(&cfg, 3));
+    }
+
+    #[test]
+    fn stop_early_default_min() {
+        let cfg = JudgeConfig {
+            min_rounds_before_stop: 1,
+        };
+        assert!(!may_stop_early(&cfg, 0));
+        assert!(may_stop_early(&cfg, 1));
+    }
+
+    // ── extract_consensus_value ──────────────────────────────────────────
+
+    #[test]
+    fn extract_plain() {
+        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: true"), Some(true));
+        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: false"), Some(false));
+    }
+
+    #[test]
+    fn extract_with_markdown() {
+        assert_eq!(extract_consensus_value("**CONSENSUS_REACHED:** true"), Some(true));
+        assert_eq!(extract_consensus_value("`CONSENSUS_REACHED`: false"), Some(false));
+    }
+
+    #[test]
+    fn extract_no_marker() {
+        assert_eq!(extract_consensus_value("some random text"), None);
+    }
+
+    #[test]
+    fn extract_bad_value() {
+        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: maybe"), None);
+    }
+}

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -17,7 +17,8 @@
 //! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
 //! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
-//! | `orchestrator.rs` | Slim coordinator (rounds → synthesis sequencing)    |
+//! | `judge.rs`        | Post-round judge + adaptive early stopping          |
+//! | `orchestrator.rs` | Slim coordinator (rounds → judge → synthesis)       |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -25,13 +26,14 @@ pub mod events;
 pub mod history;
 pub mod orchestrator;
 pub mod prompts;
+mod judge;
 mod round;
 pub mod state;
 pub mod stream_bridge;
 pub mod suggest;
 mod synthesis;
 
-pub use config::{CouncilAgent, CouncilConfig, SuggestedCouncil};
+pub use config::{CouncilAgent, CouncilConfig, JudgeConfig, SuggestedCouncil};
 pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 pub use orchestrator::run as run_council;
 pub use prompts::{contentiousness_tier_label, contentiousness_to_instruction};

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,15 +1,18 @@
 //! Top-level coordinator for a council deliberation.
 //!
 //! This module is intentionally slim — it sequences the high-level phases
-//! (debate rounds → synthesis) and delegates all per-agent and per-phase
-//! logic to dedicated sub-modules:
+//! (debate rounds → optional judge → synthesis) and delegates all per-agent
+//! and per-phase logic to dedicated sub-modules:
 //!
 //! ```text
 //! orchestrator::run()
 //!   │
 //!   ├─ for each round 0..N
 //!   │   ├─ emit RoundSeparator (round > 0)
-//!   │   └─ round::run_sequential_round()      (round.rs)
+//!   │   ├─ round::run_sequential_round()      (round.rs)
+//!   │   └─ if judge enabled:
+//!   │       └─ judge::run_judge()              (judge.rs)
+//!   │           └─ if consensus && may_stop → break
 //!   │
 //!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
@@ -17,21 +20,30 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
+use tracing::info;
 
 use gglib_core::{AgentConfig, LlmCompletionPort, ToolExecutorPort};
 
 use super::config::CouncilConfig;
 use super::events::CouncilEvent;
+use super::judge::{may_stop_early, run_judge};
 use super::round::{RoundContext, run_sequential_round};
 use super::state::CouncilState;
 use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: debate rounds → synthesis.
+/// Runs a full council deliberation: debate rounds → optional judge → synthesis.
 ///
 /// This function is the only public entry point.  It coordinates the
 /// high-level phase sequence and delegates per-agent turn execution to
-/// [`round::run_sequential_round`] and the synthesis pass to
+/// [`round::run_sequential_round`], optional judge evaluation to
+/// [`judge::run_judge`], and the synthesis pass to
 /// [`synthesis::run_synthesis`].
+///
+/// # Judge + Adaptive Early Stopping
+///
+/// When `config.judge` is `Some`, a neutral judge evaluates the debate
+/// after each round.  If the judge determines consensus has been reached
+/// and the minimum-rounds threshold is met, remaining rounds are skipped.
 ///
 /// # Errors
 ///
@@ -73,6 +85,37 @@ pub async fn run(
         }
 
         state.advance_round();
+
+        // ── optional judge evaluation ────────────────────────────────────
+        if let Some(ref judge_config) = config.judge {
+            let completed_rounds = round + 1;
+            let is_last_round = completed_rounds >= config.rounds;
+
+            // Skip judge on the final round — synthesis follows regardless.
+            if !is_last_round {
+                if let Some(verdict) = run_judge(
+                    round,
+                    config.rounds,
+                    judge_config,
+                    &llm,
+                    &tool_executor,
+                    &state,
+                    &council_tx,
+                    &config.topic,
+                )
+                .await
+                {
+                    if verdict.consensus_reached && may_stop_early(judge_config, completed_rounds) {
+                        info!(
+                            round,
+                            completed_rounds,
+                            "judge detected consensus — stopping early"
+                        );
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     // ── synthesis ────────────────────────────────────────────────────────

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -121,6 +121,36 @@ single agent could provide alone.";
 
 // ─── contentiousness mapping ─────────────────────────────────────────────────
 
+/// System prompt for the post-round judge evaluation.
+///
+/// Placeholders: `{topic}`, `{round}`, `{total_rounds}`, `{transcript}`.
+///
+/// The judge must end with a `CONSENSUS_REACHED:` line.  The parser in
+/// `judge.rs` uses robust, case-insensitive matching to tolerate markdown
+/// wrapping, extra whitespace, or conversational filler.
+pub const JUDGE_PROMPT: &str = "\
+You are a neutral judge evaluating a structured multi-agent debate on the topic: \"{topic}\"
+
+This is the end of round {round} (of a maximum of {total_rounds}).
+
+DEBATE TRANSCRIPT SO FAR:
+{transcript}
+
+YOUR TASK:
+1. Summarise the current state of the debate in 2-4 sentences: what are the key positions, \
+where do agents agree, and what genuine disagreements remain?
+2. Determine whether consensus has been reached. Consensus means the agents' core positions \
+have converged to a shared conclusion — not that they agree on every detail, but that there \
+is a clear dominant answer with no substantive opposition remaining.
+
+IMPORTANT: You MUST end your response with exactly one of these two lines:
+CONSENSUS_REACHED: true
+CONSENSUS_REACHED: false
+
+Do NOT add any text after the CONSENSUS_REACHED line.";
+
+// ─── contentiousness mapping ─────────────────────────────────────────────────
+
 /// Map a contentiousness float to a discrete behavioural instruction string.
 ///
 /// Small models cannot interpret a raw float like `0.7`.  This function maps
@@ -216,5 +246,13 @@ mod tests {
     #[test]
     fn negative_contentiousness_treated_as_collaborative() {
         assert!(contentiousness_to_instruction(-0.5).contains("collaborative"));
+    }
+
+    #[test]
+    fn judge_prompt_has_placeholders() {
+        assert!(JUDGE_PROMPT.contains("{topic}"));
+        assert!(JUDGE_PROMPT.contains("{round}"));
+        assert!(JUDGE_PROMPT.contains("{total_rounds}"));
+        assert!(JUDGE_PROMPT.contains("{transcript}"));
     }
 }

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -248,6 +248,7 @@ async fn edit_then_run(config: &mut CouncilConfig, ports: CouncilPorts) -> Resul
                     agents: config.agents.clone(),
                     rounds: config.rounds,
                     synthesis_guidance: config.synthesis_guidance.clone(),
+                    judge: config.judge.clone(),
                 };
                 let prev_json = serde_json::to_string(&prev)?;
 

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -103,6 +103,34 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 eprintln!("\n{DIM}═══════════════════ Round {round} ═══════════════════{RESET}");
             }
 
+            CouncilEvent::JudgeStart { round } => {
+                eprintln!(
+                    "\n{DIM}── Judge evaluating round {round} ──{RESET}"
+                );
+            }
+
+            CouncilEvent::JudgeTextDelta { delta } => {
+                eprint!("{DIM}{delta}{RESET}");
+                let _ = io::stderr().flush();
+            }
+
+            CouncilEvent::JudgeSummary {
+                consensus_reached,
+                summary,
+                ..
+            } => {
+                eprintln!();
+                if consensus_reached {
+                    eprintln!(
+                        "  \x1b[32m✓{RESET}  {BOLD}Consensus reached{RESET}  {DIM}{summary}{RESET}"
+                    );
+                } else {
+                    eprintln!(
+                        "  {DIM}○  No consensus — debate continues  {summary}{RESET}"
+                    );
+                }
+            }
+
             CouncilEvent::SynthesisStart => {
                 in_synthesis = true;
                 eprintln!("\n\x1b[36m{BOLD}── Council Synthesis ──{RESET}");

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -32,6 +32,9 @@ export type CouncilAction =
   | { type: 'AGENT_TOOL_CALL_COMPLETE'; agentId: string; toolName: string; result: { content: string; isError: boolean }; displayName: string; durationDisplay: string }
   | { type: 'AGENT_TURN_COMPLETE'; contribution: AgentContribution }
   | { type: 'ROUND_SEPARATOR'; round: number }
+  | { type: 'JUDGE_START'; round: number }
+  | { type: 'JUDGE_TEXT_DELTA'; delta: string }
+  | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
@@ -125,6 +128,20 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
 
     case 'ROUND_SEPARATOR':
       return { ...state, currentRound: action.round };
+
+    case 'JUDGE_START':
+      return { ...state, phase: 'judging', judgeText: '' };
+
+    case 'JUDGE_TEXT_DELTA':
+      return { ...state, judgeText: state.judgeText + action.delta };
+
+    case 'JUDGE_SUMMARY':
+      return {
+        ...state,
+        phase: 'deliberating',
+        judgeSummary: action.summary,
+        judgeConsensusReached: action.consensusReached,
+      };
 
     case 'SYNTHESIS_START':
       return { ...state, phase: 'synthesizing', synthesisText: '' };

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -97,6 +97,17 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
       };
     case 'round_separator':
       return { type: 'ROUND_SEPARATOR', round: event.round };
+    case 'judge_start':
+      return { type: 'JUDGE_START', round: event.round };
+    case 'judge_text_delta':
+      return { type: 'JUDGE_TEXT_DELTA', delta: event.delta };
+    case 'judge_summary':
+      return {
+        type: 'JUDGE_SUMMARY',
+        round: event.round,
+        summary: event.summary,
+        consensusReached: event.consensus_reached,
+      };
     case 'synthesis_start':
       return { type: 'SYNTHESIS_START' };
     case 'synthesis_text_delta':

--- a/src/services/clients/council.ts
+++ b/src/services/clients/council.ts
@@ -24,17 +24,23 @@ export interface CouncilAgent {
   tool_filter?: string[];
 }
 
+export interface JudgeConfig {
+  min_rounds_before_stop?: number;
+}
+
 export interface CouncilConfig {
   agents: CouncilAgent[];
   topic: string;
   rounds: number;
   synthesis_guidance?: string;
+  judge?: JudgeConfig;
 }
 
 export interface SuggestedCouncil {
   agents: CouncilAgent[];
   rounds: number;
   synthesis_guidance?: string;
+  judge?: JudgeConfig;
 }
 
 // ─── Suggest ────────────────────────────────────────────────────────────────

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -36,6 +36,9 @@ export type CouncilEvent =
   | AgentToolCallCompleteEvent
   | AgentTurnCompleteEvent
   | RoundSeparatorEvent
+  | JudgeStartEvent
+  | JudgeTextDeltaEvent
+  | JudgeSummaryEvent
   | SynthesisStartEvent
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
@@ -93,6 +96,23 @@ export interface RoundSeparatorEvent {
   round: number;
 }
 
+export interface JudgeStartEvent {
+  type: 'judge_start';
+  round: number;
+}
+
+export interface JudgeTextDeltaEvent {
+  type: 'judge_text_delta';
+  delta: string;
+}
+
+export interface JudgeSummaryEvent {
+  type: 'judge_summary';
+  round: number;
+  summary: string;
+  consensus_reached: boolean;
+}
+
 export interface SynthesisStartEvent {
   type: 'synthesis_start';
 }
@@ -145,6 +165,7 @@ export type CouncilPhase =
   | 'suggesting'
   | 'setup'
   | 'deliberating'
+  | 'judging'
   | 'synthesizing'
   | 'complete'
   | 'error';
@@ -177,6 +198,12 @@ export interface CouncilSession {
   activeToolCalls: AgentToolCall[];
   /** All completed contributions across rounds. */
   contributions: AgentContribution[];
+  /** Judge text accumulated during evaluation (streamed incrementally). */
+  judgeText: string;
+  /** Judge summary from the most recent evaluation. */
+  judgeSummary: string | null;
+  /** Whether the judge detected consensus. */
+  judgeConsensusReached: boolean;
   /** Synthesis text (streamed incrementally). */
   synthesisText: string;
   /** Error message if phase === 'error'. */
@@ -264,6 +291,9 @@ export function createEmptySession(): CouncilSession {
     activeAgentReasoning: '',
     activeToolCalls: [],
     contributions: [],
+    judgeText: '',
+    judgeSummary: null,
+    judgeConsensusReached: false,
     synthesisText: '',
     error: null,
   };


### PR DESCRIPTION
## Phase 1: Judge + Adaptive Early Stopping

Adds a neutral judge that evaluates each round of council debate and can trigger early stopping when consensus is reached.

### Changes

**New: `judge.rs`**
- `JudgeVerdict` struct (summary + consensus_reached)
- `run_judge()` — runs a single-iteration AgentLoop with JUDGE_PROMPT, emits JudgeStart/JudgeTextDelta/JudgeSummary events
- `parse_judge_verdict()` — scans output lines for CONSENSUS_REACHED marker
- `extract_consensus_value()` — robust parsing: strips markdown bold/backtick formatting, lowercases, handles true/false/yes/no
- `may_stop_early()` — checks completed_rounds >= min_rounds_before_stop
- 14 unit tests covering canonical, markdown, backtick, mixed-case, conversational-filler, missing-marker, yes/no alternatives

**Modified: `config.rs`**
- `JudgeConfig` struct with `min_rounds_before_stop: u32` (default 1)
- `judge: Option<JudgeConfig>` added to `CouncilConfig` and `SuggestedCouncil`

**Modified: `events.rs`**
- New variants: `JudgeStart { round }`, `JudgeTextDelta { delta }`, `JudgeSummary { round, summary, consensus_reached }`

**Modified: `prompts.rs`**
- `JUDGE_PROMPT` template with placeholders: `{topic}`, `{round}`, `{total_rounds}`, `{transcript}`

**Modified: `orchestrator.rs`**
- Post-round judge evaluation integrated into debate loop
- Early stopping when consensus detected and minimum rounds satisfied

**Modified: CLI + Frontend**
- CLI stream renderer handles new judge events
- TypeScript types, context reducer, and hook event mapping updated

### Testing
- `cargo test -p gglib-agent` — all tests pass
- `cargo clippy -p gglib-agent -p gglib-cli -- -D warnings` — clean