### PR TITLE
feat(council): enable filesystem tools when run from CLI

### DIFF
--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -19,8 +19,8 @@ use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
-    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT,
-    FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
+    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT, FINAL_ROUND_SUFFIX,
+    TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
 };
 use super::state::{AgentContribution, CouncilState};
 

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -13,12 +13,14 @@
 //! 4. Appending round-phase suffixes (rebuttal/history cue, final-round cue).
 //! 5. Wrapping the topic as a `User` message.
 
+use std::path::Path;
+
 use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
-    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE,
-    contentiousness_to_instruction,
+    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT,
+    FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
 };
 use super::state::{AgentContribution, CouncilState};
 
@@ -43,9 +45,10 @@ pub fn build_agent_messages(
     round: u32,
     total_rounds: u32,
     state: &CouncilState,
+    cwd: Option<&Path>,
 ) -> (Vec<AgentMessage>, Option<String>) {
     let (system_prompt, rebuttal_target) =
-        build_agent_system_prompt(agent, topic, round, total_rounds, state);
+        build_agent_system_prompt(agent, topic, round, total_rounds, state, cwd);
     let messages = vec![
         AgentMessage::System {
             content: system_prompt,
@@ -70,6 +73,7 @@ pub fn build_agent_system_prompt(
     round: u32,
     total_rounds: u32,
     state: &CouncilState,
+    cwd: Option<&Path>,
 ) -> (String, Option<String>) {
     let instruction = contentiousness_to_instruction(agent.contentiousness);
 
@@ -110,6 +114,14 @@ pub fn build_agent_system_prompt(
     let is_final = total_rounds > 0 && round == total_rounds - 1;
     if is_final {
         prompt.push_str(FINAL_ROUND_SUFFIX);
+    }
+
+    // Filesystem context — when a working directory is available, tell
+    // the agent about filesystem tools so it can inspect the codebase.
+    if let Some(dir) = cwd {
+        use std::fmt::Write as _;
+        prompt.push_str(FILESYSTEM_TOOLS_CONTEXT);
+        write!(prompt, "\n\nWorking directory: {}", dir.display()).unwrap();
     }
 
     (prompt, rebuttal_target)
@@ -232,7 +244,7 @@ mod tests {
     fn round_0_no_history() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, target) = build_agent_system_prompt(&a, "Test topic", 0, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Test topic", 0, 3, &state, None);
 
         assert!(prompt.contains("You are Skeptic."));
         assert!(prompt.contains("Skeptic is a test agent."));
@@ -260,7 +272,7 @@ mod tests {
         state.advance_round();
 
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _target) = build_agent_system_prompt(&a, "Test topic", 1, 3, &state);
+        let (prompt, _target) = build_agent_system_prompt(&a, "Test topic", 1, 3, &state, None);
 
         assert!(prompt.contains("DEBATE HISTORY:"));
         assert!(prompt.contains("=== Round 1 ==="));
@@ -274,7 +286,7 @@ mod tests {
     fn final_round_suffix_appended() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -282,7 +294,7 @@ mod tests {
     fn single_round_is_also_final() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -290,7 +302,7 @@ mod tests {
     fn build_agent_messages_structure() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (msgs, target) = build_agent_messages(&a, "My topic", 0, 2, &state);
+        let (msgs, target) = build_agent_messages(&a, "My topic", 0, 2, &state, None);
 
         assert_eq!(msgs.len(), 2);
         assert!(
@@ -409,7 +421,7 @@ mod tests {
 
         // Pragmatist (0.2) should target Skeptic (0.9) — most distant
         let a = agent("p", "Pragmatist", 0.2);
-        let (prompt, target) = build_agent_system_prompt(&a, "Architecture", 1, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Architecture", 1, 3, &state, None);
 
         assert!(prompt.contains("DIRECTED REBUTTAL"));
         assert!(prompt.contains("Skeptic's core claim"));
@@ -431,7 +443,7 @@ mod tests {
         state.advance_round();
 
         let a = agent("b", "Bob", 0.7);
-        let (prompt, target) = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
 
         assert!(prompt.contains("DEBATE HISTORY"));
         assert!(prompt.contains("Respond to the strongest counterarguments"));
@@ -473,7 +485,7 @@ mod tests {
 
         // At round 2, round 0 should be compacted, round 1 should be full
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
 
         // Round 0 should show compacted summary
         assert!(prompt.contains("=== Round 1 (compacted) ==="));
@@ -500,10 +512,31 @@ mod tests {
 
         // No compaction applied — should show full text
         let a = agent("p", "Pragmatist", 0.3);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
 
         assert!(prompt.contains("=== Round 1 ==="));
         assert!(!prompt.contains("(compacted)"));
         assert!(prompt.contains("Full argument text."));
+    }
+
+    // ── filesystem context tests ─────────────────────────────────────────
+
+    #[test]
+    fn cwd_none_omits_filesystem_context() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
+        assert!(!prompt.contains("filesystem tools"));
+        assert!(!prompt.contains("Working directory"));
+    }
+
+    #[test]
+    fn cwd_some_injects_filesystem_context() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let dir = std::path::PathBuf::from("/tmp/my-project");
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, Some(&dir));
+        assert!(prompt.contains("filesystem tools (read_file, list_directory, grep_search)"));
+        assert!(prompt.contains("Working directory: /tmp/my-project"));
     }
 }

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -19,6 +19,7 @@
 //!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -70,6 +71,7 @@ pub async fn run(
     llm: Arc<dyn LlmCompletionPort>,
     tool_executor: Arc<dyn ToolExecutorPort>,
     council_tx: mpsc::Sender<CouncilEvent>,
+    cwd: Option<PathBuf>,
 ) {
     let mut state = CouncilState::new();
 
@@ -79,6 +81,7 @@ pub async fn run(
         llm: &llm,
         tool_executor: &tool_executor,
         council_tx: &council_tx,
+        cwd: cwd.as_deref(),
     };
 
     // ── debate rounds ────────────────────────────────────────────────────

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -221,6 +221,21 @@ Rules:
 - If the initial or final claim is missing, classify as \"Held\" (insufficient evidence to judge movement).
 - Output ONLY the STANCE lines — no explanation, no commentary, no additional text.";
 
+// ─── filesystem context ──────────────────────────────────────────────────────
+
+/// Appended to the agent system prompt when a working directory is available,
+/// informing the agent about filesystem tools.
+///
+/// The `"\n\nWorking directory: {cwd}"` line is appended separately by the
+/// caller so this constant stays format-arg-free.
+///
+/// Phrasing mirrors `agent_question::SYSTEM_PROMPT` to keep tool descriptions
+/// consistent across CLI entry-points.
+pub const FILESYSTEM_TOOLS_CONTEXT: &str = "\n\n\
+You have access to filesystem tools (read_file, list_directory, grep_search) \
+scoped to the user's working directory. Use them to find evidence supporting \
+your position.";
+
 // ─── contentiousness mapping ─────────────────────────────────────────────────
 
 /// Map a contentiousness float to a discrete behavioural instruction string.

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -83,8 +83,14 @@ async fn run_agent_turn(
 
     // Assemble context with identity anchoring + debate transcript.
     // This also returns the rebuttal target name (if any) for the start event.
-    let (messages, rebuttal_target) =
-        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state, ctx.cwd);
+    let (messages, rebuttal_target) = build_agent_messages(
+        agent,
+        &ctx.config.topic,
+        round,
+        ctx.config.rounds,
+        state,
+        ctx.cwd,
+    );
 
     // Announce the turn (after building messages so we have the rebuttal target).
     let start = CouncilEvent::AgentTurnStart {

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -10,6 +10,7 @@
 //! - contribution recording (content + core claim extraction)
 
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -37,6 +38,7 @@ pub(super) struct RoundContext<'a> {
     pub llm: &'a Arc<dyn LlmCompletionPort>,
     pub tool_executor: &'a Arc<dyn ToolExecutorPort>,
     pub council_tx: &'a mpsc::Sender<CouncilEvent>,
+    pub cwd: Option<&'a Path>,
 }
 
 /// Execute a single debate round sequentially: each agent speaks in
@@ -82,7 +84,7 @@ async fn run_agent_turn(
     // Assemble context with identity anchoring + debate transcript.
     // This also returns the rebuttal target name (if any) for the start event.
     let (messages, rebuttal_target) =
-        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state);
+        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state, ctx.cwd);
 
     // Announce the turn (after building messages so we have the rebuttal target).
     let start = CouncilEvent::AgentTurnStart {

--- a/crates/gglib-axum/src/handlers/council/mod.rs
+++ b/crates/gglib-axum/src/handlers/council/mod.rs
@@ -37,6 +37,7 @@ pub async fn suggest(
         state.http_client.clone(),
         req.model.clone(),
         state.mcp.clone(),
+        None,
     );
 
     // Build multi-turn refinement history when the client sends a
@@ -104,6 +105,7 @@ pub async fn run(
         state.http_client.clone(),
         req.model.clone(),
         state.mcp.clone(),
+        None,
     );
 
     let agent_config: AgentConfig = req.config.map_or_else(AgentConfig::default, Into::into);
@@ -119,6 +121,7 @@ pub async fn run(
             ports.llm,
             ports.tool_executor,
             council_tx,
+            None,
         )
         .await;
     });

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -296,7 +296,15 @@ async fn run_with_ports(council: CouncilConfig, ports: CouncilPorts) -> Result<(
     let cwd = std::env::current_dir().ok();
 
     tokio::spawn(async move {
-        run_council(council, agent_config, ports.llm, ports.tool_executor, tx, cwd).await;
+        run_council(
+            council,
+            agent_config,
+            ports.llm,
+            ports.tool_executor,
+            tx,
+            cwd,
+        )
+        .await;
     });
 
     stream::render_council_stream(&mut rx).await;

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -130,11 +130,14 @@ async fn init_session(
         tracing::warn!("MCP initialisation failed: {e}");
     }
 
+    let cwd = std::env::current_dir().ok();
+
     let ports = compose_council_ports(
         format!("http://127.0.0.1:{resolved_port}"),
         ctx.http_client.clone(),
         model,
         Arc::clone(&ctx.mcp),
+        cwd,
     );
     Ok((ports, handle))
 }
@@ -290,8 +293,10 @@ async fn run_with_ports(council: CouncilConfig, ports: CouncilPorts) -> Result<(
     let agent_config = AgentConfig::default();
     let (tx, mut rx) = mpsc::channel::<CouncilEvent>(COUNCIL_EVENT_CHANNEL_CAPACITY);
 
+    let cwd = std::env::current_dir().ok();
+
     tokio::spawn(async move {
-        run_council(council, agent_config, ports.llm, ports.tool_executor, tx).await;
+        run_council(council, agent_config, ports.llm, ports.tool_executor, tx, cwd).await;
     });
 
     stream::render_council_stream(&mut rx).await;

--- a/crates/gglib-runtime/src/compose.rs
+++ b/crates/gglib-runtime/src/compose.rs
@@ -101,18 +101,25 @@ pub struct CouncilPorts {
 /// [`ToolExecutorPort`] separately, because
 /// [`gglib_agent::council::run_council`] creates per-agent `AgentLoop`
 /// instances internally (each with its own tool filter).
+///
+/// When `sandbox_root` is `Some`, filesystem tools (`read_file`,
+/// `list_directory`, `grep_search`) are enabled and scoped to that path.
 pub fn compose_council_ports(
     base_url: String,
     http_client: Client,
     model: Option<String>,
     mcp: Arc<McpService>,
+    sandbox_root: Option<PathBuf>,
 ) -> CouncilPorts {
     let llm: Arc<dyn LlmCompletionPort> = Arc::new(LlmCompletionAdapter::with_client(
         base_url,
         http_client,
         model,
     ));
-    let tool_executor: Arc<dyn ToolExecutorPort> = Arc::new(CombinedToolExecutor::new(mcp));
+    let tool_executor: Arc<dyn ToolExecutorPort> = match sandbox_root {
+        Some(root) => Arc::new(CombinedToolExecutor::with_sandbox(mcp, root)),
+        None => Arc::new(CombinedToolExecutor::new(mcp)),
+    };
     CouncilPorts { llm, tool_executor }
 }
 


### PR DESCRIPTION
Thread `sandbox_root` through `compose_council_ports()` so council agents gain access to `read_file`, `list_directory`, and `grep_search` when a working directory is available (CLI). The Axum/GUI path passes `None`, preserving the existing sandboxless behaviour.

## Problem

Running `gglib chat council` from inside a project directory gave agents zero filesystem awareness — they couldn't read files, list directories, or grep the codebase. This happened because `compose_council_ports()` created a `CombinedToolExecutor::new(mcp)` without a `sandbox_root`, which hides all filesystem builtins.

## Changes

| File | Change |
|------|--------|
| `compose.rs` | Add `sandbox_root: Option<PathBuf>` param; conditionally use `CombinedToolExecutor::with_sandbox()` |
| `orchestrator.rs` | Add `cwd: Option<PathBuf>` param; thread into `RoundContext` |
| `round.rs` | Add `cwd: Option<&Path>` to `RoundContext`; pass to `build_agent_messages()` |
| `history.rs` | Accept `cwd` in `build_agent_messages` / `build_agent_system_prompt`; append `FILESYSTEM_TOOLS_CONTEXT` + working directory when `Some` |
| `prompts.rs` | Add `FILESYSTEM_TOOLS_CONTEXT` constant (phrasing mirrors `agent_question::SYSTEM_PROMPT`) |
| CLI handler | Capture `env::current_dir()`; pass to both `compose_council_ports` and `run_council` |
| Axum handler | Pass `None` for `sandbox_root` and `cwd` (GUI parity) |

## Design

- **`Option<PathBuf>`** — GUI/Axum passes `None` (no filesystem), CLI passes `Some(cwd)`. Ready for future GUI sandbox support.
- **DRY prompt phrasing** — `FILESYSTEM_TOOLS_CONTEXT` mirrors `agent_question::SYSTEM_PROMPT` tool descriptions.
- **Shared `AgentLoop`** — no changes to the loop itself; filesystem tools are enabled at the executor level.

## Testing

- 124 council tests pass (including 2 new tests for CWD injection/omission)
- Clippy clean (`-D warnings`)