### PR TITLE
feat(council): add round compaction (Phase 3)

### DIFF
--- a/crates/gglib-agent/src/council/compaction.rs
+++ b/crates/gglib-agent/src/council/compaction.rs
@@ -1,0 +1,448 @@
+//! Round compaction — LLM-driven summarisation of completed debate rounds.
+//!
+//! After a round completes (and before the next round begins), the
+//! orchestrator may run the compactor to produce a short per-agent summary
+//! of the round's contributions.  The compacted text replaces the full
+//! transcript in subsequent agents' context windows, keeping prompt sizes
+//! manageable in long debates (4+ rounds).
+//!
+//! # Robust parsing
+//!
+//! The compactor's output must contain `SUMMARY(Agent Name): ...` lines.
+//! [`parse_compacted_summaries`] uses case-insensitive, whitespace-tolerant
+//! matching to handle common LLM quirks:
+//! - Markdown bold/backtick wrapping (`**SUMMARY(Skeptic):** ...`)
+//! - Extra spacing around the colon
+//! - Varying casing (`summary(name)`, `Summary(Name)`)
+//! - Conversational filler before/after the markers
+//!
+//! If parsing fails to extract any summaries, the round is left
+//! uncompacted — agents simply see the full transcript (graceful
+//! degradation).
+
+use std::collections::HashSet;
+use std::fmt::Write;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::events::CouncilEvent;
+use super::prompts::COMPACTION_PROMPT;
+use super::state::CouncilState;
+
+/// Run the compaction pass for a completed round.
+///
+/// Sends the round's transcript to a single-iteration `AgentLoop` (no
+/// tools) and parses the output into per-agent summaries.  If successful,
+/// stores the compacted text in `state`.
+///
+/// This function is fire-and-forget from the orchestrator's perspective —
+/// if the LLM produces unparseable output or the channel is closed, the
+/// round simply stays uncompacted and agents see the full transcript.
+pub(super) async fn compact_round(
+    round: u32,
+    state: &mut CouncilState,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+    _topic: &str,
+) {
+    let transcript = format_round_transcript(state, round);
+    if transcript.is_empty() {
+        return;
+    }
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let system = COMPACTION_PROMPT
+        .replace("{round}", &(round + 1).to_string())
+        .replace("{transcript}", &transcript);
+
+    let messages = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: format!("Summarise round {} of the debate.", round + 1),
+        },
+    ];
+
+    // Compactor gets no tools — pure text generation.
+    let agent = AgentLoop::build(
+        Arc::clone(llm),
+        Arc::clone(tool_executor),
+        Some(HashSet::new()),
+    );
+    let mut config = AgentConfig::default();
+    config.max_iterations = 1;
+
+    let (agent_tx, mut agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    let handle = {
+        let agent = Arc::clone(&agent);
+        tokio::spawn(async move { agent.run(messages, config, agent_tx).await })
+    };
+
+    // Collect the output (we don't stream compaction tokens to the client).
+    let mut content: Option<String> = None;
+    while let Some(event) = agent_rx.recv().await {
+        if let AgentEvent::FinalAnswer { content: answer } = event {
+            content = Some(answer);
+        }
+    }
+
+    let _ = handle.await;
+
+    let raw = content.unwrap_or_default();
+    if raw.is_empty() {
+        warn!(round, "compaction agent produced no output");
+        return;
+    }
+
+    // Collect agent names from this round for validation.
+    let round_agents: Vec<String> = state
+        .contributions_for_round(round)
+        .iter()
+        .map(|c| c.agent.name.clone())
+        .collect();
+
+    let summaries = parse_compacted_summaries(&raw, &round_agents);
+    if summaries.is_empty() {
+        warn!(
+            round,
+            "compaction produced no parseable summaries, keeping full transcript"
+        );
+        return;
+    }
+
+    debug!(
+        round,
+        summary_count = summaries.len(),
+        "round compacted successfully"
+    );
+
+    // Build the compacted text block.
+    let mut compacted = String::new();
+    for (name, summary) in &summaries {
+        let _ = writeln!(compacted, "[{name}]: {summary}");
+    }
+
+    state.set_compacted(round, compacted.trim().to_owned());
+
+    // Emit a council event so the frontend/CLI can optionally display it.
+    let _ = council_tx
+        .send(CouncilEvent::RoundCompacted {
+            round,
+            summary: state.compacted_summary(round).unwrap_or_default().to_owned(),
+        })
+        .await;
+}
+
+/// Format a single round's contributions for the compaction prompt.
+fn format_round_transcript(state: &CouncilState, round: u32) -> String {
+    let mut out = String::new();
+    for c in state.contributions_for_round(round) {
+        let _ = writeln!(out, "[{}]: {}", c.agent.name, c.content);
+    }
+    out
+}
+
+/// Robust extraction of `SUMMARY(Agent Name): ...` lines from LLM output.
+///
+/// Handles common LLM formatting quirks:
+/// - `SUMMARY(Skeptic): They argued ...` (canonical)
+/// - `**SUMMARY(Skeptic):** They argued ...` (markdown bold)
+/// - `` `SUMMARY(Skeptic)`: They argued ... `` (backtick wrapping)
+/// - `summary(skeptic): They argued ...` (lowercase)
+/// - `SUMMARY (Skeptic) : They argued ...` (extra spaces)
+///
+/// Returns `(agent_name, summary_text)` pairs.  If no summaries are found,
+/// returns an empty vec (the caller should keep the full transcript).
+pub(super) fn parse_compacted_summaries(
+    raw: &str,
+    expected_agents: &[String],
+) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+
+    for line in raw.lines() {
+        if let Some((name, summary)) = extract_summary_line(line) {
+            results.push((name, summary));
+        }
+    }
+
+    // If we found at least one summary, return what we have.
+    // We don't require all agents — some may have been omitted by the LLM.
+    if !results.is_empty() {
+        return results;
+    }
+
+    // Fallback: try to match lines that look like "[Agent]: summary"
+    // (some models may omit the SUMMARY() wrapper entirely).
+    for line in raw.lines() {
+        if let Some((name, summary)) = extract_bracket_line(line, expected_agents) {
+            results.push((name, summary));
+        }
+    }
+
+    results
+}
+
+/// Try to extract a `SUMMARY(name): text` pattern from a single line.
+///
+/// Strips markdown bold (`**`) and backtick (`` ` ``) wrapping before
+/// parsing.
+fn extract_summary_line(line: &str) -> Option<(String, String)> {
+    // Strip markdown wrappers.
+    let cleaned: String = line
+        .chars()
+        .filter(|c| *c != '*' && *c != '`')
+        .collect();
+
+    let lower = cleaned.to_lowercase();
+
+    // Find "summary" followed by "(" somewhere.
+    let summary_idx = lower.find("summary")?;
+    let after_summary = &cleaned[summary_idx + "summary".len()..];
+
+    // Skip optional whitespace, then expect '('.
+    let after_ws = after_summary.trim_start();
+    let after_paren = after_ws.strip_prefix('(')?;
+
+    // Find the closing ')'.
+    let close_idx = after_paren.find(')')?;
+    let name = after_paren[..close_idx].trim();
+
+    if name.is_empty() {
+        return None;
+    }
+
+    // Everything after ')' — skip optional ':' and whitespace.
+    let rest = &after_paren[close_idx + 1..];
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix(':').unwrap_or(rest);
+    let rest = rest.trim();
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    Some((name.to_owned(), rest.to_owned()))
+}
+
+/// Fallback: try to match `[Agent Name]: summary` lines against known agents.
+fn extract_bracket_line(line: &str, expected_agents: &[String]) -> Option<(String, String)> {
+    let trimmed = line.trim();
+    let after_bracket = trimmed.strip_prefix('[')?;
+    let close_idx = after_bracket.find(']')?;
+    let name = after_bracket[..close_idx].trim();
+
+    // Only accept if the name matches a known agent.
+    let matched = expected_agents
+        .iter()
+        .any(|a| a.eq_ignore_ascii_case(name));
+    if !matched {
+        return None;
+    }
+
+    let rest = &after_bracket[close_idx + 1..];
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix(':').unwrap_or(rest);
+    let rest = rest.trim();
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    Some((name.to_owned(), rest.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── extract_summary_line ─────────────────────────────────────────────
+
+    #[test]
+    fn canonical_summary_line() {
+        let (name, text) =
+            extract_summary_line("SUMMARY(Skeptic): They argued against the proposal.")
+                .unwrap();
+        assert_eq!(name, "Skeptic");
+        assert_eq!(text, "They argued against the proposal.");
+    }
+
+    #[test]
+    fn markdown_bold_wrapping() {
+        let (name, text) =
+            extract_summary_line("**SUMMARY(Pragmatist):** A practical approach was suggested.")
+                .unwrap();
+        assert_eq!(name, "Pragmatist");
+        assert_eq!(text, "A practical approach was suggested.");
+    }
+
+    #[test]
+    fn backtick_wrapping() {
+        let (name, text) =
+            extract_summary_line("`SUMMARY(Expert)`: Domain-specific evidence was cited.")
+                .unwrap();
+        assert_eq!(name, "Expert");
+        assert_eq!(text, "Domain-specific evidence was cited.");
+    }
+
+    #[test]
+    fn lowercase_summary() {
+        let (name, text) =
+            extract_summary_line("summary(devil's advocate): Everything is wrong.")
+                .unwrap();
+        assert_eq!(name, "devil's advocate");
+        assert_eq!(text, "Everything is wrong.");
+    }
+
+    #[test]
+    fn extra_spacing() {
+        let (name, text) =
+            extract_summary_line("SUMMARY ( Skeptic ) :  They had concerns.  ")
+                .unwrap();
+        assert_eq!(name, "Skeptic");
+        assert_eq!(text, "They had concerns.");
+    }
+
+    #[test]
+    fn empty_name_returns_none() {
+        assert!(extract_summary_line("SUMMARY(): No name.").is_none());
+    }
+
+    #[test]
+    fn empty_text_returns_none() {
+        assert!(extract_summary_line("SUMMARY(Skeptic):").is_none());
+        assert!(extract_summary_line("SUMMARY(Skeptic):   ").is_none());
+    }
+
+    #[test]
+    fn no_summary_marker_returns_none() {
+        assert!(extract_summary_line("Just some regular text.").is_none());
+    }
+
+    #[test]
+    fn missing_close_paren_returns_none() {
+        assert!(extract_summary_line("SUMMARY(Skeptic: missing paren").is_none());
+    }
+
+    // ── extract_bracket_line ─────────────────────────────────────────────
+
+    #[test]
+    fn bracket_line_matches_known_agent() {
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let (name, text) =
+            extract_bracket_line("[Skeptic]: They disagreed.", &agents).unwrap();
+        assert_eq!(name, "Skeptic");
+        assert_eq!(text, "They disagreed.");
+    }
+
+    #[test]
+    fn bracket_line_case_insensitive_match() {
+        let agents = vec!["Skeptic".into()];
+        let (name, _) =
+            extract_bracket_line("[skeptic]: Something.", &agents).unwrap();
+        assert_eq!(name, "skeptic");
+    }
+
+    #[test]
+    fn bracket_line_unknown_agent_returns_none() {
+        let agents = vec!["Skeptic".into()];
+        assert!(extract_bracket_line("[Unknown]: Something.", &agents).is_none());
+    }
+
+    #[test]
+    fn bracket_line_empty_text_returns_none() {
+        let agents = vec!["Skeptic".into()];
+        assert!(extract_bracket_line("[Skeptic]:", &agents).is_none());
+    }
+
+    // ── parse_compacted_summaries ────────────────────────────────────────
+
+    #[test]
+    fn parse_canonical_summaries() {
+        let raw = "\
+SUMMARY(Skeptic): Bad idea overall.
+SUMMARY(Pragmatist): Practical compromise needed.
+SUMMARY(Expert): Evidence supports option B.";
+
+        let agents = vec![
+            "Skeptic".into(),
+            "Pragmatist".into(),
+            "Expert".into(),
+        ];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].0, "Skeptic");
+        assert_eq!(result[1].0, "Pragmatist");
+        assert_eq!(result[2].0, "Expert");
+    }
+
+    #[test]
+    fn parse_with_preamble_and_filler() {
+        let raw = "\
+Here are the summaries for this round:
+
+SUMMARY(Skeptic): They had strong objections.
+SUMMARY(Pragmatist): They proposed a middle ground.
+
+Hope this helps!";
+
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn parse_fallback_to_bracket_format() {
+        let raw = "\
+[Skeptic]: They disagreed strongly.
+[Pragmatist]: They offered a compromise.";
+
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, "Skeptic");
+    }
+
+    #[test]
+    fn parse_empty_output() {
+        let result = parse_compacted_summaries("", &["Skeptic".into()]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_no_valid_lines() {
+        let raw = "I couldn't really summarise the debate.";
+        let result = parse_compacted_summaries(raw, &["Skeptic".into()]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_markdown_bold_summaries() {
+        let raw = "\
+**SUMMARY(Skeptic):** Strong opposition based on cost analysis.
+**SUMMARY(Advocate):** Supported the proposal citing long-term ROI.";
+
+        let agents = vec!["Skeptic".into(), "Advocate".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn parse_partial_summaries_still_accepted() {
+        // LLM only summarised one of two agents — we accept what we get.
+        let raw = "SUMMARY(Skeptic): They had concerns.";
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "Skeptic");
+    }
+}

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -98,6 +98,12 @@ pub enum CouncilEvent {
         summary: String,
         consensus_reached: bool,
     },
+    // ── compaction ────────────────────────────────────────────────────────
+    /// A completed round has been compacted into a shorter summary.
+    ///
+    /// The frontend/CLI can optionally display this.  The compacted text
+    /// replaces the full transcript in subsequent agents' context windows.
+    RoundCompacted { round: u32, summary: String },
 
     // ── synthesis ────────────────────────────────────────────────────────
     /// The synthesis phase has begun.  The frontend renders a
@@ -213,6 +219,10 @@ mod tests {
                 round: 1,
                 summary: "Agents are converging.".into(),
                 consensus_reached: true,
+            },
+            CouncilEvent::RoundCompacted {
+                round: 0,
+                summary: "[Skeptic]: Bad idea.\n[Pragmatist]: Good idea.".into(),
             },
             CouncilEvent::SynthesisStart,
             CouncilEvent::SynthesisTextDelta {

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -5,7 +5,8 @@
 //! 1. Constructing a system prompt with identity anchoring (agent name,
 //!    persona, contentiousness instruction — re-injected every turn).
 //! 2. Formatting the debate transcript from prior rounds as a labelled
-//!    `[Agent Name]: content` block.
+//!    `[Agent Name]: content` block.  Rounds that have been compacted are
+//!    replaced with their short summary, keeping context sizes manageable.
 //! 3. Selecting a directed rebuttal target (the prior-round agent with a
 //!    core claim whose contentiousness is most different from the current
 //!    agent), or falling back to a generic debate-history cue.
@@ -107,13 +108,19 @@ pub fn build_agent_system_prompt(
 
 /// Format prior contributions as a labelled transcript block.
 ///
+/// For rounds that have been compacted, the short summary is used in
+/// place of the full per-agent contributions.  The most recent round
+/// (`up_to_round - 1`) is always shown in full — compaction only
+/// applies to older rounds.
+///
 /// Output format:
 /// ```text
-/// === Round 1 ===
-/// [Skeptic]: Their argument text...
-/// [Pragmatist]: Their argument text...
+/// === Round 1 (compacted) ===
+/// [Skeptic]: Short summary of their position.
+/// [Pragmatist]: Short summary of their position.
 /// === Round 2 ===
-/// ...
+/// [Skeptic]: Their full argument text...
+/// [Pragmatist]: Their full argument text...
 /// ```
 ///
 /// Only includes rounds `0..round` (exclusive of the current round).
@@ -122,6 +129,13 @@ fn format_transcript(state: &CouncilState, up_to_round: u32) -> String {
     use std::fmt::Write;
     let mut out = String::new();
     for r in 0..up_to_round {
+        // Use compacted summary for older rounds if available.
+        if let Some(compacted) = state.compacted_summary(r) {
+            let _ = writeln!(out, "=== Round {} (compacted) ===", r + 1);
+            let _ = writeln!(out, "{compacted}");
+            continue;
+        }
+
         let contributions = state.contributions_for_round(r);
         if contributions.is_empty() {
             continue;
@@ -413,5 +427,73 @@ mod tests {
         assert!(prompt.contains("DEBATE HISTORY"));
         assert!(prompt.contains("Respond to the strongest counterarguments"));
         assert!(!prompt.contains("DIRECTED REBUTTAL"));
+    }
+
+    // ── compacted transcript tests ───────────────────────────────────────
+
+    #[test]
+    fn compacted_round_uses_summary() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Very long argument about monoliths...".into(),
+            core_claim: Some("Monoliths scale better.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Very long argument about microservices...".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.set_compacted(
+            0,
+            "[Skeptic]: Opposed the proposal.\n[Pragmatist]: Supported compromise.".into(),
+        );
+        state.advance_round();
+
+        // Round 1 contributions
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Round 1 full text from Skeptic.".into(),
+            core_claim: None,
+            round: 1,
+        });
+        state.advance_round();
+
+        // At round 2, round 0 should be compacted, round 1 should be full
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+
+        // Round 0 should show compacted summary
+        assert!(prompt.contains("=== Round 1 (compacted) ==="));
+        assert!(prompt.contains("[Skeptic]: Opposed the proposal."));
+        assert!(prompt.contains("[Pragmatist]: Supported compromise."));
+        // Full text from round 0 should NOT appear
+        assert!(!prompt.contains("Very long argument about monoliths"));
+
+        // Round 1 should show full text
+        assert!(prompt.contains("=== Round 2 ==="));
+        assert!(prompt.contains("Round 1 full text from Skeptic."));
+    }
+
+    #[test]
+    fn uncompacted_round_shows_full_text() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Full argument text.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.advance_round();
+
+        // No compaction applied — should show full text
+        let a = agent("p", "Pragmatist", 0.3);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+
+        assert!(prompt.contains("=== Round 1 ==="));
+        assert!(!prompt.contains("(compacted)"));
+        assert!(prompt.contains("Full argument text."));
     }
 }

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -18,7 +18,8 @@
 //! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
 //! | `judge.rs`        | Post-round judge + adaptive early stopping          |
-//! | `orchestrator.rs` | Slim coordinator (rounds → judge → synthesis)       |
+//! | `compaction.rs`   | LLM-driven round summarisation for context control  |
+//! | `orchestrator.rs` | Slim coordinator (rounds → compaction → judge → synthesis) |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -26,6 +27,7 @@ pub mod events;
 pub mod history;
 pub mod orchestrator;
 pub mod prompts;
+mod compaction;
 mod judge;
 mod round;
 pub mod state;

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,8 +1,8 @@
 //! Top-level coordinator for a council deliberation.
 //!
 //! This module is intentionally slim — it sequences the high-level phases
-//! (debate rounds → optional judge → synthesis) and delegates all per-agent
-//! and per-phase logic to dedicated sub-modules:
+//! (debate rounds → compaction → optional judge → synthesis) and delegates
+//! all per-agent and per-phase logic to dedicated sub-modules:
 //!
 //! ```text
 //! orchestrator::run()
@@ -10,6 +10,7 @@
 //!   ├─ for each round 0..N
 //!   │   ├─ emit RoundSeparator (round > 0)
 //!   │   ├─ round::run_sequential_round()      (round.rs)
+//!   │   ├─ compaction::compact_round()         (compaction.rs)
 //!   │   └─ if judge enabled:
 //!   │       └─ judge::run_judge()              (judge.rs)
 //!   │           └─ if consensus && may_stop → break
@@ -24,6 +25,7 @@ use tracing::info;
 
 use gglib_core::{AgentConfig, LlmCompletionPort, ToolExecutorPort};
 
+use super::compaction::compact_round;
 use super::config::CouncilConfig;
 use super::events::CouncilEvent;
 use super::judge::{may_stop_early, run_judge};
@@ -31,13 +33,22 @@ use super::round::{RoundContext, run_sequential_round};
 use super::state::CouncilState;
 use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: debate rounds → optional judge → synthesis.
+/// Runs a full council deliberation: debate rounds → compaction → optional judge → synthesis.
 ///
 /// This function is the only public entry point.  It coordinates the
 /// high-level phase sequence and delegates per-agent turn execution to
-/// [`round::run_sequential_round`], optional judge evaluation to
+/// [`round::run_sequential_round`], round compaction to
+/// [`compaction::compact_round`], optional judge evaluation to
 /// [`judge::run_judge`], and the synthesis pass to
 /// [`synthesis::run_synthesis`].
+///
+/// # Round Compaction
+///
+/// After each round completes (except the most recent), the orchestrator
+/// runs a lightweight compaction pass that summarises the round's
+/// contributions into a short per-agent summary.  Subsequent agents see
+/// the compacted text instead of the full transcript, keeping context
+/// sizes manageable in long debates.
 ///
 /// # Judge + Adaptive Early Stopping
 ///
@@ -85,6 +96,11 @@ pub async fn run(
         }
 
         state.advance_round();
+
+        // ── compaction ───────────────────────────────────────────────────
+        // Summarise the just-completed round so that future agents see a
+        // compact version rather than the full transcript.
+        compact_round(round, &mut state, &llm, &tool_executor, &council_tx, &config.topic).await;
 
         // ── optional judge evaluation ────────────────────────────────────
         if let Some(ref judge_config) = config.judge {

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -131,7 +131,36 @@ Write the synthesis as a well-structured response. Do NOT simply list each agent
 Integrate and analyze the arguments to produce a genuinely higher-quality answer than any \
 single agent could provide alone.";
 
-// ─── contentiousness mapping ─────────────────────────────────────────────────
+// ─── round compaction ────────────────────────────────────────────────────────
+
+/// System prompt for the round-compaction pass.
+///
+/// Placeholders: `{round}`, `{transcript}`.
+///
+/// Each agent's contribution must be summarised with a
+/// `SUMMARY(agent_name): ...` line.  The parser in `compaction.rs` uses
+/// robust, case-insensitive matching to tolerate markdown wrapping and
+/// extra whitespace.
+pub const COMPACTION_PROMPT: &str = "\
+You are a concise note-taker for a multi-agent debate. Your job is to compress \
+a single round of debate into a brief summary that preserves each agent's core \
+position and key evidence.
+
+ROUND {round} TRANSCRIPT:
+{transcript}
+
+YOUR TASK:
+For each agent who spoke in this round, write exactly one line:
+SUMMARY(Agent Name): 1-2 sentence summary of their position and key evidence.
+
+Rules:
+- Preserve each agent's distinct position — do NOT merge or reconcile views.
+- Include any specific evidence, data points, or examples they cited.
+- Keep each summary to 1-2 sentences maximum.
+- Do NOT add any commentary, analysis, or additional text.
+- Use the exact agent name as it appears in the transcript.";
+
+// ─── judge ───────────────────────────────────────────────────────────────────
 
 /// System prompt for the post-round judge evaluation.
 ///
@@ -272,5 +301,11 @@ mod tests {
     fn rebuttal_cue_has_placeholders() {
         assert!(TARGETED_REBUTTAL_CUE.contains("{target_name}"));
         assert!(TARGETED_REBUTTAL_CUE.contains("{target_claim}"));
+    }
+
+    #[test]
+    fn compaction_prompt_has_placeholders() {
+        assert!(COMPACTION_PROMPT.contains("{round}"));
+        assert!(COMPACTION_PROMPT.contains("{transcript}"));
     }
 }

--- a/crates/gglib-agent/src/council/state.rs
+++ b/crates/gglib-agent/src/council/state.rs
@@ -4,6 +4,16 @@
 //! organised by round.  It is the single mutable data structure that the
 //! orchestrator writes to and that [`crate::council::history`] reads from
 //! when assembling per-agent context.
+//!
+//! # Round compaction
+//!
+//! After a round completes, the orchestrator may store a compacted summary
+//! via [`CouncilState::set_compacted`].  When compacted text exists for a
+//! round, the history module uses the short summary instead of the full
+//! agent contributions, keeping the context window manageable in long
+//! debates.
+
+use std::collections::HashMap;
 
 use super::config::CouncilAgent;
 
@@ -59,6 +69,11 @@ pub struct CouncilState {
     contributions: Vec<AgentContribution>,
     /// Current round (zero-indexed).
     current_round: u32,
+    /// Compacted round summaries, keyed by zero-indexed round number.
+    ///
+    /// When the history module encounters a compacted round, it uses this
+    /// summary instead of replaying all individual contributions.
+    compacted: HashMap<u32, String>,
 }
 
 impl CouncilState {
@@ -115,6 +130,26 @@ impl CouncilState {
             .map(|r| (r, self.contributions_for_round(r)))
             .filter(|(_, cs)| !cs.is_empty())
             .collect()
+    }
+
+    /// Store a compacted summary for a completed round.
+    ///
+    /// The history module will use this instead of the full contributions
+    /// when building agent context for subsequent rounds.
+    pub fn set_compacted(&mut self, round: u32, summary: String) {
+        self.compacted.insert(round, summary);
+    }
+
+    /// Retrieve the compacted summary for a round, if any.
+    #[must_use]
+    pub fn compacted_summary(&self, round: u32) -> Option<&str> {
+        self.compacted.get(&round).map(String::as_str)
+    }
+
+    /// Whether a given round has been compacted.
+    #[must_use]
+    pub fn is_compacted(&self, round: u32) -> bool {
+        self.compacted.contains_key(&round)
     }
 }
 
@@ -216,5 +251,27 @@ mod tests {
         assert_eq!(rounds[0].1.len(), 2);
         assert_eq!(rounds[1].0, 1);
         assert_eq!(rounds[1].1.len(), 1);
+    }
+
+    // ── compaction ───────────────────────────────────────────────────────
+
+    #[test]
+    fn compacted_summary_round_trip() {
+        let mut state = CouncilState::new();
+        assert!(!state.is_compacted(0));
+        assert!(state.compacted_summary(0).is_none());
+
+        state.set_compacted(0, "Round 0 summary.".into());
+        assert!(state.is_compacted(0));
+        assert_eq!(state.compacted_summary(0), Some("Round 0 summary."));
+        assert!(!state.is_compacted(1));
+    }
+
+    #[test]
+    fn compacted_overwrites_previous() {
+        let mut state = CouncilState::new();
+        state.set_compacted(0, "First.".into());
+        state.set_compacted(0, "Second.".into());
+        assert_eq!(state.compacted_summary(0), Some("Second."));
     }
 }

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -131,6 +131,10 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 }
             }
 
+            CouncilEvent::RoundCompacted { round, .. } => {
+                eprintln!("{DIM}  ↹ Round {round} compacted{RESET}");
+            }
+
             CouncilEvent::SynthesisStart => {
                 in_synthesis = true;
                 eprintln!("\n\x1b[36m{BOLD}── Council Synthesis ──{RESET}");

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -35,6 +35,7 @@ export type CouncilAction =
   | { type: 'JUDGE_START'; round: number }
   | { type: 'JUDGE_TEXT_DELTA'; delta: string }
   | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
+  | { type: 'ROUND_COMPACTED'; round: number; summary: string }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
@@ -142,6 +143,10 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         judgeSummary: action.summary,
         judgeConsensusReached: action.consensusReached,
       };
+
+    case 'ROUND_COMPACTED':
+      // Informational only — no state change needed for the UI.
+      return state;
 
     case 'SYNTHESIS_START':
       return { ...state, phase: 'synthesizing', synthesisText: '' };

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -108,6 +108,8 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
         summary: event.summary,
         consensusReached: event.consensus_reached,
       };
+    case 'round_compacted':
+      return { type: 'ROUND_COMPACTED', round: event.round, summary: event.summary };
     case 'synthesis_start':
       return { type: 'SYNTHESIS_START' };
     case 'synthesis_text_delta':

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -39,6 +39,7 @@ export type CouncilEvent =
   | JudgeStartEvent
   | JudgeTextDeltaEvent
   | JudgeSummaryEvent
+  | RoundCompactedEvent
   | SynthesisStartEvent
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
@@ -111,6 +112,12 @@ export interface JudgeSummaryEvent {
   round: number;
   summary: string;
   consensus_reached: boolean;
+}
+
+export interface RoundCompactedEvent {
+  type: 'round_compacted';
+  round: number;
+  summary: string;
 }
 
 export interface SynthesisStartEvent {


### PR DESCRIPTION
## Phase 3: Round Compaction

After each debate round completes, a lightweight compaction pass summarises each agent's contribution into 1-2 sentences. Subsequent agents see the compacted text instead of the full transcript for older rounds, keeping context sizes manageable in long debates.

### New module: `compaction.rs`
- `compact_round()` runs a single-iteration `AgentLoop` with `COMPACTION_PROMPT`
- Robust parsing: `SUMMARY(Name): ...` format with `[Name]: ...` fallback
- Strips markdown formatting artifacts (`*`, `` ` ``) before parsing
- 15 unit tests covering normal, edge, and adversarial LLM output

### State/event changes
- `state.rs`: `HashMap<u32, String>` for compacted round storage + 3 accessor methods
- `events.rs`: `RoundCompacted { round, summary }` variant
- `history.rs`: `format_transcript()` uses compacted summaries for older rounds; 2 new tests

### Integration
- `orchestrator.rs`: calls `compact_round()` after each `state.advance_round()`
- CLI `stream.rs`: dim `↹ Round N compacted` output
- TypeScript: `RoundCompactedEvent` type, reducer case, event mapping

### Test results
98 council tests pass, 0 clippy warnings.