### PR TITLE
fix(cli): use kebab-case keys and bare values in settings display

### DIFF
--- a/crates/gglib-cli/src/handlers/config/settings.rs
+++ b/crates/gglib-cli/src/handlers/config/settings.rs
@@ -149,9 +149,7 @@ fn settings_display_rows(
         .map(|(snake_key, val)| {
             let kebab_key = snake_key.replace('_', "-");
             let display_val = if kebab_key == "default-model-id" {
-                model_display
-                    .clone()
-                    .unwrap_or_else(|| "None".to_owned())
+                model_display.clone().unwrap_or_else(|| "None".to_owned())
             } else {
                 match val {
                     serde_json::Value::Null => "None".to_owned(),
@@ -323,7 +321,8 @@ mod tests {
 
         for (key, _) in &rows {
             assert!(
-                key.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                key.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
                 "key {key:?} must contain only [a-z0-9-]"
             );
             assert!(

--- a/crates/gglib-cli/src/handlers/config/settings.rs
+++ b/crates/gglib-cli/src/handlers/config/settings.rs
@@ -4,6 +4,8 @@
 //! They now live inside the `config/` directory alongside llama, assistant-ui,
 //! check-deps, and paths.
 
+use std::collections::BTreeSet;
+
 use anyhow::Result;
 
 use crate::bootstrap::CliContext;
@@ -113,55 +115,71 @@ pub fn handle_models_dir(command: ModelsDirCommand) -> Result<()> {
     }
 }
 
+/// Resolve the display string for `default-model-id`, performing a DB lookup when set.
+///
+/// Returns `Some("42 (ModelName)")`, `Some("42 (not found)")`, or `None`.
+async fn resolve_model_display(ctx: &CliContext, settings: &Settings) -> Result<Option<String>> {
+    match settings.default_model_id {
+        Some(model_id) => match ctx.app.models().get_by_id(model_id).await? {
+            Some(model) => Ok(Some(format!("{} ({})", model_id, model.name))),
+            None => Ok(Some(format!("{} (not found)", model_id))),
+        },
+        None => Ok(None),
+    }
+}
+
+/// Build display rows for a [`Settings`] value as `(kebab-case-key, bare-value)` pairs.
+///
+/// Keys are derived dynamically from `serde_json::to_value` by replacing every `_` with `-`,
+/// so new fields added to [`Settings`] appear here automatically without manual updates.
+/// `default-model-id` is substituted with the pre-resolved `model_display` string (or `"None"`).
+///
+/// Values use clean bare JSON representation (`4096`, `true`, `"None"`) rather than Rust's
+/// `Debug` format (`Some(4096)`, `None`).
+fn settings_display_rows(
+    settings: &Settings,
+    model_display: Option<String>,
+) -> Vec<(String, String)> {
+    let obj = match serde_json::to_value(settings) {
+        Ok(serde_json::Value::Object(m)) => m,
+        _ => return Vec::new(),
+    };
+
+    obj.into_iter()
+        .map(|(snake_key, val)| {
+            let kebab_key = snake_key.replace('_', "-");
+            let display_val = if kebab_key == "default-model-id" {
+                model_display
+                    .clone()
+                    .unwrap_or_else(|| "None".to_owned())
+            } else {
+                match val {
+                    serde_json::Value::Null => "None".to_owned(),
+                    serde_json::Value::String(s) => s,
+                    other => other.to_string(),
+                }
+            };
+            (kebab_key, display_val)
+        })
+        .collect()
+}
+
+/// Print display rows with dynamic column alignment.
+fn print_display_rows(rows: &[(String, String)]) {
+    let max_key_len = rows.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
+    for (key, val) in rows {
+        println!("  {:<width$}  {}", key, val, width = max_key_len);
+    }
+}
+
 pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<()> {
     match command {
         SettingsCommand::Show => {
             let settings = ctx.app.settings().get().await?;
+            let model_display = resolve_model_display(ctx, &settings).await?;
+            let rows = settings_display_rows(&settings, model_display);
             println!("Current application settings:");
-            println!(
-                "  default_download_path:       {:?}",
-                settings.default_download_path
-            );
-            println!(
-                "  default_context_size:        {:?}",
-                settings.default_context_size
-            );
-            println!("  proxy_port:                  {:?}", settings.proxy_port);
-            println!(
-                "  llama_base_port:             {:?}",
-                settings.llama_base_port
-            );
-            println!(
-                "  max_download_queue_size:     {:?}",
-                settings.max_download_queue_size
-            );
-            println!(
-                "  max_tool_iterations:         {:?}",
-                settings.max_tool_iterations
-            );
-            println!(
-                "  max_stagnation_steps:        {:?}",
-                settings.max_stagnation_steps
-            );
-            println!(
-                "  show_memory_fit_indicators:  {:?}",
-                settings.show_memory_fit_indicators
-            );
-
-            // Show default model with name if available
-            match settings.default_model_id {
-                Some(model_id) => match ctx.app.models().get_by_id(model_id).await? {
-                    Some(model) => {
-                        println!("  default_model_id:        {} ({})", model_id, model.name);
-                    }
-                    None => {
-                        println!("  default_model_id:        {} (not found)", model_id);
-                    }
-                },
-                None => {
-                    println!("  default_model_id:        None");
-                }
-            }
+            print_display_rows(&rows);
             Ok(())
         }
         SettingsCommand::Set {
@@ -174,30 +192,38 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             max_stagnation_steps,
             show_memory_fit_indicators,
         } => {
-            // Check if any settings were provided
-            let has_default_download_path = default_download_path.is_some();
-            let has_default_context_size = default_context_size.is_some();
-            let has_proxy_port = proxy_port.is_some();
-            let has_llama_base_port = llama_base_port.is_some();
-            let has_max_download_queue_size = max_download_queue_size.is_some();
-            let has_max_tool_iterations = max_tool_iterations.is_some();
-            let has_max_stagnation_steps = max_stagnation_steps.is_some();
-            let has_show_memory_fit_indicators = show_memory_fit_indicators.is_some();
+            // Collect the kebab-case keys of every flag that was provided.
+            let mut changed: BTreeSet<&str> = BTreeSet::new();
+            if default_download_path.is_some() {
+                changed.insert("default-download-path");
+            }
+            if default_context_size.is_some() {
+                changed.insert("default-context-size");
+            }
+            if proxy_port.is_some() {
+                changed.insert("proxy-port");
+            }
+            if llama_base_port.is_some() {
+                changed.insert("llama-base-port");
+            }
+            if max_download_queue_size.is_some() {
+                changed.insert("max-download-queue-size");
+            }
+            if max_tool_iterations.is_some() {
+                changed.insert("max-tool-iterations");
+            }
+            if max_stagnation_steps.is_some() {
+                changed.insert("max-stagnation-steps");
+            }
+            if show_memory_fit_indicators.is_some() {
+                changed.insert("show-memory-fit-indicators");
+            }
 
-            if !has_default_download_path
-                && !has_default_context_size
-                && !has_proxy_port
-                && !has_llama_base_port
-                && !has_max_download_queue_size
-                && !has_max_tool_iterations
-                && !has_max_stagnation_steps
-                && !has_show_memory_fit_indicators
-            {
+            if changed.is_empty() {
                 println!("No settings provided. Use --help to see available options.");
                 return Ok(());
             }
 
-            // Build update request
             let update = SettingsUpdate {
                 default_download_path: default_download_path.map(Some),
                 default_context_size: default_context_size.map(Some),
@@ -222,72 +248,45 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
                 title_generation_prompt: None,
             };
 
-            // Get current settings and apply updates for validation
-            let mut current = ctx.app.settings().get().await?;
+            // Pre-validate: merge the prospective update into a local copy and validate
+            // before persisting, so the user gets a clear error without a partial write.
+            let mut prospective = ctx.app.settings().get().await?;
             if let Some(Some(v)) = &update.default_download_path {
-                current.default_download_path = Some(v.clone());
+                prospective.default_download_path = Some(v.clone());
             }
             if let Some(Some(v)) = update.default_context_size {
-                current.default_context_size = Some(v);
+                prospective.default_context_size = Some(v);
             }
             if let Some(Some(v)) = update.proxy_port {
-                current.proxy_port = Some(v);
+                prospective.proxy_port = Some(v);
             }
             if let Some(Some(v)) = update.llama_base_port {
-                current.llama_base_port = Some(v);
+                prospective.llama_base_port = Some(v);
             }
             if let Some(Some(v)) = update.max_download_queue_size {
-                current.max_download_queue_size = Some(v);
+                prospective.max_download_queue_size = Some(v);
             }
             if let Some(Some(v)) = update.max_tool_iterations {
-                current.max_tool_iterations = Some(v);
+                prospective.max_tool_iterations = Some(v);
             }
             if let Some(Some(v)) = update.max_stagnation_steps {
-                current.max_stagnation_steps = Some(v);
+                prospective.max_stagnation_steps = Some(v);
             }
             if let Some(Some(v)) = update.show_memory_fit_indicators {
-                current.show_memory_fit_indicators = Some(v);
+                prospective.show_memory_fit_indicators = Some(v);
             }
+            validate_settings(&prospective)?;
 
-            // Validate before saving
-            validate_settings(&current)?;
-
-            // Save settings
             let updated = ctx.app.settings().update(update).await?;
+            let model_display = resolve_model_display(ctx, &updated).await?;
+            let all_rows = settings_display_rows(&updated, model_display);
+            let changed_rows: Vec<_> = all_rows
+                .into_iter()
+                .filter(|(k, _)| changed.contains(k.as_str()))
+                .collect();
+
             println!("✓ Settings updated successfully:");
-            if has_default_download_path {
-                println!(
-                    "  default_download_path: {:?}",
-                    updated.default_download_path
-                );
-            }
-            if has_default_context_size {
-                println!("  default_context_size: {:?}", updated.default_context_size);
-            }
-            if has_proxy_port {
-                println!("  proxy_port: {:?}", updated.proxy_port);
-            }
-            if has_llama_base_port {
-                println!("  llama_base_port: {:?}", updated.llama_base_port);
-            }
-            if has_max_download_queue_size {
-                println!(
-                    "  max_download_queue_size: {:?}",
-                    updated.max_download_queue_size
-                );
-            }
-            if has_max_tool_iterations {
-                println!("  max_tool_iterations: {:?}", updated.max_tool_iterations);
-            }
-            if has_max_stagnation_steps {
-                println!("  max_stagnation_steps: {:?}", updated.max_stagnation_steps);
-            }
-            if has_show_memory_fit_indicators {
-                println!(
-                    "  show_memory_fit_indicators: {:?}",
-                    updated.show_memory_fit_indicators
-                );
-            }
+            print_display_rows(&changed_rows);
             Ok(())
         }
         SettingsCommand::Reset { force } => {
@@ -311,8 +310,60 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
 
 #[cfg(test)]
 mod tests {
+    use gglib_core::Settings;
+
+    use super::settings_display_rows;
+
     #[test]
-    fn test_config_handler_exists() {
-        // Placeholder test to ensure module compiles
+    fn settings_display_rows_uses_kebab_case_keys() {
+        let settings = Settings::default();
+        let rows = settings_display_rows(&settings, None);
+
+        assert!(!rows.is_empty(), "should produce at least one row");
+
+        for (key, _) in &rows {
+            assert!(
+                key.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "key {key:?} must contain only [a-z0-9-]"
+            );
+            assert!(
+                !key.contains('_'),
+                "key {key:?} must not contain underscores"
+            );
+        }
+
+        // No duplicate keys
+        let mut seen = std::collections::BTreeSet::new();
+        for (key, _) in &rows {
+            assert!(seen.insert(key.clone()), "duplicate key {key:?}");
+        }
+    }
+
+    #[test]
+    fn settings_display_rows_model_display_override() {
+        let settings = Settings {
+            default_model_id: Some(42),
+            ..Default::default()
+        };
+        let rows = settings_display_rows(&settings, Some("42 (TestModel)".to_owned()));
+        let model_row = rows
+            .iter()
+            .find(|(k, _)| k == "default-model-id")
+            .expect("default-model-id row should be present");
+        assert_eq!(model_row.1, "42 (TestModel)");
+    }
+
+    #[test]
+    fn settings_display_rows_null_displays_as_none() {
+        let settings = Settings {
+            default_download_path: None,
+            ..Default::default()
+        };
+        let rows = settings_display_rows(&settings, None);
+        let row = rows
+            .iter()
+            .find(|(k, _)| k == "default-download-path")
+            .expect("default-download-path should be present");
+        assert_eq!(row.1, "None");
     }
 }


### PR DESCRIPTION
Closes #441

## What

`gglib config settings show` printed field names as `snake_case` while `gglib config settings set` accepted `--kebab-case` flags. They now use the same format. Values also switch from Rust Debug format (`Some(4096)`) to clean bare values (`4096`, `None`).

## How

A single private helper `settings_display_rows(s: &Settings, model_display: Option<String>) -> Vec<(String, String)>` is the new source of truth for all settings display. It uses `serde_json::to_value` + `.replace('_', "-")` to derive kebab-case keys dynamically — new `Settings` fields appear in CLI output automatically without any further handler changes.

**`show`** calls the helper and computes column alignment dynamically.

**`set` output** collects changed keys into a `BTreeSet<&str>`, calls the same helper on the updated settings, then filters by the changed set — replacing 8 `has_*` booleans and 8 duplicated `println!` calls.

**`default-model-id`** is resolved async first, then passed as a pre-formatted string into the helper, keeping it fully in the single source of truth.

## Before / After

```
# Before
Current application settings:
  default_context_size:        Some(4096)
  proxy_port:                  Some(8080)
  default_model_id:        None

# After
Current application settings:
  default-context-size    4096
  proxy-port              8080
  default-model-id        None
```

## Tests

Replaces the placeholder `test_config_handler_exists` with three real unit tests:
- `settings_display_rows_uses_kebab_case_keys` — all keys match `[a-z0-9-]+`, no duplicates
- `settings_display_rows_model_display_override` — `default-model-id` uses passed-in string
- `settings_display_rows_null_displays_as_none` — `null` JSON → `"None"` display string
