### PR TITLE
fix(chat): conversation export includes messages

### DIFF
--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -61,7 +61,8 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `council/stream_bridge` | `AgentEvent` → `CouncilEvent` mapper |
 | `council/round` | Sequential round execution (per-agent turn driver) |
 | `council/synthesis` | Synthesis pass (transcript → unified answer) |
-| `council/orchestrator` | Slim coordinator (rounds → synthesis sequencing) |
+| `council/judge` | Post-round judge evaluation + adaptive early stopping |
+| `council/orchestrator` | Slim coordinator (rounds → judge → synthesis) |
 | `council/suggest` | `suggest_council()` — shared suggest orchestration |
 <!-- MODULE_TABLE_END -->
 

--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -57,7 +57,7 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `council/events` | `CouncilEvent` SSE enum (wire format) |
 | `council/prompts` | Prompt templates + contentiousness mapping |
 | `council/state` | Round/contribution accumulator |
-| `council/history` | Per-turn context builder (identity + transcript) |
+| `council/history` | Per-turn context builder (identity + transcript + directed rebuttals) |
 | `council/stream_bridge` | `AgentEvent` → `CouncilEvent` mapper |
 | `council/round` | Sequential round execution (per-agent turn driver) |
 | `council/synthesis` | Synthesis pass (transcript → unified answer) |

--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -62,7 +62,9 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `council/round` | Sequential round execution (per-agent turn driver) |
 | `council/synthesis` | Synthesis pass (transcript → unified answer) |
 | `council/judge` | Post-round judge evaluation + adaptive early stopping |
-| `council/orchestrator` | Slim coordinator (rounds → judge → synthesis) |
+| `council/compaction` | LLM-driven round summarisation for context control |
+| `council/stance` | Post-debate stance tracking (Held/Shifted/Conceded) |
+| `council/orchestrator` | Slim coordinator (rounds → compaction → judge → stance → synthesis) |
 | `council/suggest` | `suggest_council()` — shared suggest orchestration |
 <!-- MODULE_TABLE_END -->
 

--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -53,6 +53,16 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `stream_collector` | Consumes `LlmStreamEvent` stream, forwards text live |
 | `tool_execution` | Parallel tool dispatch with semaphore + timeout |
 | `util` | Shared internal utilities |
+| `council/config` | `CouncilConfig`, `CouncilAgent`, `SuggestedCouncil` |
+| `council/events` | `CouncilEvent` SSE enum (wire format) |
+| `council/prompts` | Prompt templates + contentiousness mapping |
+| `council/state` | Round/contribution accumulator |
+| `council/history` | Per-turn context builder (identity + transcript) |
+| `council/stream_bridge` | `AgentEvent` → `CouncilEvent` mapper |
+| `council/round` | Sequential round execution (per-agent turn driver) |
+| `council/synthesis` | Synthesis pass (transcript → unified answer) |
+| `council/orchestrator` | Slim coordinator (rounds → synthesis sequencing) |
+| `council/suggest` | `suggest_council()` — shared suggest orchestration |
 <!-- MODULE_TABLE_END -->
 
 <details>

--- a/crates/gglib-agent/src/council/compaction.rs
+++ b/crates/gglib-agent/src/council/compaction.rs
@@ -1,0 +1,448 @@
+//! Round compaction — LLM-driven summarisation of completed debate rounds.
+//!
+//! After a round completes (and before the next round begins), the
+//! orchestrator may run the compactor to produce a short per-agent summary
+//! of the round's contributions.  The compacted text replaces the full
+//! transcript in subsequent agents' context windows, keeping prompt sizes
+//! manageable in long debates (4+ rounds).
+//!
+//! # Robust parsing
+//!
+//! The compactor's output must contain `SUMMARY(Agent Name): ...` lines.
+//! [`parse_compacted_summaries`] uses case-insensitive, whitespace-tolerant
+//! matching to handle common LLM quirks:
+//! - Markdown bold/backtick wrapping (`**SUMMARY(Skeptic):** ...`)
+//! - Extra spacing around the colon
+//! - Varying casing (`summary(name)`, `Summary(Name)`)
+//! - Conversational filler before/after the markers
+//!
+//! If parsing fails to extract any summaries, the round is left
+//! uncompacted — agents simply see the full transcript (graceful
+//! degradation).
+
+use std::collections::HashSet;
+use std::fmt::Write;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::events::CouncilEvent;
+use super::prompts::COMPACTION_PROMPT;
+use super::state::CouncilState;
+
+/// Run the compaction pass for a completed round.
+///
+/// Sends the round's transcript to a single-iteration `AgentLoop` (no
+/// tools) and parses the output into per-agent summaries.  If successful,
+/// stores the compacted text in `state`.
+///
+/// This function is fire-and-forget from the orchestrator's perspective —
+/// if the LLM produces unparseable output or the channel is closed, the
+/// round simply stays uncompacted and agents see the full transcript.
+pub(super) async fn compact_round(
+    round: u32,
+    state: &mut CouncilState,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+    _topic: &str,
+) {
+    let transcript = format_round_transcript(state, round);
+    if transcript.is_empty() {
+        return;
+    }
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let system = COMPACTION_PROMPT
+        .replace("{round}", &(round + 1).to_string())
+        .replace("{transcript}", &transcript);
+
+    let messages = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: format!("Summarise round {} of the debate.", round + 1),
+        },
+    ];
+
+    // Compactor gets no tools — pure text generation.
+    let agent = AgentLoop::build(
+        Arc::clone(llm),
+        Arc::clone(tool_executor),
+        Some(HashSet::new()),
+    );
+    let mut config = AgentConfig::default();
+    config.max_iterations = 1;
+
+    let (agent_tx, mut agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    let handle = {
+        let agent = Arc::clone(&agent);
+        tokio::spawn(async move { agent.run(messages, config, agent_tx).await })
+    };
+
+    // Collect the output (we don't stream compaction tokens to the client).
+    let mut content: Option<String> = None;
+    while let Some(event) = agent_rx.recv().await {
+        if let AgentEvent::FinalAnswer { content: answer } = event {
+            content = Some(answer);
+        }
+    }
+
+    let _ = handle.await;
+
+    let raw = content.unwrap_or_default();
+    if raw.is_empty() {
+        warn!(round, "compaction agent produced no output");
+        return;
+    }
+
+    // Collect agent names from this round for validation.
+    let round_agents: Vec<String> = state
+        .contributions_for_round(round)
+        .iter()
+        .map(|c| c.agent.name.clone())
+        .collect();
+
+    let summaries = parse_compacted_summaries(&raw, &round_agents);
+    if summaries.is_empty() {
+        warn!(
+            round,
+            "compaction produced no parseable summaries, keeping full transcript"
+        );
+        return;
+    }
+
+    debug!(
+        round,
+        summary_count = summaries.len(),
+        "round compacted successfully"
+    );
+
+    // Build the compacted text block.
+    let mut compacted = String::new();
+    for (name, summary) in &summaries {
+        let _ = writeln!(compacted, "[{name}]: {summary}");
+    }
+
+    state.set_compacted(round, compacted.trim().to_owned());
+
+    // Emit a council event so the frontend/CLI can optionally display it.
+    let _ = council_tx
+        .send(CouncilEvent::RoundCompacted {
+            round,
+            summary: state.compacted_summary(round).unwrap_or_default().to_owned(),
+        })
+        .await;
+}
+
+/// Format a single round's contributions for the compaction prompt.
+fn format_round_transcript(state: &CouncilState, round: u32) -> String {
+    let mut out = String::new();
+    for c in state.contributions_for_round(round) {
+        let _ = writeln!(out, "[{}]: {}", c.agent.name, c.content);
+    }
+    out
+}
+
+/// Robust extraction of `SUMMARY(Agent Name): ...` lines from LLM output.
+///
+/// Handles common LLM formatting quirks:
+/// - `SUMMARY(Skeptic): They argued ...` (canonical)
+/// - `**SUMMARY(Skeptic):** They argued ...` (markdown bold)
+/// - `` `SUMMARY(Skeptic)`: They argued ... `` (backtick wrapping)
+/// - `summary(skeptic): They argued ...` (lowercase)
+/// - `SUMMARY (Skeptic) : They argued ...` (extra spaces)
+///
+/// Returns `(agent_name, summary_text)` pairs.  If no summaries are found,
+/// returns an empty vec (the caller should keep the full transcript).
+pub(super) fn parse_compacted_summaries(
+    raw: &str,
+    expected_agents: &[String],
+) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+
+    for line in raw.lines() {
+        if let Some((name, summary)) = extract_summary_line(line) {
+            results.push((name, summary));
+        }
+    }
+
+    // If we found at least one summary, return what we have.
+    // We don't require all agents — some may have been omitted by the LLM.
+    if !results.is_empty() {
+        return results;
+    }
+
+    // Fallback: try to match lines that look like "[Agent]: summary"
+    // (some models may omit the SUMMARY() wrapper entirely).
+    for line in raw.lines() {
+        if let Some((name, summary)) = extract_bracket_line(line, expected_agents) {
+            results.push((name, summary));
+        }
+    }
+
+    results
+}
+
+/// Try to extract a `SUMMARY(name): text` pattern from a single line.
+///
+/// Strips markdown bold (`**`) and backtick (`` ` ``) wrapping before
+/// parsing.
+fn extract_summary_line(line: &str) -> Option<(String, String)> {
+    // Strip markdown wrappers.
+    let cleaned: String = line
+        .chars()
+        .filter(|c| *c != '*' && *c != '`')
+        .collect();
+
+    let lower = cleaned.to_lowercase();
+
+    // Find "summary" followed by "(" somewhere.
+    let summary_idx = lower.find("summary")?;
+    let after_summary = &cleaned[summary_idx + "summary".len()..];
+
+    // Skip optional whitespace, then expect '('.
+    let after_ws = after_summary.trim_start();
+    let after_paren = after_ws.strip_prefix('(')?;
+
+    // Find the closing ')'.
+    let close_idx = after_paren.find(')')?;
+    let name = after_paren[..close_idx].trim();
+
+    if name.is_empty() {
+        return None;
+    }
+
+    // Everything after ')' — skip optional ':' and whitespace.
+    let rest = &after_paren[close_idx + 1..];
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix(':').unwrap_or(rest);
+    let rest = rest.trim();
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    Some((name.to_owned(), rest.to_owned()))
+}
+
+/// Fallback: try to match `[Agent Name]: summary` lines against known agents.
+fn extract_bracket_line(line: &str, expected_agents: &[String]) -> Option<(String, String)> {
+    let trimmed = line.trim();
+    let after_bracket = trimmed.strip_prefix('[')?;
+    let close_idx = after_bracket.find(']')?;
+    let name = after_bracket[..close_idx].trim();
+
+    // Only accept if the name matches a known agent.
+    let matched = expected_agents
+        .iter()
+        .any(|a| a.eq_ignore_ascii_case(name));
+    if !matched {
+        return None;
+    }
+
+    let rest = &after_bracket[close_idx + 1..];
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix(':').unwrap_or(rest);
+    let rest = rest.trim();
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    Some((name.to_owned(), rest.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── extract_summary_line ─────────────────────────────────────────────
+
+    #[test]
+    fn canonical_summary_line() {
+        let (name, text) =
+            extract_summary_line("SUMMARY(Skeptic): They argued against the proposal.")
+                .unwrap();
+        assert_eq!(name, "Skeptic");
+        assert_eq!(text, "They argued against the proposal.");
+    }
+
+    #[test]
+    fn markdown_bold_wrapping() {
+        let (name, text) =
+            extract_summary_line("**SUMMARY(Pragmatist):** A practical approach was suggested.")
+                .unwrap();
+        assert_eq!(name, "Pragmatist");
+        assert_eq!(text, "A practical approach was suggested.");
+    }
+
+    #[test]
+    fn backtick_wrapping() {
+        let (name, text) =
+            extract_summary_line("`SUMMARY(Expert)`: Domain-specific evidence was cited.")
+                .unwrap();
+        assert_eq!(name, "Expert");
+        assert_eq!(text, "Domain-specific evidence was cited.");
+    }
+
+    #[test]
+    fn lowercase_summary() {
+        let (name, text) =
+            extract_summary_line("summary(devil's advocate): Everything is wrong.")
+                .unwrap();
+        assert_eq!(name, "devil's advocate");
+        assert_eq!(text, "Everything is wrong.");
+    }
+
+    #[test]
+    fn extra_spacing() {
+        let (name, text) =
+            extract_summary_line("SUMMARY ( Skeptic ) :  They had concerns.  ")
+                .unwrap();
+        assert_eq!(name, "Skeptic");
+        assert_eq!(text, "They had concerns.");
+    }
+
+    #[test]
+    fn empty_name_returns_none() {
+        assert!(extract_summary_line("SUMMARY(): No name.").is_none());
+    }
+
+    #[test]
+    fn empty_text_returns_none() {
+        assert!(extract_summary_line("SUMMARY(Skeptic):").is_none());
+        assert!(extract_summary_line("SUMMARY(Skeptic):   ").is_none());
+    }
+
+    #[test]
+    fn no_summary_marker_returns_none() {
+        assert!(extract_summary_line("Just some regular text.").is_none());
+    }
+
+    #[test]
+    fn missing_close_paren_returns_none() {
+        assert!(extract_summary_line("SUMMARY(Skeptic: missing paren").is_none());
+    }
+
+    // ── extract_bracket_line ─────────────────────────────────────────────
+
+    #[test]
+    fn bracket_line_matches_known_agent() {
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let (name, text) =
+            extract_bracket_line("[Skeptic]: They disagreed.", &agents).unwrap();
+        assert_eq!(name, "Skeptic");
+        assert_eq!(text, "They disagreed.");
+    }
+
+    #[test]
+    fn bracket_line_case_insensitive_match() {
+        let agents = vec!["Skeptic".into()];
+        let (name, _) =
+            extract_bracket_line("[skeptic]: Something.", &agents).unwrap();
+        assert_eq!(name, "skeptic");
+    }
+
+    #[test]
+    fn bracket_line_unknown_agent_returns_none() {
+        let agents = vec!["Skeptic".into()];
+        assert!(extract_bracket_line("[Unknown]: Something.", &agents).is_none());
+    }
+
+    #[test]
+    fn bracket_line_empty_text_returns_none() {
+        let agents = vec!["Skeptic".into()];
+        assert!(extract_bracket_line("[Skeptic]:", &agents).is_none());
+    }
+
+    // ── parse_compacted_summaries ────────────────────────────────────────
+
+    #[test]
+    fn parse_canonical_summaries() {
+        let raw = "\
+SUMMARY(Skeptic): Bad idea overall.
+SUMMARY(Pragmatist): Practical compromise needed.
+SUMMARY(Expert): Evidence supports option B.";
+
+        let agents = vec![
+            "Skeptic".into(),
+            "Pragmatist".into(),
+            "Expert".into(),
+        ];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].0, "Skeptic");
+        assert_eq!(result[1].0, "Pragmatist");
+        assert_eq!(result[2].0, "Expert");
+    }
+
+    #[test]
+    fn parse_with_preamble_and_filler() {
+        let raw = "\
+Here are the summaries for this round:
+
+SUMMARY(Skeptic): They had strong objections.
+SUMMARY(Pragmatist): They proposed a middle ground.
+
+Hope this helps!";
+
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn parse_fallback_to_bracket_format() {
+        let raw = "\
+[Skeptic]: They disagreed strongly.
+[Pragmatist]: They offered a compromise.";
+
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, "Skeptic");
+    }
+
+    #[test]
+    fn parse_empty_output() {
+        let result = parse_compacted_summaries("", &["Skeptic".into()]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_no_valid_lines() {
+        let raw = "I couldn't really summarise the debate.";
+        let result = parse_compacted_summaries(raw, &["Skeptic".into()]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_markdown_bold_summaries() {
+        let raw = "\
+**SUMMARY(Skeptic):** Strong opposition based on cost analysis.
+**SUMMARY(Advocate):** Supported the proposal citing long-term ROI.";
+
+        let agents = vec!["Skeptic".into(), "Advocate".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn parse_partial_summaries_still_accepted() {
+        // LLM only summarised one of two agents — we accept what we get.
+        let raw = "SUMMARY(Skeptic): They had concerns.";
+        let agents = vec!["Skeptic".into(), "Pragmatist".into()];
+        let result = parse_compacted_summaries(raw, &agents);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "Skeptic");
+    }
+}

--- a/crates/gglib-agent/src/council/compaction.rs
+++ b/crates/gglib-agent/src/council/compaction.rs
@@ -138,7 +138,10 @@ pub(super) async fn compact_round(
     let _ = council_tx
         .send(CouncilEvent::RoundCompacted {
             round,
-            summary: state.compacted_summary(round).unwrap_or_default().to_owned(),
+            summary: state
+                .compacted_summary(round)
+                .unwrap_or_default()
+                .to_owned(),
         })
         .await;
 }
@@ -198,10 +201,7 @@ pub(super) fn parse_compacted_summaries(
 /// parsing.
 fn extract_summary_line(line: &str) -> Option<(String, String)> {
     // Strip markdown wrappers.
-    let cleaned: String = line
-        .chars()
-        .filter(|c| *c != '*' && *c != '`')
-        .collect();
+    let cleaned: String = line.chars().filter(|c| *c != '*' && *c != '`').collect();
 
     let lower = cleaned.to_lowercase();
 
@@ -242,9 +242,7 @@ fn extract_bracket_line(line: &str, expected_agents: &[String]) -> Option<(Strin
     let name = after_bracket[..close_idx].trim();
 
     // Only accept if the name matches a known agent.
-    let matched = expected_agents
-        .iter()
-        .any(|a| a.eq_ignore_ascii_case(name));
+    let matched = expected_agents.iter().any(|a| a.eq_ignore_ascii_case(name));
     if !matched {
         return None;
     }
@@ -270,8 +268,7 @@ mod tests {
     #[test]
     fn canonical_summary_line() {
         let (name, text) =
-            extract_summary_line("SUMMARY(Skeptic): They argued against the proposal.")
-                .unwrap();
+            extract_summary_line("SUMMARY(Skeptic): They argued against the proposal.").unwrap();
         assert_eq!(name, "Skeptic");
         assert_eq!(text, "They argued against the proposal.");
     }
@@ -288,8 +285,7 @@ mod tests {
     #[test]
     fn backtick_wrapping() {
         let (name, text) =
-            extract_summary_line("`SUMMARY(Expert)`: Domain-specific evidence was cited.")
-                .unwrap();
+            extract_summary_line("`SUMMARY(Expert)`: Domain-specific evidence was cited.").unwrap();
         assert_eq!(name, "Expert");
         assert_eq!(text, "Domain-specific evidence was cited.");
     }
@@ -297,8 +293,7 @@ mod tests {
     #[test]
     fn lowercase_summary() {
         let (name, text) =
-            extract_summary_line("summary(devil's advocate): Everything is wrong.")
-                .unwrap();
+            extract_summary_line("summary(devil's advocate): Everything is wrong.").unwrap();
         assert_eq!(name, "devil's advocate");
         assert_eq!(text, "Everything is wrong.");
     }
@@ -306,8 +301,7 @@ mod tests {
     #[test]
     fn extra_spacing() {
         let (name, text) =
-            extract_summary_line("SUMMARY ( Skeptic ) :  They had concerns.  ")
-                .unwrap();
+            extract_summary_line("SUMMARY ( Skeptic ) :  They had concerns.  ").unwrap();
         assert_eq!(name, "Skeptic");
         assert_eq!(text, "They had concerns.");
     }
@@ -338,8 +332,7 @@ mod tests {
     #[test]
     fn bracket_line_matches_known_agent() {
         let agents = vec!["Skeptic".into(), "Pragmatist".into()];
-        let (name, text) =
-            extract_bracket_line("[Skeptic]: They disagreed.", &agents).unwrap();
+        let (name, text) = extract_bracket_line("[Skeptic]: They disagreed.", &agents).unwrap();
         assert_eq!(name, "Skeptic");
         assert_eq!(text, "They disagreed.");
     }
@@ -347,8 +340,7 @@ mod tests {
     #[test]
     fn bracket_line_case_insensitive_match() {
         let agents = vec!["Skeptic".into()];
-        let (name, _) =
-            extract_bracket_line("[skeptic]: Something.", &agents).unwrap();
+        let (name, _) = extract_bracket_line("[skeptic]: Something.", &agents).unwrap();
         assert_eq!(name, "skeptic");
     }
 
@@ -373,11 +365,7 @@ SUMMARY(Skeptic): Bad idea overall.
 SUMMARY(Pragmatist): Practical compromise needed.
 SUMMARY(Expert): Evidence supports option B.";
 
-        let agents = vec![
-            "Skeptic".into(),
-            "Pragmatist".into(),
-            "Expert".into(),
-        ];
+        let agents = vec!["Skeptic".into(), "Pragmatist".into(), "Expert".into()];
         let result = parse_compacted_summaries(raw, &agents);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].0, "Skeptic");

--- a/crates/gglib-agent/src/council/config.rs
+++ b/crates/gglib-agent/src/council/config.rs
@@ -74,6 +74,37 @@ pub struct CouncilConfig {
     /// final answer's focus (e.g. "prioritise actionable recommendations").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub synthesis_guidance: Option<String>,
+
+    /// Optional judge configuration for adaptive early stopping.
+    ///
+    /// When present, a neutral judge agent evaluates the debate after each
+    /// round and may terminate early if consensus is detected.  When
+    /// absent, the council always runs the full `rounds` count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge: Option<JudgeConfig>,
+}
+
+// ─── judge config ────────────────────────────────────────────────────────────
+
+/// Configuration for the optional post-round judge.
+///
+/// The judge is a neutral LLM pass that evaluates the debate transcript
+/// after each round, summarises the current state, and decides whether
+/// consensus has been reached (triggering early stopping).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JudgeConfig {
+    /// Minimum number of rounds before the judge may stop the debate.
+    ///
+    /// Prevents premature consensus on the very first round.
+    /// Defaults to `1` (allow stopping after round 1, i.e. at least 2
+    /// rounds of debate if the first round yields consensus).
+    #[serde(default = "default_min_rounds_before_stop")]
+    pub min_rounds_before_stop: u32,
+}
+
+/// Default: allow early stopping after at least 1 completed round.
+const fn default_min_rounds_before_stop() -> u32 {
+    1
 }
 
 // ─── suggested council (returned by /api/council/suggest) ────────────────────
@@ -95,6 +126,10 @@ pub struct SuggestedCouncil {
     /// Suggested synthesis guidance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub synthesis_guidance: Option<String>,
+
+    /// Suggested judge configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub judge: Option<JudgeConfig>,
 }
 
 /// Default agent colours, cycled when the LLM omits `color`.
@@ -117,6 +152,7 @@ impl SuggestedCouncil {
             topic,
             rounds: self.rounds,
             synthesis_guidance: self.synthesis_guidance,
+            judge: self.judge,
         }
     }
 
@@ -226,6 +262,7 @@ mod tests {
             ],
             rounds: 2,
             synthesis_guidance: None,
+            judge: None,
         };
         council.backfill_defaults();
         assert_eq!(council.agents[0].id, "kept-id");

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -98,6 +98,12 @@ pub enum CouncilEvent {
         summary: String,
         consensus_reached: bool,
     },
+    // ── compaction ────────────────────────────────────────────────────────
+    /// A completed round has been compacted into a shorter summary.
+    ///
+    /// The frontend/CLI can optionally display this.  The compacted text
+    /// replaces the full transcript in subsequent agents' context windows.
+    RoundCompacted { round: u32, summary: String },
 
     // ── synthesis ────────────────────────────────────────────────────────
     /// The synthesis phase has begun.  The frontend renders a
@@ -213,6 +219,10 @@ mod tests {
                 round: 1,
                 summary: "Agents are converging.".into(),
                 consensus_reached: true,
+            },
+            CouncilEvent::RoundCompacted {
+                round: 0,
+                summary: "[Skeptic]: Bad idea.\n[Pragmatist]: Good idea.".into(),
             },
             CouncilEvent::SynthesisStart,
             CouncilEvent::SynthesisTextDelta {

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -105,6 +105,13 @@ pub enum CouncilEvent {
     /// replaces the full transcript in subsequent agents' context windows.
     RoundCompacted { round: u32, summary: String },
 
+    // ── stance tracking ───────────────────────────────────────────────────
+    /// Per-agent stance trajectory evaluation emitted after all debate
+    /// rounds complete and before synthesis begins.
+    StanceMap {
+        stances: Vec<super::stance::AgentStance>,
+    },
+
     // ── synthesis ────────────────────────────────────────────────────────
     /// The synthesis phase has begun.  The frontend renders a
     /// "Synthesising…" placeholder.
@@ -223,6 +230,12 @@ mod tests {
             CouncilEvent::RoundCompacted {
                 round: 0,
                 summary: "[Skeptic]: Bad idea.\n[Pragmatist]: Good idea.".into(),
+            },
+            CouncilEvent::StanceMap {
+                stances: vec![crate::council::stance::AgentStance {
+                    agent_name: "Skeptic".into(),
+                    trajectory: crate::council::stance::StanceTrajectory::Held,
+                }],
             },
             CouncilEvent::SynthesisStart,
             CouncilEvent::SynthesisTextDelta {

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -34,6 +34,9 @@ pub enum CouncilEvent {
         color: String,
         round: u32,
         contentiousness: f32,
+        /// Name of the agent whose claim is being rebutted, if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rebuttal_target: Option<String>,
     },
 
     /// Incremental text token from the current agent's response.
@@ -143,11 +146,13 @@ mod tests {
             color: "#ef4444".into(),
             round: 1,
             contentiousness: 0.8,
+            rebuttal_target: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "agent_turn_start");
         assert_eq!(json["agent_name"], "Skeptic");
         assert_eq!(json["round"], 1);
+        assert!(json.get("rebuttal_target").is_none());
     }
 
     #[test]
@@ -208,6 +213,7 @@ mod tests {
                 color: "#000".into(),
                 round: 1,
                 contentiousness: 0.5,
+                rebuttal_target: Some("B".into()),
             },
             CouncilEvent::AgentTextDelta {
                 agent_id: "a".into(),

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -34,9 +34,6 @@ pub enum CouncilEvent {
         color: String,
         round: u32,
         contentiousness: f32,
-        /// Name of the agent whose claim is being rebutted, if any.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        rebuttal_target: Option<String>,
     },
 
     /// Incremental text token from the current agent's response.
@@ -146,13 +143,11 @@ mod tests {
             color: "#ef4444".into(),
             round: 1,
             contentiousness: 0.8,
-            rebuttal_target: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "agent_turn_start");
         assert_eq!(json["agent_name"], "Skeptic");
         assert_eq!(json["round"], 1);
-        assert!(json.get("rebuttal_target").is_none());
     }
 
     #[test]
@@ -213,7 +208,6 @@ mod tests {
                 color: "#000".into(),
                 round: 1,
                 contentiousness: 0.5,
-                rebuttal_target: Some("B".into()),
             },
             CouncilEvent::AgentTextDelta {
                 agent_id: "a".into(),

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -81,6 +81,24 @@ pub enum CouncilEvent {
     /// divider — no gradient, no tension metric (v1).
     RoundSeparator { round: u32 },
 
+    // ── judge ────────────────────────────────────────────────────────────
+    /// The judge evaluation phase has begun for this round.
+    JudgeStart { round: u32 },
+
+    /// Incremental text token from the judge agent.
+    JudgeTextDelta { delta: String },
+
+    /// The judge has completed its evaluation.
+    ///
+    /// `summary` is the judge's narrative assessment.
+    /// `consensus_reached` indicates whether the judge determined
+    /// that the agents have converged on a shared position.
+    JudgeSummary {
+        round: u32,
+        summary: String,
+        consensus_reached: bool,
+    },
+
     // ── synthesis ────────────────────────────────────────────────────────
     /// The synthesis phase has begun.  The frontend renders a
     /// "Synthesising…" placeholder.
@@ -187,6 +205,15 @@ mod tests {
                 delta: "thinking...".into(),
             },
             CouncilEvent::RoundSeparator { round: 1 },
+            CouncilEvent::JudgeStart { round: 1 },
+            CouncilEvent::JudgeTextDelta {
+                delta: "evaluating".into(),
+            },
+            CouncilEvent::JudgeSummary {
+                round: 1,
+                summary: "Agents are converging.".into(),
+                consensus_reached: true,
+            },
             CouncilEvent::SynthesisStart,
             CouncilEvent::SynthesisTextDelta {
                 delta: "synth".into(),

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -84,6 +84,13 @@ pub fn build_agent_system_prompt(
             prompt.push_str("\n\nDEBATE HISTORY:\n");
             prompt.push_str(&transcript);
             prompt.push_str(GUIDED_REBUTTAL_CUE);
+
+            // Anti-dogpile: show which claims earlier agents already
+            // addressed this round so this agent picks a different target.
+            let already = format_already_addressed(state, round, &agent.name);
+            if !already.is_empty() {
+                prompt.push_str(&already);
+            }
         }
     }
 
@@ -102,6 +109,34 @@ pub fn build_agent_system_prompt(
     }
 
     prompt
+}
+
+/// Summarise which prior claims earlier agents in this round have already
+/// rebutted, so the current agent can pick a different target.
+///
+/// Returns an empty string when no earlier agents have spoken this round
+/// or none of them produced a core claim.
+#[must_use]
+fn format_already_addressed(state: &CouncilState, round: u32, self_name: &str) -> String {
+    use std::fmt::Write;
+    let earlier: Vec<_> = state
+        .contributions_for_round(round)
+        .into_iter()
+        .filter(|c| c.agent.name != self_name)
+        .filter_map(|c| c.core_claim.as_deref().map(|claim| (&*c.agent.name, claim)))
+        .collect();
+
+    if earlier.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from(
+        "\n\nCLAIMS ALREADY ADDRESSED THIS ROUND (choose a different target if possible):\n",
+    );
+    for (name, claim) in &earlier {
+        let _ = writeln!(out, "- {name}: \"{claim}\"");
+    }
+    out
 }
 
 /// Format prior contributions as a labelled transcript block.
@@ -382,5 +417,89 @@ mod tests {
         let prompt = build_agent_system_prompt(&a, "Topic", 0, 1, &state, Some(&dir));
         assert!(prompt.contains("filesystem tools (read_file, list_directory, grep_search)"));
         assert!(prompt.contains("Working directory: /tmp/my-project"));
+    }
+
+    // ── anti-dogpile tests ───────────────────────────────────────────────
+
+    #[test]
+    fn anti_dogpile_context_absent_for_first_agent_in_round() {
+        let mut state = CouncilState::new();
+        // Round 0 contributions
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Skeptic round 0.".into(),
+            core_claim: Some("Monoliths scale.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Pragmatist round 0.".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // First agent in round 1 — no one has spoken yet this round
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
+        assert!(!prompt.contains("CLAIMS ALREADY ADDRESSED THIS ROUND"));
+    }
+
+    #[test]
+    fn anti_dogpile_context_present_for_later_agent() {
+        let mut state = CouncilState::new();
+        // Round 0
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Skeptic round 0.".into(),
+            core_claim: Some("Monoliths scale.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Pragmatist round 0.".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Round 1: Skeptic has already spoken
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Skeptic round 1.".into(),
+            core_claim: Some("Still monoliths.".into()),
+            round: 1,
+        });
+
+        // Now Pragmatist speaks — should see Skeptic's claim listed
+        let a = agent("p", "Pragmatist", 0.3);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
+        assert!(prompt.contains("CLAIMS ALREADY ADDRESSED THIS ROUND"));
+        assert!(prompt.contains("Skeptic: \"Still monoliths.\""));
+    }
+
+    #[test]
+    fn anti_dogpile_skips_agents_without_core_claim() {
+        let mut state = CouncilState::new();
+        // Round 0
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Round 0.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.advance_round();
+
+        // Round 1: Skeptic spoke but without a core claim
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Skeptic round 1 no claim.".into(),
+            core_claim: None,
+            round: 1,
+        });
+
+        let a = agent("p", "Pragmatist", 0.3);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
+        assert!(!prompt.contains("CLAIMS ALREADY ADDRESSED THIS ROUND"));
     }
 }

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -19,8 +19,8 @@ use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
-    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT,
-    FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
+    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT, FINAL_ROUND_SUFFIX,
+    TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
 };
 use super::state::{AgentContribution, CouncilState};
 

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -24,9 +24,10 @@ use super::state::{AgentContribution, CouncilState};
 
 /// Build the message list for a single agent's turn in the council debate.
 ///
-/// Returns `[System(prompt), User(topic)]` — a two-message conversation
-/// that the `AgentLoop` will extend with tool calls and responses during
-/// its own run.
+/// Returns `(messages, rebuttal_target)` — the messages are
+/// `[System(prompt), User(topic)]` that the `AgentLoop` will extend with
+/// tool calls and responses during its own run.  `rebuttal_target` is the
+/// name of the agent whose claim is being rebutted, if any.
 ///
 /// # Arguments
 ///
@@ -42,19 +43,24 @@ pub fn build_agent_messages(
     round: u32,
     total_rounds: u32,
     state: &CouncilState,
-) -> Vec<AgentMessage> {
-    let system_prompt = build_agent_system_prompt(agent, topic, round, total_rounds, state);
-    vec![
+) -> (Vec<AgentMessage>, Option<String>) {
+    let (system_prompt, rebuttal_target) =
+        build_agent_system_prompt(agent, topic, round, total_rounds, state);
+    let messages = vec![
         AgentMessage::System {
             content: system_prompt,
         },
         AgentMessage::User {
             content: topic.to_owned(),
         },
-    ]
+    ];
+    (messages, rebuttal_target)
 }
 
 /// Assemble the full system prompt for a single agent turn.
+///
+/// Returns `(prompt, rebuttal_target_name)`.  The target name is `Some`
+/// only when a directed rebuttal cue was injected into the prompt.
 ///
 /// This is separated from [`build_agent_messages`] for testability.
 #[must_use]
@@ -64,7 +70,7 @@ pub fn build_agent_system_prompt(
     round: u32,
     total_rounds: u32,
     state: &CouncilState,
-) -> String {
+) -> (String, Option<String>) {
     let instruction = contentiousness_to_instruction(agent.contentiousness);
 
     #[allow(clippy::literal_string_with_formatting_args)]
@@ -74,6 +80,8 @@ pub fn build_agent_system_prompt(
         .replace("{topic}", topic)
         .replace("{perspective}", &agent.perspective)
         .replace("{contentiousness_instruction}", instruction);
+
+    let mut rebuttal_target = None;
 
     // Inject debate history from prior rounds.
     if round > 0 {
@@ -91,6 +99,7 @@ pub fn build_agent_system_prompt(
                         .replace("{target_name}", &target.agent.name)
                         .replace("{target_claim}", claim),
                 );
+                rebuttal_target = Some(target.agent.name.clone());
             } else {
                 prompt.push_str(DEBATE_HISTORY_SUFFIX);
             }
@@ -103,7 +112,7 @@ pub fn build_agent_system_prompt(
         prompt.push_str(FINAL_ROUND_SUFFIX);
     }
 
-    prompt
+    (prompt, rebuttal_target)
 }
 
 /// Format prior contributions as a labelled transcript block.
@@ -223,13 +232,14 @@ mod tests {
     fn round_0_no_history() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let prompt = build_agent_system_prompt(&a, "Test topic", 0, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Test topic", 0, 3, &state);
 
         assert!(prompt.contains("You are Skeptic."));
         assert!(prompt.contains("Skeptic is a test agent."));
         assert!(prompt.contains("rigorous critic"));
         assert!(!prompt.contains("DEBATE HISTORY"));
         assert!(!prompt.contains("FINAL ROUND"));
+        assert!(target.is_none());
     }
 
     #[test]
@@ -250,7 +260,7 @@ mod tests {
         state.advance_round();
 
         let a = agent("s", "Skeptic", 0.7);
-        let prompt = build_agent_system_prompt(&a, "Test topic", 1, 3, &state);
+        let (prompt, _target) = build_agent_system_prompt(&a, "Test topic", 1, 3, &state);
 
         assert!(prompt.contains("DEBATE HISTORY:"));
         assert!(prompt.contains("=== Round 1 ==="));
@@ -264,7 +274,7 @@ mod tests {
     fn final_round_suffix_appended() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -272,7 +282,7 @@ mod tests {
     fn single_round_is_also_final() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let prompt = build_agent_system_prompt(&a, "Topic", 0, 1, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -280,13 +290,14 @@ mod tests {
     fn build_agent_messages_structure() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let msgs = build_agent_messages(&a, "My topic", 0, 2, &state);
+        let (msgs, target) = build_agent_messages(&a, "My topic", 0, 2, &state);
 
         assert_eq!(msgs.len(), 2);
         assert!(
             matches!(&msgs[0], AgentMessage::System { content } if content.contains("Skeptic"))
         );
         assert!(matches!(&msgs[1], AgentMessage::User { content } if content == "My topic"));
+        assert!(target.is_none());
     }
 
     #[test]
@@ -398,13 +409,14 @@ mod tests {
 
         // Pragmatist (0.2) should target Skeptic (0.9) — most distant
         let a = agent("p", "Pragmatist", 0.2);
-        let prompt = build_agent_system_prompt(&a, "Architecture", 1, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Architecture", 1, 3, &state);
 
         assert!(prompt.contains("DIRECTED REBUTTAL"));
         assert!(prompt.contains("Skeptic's core claim"));
         assert!(prompt.contains("Monoliths scale better."));
         // Generic suffix should NOT appear when rebuttal cue is used
         assert!(!prompt.contains("Respond to the strongest counterarguments"));
+        assert_eq!(target.as_deref(), Some("Skeptic"));
     }
 
     #[test]
@@ -419,11 +431,12 @@ mod tests {
         state.advance_round();
 
         let a = agent("b", "Bob", 0.7);
-        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
 
         assert!(prompt.contains("DEBATE HISTORY"));
         assert!(prompt.contains("Respond to the strongest counterarguments"));
         assert!(!prompt.contains("DIRECTED REBUTTAL"));
+        assert!(target.is_none());
     }
 
     // ── compacted transcript tests ───────────────────────────────────────
@@ -460,7 +473,7 @@ mod tests {
 
         // At round 2, round 0 should be compacted, round 1 should be full
         let a = agent("s", "Skeptic", 0.7);
-        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
 
         // Round 0 should show compacted summary
         assert!(prompt.contains("=== Round 1 (compacted) ==="));
@@ -487,7 +500,7 @@ mod tests {
 
         // No compaction applied — should show full text
         let a = agent("p", "Pragmatist", 0.3);
-        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
 
         assert!(prompt.contains("=== Round 1 ==="));
         assert!(!prompt.contains("(compacted)"));

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -6,17 +6,20 @@
 //!    persona, contentiousness instruction — re-injected every turn).
 //! 2. Formatting the debate transcript from prior rounds as a labelled
 //!    `[Agent Name]: content` block.
-//! 3. Appending round-phase suffixes (debate-history cue, final-round cue).
-//! 4. Wrapping the topic as a `User` message.
+//! 3. Selecting a directed rebuttal target (the prior-round agent with a
+//!    core claim whose contentiousness is most different from the current
+//!    agent), or falling back to a generic debate-history cue.
+//! 4. Appending round-phase suffixes (rebuttal/history cue, final-round cue).
+//! 5. Wrapping the topic as a `User` message.
 
 use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
     AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX,
-    contentiousness_to_instruction,
+    TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
 };
-use super::state::CouncilState;
+use super::state::{AgentContribution, CouncilState};
 
 /// Build the message list for a single agent's turn in the council debate.
 ///
@@ -77,7 +80,19 @@ pub fn build_agent_system_prompt(
         if !transcript.is_empty() {
             prompt.push_str("\n\nDEBATE HISTORY:\n");
             prompt.push_str(&transcript);
-            prompt.push_str(DEBATE_HISTORY_SUFFIX);
+
+            // Directed rebuttal cue targeting the most opposed agent's
+            // core claim, or generic debate-history suffix as fallback.
+            if let Some(target) = select_rebuttal_target(agent, state, round) {
+                let claim = target.core_claim.as_deref().unwrap_or_default();
+                prompt.push_str(
+                    &TARGETED_REBUTTAL_CUE
+                        .replace("{target_name}", &target.agent.name)
+                        .replace("{target_claim}", claim),
+                );
+            } else {
+                prompt.push_str(DEBATE_HISTORY_SUFFIX);
+            }
         }
     }
 
@@ -117,6 +132,38 @@ fn format_transcript(state: &CouncilState, up_to_round: u32) -> String {
         }
     }
     out
+}
+
+/// Select the best rebuttal target for an agent entering a new round.
+///
+/// Picks the contribution from the **previous round** whose `core_claim` is
+/// present and whose contentiousness is most different from the current
+/// agent's — a lightweight proxy for "most semantically distant" without
+/// requiring embeddings.
+///
+/// Returns `None` when:
+/// - `round == 0` (no prior contributions exist)
+/// - no other agent produced a core claim in the previous round
+fn select_rebuttal_target<'a>(
+    agent: &CouncilAgent,
+    state: &'a CouncilState,
+    round: u32,
+) -> Option<&'a AgentContribution> {
+    if round == 0 {
+        return None;
+    }
+    let prev_round = round - 1;
+    state
+        .contributions_for_round(prev_round)
+        .into_iter()
+        .filter(|c| c.agent.id != agent.id && c.core_claim.is_some())
+        .max_by(|a, b| {
+            let dist_a = (a.agent.contentiousness - agent.contentiousness).abs();
+            let dist_b = (b.agent.contentiousness - agent.contentiousness).abs();
+            dist_a
+                .partial_cmp(&dist_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
 }
 
 /// Format the full transcript for the synthesis prompt (all rounds).
@@ -239,5 +286,132 @@ mod tests {
         });
         let transcript = format_synthesis_transcript(&state);
         assert!(transcript.contains("[Skeptic (Skeptic's angle)]: Bad idea."));
+    }
+
+    // ── directed rebuttal tests ──────────────────────────────────────────
+
+    #[test]
+    fn rebuttal_target_none_at_round_0() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        assert!(select_rebuttal_target(&a, &state, 0).is_none());
+    }
+
+    #[test]
+    fn rebuttal_target_picks_most_opposed() {
+        let mut state = CouncilState::new();
+        // Round 0: three agents with core claims
+        state.push(AgentContribution {
+            agent: agent("c", "Collaborator", 0.1),
+            content: "We should cooperate.".into(),
+            core_claim: Some("Cooperation wins.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("b", "Balanced", 0.5),
+            content: "Both sides have merit.".into(),
+            core_claim: Some("Balance is key.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("d", "Devil", 0.9),
+            content: "Everything is wrong.".into(),
+            core_claim: Some("Total opposition.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Current agent is Collaborator (0.1) — most distant is Devil (0.9)
+        let a = agent("c", "Collaborator", 0.1);
+        let target = select_rebuttal_target(&a, &state, 1).unwrap();
+        assert_eq!(target.agent.id, "d");
+        assert_eq!(
+            target.core_claim.as_deref(),
+            Some("Total opposition.")
+        );
+    }
+
+    #[test]
+    fn rebuttal_target_skips_self() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.9),
+            content: "My argument.".into(),
+            core_claim: Some("My claim.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Only contribution in previous round is from self — no target
+        let a = agent("s", "Skeptic", 0.9);
+        assert!(select_rebuttal_target(&a, &state, 1).is_none());
+    }
+
+    #[test]
+    fn rebuttal_target_none_when_no_core_claims() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("a", "Alice", 0.3),
+            content: "Some argument.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("b", "Bob", 0.8),
+            content: "Another argument.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.advance_round();
+
+        let a = agent("a", "Alice", 0.3);
+        assert!(select_rebuttal_target(&a, &state, 1).is_none());
+    }
+
+    #[test]
+    fn rebuttal_cue_injected_in_prompt() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.9),
+            content: "Bad idea.".into(),
+            core_claim: Some("Monoliths scale better.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.2),
+            content: "Let's be practical.".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        // Pragmatist (0.2) should target Skeptic (0.9) — most distant
+        let a = agent("p", "Pragmatist", 0.2);
+        let prompt = build_agent_system_prompt(&a, "Architecture", 1, 3, &state);
+
+        assert!(prompt.contains("DIRECTED REBUTTAL"));
+        assert!(prompt.contains("Skeptic's core claim"));
+        assert!(prompt.contains("Monoliths scale better."));
+        // Generic suffix should NOT appear when rebuttal cue is used
+        assert!(!prompt.contains("Respond to the strongest counterarguments"));
+    }
+
+    #[test]
+    fn generic_suffix_when_no_rebuttal_target() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("a", "Alice", 0.3),
+            content: "Some argument.".into(),
+            core_claim: None, // no core claim
+            round: 0,
+        });
+        state.advance_round();
+
+        let a = agent("b", "Bob", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+
+        assert!(prompt.contains("DEBATE HISTORY"));
+        assert!(prompt.contains("Respond to the strongest counterarguments"));
+        assert!(!prompt.contains("DIRECTED REBUTTAL"));
     }
 }

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -13,12 +13,14 @@
 //! 4. Appending round-phase suffixes (rebuttal/history cue, final-round cue).
 //! 5. Wrapping the topic as a `User` message.
 
+use std::path::Path;
+
 use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
-    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE,
-    contentiousness_to_instruction,
+    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT,
+    FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
 };
 use super::state::{AgentContribution, CouncilState};
 
@@ -43,9 +45,10 @@ pub fn build_agent_messages(
     round: u32,
     total_rounds: u32,
     state: &CouncilState,
+    cwd: Option<&Path>,
 ) -> (Vec<AgentMessage>, Option<String>) {
     let (system_prompt, rebuttal_target) =
-        build_agent_system_prompt(agent, topic, round, total_rounds, state);
+        build_agent_system_prompt(agent, topic, round, total_rounds, state, cwd);
     let messages = vec![
         AgentMessage::System {
             content: system_prompt,
@@ -70,6 +73,7 @@ pub fn build_agent_system_prompt(
     round: u32,
     total_rounds: u32,
     state: &CouncilState,
+    cwd: Option<&Path>,
 ) -> (String, Option<String>) {
     let instruction = contentiousness_to_instruction(agent.contentiousness);
 
@@ -110,6 +114,14 @@ pub fn build_agent_system_prompt(
     let is_final = total_rounds > 0 && round == total_rounds - 1;
     if is_final {
         prompt.push_str(FINAL_ROUND_SUFFIX);
+    }
+
+    // Filesystem context — when a working directory is available, tell
+    // the agent about filesystem tools so it can inspect the codebase.
+    if let Some(dir) = cwd {
+        use std::fmt::Write as _;
+        prompt.push_str(FILESYSTEM_TOOLS_CONTEXT);
+        write!(prompt, "\n\nWorking directory: {}", dir.display()).unwrap();
     }
 
     (prompt, rebuttal_target)
@@ -232,7 +244,7 @@ mod tests {
     fn round_0_no_history() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, target) = build_agent_system_prompt(&a, "Test topic", 0, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Test topic", 0, 3, &state, None);
 
         assert!(prompt.contains("You are Skeptic."));
         assert!(prompt.contains("Skeptic is a test agent."));
@@ -260,7 +272,7 @@ mod tests {
         state.advance_round();
 
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _target) = build_agent_system_prompt(&a, "Test topic", 1, 3, &state);
+        let (prompt, _target) = build_agent_system_prompt(&a, "Test topic", 1, 3, &state, None);
 
         assert!(prompt.contains("DEBATE HISTORY:"));
         assert!(prompt.contains("=== Round 1 ==="));
@@ -274,7 +286,7 @@ mod tests {
     fn final_round_suffix_appended() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -282,7 +294,7 @@ mod tests {
     fn single_round_is_also_final() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -290,7 +302,7 @@ mod tests {
     fn build_agent_messages_structure() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (msgs, target) = build_agent_messages(&a, "My topic", 0, 2, &state);
+        let (msgs, target) = build_agent_messages(&a, "My topic", 0, 2, &state, None);
 
         assert_eq!(msgs.len(), 2);
         assert!(
@@ -409,7 +421,7 @@ mod tests {
 
         // Pragmatist (0.2) should target Skeptic (0.9) — most distant
         let a = agent("p", "Pragmatist", 0.2);
-        let (prompt, target) = build_agent_system_prompt(&a, "Architecture", 1, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Architecture", 1, 3, &state, None);
 
         assert!(prompt.contains("DIRECTED REBUTTAL"));
         assert!(prompt.contains("Skeptic's core claim"));
@@ -431,7 +443,7 @@ mod tests {
         state.advance_round();
 
         let a = agent("b", "Bob", 0.7);
-        let (prompt, target) = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+        let (prompt, target) = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
 
         assert!(prompt.contains("DEBATE HISTORY"));
         assert!(prompt.contains("Respond to the strongest counterarguments"));
@@ -473,7 +485,7 @@ mod tests {
 
         // At round 2, round 0 should be compacted, round 1 should be full
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
 
         // Round 0 should show compacted summary
         assert!(prompt.contains("=== Round 1 (compacted) ==="));
@@ -500,10 +512,31 @@ mod tests {
 
         // No compaction applied — should show full text
         let a = agent("p", "Pragmatist", 0.3);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
 
         assert!(prompt.contains("=== Round 1 ==="));
         assert!(!prompt.contains("(compacted)"));
         assert!(prompt.contains("Full argument text."));
+    }
+
+    // ── filesystem context tests ─────────────────────────────────────────
+
+    #[test]
+    fn cwd_none_omits_filesystem_context() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
+        assert!(!prompt.contains("filesystem tools"));
+        assert!(!prompt.contains("Working directory"));
+    }
+
+    #[test]
+    fn cwd_some_injects_filesystem_context() {
+        let state = CouncilState::new();
+        let a = agent("s", "Skeptic", 0.7);
+        let dir = std::path::PathBuf::from("/tmp/my-project");
+        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, Some(&dir));
+        assert!(prompt.contains("filesystem tools (read_file, list_directory, grep_search)"));
+        assert!(prompt.contains("Working directory: /tmp/my-project"));
     }
 }

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -5,7 +5,8 @@
 //! 1. Constructing a system prompt with identity anchoring (agent name,
 //!    persona, contentiousness instruction — re-injected every turn).
 //! 2. Formatting the debate transcript from prior rounds as a labelled
-//!    `[Agent Name]: content` block.
+//!    `[Agent Name]: content` block.  Rounds that have been compacted are
+//!    replaced with their short summary, keeping context sizes manageable.
 //! 3. Selecting a directed rebuttal target (the prior-round agent with a
 //!    core claim whose contentiousness is most different from the current
 //!    agent), or falling back to a generic debate-history cue.
@@ -107,13 +108,19 @@ pub fn build_agent_system_prompt(
 
 /// Format prior contributions as a labelled transcript block.
 ///
+/// For rounds that have been compacted, the short summary is used in
+/// place of the full per-agent contributions.  The most recent round
+/// (`up_to_round - 1`) is always shown in full — compaction only
+/// applies to older rounds.
+///
 /// Output format:
 /// ```text
-/// === Round 1 ===
-/// [Skeptic]: Their argument text...
-/// [Pragmatist]: Their argument text...
+/// === Round 1 (compacted) ===
+/// [Skeptic]: Short summary of their position.
+/// [Pragmatist]: Short summary of their position.
 /// === Round 2 ===
-/// ...
+/// [Skeptic]: Their full argument text...
+/// [Pragmatist]: Their full argument text...
 /// ```
 ///
 /// Only includes rounds `0..round` (exclusive of the current round).
@@ -122,6 +129,13 @@ fn format_transcript(state: &CouncilState, up_to_round: u32) -> String {
     use std::fmt::Write;
     let mut out = String::new();
     for r in 0..up_to_round {
+        // Use compacted summary for older rounds if available.
+        if let Some(compacted) = state.compacted_summary(r) {
+            let _ = writeln!(out, "=== Round {} (compacted) ===", r + 1);
+            let _ = writeln!(out, "{compacted}");
+            continue;
+        }
+
         let contributions = state.contributions_for_round(r);
         if contributions.is_empty() {
             continue;
@@ -413,5 +427,73 @@ mod tests {
         assert!(prompt.contains("DEBATE HISTORY"));
         assert!(prompt.contains("Respond to the strongest counterarguments"));
         assert!(!prompt.contains("DIRECTED REBUTTAL"));
+    }
+
+    // ── compacted transcript tests ───────────────────────────────────────
+
+    #[test]
+    fn compacted_round_uses_summary() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Very long argument about monoliths...".into(),
+            core_claim: Some("Monoliths scale better.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Very long argument about microservices...".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.set_compacted(
+            0,
+            "[Skeptic]: Opposed the proposal.\n[Pragmatist]: Supported compromise.".into(),
+        );
+        state.advance_round();
+
+        // Round 1 contributions
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Round 1 full text from Skeptic.".into(),
+            core_claim: None,
+            round: 1,
+        });
+        state.advance_round();
+
+        // At round 2, round 0 should be compacted, round 1 should be full
+        let a = agent("s", "Skeptic", 0.7);
+        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state);
+
+        // Round 0 should show compacted summary
+        assert!(prompt.contains("=== Round 1 (compacted) ==="));
+        assert!(prompt.contains("[Skeptic]: Opposed the proposal."));
+        assert!(prompt.contains("[Pragmatist]: Supported compromise."));
+        // Full text from round 0 should NOT appear
+        assert!(!prompt.contains("Very long argument about monoliths"));
+
+        // Round 1 should show full text
+        assert!(prompt.contains("=== Round 2 ==="));
+        assert!(prompt.contains("Round 1 full text from Skeptic."));
+    }
+
+    #[test]
+    fn uncompacted_round_shows_full_text() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Full argument text.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.advance_round();
+
+        // No compaction applied — should show full text
+        let a = agent("p", "Pragmatist", 0.3);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state);
+
+        assert!(prompt.contains("=== Round 1 ==="));
+        assert!(!prompt.contains("(compacted)"));
+        assert!(prompt.contains("Full argument text."));
     }
 }

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -17,8 +17,8 @@ use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
-    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX,
-    TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
+    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FINAL_ROUND_SUFFIX, TARGETED_REBUTTAL_CUE,
+    contentiousness_to_instruction,
 };
 use super::state::{AgentContribution, CouncilState};
 
@@ -339,10 +339,7 @@ mod tests {
         let a = agent("c", "Collaborator", 0.1);
         let target = select_rebuttal_target(&a, &state, 1).unwrap();
         assert_eq!(target.agent.id, "d");
-        assert_eq!(
-            target.core_claim.as_deref(),
-            Some("Total opposition.")
-        );
+        assert_eq!(target.core_claim.as_deref(), Some("Total opposition."));
     }
 
     #[test]

--- a/crates/gglib-agent/src/council/history.rs
+++ b/crates/gglib-agent/src/council/history.rs
@@ -7,10 +7,9 @@
 //! 2. Formatting the debate transcript from prior rounds as a labelled
 //!    `[Agent Name]: content` block.  Rounds that have been compacted are
 //!    replaced with their short summary, keeping context sizes manageable.
-//! 3. Selecting a directed rebuttal target (the prior-round agent with a
-//!    core claim whose contentiousness is most different from the current
-//!    agent), or falling back to a generic debate-history cue.
-//! 4. Appending round-phase suffixes (rebuttal/history cue, final-round cue).
+//! 3. Appending a guided rebuttal cue that lets the agent autonomously
+//!    choose which prior argument to rebut based on genuine conflict.
+//! 4. Appending round-phase suffixes (rebuttal cue, final-round cue).
 //! 5. Wrapping the topic as a `User` message.
 
 use std::path::Path;
@@ -19,17 +18,15 @@ use gglib_core::AgentMessage;
 
 use super::config::CouncilAgent;
 use super::prompts::{
-    AGENT_TURN_SYSTEM_PROMPT, DEBATE_HISTORY_SUFFIX, FILESYSTEM_TOOLS_CONTEXT, FINAL_ROUND_SUFFIX,
-    TARGETED_REBUTTAL_CUE, contentiousness_to_instruction,
+    AGENT_TURN_SYSTEM_PROMPT, FILESYSTEM_TOOLS_CONTEXT, FINAL_ROUND_SUFFIX, GUIDED_REBUTTAL_CUE,
+    contentiousness_to_instruction,
 };
-use super::state::{AgentContribution, CouncilState};
+use super::state::CouncilState;
 
 /// Build the message list for a single agent's turn in the council debate.
 ///
-/// Returns `(messages, rebuttal_target)` — the messages are
-/// `[System(prompt), User(topic)]` that the `AgentLoop` will extend with
-/// tool calls and responses during its own run.  `rebuttal_target` is the
-/// name of the agent whose claim is being rebutted, if any.
+/// Returns `[System(prompt), User(topic)]` that the `AgentLoop` will extend
+/// with tool calls and responses during its own run.
 ///
 /// # Arguments
 ///
@@ -46,24 +43,19 @@ pub fn build_agent_messages(
     total_rounds: u32,
     state: &CouncilState,
     cwd: Option<&Path>,
-) -> (Vec<AgentMessage>, Option<String>) {
-    let (system_prompt, rebuttal_target) =
-        build_agent_system_prompt(agent, topic, round, total_rounds, state, cwd);
-    let messages = vec![
+) -> Vec<AgentMessage> {
+    let system_prompt = build_agent_system_prompt(agent, topic, round, total_rounds, state, cwd);
+    vec![
         AgentMessage::System {
             content: system_prompt,
         },
         AgentMessage::User {
             content: topic.to_owned(),
         },
-    ];
-    (messages, rebuttal_target)
+    ]
 }
 
 /// Assemble the full system prompt for a single agent turn.
-///
-/// Returns `(prompt, rebuttal_target_name)`.  The target name is `Some`
-/// only when a directed rebuttal cue was injected into the prompt.
 ///
 /// This is separated from [`build_agent_messages`] for testability.
 #[must_use]
@@ -74,7 +66,7 @@ pub fn build_agent_system_prompt(
     total_rounds: u32,
     state: &CouncilState,
     cwd: Option<&Path>,
-) -> (String, Option<String>) {
+) -> String {
     let instruction = contentiousness_to_instruction(agent.contentiousness);
 
     #[allow(clippy::literal_string_with_formatting_args)]
@@ -85,28 +77,13 @@ pub fn build_agent_system_prompt(
         .replace("{perspective}", &agent.perspective)
         .replace("{contentiousness_instruction}", instruction);
 
-    let mut rebuttal_target = None;
-
     // Inject debate history from prior rounds.
     if round > 0 {
         let transcript = format_transcript(state, round);
         if !transcript.is_empty() {
             prompt.push_str("\n\nDEBATE HISTORY:\n");
             prompt.push_str(&transcript);
-
-            // Directed rebuttal cue targeting the most opposed agent's
-            // core claim, or generic debate-history suffix as fallback.
-            if let Some(target) = select_rebuttal_target(agent, state, round) {
-                let claim = target.core_claim.as_deref().unwrap_or_default();
-                prompt.push_str(
-                    &TARGETED_REBUTTAL_CUE
-                        .replace("{target_name}", &target.agent.name)
-                        .replace("{target_claim}", claim),
-                );
-                rebuttal_target = Some(target.agent.name.clone());
-            } else {
-                prompt.push_str(DEBATE_HISTORY_SUFFIX);
-            }
+            prompt.push_str(GUIDED_REBUTTAL_CUE);
         }
     }
 
@@ -124,7 +101,7 @@ pub fn build_agent_system_prompt(
         write!(prompt, "\n\nWorking directory: {}", dir.display()).unwrap();
     }
 
-    (prompt, rebuttal_target)
+    prompt
 }
 
 /// Format prior contributions as a labelled transcript block.
@@ -167,38 +144,6 @@ fn format_transcript(state: &CouncilState, up_to_round: u32) -> String {
         }
     }
     out
-}
-
-/// Select the best rebuttal target for an agent entering a new round.
-///
-/// Picks the contribution from the **previous round** whose `core_claim` is
-/// present and whose contentiousness is most different from the current
-/// agent's — a lightweight proxy for "most semantically distant" without
-/// requiring embeddings.
-///
-/// Returns `None` when:
-/// - `round == 0` (no prior contributions exist)
-/// - no other agent produced a core claim in the previous round
-fn select_rebuttal_target<'a>(
-    agent: &CouncilAgent,
-    state: &'a CouncilState,
-    round: u32,
-) -> Option<&'a AgentContribution> {
-    if round == 0 {
-        return None;
-    }
-    let prev_round = round - 1;
-    state
-        .contributions_for_round(prev_round)
-        .into_iter()
-        .filter(|c| c.agent.id != agent.id && c.core_claim.is_some())
-        .max_by(|a, b| {
-            let dist_a = (a.agent.contentiousness - agent.contentiousness).abs();
-            let dist_b = (b.agent.contentiousness - agent.contentiousness).abs();
-            dist_a
-                .partial_cmp(&dist_b)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
 }
 
 /// Format the full transcript for the synthesis prompt (all rounds).
@@ -244,14 +189,13 @@ mod tests {
     fn round_0_no_history() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, target) = build_agent_system_prompt(&a, "Test topic", 0, 3, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Test topic", 0, 3, &state, None);
 
         assert!(prompt.contains("You are Skeptic."));
         assert!(prompt.contains("Skeptic is a test agent."));
         assert!(prompt.contains("rigorous critic"));
         assert!(!prompt.contains("DEBATE HISTORY"));
         assert!(!prompt.contains("FINAL ROUND"));
-        assert!(target.is_none());
     }
 
     #[test]
@@ -272,13 +216,13 @@ mod tests {
         state.advance_round();
 
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _target) = build_agent_system_prompt(&a, "Test topic", 1, 3, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Test topic", 1, 3, &state, None);
 
         assert!(prompt.contains("DEBATE HISTORY:"));
         assert!(prompt.contains("=== Round 1 ==="));
         assert!(prompt.contains("[Skeptic]: I disagree strongly."));
         assert!(prompt.contains("[Pragmatist]: Let's find middle ground."));
-        assert!(prompt.contains("Respond to the strongest counterarguments"));
+        assert!(prompt.contains("conflicts with your perspective"));
         assert!(!prompt.contains("FINAL ROUND"));
     }
 
@@ -286,7 +230,7 @@ mod tests {
     fn final_round_suffix_appended() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -294,7 +238,7 @@ mod tests {
     fn single_round_is_also_final() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
         assert!(prompt.contains("FINAL ROUND"));
     }
 
@@ -302,14 +246,13 @@ mod tests {
     fn build_agent_messages_structure() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (msgs, target) = build_agent_messages(&a, "My topic", 0, 2, &state, None);
+        let msgs = build_agent_messages(&a, "My topic", 0, 2, &state, None);
 
         assert_eq!(msgs.len(), 2);
         assert!(
             matches!(&msgs[0], AgentMessage::System { content } if content.contains("Skeptic"))
         );
         assert!(matches!(&msgs[1], AgentMessage::User { content } if content == "My topic"));
-        assert!(target.is_none());
     }
 
     #[test]
@@ -325,85 +268,10 @@ mod tests {
         assert!(transcript.contains("[Skeptic (Skeptic's angle)]: Bad idea."));
     }
 
-    // ── directed rebuttal tests ──────────────────────────────────────────
+    // ── guided rebuttal cue tests ─────────────────────────────────────────
 
     #[test]
-    fn rebuttal_target_none_at_round_0() {
-        let state = CouncilState::new();
-        let a = agent("s", "Skeptic", 0.7);
-        assert!(select_rebuttal_target(&a, &state, 0).is_none());
-    }
-
-    #[test]
-    fn rebuttal_target_picks_most_opposed() {
-        let mut state = CouncilState::new();
-        // Round 0: three agents with core claims
-        state.push(AgentContribution {
-            agent: agent("c", "Collaborator", 0.1),
-            content: "We should cooperate.".into(),
-            core_claim: Some("Cooperation wins.".into()),
-            round: 0,
-        });
-        state.push(AgentContribution {
-            agent: agent("b", "Balanced", 0.5),
-            content: "Both sides have merit.".into(),
-            core_claim: Some("Balance is key.".into()),
-            round: 0,
-        });
-        state.push(AgentContribution {
-            agent: agent("d", "Devil", 0.9),
-            content: "Everything is wrong.".into(),
-            core_claim: Some("Total opposition.".into()),
-            round: 0,
-        });
-        state.advance_round();
-
-        // Current agent is Collaborator (0.1) — most distant is Devil (0.9)
-        let a = agent("c", "Collaborator", 0.1);
-        let target = select_rebuttal_target(&a, &state, 1).unwrap();
-        assert_eq!(target.agent.id, "d");
-        assert_eq!(target.core_claim.as_deref(), Some("Total opposition."));
-    }
-
-    #[test]
-    fn rebuttal_target_skips_self() {
-        let mut state = CouncilState::new();
-        state.push(AgentContribution {
-            agent: agent("s", "Skeptic", 0.9),
-            content: "My argument.".into(),
-            core_claim: Some("My claim.".into()),
-            round: 0,
-        });
-        state.advance_round();
-
-        // Only contribution in previous round is from self — no target
-        let a = agent("s", "Skeptic", 0.9);
-        assert!(select_rebuttal_target(&a, &state, 1).is_none());
-    }
-
-    #[test]
-    fn rebuttal_target_none_when_no_core_claims() {
-        let mut state = CouncilState::new();
-        state.push(AgentContribution {
-            agent: agent("a", "Alice", 0.3),
-            content: "Some argument.".into(),
-            core_claim: None,
-            round: 0,
-        });
-        state.push(AgentContribution {
-            agent: agent("b", "Bob", 0.8),
-            content: "Another argument.".into(),
-            core_claim: None,
-            round: 0,
-        });
-        state.advance_round();
-
-        let a = agent("a", "Alice", 0.3);
-        assert!(select_rebuttal_target(&a, &state, 1).is_none());
-    }
-
-    #[test]
-    fn rebuttal_cue_injected_in_prompt() {
+    fn guided_rebuttal_cue_in_prompt() {
         let mut state = CouncilState::new();
         state.push(AgentContribution {
             agent: agent("s", "Skeptic", 0.9),
@@ -419,36 +287,12 @@ mod tests {
         });
         state.advance_round();
 
-        // Pragmatist (0.2) should target Skeptic (0.9) — most distant
         let a = agent("p", "Pragmatist", 0.2);
-        let (prompt, target) = build_agent_system_prompt(&a, "Architecture", 1, 3, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Architecture", 1, 3, &state, None);
 
-        assert!(prompt.contains("DIRECTED REBUTTAL"));
-        assert!(prompt.contains("Skeptic's core claim"));
-        assert!(prompt.contains("Monoliths scale better."));
-        // Generic suffix should NOT appear when rebuttal cue is used
-        assert!(!prompt.contains("Respond to the strongest counterarguments"));
-        assert_eq!(target.as_deref(), Some("Skeptic"));
-    }
-
-    #[test]
-    fn generic_suffix_when_no_rebuttal_target() {
-        let mut state = CouncilState::new();
-        state.push(AgentContribution {
-            agent: agent("a", "Alice", 0.3),
-            content: "Some argument.".into(),
-            core_claim: None, // no core claim
-            round: 0,
-        });
-        state.advance_round();
-
-        let a = agent("b", "Bob", 0.7);
-        let (prompt, target) = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
-
-        assert!(prompt.contains("DEBATE HISTORY"));
-        assert!(prompt.contains("Respond to the strongest counterarguments"));
+        // Guided rebuttal cue should appear — no directed rebuttal
+        assert!(prompt.contains("conflicts with your perspective"));
         assert!(!prompt.contains("DIRECTED REBUTTAL"));
-        assert!(target.is_none());
     }
 
     // ── compacted transcript tests ───────────────────────────────────────
@@ -485,7 +329,7 @@ mod tests {
 
         // At round 2, round 0 should be compacted, round 1 should be full
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Topic", 2, 3, &state, None);
 
         // Round 0 should show compacted summary
         assert!(prompt.contains("=== Round 1 (compacted) ==="));
@@ -512,7 +356,7 @@ mod tests {
 
         // No compaction applied — should show full text
         let a = agent("p", "Pragmatist", 0.3);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Topic", 1, 3, &state, None);
 
         assert!(prompt.contains("=== Round 1 ==="));
         assert!(!prompt.contains("(compacted)"));
@@ -525,7 +369,7 @@ mod tests {
     fn cwd_none_omits_filesystem_context() {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
+        let prompt = build_agent_system_prompt(&a, "Topic", 0, 1, &state, None);
         assert!(!prompt.contains("filesystem tools"));
         assert!(!prompt.contains("Working directory"));
     }
@@ -535,7 +379,7 @@ mod tests {
         let state = CouncilState::new();
         let a = agent("s", "Skeptic", 0.7);
         let dir = std::path::PathBuf::from("/tmp/my-project");
-        let (prompt, _) = build_agent_system_prompt(&a, "Topic", 0, 1, &state, Some(&dir));
+        let prompt = build_agent_system_prompt(&a, "Topic", 0, 1, &state, Some(&dir));
         assert!(prompt.contains("filesystem tools (read_file, list_directory, grep_search)"));
         assert!(prompt.contains("Working directory: /tmp/my-project"));
     }

--- a/crates/gglib-agent/src/council/judge.rs
+++ b/crates/gglib-agent/src/council/judge.rs
@@ -1,0 +1,371 @@
+//! Post-round judge evaluation with adaptive early stopping.
+//!
+//! After each debate round, an optional neutral judge agent evaluates the
+//! transcript, produces a narrative summary, and determines whether the
+//! agents have reached consensus.  If consensus is detected and the
+//! minimum-rounds threshold has been met, the orchestrator skips remaining
+//! rounds and proceeds directly to synthesis.
+//!
+//! # Robust marker parsing
+//!
+//! The judge's output must contain a `CONSENSUS_REACHED: true/false` line.
+//! [`parse_judge_verdict`] uses case-insensitive, whitespace-tolerant
+//! matching to handle common LLM quirks:
+//! - Markdown bold/backtick wrapping (`**CONSENSUS_REACHED:** true`)
+//! - Leading prose / conversational filler
+//! - Extra spacing around the colon
+//! - Varying casing (`consensus_reached`, `Consensus_Reached`, etc.)
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::JudgeConfig;
+use super::events::CouncilEvent;
+use super::history::format_synthesis_transcript;
+use super::prompts::JUDGE_PROMPT;
+use super::state::CouncilState;
+
+/// The judge's parsed verdict after evaluating a round.
+#[derive(Debug, Clone)]
+pub(super) struct JudgeVerdict {
+    /// The judge's narrative summary of the debate state.
+    pub summary: String,
+    /// Whether the judge determined consensus has been reached.
+    pub consensus_reached: bool,
+}
+
+/// Run the judge evaluation for the given round.
+///
+/// Emits `JudgeStart`, streams `JudgeTextDelta` tokens, then emits
+/// `JudgeSummary` with the parsed verdict.
+///
+/// Returns `None` if the channel is closed or the judge produces no
+/// output (the orchestrator should treat this as "no consensus").
+pub(super) async fn run_judge(
+    round: u32,
+    total_rounds: u32,
+    _judge_config: &JudgeConfig,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    state: &CouncilState,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+    topic: &str,
+) -> Option<JudgeVerdict> {
+    // Announce the judge phase.
+    if council_tx
+        .send(CouncilEvent::JudgeStart { round })
+        .await
+        .is_err()
+    {
+        return None;
+    }
+
+    let transcript = format_synthesis_transcript(state);
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let system = JUDGE_PROMPT
+        .replace("{topic}", topic)
+        .replace("{round}", &(round + 1).to_string())
+        .replace("{total_rounds}", &total_rounds.to_string())
+        .replace("{transcript}", &transcript);
+
+    let messages = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: format!("Evaluate the debate state after round {}.", round + 1),
+        },
+    ];
+
+    // Judge gets no tools — pure evaluation.
+    let agent = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), Some(HashSet::new()));
+    let mut config = AgentConfig::default();
+    config.max_iterations = 1;
+
+    let (agent_tx, mut agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    let handle = {
+        let agent = Arc::clone(&agent);
+        tokio::spawn(async move { agent.run(messages, config, agent_tx).await })
+    };
+
+    // Bridge agent events → judge events.
+    let mut content: Option<String> = None;
+    while let Some(event) = agent_rx.recv().await {
+        match event {
+            AgentEvent::TextDelta { content: delta } => {
+                let _ = council_tx
+                    .send(CouncilEvent::JudgeTextDelta { delta })
+                    .await;
+            }
+            AgentEvent::FinalAnswer { content: answer } => {
+                content = Some(answer);
+            }
+            _ => {}
+        }
+    }
+
+    let _ = handle.await;
+
+    let raw = content.unwrap_or_default();
+    if raw.is_empty() {
+        warn!(round, "judge produced no output");
+        return None;
+    }
+
+    let verdict = parse_judge_verdict(&raw, round);
+
+    let _ = council_tx
+        .send(CouncilEvent::JudgeSummary {
+            round,
+            summary: verdict.summary.clone(),
+            consensus_reached: verdict.consensus_reached,
+        })
+        .await;
+
+    Some(verdict)
+}
+
+/// Robust, case-insensitive extraction of the `CONSENSUS_REACHED` marker.
+///
+/// Handles common LLM output variations:
+/// - `CONSENSUS_REACHED: true` (canonical)
+/// - `**CONSENSUS_REACHED:** false` (markdown bold)
+/// - `` `CONSENSUS_REACHED`: true `` (markdown backtick)
+/// - `consensus_reached : True` (extra spacing, mixed case)
+/// - `Consensus_Reached: FALSE` (title case)
+///
+/// The summary is everything *before* the marker line.  If the marker is
+/// absent, defaults to `consensus_reached = false`.
+fn parse_judge_verdict(raw: &str, round: u32) -> JudgeVerdict {
+    // Scan lines from the end — the prompt asks for the marker at the bottom.
+    let mut consensus_reached = false;
+    let mut marker_line_idx: Option<usize> = None;
+
+    let lines: Vec<&str> = raw.lines().collect();
+    for (i, line) in lines.iter().enumerate().rev() {
+        if let Some(value) = extract_consensus_value(line) {
+            consensus_reached = value;
+            marker_line_idx = Some(i);
+            break;
+        }
+    }
+
+    if marker_line_idx.is_none() {
+        debug!(round, "judge output missing CONSENSUS_REACHED marker, defaulting to false");
+    }
+
+    // Summary = everything before the marker line (or the full text if no marker).
+    let summary = match marker_line_idx {
+        Some(idx) => lines[..idx]
+            .iter()
+            .copied()
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_owned(),
+        None => raw.trim().to_owned(),
+    };
+
+    JudgeVerdict {
+        summary,
+        consensus_reached,
+    }
+}
+
+/// Try to extract a boolean value from a line containing `CONSENSUS_REACHED`.
+///
+/// Strips markdown formatting (`**`, `` ` ``), normalises whitespace, and
+/// performs case-insensitive matching.  Returns `None` if the line does not
+/// contain the marker.
+fn extract_consensus_value(line: &str) -> Option<bool> {
+    // Strip common markdown wrappers.
+    let cleaned: String = line
+        .chars()
+        .filter(|c| *c != '*' && *c != '`')
+        .collect();
+
+    let lower = cleaned.to_lowercase();
+
+    // Look for "consensus_reached" anywhere in the line.
+    let idx = lower.find("consensus_reached")?;
+
+    // Everything after the marker keyword.
+    let after = &lower[idx + "consensus_reached".len()..];
+
+    // Strip optional colon and whitespace.
+    let after = after.trim_start();
+    let after = after.strip_prefix(':').unwrap_or(after);
+    let after = after.trim();
+
+    // Parse the boolean value.
+    if after.starts_with("true") || after.starts_with("yes") {
+        Some(true)
+    } else if after.starts_with("false") || after.starts_with("no") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Whether the judge should allow early stopping at this round.
+///
+/// Returns `true` if the completed round count meets the minimum threshold
+/// configured in [`JudgeConfig`].
+pub(super) fn may_stop_early(judge_config: &JudgeConfig, completed_rounds: u32) -> bool {
+    completed_rounds >= judge_config.min_rounds_before_stop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_judge_verdict ──────────────────────────────────────────────
+
+    #[test]
+    fn canonical_true() {
+        let raw = "The agents agree on the core approach.\nCONSENSUS_REACHED: true";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(v.consensus_reached);
+        assert_eq!(v.summary, "The agents agree on the core approach.");
+    }
+
+    #[test]
+    fn canonical_false() {
+        let raw = "Significant disagreement remains.\nCONSENSUS_REACHED: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert_eq!(v.summary, "Significant disagreement remains.");
+    }
+
+    #[test]
+    fn markdown_bold_wrapping() {
+        let raw = "Summary here.\n**CONSENSUS_REACHED:** true";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(v.consensus_reached);
+        assert_eq!(v.summary, "Summary here.");
+    }
+
+    #[test]
+    fn markdown_backtick_wrapping() {
+        let raw = "Summary.\n`CONSENSUS_REACHED`: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+    }
+
+    #[test]
+    fn mixed_case() {
+        let raw = "Debate ongoing.\nConsensus_Reached: True";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(v.consensus_reached);
+    }
+
+    #[test]
+    fn extra_spacing() {
+        let raw = "Still debating.\nconsensus_reached :  false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+    }
+
+    #[test]
+    fn conversational_filler_before_marker() {
+        let raw = "Here is my verdict:\n\nThe agents remain divided on implementation.\n\nCONSENSUS_REACHED: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert!(v.summary.contains("Here is my verdict:"));
+        assert!(v.summary.contains("remain divided"));
+    }
+
+    #[test]
+    fn missing_marker_defaults_to_false() {
+        let raw = "The debate is interesting but I cannot decide.";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert_eq!(v.summary, raw);
+    }
+
+    #[test]
+    fn yes_no_alternatives() {
+        let raw = "All agree.\nCONSENSUS_REACHED: yes";
+        assert!(parse_judge_verdict(raw, 0).consensus_reached);
+
+        let raw = "No agreement.\nCONSENSUS_REACHED: no";
+        assert!(!parse_judge_verdict(raw, 0).consensus_reached);
+    }
+
+    #[test]
+    fn marker_in_middle_of_text() {
+        // Some models might put text after the marker — the parser should
+        // still find the last occurrence scanning from the bottom.
+        let raw = "Round 1 summary.\nCONSENSUS_REACHED: true\nExtra text here.";
+        let v = parse_judge_verdict(raw, 0);
+        // The scanner finds the marker line and uses text before it as summary.
+        // Because we scan from the end, the last CONSENSUS_REACHED line wins.
+        // In this case there's only one, but "Extra text here." is after it.
+        assert!(v.consensus_reached);
+    }
+
+    #[test]
+    fn multiline_summary_preserved() {
+        let raw = "Point 1.\nPoint 2.\nPoint 3.\n\nCONSENSUS_REACHED: false";
+        let v = parse_judge_verdict(raw, 0);
+        assert!(!v.consensus_reached);
+        assert!(v.summary.contains("Point 1."));
+        assert!(v.summary.contains("Point 3."));
+    }
+
+    // ── may_stop_early ───────────────────────────────────────────────────
+
+    #[test]
+    fn stop_early_respects_minimum() {
+        let cfg = JudgeConfig {
+            min_rounds_before_stop: 2,
+        };
+        assert!(!may_stop_early(&cfg, 0));
+        assert!(!may_stop_early(&cfg, 1));
+        assert!(may_stop_early(&cfg, 2));
+        assert!(may_stop_early(&cfg, 3));
+    }
+
+    #[test]
+    fn stop_early_default_min() {
+        let cfg = JudgeConfig {
+            min_rounds_before_stop: 1,
+        };
+        assert!(!may_stop_early(&cfg, 0));
+        assert!(may_stop_early(&cfg, 1));
+    }
+
+    // ── extract_consensus_value ──────────────────────────────────────────
+
+    #[test]
+    fn extract_plain() {
+        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: true"), Some(true));
+        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: false"), Some(false));
+    }
+
+    #[test]
+    fn extract_with_markdown() {
+        assert_eq!(extract_consensus_value("**CONSENSUS_REACHED:** true"), Some(true));
+        assert_eq!(extract_consensus_value("`CONSENSUS_REACHED`: false"), Some(false));
+    }
+
+    #[test]
+    fn extract_no_marker() {
+        assert_eq!(extract_consensus_value("some random text"), None);
+    }
+
+    #[test]
+    fn extract_bad_value() {
+        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: maybe"), None);
+    }
+}

--- a/crates/gglib-agent/src/council/judge.rs
+++ b/crates/gglib-agent/src/council/judge.rs
@@ -88,7 +88,11 @@ pub(super) async fn run_judge(
     ];
 
     // Judge gets no tools — pure evaluation.
-    let agent = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), Some(HashSet::new()));
+    let agent = AgentLoop::build(
+        Arc::clone(llm),
+        Arc::clone(tool_executor),
+        Some(HashSet::new()),
+    );
     let mut config = AgentConfig::default();
     config.max_iterations = 1;
 
@@ -162,7 +166,10 @@ fn parse_judge_verdict(raw: &str, round: u32) -> JudgeVerdict {
     }
 
     if marker_line_idx.is_none() {
-        debug!(round, "judge output missing CONSENSUS_REACHED marker, defaulting to false");
+        debug!(
+            round,
+            "judge output missing CONSENSUS_REACHED marker, defaulting to false"
+        );
     }
 
     // Summary = everything before the marker line (or the full text if no marker).
@@ -184,10 +191,7 @@ fn parse_judge_verdict(raw: &str, round: u32) -> JudgeVerdict {
 /// contain the marker.
 fn extract_consensus_value(line: &str) -> Option<bool> {
     // Strip common markdown wrappers.
-    let cleaned: String = line
-        .chars()
-        .filter(|c| *c != '*' && *c != '`')
-        .collect();
+    let cleaned: String = line.chars().filter(|c| *c != '*' && *c != '`').collect();
 
     let lower = cleaned.to_lowercase();
 
@@ -344,14 +348,26 @@ mod tests {
 
     #[test]
     fn extract_plain() {
-        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: true"), Some(true));
-        assert_eq!(extract_consensus_value("CONSENSUS_REACHED: false"), Some(false));
+        assert_eq!(
+            extract_consensus_value("CONSENSUS_REACHED: true"),
+            Some(true)
+        );
+        assert_eq!(
+            extract_consensus_value("CONSENSUS_REACHED: false"),
+            Some(false)
+        );
     }
 
     #[test]
     fn extract_with_markdown() {
-        assert_eq!(extract_consensus_value("**CONSENSUS_REACHED:** true"), Some(true));
-        assert_eq!(extract_consensus_value("`CONSENSUS_REACHED`: false"), Some(false));
+        assert_eq!(
+            extract_consensus_value("**CONSENSUS_REACHED:** true"),
+            Some(true)
+        );
+        assert_eq!(
+            extract_consensus_value("`CONSENSUS_REACHED`: false"),
+            Some(false)
+        );
     }
 
     #[test]

--- a/crates/gglib-agent/src/council/judge.rs
+++ b/crates/gglib-agent/src/council/judge.rs
@@ -51,6 +51,7 @@ pub(super) struct JudgeVerdict {
 ///
 /// Returns `None` if the channel is closed or the judge produces no
 /// output (the orchestrator should treat this as "no consensus").
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn run_judge(
     round: u32,
     total_rounds: u32,
@@ -165,16 +166,10 @@ fn parse_judge_verdict(raw: &str, round: u32) -> JudgeVerdict {
     }
 
     // Summary = everything before the marker line (or the full text if no marker).
-    let summary = match marker_line_idx {
-        Some(idx) => lines[..idx]
-            .iter()
-            .copied()
-            .collect::<Vec<_>>()
-            .join("\n")
-            .trim()
-            .to_owned(),
-        None => raw.trim().to_owned(),
-    };
+    let summary = marker_line_idx.map_or_else(
+        || raw.trim().to_owned(),
+        |idx| lines[..idx].to_vec().join("\n").trim().to_owned(),
+    );
 
     JudgeVerdict {
         summary,
@@ -221,7 +216,7 @@ fn extract_consensus_value(line: &str) -> Option<bool> {
 ///
 /// Returns `true` if the completed round count meets the minimum threshold
 /// configured in [`JudgeConfig`].
-pub(super) fn may_stop_early(judge_config: &JudgeConfig, completed_rounds: u32) -> bool {
+pub(super) const fn may_stop_early(judge_config: &JudgeConfig, completed_rounds: u32) -> bool {
     completed_rounds >= judge_config.min_rounds_before_stop
 }
 

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -18,7 +18,8 @@
 //! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
 //! | `judge.rs`        | Post-round judge + adaptive early stopping          |
-//! | `orchestrator.rs` | Slim coordinator (rounds → judge → synthesis)       |
+//! | `compaction.rs`   | LLM-driven round summarisation for context control  |
+//! | `orchestrator.rs` | Slim coordinator (rounds → compaction → judge → synthesis) |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -26,6 +27,7 @@ pub mod events;
 pub mod history;
 pub mod orchestrator;
 pub mod prompts;
+mod compaction;
 mod judge;
 mod round;
 pub mod state;

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -17,7 +17,8 @@
 //! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
 //! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
-//! | `orchestrator.rs` | Slim coordinator (rounds → synthesis sequencing)    |
+//! | `judge.rs`        | Post-round judge + adaptive early stopping          |
+//! | `orchestrator.rs` | Slim coordinator (rounds → judge → synthesis)       |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -25,13 +26,14 @@ pub mod events;
 pub mod history;
 pub mod orchestrator;
 pub mod prompts;
+mod judge;
 mod round;
 pub mod state;
 pub mod stream_bridge;
 pub mod suggest;
 mod synthesis;
 
-pub use config::{CouncilAgent, CouncilConfig, SuggestedCouncil};
+pub use config::{CouncilAgent, CouncilConfig, JudgeConfig, SuggestedCouncil};
 pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 pub use orchestrator::run as run_council;
 pub use prompts::{contentiousness_tier_label, contentiousness_to_instruction};

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -19,7 +19,8 @@
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
 //! | `judge.rs`        | Post-round judge + adaptive early stopping          |
 //! | `compaction.rs`   | LLM-driven round summarisation for context control  |
-//! | `orchestrator.rs` | Slim coordinator (rounds → compaction → judge → synthesis) |
+//! | `stance.rs`       | Post-debate stance tracking (Held/Shifted/Conceded)  |
+//! | `orchestrator.rs` | Slim coordinator (rounds → compaction → judge → stance → synthesis) |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -30,6 +31,7 @@ pub mod prompts;
 mod compaction;
 mod judge;
 mod round;
+pub mod stance;
 pub mod state;
 pub mod stream_bridge;
 pub mod suggest;

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -15,7 +15,9 @@
 //! | `state.rs`        | Round/contribution accumulator                      |
 //! | `history.rs`      | Per-turn context builder (identity + transcript)    |
 //! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
-//! | `orchestrator.rs` | Round×agent loop driver + synthesis dispatch         |
+//! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
+//! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |
+//! | `orchestrator.rs` | Slim coordinator (rounds → synthesis sequencing)    |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
 pub mod config;
@@ -23,9 +25,11 @@ pub mod events;
 pub mod history;
 pub mod orchestrator;
 pub mod prompts;
+mod round;
 pub mod state;
 pub mod stream_bridge;
 pub mod suggest;
+mod synthesis;
 
 pub use config::{CouncilAgent, CouncilConfig, SuggestedCouncil};
 pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -23,13 +23,13 @@
 //! | `orchestrator.rs` | Slim coordinator (rounds → compaction → judge → stance → synthesis) |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
 
+mod compaction;
 pub mod config;
 pub mod events;
 pub mod history;
+mod judge;
 pub mod orchestrator;
 pub mod prompts;
-mod compaction;
-mod judge;
 mod round;
 pub mod stance;
 pub mod state;

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -13,7 +13,7 @@
 //! | `events.rs`       | `CouncilEvent` SSE enum (wire format)               |
 //! | `prompts.rs`      | Prompt templates + contentiousness mapping          |
 //! | `state.rs`        | Round/contribution accumulator                      |
-//! | `history.rs`      | Per-turn context builder (identity + transcript)    |
+//! | `history.rs`      | Per-turn context builder (identity + transcript + directed rebuttals) |
 //! | `stream_bridge.rs`| `AgentEvent` → `CouncilEvent` mapper                |
 //! | `round.rs`        | Sequential round execution (per-agent turn driver)  |
 //! | `synthesis.rs`    | Synthesis pass (transcript → unified answer)        |

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -15,6 +15,7 @@
 //!   │       └─ judge::run_judge()              (judge.rs)
 //!   │           └─ if consensus && may_stop → break
 //!   │
+//!   ├─ stance::evaluate_stances()              (stance.rs)
 //!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
 
@@ -30,10 +31,11 @@ use super::config::CouncilConfig;
 use super::events::CouncilEvent;
 use super::judge::{may_stop_early, run_judge};
 use super::round::{RoundContext, run_sequential_round};
+use super::stance::evaluate_stances;
 use super::state::CouncilState;
 use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: debate rounds → compaction → optional judge → synthesis.
+/// Runs a full council deliberation: debate rounds → compaction → optional judge → stance evaluation → synthesis.
 ///
 /// This function is the only public entry point.  It coordinates the
 /// high-level phase sequence and delegates per-agent turn execution to
@@ -133,6 +135,9 @@ pub async fn run(
             }
         }
     }
+
+    // ── stance evaluation ────────────────────────────────────────────────
+    evaluate_stances(&state, &llm, &tool_executor, &council_tx, &config.topic).await;
 
     // ── synthesis ────────────────────────────────────────────────────────
     run_synthesis(

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -102,7 +102,15 @@ pub async fn run(
         // ── compaction ───────────────────────────────────────────────────
         // Summarise the just-completed round so that future agents see a
         // compact version rather than the full transcript.
-        compact_round(round, &mut state, &llm, &tool_executor, &council_tx, &config.topic).await;
+        compact_round(
+            round,
+            &mut state,
+            &llm,
+            &tool_executor,
+            &council_tx,
+            &config.topic,
+        )
+        .await;
 
         // ── optional judge evaluation ────────────────────────────────────
         if let Some(ref judge_config) = config.judge {
@@ -126,8 +134,7 @@ pub async fn run(
                     if verdict.consensus_reached && may_stop_early(judge_config, completed_rounds) {
                         info!(
                             round,
-                            completed_rounds,
-                            "judge detected consensus — stopping early"
+                            completed_rounds, "judge detected consensus — stopping early"
                         );
                         break;
                     }

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,58 +1,44 @@
-//! Round×agent orchestration loop for a council deliberation.
+//! Top-level coordinator for a council deliberation.
+//!
+//! This module is intentionally slim — it sequences the high-level phases
+//! (debate rounds → synthesis) and delegates all per-agent and per-phase
+//! logic to dedicated sub-modules:
 //!
 //! ```text
-//! CouncilOrchestrator::run()
+//! orchestrator::run()
 //!   │
 //!   ├─ for each round 0..N
 //!   │   ├─ emit RoundSeparator (round > 0)
-//!   │   └─ for each agent
-//!   │       ├─ emit AgentTurnStart
-//!   │       ├─ build_agent_messages()          (history.rs)
-//!   │       ├─ AgentLoop::run()                (delegated, stagnation+loop guards active)
-//!   │       ├─ bridge_agent_events()           (stream_bridge.rs)
-//!   │       ├─ emit AgentTurnComplete          (with core claim extraction)
-//!   │       └─ state.push(contribution)
+//!   │   └─ round::run_sequential_round()      (round.rs)
 //!   │
-//!   ├─ emit SynthesisStart
-//!   ├─ AgentLoop::run() with synthesis prompt
-//!   ├─ bridge synthesis events
-//!   ├─ emit SynthesisComplete
-//!   └─ emit CouncilComplete
+//!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
 
-use gglib_core::{
-    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
-    ToolExecutorPort,
-};
-
-use crate::AgentLoop;
+use gglib_core::{AgentConfig, LlmCompletionPort, ToolExecutorPort};
 
 use super::config::CouncilConfig;
 use super::events::CouncilEvent;
-use super::history::{build_agent_messages, format_synthesis_transcript};
-use super::prompts::SYNTHESIS_PROMPT;
-use super::state::{AgentContribution, CouncilState, extract_core_claim};
-use super::stream_bridge::{bridge_agent_events, emit_turn_complete};
+use super::round::{RoundContext, run_sequential_round};
+use super::state::CouncilState;
+use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: rounds → agent turns → synthesis.
+/// Runs a full council deliberation: debate rounds → synthesis.
 ///
-/// This function is the only public entry point.  It owns the round×agent
-/// loop and delegates each agent turn to an [`AgentLoop`] via the existing
-/// port traits.  The caller provides a `council_tx` to receive streamed
-/// [`CouncilEvent`]s.
+/// This function is the only public entry point.  It coordinates the
+/// high-level phase sequence and delegates per-agent turn execution to
+/// [`round::run_sequential_round`] and the synthesis pass to
+/// [`synthesis::run_synthesis`].
 ///
 /// # Errors
 ///
 /// Individual agent errors (stagnation, loop detection, max iterations) are
-/// handled gracefully — the contribution is recorded as-is and the council
-/// proceeds.  Only infrastructure-level failures (channel closure) cause an
-/// early return.
+/// handled gracefully inside `round.rs` — the contribution is recorded
+/// as-is and the council proceeds.  Only infrastructure-level failures
+/// (channel closure) cause an early return.
 pub async fn run(
     config: CouncilConfig,
     agent_config: AgentConfig,
@@ -62,10 +48,19 @@ pub async fn run(
 ) {
     let mut state = CouncilState::new();
 
+    let ctx = RoundContext {
+        config: &config,
+        agent_config: &agent_config,
+        llm: &llm,
+        tool_executor: &tool_executor,
+        council_tx: &council_tx,
+    };
+
     // ── debate rounds ────────────────────────────────────────────────────
     for round in 0..config.rounds {
         if round > 0 {
-            if send(&council_tx, CouncilEvent::RoundSeparator { round })
+            if council_tx
+                .send(CouncilEvent::RoundSeparator { round })
                 .await
                 .is_err()
             {
@@ -73,68 +68,8 @@ pub async fn run(
             }
         }
 
-        for agent in &config.agents {
-            // Announce the turn.
-            let start = CouncilEvent::AgentTurnStart {
-                agent_id: agent.id.clone(),
-                agent_name: agent.name.clone(),
-                color: agent.color.clone(),
-                round,
-                contentiousness: agent.contentiousness,
-            };
-            if send(&council_tx, start).await.is_err() {
-                return;
-            }
-
-            // Build per-agent tool filter.
-            let filter = agent
-                .tool_filter
-                .as_ref()
-                .map(|names| names.iter().cloned().collect::<HashSet<String>>());
-
-            // Build the agent loop with per-agent tool restrictions.
-            let agent_loop = AgentLoop::build(Arc::clone(&llm), Arc::clone(&tool_executor), filter);
-
-            // Assemble context with identity anchoring + debate transcript.
-            let messages = build_agent_messages(agent, &config.topic, round, config.rounds, &state);
-
-            // Delegate to AgentLoop — stagnation + loop guards are active
-            // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).
-            let (agent_tx, agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
-            let loop_handle = {
-                let agent_loop = Arc::clone(&agent_loop);
-                let cfg = agent_config.clone();
-                tokio::spawn(async move { agent_loop.run(messages, cfg, agent_tx).await })
-            };
-
-            // Bridge events from agent → council stream.
-            let answer = bridge_agent_events(agent, round, agent_rx, &council_tx).await;
-
-            // Await the agent loop completion (the channel is already drained).
-            match loop_handle.await {
-                Ok(Ok(_output)) => {
-                    debug!(agent_id = %agent.id, round, "agent turn completed normally");
-                }
-                Ok(Err(e)) => {
-                    // Stagnation, loop detection, max iterations — all graceful.
-                    warn!(agent_id = %agent.id, round, error = %e, "agent turn ended early");
-                }
-                Err(e) => {
-                    warn!(agent_id = %agent.id, round, error = %e, "agent task panicked");
-                }
-            }
-
-            // Record the contribution (use whatever content we got).
-            let content = answer.unwrap_or_default();
-            let core_claim = extract_core_claim(&content);
-            emit_turn_complete(agent, round, &content, &council_tx).await;
-
-            state.push(AgentContribution {
-                agent: agent.clone(),
-                content,
-                core_claim,
-                round,
-            });
+        if run_sequential_round(round, &ctx, &mut state).await.is_err() {
+            return;
         }
 
         state.advance_round();
@@ -150,99 +85,4 @@ pub async fn run(
         &council_tx,
     )
     .await;
-}
-
-/// Synthesis pass: build the transcript, run a single-iteration agent loop,
-/// and emit `SynthesisStart` / `SynthesisTextDelta` / `SynthesisComplete` /
-/// `CouncilComplete`.
-async fn run_synthesis(
-    config: &CouncilConfig,
-    agent_config: AgentConfig,
-    llm: &Arc<dyn LlmCompletionPort>,
-    tool_executor: &Arc<dyn ToolExecutorPort>,
-    state: &CouncilState,
-    council_tx: &mpsc::Sender<CouncilEvent>,
-) {
-    if send(council_tx, CouncilEvent::SynthesisStart)
-        .await
-        .is_err()
-    {
-        return;
-    }
-
-    let transcript = format_synthesis_transcript(state);
-    let guidance = config
-        .synthesis_guidance
-        .as_deref()
-        .unwrap_or("Provide an actionable synthesis.");
-
-    #[allow(clippy::literal_string_with_formatting_args)]
-    let synthesis_prompt = SYNTHESIS_PROMPT
-        .replace("{agent_count}", &config.agents.len().to_string())
-        .replace("{topic}", &config.topic)
-        .replace("{transcript}", &transcript)
-        .replace("{synthesis_guidance}", guidance);
-
-    let synth_messages = vec![
-        AgentMessage::System {
-            content: synthesis_prompt,
-        },
-        AgentMessage::User {
-            content: config.topic.clone(),
-        },
-    ];
-
-    let synth_loop = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), None);
-    let (synth_agent_tx, synth_agent_rx) =
-        mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
-
-    // Synthesis uses a restricted config — no tools needed, single iteration.
-    let mut synth_config = agent_config;
-    synth_config.max_iterations = 1;
-
-    let synth_handle = {
-        let synth_loop = Arc::clone(&synth_loop);
-        tokio::spawn(async move {
-            synth_loop
-                .run(synth_messages, synth_config, synth_agent_tx)
-                .await
-        })
-    };
-
-    // Bridge synthesis events — map TextDelta → SynthesisTextDelta.
-    let synth_content = bridge_synthesis_events(synth_agent_rx, council_tx).await;
-
-    let _ = synth_handle.await;
-
-    let content = synth_content.unwrap_or_default();
-    let _ = send(council_tx, CouncilEvent::SynthesisComplete { content }).await;
-    let _ = send(council_tx, CouncilEvent::CouncilComplete).await;
-}
-
-/// Bridge synthesis-phase events (only text deltas are relevant).
-async fn bridge_synthesis_events(
-    mut rx: mpsc::Receiver<AgentEvent>,
-    tx: &mpsc::Sender<CouncilEvent>,
-) -> Option<String> {
-    let mut content: Option<String> = None;
-    while let Some(event) = rx.recv().await {
-        match event {
-            AgentEvent::TextDelta { content: delta } => {
-                let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
-            }
-            AgentEvent::FinalAnswer { content: answer } => {
-                content = Some(answer);
-            }
-            _ => {}
-        }
-    }
-    content
-}
-
-/// Best-effort send helper — returns `Err` when the receiver is gone.
-async fn send(
-    tx: &mpsc::Sender<CouncilEvent>,
-    event: CouncilEvent,
-) -> Result<(), mpsc::error::SendError<CouncilEvent>> {
-    tx.send(event).await
 }

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -19,6 +19,7 @@
 //!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -70,6 +71,7 @@ pub async fn run(
     llm: Arc<dyn LlmCompletionPort>,
     tool_executor: Arc<dyn ToolExecutorPort>,
     council_tx: mpsc::Sender<CouncilEvent>,
+    cwd: Option<PathBuf>,
 ) {
     let mut state = CouncilState::new();
 
@@ -79,6 +81,7 @@ pub async fn run(
         llm: &llm,
         tool_executor: &tool_executor,
         council_tx: &council_tx,
+        cwd: cwd.as_deref(),
     };
 
     // ── debate rounds ────────────────────────────────────────────────────

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,15 +1,18 @@
 //! Top-level coordinator for a council deliberation.
 //!
 //! This module is intentionally slim — it sequences the high-level phases
-//! (debate rounds → synthesis) and delegates all per-agent and per-phase
-//! logic to dedicated sub-modules:
+//! (debate rounds → optional judge → synthesis) and delegates all per-agent
+//! and per-phase logic to dedicated sub-modules:
 //!
 //! ```text
 //! orchestrator::run()
 //!   │
 //!   ├─ for each round 0..N
 //!   │   ├─ emit RoundSeparator (round > 0)
-//!   │   └─ round::run_sequential_round()      (round.rs)
+//!   │   ├─ round::run_sequential_round()      (round.rs)
+//!   │   └─ if judge enabled:
+//!   │       └─ judge::run_judge()              (judge.rs)
+//!   │           └─ if consensus && may_stop → break
 //!   │
 //!   └─ synthesis::run_synthesis()              (synthesis.rs)
 //! ```
@@ -17,21 +20,30 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
+use tracing::info;
 
 use gglib_core::{AgentConfig, LlmCompletionPort, ToolExecutorPort};
 
 use super::config::CouncilConfig;
 use super::events::CouncilEvent;
+use super::judge::{may_stop_early, run_judge};
 use super::round::{RoundContext, run_sequential_round};
 use super::state::CouncilState;
 use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: debate rounds → synthesis.
+/// Runs a full council deliberation: debate rounds → optional judge → synthesis.
 ///
 /// This function is the only public entry point.  It coordinates the
 /// high-level phase sequence and delegates per-agent turn execution to
-/// [`round::run_sequential_round`] and the synthesis pass to
+/// [`round::run_sequential_round`], optional judge evaluation to
+/// [`judge::run_judge`], and the synthesis pass to
 /// [`synthesis::run_synthesis`].
+///
+/// # Judge + Adaptive Early Stopping
+///
+/// When `config.judge` is `Some`, a neutral judge evaluates the debate
+/// after each round.  If the judge determines consensus has been reached
+/// and the minimum-rounds threshold is met, remaining rounds are skipped.
 ///
 /// # Errors
 ///
@@ -73,6 +85,37 @@ pub async fn run(
         }
 
         state.advance_round();
+
+        // ── optional judge evaluation ────────────────────────────────────
+        if let Some(ref judge_config) = config.judge {
+            let completed_rounds = round + 1;
+            let is_last_round = completed_rounds >= config.rounds;
+
+            // Skip judge on the final round — synthesis follows regardless.
+            if !is_last_round {
+                if let Some(verdict) = run_judge(
+                    round,
+                    config.rounds,
+                    judge_config,
+                    &llm,
+                    &tool_executor,
+                    &state,
+                    &council_tx,
+                    &config.topic,
+                )
+                .await
+                {
+                    if verdict.consensus_reached && may_stop_early(judge_config, completed_rounds) {
+                        info!(
+                            round,
+                            completed_rounds,
+                            "judge detected consensus — stopping early"
+                        );
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     // ── synthesis ────────────────────────────────────────────────────────

--- a/crates/gglib-agent/src/council/orchestrator.rs
+++ b/crates/gglib-agent/src/council/orchestrator.rs
@@ -1,8 +1,8 @@
 //! Top-level coordinator for a council deliberation.
 //!
 //! This module is intentionally slim — it sequences the high-level phases
-//! (debate rounds → optional judge → synthesis) and delegates all per-agent
-//! and per-phase logic to dedicated sub-modules:
+//! (debate rounds → compaction → optional judge → synthesis) and delegates
+//! all per-agent and per-phase logic to dedicated sub-modules:
 //!
 //! ```text
 //! orchestrator::run()
@@ -10,6 +10,7 @@
 //!   ├─ for each round 0..N
 //!   │   ├─ emit RoundSeparator (round > 0)
 //!   │   ├─ round::run_sequential_round()      (round.rs)
+//!   │   ├─ compaction::compact_round()         (compaction.rs)
 //!   │   └─ if judge enabled:
 //!   │       └─ judge::run_judge()              (judge.rs)
 //!   │           └─ if consensus && may_stop → break
@@ -24,6 +25,7 @@ use tracing::info;
 
 use gglib_core::{AgentConfig, LlmCompletionPort, ToolExecutorPort};
 
+use super::compaction::compact_round;
 use super::config::CouncilConfig;
 use super::events::CouncilEvent;
 use super::judge::{may_stop_early, run_judge};
@@ -31,13 +33,22 @@ use super::round::{RoundContext, run_sequential_round};
 use super::state::CouncilState;
 use super::synthesis::run_synthesis;
 
-/// Runs a full council deliberation: debate rounds → optional judge → synthesis.
+/// Runs a full council deliberation: debate rounds → compaction → optional judge → synthesis.
 ///
 /// This function is the only public entry point.  It coordinates the
 /// high-level phase sequence and delegates per-agent turn execution to
-/// [`round::run_sequential_round`], optional judge evaluation to
+/// [`round::run_sequential_round`], round compaction to
+/// [`compaction::compact_round`], optional judge evaluation to
 /// [`judge::run_judge`], and the synthesis pass to
 /// [`synthesis::run_synthesis`].
+///
+/// # Round Compaction
+///
+/// After each round completes (except the most recent), the orchestrator
+/// runs a lightweight compaction pass that summarises the round's
+/// contributions into a short per-agent summary.  Subsequent agents see
+/// the compacted text instead of the full transcript, keeping context
+/// sizes manageable in long debates.
 ///
 /// # Judge + Adaptive Early Stopping
 ///
@@ -85,6 +96,11 @@ pub async fn run(
         }
 
         state.advance_round();
+
+        // ── compaction ───────────────────────────────────────────────────
+        // Summarise the just-completed round so that future agents see a
+        // compact version rather than the full transcript.
+        compact_round(round, &mut state, &llm, &tool_executor, &council_tx, &config.topic).await;
 
         // ── optional judge evaluation ────────────────────────────────────
         if let Some(ref judge_config) = config.judge {

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -121,6 +121,36 @@ single agent could provide alone.";
 
 // ─── contentiousness mapping ─────────────────────────────────────────────────
 
+/// System prompt for the post-round judge evaluation.
+///
+/// Placeholders: `{topic}`, `{round}`, `{total_rounds}`, `{transcript}`.
+///
+/// The judge must end with a `CONSENSUS_REACHED:` line.  The parser in
+/// `judge.rs` uses robust, case-insensitive matching to tolerate markdown
+/// wrapping, extra whitespace, or conversational filler.
+pub const JUDGE_PROMPT: &str = "\
+You are a neutral judge evaluating a structured multi-agent debate on the topic: \"{topic}\"
+
+This is the end of round {round} (of a maximum of {total_rounds}).
+
+DEBATE TRANSCRIPT SO FAR:
+{transcript}
+
+YOUR TASK:
+1. Summarise the current state of the debate in 2-4 sentences: what are the key positions, \
+where do agents agree, and what genuine disagreements remain?
+2. Determine whether consensus has been reached. Consensus means the agents' core positions \
+have converged to a shared conclusion — not that they agree on every detail, but that there \
+is a clear dominant answer with no substantive opposition remaining.
+
+IMPORTANT: You MUST end your response with exactly one of these two lines:
+CONSENSUS_REACHED: true
+CONSENSUS_REACHED: false
+
+Do NOT add any text after the CONSENSUS_REACHED line.";
+
+// ─── contentiousness mapping ─────────────────────────────────────────────────
+
 /// Map a contentiousness float to a discrete behavioural instruction string.
 ///
 /// Small models cannot interpret a raw float like `0.7`.  This function maps
@@ -216,5 +246,13 @@ mod tests {
     #[test]
     fn negative_contentiousness_treated_as_collaborative() {
         assert!(contentiousness_to_instruction(-0.5).contains("collaborative"));
+    }
+
+    #[test]
+    fn judge_prompt_has_placeholders() {
+        assert!(JUDGE_PROMPT.contains("{topic}"));
+        assert!(JUDGE_PROMPT.contains("{round}"));
+        assert!(JUDGE_PROMPT.contains("{total_rounds}"));
+        assert!(JUDGE_PROMPT.contains("{transcript}"));
     }
 }

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -190,6 +190,37 @@ CONSENSUS_REACHED: false
 
 Do NOT add any text after the CONSENSUS_REACHED line.";
 
+// ─── stance evaluation ───────────────────────────────────────────────────────
+
+/// System prompt for the post-debate stance evaluation pass.
+///
+/// Placeholders: `{topic}`, `{claims}`.
+///
+/// The parser in `stance.rs` expects one `STANCE(Agent Name): Held|Shifted|Conceded`
+/// line per agent.  Parsing is case-insensitive, whitespace-tolerant, and
+/// strips markdown formatting artefacts.
+pub const STANCE_PROMPT: &str = "\
+You are an impartial analyst reviewing a multi-agent debate on the topic: \"{topic}\"
+
+For each agent below you are given their INITIAL core claim (from round 1) \
+and their FINAL core claim (from the last round). Your task is to classify \
+how each agent's position evolved during the debate.
+
+{claims}
+
+For each agent, output exactly one line:
+STANCE(Agent Name): <trajectory>
+
+Where <trajectory> is one of:
+- Held — the agent's final position is substantively the same as their initial position
+- Shifted — the agent materially changed their position but did not fully adopt an opposing view
+- Conceded — the agent abandoned their initial position and adopted a substantially different or opposing view
+
+Rules:
+- Compare the MEANING of the claims, not the exact wording. Minor rephrasing is \"Held\".
+- If the initial or final claim is missing, classify as \"Held\" (insufficient evidence to judge movement).
+- Output ONLY the STANCE lines — no explanation, no commentary, no additional text.";
+
 // ─── contentiousness mapping ─────────────────────────────────────────────────
 
 /// Map a contentiousness float to a discrete behavioural instruction string.
@@ -307,5 +338,11 @@ mod tests {
     fn compaction_prompt_has_placeholders() {
         assert!(COMPACTION_PROMPT.contains("{round}"));
         assert!(COMPACTION_PROMPT.contains("{transcript}"));
+    }
+
+    #[test]
+    fn stance_prompt_has_placeholders() {
+        assert!(STANCE_PROMPT.contains("{topic}"));
+        assert!(STANCE_PROMPT.contains("{claims}"));
     }
 }

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -221,6 +221,21 @@ Rules:
 - If the initial or final claim is missing, classify as \"Held\" (insufficient evidence to judge movement).
 - Output ONLY the STANCE lines — no explanation, no commentary, no additional text.";
 
+// ─── filesystem context ──────────────────────────────────────────────────────
+
+/// Appended to the agent system prompt when a working directory is available,
+/// informing the agent about filesystem tools.
+///
+/// The `"\n\nWorking directory: {cwd}"` line is appended separately by the
+/// caller so this constant stays format-arg-free.
+///
+/// Phrasing mirrors `agent_question::SYSTEM_PROMPT` to keep tool descriptions
+/// consistent across CLI entry-points.
+pub const FILESYSTEM_TOOLS_CONTEXT: &str = "\n\n\
+You have access to filesystem tools (read_file, list_directory, grep_search) \
+scoped to the user's working directory. Use them to find evidence supporting \
+your position.";
+
 // ─── contentiousness mapping ─────────────────────────────────────────────────
 
 /// Map a contentiousness float to a discrete behavioural instruction string.

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -82,22 +82,13 @@ RULES:
 prefixed with \"CORE CLAIM:\" (e.g., \"CORE CLAIM: Microservices add more operational cost \
 than they save for teams under 20 engineers.\"). If you cannot form a single claim, omit this line.";
 
-/// Appended to the system prompt when the agent has prior rounds to respond to
-/// but no directed rebuttal target is available (no prior core claims).
-pub const DEBATE_HISTORY_SUFFIX: &str = "\n\n\
-Respond to the strongest counterarguments from previous rounds. \
-Strengthen, revise, or concede specific points.";
-
-/// Appended instead of [`DEBATE_HISTORY_SUFFIX`] when a directed rebuttal
-/// target has been selected.
-///
-/// Placeholders: `{target_name}`, `{target_claim}`.
-pub const TARGETED_REBUTTAL_CUE: &str = "\n\n\
-DIRECTED REBUTTAL: You must directly address {target_name}'s core claim: \
-\"{target_claim}\"\n\
-Explain specifically why you agree or disagree with this position from your \
-perspective. Strengthen, revise, or concede specific points — but do not \
-ignore their argument.";
+/// Appended to the system prompt when the agent has prior rounds to respond
+/// to.  Lets the agent autonomously choose which argument to rebut based on
+/// genuine conflict rather than a mechanically-assigned target.
+pub const GUIDED_REBUTTAL_CUE: &str = "\n\n\
+Review the previous round's core claims. Identify the argument that most \
+directly conflicts with your perspective and construct a focused rebuttal \
+against it. Strengthen, revise, or concede specific points.";
 
 /// Appended to the system prompt in the last debate round.
 pub const FINAL_ROUND_SUFFIX: &str = "\n\n\
@@ -344,9 +335,9 @@ mod tests {
     }
 
     #[test]
-    fn rebuttal_cue_has_placeholders() {
-        assert!(TARGETED_REBUTTAL_CUE.contains("{target_name}"));
-        assert!(TARGETED_REBUTTAL_CUE.contains("{target_claim}"));
+    fn guided_rebuttal_cue_is_non_empty() {
+        assert!(!GUIDED_REBUTTAL_CUE.is_empty());
+        assert!(GUIDED_REBUTTAL_CUE.contains("conflicts with your perspective"));
     }
 
     #[test]

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -82,10 +82,22 @@ RULES:
 prefixed with \"CORE CLAIM:\" (e.g., \"CORE CLAIM: Microservices add more operational cost \
 than they save for teams under 20 engineers.\"). If you cannot form a single claim, omit this line.";
 
-/// Appended to the system prompt when the agent has prior rounds to respond to.
+/// Appended to the system prompt when the agent has prior rounds to respond to
+/// but no directed rebuttal target is available (no prior core claims).
 pub const DEBATE_HISTORY_SUFFIX: &str = "\n\n\
 Respond to the strongest counterarguments from previous rounds. \
 Strengthen, revise, or concede specific points.";
+
+/// Appended instead of [`DEBATE_HISTORY_SUFFIX`] when a directed rebuttal
+/// target has been selected.
+///
+/// Placeholders: `{target_name}`, `{target_claim}`.
+pub const TARGETED_REBUTTAL_CUE: &str = "\n\n\
+DIRECTED REBUTTAL: You must directly address {target_name}'s core claim: \
+\"{target_claim}\"\n\
+Explain specifically why you agree or disagree with this position from your \
+perspective. Strengthen, revise, or concede specific points — but do not \
+ignore their argument.";
 
 /// Appended to the system prompt in the last debate round.
 pub const FINAL_ROUND_SUFFIX: &str = "\n\n\
@@ -254,5 +266,11 @@ mod tests {
         assert!(JUDGE_PROMPT.contains("{round}"));
         assert!(JUDGE_PROMPT.contains("{total_rounds}"));
         assert!(JUDGE_PROMPT.contains("{transcript}"));
+    }
+
+    #[test]
+    fn rebuttal_cue_has_placeholders() {
+        assert!(TARGETED_REBUTTAL_CUE.contains("{target_name}"));
+        assert!(TARGETED_REBUTTAL_CUE.contains("{target_claim}"));
     }
 }

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -82,8 +82,9 @@ RULES:
 prefixed with \"CORE CLAIM:\" (e.g., \"CORE CLAIM: Microservices add more operational cost \
 than they save for teams under 20 engineers.\"). If you cannot form a single claim, omit this line.";
 
-/// Appended to the system prompt when the agent has prior rounds to respond
-/// to.  Lets the agent autonomously choose which argument to rebut based on
+/// Appended when prior rounds exist.
+///
+/// Lets the agent autonomously choose which argument to rebut based on
 /// genuine conflict rather than a mechanically-assigned target.
 pub const GUIDED_REBUTTAL_CUE: &str = "\n\n\
 Review the previous round's core claims. Identify the argument that most \
@@ -336,7 +337,6 @@ mod tests {
 
     #[test]
     fn guided_rebuttal_cue_is_non_empty() {
-        assert!(!GUIDED_REBUTTAL_CUE.is_empty());
         assert!(GUIDED_REBUTTAL_CUE.contains("conflicts with your perspective"));
     }
 

--- a/crates/gglib-agent/src/council/prompts.rs
+++ b/crates/gglib-agent/src/council/prompts.rs
@@ -131,7 +131,36 @@ Write the synthesis as a well-structured response. Do NOT simply list each agent
 Integrate and analyze the arguments to produce a genuinely higher-quality answer than any \
 single agent could provide alone.";
 
-// ─── contentiousness mapping ─────────────────────────────────────────────────
+// ─── round compaction ────────────────────────────────────────────────────────
+
+/// System prompt for the round-compaction pass.
+///
+/// Placeholders: `{round}`, `{transcript}`.
+///
+/// Each agent's contribution must be summarised with a
+/// `SUMMARY(agent_name): ...` line.  The parser in `compaction.rs` uses
+/// robust, case-insensitive matching to tolerate markdown wrapping and
+/// extra whitespace.
+pub const COMPACTION_PROMPT: &str = "\
+You are a concise note-taker for a multi-agent debate. Your job is to compress \
+a single round of debate into a brief summary that preserves each agent's core \
+position and key evidence.
+
+ROUND {round} TRANSCRIPT:
+{transcript}
+
+YOUR TASK:
+For each agent who spoke in this round, write exactly one line:
+SUMMARY(Agent Name): 1-2 sentence summary of their position and key evidence.
+
+Rules:
+- Preserve each agent's distinct position — do NOT merge or reconcile views.
+- Include any specific evidence, data points, or examples they cited.
+- Keep each summary to 1-2 sentences maximum.
+- Do NOT add any commentary, analysis, or additional text.
+- Use the exact agent name as it appears in the transcript.";
+
+// ─── judge ───────────────────────────────────────────────────────────────────
 
 /// System prompt for the post-round judge evaluation.
 ///
@@ -272,5 +301,11 @@ mod tests {
     fn rebuttal_cue_has_placeholders() {
         assert!(TARGETED_REBUTTAL_CUE.contains("{target_name}"));
         assert!(TARGETED_REBUTTAL_CUE.contains("{target_claim}"));
+    }
+
+    #[test]
+    fn compaction_prompt_has_placeholders() {
+        assert!(COMPACTION_PROMPT.contains("{round}"));
+        assert!(COMPACTION_PROMPT.contains("{transcript}"));
     }
 }

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -89,17 +89,10 @@ async fn run_agent_turn(
         .map(|names| names.iter().cloned().collect::<HashSet<String>>());
 
     // Build the agent loop with per-agent tool restrictions.
-    let agent_loop =
-        AgentLoop::build(Arc::clone(ctx.llm), Arc::clone(ctx.tool_executor), filter);
+    let agent_loop = AgentLoop::build(Arc::clone(ctx.llm), Arc::clone(ctx.tool_executor), filter);
 
     // Assemble context with identity anchoring + debate transcript.
-    let messages = build_agent_messages(
-        agent,
-        &ctx.config.topic,
-        round,
-        ctx.config.rounds,
-        state,
-    );
+    let messages = build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state);
 
     // Delegate to AgentLoop — stagnation + loop guards are active
     // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -70,18 +70,6 @@ async fn run_agent_turn(
     ctx: &RoundContext<'_>,
     state: &mut CouncilState,
 ) -> Result<(), ()> {
-    // Announce the turn.
-    let start = CouncilEvent::AgentTurnStart {
-        agent_id: agent.id.clone(),
-        agent_name: agent.name.clone(),
-        color: agent.color.clone(),
-        round,
-        contentiousness: agent.contentiousness,
-    };
-    if ctx.council_tx.send(start).await.is_err() {
-        return Err(());
-    }
-
     // Build per-agent tool filter.
     let filter = agent
         .tool_filter
@@ -92,7 +80,22 @@ async fn run_agent_turn(
     let agent_loop = AgentLoop::build(Arc::clone(ctx.llm), Arc::clone(ctx.tool_executor), filter);
 
     // Assemble context with identity anchoring + debate transcript.
-    let messages = build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state);
+    // This also returns the rebuttal target name (if any) for the start event.
+    let (messages, rebuttal_target) =
+        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state);
+
+    // Announce the turn (after building messages so we have the rebuttal target).
+    let start = CouncilEvent::AgentTurnStart {
+        agent_id: agent.id.clone(),
+        agent_name: agent.name.clone(),
+        color: agent.color.clone(),
+        round,
+        contentiousness: agent.contentiousness,
+        rebuttal_target,
+    };
+    if ctx.council_tx.send(start).await.is_err() {
+        return Err(());
+    }
 
     // Delegate to AgentLoop — stagnation + loop guards are active
     // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -83,8 +83,14 @@ async fn run_agent_turn(
 
     // Assemble context with identity anchoring + debate transcript.
     // This also returns the rebuttal target name (if any) for the start event.
-    let (messages, rebuttal_target) =
-        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state, ctx.cwd);
+    let (messages, rebuttal_target) = build_agent_messages(
+        agent,
+        &ctx.config.topic,
+        round,
+        ctx.config.rounds,
+        state,
+        ctx.cwd,
+    );
 
     // Announce the turn (after building messages so we have the rebuttal target).
     let start = CouncilEvent::AgentTurnStart {

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -10,6 +10,7 @@
 //! - contribution recording (content + core claim extraction)
 
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -37,6 +38,7 @@ pub(super) struct RoundContext<'a> {
     pub llm: &'a Arc<dyn LlmCompletionPort>,
     pub tool_executor: &'a Arc<dyn ToolExecutorPort>,
     pub council_tx: &'a mpsc::Sender<CouncilEvent>,
+    pub cwd: Option<&'a Path>,
 }
 
 /// Execute a single debate round sequentially: each agent speaks in
@@ -82,7 +84,7 @@ async fn run_agent_turn(
     // Assemble context with identity anchoring + debate transcript.
     // This also returns the rebuttal target name (if any) for the start event.
     let (messages, rebuttal_target) =
-        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state);
+        build_agent_messages(agent, &ctx.config.topic, round, ctx.config.rounds, state, ctx.cwd);
 
     // Announce the turn (after building messages so we have the rebuttal target).
     let start = CouncilEvent::AgentTurnStart {

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -1,0 +1,143 @@
+//! Sequential round execution for a council deliberation.
+//!
+//! Each round iterates over agents in declaration order, delegating each
+//! turn to an [`AgentLoop`](crate::AgentLoop) and recording the resulting
+//! [`AgentContribution`] in the shared [`CouncilState`].
+//!
+//! This module owns:
+//! - per-agent tool filter construction
+//! - agent loop spawning + error handling
+//! - contribution recording (content + core claim extraction)
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, LlmCompletionPort, ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::{CouncilAgent, CouncilConfig};
+use super::events::CouncilEvent;
+use super::history::build_agent_messages;
+use super::state::{AgentContribution, CouncilState, extract_core_claim};
+use super::stream_bridge::{bridge_agent_events, emit_turn_complete};
+
+/// Shared, immutable context threaded through every agent turn in a round.
+///
+/// Bundles the dependencies that every turn needs so individual functions
+/// stay below the clippy `too_many_arguments` threshold.
+pub(super) struct RoundContext<'a> {
+    pub config: &'a CouncilConfig,
+    pub agent_config: &'a AgentConfig,
+    pub llm: &'a Arc<dyn LlmCompletionPort>,
+    pub tool_executor: &'a Arc<dyn ToolExecutorPort>,
+    pub council_tx: &'a mpsc::Sender<CouncilEvent>,
+}
+
+/// Execute a single debate round sequentially: each agent speaks in
+/// declaration order, receiving the full debate transcript up to this point.
+///
+/// Returns `Err(())` if the council channel is closed (caller should stop).
+pub(super) async fn run_sequential_round(
+    round: u32,
+    ctx: &RoundContext<'_>,
+    state: &mut CouncilState,
+) -> Result<(), ()> {
+    for agent in &ctx.config.agents {
+        run_agent_turn(agent, round, ctx, state).await?;
+    }
+    Ok(())
+}
+
+/// Execute a single agent's turn within a round.
+///
+/// Steps:
+/// 1. Emit `AgentTurnStart`
+/// 2. Build identity-anchored messages with debate transcript
+/// 3. Spawn `AgentLoop::run()` with per-agent tool filter
+/// 4. Bridge events from agent → council stream
+/// 5. Record contribution (content + core claim)
+///
+/// Returns `Err(())` if the council channel is closed.
+async fn run_agent_turn(
+    agent: &CouncilAgent,
+    round: u32,
+    ctx: &RoundContext<'_>,
+    state: &mut CouncilState,
+) -> Result<(), ()> {
+    // Announce the turn.
+    let start = CouncilEvent::AgentTurnStart {
+        agent_id: agent.id.clone(),
+        agent_name: agent.name.clone(),
+        color: agent.color.clone(),
+        round,
+        contentiousness: agent.contentiousness,
+    };
+    if ctx.council_tx.send(start).await.is_err() {
+        return Err(());
+    }
+
+    // Build per-agent tool filter.
+    let filter = agent
+        .tool_filter
+        .as_ref()
+        .map(|names| names.iter().cloned().collect::<HashSet<String>>());
+
+    // Build the agent loop with per-agent tool restrictions.
+    let agent_loop =
+        AgentLoop::build(Arc::clone(ctx.llm), Arc::clone(ctx.tool_executor), filter);
+
+    // Assemble context with identity anchoring + debate transcript.
+    let messages = build_agent_messages(
+        agent,
+        &ctx.config.topic,
+        round,
+        ctx.config.rounds,
+        state,
+    );
+
+    // Delegate to AgentLoop — stagnation + loop guards are active
+    // via agent_config settings (max_stagnation_steps, max_repeated_batch_steps).
+    let (agent_tx, agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+    let loop_handle = {
+        let agent_loop = Arc::clone(&agent_loop);
+        let cfg = ctx.agent_config.clone();
+        tokio::spawn(async move { agent_loop.run(messages, cfg, agent_tx).await })
+    };
+
+    // Bridge events from agent → council stream.
+    let answer = bridge_agent_events(agent, round, agent_rx, ctx.council_tx).await;
+
+    // Await the agent loop completion (the channel is already drained).
+    match loop_handle.await {
+        Ok(Ok(_output)) => {
+            debug!(agent_id = %agent.id, round, "agent turn completed normally");
+        }
+        Ok(Err(e)) => {
+            // Stagnation, loop detection, max iterations — all graceful.
+            warn!(agent_id = %agent.id, round, error = %e, "agent turn ended early");
+        }
+        Err(e) => {
+            warn!(agent_id = %agent.id, round, error = %e, "agent task panicked");
+        }
+    }
+
+    // Record the contribution (use whatever content we got).
+    let content = answer.unwrap_or_default();
+    let core_claim = extract_core_claim(&content);
+    emit_turn_complete(agent, round, &content, ctx.council_tx).await;
+
+    state.push(AgentContribution {
+        agent: agent.clone(),
+        content,
+        core_claim,
+        round,
+    });
+
+    Ok(())
+}

--- a/crates/gglib-agent/src/council/round.rs
+++ b/crates/gglib-agent/src/council/round.rs
@@ -82,8 +82,7 @@ async fn run_agent_turn(
     let agent_loop = AgentLoop::build(Arc::clone(ctx.llm), Arc::clone(ctx.tool_executor), filter);
 
     // Assemble context with identity anchoring + debate transcript.
-    // This also returns the rebuttal target name (if any) for the start event.
-    let (messages, rebuttal_target) = build_agent_messages(
+    let messages = build_agent_messages(
         agent,
         &ctx.config.topic,
         round,
@@ -92,14 +91,13 @@ async fn run_agent_turn(
         ctx.cwd,
     );
 
-    // Announce the turn (after building messages so we have the rebuttal target).
+    // Announce the turn.
     let start = CouncilEvent::AgentTurnStart {
         agent_id: agent.id.clone(),
         agent_name: agent.name.clone(),
         color: agent.color.clone(),
         round,
         contentiousness: agent.contentiousness,
-        rebuttal_target,
     };
     if ctx.council_tx.send(start).await.is_err() {
         return Err(());

--- a/crates/gglib-agent/src/council/stance.rs
+++ b/crates/gglib-agent/src/council/stance.rs
@@ -171,7 +171,10 @@ pub(super) async fn evaluate_stances(
     let pairs = gather_claim_pairs(state);
 
     // If no agent ever produced a core claim, skip entirely.
-    if pairs.iter().all(|p| p.initial.is_none() && p.r#final.is_none()) {
+    if pairs
+        .iter()
+        .all(|p| p.initial.is_none() && p.r#final.is_none())
+    {
         debug!("no core claims found — skipping stance evaluation");
         return;
     }
@@ -278,10 +281,7 @@ pub(crate) fn parse_stances(raw: &str, agent_names: &[&str]) -> StanceMap {
 
 /// Try to extract a `STANCE(Name): Trajectory` from a single line.
 fn extract_stance_line(line: &str, agent_names: &[&str]) -> Option<AgentStance> {
-    let cleaned = line
-        .trim()
-        .replace("**", "")
-        .replace(['`', '*'], "");
+    let cleaned = line.trim().replace("**", "").replace(['`', '*'], "");
     let lower = cleaned.to_lowercase();
 
     // Find "stance(" case-insensitively
@@ -293,7 +293,9 @@ fn extract_stance_line(line: &str, agent_names: &[&str]) -> Option<AgentStance> 
     let name_raw = after_paren[..close_paren].trim();
 
     // Validate the name against known agents (case-insensitive)
-    let matched_name = agent_names.iter().find(|n| n.eq_ignore_ascii_case(name_raw))?;
+    let matched_name = agent_names
+        .iter()
+        .find(|n| n.eq_ignore_ascii_case(name_raw))?;
 
     // Get the trajectory after the colon
     let rest = after_paren[close_paren + 1..].trim();
@@ -309,10 +311,7 @@ fn extract_stance_line(line: &str, agent_names: &[&str]) -> Option<AgentStance> 
 
 /// Fallback parser: `[Agent Name]: Trajectory`
 fn extract_bracket_stance(line: &str, agent_names: &[&str]) -> Option<AgentStance> {
-    let cleaned = line
-        .trim()
-        .replace("**", "")
-        .replace(['`', '*'], "");
+    let cleaned = line.trim().replace("**", "").replace(['`', '*'], "");
     let trimmed = cleaned.trim();
 
     if !trimmed.starts_with('[') {
@@ -322,7 +321,9 @@ fn extract_bracket_stance(line: &str, agent_names: &[&str]) -> Option<AgentStanc
     let close_bracket = trimmed.find(']')?;
     let name_raw = trimmed[1..close_bracket].trim();
 
-    let matched_name = agent_names.iter().find(|n| n.eq_ignore_ascii_case(name_raw))?;
+    let matched_name = agent_names
+        .iter()
+        .find(|n| n.eq_ignore_ascii_case(name_raw))?;
 
     let rest = trimmed[close_bracket + 1..].trim();
     let trajectory_str = rest.strip_prefix(':').unwrap_or(rest).trim();
@@ -621,10 +622,7 @@ STANCE(Optimist): Conceded";
 
     #[test]
     fn trajectory_shifted() {
-        assert_eq!(
-            parse_trajectory("Shifted"),
-            Some(StanceTrajectory::Shifted)
-        );
+        assert_eq!(parse_trajectory("Shifted"), Some(StanceTrajectory::Shifted));
         assert_eq!(
             parse_trajectory("shifted position"),
             Some(StanceTrajectory::Shifted)

--- a/crates/gglib-agent/src/council/stance.rs
+++ b/crates/gglib-agent/src/council/stance.rs
@@ -1,0 +1,685 @@
+//! Post-debate stance tracking — LLM-driven evaluation of how each agent's
+//! position evolved from their initial claim to their final claim.
+//!
+//! After the debate rounds complete (and before synthesis), the orchestrator
+//! calls [`evaluate_stances`] to produce a [`StanceMap`] — a per-agent
+//! classification of whether each agent **Held**, **Shifted**, or
+//! **Conceded** their original position.
+//!
+//! # DRY state
+//!
+//! This module does **not** duplicate `core_claim` data into a new index.
+//! Instead, [`gather_claim_pairs`] iterates over the existing contributions
+//! in [`CouncilState`] to extract the first and final core claims per agent.
+//!
+//! # Robust parsing
+//!
+//! The LLM's output must contain `STANCE(Agent Name): Held|Shifted|Conceded`
+//! lines.  [`parse_stances`] uses case-insensitive, whitespace-tolerant
+//! matching identical to the compaction/judge parsers — stripping markdown
+//! wrapping, normalising whitespace, and falling back gracefully when lines
+//! are unparseable.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::events::CouncilEvent;
+use super::prompts::STANCE_PROMPT;
+use super::state::CouncilState;
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+/// How an agent's position evolved during the debate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StanceTrajectory {
+    /// Position substantively unchanged from initial claim.
+    Held,
+    /// Position materially changed but not fully reversed.
+    Shifted,
+    /// Agent abandoned their initial position entirely.
+    Conceded,
+}
+
+impl StanceTrajectory {
+    /// Human-readable label for display.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Held => "Held",
+            Self::Shifted => "Shifted",
+            Self::Conceded => "Conceded",
+        }
+    }
+}
+
+/// Per-agent stance evaluation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentStance {
+    pub agent_name: String,
+    pub trajectory: StanceTrajectory,
+}
+
+/// A map of agent name → stance trajectory, ordered by insertion.
+pub type StanceMap = Vec<AgentStance>;
+
+// ─── claim pair extraction (DRY — reads from existing contributions) ─────────
+
+/// A pair of initial and final core claims for a single agent.
+#[derive(Debug)]
+pub(crate) struct ClaimPair {
+    pub agent_name: String,
+    pub initial: Option<String>,
+    pub r#final: Option<String>,
+}
+
+/// Extract the first and final core claims for each agent from the
+/// existing contributions in `state`.
+///
+/// This avoids duplicating claim data into a separate index — it scans
+/// the contributions vec directly, which is small (agents × rounds).
+#[must_use]
+pub(crate) fn gather_claim_pairs(state: &CouncilState) -> Vec<ClaimPair> {
+    // Collect unique agent names in order of first appearance.
+    let mut seen = HashSet::new();
+    let mut agent_order: Vec<String> = Vec::new();
+
+    // first claim and final claim per agent
+    let mut first: HashMap<&str, String> = HashMap::new();
+    let mut last: HashMap<&str, String> = HashMap::new();
+
+    for c in state.all_contributions() {
+        let name = c.agent.name.as_str();
+        if seen.insert(name.to_owned()) {
+            agent_order.push(name.to_owned());
+        }
+        if let Some(ref claim) = c.core_claim {
+            first.entry(name).or_insert_with(|| claim.clone());
+            last.insert(name, claim.clone());
+        }
+    }
+
+    agent_order
+        .into_iter()
+        .map(|name| {
+            let initial = first.get(name.as_str()).cloned();
+            let fin = last.get(name.as_str()).cloned();
+            ClaimPair {
+                agent_name: name,
+                initial,
+                r#final: fin,
+            }
+        })
+        .collect()
+}
+
+/// Format claim pairs into the block that gets injected into the prompt.
+fn format_claims_block(pairs: &[ClaimPair]) -> String {
+    let mut out = String::new();
+    for p in pairs {
+        let _ = writeln!(out, "Agent: {}", p.agent_name);
+        match &p.initial {
+            Some(c) => {
+                let _ = writeln!(out, "  Initial claim: \"{c}\"");
+            }
+            None => {
+                let _ = writeln!(out, "  Initial claim: (none stated)");
+            }
+        }
+        match &p.r#final {
+            Some(c) => {
+                let _ = writeln!(out, "  Final claim: \"{c}\"");
+            }
+            None => {
+                let _ = writeln!(out, "  Final claim: (none stated)");
+            }
+        }
+        let _ = writeln!(out);
+    }
+    out
+}
+
+// ─── LLM evaluation ─────────────────────────────────────────────────────────
+
+/// Run the stance evaluation pass after all debate rounds complete.
+///
+/// Makes a single bulk LLM call with all agents' initial and final claims,
+/// parses the response into a [`StanceMap`], and emits a
+/// [`CouncilEvent::StanceMap`] event.
+///
+/// If no agents have any core claims, or parsing fails entirely, the step
+/// is silently skipped — stance tracking is informational, not critical.
+pub(super) async fn evaluate_stances(
+    state: &CouncilState,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+    topic: &str,
+) {
+    let pairs = gather_claim_pairs(state);
+
+    // If no agent ever produced a core claim, skip entirely.
+    if pairs.iter().all(|p| p.initial.is_none() && p.r#final.is_none()) {
+        debug!("no core claims found — skipping stance evaluation");
+        return;
+    }
+
+    let claims_block = format_claims_block(&pairs);
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let system = STANCE_PROMPT
+        .replace("{topic}", topic)
+        .replace("{claims}", &claims_block);
+
+    let messages = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: "Evaluate how each agent's stance evolved during this debate.".into(),
+        },
+    ];
+
+    let agent = AgentLoop::build(
+        Arc::clone(llm),
+        Arc::clone(tool_executor),
+        Some(HashSet::new()),
+    );
+    let mut config = AgentConfig::default();
+    config.max_iterations = 1;
+
+    let (agent_tx, mut agent_rx) = mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    let handle = {
+        let agent = Arc::clone(&agent);
+        tokio::spawn(async move { agent.run(messages, config, agent_tx).await })
+    };
+
+    let mut content: Option<String> = None;
+    while let Some(event) = agent_rx.recv().await {
+        if let AgentEvent::FinalAnswer { content: answer } = event {
+            content = Some(answer);
+        }
+    }
+
+    let _ = handle.await;
+
+    let raw = content.unwrap_or_default();
+    if raw.is_empty() {
+        warn!("stance evaluation agent produced no output");
+        return;
+    }
+
+    let agent_names: Vec<&str> = pairs.iter().map(|p| p.agent_name.as_str()).collect();
+    let stances = parse_stances(&raw, &agent_names);
+
+    if stances.is_empty() {
+        warn!("stance evaluation produced no parseable results");
+        return;
+    }
+
+    debug!(count = stances.len(), "stance evaluation complete");
+
+    let _ = council_tx
+        .send(CouncilEvent::StanceMap {
+            stances: stances.clone(),
+        })
+        .await;
+}
+
+// ─── robust parsing ─────────────────────────────────────────────────────────
+
+/// Parse `STANCE(Agent Name): Held|Shifted|Conceded` lines from LLM output.
+///
+/// Uses the same robust techniques as `compaction::parse_compacted_summaries`:
+/// - Case-insensitive matching of the `STANCE` keyword
+/// - Strips markdown bold/backtick wrapping (`**`, `` ` ``)
+/// - Tolerates extra whitespace around the colon
+/// - Validates agent names against the known list
+/// - Falls back to `[Agent]: Trajectory` bracket format
+#[must_use]
+pub(crate) fn parse_stances(raw: &str, agent_names: &[&str]) -> StanceMap {
+    let mut results = Vec::new();
+    let mut matched_names: HashSet<String> = HashSet::new();
+
+    for line in raw.lines() {
+        if let Some(stance) = extract_stance_line(line, agent_names) {
+            let key = stance.agent_name.to_lowercase();
+            if matched_names.insert(key) {
+                results.push(stance);
+            }
+        }
+    }
+
+    // Fallback: try bracket format [Agent]: Trajectory
+    if results.is_empty() {
+        for line in raw.lines() {
+            if let Some(stance) = extract_bracket_stance(line, agent_names) {
+                let key = stance.agent_name.to_lowercase();
+                if matched_names.insert(key) {
+                    results.push(stance);
+                }
+            }
+        }
+    }
+
+    results
+}
+
+/// Try to extract a `STANCE(Name): Trajectory` from a single line.
+fn extract_stance_line(line: &str, agent_names: &[&str]) -> Option<AgentStance> {
+    let cleaned = line
+        .trim()
+        .replace("**", "")
+        .replace(['`', '*'], "");
+    let lower = cleaned.to_lowercase();
+
+    // Find "stance(" case-insensitively
+    let stance_pos = lower.find("stance(")?;
+    let after_paren = &cleaned[stance_pos + 7..]; // skip "stance(" (7 chars)
+
+    // Find the closing paren
+    let close_paren = after_paren.find(')')?;
+    let name_raw = after_paren[..close_paren].trim();
+
+    // Validate the name against known agents (case-insensitive)
+    let matched_name = agent_names.iter().find(|n| n.eq_ignore_ascii_case(name_raw))?;
+
+    // Get the trajectory after the colon
+    let rest = after_paren[close_paren + 1..].trim();
+    let trajectory_str = rest.strip_prefix(':').unwrap_or(rest).trim();
+
+    let trajectory = parse_trajectory(trajectory_str)?;
+
+    Some(AgentStance {
+        agent_name: (*matched_name).to_owned(),
+        trajectory,
+    })
+}
+
+/// Fallback parser: `[Agent Name]: Trajectory`
+fn extract_bracket_stance(line: &str, agent_names: &[&str]) -> Option<AgentStance> {
+    let cleaned = line
+        .trim()
+        .replace("**", "")
+        .replace(['`', '*'], "");
+    let trimmed = cleaned.trim();
+
+    if !trimmed.starts_with('[') {
+        return None;
+    }
+
+    let close_bracket = trimmed.find(']')?;
+    let name_raw = trimmed[1..close_bracket].trim();
+
+    let matched_name = agent_names.iter().find(|n| n.eq_ignore_ascii_case(name_raw))?;
+
+    let rest = trimmed[close_bracket + 1..].trim();
+    let trajectory_str = rest.strip_prefix(':').unwrap_or(rest).trim();
+
+    let trajectory = parse_trajectory(trajectory_str)?;
+
+    Some(AgentStance {
+        agent_name: (*matched_name).to_owned(),
+        trajectory,
+    })
+}
+
+/// Parse a trajectory keyword from text that may contain trailing prose.
+fn parse_trajectory(s: &str) -> Option<StanceTrajectory> {
+    let lower = s.to_lowercase();
+    // Check prefix to tolerate trailing explanation (e.g. "Held — position unchanged")
+    if lower.starts_with("held") {
+        Some(StanceTrajectory::Held)
+    } else if lower.starts_with("shifted") {
+        Some(StanceTrajectory::Shifted)
+    } else if lower.starts_with("conceded") {
+        Some(StanceTrajectory::Conceded)
+    } else {
+        None
+    }
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::council::config::CouncilAgent;
+    use crate::council::state::AgentContribution;
+
+    fn agent(id: &str, name: &str, contentiousness: f32) -> CouncilAgent {
+        CouncilAgent {
+            id: id.into(),
+            name: name.into(),
+            color: "#000".into(),
+            persona: "Test persona.".into(),
+            perspective: "Test perspective.".into(),
+            contentiousness,
+            tool_filter: None,
+        }
+    }
+
+    // ── gather_claim_pairs ───────────────────────────────────────────────
+
+    #[test]
+    fn gather_claims_two_rounds() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Round 0 text.\nCORE CLAIM: Monoliths are better.".into(),
+            core_claim: Some("Monoliths are better.".into()),
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Round 0 text.\nCORE CLAIM: Use what works.".into(),
+            core_claim: Some("Use what works.".into()),
+            round: 0,
+        });
+        state.advance_round();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "Round 1 text.\nCORE CLAIM: Monoliths scale better for small teams.".into(),
+            core_claim: Some("Monoliths scale better for small teams.".into()),
+            round: 1,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Round 1 text.\nCORE CLAIM: Pragmatic choice depends on team size.".into(),
+            core_claim: Some("Pragmatic choice depends on team size.".into()),
+            round: 1,
+        });
+        state.advance_round();
+
+        let pairs = gather_claim_pairs(&state);
+        assert_eq!(pairs.len(), 2);
+
+        assert_eq!(pairs[0].agent_name, "Skeptic");
+        assert_eq!(pairs[0].initial.as_deref(), Some("Monoliths are better."));
+        assert_eq!(
+            pairs[0].r#final.as_deref(),
+            Some("Monoliths scale better for small teams.")
+        );
+
+        assert_eq!(pairs[1].agent_name, "Pragmatist");
+        assert_eq!(pairs[1].initial.as_deref(), Some("Use what works."));
+        assert_eq!(
+            pairs[1].r#final.as_deref(),
+            Some("Pragmatic choice depends on team size.")
+        );
+    }
+
+    #[test]
+    fn gather_claims_missing_some() {
+        let mut state = CouncilState::new();
+        state.push(AgentContribution {
+            agent: agent("s", "Skeptic", 0.7),
+            content: "No claim here.".into(),
+            core_claim: None,
+            round: 0,
+        });
+        state.push(AgentContribution {
+            agent: agent("p", "Pragmatist", 0.3),
+            content: "Has a claim.\nCORE CLAIM: One claim only.".into(),
+            core_claim: Some("One claim only.".into()),
+            round: 0,
+        });
+        state.advance_round();
+
+        let pairs = gather_claim_pairs(&state);
+        assert_eq!(pairs.len(), 2);
+
+        // Skeptic has no claims at all
+        assert!(pairs[0].initial.is_none());
+        assert!(pairs[0].r#final.is_none());
+
+        // Pragmatist: initial == final (only one claim)
+        assert_eq!(pairs[1].initial.as_deref(), Some("One claim only."));
+        assert_eq!(pairs[1].r#final.as_deref(), Some("One claim only."));
+    }
+
+    #[test]
+    fn gather_claims_empty_state() {
+        let state = CouncilState::new();
+        let pairs = gather_claim_pairs(&state);
+        assert!(pairs.is_empty());
+    }
+
+    // ── format_claims_block ──────────────────────────────────────────────
+
+    #[test]
+    fn format_claims_block_output() {
+        let pairs = vec![
+            ClaimPair {
+                agent_name: "Skeptic".into(),
+                initial: Some("Bad idea.".into()),
+                r#final: Some("Maybe okay for small teams.".into()),
+            },
+            ClaimPair {
+                agent_name: "Optimist".into(),
+                initial: None,
+                r#final: Some("Great idea.".into()),
+            },
+        ];
+        let block = format_claims_block(&pairs);
+        assert!(block.contains("Agent: Skeptic"));
+        assert!(block.contains("Initial claim: \"Bad idea.\""));
+        assert!(block.contains("Final claim: \"Maybe okay for small teams.\""));
+        assert!(block.contains("Agent: Optimist"));
+        assert!(block.contains("Initial claim: (none stated)"));
+        assert!(block.contains("Final claim: \"Great idea.\""));
+    }
+
+    // ── parse_stances ────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_clean_output() {
+        let raw = "\
+STANCE(Skeptic): Held
+STANCE(Pragmatist): Shifted
+STANCE(Optimist): Conceded";
+        let names = ["Skeptic", "Pragmatist", "Optimist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 3);
+        assert_eq!(stances[0].agent_name, "Skeptic");
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+        assert_eq!(stances[1].agent_name, "Pragmatist");
+        assert_eq!(stances[1].trajectory, StanceTrajectory::Shifted);
+        assert_eq!(stances[2].agent_name, "Optimist");
+        assert_eq!(stances[2].trajectory, StanceTrajectory::Conceded);
+    }
+
+    #[test]
+    fn parse_with_markdown_wrapping() {
+        let raw = "**STANCE(Skeptic):** Held\n`STANCE(Pragmatist):` Shifted";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 2);
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+        assert_eq!(stances[1].trajectory, StanceTrajectory::Shifted);
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        let raw = "stance(skeptic): held\nStAnCe(Pragmatist): SHIFTED";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 2);
+        assert_eq!(stances[0].agent_name, "Skeptic"); // canonical name
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+        assert_eq!(stances[1].trajectory, StanceTrajectory::Shifted);
+    }
+
+    #[test]
+    fn parse_with_trailing_explanation() {
+        let raw = "STANCE(Skeptic): Held — position unchanged throughout\n\
+                   STANCE(Pragmatist): Shifted (moved from strong support to moderate)";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 2);
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+        assert_eq!(stances[1].trajectory, StanceTrajectory::Shifted);
+    }
+
+    #[test]
+    fn parse_extra_whitespace() {
+        let raw = "  STANCE( Skeptic )  :  Held  \n  STANCE(  Pragmatist  ):   Conceded  ";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 2);
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+        assert_eq!(stances[1].trajectory, StanceTrajectory::Conceded);
+    }
+
+    #[test]
+    fn parse_unknown_agent_ignored() {
+        let raw = "STANCE(Skeptic): Held\nSTANCE(Unknown): Shifted";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 1);
+        assert_eq!(stances[0].agent_name, "Skeptic");
+    }
+
+    #[test]
+    fn parse_invalid_trajectory_ignored() {
+        let raw = "STANCE(Skeptic): Held\nSTANCE(Pragmatist): Flipped";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 1);
+        assert_eq!(stances[0].agent_name, "Skeptic");
+    }
+
+    #[test]
+    fn parse_duplicate_agent_takes_first() {
+        let raw = "STANCE(Skeptic): Held\nSTANCE(Skeptic): Shifted";
+        let names = ["Skeptic"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 1);
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+    }
+
+    #[test]
+    fn parse_empty_input() {
+        let stances = parse_stances("", &["Skeptic"]);
+        assert!(stances.is_empty());
+    }
+
+    #[test]
+    fn parse_no_stance_lines() {
+        let raw = "The debate was interesting.\nAll agents performed well.";
+        let stances = parse_stances(raw, &["Skeptic", "Pragmatist"]);
+        assert!(stances.is_empty());
+    }
+
+    // ── bracket fallback ─────────────────────────────────────────────────
+
+    #[test]
+    fn parse_bracket_fallback() {
+        let raw = "[Skeptic]: Held\n[Pragmatist]: Conceded";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        assert_eq!(stances.len(), 2);
+        assert_eq!(stances[0].agent_name, "Skeptic");
+        assert_eq!(stances[0].trajectory, StanceTrajectory::Held);
+        assert_eq!(stances[1].trajectory, StanceTrajectory::Conceded);
+    }
+
+    #[test]
+    fn bracket_not_used_when_primary_succeeds() {
+        // Primary format succeeds for Skeptic, bracket exists for Pragmatist.
+        // But bracket is only tried when primary finds ZERO results.
+        let raw = "STANCE(Skeptic): Held\n[Pragmatist]: Conceded";
+        let names = ["Skeptic", "Pragmatist"];
+        let stances = parse_stances(raw, &names);
+        // Primary finds Skeptic → bracket not tried → Pragmatist missing
+        assert_eq!(stances.len(), 1);
+        assert_eq!(stances[0].agent_name, "Skeptic");
+    }
+
+    // ── trajectory parsing ───────────────────────────────────────────────
+
+    #[test]
+    fn trajectory_held() {
+        assert_eq!(parse_trajectory("Held"), Some(StanceTrajectory::Held));
+        assert_eq!(parse_trajectory("held"), Some(StanceTrajectory::Held));
+        assert_eq!(
+            parse_trajectory("Held — unchanged"),
+            Some(StanceTrajectory::Held)
+        );
+    }
+
+    #[test]
+    fn trajectory_shifted() {
+        assert_eq!(
+            parse_trajectory("Shifted"),
+            Some(StanceTrajectory::Shifted)
+        );
+        assert_eq!(
+            parse_trajectory("shifted position"),
+            Some(StanceTrajectory::Shifted)
+        );
+    }
+
+    #[test]
+    fn trajectory_conceded() {
+        assert_eq!(
+            parse_trajectory("Conceded"),
+            Some(StanceTrajectory::Conceded)
+        );
+        assert_eq!(
+            parse_trajectory("CONCEDED"),
+            Some(StanceTrajectory::Conceded)
+        );
+    }
+
+    #[test]
+    fn trajectory_invalid() {
+        assert_eq!(parse_trajectory("Flipped"), None);
+        assert_eq!(parse_trajectory(""), None);
+        assert_eq!(parse_trajectory("   "), None);
+    }
+
+    // ── StanceTrajectory label ───────────────────────────────────────────
+
+    #[test]
+    fn trajectory_labels() {
+        assert_eq!(StanceTrajectory::Held.label(), "Held");
+        assert_eq!(StanceTrajectory::Shifted.label(), "Shifted");
+        assert_eq!(StanceTrajectory::Conceded.label(), "Conceded");
+    }
+
+    // ── serde round-trip ─────────────────────────────────────────────────
+
+    #[test]
+    fn agent_stance_serde_round_trip() {
+        let stance = AgentStance {
+            agent_name: "Skeptic".into(),
+            trajectory: StanceTrajectory::Shifted,
+        };
+        let json = serde_json::to_string(&stance).unwrap();
+        let back: AgentStance = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.agent_name, "Skeptic");
+        assert_eq!(back.trajectory, StanceTrajectory::Shifted);
+    }
+
+    #[test]
+    fn trajectory_serializes_snake_case() {
+        let json = serde_json::to_string(&StanceTrajectory::Held).unwrap();
+        assert_eq!(json, "\"held\"");
+        let json = serde_json::to_string(&StanceTrajectory::Shifted).unwrap();
+        assert_eq!(json, "\"shifted\"");
+        let json = serde_json::to_string(&StanceTrajectory::Conceded).unwrap();
+        assert_eq!(json, "\"conceded\"");
+    }
+}

--- a/crates/gglib-agent/src/council/state.rs
+++ b/crates/gglib-agent/src/council/state.rs
@@ -4,6 +4,16 @@
 //! organised by round.  It is the single mutable data structure that the
 //! orchestrator writes to and that [`crate::council::history`] reads from
 //! when assembling per-agent context.
+//!
+//! # Round compaction
+//!
+//! After a round completes, the orchestrator may store a compacted summary
+//! via [`CouncilState::set_compacted`].  When compacted text exists for a
+//! round, the history module uses the short summary instead of the full
+//! agent contributions, keeping the context window manageable in long
+//! debates.
+
+use std::collections::HashMap;
 
 use super::config::CouncilAgent;
 
@@ -59,6 +69,11 @@ pub struct CouncilState {
     contributions: Vec<AgentContribution>,
     /// Current round (zero-indexed).
     current_round: u32,
+    /// Compacted round summaries, keyed by zero-indexed round number.
+    ///
+    /// When the history module encounters a compacted round, it uses this
+    /// summary instead of replaying all individual contributions.
+    compacted: HashMap<u32, String>,
 }
 
 impl CouncilState {
@@ -115,6 +130,26 @@ impl CouncilState {
             .map(|r| (r, self.contributions_for_round(r)))
             .filter(|(_, cs)| !cs.is_empty())
             .collect()
+    }
+
+    /// Store a compacted summary for a completed round.
+    ///
+    /// The history module will use this instead of the full contributions
+    /// when building agent context for subsequent rounds.
+    pub fn set_compacted(&mut self, round: u32, summary: String) {
+        self.compacted.insert(round, summary);
+    }
+
+    /// Retrieve the compacted summary for a round, if any.
+    #[must_use]
+    pub fn compacted_summary(&self, round: u32) -> Option<&str> {
+        self.compacted.get(&round).map(String::as_str)
+    }
+
+    /// Whether a given round has been compacted.
+    #[must_use]
+    pub fn is_compacted(&self, round: u32) -> bool {
+        self.compacted.contains_key(&round)
     }
 }
 
@@ -216,5 +251,27 @@ mod tests {
         assert_eq!(rounds[0].1.len(), 2);
         assert_eq!(rounds[1].0, 1);
         assert_eq!(rounds[1].1.len(), 1);
+    }
+
+    // ── compaction ───────────────────────────────────────────────────────
+
+    #[test]
+    fn compacted_summary_round_trip() {
+        let mut state = CouncilState::new();
+        assert!(!state.is_compacted(0));
+        assert!(state.compacted_summary(0).is_none());
+
+        state.set_compacted(0, "Round 0 summary.".into());
+        assert!(state.is_compacted(0));
+        assert_eq!(state.compacted_summary(0), Some("Round 0 summary."));
+        assert!(!state.is_compacted(1));
+    }
+
+    #[test]
+    fn compacted_overwrites_previous() {
+        let mut state = CouncilState::new();
+        state.set_compacted(0, "First.".into());
+        state.set_compacted(0, "Second.".into());
+        assert_eq!(state.compacted_summary(0), Some("Second."));
     }
 }

--- a/crates/gglib-agent/src/council/synthesis.rs
+++ b/crates/gglib-agent/src/council/synthesis.rs
@@ -89,30 +89,83 @@ pub(super) async fn run_synthesis(
     // Bridge synthesis events — map TextDelta → SynthesisTextDelta.
     let synth_content = bridge_synthesis_events(synth_agent_rx, council_tx).await;
 
-    let _ = synth_handle.await;
+    // Check for task-level failures (panic, join error).
+    match synth_handle.await {
+        Ok(Err(e)) => {
+            tracing::error!(%e, "synthesis agent loop failed");
+            // The bridge already forwarded any AgentEvent::Error, but if the
+            // task returned an error without emitting one (shouldn't happen,
+            // but defensive), emit it now.
+            if synth_content.is_none() {
+                let _ = send(
+                    council_tx,
+                    CouncilEvent::CouncilError {
+                        message: format!("Synthesis agent error: {e}"),
+                    },
+                )
+                .await;
+            }
+        }
+        Err(join_err) => {
+            tracing::error!(%join_err, "synthesis task panicked");
+            let _ = send(
+                council_tx,
+                CouncilEvent::CouncilError {
+                    message: "Synthesis task panicked".into(),
+                },
+            )
+            .await;
+        }
+        Ok(Ok(_)) => {}
+    }
 
     let content = synth_content.unwrap_or_default();
     let _ = send(council_tx, CouncilEvent::SynthesisComplete { content }).await;
     let _ = send(council_tx, CouncilEvent::CouncilComplete).await;
 }
 
-/// Bridge synthesis-phase events (only text deltas are relevant).
+/// Bridge synthesis-phase events, forwarding text deltas and errors.
 async fn bridge_synthesis_events(
     mut rx: mpsc::Receiver<AgentEvent>,
     tx: &mpsc::Sender<CouncilEvent>,
 ) -> Option<String> {
     let mut content: Option<String> = None;
+    let mut has_streamed = false;
     while let Some(event) = rx.recv().await {
         match event {
             AgentEvent::TextDelta { content: delta } => {
+                has_streamed = true;
                 let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
             }
             AgentEvent::FinalAnswer { content: answer } => {
                 content = Some(answer);
             }
+            AgentEvent::Error { message } => {
+                let _ = tx
+                    .send(CouncilEvent::CouncilError {
+                        message: format!("Synthesis failed: {message}"),
+                    })
+                    .await;
+            }
             _ => {}
         }
     }
+
+    // Safety net: if FinalAnswer arrived but no TextDelta events were
+    // streamed (e.g. non-streaming LLM response), emit the full answer
+    // as a single delta so the user sees it.
+    if !has_streamed {
+        if let Some(ref answer) = content {
+            if !answer.is_empty() {
+                let _ = tx
+                    .send(CouncilEvent::SynthesisTextDelta {
+                        delta: answer.clone(),
+                    })
+                    .await;
+            }
+        }
+    }
+
     content
 }
 

--- a/crates/gglib-agent/src/council/synthesis.rs
+++ b/crates/gglib-agent/src/council/synthesis.rs
@@ -1,0 +1,125 @@
+//! Synthesis pass for a council deliberation.
+//!
+//! After all debate rounds complete, the synthesiser builds a full debate
+//! transcript and runs a single-iteration [`AgentLoop`](crate::AgentLoop)
+//! to produce a unified answer that integrates all agent positions.
+//!
+//! This module owns:
+//! - transcript → synthesis prompt assembly
+//! - synthesis event bridging (`TextDelta` → `SynthesisTextDelta`)
+//! - `SynthesisComplete` / `CouncilComplete` emission
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use gglib_core::{
+    AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentEvent, AgentMessage, LlmCompletionPort,
+    ToolExecutorPort,
+};
+
+use crate::AgentLoop;
+
+use super::config::CouncilConfig;
+use super::events::CouncilEvent;
+use super::history::format_synthesis_transcript;
+use super::prompts::SYNTHESIS_PROMPT;
+use super::state::CouncilState;
+
+/// Run the synthesis phase: build the transcript, call a single-iteration
+/// [`AgentLoop`], and emit `SynthesisStart` / `SynthesisTextDelta` /
+/// `SynthesisComplete` / `CouncilComplete`.
+///
+/// The synthesis agent has no tool restrictions and runs for exactly one
+/// iteration — it produces a prose answer, never tool calls.
+pub(super) async fn run_synthesis(
+    config: &CouncilConfig,
+    agent_config: AgentConfig,
+    llm: &Arc<dyn LlmCompletionPort>,
+    tool_executor: &Arc<dyn ToolExecutorPort>,
+    state: &CouncilState,
+    council_tx: &mpsc::Sender<CouncilEvent>,
+) {
+    if send(council_tx, CouncilEvent::SynthesisStart)
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let transcript = format_synthesis_transcript(state);
+    let guidance = config
+        .synthesis_guidance
+        .as_deref()
+        .unwrap_or("Provide an actionable synthesis.");
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let synthesis_prompt = SYNTHESIS_PROMPT
+        .replace("{agent_count}", &config.agents.len().to_string())
+        .replace("{topic}", &config.topic)
+        .replace("{transcript}", &transcript)
+        .replace("{synthesis_guidance}", guidance);
+
+    let synth_messages = vec![
+        AgentMessage::System {
+            content: synthesis_prompt,
+        },
+        AgentMessage::User {
+            content: config.topic.clone(),
+        },
+    ];
+
+    let synth_loop = AgentLoop::build(Arc::clone(llm), Arc::clone(tool_executor), None);
+    let (synth_agent_tx, synth_agent_rx) =
+        mpsc::channel::<AgentEvent>(AGENT_EVENT_CHANNEL_CAPACITY);
+
+    // Synthesis uses a restricted config — no tools needed, single iteration.
+    let mut synth_config = agent_config;
+    synth_config.max_iterations = 1;
+
+    let synth_handle = {
+        let synth_loop = Arc::clone(&synth_loop);
+        tokio::spawn(async move {
+            synth_loop
+                .run(synth_messages, synth_config, synth_agent_tx)
+                .await
+        })
+    };
+
+    // Bridge synthesis events — map TextDelta → SynthesisTextDelta.
+    let synth_content = bridge_synthesis_events(synth_agent_rx, council_tx).await;
+
+    let _ = synth_handle.await;
+
+    let content = synth_content.unwrap_or_default();
+    let _ = send(council_tx, CouncilEvent::SynthesisComplete { content }).await;
+    let _ = send(council_tx, CouncilEvent::CouncilComplete).await;
+}
+
+/// Bridge synthesis-phase events (only text deltas are relevant).
+async fn bridge_synthesis_events(
+    mut rx: mpsc::Receiver<AgentEvent>,
+    tx: &mpsc::Sender<CouncilEvent>,
+) -> Option<String> {
+    let mut content: Option<String> = None;
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::TextDelta { content: delta } => {
+                let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
+            }
+            AgentEvent::FinalAnswer { content: answer } => {
+                content = Some(answer);
+            }
+            _ => {}
+        }
+    }
+    content
+}
+
+/// Best-effort send helper — returns `Err` when the receiver is gone.
+async fn send(
+    tx: &mpsc::Sender<CouncilEvent>,
+    event: CouncilEvent,
+) -> Result<(), mpsc::error::SendError<CouncilEvent>> {
+    tx.send(event).await
+}

--- a/crates/gglib-axum/src/handlers/council/mod.rs
+++ b/crates/gglib-axum/src/handlers/council/mod.rs
@@ -37,6 +37,7 @@ pub async fn suggest(
         state.http_client.clone(),
         req.model.clone(),
         state.mcp.clone(),
+        None,
     );
 
     // Build multi-turn refinement history when the client sends a
@@ -104,6 +105,7 @@ pub async fn run(
         state.http_client.clone(),
         req.model.clone(),
         state.mcp.clone(),
+        None,
     );
 
     let agent_config: AgentConfig = req.config.map_or_else(AgentConfig::default, Into::into);
@@ -119,6 +121,7 @@ pub async fn run(
             ports.llm,
             ports.tool_executor,
             council_tx,
+            None,
         )
         .await;
     });

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -50,6 +50,8 @@ pub enum ChatCommand {
         /// Reuse an already-running llama-server on this port (skips auto-start)
         #[arg(long)]
         port: Option<u16>,
+        #[command(flatten)]
+        context: ContextArgs,
     },
 }
 

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -74,6 +74,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                         agent_count,
                         model,
                         port,
+                        context,
                     } => {
                         if suggest {
                             handlers::council::execute_suggest(
@@ -82,6 +83,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                                 port,
                                 agent_count,
                                 model,
+                                context.ctx_size.clone(),
                             )
                             .await?;
                         } else if let Some(config_path) = config {
@@ -92,6 +94,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                                     &topic,
                                     port,
                                     model,
+                                    context.ctx_size.clone(),
                                 )
                                 .await?;
                             } else {
@@ -101,6 +104,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                                     &topic,
                                     port,
                                     model,
+                                    context.ctx_size.clone(),
                                 )
                                 .await?;
                             }
@@ -111,6 +115,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                                 port,
                                 agent_count,
                                 model,
+                                context.ctx_size,
                             )
                             .await?;
                         }

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -296,7 +296,15 @@ async fn run_with_ports(council: CouncilConfig, ports: CouncilPorts) -> Result<(
     let cwd = std::env::current_dir().ok();
 
     tokio::spawn(async move {
-        run_council(council, agent_config, ports.llm, ports.tool_executor, tx, cwd).await;
+        run_council(
+            council,
+            agent_config,
+            ports.llm,
+            ports.tool_executor,
+            tx,
+            cwd,
+        )
+        .await;
     });
 
     stream::render_council_stream(&mut rx).await;

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -248,6 +248,7 @@ async fn edit_then_run(config: &mut CouncilConfig, ports: CouncilPorts) -> Resul
                     agents: config.agents.clone(),
                     rounds: config.rounds,
                     synthesis_guidance: config.synthesis_guidance.clone(),
+                    judge: config.judge.clone(),
                 };
                 let prev_json = serde_json::to_string(&prev)?;
 

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -207,12 +207,7 @@ async fn resolve_port(
         server_config = server_config.with_reasoning_format(format);
     }
 
-    let settings = ctx
-        .app
-        .settings()
-        .get()
-        .await
-        .unwrap_or_default();
+    let settings = ctx.app.settings().get().await.unwrap_or_default();
     let context_resolution = resolve_context_size(ContextInput {
         flag: ctx_size,
         model_context_length: model_id.context_length,

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -28,7 +28,9 @@ use gglib_core::domain::agent::AgentConfig;
 use gglib_core::{AgentMessage, AssistantContent, ProcessHandle, ServerConfig};
 use gglib_runtime::CouncilPorts;
 use gglib_runtime::compose_council_ports;
-use gglib_runtime::llama::args::{resolve_jinja_flag, resolve_reasoning_format};
+use gglib_runtime::llama::args::{
+    ContextInput, resolve_context_size, resolve_jinja_flag, resolve_reasoning_format,
+};
 
 use crate::bootstrap::CliContext;
 use crate::presentation::style;
@@ -43,8 +45,9 @@ pub async fn execute_suggest(
     port: Option<u16>,
     agent_count: u32,
     model: Option<String>,
+    ctx_size: Option<String>,
 ) -> Result<()> {
-    let (ports, handle) = init_session(ctx, port, model).await?;
+    let (ports, handle) = init_session(ctx, port, model, ctx_size).await?;
     let res = suggest_council(ports.llm, ports.tool_executor, topic, agent_count, None).await;
     stop_server(ctx, &handle).await;
     let council = res?;
@@ -61,9 +64,10 @@ pub async fn execute_run(
     topic: &str,
     port: Option<u16>,
     model: Option<String>,
+    ctx_size: Option<String>,
 ) -> Result<()> {
     let config = load_config(config_path, topic)?;
-    let (ports, handle) = init_session(ctx, port, model).await?;
+    let (ports, handle) = init_session(ctx, port, model, ctx_size).await?;
     let res = run_with_ports(config, ports).await;
     stop_server(ctx, &handle).await;
     res
@@ -78,8 +82,9 @@ pub async fn execute_interactive(
     port: Option<u16>,
     agent_count: u32,
     model: Option<String>,
+    ctx_size: Option<String>,
 ) -> Result<()> {
-    let (ports, handle) = init_session(ctx, port, model).await?;
+    let (ports, handle) = init_session(ctx, port, model, ctx_size).await?;
     let suggested = suggest_council(
         Arc::clone(&ports.llm),
         Arc::clone(&ports.tool_executor),
@@ -105,9 +110,10 @@ pub async fn execute_edit(
     topic: &str,
     port: Option<u16>,
     model: Option<String>,
+    ctx_size: Option<String>,
 ) -> Result<()> {
     let mut config = load_config(config_path, topic)?;
-    let (ports, handle) = init_session(ctx, port, model).await?;
+    let (ports, handle) = init_session(ctx, port, model, ctx_size).await?;
     render::render_config(&config);
     let res = edit_then_run(&mut config, ports).await;
     stop_server(ctx, &handle).await;
@@ -123,8 +129,9 @@ async fn init_session(
     ctx: &CliContext,
     port: Option<u16>,
     model: Option<String>,
+    ctx_size: Option<String>,
 ) -> Result<(CouncilPorts, Option<ProcessHandle>)> {
-    let (resolved_port, handle) = resolve_port(ctx, port, &model).await?;
+    let (resolved_port, handle) = resolve_port(ctx, port, &model, ctx_size).await?;
 
     if let Err(e) = ctx.mcp.initialize().await {
         tracing::warn!("MCP initialisation failed: {e}");
@@ -149,6 +156,7 @@ async fn resolve_port(
     ctx: &CliContext,
     port: Option<u16>,
     model_arg: &Option<String>,
+    ctx_size: Option<String>,
 ) -> Result<(u16, Option<ProcessHandle>)> {
     if let Some(p) = port {
         return Ok((p, None));
@@ -197,6 +205,21 @@ async fn resolve_port(
     let reasoning = resolve_reasoning_format(None, &model_id.tags);
     if let Some(format) = reasoning.format {
         server_config = server_config.with_reasoning_format(format);
+    }
+
+    let settings = ctx
+        .app
+        .settings()
+        .get()
+        .await
+        .unwrap_or_default();
+    let context_resolution = resolve_context_size(ContextInput {
+        flag: ctx_size,
+        model_context_length: model_id.context_length,
+        settings_default: settings.default_context_size,
+    })?;
+    if let Some(ctx) = context_resolution.value {
+        server_config = server_config.with_context_size(u64::from(ctx));
     }
 
     style::print_info_banner("Council", "\u{1f3db}\u{fe0f}");

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -130,11 +130,14 @@ async fn init_session(
         tracing::warn!("MCP initialisation failed: {e}");
     }
 
+    let cwd = std::env::current_dir().ok();
+
     let ports = compose_council_ports(
         format!("http://127.0.0.1:{resolved_port}"),
         ctx.http_client.clone(),
         model,
         Arc::clone(&ctx.mcp),
+        cwd,
     );
     Ok((ports, handle))
 }
@@ -290,8 +293,10 @@ async fn run_with_ports(council: CouncilConfig, ports: CouncilPorts) -> Result<(
     let agent_config = AgentConfig::default();
     let (tx, mut rx) = mpsc::channel::<CouncilEvent>(COUNCIL_EVENT_CHANNEL_CAPACITY);
 
+    let cwd = std::env::current_dir().ok();
+
     tokio::spawn(async move {
-        run_council(council, agent_config, ports.llm, ports.tool_executor, tx).await;
+        run_council(council, agent_config, ports.llm, ports.tool_executor, tx, cwd).await;
     });
 
     stream::render_council_stream(&mut rx).await;

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -103,6 +103,34 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 eprintln!("\n{DIM}═══════════════════ Round {round} ═══════════════════{RESET}");
             }
 
+            CouncilEvent::JudgeStart { round } => {
+                eprintln!(
+                    "\n{DIM}── Judge evaluating round {round} ──{RESET}"
+                );
+            }
+
+            CouncilEvent::JudgeTextDelta { delta } => {
+                eprint!("{DIM}{delta}{RESET}");
+                let _ = io::stderr().flush();
+            }
+
+            CouncilEvent::JudgeSummary {
+                consensus_reached,
+                summary,
+                ..
+            } => {
+                eprintln!();
+                if consensus_reached {
+                    eprintln!(
+                        "  \x1b[32m✓{RESET}  {BOLD}Consensus reached{RESET}  {DIM}{summary}{RESET}"
+                    );
+                } else {
+                    eprintln!(
+                        "  {DIM}○  No consensus — debate continues  {summary}{RESET}"
+                    );
+                }
+            }
+
             CouncilEvent::SynthesisStart => {
                 in_synthesis = true;
                 eprintln!("\n\x1b[36m{BOLD}── Council Synthesis ──{RESET}");

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -42,12 +42,16 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 agent_name,
                 round,
                 contentiousness,
+                rebuttal_target,
                 ..
             } => {
                 let color = temperature_fg(contentiousness);
                 current_agent_color = color;
                 in_synthesis = false;
                 eprintln!("\n{color}{BOLD}── {agent_name}{RESET}  {DIM}(round {round}){RESET}");
+                if let Some(target) = rebuttal_target {
+                    eprintln!("  {DIM}↳ responding to {target}{RESET}");
+                }
             }
 
             CouncilEvent::AgentTextDelta { delta, .. } => {

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -131,6 +131,10 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 }
             }
 
+            CouncilEvent::RoundCompacted { round, .. } => {
+                eprintln!("{DIM}  ↹ Round {round} compacted{RESET}");
+            }
+
             CouncilEvent::SynthesisStart => {
                 in_synthesis = true;
                 eprintln!("\n\x1b[36m{BOLD}── Council Synthesis ──{RESET}");

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -42,16 +42,12 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 agent_name,
                 round,
                 contentiousness,
-                rebuttal_target,
                 ..
             } => {
                 let color = temperature_fg(contentiousness);
                 current_agent_color = color;
                 in_synthesis = false;
                 eprintln!("\n{color}{BOLD}── {agent_name}{RESET}  {DIM}(round {round}){RESET}");
-                if let Some(target) = rebuttal_target {
-                    eprintln!("  {DIM}↳ responding to {target}{RESET}");
-                }
             }
 
             CouncilEvent::AgentTextDelta { delta, .. } => {

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -104,9 +104,7 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
             }
 
             CouncilEvent::JudgeStart { round } => {
-                eprintln!(
-                    "\n{DIM}── Judge evaluating round {round} ──{RESET}"
-                );
+                eprintln!("\n{DIM}── Judge evaluating round {round} ──{RESET}");
             }
 
             CouncilEvent::JudgeTextDelta { delta } => {
@@ -125,9 +123,7 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                         "  \x1b[32m✓{RESET}  {BOLD}Consensus reached{RESET}  {DIM}{summary}{RESET}"
                     );
                 } else {
-                    eprintln!(
-                        "  {DIM}○  No consensus — debate continues  {summary}{RESET}"
-                    );
+                    eprintln!("  {DIM}○  No consensus — debate continues  {summary}{RESET}");
                 }
             }
 
@@ -138,7 +134,11 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
             CouncilEvent::StanceMap { stances } => {
                 eprintln!("\n{DIM}── Stance Trajectories ──{RESET}");
                 // Find the longest agent name for alignment.
-                let max_name = stances.iter().map(|s| s.agent_name.len()).max().unwrap_or(0);
+                let max_name = stances
+                    .iter()
+                    .map(|s| s.agent_name.len())
+                    .max()
+                    .unwrap_or(0);
                 for s in &stances {
                     let label = s.trajectory.label();
                     let color = match s.trajectory {

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -135,6 +135,25 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 eprintln!("{DIM}  ↹ Round {round} compacted{RESET}");
             }
 
+            CouncilEvent::StanceMap { stances } => {
+                eprintln!("\n{DIM}── Stance Trajectories ──{RESET}");
+                // Find the longest agent name for alignment.
+                let max_name = stances.iter().map(|s| s.agent_name.len()).max().unwrap_or(0);
+                for s in &stances {
+                    let label = s.trajectory.label();
+                    let color = match s.trajectory {
+                        gglib_agent::council::stance::StanceTrajectory::Held => "\x1b[32m",
+                        gglib_agent::council::stance::StanceTrajectory::Shifted => "\x1b[33m",
+                        gglib_agent::council::stance::StanceTrajectory::Conceded => "\x1b[31m",
+                    };
+                    eprintln!(
+                        "  {BOLD}{:<width$}{RESET}  {color}{label}{RESET}",
+                        s.agent_name,
+                        width = max_name,
+                    );
+                }
+            }
+
             CouncilEvent::SynthesisStart => {
                 in_synthesis = true;
                 eprintln!("\n\x1b[36m{BOLD}── Council Synthesis ──{RESET}");

--- a/crates/gglib-runtime/src/compose.rs
+++ b/crates/gglib-runtime/src/compose.rs
@@ -101,18 +101,25 @@ pub struct CouncilPorts {
 /// [`ToolExecutorPort`] separately, because
 /// [`gglib_agent::council::run_council`] creates per-agent `AgentLoop`
 /// instances internally (each with its own tool filter).
+///
+/// When `sandbox_root` is `Some`, filesystem tools (`read_file`,
+/// `list_directory`, `grep_search`) are enabled and scoped to that path.
 pub fn compose_council_ports(
     base_url: String,
     http_client: Client,
     model: Option<String>,
     mcp: Arc<McpService>,
+    sandbox_root: Option<PathBuf>,
 ) -> CouncilPorts {
     let llm: Arc<dyn LlmCompletionPort> = Arc::new(LlmCompletionAdapter::with_client(
         base_url,
         http_client,
         model,
     ));
-    let tool_executor: Arc<dyn ToolExecutorPort> = Arc::new(CombinedToolExecutor::new(mcp));
+    let tool_executor: Arc<dyn ToolExecutorPort> = match sandbox_root {
+        Some(root) => Arc::new(CombinedToolExecutor::with_sandbox(mcp, root)),
+        None => Arc::new(CombinedToolExecutor::new(mcp)),
+    };
     CouncilPorts { llm, tool_executor }
 }
 

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -41,12 +41,14 @@ mod sse_decoder;
 mod sse_parser;
 use sse_decoder::SseStreamDecoder;
 
-/// Timeout (seconds) for the `.send()` phase of each LLM request.
+/// Default timeout (seconds) for the `.send()` phase of each LLM request.
 ///
-/// Covers TCP connect + TLS handshake + HTTP response headers.  Does **not**
-/// apply to the streaming body, which can take arbitrarily long during prompt
-/// pre-fill.  Chosen conservatively; the llama-server is always local.
-const LLM_CONNECT_TIMEOUT_SECS: u64 = 30;
+/// Covers TCP connect + TLS handshake + HTTP response headers.  Because
+/// llama-server does not send response headers until prompt pre-fill
+/// completes, this effectively caps time-to-first-token.  Large prompts
+/// (e.g. council synthesis transcripts) can require significant pre-fill
+/// time, so the default is generous.
+const DEFAULT_SEND_TIMEOUT_SECS: u64 = 120;
 
 // =============================================================================
 // Adapter struct
@@ -69,6 +71,9 @@ pub struct LlmCompletionAdapter {
     client: Client,
     /// Optional sampling overrides injected into every request body.
     sampling: Option<InferenceConfig>,
+    /// Timeout (seconds) for the `.send()` phase (connect through response
+    /// headers).  Defaults to [`DEFAULT_SEND_TIMEOUT_SECS`].
+    send_timeout_secs: u64,
 }
 
 /// Build the completions endpoint URL from a base URL.
@@ -116,6 +121,7 @@ impl LlmCompletionAdapter {
             model: model.unwrap_or_default(),
             client,
             sampling: None,
+            send_timeout_secs: DEFAULT_SEND_TIMEOUT_SECS,
         }
     }
 
@@ -123,6 +129,14 @@ impl LlmCompletionAdapter {
     #[must_use]
     pub fn with_sampling(mut self, sampling: Option<InferenceConfig>) -> Self {
         self.sampling = sampling;
+        self
+    }
+
+    /// Override the send-phase timeout (connect through first response
+    /// headers).  The default is [`DEFAULT_SEND_TIMEOUT_SECS`] (120 s).
+    #[must_use]
+    pub fn with_send_timeout(mut self, secs: u64) -> Self {
+        self.send_timeout_secs = secs;
         self
     }
 }
@@ -245,17 +259,18 @@ impl LlmCompletionPort for LlmCompletionAdapter {
         }
 
         // Gate the connect + first-byte phase with a hard timeout so a
-        // stalled or slow llama-server doesn’t hang the agent task
-        // indefinitely.  The timeout covers only `.send()` (connect through
-        // HTTP response headers); subsequent streaming body reads are not
-        // gated here because prompt pre-fill can be arbitrarily long.
+        // stalled or unresponsive llama-server doesn't hang the agent task
+        // indefinitely.  The timeout covers `.send()` — TCP connect through
+        // HTTP response headers — which includes prompt pre-fill because
+        // llama-server doesn't send headers until pre-fill finishes.
+        let timeout_secs = self.send_timeout_secs;
         let response = tokio::time::timeout(
-            std::time::Duration::from_secs(LLM_CONNECT_TIMEOUT_SECS),
+            std::time::Duration::from_secs(timeout_secs),
             self.client.post(&self.url).json(&body).send(),
         )
         .await
         .map_err(|_| {
-            anyhow!("llama-server connection timed out after {LLM_CONNECT_TIMEOUT_SECS}s")
+            anyhow!("llama-server connection timed out after {timeout_secs}s")
         })?
         .map_err(|e| anyhow!("request to llama-server failed: {e}"))?;
 

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -269,9 +269,7 @@ impl LlmCompletionPort for LlmCompletionAdapter {
             self.client.post(&self.url).json(&body).send(),
         )
         .await
-        .map_err(|_| {
-            anyhow!("llama-server connection timed out after {timeout_secs}s")
-        })?
+        .map_err(|_| anyhow!("llama-server connection timed out after {timeout_secs}s"))?
         .map_err(|e| anyhow!("request to llama-server failed: {e}"))?;
 
         if !response.status().is_success() {

--- a/src/components/Council/Messages/CompactionNotice.tsx
+++ b/src/components/Council/Messages/CompactionNotice.tsx
@@ -1,0 +1,29 @@
+/**
+ * Renders a compaction notice in the council thread.
+ *
+ * Lightweight system-level notification indicating that a round's
+ * full transcript was replaced by a summary to keep the context
+ * window manageable.
+ *
+ * @module components/Council/Messages/CompactionNotice
+ */
+
+import type { FC } from 'react';
+import { Minimize2 } from 'lucide-react';
+import { Icon } from '../../ui/Icon';
+
+export interface CompactionNoticeProps {
+  round: number;
+  summary: string;
+}
+
+export const CompactionNotice: FC<CompactionNoticeProps> = ({ round, summary }) => (
+  <div className="flex items-start gap-sm px-md py-sm text-xs text-text-muted">
+    <Icon icon={Minimize2} size={12} className="mt-[2px] shrink-0 opacity-60" />
+    <div>
+      <span className="font-medium">Round {round + 1} compacted</span>
+      <span className="mx-[4px]">—</span>
+      <span className="italic">{summary}</span>
+    </div>
+  </div>
+);

--- a/src/components/Council/Messages/CouncilMessage.tsx
+++ b/src/components/Council/Messages/CouncilMessage.tsx
@@ -69,7 +69,6 @@ export interface CouncilMessageProps {
     text: string;
     reasoning: string;
     toolCalls: AgentToolCall[];
-    rebuttalTarget?: string;
   };
 }
 
@@ -82,7 +81,6 @@ export const CouncilMessage: FC<CouncilMessageProps> = ({ contribution, streamin
   const reasoning = streaming?.reasoning ?? '';
   const toolCalls = streaming?.toolCalls ?? [];
   const coreClaim = contribution?.coreClaim;
-  const rebuttalTarget = contribution?.rebuttalTarget ?? streaming?.rebuttalTarget;
   const isStreaming = !!streaming;
 
   return (
@@ -106,11 +104,6 @@ export const CouncilMessage: FC<CouncilMessageProps> = ({ contribution, streamin
         <span className="text-sm font-semibold text-text">{source.agentName}</span>
         {contribution && (
           <span className="text-xs text-text-muted">Round {contribution.round + 1}</span>
-        )}
-        {rebuttalTarget && (
-          <span className="text-xs text-text-secondary italic">
-            ↳ responding to {rebuttalTarget}
-          </span>
         )}
       </div>
 

--- a/src/components/Council/Messages/CouncilMessage.tsx
+++ b/src/components/Council/Messages/CouncilMessage.tsx
@@ -69,6 +69,7 @@ export interface CouncilMessageProps {
     text: string;
     reasoning: string;
     toolCalls: AgentToolCall[];
+    rebuttalTarget?: string;
   };
 }
 
@@ -81,6 +82,7 @@ export const CouncilMessage: FC<CouncilMessageProps> = ({ contribution, streamin
   const reasoning = streaming?.reasoning ?? '';
   const toolCalls = streaming?.toolCalls ?? [];
   const coreClaim = contribution?.coreClaim;
+  const rebuttalTarget = contribution?.rebuttalTarget ?? streaming?.rebuttalTarget;
   const isStreaming = !!streaming;
 
   return (
@@ -104,6 +106,11 @@ export const CouncilMessage: FC<CouncilMessageProps> = ({ contribution, streamin
         <span className="text-sm font-semibold text-text">{source.agentName}</span>
         {contribution && (
           <span className="text-xs text-text-muted">Round {contribution.round + 1}</span>
+        )}
+        {rebuttalTarget && (
+          <span className="text-xs text-text-secondary italic">
+            ↳ responding to {rebuttalTarget}
+          </span>
         )}
       </div>
 

--- a/src/components/Council/Messages/CouncilThread.tsx
+++ b/src/components/Council/Messages/CouncilThread.tsx
@@ -252,7 +252,6 @@ export const CouncilThread: FC<CouncilThreadProps> = ({
                   text: session.activeAgentText,
                   reasoning: session.activeAgentReasoning,
                   toolCalls: session.activeToolCalls,
-                  rebuttalTarget: session.activeRebuttalTarget,
                 }}
               />
             );

--- a/src/components/Council/Messages/CouncilThread.tsx
+++ b/src/components/Council/Messages/CouncilThread.tsx
@@ -15,6 +15,9 @@ import { type FC, useMemo, useRef } from 'react';
 import { useCouncilContext } from '../../../contexts/CouncilContext';
 import type { CouncilAgent, CouncilConfig } from '../../../types/council';
 import { CouncilMessage } from './CouncilMessage';
+import { JudgeMessage } from './JudgeMessage';
+import { StanceTable } from './StanceTable';
+import { CompactionNotice } from './CompactionNotice';
 import { SynthesisMessage } from './SynthesisMessage';
 import { RoundSeparator } from './RoundSeparator';
 import { CouncilSetupPanel } from '../Setup/CouncilSetupPanel';
@@ -32,6 +35,10 @@ export interface CouncilThreadProps {
 type ThreadItem =
   | { kind: 'round'; round: number }
   | { kind: 'contribution'; index: number }
+  | { kind: 'judge'; assessmentIndex: number }
+  | { kind: 'judge-streaming' }
+  | { kind: 'stances' }
+  | { kind: 'compacted'; compactedIndex: number }
   | { kind: 'streaming' }
   | { kind: 'synthesis' };
 
@@ -74,13 +81,48 @@ export const CouncilThread: FC<CouncilThreadProps> = ({
     const result: ThreadItem[] = [];
     let lastRound = -1;
 
+    // Lookup maps for post-round items
+    const judgeByRound = new Map(session.judgeAssessments.map((a, i) => [a.round, i]));
+    const compactedByRound = new Map(session.compactedRounds.map((c, i) => [c.round, i]));
+    const lastJudgeRound = session.judgeAssessments.length > 0
+      ? session.judgeAssessments[session.judgeAssessments.length - 1].round
+      : -1;
+
+    const pushPostRound = (round: number) => {
+      const jIdx = judgeByRound.get(round);
+      if (jIdx !== undefined) {
+        result.push({ kind: 'judge', assessmentIndex: jIdx });
+        // Show stances after the most recent completed judge
+        if (round === lastJudgeRound && session.stances.length > 0) {
+          result.push({ kind: 'stances' });
+        }
+      }
+      const cIdx = compactedByRound.get(round);
+      if (cIdx !== undefined) {
+        result.push({ kind: 'compacted', compactedIndex: cIdx });
+      }
+    };
+
     for (let i = 0; i < session.contributions.length; i++) {
       const c = session.contributions[i];
       if (c.round !== lastRound) {
+        // Inject post-round items for the previous round before starting a new one
+        if (lastRound >= 0) pushPostRound(lastRound);
         result.push({ kind: 'round', round: c.round });
         lastRound = c.round;
       }
       result.push({ kind: 'contribution', index: i });
+    }
+
+    // Post-round items for the final round of contributions
+    if (lastRound >= 0) pushPostRound(lastRound);
+
+    // Streaming judge evaluation
+    if (session.phase === 'judging') {
+      result.push({ kind: 'judge-streaming' });
+      if (session.stances.length > 0) {
+        result.push({ kind: 'stances' });
+      }
     }
 
     // Active streaming turn
@@ -97,7 +139,11 @@ export const CouncilThread: FC<CouncilThreadProps> = ({
     }
 
     return result;
-  }, [session.contributions, session.activeAgentId, session.currentRound, session.phase]);
+  }, [
+    session.contributions, session.activeAgentId, session.currentRound,
+    session.phase, session.judgeAssessments, session.stances,
+    session.compactedRounds,
+  ]);
 
   // Idle phase: nothing to render
   if (session.phase === 'idle') {
@@ -206,9 +252,43 @@ export const CouncilThread: FC<CouncilThreadProps> = ({
                   text: session.activeAgentText,
                   reasoning: session.activeAgentReasoning,
                   toolCalls: session.activeToolCalls,
+                  rebuttalTarget: session.activeRebuttalTarget,
                 }}
               />
             );
+
+          case 'judge': {
+            const a = session.judgeAssessments[item.assessmentIndex];
+            return (
+              <JudgeMessage
+                key={`judge-${a.round}`}
+                assessment={a}
+              />
+            );
+          }
+
+          case 'judge-streaming':
+            return (
+              <JudgeMessage
+                key="judge-streaming"
+                streamingText={session.activeJudgeText}
+                streamingRound={session.activeJudgeRound}
+              />
+            );
+
+          case 'stances':
+            return <StanceTable key={`stances-${session.stances.length}`} stances={session.stances} />;
+
+          case 'compacted': {
+            const cr = session.compactedRounds[item.compactedIndex];
+            return (
+              <CompactionNotice
+                key={`compacted-${cr.round}`}
+                round={cr.round}
+                summary={cr.summary}
+              />
+            );
+          }
 
           case 'synthesis':
             return (

--- a/src/components/Council/Messages/HistoricalCouncilThread.tsx
+++ b/src/components/Council/Messages/HistoricalCouncilThread.tsx
@@ -11,6 +11,9 @@
 import { type FC, useMemo } from 'react';
 import type { SerializableCouncilSession } from '../../../types/council';
 import { CouncilMessage } from './CouncilMessage';
+import { JudgeMessage } from './JudgeMessage';
+import { StanceTable } from './StanceTable';
+import { CompactionNotice } from './CompactionNotice';
 import { SynthesisMessage } from './SynthesisMessage';
 import { RoundSeparator } from './RoundSeparator';
 
@@ -21,6 +24,9 @@ export interface HistoricalCouncilThreadProps {
 type ThreadItem =
   | { kind: 'round'; round: number }
   | { kind: 'contribution'; index: number }
+  | { kind: 'judge'; assessmentIndex: number }
+  | { kind: 'stances' }
+  | { kind: 'compacted'; compactedIndex: number }
   | { kind: 'synthesis' };
 
 export const HistoricalCouncilThread: FC<HistoricalCouncilThreadProps> = ({ session }) => {
@@ -28,21 +34,44 @@ export const HistoricalCouncilThread: FC<HistoricalCouncilThreadProps> = ({ sess
     const result: ThreadItem[] = [];
     let lastRound = -1;
 
+    const judges = session.judgeAssessments ?? [];
+    const compacted = session.compactedRounds ?? [];
+    const judgeByRound = new Map(judges.map((a, i) => [a.round, i]));
+    const compactedByRound = new Map(compacted.map((c, i) => [c.round, i]));
+    const lastJudgeRound = judges.length > 0 ? judges[judges.length - 1].round : -1;
+
+    const pushPostRound = (round: number) => {
+      const jIdx = judgeByRound.get(round);
+      if (jIdx !== undefined) {
+        result.push({ kind: 'judge', assessmentIndex: jIdx });
+        if (round === lastJudgeRound && (session.stances?.length ?? 0) > 0) {
+          result.push({ kind: 'stances' });
+        }
+      }
+      const cIdx = compactedByRound.get(round);
+      if (cIdx !== undefined) {
+        result.push({ kind: 'compacted', compactedIndex: cIdx });
+      }
+    };
+
     for (let i = 0; i < session.contributions.length; i++) {
       const c = session.contributions[i];
       if (c.round !== lastRound) {
+        if (lastRound >= 0) pushPostRound(lastRound);
         result.push({ kind: 'round', round: c.round });
         lastRound = c.round;
       }
       result.push({ kind: 'contribution', index: i });
     }
 
+    if (lastRound >= 0) pushPostRound(lastRound);
+
     if (session.synthesisText) {
       result.push({ kind: 'synthesis' });
     }
 
     return result;
-  }, [session.contributions, session.synthesisText]);
+  }, [session]);
 
   if (items.length === 0 && session.error) {
     return (
@@ -64,6 +93,29 @@ export const HistoricalCouncilThread: FC<HistoricalCouncilThreadProps> = ({ sess
               <CouncilMessage
                 key={`contrib-${c.agentId}-${c.round}`}
                 contribution={c}
+              />
+            );
+          }
+          case 'judge': {
+            const judges = session.judgeAssessments ?? [];
+            const a = judges[item.assessmentIndex];
+            return (
+              <JudgeMessage
+                key={`judge-${a.round}`}
+                assessment={a}
+              />
+            );
+          }
+          case 'stances':
+            return <StanceTable key="stances" stances={session.stances ?? []} />;
+          case 'compacted': {
+            const compacted = session.compactedRounds ?? [];
+            const cr = compacted[item.compactedIndex];
+            return (
+              <CompactionNotice
+                key={`compacted-${cr.round}`}
+                round={cr.round}
+                summary={cr.summary}
               />
             );
           }

--- a/src/components/Council/Messages/JudgeMessage.tsx
+++ b/src/components/Council/Messages/JudgeMessage.tsx
@@ -1,0 +1,76 @@
+/**
+ * Renders a judge assessment in the council thread.
+ *
+ * Amber/gold accent to distinguish from agent turns and synthesis.
+ * Supports both streaming (live `activeText`) and completed states
+ * (from `JudgeAssessment`). Shows consensus/continue badge.
+ *
+ * @module components/Council/Messages/JudgeMessage
+ */
+
+import type { FC } from 'react';
+import { Gavel } from 'lucide-react';
+import type { JudgeAssessment } from '../../../types/council';
+import { cn } from '../../../utils/cn';
+import { Icon } from '../../ui/Icon';
+import MarkdownMessageContent from '../../ChatMessagesPanel/components/MarkdownMessageContent';
+
+export interface JudgeMessageProps {
+  /** Completed assessment (for finished evaluations). */
+  assessment?: JudgeAssessment;
+  /** Live-streaming text (for the active judge turn). */
+  streamingText?: string;
+  /** Round being evaluated (used during streaming). */
+  streamingRound?: number;
+}
+
+export const JudgeMessage: FC<JudgeMessageProps> = ({
+  assessment,
+  streamingText,
+  streamingRound,
+}) => {
+  const text = assessment?.summary ?? streamingText ?? '';
+  const round = assessment?.round ?? streamingRound;
+  const isStreaming = !assessment && streamingText !== undefined;
+  const consensusReached = assessment?.consensusReached;
+
+  return (
+    <div
+      className={cn(
+        'rounded-base border-l-[3px] p-md transition-colors duration-200',
+        'bg-[color-mix(in_srgb,#d97706_6%,var(--color-surface))]',
+        'border-[color-mix(in_srgb,#d97706_40%,transparent)]',
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-sm mb-sm">
+        <span className="w-6 h-6 rounded-full flex items-center justify-center bg-amber-600/20 shrink-0">
+          <Icon icon={Gavel} size={14} className="text-amber-600" />
+        </span>
+        <span className="text-sm font-semibold text-amber-600">Judge</span>
+        {round !== undefined && (
+          <span className="text-xs text-text-muted">Round {round + 1}</span>
+        )}
+        {consensusReached !== undefined && (
+          <span
+            className={cn(
+              'ml-auto text-xs font-medium px-sm py-[1px] rounded-full',
+              consensusReached
+                ? 'bg-success/15 text-success'
+                : 'bg-warning/15 text-warning',
+            )}
+          >
+            {consensusReached ? 'Consensus' : 'Continue'}
+          </span>
+        )}
+      </div>
+
+      {/* Content */}
+      {text ? (
+        <MarkdownMessageContent text={text} />
+      ) : isStreaming ? (
+        <span className="text-sm text-text-muted animate-pulse">Evaluating…</span>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/Council/Messages/StanceTable.tsx
+++ b/src/components/Council/Messages/StanceTable.tsx
@@ -1,0 +1,49 @@
+/**
+ * Renders the stance trajectory table after a round's judge evaluation.
+ *
+ * Shows each agent's stance (held / shifted / conceded) as a compact
+ * row with a colour-coded badge. Designed to sit between the judge
+ * assessment and the next round separator.
+ *
+ * @module components/Council/Messages/StanceTable
+ */
+
+import type { FC } from 'react';
+import type { AgentStance, StanceTrajectory } from '../../../types/council';
+import { cn } from '../../../utils/cn';
+
+export interface StanceTableProps {
+  stances: AgentStance[];
+}
+
+const trajectoryConfig: Record<StanceTrajectory, { label: string; className: string }> = {
+  held:     { label: 'Held',     className: 'bg-sky-500/15 text-sky-600' },
+  shifted:  { label: 'Shifted',  className: 'bg-amber-500/15 text-amber-600' },
+  conceded: { label: 'Conceded', className: 'bg-rose-500/15 text-rose-600' },
+};
+
+export const StanceTable: FC<StanceTableProps> = ({ stances }) => {
+  if (stances.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-sm px-md py-xs">
+      <span className="text-xs font-medium text-text-muted">Stances:</span>
+      {stances.map((s) => {
+        const cfg = trajectoryConfig[s.trajectory];
+        return (
+          <span
+            key={s.agent_name}
+            className={cn(
+              'inline-flex items-center gap-[4px] text-xs px-sm py-[1px] rounded-full font-medium',
+              cfg.className,
+            )}
+          >
+            {s.agent_name}
+            <span className="opacity-70">·</span>
+            {cfg.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -32,6 +32,9 @@ export type CouncilAction =
   | { type: 'AGENT_TOOL_CALL_COMPLETE'; agentId: string; toolName: string; result: { content: string; isError: boolean }; displayName: string; durationDisplay: string }
   | { type: 'AGENT_TURN_COMPLETE'; contribution: AgentContribution }
   | { type: 'ROUND_SEPARATOR'; round: number }
+  | { type: 'JUDGE_START'; round: number }
+  | { type: 'JUDGE_TEXT_DELTA'; delta: string }
+  | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
@@ -125,6 +128,20 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
 
     case 'ROUND_SEPARATOR':
       return { ...state, currentRound: action.round };
+
+    case 'JUDGE_START':
+      return { ...state, phase: 'judging', judgeText: '' };
+
+    case 'JUDGE_TEXT_DELTA':
+      return { ...state, judgeText: state.judgeText + action.delta };
+
+    case 'JUDGE_SUMMARY':
+      return {
+        ...state,
+        phase: 'deliberating',
+        judgeSummary: action.summary,
+        judgeConsensusReached: action.consensusReached,
+      };
 
     case 'SYNTHESIS_START':
       return { ...state, phase: 'synthesizing', synthesisText: '' };

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -36,6 +36,7 @@ export type CouncilAction =
   | { type: 'JUDGE_TEXT_DELTA'; delta: string }
   | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
   | { type: 'ROUND_COMPACTED'; round: number; summary: string }
+  | { type: 'STANCE_MAP'; stances: import('./types/council').AgentStance[] }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
@@ -146,6 +147,10 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
 
     case 'ROUND_COMPACTED':
       // Informational only — no state change needed for the UI.
+      return state;
+
+    case 'STANCE_MAP':
+      // Informational only — stances are rendered from the event stream.
       return state;
 
     case 'SYNTHESIS_START':

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -26,7 +26,7 @@ export type CouncilAction =
   | { type: 'SUGGEST_COMPLETE'; agents: CouncilAgent[]; rounds: number; synthesisGuidance?: string }
   | { type: 'SUGGEST_ERROR'; error: string }
   | { type: 'START_DELIBERATION'; topic: string; totalRounds: number }
-  | { type: 'AGENT_TURN_START'; agentId: string; agentName: string; color: string; round: number; contentiousness: number; rebuttalTarget?: string }
+  | { type: 'AGENT_TURN_START'; agentId: string; agentName: string; color: string; round: number; contentiousness: number }
   | { type: 'AGENT_TEXT_DELTA'; agentId: string; delta: string }
   | { type: 'AGENT_REASONING_DELTA'; agentId: string; delta: string }
   | { type: 'AGENT_TOOL_CALL_START'; toolCall: AgentToolCall }
@@ -92,7 +92,6 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         activeAgentText: '',
         activeAgentReasoning: '',
         activeToolCalls: [],
-        activeRebuttalTarget: action.rebuttalTarget,
         currentRound: action.round,
       };
 
@@ -118,10 +117,6 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
       };
 
     case 'AGENT_TURN_COMPLETE': {
-      const enriched: AgentContribution = {
-        ...action.contribution,
-        rebuttalTarget: action.contribution.rebuttalTarget ?? state.activeRebuttalTarget,
-      };
       return {
         ...state,
         activeAgentId: null,
@@ -131,8 +126,7 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         activeAgentText: '',
         activeAgentReasoning: '',
         activeToolCalls: [],
-        activeRebuttalTarget: undefined,
-        contributions: [...state.contributions, enriched],
+        contributions: [...state.contributions, action.contribution],
       };
     }
 

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -35,6 +35,7 @@ export type CouncilAction =
   | { type: 'JUDGE_START'; round: number }
   | { type: 'JUDGE_TEXT_DELTA'; delta: string }
   | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
+  | { type: 'ROUND_COMPACTED'; round: number; summary: string }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
@@ -142,6 +143,10 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         judgeSummary: action.summary,
         judgeConsensusReached: action.consensusReached,
       };
+
+    case 'ROUND_COMPACTED':
+      // Informational only — no state change needed for the UI.
+      return state;
 
     case 'SYNTHESIS_START':
       return { ...state, phase: 'synthesizing', synthesisText: '' };

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -15,6 +15,7 @@ import {
   type CouncilAgent,
   type AgentContribution,
   type AgentToolCall,
+  type AgentStance,
 } from '../types/council';
 
 // ─── Actions ────────────────────────────────────────────────────────────────
@@ -25,7 +26,7 @@ export type CouncilAction =
   | { type: 'SUGGEST_COMPLETE'; agents: CouncilAgent[]; rounds: number; synthesisGuidance?: string }
   | { type: 'SUGGEST_ERROR'; error: string }
   | { type: 'START_DELIBERATION'; topic: string; totalRounds: number }
-  | { type: 'AGENT_TURN_START'; agentId: string; agentName: string; color: string; round: number; contentiousness: number }
+  | { type: 'AGENT_TURN_START'; agentId: string; agentName: string; color: string; round: number; contentiousness: number; rebuttalTarget?: string }
   | { type: 'AGENT_TEXT_DELTA'; agentId: string; delta: string }
   | { type: 'AGENT_REASONING_DELTA'; agentId: string; delta: string }
   | { type: 'AGENT_TOOL_CALL_START'; toolCall: AgentToolCall }
@@ -36,7 +37,7 @@ export type CouncilAction =
   | { type: 'JUDGE_TEXT_DELTA'; delta: string }
   | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
   | { type: 'ROUND_COMPACTED'; round: number; summary: string }
-  | { type: 'STANCE_MAP'; stances: import('../types/council').AgentStance[] }
+  | { type: 'STANCE_MAP'; stances: AgentStance[] }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
@@ -91,6 +92,7 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         activeAgentText: '',
         activeAgentReasoning: '',
         activeToolCalls: [],
+        activeRebuttalTarget: action.rebuttalTarget,
         currentRound: action.round,
       };
 
@@ -115,7 +117,11 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         ),
       };
 
-    case 'AGENT_TURN_COMPLETE':
+    case 'AGENT_TURN_COMPLETE': {
+      const enriched: AgentContribution = {
+        ...action.contribution,
+        rebuttalTarget: action.contribution.rebuttalTarget ?? state.activeRebuttalTarget,
+      };
       return {
         ...state,
         activeAgentId: null,
@@ -125,33 +131,42 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
         activeAgentText: '',
         activeAgentReasoning: '',
         activeToolCalls: [],
-        contributions: [...state.contributions, action.contribution],
+        activeRebuttalTarget: undefined,
+        contributions: [...state.contributions, enriched],
       };
+    }
 
     case 'ROUND_SEPARATOR':
       return { ...state, currentRound: action.round };
 
     case 'JUDGE_START':
-      return { ...state, phase: 'judging', judgeText: '' };
+      return { ...state, phase: 'judging', activeJudgeText: '', activeJudgeRound: action.round };
 
     case 'JUDGE_TEXT_DELTA':
-      return { ...state, judgeText: state.judgeText + action.delta };
+      return { ...state, activeJudgeText: state.activeJudgeText + action.delta };
 
     case 'JUDGE_SUMMARY':
       return {
         ...state,
         phase: 'deliberating',
-        judgeSummary: action.summary,
-        judgeConsensusReached: action.consensusReached,
+        judgeAssessments: [
+          ...state.judgeAssessments,
+          { round: action.round, summary: action.summary, consensusReached: action.consensusReached },
+        ],
+        activeJudgeText: '',
       };
 
     case 'ROUND_COMPACTED':
-      // Informational only — no state change needed for the UI.
-      return state;
+      return {
+        ...state,
+        compactedRounds: [
+          ...state.compactedRounds,
+          { round: action.round, summary: action.summary },
+        ],
+      };
 
     case 'STANCE_MAP':
-      // Informational only — stances are rendered from the event stream.
-      return state;
+      return { ...state, stances: action.stances };
 
     case 'SYNTHESIS_START':
       return { ...state, phase: 'synthesizing', synthesisText: '' };

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -36,7 +36,7 @@ export type CouncilAction =
   | { type: 'JUDGE_TEXT_DELTA'; delta: string }
   | { type: 'JUDGE_SUMMARY'; round: number; summary: string; consensusReached: boolean }
   | { type: 'ROUND_COMPACTED'; round: number; summary: string }
-  | { type: 'STANCE_MAP'; stances: import('./types/council').AgentStance[] }
+  | { type: 'STANCE_MAP'; stances: import('../types/council').AgentStance[] }
   | { type: 'SYNTHESIS_START' }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -97,6 +97,17 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
       };
     case 'round_separator':
       return { type: 'ROUND_SEPARATOR', round: event.round };
+    case 'judge_start':
+      return { type: 'JUDGE_START', round: event.round };
+    case 'judge_text_delta':
+      return { type: 'JUDGE_TEXT_DELTA', delta: event.delta };
+    case 'judge_summary':
+      return {
+        type: 'JUDGE_SUMMARY',
+        round: event.round,
+        summary: event.summary,
+        consensusReached: event.consensus_reached,
+      };
     case 'synthesis_start':
       return { type: 'SYNTHESIS_START' };
     case 'synthesis_text_delta':

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -58,7 +58,6 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
         color: event.color,
         round: event.round,
         contentiousness: event.contentiousness,
-        rebuttalTarget: event.rebuttal_target,
       };
     case 'agent_text_delta':
       return { type: 'AGENT_TEXT_DELTA', agentId: event.agent_id, delta: event.delta };

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -108,6 +108,8 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
         summary: event.summary,
         consensusReached: event.consensus_reached,
       };
+    case 'round_compacted':
+      return { type: 'ROUND_COMPACTED', round: event.round, summary: event.summary };
     case 'synthesis_start':
       return { type: 'SYNTHESIS_START' };
     case 'synthesis_text_delta':

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -110,6 +110,8 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
       };
     case 'round_compacted':
       return { type: 'ROUND_COMPACTED', round: event.round, summary: event.summary };
+    case 'stance_map':
+      return { type: 'STANCE_MAP', stances: event.stances };
     case 'synthesis_start':
       return { type: 'SYNTHESIS_START' };
     case 'synthesis_text_delta':

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -58,6 +58,7 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
         color: event.color,
         round: event.round,
         contentiousness: event.contentiousness,
+        rebuttalTarget: event.rebuttal_target,
       };
     case 'agent_text_delta':
       return { type: 'AGENT_TEXT_DELTA', agentId: event.agent_id, delta: event.delta };

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -30,6 +30,7 @@ import {
   deleteConversation,
   updateConversationTitle,
   updateConversationSystemPrompt,
+  getMessages,
   DEFAULT_TITLE_GENERATION_PROMPT,
 } from '../services/clients/chat';
 import type { ConversationSummary } from '../services/clients/chat';
@@ -391,18 +392,21 @@ export default function ChatPage({
     }
   };
 
-  const handleExportConversation = () => {
-    // Export would require access to runtime - simplified version
+  const handleExportConversation = async () => {
     if (!activeConversation) return;
-    // For now, just export conversation metadata
-    const data = { conversation: activeConversation };
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = `conversation-${activeConversation.id}.json`;
-    anchor.click();
-    URL.revokeObjectURL(url);
+    try {
+      const messages = await getMessages(activeConversation.id);
+      const data = { conversation: activeConversation, messages };
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `conversation-${activeConversation.id}.json`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      setChatError(error instanceof Error ? error.message : String(error));
+    }
   };
 
   const handleUpdateSystemPrompt = async (prompt: string | null) => {

--- a/src/services/clients/council.ts
+++ b/src/services/clients/council.ts
@@ -24,17 +24,23 @@ export interface CouncilAgent {
   tool_filter?: string[];
 }
 
+export interface JudgeConfig {
+  min_rounds_before_stop?: number;
+}
+
 export interface CouncilConfig {
   agents: CouncilAgent[];
   topic: string;
   rounds: number;
   synthesis_guidance?: string;
+  judge?: JudgeConfig;
 }
 
 export interface SuggestedCouncil {
   agents: CouncilAgent[];
   rounds: number;
   synthesis_guidance?: string;
+  judge?: JudgeConfig;
 }
 
 // ─── Suggest ────────────────────────────────────────────────────────────────

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -39,6 +39,7 @@ export type CouncilEvent =
   | JudgeStartEvent
   | JudgeTextDeltaEvent
   | JudgeSummaryEvent
+  | RoundCompactedEvent
   | SynthesisStartEvent
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
@@ -111,6 +112,12 @@ export interface JudgeSummaryEvent {
   round: number;
   summary: string;
   consensus_reached: boolean;
+}
+
+export interface RoundCompactedEvent {
+  type: 'round_compacted';
+  round: number;
+  summary: string;
 }
 
 export interface SynthesisStartEvent {

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -54,7 +54,6 @@ export interface AgentTurnStartEvent {
   color: string;
   round: number;
   contentiousness: number;
-  rebuttal_target?: string;
 }
 
 export interface AgentTextDeltaEvent {
@@ -168,8 +167,6 @@ export interface AgentContribution {
   content: string;
   coreClaim?: string;
   round: number;
-  /** Name of the agent whose claim is being rebutted, if any. */
-  rebuttalTarget?: string;
 }
 
 /** Tool call in progress or completed. */
@@ -244,8 +241,6 @@ export interface CouncilSession {
   stances: AgentStance[];
   /** Compacted round summaries. */
   compactedRounds: CompactedRound[];
-  /** Rebuttal target for the currently speaking agent. */
-  activeRebuttalTarget?: string;
   /** Synthesis text (streamed incrementally). */
   synthesisText: string;
   /** Error message if phase === 'error'. */

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -36,6 +36,9 @@ export type CouncilEvent =
   | AgentToolCallCompleteEvent
   | AgentTurnCompleteEvent
   | RoundSeparatorEvent
+  | JudgeStartEvent
+  | JudgeTextDeltaEvent
+  | JudgeSummaryEvent
   | SynthesisStartEvent
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
@@ -93,6 +96,23 @@ export interface RoundSeparatorEvent {
   round: number;
 }
 
+export interface JudgeStartEvent {
+  type: 'judge_start';
+  round: number;
+}
+
+export interface JudgeTextDeltaEvent {
+  type: 'judge_text_delta';
+  delta: string;
+}
+
+export interface JudgeSummaryEvent {
+  type: 'judge_summary';
+  round: number;
+  summary: string;
+  consensus_reached: boolean;
+}
+
 export interface SynthesisStartEvent {
   type: 'synthesis_start';
 }
@@ -145,6 +165,7 @@ export type CouncilPhase =
   | 'suggesting'
   | 'setup'
   | 'deliberating'
+  | 'judging'
   | 'synthesizing'
   | 'complete'
   | 'error';
@@ -177,6 +198,12 @@ export interface CouncilSession {
   activeToolCalls: AgentToolCall[];
   /** All completed contributions across rounds. */
   contributions: AgentContribution[];
+  /** Judge text accumulated during evaluation (streamed incrementally). */
+  judgeText: string;
+  /** Judge summary from the most recent evaluation. */
+  judgeSummary: string | null;
+  /** Whether the judge detected consensus. */
+  judgeConsensusReached: boolean;
   /** Synthesis text (streamed incrementally). */
   synthesisText: string;
   /** Error message if phase === 'error'. */
@@ -264,6 +291,9 @@ export function createEmptySession(): CouncilSession {
     activeAgentReasoning: '',
     activeToolCalls: [],
     contributions: [],
+    judgeText: '',
+    judgeSummary: null,
+    judgeConsensusReached: false,
     synthesisText: '',
     error: null,
   };

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -54,6 +54,7 @@ export interface AgentTurnStartEvent {
   color: string;
   round: number;
   contentiousness: number;
+  rebuttal_target?: string;
 }
 
 export interface AgentTextDeltaEvent {
@@ -167,6 +168,8 @@ export interface AgentContribution {
   content: string;
   coreClaim?: string;
   round: number;
+  /** Name of the agent whose claim is being rebutted, if any. */
+  rebuttalTarget?: string;
 }
 
 /** Tool call in progress or completed. */
@@ -177,6 +180,19 @@ export interface AgentToolCall {
   argsSummary?: string;
   result?: { content: string; isError: boolean };
   durationDisplay?: string;
+}
+
+/** Judge assessment for a single round. */
+export interface JudgeAssessment {
+  round: number;
+  summary: string;
+  consensusReached: boolean;
+}
+
+/** Summary of a compacted round. */
+export interface CompactedRound {
+  round: number;
+  summary: string;
 }
 
 /** Session lifecycle phases. */
@@ -218,12 +234,18 @@ export interface CouncilSession {
   activeToolCalls: AgentToolCall[];
   /** All completed contributions across rounds. */
   contributions: AgentContribution[];
-  /** Judge text accumulated during evaluation (streamed incrementally). */
-  judgeText: string;
-  /** Judge summary from the most recent evaluation. */
-  judgeSummary: string | null;
-  /** Whether the judge detected consensus. */
-  judgeConsensusReached: boolean;
+  /** Judge assessments, one per evaluated round. */
+  judgeAssessments: JudgeAssessment[];
+  /** Judge text accumulated during current evaluation (streamed). */
+  activeJudgeText: string;
+  /** Round currently being evaluated by the judge. */
+  activeJudgeRound: number;
+  /** Stance trajectories from the post-debate evaluation. */
+  stances: AgentStance[];
+  /** Compacted round summaries. */
+  compactedRounds: CompactedRound[];
+  /** Rebuttal target for the currently speaking agent. */
+  activeRebuttalTarget?: string;
   /** Synthesis text (streamed incrementally). */
   synthesisText: string;
   /** Error message if phase === 'error'. */
@@ -277,6 +299,12 @@ export interface SerializableCouncilSession {
   totalRounds: number;
   contributions: AgentContribution[];
   synthesisText: string;
+  /** Judge assessments, one per evaluated round. */
+  judgeAssessments?: JudgeAssessment[];
+  /** Stance trajectories from the post-debate evaluation. */
+  stances?: AgentStance[];
+  /** Compacted round summaries. */
+  compactedRounds?: CompactedRound[];
   /** Non-null only for sessions that ended in error. */
   error?: string | null;
 }
@@ -288,6 +316,9 @@ export function toSerializableSession(s: CouncilSession): SerializableCouncilSes
     totalRounds: s.totalRounds,
     contributions: s.contributions,
     synthesisText: s.synthesisText,
+    ...(s.judgeAssessments.length > 0 ? { judgeAssessments: s.judgeAssessments } : {}),
+    ...(s.stances.length > 0 ? { stances: s.stances } : {}),
+    ...(s.compactedRounds.length > 0 ? { compactedRounds: s.compactedRounds } : {}),
     ...(s.error ? { error: s.error } : {}),
   };
 }
@@ -311,9 +342,11 @@ export function createEmptySession(): CouncilSession {
     activeAgentReasoning: '',
     activeToolCalls: [],
     contributions: [],
-    judgeText: '',
-    judgeSummary: null,
-    judgeConsensusReached: false,
+    judgeAssessments: [],
+    activeJudgeText: '',
+    activeJudgeRound: 0,
+    stances: [],
+    compactedRounds: [],
     synthesisText: '',
     error: null,
   };

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -40,6 +40,7 @@ export type CouncilEvent =
   | JudgeTextDeltaEvent
   | JudgeSummaryEvent
   | RoundCompactedEvent
+  | StanceMapEvent
   | SynthesisStartEvent
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
@@ -118,6 +119,18 @@ export interface RoundCompactedEvent {
   type: 'round_compacted';
   round: number;
   summary: string;
+}
+
+export type StanceTrajectory = 'held' | 'shifted' | 'conceded';
+
+export interface AgentStance {
+  agent_name: string;
+  trajectory: StanceTrajectory;
+}
+
+export interface StanceMapEvent {
+  type: 'stance_map';
+  stances: AgentStance[];
 }
 
 export interface SynthesisStartEvent {


### PR DESCRIPTION
## Problem

The "Export conversation" button only serialised conversation metadata — `id`, `title`, `model_id`, `system_prompt`, and timestamps. It never fetched the actual messages, so the exported JSON was always an empty shell like:

```json
{
  "conversation": {
    "id": 1,
    "title": "New Chat",
    "model_id": null,
    "system_prompt": "You are a helpful assistant.",
    "created_at": "2026-04-19 04:22:26",
    "updated_at": "2026-04-19 06:21:04"
  }
}
```

This was caused by `handleExportConversation` in `ChatPage.tsx` building the blob from `activeConversation` only, with a `// For now, just export conversation metadata` comment left in place.

## Fix

- Make `handleExportConversation` `async`
- Call `getMessages(activeConversation.id)` against the already-fully-implemented `GET /api/conversations/{id}/messages` endpoint
- Include the result as a top-level `messages` array in the exported JSON

**Exported shape is now:**
```json
{
  "conversation": { ... },
  "messages": [
    { "id": 1, "role": "user", "content": "...", "created_at": "..." },
    { "id": 2, "role": "assistant", "content": "...", "created_at": "..." }
  ]
}
```

- Errors are surfaced via `setChatError` (consistent with the rest of `ChatPage.tsx`)
- No backend changes — the endpoint was already complete

## Testing

Verified with `tsc --noEmit`: no type errors introduced.