### PR TITLE
feat: stream prompt pre-fill progress via return_progress

### DIFF
--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -43,6 +43,18 @@ pub enum CouncilEvent {
     /// expose `CoT`).  Rendered in a collapsible "thinking" block.
     AgentReasoningDelta { agent_id: String, delta: String },
 
+    /// Prompt-processing progress during an agent's LLM call.
+    ///
+    /// Emitted during pre-fill so the frontend can show how far along
+    /// the token ingestion is for this agent's turn.
+    AgentProgress {
+        agent_id: String,
+        processed: u32,
+        total: u32,
+        cached: u32,
+        time_ms: u64,
+    },
+
     /// The current agent has initiated a tool call.  The frontend shows a
     /// spinner with `display_name` and an optional `args_summary`.
     AgentToolCallStart {
@@ -116,6 +128,17 @@ pub enum CouncilEvent {
     /// The synthesis phase has begun.  The frontend renders a
     /// "Synthesising…" placeholder.
     SynthesisStart,
+
+    /// Prompt-processing progress during the synthesis LLM call.
+    ///
+    /// Emitted during pre-fill so the frontend can show how far along
+    /// the token ingestion is (e.g. "processing prompt: 4096 / 12288").
+    SynthesisProgress {
+        processed: u32,
+        total: u32,
+        cached: u32,
+        time_ms: u64,
+    },
 
     /// Incremental text token from the synthesiser agent.
     SynthesisTextDelta { delta: String },
@@ -237,7 +260,20 @@ mod tests {
                     trajectory: crate::council::stance::StanceTrajectory::Held,
                 }],
             },
+            CouncilEvent::AgentProgress {
+                agent_id: "a".into(),
+                processed: 100,
+                total: 500,
+                cached: 50,
+                time_ms: 42,
+            },
             CouncilEvent::SynthesisStart,
+            CouncilEvent::SynthesisProgress {
+                processed: 200,
+                total: 1000,
+                cached: 100,
+                time_ms: 84,
+            },
             CouncilEvent::SynthesisTextDelta {
                 delta: "synth".into(),
             },

--- a/crates/gglib-agent/src/council/stream_bridge.rs
+++ b/crates/gglib-agent/src/council/stream_bridge.rs
@@ -49,6 +49,14 @@ pub async fn bridge_agent_events(
                 delta: content,
             },
 
+            AgentEvent::PromptProgress { processed, total, cached, time_ms } => CouncilEvent::AgentProgress {
+                agent_id: id.clone(),
+                processed,
+                total,
+                cached,
+                time_ms,
+            },
+
             AgentEvent::ToolCallStart {
                 tool_call,
                 display_name,

--- a/crates/gglib-agent/src/council/synthesis.rs
+++ b/crates/gglib-agent/src/council/synthesis.rs
@@ -137,6 +137,9 @@ async fn bridge_synthesis_events(
                 has_streamed = true;
                 let _ = tx.send(CouncilEvent::SynthesisTextDelta { delta }).await;
             }
+            AgentEvent::PromptProgress { processed, total, cached, time_ms } => {
+                let _ = tx.send(CouncilEvent::SynthesisProgress { processed, total, cached, time_ms }).await;
+            }
             AgentEvent::FinalAnswer { content: answer } => {
                 content = Some(answer);
             }

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -153,6 +153,11 @@ pub async fn collect_stream(
                 let _ = tx.send(AgentEvent::ReasoningDelta { content }).await;
             }
 
+            LlmStreamEvent::PromptProgress { processed, total, cached, time_ms } => {
+                // Forward pre-fill progress so consumers can display it.
+                let _ = tx.send(AgentEvent::PromptProgress { processed, total, cached, time_ms }).await;
+            }
+
             LlmStreamEvent::ToolCallDelta {
                 index,
                 id,

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -126,6 +126,10 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
         AgentEvent::Error { message } => {
             eprintln!("\n  ❌  {message}");
         }
+
+        AgentEvent::PromptProgress { .. } => {
+            // Prompt pre-fill progress — silently ignored in CLI for now.
+        }
     }
 }
 

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -159,6 +159,10 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 eprintln!("\n\x1b[36m{BOLD}── Council Synthesis ──{RESET}");
             }
 
+            CouncilEvent::SynthesisProgress { .. } | CouncilEvent::AgentProgress { .. } => {
+                // Prompt pre-fill progress — silently ignored in CLI for now.
+            }
+
             CouncilEvent::SynthesisTextDelta { delta } => {
                 print!("{delta}");
                 let _ = io::stdout().flush();

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -79,6 +79,22 @@ pub enum AgentEvent {
         content: String,
     },
 
+    /// Prompt-processing progress from the LLM backend.
+    ///
+    /// Emitted during the pre-fill phase when llama-server is streaming
+    /// `prompt_progress` frames.  Surfaces token-level progress so the UI
+    /// can show "processing prompt: 2048 / 8192 tokens".
+    PromptProgress {
+        /// Number of tokens processed so far.
+        processed: u32,
+        /// Total number of tokens in the prompt.
+        total: u32,
+        /// Number of tokens served from KV cache (already processed).
+        cached: u32,
+        /// Elapsed wall-clock time in milliseconds since processing began.
+        time_ms: u64,
+    },
+
     /// A fatal error has terminated the loop.
     Error {
         /// Human-readable description of the failure.
@@ -136,6 +152,22 @@ pub enum LlmStreamEvent {
         name: Option<String>,
         /// Partial arguments JSON string fragment (accumulate with `push_str`).
         arguments: Option<String>,
+    },
+
+    /// Prompt-processing progress from llama-server.
+    ///
+    /// Emitted when the request includes `return_progress: true`.  These
+    /// frames arrive during the pre-fill phase (before any `TextDelta`),
+    /// giving real-time visibility into how far along token ingestion is.
+    PromptProgress {
+        /// Number of tokens processed so far.
+        processed: u32,
+        /// Total number of tokens in the prompt.
+        total: u32,
+        /// Number of tokens served from KV cache (already processed).
+        cached: u32,
+        /// Elapsed wall-clock time in milliseconds since processing began.
+        time_ms: u64,
     },
 
     /// Signals the end of the stream.

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -43,12 +43,13 @@ use sse_decoder::SseStreamDecoder;
 
 /// Default timeout (seconds) for the `.send()` phase of each LLM request.
 ///
-/// Covers TCP connect + TLS handshake + HTTP response headers.  Because
-/// llama-server does not send response headers until prompt pre-fill
-/// completes, this effectively caps time-to-first-token.  Large prompts
-/// (e.g. council synthesis transcripts) can require significant pre-fill
-/// time, so the default is generous.
-const DEFAULT_SEND_TIMEOUT_SECS: u64 = 120;
+/// With `return_progress: true` in the request body, llama-server sends HTTP
+/// response headers immediately (before prompt pre-fill), so `.send()`
+/// completes in well under a second for any reachable server.  This timeout
+/// is therefore a **safety net** against a truly unreachable or hung server,
+/// not a pre-fill time limit.  The generous value avoids false positives
+/// while still bounding resource usage for a dead connection.
+const DEFAULT_SEND_TIMEOUT_SECS: u64 = 600;
 
 // =============================================================================
 // Adapter struct
@@ -235,6 +236,7 @@ impl LlmCompletionPort for LlmCompletionAdapter {
             "model": self.model,
             "messages": openai_messages,
             "stream": true,
+            "return_progress": true,
         });
         if !openai_tools.is_empty() {
             body["tools"] = json!(openai_tools);

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/sse_parser.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/sse_parser.rs
@@ -48,6 +48,20 @@ pub(crate) fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
     let parsed: serde_json::Value = serde_json::from_str(data)
         .map_err(|e| anyhow!("SSE frame JSON parse error: {e} — data: {data}"))?;
 
+    // ── Prompt-progress frames (llama-server `return_progress: true`) ────
+    // These arrive during the pre-fill phase and have no `choices` array.
+    // We check for them *before* the choices guard so they aren't silently
+    // dropped as "no choices" frames.
+    if let Some(pp) = parsed.get("prompt_progress") {
+        let processed = pp["processed"].as_u64().unwrap_or(0) as u32;
+        let total = pp["total"].as_u64().unwrap_or(0) as u32;
+        let cached = pp["cache"].as_u64().unwrap_or(0) as u32;
+        let time_ms = pp["time_ms"].as_u64().unwrap_or(0);
+        return Ok(SseParseResult::Events(vec![
+            LlmStreamEvent::PromptProgress { processed, total, cached, time_ms },
+        ]));
+    }
+
     // Guard against keepalive / error frames that carry no `choices` array.
     // Without this check every field access falls through to `Value::Null`,
     // events are silently dropped, and a `finish_reason: "stop"` in such a
@@ -379,5 +393,47 @@ mod tests {
             matches!(&events[1], LlmStreamEvent::TextDelta { content } if content == "ok"),
             "TextDelta must come second"
         );
+    }
+
+    #[test]
+    fn prompt_progress_frame_produces_progress_event() {
+        let frame = serde_json::json!({
+            "prompt_progress": {
+                "processed": 2048,
+                "total": 8192,
+                "cache": 512,
+                "time_ms": 1234
+            }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            LlmStreamEvent::PromptProgress { processed: 2048, total: 8192, cached: 512, time_ms: 1234 }
+        ));
+    }
+
+    #[test]
+    fn prompt_progress_frame_not_confused_with_choices() {
+        // A prompt_progress frame has no `choices` array.  The parser should
+        // recognise it as progress, not drop it as a no-choices keepalive.
+        let frame = serde_json::json!({
+            "prompt_progress": {
+                "processed": 100,
+                "total": 100,
+                "cache": 0,
+                "time_ms": 50
+            }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert!(!events.is_empty(), "prompt_progress frame must not be skipped");
     }
 }

--- a/src/contexts/CouncilContext.tsx
+++ b/src/contexts/CouncilContext.tsx
@@ -39,6 +39,8 @@ export type CouncilAction =
   | { type: 'ROUND_COMPACTED'; round: number; summary: string }
   | { type: 'STANCE_MAP'; stances: AgentStance[] }
   | { type: 'SYNTHESIS_START' }
+  | { type: 'SYNTHESIS_PROGRESS'; processed: number; total: number; cached: number; timeMs: number }
+  | { type: 'AGENT_PROGRESS'; agentId: string; processed: number; total: number; cached: number; timeMs: number }
   | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
   | { type: 'SYNTHESIS_COMPLETE'; content: string }
   | { type: 'COUNCIL_ERROR'; error: string }
@@ -163,10 +165,17 @@ export function councilReducer(state: CouncilSession, action: CouncilAction): Co
       return { ...state, stances: action.stances };
 
     case 'SYNTHESIS_START':
-      return { ...state, phase: 'synthesizing', synthesisText: '' };
+      return { ...state, phase: 'synthesizing', synthesisText: '', synthesisProgress: null };
+
+    case 'SYNTHESIS_PROGRESS':
+      return { ...state, synthesisProgress: { processed: action.processed, total: action.total, cached: action.cached, timeMs: action.timeMs } };
+
+    case 'AGENT_PROGRESS':
+      // Progress events are informational; store for display if needed.
+      return state;
 
     case 'SYNTHESIS_TEXT_DELTA':
-      return { ...state, synthesisText: state.synthesisText + action.delta };
+      return { ...state, synthesisText: state.synthesisText + action.delta, synthesisProgress: null };
 
     case 'SYNTHESIS_COMPLETE':
       return { ...state, synthesisText: action.content };

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -114,6 +114,10 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
       return { type: 'STANCE_MAP', stances: event.stances };
     case 'synthesis_start':
       return { type: 'SYNTHESIS_START' };
+    case 'synthesis_progress':
+      return { type: 'SYNTHESIS_PROGRESS', processed: event.processed, total: event.total, cached: event.cached, timeMs: event.time_ms };
+    case 'agent_progress':
+      return { type: 'AGENT_PROGRESS', agentId: event.agent_id, processed: event.processed, total: event.total, cached: event.cached, timeMs: event.time_ms };
     case 'synthesis_text_delta':
       return { type: 'SYNTHESIS_TEXT_DELTA', delta: event.delta };
     case 'synthesis_complete':

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -42,6 +42,8 @@ export type CouncilEvent =
   | RoundCompactedEvent
   | StanceMapEvent
   | SynthesisStartEvent
+  | SynthesisProgressEvent
+  | AgentProgressEvent
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
   | CouncilErrorEvent
@@ -135,6 +137,23 @@ export interface StanceMapEvent {
 
 export interface SynthesisStartEvent {
   type: 'synthesis_start';
+}
+
+export interface SynthesisProgressEvent {
+  type: 'synthesis_progress';
+  processed: number;
+  total: number;
+  cached: number;
+  time_ms: number;
+}
+
+export interface AgentProgressEvent {
+  type: 'agent_progress';
+  agent_id: string;
+  processed: number;
+  total: number;
+  cached: number;
+  time_ms: number;
 }
 
 export interface SynthesisTextDeltaEvent {
@@ -243,6 +262,8 @@ export interface CouncilSession {
   compactedRounds: CompactedRound[];
   /** Synthesis text (streamed incrementally). */
   synthesisText: string;
+  /** Pre-fill progress during synthesis (null when not in pre-fill). */
+  synthesisProgress: { processed: number; total: number; cached: number; timeMs: number } | null;
   /** Error message if phase === 'error'. */
   error: string | null;
 }
@@ -343,6 +364,7 @@ export function createEmptySession(): CouncilSession {
     stances: [],
     compactedRounds: [],
     synthesisText: '',
+    synthesisProgress: null,
     error: null,
   };
 }

--- a/src/types/events/agentEvent.ts
+++ b/src/types/events/agentEvent.ts
@@ -100,6 +100,15 @@ export interface AgentErrorEvent {
   message: string;
 }
 
+/** Prompt pre-fill progress from the LLM backend. */
+export interface AgentPromptProgressEvent {
+  type: 'prompt_progress';
+  processed: number;
+  total: number;
+  cached: number;
+  time_ms: number;
+}
+
 /**
  * Union of all events emitted by the backend agentic loop over SSE.
  *
@@ -113,4 +122,5 @@ export type AgentEvent =
   | AgentToolCallCompleteEvent
   | AgentIterationCompleteEvent
   | AgentFinalAnswerEvent
-  | AgentErrorEvent;
+  | AgentErrorEvent
+  | AgentPromptProgressEvent;


### PR DESCRIPTION
## Problem

Council synthesis fails with "llama-server connection timed out after 120s" when processing large debate transcripts. The root cause: llama-server doesn't send HTTP response headers until prompt pre-fill completes, so `tokio::time::timeout` wrapping `.send()` fires during the pre-fill phase — not because the server is unresponsive, but because it's busy ingesting tokens.

Bumping the timeout (PR #435) is a band-aid. For sufficiently long transcripts, any fixed timeout will eventually be exceeded.

## Solution

Use llama-server's `return_progress: true` request body parameter. When set, llama-server:
1. Sends HTTP response headers **immediately** (before pre-fill starts)
2. Streams `prompt_progress` SSE frames during pre-fill with `{ total, cache, processed, time_ms }`
3. Then streams normal `choices` frames as usual

This **eliminates the timeout problem entirely** because `.send()` returns in under a second for any reachable server. The 600s hard timeout is now just a safety net for a truly dead server.

## Changes

### Backend (Rust)

| File | Change |
|------|--------|
| `gglib-core/.../events.rs` | Add `PromptProgress` variant to both `LlmStreamEvent` and `AgentEvent` |
| `gglib-runtime/.../sse_parser.rs` | Parse `prompt_progress` SSE frames before the `choices` guard + 2 unit tests |
| `gglib-runtime/.../mod.rs` | Add `"return_progress": true` to request body, bump safety timeout 120→600s |
| `gglib-agent/stream_collector.rs` | Forward `PromptProgress` through `AgentEvent` channel |
| `gglib-agent/council/events.rs` | Add `AgentProgress` and `SynthesisProgress` to `CouncilEvent` |
| `gglib-agent/council/synthesis.rs` | Bridge `AgentEvent::PromptProgress` → `CouncilEvent::SynthesisProgress` |
| `gglib-agent/council/stream_bridge.rs` | Bridge `AgentEvent::PromptProgress` → `CouncilEvent::AgentProgress` |
| `gglib-cli/.../renderer.rs` | Handle `PromptProgress` (silent for now) |
| `gglib-cli/.../stream.rs` | Handle `SynthesisProgress` / `AgentProgress` (silent for now) |

### Frontend (TypeScript)

| File | Change |
|------|--------|
| `types/events/agentEvent.ts` | Add `AgentPromptProgressEvent` to union |
| `types/council.ts` | Add `SynthesisProgressEvent`, `AgentProgressEvent`, `synthesisProgress` to session |
| `hooks/useCouncil.ts` | Map SSE events to reducer actions |
| `contexts/CouncilContext.tsx` | Add reducer cases, track `synthesisProgress` state |

## Scope

This is **universal** — affects all llama-server calls across both GUI and CLI, not just council. The `return_progress` param and SSE parsing live in the shared `LlmCompletionAdapter`.

## Testing

- ✅ `cargo check --workspace` — clean
- ✅ `cargo clippy --workspace -- -D warnings` — clean
- ✅ All SSE parser tests pass (14/14), including 2 new prompt_progress tests
- ✅ All gglib-agent tests pass (8/8), including council event round-trip
- ⚠️ 2 pre-existing proxy supervisor test failures (sandbox networking, unrelated)