### PR TITLE
feat(council): Phase 2 — Directed Rebuttals

### DIFF
--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -57,7 +57,7 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `council/events` | `CouncilEvent` SSE enum (wire format) |
 | `council/prompts` | Prompt templates + contentiousness mapping |
 | `council/state` | Round/contribution accumulator |
-| `council/history` | Per-turn context builder (identity + transcript) |
+| `council/history` | Per-turn context builder (identity + transcript + directed rebuttals) |
 | `council/stream_bridge` | `AgentEvent` → `CouncilEvent` mapper |
 | `council/round` | Sequential round execution (per-agent turn driver) |
 | `council/synthesis` | Synthesis pass (transcript → unified answer) |

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -6,17 +6,20 @@
 //!    persona, contentiousness instruction — re-injected every turn).
 //! 2. Formatting the debate transcript from prior rounds as a labelled
 //!    `[Agent Name]: content` block.
-//! 3. Appending round-phase suffixes (debate-history cue, final-round cue).
-//! 4. Wrapping the topic as a `User` message.
+//! 3. Selecting a directed rebuttal target (the prior-round agent with a
+//!    core claim whose contentiousness is most different from the current
+//!    agent), or falling back to a generic debate-history cue.
+//! 4. Appending round-phase suffixes (rebuttal/history cue, final-round cue).
+//! 5. Wrapping the topic as a `User` message.
 
 use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
     AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX,
-    contentiousness_to_instruction,
+    TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
 };
-use super::state::CouncilState;
+use super::state::{AgentContribution, CouncilState};
 
 /// Build the message list for a single agent's turn in the council debate.
 ///
@@ -77,7 +80,19 @@ pub fn build_agent_system_prompt(
         if !transcript.is_empty() {
             prompt.push_str("\n\nDEBATE HISTORY:\n");
             prompt.push_str(&transcript);
-            prompt.push_str(DEBATE_HISTORY_SUFFIX);
+
+            // Directed rebuttal cue targeting the most opposed agent's
+            // core claim, or generic debate-history suffix as fallback.
+            if let Some(target) = select_rebuttal_target(agent, state, round) {
+                let claim = target.core_claim.as_deref().unwrap_or_default();
+                prompt.push_str(
+                    &TARGETED_REBUTTAL_CUE
+                        .replace("{target_name}", &target.agent.name)
+                        .replace("{target_claim}", claim),
+                );
+            } else {
+                prompt.push_str(DEBATE_HISTORY_SUFFIX);
+            }
         }
     }
 
@@ -117,6 +132,38 @@ fn format_transcript(state: &CouncilState, up_to_round: u32) -> String {
         }
     }
     out
+}
+
+/// Select the best rebuttal target for an agent entering a new round.
+///
+/// Picks the contribution from the **previous round** whose `core_claim` is
+/// present and whose contentiousness is most different from the current
+/// agent's — a lightweight proxy for "most semantically distant" without
+/// requiring embeddings.
+///
+/// Returns `None` when:
+/// - `round == 0` (no prior contributions exist)
+/// - no other agent produced a core claim in the previous round
+fn select_rebuttal_target<'a>(
+    agent: &CouncilAgent,
+    state: &'a CouncilState,
+    round: u32,
+) -> Option<&'a AgentContribution> {
+    if round == 0 {
+        return None;
+    }
+    let prev_round = round - 1;
+    state
+        .contributions_for_round(prev_round)
+        .into_iter()
+        .filter(|c| c.agent.id != agent.id && c.core_claim.is_some())
+        .max_by(|a, b| {
+            let dist_a = (a.agent.contentiousness - agent.contentiousness).abs();
+            let dist_b = (b.agent.contentiousness - agent.contentiousness).abs();
+            dist_a
+                .partial_cmp(&dist_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
 }
 
 /// Format the full transcript for the synthesis prompt (all rounds).
@@ -239,5 +286,132 @@ mod tests {
         });
         let transcript = format_synthesis_transcript(&state);
         assert!(transcript.contains("[Skeptic (Skeptic's angle)]: Bad idea."));
+    }
+
+    // ── directed rebuttal tests ──────────────────────────────────────────
+
+    #[test]
+    fn rebuttal_target_none_at_round_0() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        assert!(select_rebuttal_target(&a, &state, 0).is_none());
+    }
+
+    #[test]
+    fn rebuttal_target_picks_most_opposed() {
+        let mut state = CouncilState::new();
+        // Round 0: three agents with core claims
+        state.push(AgentContribution {
+            agent: agent("c", "Collaborator", 0.1),
+            content: "We should cooperate.".into(),
+            core_claim: Some("Cooperation wins.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("b", "Balanced", 0.5),
+            content: "Both sides have merit.".into(),
+            core_claim: Some("Balance is key.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("d", "Devil", 0.9),
+            content: "Everything is wrong.".into(),
+            core_claim: Some("Total opposition.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Current agent is Collaborator (0.1) — most distant is Devil (0.9)
+        let a = agent("c", "Collaborator", 0.1);
+        let target = select_rebuttal_target(&a, &state, 1).unwrap();
+        assert_eq!(target.agent.id, "d");
+        assert_eq!(
+            target.core_claim.as_deref(),
+            Some("Total opposition.")
+        );
+    }
+
+    #[test]
+    fn rebuttal_target_skips_self() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.9),
+            content: "My argument.".into(),
+            core_claim: Some("My claim.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Only contribution in previous round is from self — no target
+        let a = agent("s", "Skeptic", 0.9);
+        assert!(select_rebuttal_target(&a, &state, 1).is_none());
+    }
+
+    #[test]
+    fn rebuttal_target_none_when_no_core_claims() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("a", "Alice", 0.3),
+            content: "Some argument.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("b", "Bob", 0.8),
+            content: "Another argument.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.advance_round();
+
+        let a = agent("a", "Alice", 0.3);
+        assert!(select_rebuttal_target(&a, &state, 1).is_none());
+    }
+
+    #[test]
+    fn rebuttal_cue_injected_in_prompt() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.9),
+            content: "Bad idea.".into(),
+            core_claim: Some("Monoliths scale better.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.2),
+            content: "Let's be practical.".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Pragmatist (0.2) should target Skeptic (0.9) — most distant
+        let a = agent("p", "Pragmatist", 0.2);
+        let prompt = build_agent_system_prompt(&a, "Architecture", 1, 3, &state);
+
+        assert!(prompt.contains("DIRECTED REBUTTAL"));
+        assert!(prompt.contains("Skeptic's core claim"));
+        assert!(prompt.contains("Monoliths scale better."));
+        // Generic suffix should NOT appear when rebuttal cue is used
+        assert!(!prompt.contains("Respond to the strongest counterarguments"));
+    }
+
+    #[test]
+    fn generic_suffix_when_no_rebuttal_target() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("a", "Alice", 0.3),
+            content: "Some argument.".into(),
+            core_claim: None, // no core claim
+            round: 0,
+        });
+        state.advance_round();
+
+        let a = agent("b", "Bob", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+
+        assert!(prompt.contains("DEBATE HISTORY"));
+        assert!(prompt.contains("Respond to the strongest counterarguments"));
+        assert!(!prompt.contains("DIRECTED REBUTTAL"));
     }
 }

--- a/crates/gglib-agent/src/council/judge.rs
+++ b/crates/gglib-agent/src/council/judge.rs
@@ -51,6 +51,7 @@ pub(super) struct JudgeVerdict {
 ///
 /// Returns `None` if the channel is closed or the judge produces no
 /// output (the orchestrator should treat this as "no consensus").
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn run_judge(
     round: u32,
     total_rounds: u32,
@@ -165,16 +166,10 @@ fn parse_judge_verdict(raw: &str, round: u32) -> JudgeVerdict {
     }
 
     // Summary = everything before the marker line (or the full text if no marker).
-    let summary = match marker_line_idx {
-        Some(idx) => lines[..idx]
-            .iter()
-            .copied()
-            .collect::<Vec<_>>()
-            .join("\n")
-            .trim()
-            .to_owned(),
-        None => raw.trim().to_owned(),
-    };
+    let summary = marker_line_idx.map_or_else(
+        || raw.trim().to_owned(),
+        |idx| lines[..idx].to_vec().join("\n").trim().to_owned(),
+    );
 
     JudgeVerdict {
         summary,
@@ -221,7 +216,7 @@ fn extract_consensus_value(line: &str) -> Option<bool> {
 ///
 /// Returns `true` if the completed round count meets the minimum threshold
 /// configured in [`JudgeConfig`].
-pub(super) fn may_stop_early(judge_config: &JudgeConfig, completed_rounds: u32) -> bool {
+pub(super) const fn may_stop_early(judge_config: &JudgeConfig, completed_rounds: u32) -> bool {
     completed_rounds >= judge_config.min_rounds_before_stop
 }
 

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -13,7 +13,7 @@
 //! | `events.rs`       | `CouncilEvent` SSE enum (wire format)               |
 //! | `prompts.rs`      | Prompt templates + contentiousness mapping          |
 //! | `state.rs`        | Round/contribution accumulator                      |
-//! | `history.rs`      | Per-turn context builder (identity + transcript)    |
+//! | `history.rs`      | Per-turn context builder (identity + transcript + directed rebuttals) |
 //! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
 //! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -82,10 +82,22 @@ RULES:
 prefixed with \"CORE CLAIM:\" (e.g., \"CORE CLAIM: Microservices add more operational cost \
 than they save for teams under 20 engineers.\"). If you cannot form a single claim, omit this line.";
 
-/// Appended to the system prompt when the agent has prior rounds to respond to.
+/// Appended to the system prompt when the agent has prior rounds to respond to
+/// but no directed rebuttal target is available (no prior core claims).
 pub const DEBATE_HISTORY_SUFFIX: &str = "\n\n\
 Respond to the strongest counterarguments from previous rounds. \
 Strengthen, revise, or concede specific points.";
+
+/// Appended instead of [`DEBATE_HISTORY_SUFFIX`] when a directed rebuttal
+/// target has been selected.
+///
+/// Placeholders: `{target_name}`, `{target_claim}`.
+pub const TARGETED_REBUTTAL_CUE: &str = "\n\n\
+DIRECTED REBUTTAL: You must directly address {target_name}'s core claim: \
+\"{target_claim}\"\n\
+Explain specifically why you agree or disagree with this position from your \
+perspective. Strengthen, revise, or concede specific points — but do not \
+ignore their argument.";
 
 /// Appended to the system prompt in the last debate round.
 pub const FINAL_ROUND_SUFFIX: &str = "\n\n\
@@ -254,5 +266,11 @@ mod tests {
         assert!(JUDGE_PROMPT.contains("{round}"));
         assert!(JUDGE_PROMPT.contains("{total_rounds}"));
         assert!(JUDGE_PROMPT.contains("{transcript}"));
+    }
+
+    #[test]
+    fn rebuttal_cue_has_placeholders() {
+        assert!(TARGETED_REBUTTAL_CUE.contains("{target_name}"));
+        assert!(TARGETED_REBUTTAL_CUE.contains("{target_claim}"));
     }
 }


### PR DESCRIPTION
## Phase 2: Directed Rebuttals

Adds targeted rebuttal cues that focus each agent's response on the most opposed prior argument, replacing the generic "respond to counterarguments" instruction when a rebuttal target is available.

### Changes

**Modified: `history.rs`**
- `select_rebuttal_target()` — picks the contribution from the previous round whose `core_claim` exists and whose contentiousness is most different from the current agent (a lightweight proxy for "most semantically distant" without requiring embeddings)
- `build_agent_system_prompt()` — injects `TARGETED_REBUTTAL_CUE` when a rebuttal target is available; falls back to the generic `DEBATE_HISTORY_SUFFIX` when no prior core claims exist
- Gracefully handles round 0 (no prior contributions) and self-exclusion
- Updated module doc comment to reflect the new rebuttal step

**Modified: `prompts.rs`**
- `TARGETED_REBUTTAL_CUE` — directed rebuttal prompt with `{target_name}` and `{target_claim}` placeholders
- Updated `DEBATE_HISTORY_SUFFIX` doc comment to clarify it's the fallback

**Cleanup: `judge.rs`** (from Phase 1)
- Fixed 4 clippy lints: `too_many_arguments` allow, `map_or_else`, `iter_cloned_collect` → `to_vec()`, `const fn`

**Modified: `mod.rs` + `README.md`**
- Updated history.rs description in module tables

### Design

The rebuttal target selection uses **contentiousness distance** as a proxy for semantic distance:
- A collaborative agent (0.1) will be directed to rebut the devil's advocate (0.9)
- An adversarial agent will be directed to rebut the most collaborative one
- This ensures maximum productive tension without requiring embeddings

Fallback behavior:
- Round 0: no rebuttal (no prior claims exist)
- No core claims in previous round: generic debate-history suffix
- Only self has a core claim: generic debate-history suffix

### Testing
- 7 new unit tests covering target selection, self-exclusion, no-claims fallback, prompt injection, and generic suffix fallback
- `cargo test -p gglib-agent --lib` — 106 tests pass
- `cargo clippy -p gglib-agent -- -D warnings` — clean
- `cargo check` (full workspace) — clean