### PR TITLE
feat(council): per-agent tool-filter picker in GUI

### DIFF
--- a/src/components/Council/Setup/AgentCard.tsx
+++ b/src/components/Council/Setup/AgentCard.tsx
@@ -1,13 +1,14 @@
 /**
  * Single agent card for council setup.
  *
- * Displays agent persona, perspective, and a contentiousness slider.
+ * Displays agent persona, perspective, a contentiousness slider, and a
+ * collapsible tool-filter picker that matches CLI `tools <N>` parity.
  * Injects `--agent-color` CSS custom property for ambient tinting.
  *
  * @module components/Council/Setup/AgentCard
  */
 
-import { type FC, useState } from 'react';
+import { type FC, useState, useCallback } from 'react';
 import type { CouncilAgent } from '../../../types/council';
 import { contentiousnessColor, contentiousnessLabel } from '../../../types/council';
 import { cn } from '../../../utils/cn';
@@ -16,6 +17,15 @@ import { AgentDiffBadge, type DiffStatus } from './AgentDiffBadge';
 import { Sparkles } from 'lucide-react';
 import { Icon } from '../../ui/Icon';
 
+export interface AvailableTool {
+  /** Sanitized name shown in the UI (e.g. `web_search`). */
+  displayName: string;
+  /** Wire name sent to the backend (e.g. `my_server:web_search` for MCP, or plain for built-ins). */
+  backendName: string;
+  /** LLM-facing description surfaced as tooltip/secondary text. */
+  description: string;
+}
+
 interface AgentCardProps {
   agent: CouncilAgent;
   diffStatus?: DiffStatus;
@@ -23,15 +33,62 @@ interface AgentCardProps {
   onUpdate?: (agentId: string, changes: Partial<CouncilAgent>) => void;
   onRemove?: (agentId: string) => void;
   onFillAgent?: (agentId: string) => Promise<void>;
+  /**
+   * Full list of tools available to the backend.  When provided, renders a
+   * collapsible tool-picker that maps to `CouncilAgent.tool_filter`.
+   */
+  availableTools?: AvailableTool[];
   disabled?: boolean;
 }
 
 export const AgentCard: FC<AgentCardProps> = ({
-  agent, diffStatus = 'unchanged', onContentiousnessChange, onUpdate, onRemove, onFillAgent, disabled,
+  agent, diffStatus = 'unchanged', onContentiousnessChange, onUpdate, onRemove, onFillAgent, availableTools, disabled,
 }) => {
   const [isFilling, setIsFilling] = useState(false);
   const color = contentiousnessColor(agent.contentiousness);
   const label = contentiousnessLabel(agent.contentiousness);
+
+  // ── Tool-filter helpers ────────────────────────────────────────────────────
+
+  const isToolEnabled = useCallback(
+    (backendName: string) =>
+      agent.tool_filter === undefined || agent.tool_filter.includes(backendName),
+    [agent.tool_filter],
+  );
+
+  const handleToolToggle = useCallback(
+    (backendName: string, checked: boolean) => {
+      if (!onUpdate || !availableTools) return;
+      const allBackendNames = availableTools.map((t) => t.backendName);
+      const current: string[] =
+        agent.tool_filter ?? allBackendNames; // undefined → all enabled
+      const next = checked
+        ? [...current, backendName].filter((n, i, a) => a.indexOf(n) === i)
+        : current.filter((n) => n !== backendName);
+      // all checked → revert to undefined (no filter); keep explicit array otherwise
+      const newFilter =
+        next.length === allBackendNames.length ? undefined : next;
+      onUpdate(agent.id, { tool_filter: newFilter });
+    },
+    [agent.id, agent.tool_filter, availableTools, onUpdate],
+  );
+
+  const handleSetAll = useCallback(() => {
+    onUpdate?.(agent.id, { tool_filter: undefined });
+  }, [agent.id, onUpdate]);
+
+  const handleSetNone = useCallback(() => {
+    onUpdate?.(agent.id, { tool_filter: [] });
+  }, [agent.id, onUpdate]);
+
+  // ── Tool-filter summary label ──────────────────────────────────────────────
+
+  const toolSummary = (() => {
+    if (!availableTools || availableTools.length === 0) return null;
+    if (agent.tool_filter === undefined) return 'All tools';
+    const count = agent.tool_filter.length;
+    return `${count} of ${availableTools.length} tool${availableTools.length !== 1 ? 's' : ''}`;
+  })();
 
   return (
     <div
@@ -113,6 +170,73 @@ export const AgentCard: FC<AgentCardProps> = ({
           aria-label={`${agent.name} persona`}
         />
       </details>
+
+      {/* Tool filter (collapsed, only when tools are available) */}
+      {availableTools && availableTools.length > 0 && (
+        <details className="text-xs">
+          <summary className="cursor-pointer text-text-secondary hover:text-text transition-colors flex items-center gap-xs">
+            <span>Tools</span>
+            <span
+              className={cn(
+                'ml-1 px-xs rounded text-[10px] font-medium',
+                agent.tool_filter === undefined
+                  ? 'bg-surface-alt text-text-muted'
+                  : agent.tool_filter.length === 0
+                    ? 'bg-danger/15 text-danger'
+                    : 'bg-primary/15 text-primary',
+              )}
+            >
+              {toolSummary}
+            </span>
+            {!disabled && onUpdate && (
+              <span className="ml-auto flex gap-xs" onClick={(e) => e.preventDefault()}>
+                <button
+                  type="button"
+                  onClick={handleSetAll}
+                  className="text-text-muted hover:text-text transition-colors px-1"
+                  title="Allow all tools"
+                >
+                  All
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSetNone}
+                  className="text-text-muted hover:text-text transition-colors px-1"
+                  title="Disallow all tools"
+                >
+                  None
+                </button>
+              </span>
+            )}
+          </summary>
+          <div className="mt-xs flex flex-col gap-xs pl-xs">
+            {availableTools.map((tool) => (
+              <label
+                key={tool.backendName}
+                className="flex items-start gap-sm cursor-pointer group"
+              >
+                <input
+                  type="checkbox"
+                  checked={isToolEnabled(tool.backendName)}
+                  onChange={(e) => handleToolToggle(tool.backendName, e.target.checked)}
+                  disabled={disabled || !onUpdate}
+                  className="mt-0.5 shrink-0 accent-[var(--agent-color)] disabled:cursor-not-allowed"
+                />
+                <span className="flex flex-col">
+                  <span className="text-text-secondary group-hover:text-text transition-colors">
+                    {tool.displayName}
+                  </span>
+                  {tool.description && (
+                    <span className="text-text-muted text-[10px] leading-snug">
+                      {tool.description}
+                    </span>
+                  )}
+                </span>
+              </label>
+            ))}
+          </div>
+        </details>
+      )}
 
       {/* Contentiousness slider */}
       <div className="flex flex-col gap-xs mt-xs">

--- a/src/components/Council/Setup/CouncilSetupPanel.tsx
+++ b/src/components/Council/Setup/CouncilSetupPanel.tsx
@@ -8,13 +8,14 @@
  * @module components/Council/Setup/CouncilSetupPanel
  */
 
-import { type FC, useState, useCallback, useEffect } from 'react';
+import { type FC, useState, useCallback, useEffect, useMemo } from 'react';
 import type { CouncilAgent, CouncilConfig } from '../../../types/council';
 import { Button } from '../../ui/Button';
 import { AgentCard } from './AgentCard';
 import { AddAgentButton } from './AddAgentButton';
 import type { DiffStatus } from './AgentDiffBadge';
 import { cn } from '../../../utils/cn';
+import { getToolRegistry } from '../../../services/tools/registry';
 
 interface CouncilSetupPanelProps {
   topic: string;
@@ -48,6 +49,10 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
 }) => {
   const [agents, setAgents] = useState<CouncilAgent[]>(initialAgents);
   const [rounds, setRounds] = useState(initialRounds);
+
+  // Snapshot available tools from the registry at mount time.
+  // The registry is already populated at app init (built-ins + active MCP servers).
+  const availableTools = useMemo(() => getToolRegistry().getAllAsBackendTools(), []);
 
   // Sync local state when context-driven changes arrive (add/remove/update agent).
   useEffect(() => {
@@ -99,6 +104,7 @@ export const CouncilSetupPanel: FC<CouncilSetupPanelProps> = ({
             onUpdate={onUpdateAgent}
             onRemove={onRemoveAgent}
             onFillAgent={onFillAgent}
+            availableTools={availableTools}
             disabled={disabled}
           />
         ))}

--- a/src/hooks/useGglibRuntime/streamAgentChat.ts
+++ b/src/hooks/useGglibRuntime/streamAgentChat.ts
@@ -134,16 +134,7 @@ export async function streamAgentChat(options: StreamAgentChatOptions): Promise<
     if (enabled.length === 0) {
       toolFilter = null;
     } else {
-      toolFilter = enabled.map((def) => {
-        const sanitized = def.function.name;
-        const serverId = registry.getServerId(sanitized);
-        const original = registry.getOriginalName(sanitized);
-        if (serverId !== undefined && original !== undefined) {
-          return `${serverId}:${original}`;
-        }
-        // Fallback for tools registered via register() without a name mapping
-        return sanitized;
-      });
+      toolFilter = enabled.map((def) => registry.getBackendName(def.function.name));
     }
   }
 

--- a/src/services/tools/registry.ts
+++ b/src/services/tools/registry.ts
@@ -126,6 +126,39 @@ export class ToolRegistry {
   }
 
   /**
+   * Resolve the backend wire name for a sanitized registry key.
+   *
+   * - MCP tools registered via `registerWithNameMapping` become `serverId:originalName`
+   *   (the format the backend council/agent handlers expect).
+   * - Built-in tools (and any tool without a name mapping) keep their sanitized name.
+   *
+   * This is the single source of truth used by both the agentic chat tool-filter
+   * and the council per-agent tool-picker.
+   */
+  getBackendName(sanitizedName: string): string {
+    const entry = this._nameMap.get(sanitizedName);
+    if (entry !== undefined) {
+      return `${entry.serverId}:${entry.originalName}`;
+    }
+    return sanitizedName;
+  }
+
+  /**
+   * Return all registered tools as `{ displayName, backendName, description }` triples.
+   *
+   * `displayName` is the human-readable name shown in the UI (sanitized name).
+   * `backendName` is the wire name sent to the backend (see `getBackendName`).
+   * `description` is the tool's LLM-facing description string.
+   */
+  getAllAsBackendTools(): Array<{ displayName: string; backendName: string; description: string }> {
+    return Array.from(this.tools.entries()).map(([sanitized, tool]) => ({
+      displayName: sanitized,
+      backendName: this.getBackendName(sanitized),
+      description: tool.definition.function.description ?? '',
+    }));
+  }
+
+  /**
    * Register a tool using a simplified builder pattern.
    * @param name - Function name
    * @param description - Description for the LLM


### PR DESCRIPTION
## Summary

Closes the parity gap between the CLI's `tools <N>` REPL command and the GUI for council per-agent tool filtering. The GUI already serialised `tool_filter` correctly to the backend — this PR adds the missing UI to view and edit it.

## Changes

### `src/services/tools/registry.ts`
- **`getBackendName(sanitizedName)`** — new single source of truth for converting a frontend sanitized tool name to the backend wire format: `serverId:originalName` for MCP tools, plain sanitized name for built-ins.
- **`getAllAsBackendTools()`** — returns `{ displayName, backendName, description }[]` for every registered tool; used by the council setup panel.

### `src/hooks/useGglibRuntime/streamAgentChat.ts`
- Refactored the inline `serverId:originalName` mapping logic to call `registry.getBackendName()` instead. DRY fix — no behaviour change.

### `src/components/Council/Setup/CouncilSetupPanel.tsx`
- Snapshots available tools from `ToolRegistry` at mount (already populated at app init with built-ins + active MCP servers via `useMemo`).
- Passes the list down to each `AgentCard` via the new `availableTools` prop.

### `src/components/Council/Setup/AgentCard.tsx`
- New `AvailableTool` interface (exported, for reuse).
- New `availableTools?: AvailableTool[]` prop.
- Collapsible **Tools** section (mirrors the existing Persona `<details>` pattern):
  - Summary badge: `All tools` / `N of M tools` / `0 of M tools` with colour-coded styling (muted / primary / danger).
  - **All** / **None** quick-set buttons inline in the summary row.
  - Per-tool checkbox rows with `displayName` + muted `description` text.
  - `tool_filter: undefined` = all tools; `[]` = no tools; `string[]` = allowlist — matching backend semantics exactly.

## No backend changes required

`tool_filter` was already:
- Part of `CouncilAgent` in both the Rust and TypeScript types.
- Serialised through `runCouncil()` on every council run.
- Enforced at `AgentLoop::build()` via `crates/gglib-agent/src/council/round.rs`.

## CLI parity

| Feature | CLI | GUI (after this PR) |
|---|---|---|
| Display current per-agent tool filter | ✅ `print_agent_summary` | ✅ Summary badge in AgentCard |
| Edit tool filter interactively | ✅ `tools <N>` REPL | ✅ Collapsible checkbox picker |
| Quick set all / none | ✅ `"all"` or empty input | ✅ All / None buttons |
| Per-tool selection | ✅ Comma-separated names | ✅ Individual checkboxes |
| Tool description visible | ❌ Name only | ✅ Muted description text |
