### PR TITLE
feat(council): shared tool_filter_parser — numeric indices, ranges, and exclusions

### DIFF
--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -66,6 +66,7 @@ any other infrastructure crate.  Concrete `LlmCompletionPort` and
 | `council/stance` | Post-debate stance tracking (Held/Shifted/Conceded) |
 | `council/orchestrator` | Slim coordinator (rounds → compaction → judge → stance → synthesis) |
 | `council/suggest` | `suggest_council()` — shared suggest orchestration |
+| `council/tool_filter_parser` | `parse_tool_filter()` — shared tool-filter expression parser |
 <!-- MODULE_TABLE_END -->
 
 <details>

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -22,6 +22,7 @@
 //! | `stance.rs`       | Post-debate stance tracking (Held/Shifted/Conceded)  |
 //! | `orchestrator.rs` | Slim coordinator (rounds → compaction → judge → stance → synthesis) |
 //! | `suggest.rs`      | `suggest_council()` — shared suggest orchestration  |
+//! | `tool_filter_parser.rs` | `parse_tool_filter()` — shared tool-filter expression parser |
 
 mod compaction;
 pub mod config;
@@ -36,8 +37,10 @@ pub mod state;
 pub mod stream_bridge;
 pub mod suggest;
 mod synthesis;
+pub mod tool_filter_parser;
 
 pub use config::{CouncilAgent, CouncilConfig, JudgeConfig, SuggestedCouncil};
+pub use tool_filter_parser::parse_tool_filter;
 pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 pub use orchestrator::run as run_council;
 pub use prompts::{contentiousness_tier_label, contentiousness_to_instruction};

--- a/crates/gglib-agent/src/council/mod.rs
+++ b/crates/gglib-agent/src/council/mod.rs
@@ -40,10 +40,10 @@ mod synthesis;
 pub mod tool_filter_parser;
 
 pub use config::{CouncilAgent, CouncilConfig, JudgeConfig, SuggestedCouncil};
-pub use tool_filter_parser::parse_tool_filter;
 pub use events::{COUNCIL_EVENT_CHANNEL_CAPACITY, CouncilEvent};
 pub use orchestrator::run as run_council;
 pub use prompts::{contentiousness_tier_label, contentiousness_to_instruction};
 pub use state::{AgentContribution, CouncilState, extract_core_claim};
 pub use stream_bridge::{bridge_agent_events, emit_turn_complete};
 pub use suggest::suggest_council;
+pub use tool_filter_parser::parse_tool_filter;

--- a/crates/gglib-agent/src/council/tool_filter_parser.rs
+++ b/crates/gglib-agent/src/council/tool_filter_parser.rs
@@ -68,10 +68,7 @@ use anyhow::{Result, bail};
 ///
 /// Returns `Ok(None)` when all tools should be allowed; `Ok(Some(names))` for
 /// an explicit subset; `Err` on invalid syntax or out-of-range indices.
-pub fn parse_tool_filter(
-    input: &str,
-    available: &[String],
-) -> Result<Option<Vec<String>>> {
+pub fn parse_tool_filter(input: &str, available: &[String]) -> Result<Option<Vec<String>>> {
     let trimmed = input.trim();
 
     // Fast path: empty or literal "all"

--- a/crates/gglib-agent/src/council/tool_filter_parser.rs
+++ b/crates/gglib-agent/src/council/tool_filter_parser.rs
@@ -1,0 +1,429 @@
+//! Parser for the council agent tool-filter input syntax.
+//!
+//! This module provides [`parse_tool_filter`], the canonical implementation used
+//! by every frontend (CLI, Axum web API, Tauri GUI) so that tool-filter entry
+//! behaviour is **identical** across all surfaces.
+//!
+//! # Syntax
+//!
+//! Input is a comma-separated list of *tokens*.  Whitespace around commas and
+//! around each token is ignored.  The following token forms are accepted:
+//!
+//! | Token | Meaning |
+//! |-------|---------|
+//! | `all` | All available tools (case-insensitive) |
+//! | `5` | The tool at 1-based position 5 in the available list |
+//! | `5:9` | Tools at positions 5 through 9 inclusive (1-based) |
+//! | `name` | The tool whose name is exactly `name` |
+//! | `!5` | *Exclude* tool at position 5 |
+//! | `!5:9` | *Exclude* tools at positions 5–9 |
+//! | `!name` | *Exclude* the named tool |
+//!
+//! ## Exclusion semantics
+//!
+//! When the input contains **only exclusion tokens** (e.g. `!6`), the
+//! inclusion set is implicitly the full available list — "all tools except
+//! those excluded".
+//!
+//! ## Return value
+//!
+//! - [`None`] — the agent should receive all available tools (equivalent to
+//!   clearing the filter).
+//! - [`Some(names)`] — an explicit allowlist of tool names.
+//!
+//! # Examples
+//!
+//! ```
+//! # use gglib_agent::council::parse_tool_filter;
+//! let tools: Vec<String> = (1..=9)
+//!     .map(|i| format!("tool_{i}"))
+//!     .collect();
+//!
+//! // Numeric range
+//! let r = parse_tool_filter("5:7", &tools).unwrap();
+//! assert_eq!(r, Some(vec!["tool_5".into(), "tool_6".into(), "tool_7".into()]));
+//!
+//! // Exclusion only — implicit "all except"
+//! let r = parse_tool_filter("!1", &tools).unwrap();
+//! assert_eq!(r.unwrap().len(), 8);
+//!
+//! // Mixed range + exclusion
+//! let r = parse_tool_filter("5:9,!6", &tools).unwrap();
+//! assert_eq!(r, Some(vec!["tool_5".into(), "tool_7".into(), "tool_8".into(), "tool_9".into()]));
+//!
+//! // "all" or empty → None
+//! assert_eq!(parse_tool_filter("all", &tools).unwrap(), None);
+//! assert_eq!(parse_tool_filter("", &tools).unwrap(), None);
+//! ```
+
+use anyhow::{Result, bail};
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/// Parse a tool-filter expression and return the resolved allowlist.
+///
+/// `available` is the ordered list of tool names the executor exposes.  The
+/// caller is responsible for printing these to the user (with 1-based indices)
+/// before collecting input.
+///
+/// Returns `Ok(None)` when all tools should be allowed; `Ok(Some(names))` for
+/// an explicit subset; `Err` on invalid syntax or out-of-range indices.
+pub fn parse_tool_filter(
+    input: &str,
+    available: &[String],
+) -> Result<Option<Vec<String>>> {
+    let trimmed = input.trim();
+
+    // Fast path: empty or literal "all"
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("all") {
+        return Ok(None);
+    }
+
+    // Tokenise on commas
+    let tokens: Vec<&str> = trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let mut inclusions: Vec<String> = Vec::new();
+    let mut exclusions: Vec<String> = Vec::new();
+    let mut has_explicit_inclusions = false;
+
+    for token in &tokens {
+        if let Some(rest) = token.strip_prefix('!') {
+            let resolved = resolve_token(rest.trim(), available)?;
+            exclusions.extend(resolved);
+        } else {
+            has_explicit_inclusions = true;
+            let resolved = resolve_token(token, available)?;
+            inclusions.extend(resolved);
+        }
+    }
+
+    // If only exclusions were given, start from the full available set
+    let mut selected: Vec<String> = if has_explicit_inclusions {
+        inclusions
+    } else {
+        available.to_vec()
+    };
+
+    // Deduplicate (preserving first-occurrence order)
+    dedup_preserve_order(&mut selected);
+
+    // Remove exclusions
+    selected.retain(|name| !exclusions.contains(name));
+
+    // If the result equals the full available set, return None (no filter needed)
+    if selected == available {
+        return Ok(None);
+    }
+
+    Ok(Some(selected))
+}
+
+// ─── Private helpers ─────────────────────────────────────────────────────────
+
+/// Resolve a single (non-`!`-prefixed) token into a list of tool names.
+///
+/// Handles:
+/// - `"all"` → all available names
+/// - `"N"` (integer) → the tool at 1-based index N
+/// - `"N:M"` (range, both sides numeric) → tools at positions N through M inclusive
+/// - anything else → exact name lookup
+fn resolve_token(token: &str, available: &[String]) -> Result<Vec<String>> {
+    if token.eq_ignore_ascii_case("all") {
+        return Ok(available.to_vec());
+    }
+
+    // Range: N:M — only when both sides are purely numeric so that tool names
+    // containing ':' (e.g. "tavily:search") are not mis-parsed as ranges.
+    if let Some((start_str, end_str)) = token.split_once(':') {
+        let start_str = start_str.trim();
+        let end_str = end_str.trim();
+        if start_str.bytes().all(|b| b.is_ascii_digit())
+            && end_str.bytes().all(|b| b.is_ascii_digit())
+        {
+            let start = parse_index(start_str, available.len())?;
+            let end = parse_index(end_str, available.len())?;
+            if start > end {
+                bail!(
+                    "range start ({}) must not be greater than range end ({})",
+                    start + 1,
+                    end + 1
+                );
+            }
+            return Ok(available[start..=end].to_vec());
+        }
+    }
+
+    // Single integer index
+    if token.bytes().all(|b| b.is_ascii_digit()) {
+        let idx = parse_index(token, available.len())?;
+        return Ok(vec![available[idx].clone()]);
+    }
+
+    // Exact name
+    if available.iter().any(|a| a == token) {
+        return Ok(vec![token.to_owned()]);
+    }
+
+    bail!("unknown tool: {token}")
+}
+
+/// Parse a 1-based index string into a 0-based `usize`, validating bounds.
+fn parse_index(s: &str, len: usize) -> Result<usize> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| anyhow::anyhow!("expected a number, got {s:?}"))?;
+    if n == 0 || n > len {
+        bail!("tool index {n} is out of range (1–{len})");
+    }
+    Ok(n - 1)
+}
+
+/// Remove duplicates from `v`, keeping the first occurrence of each element.
+fn dedup_preserve_order(v: &mut Vec<String>) {
+    let mut seen = std::collections::HashSet::new();
+    v.retain(|item| seen.insert(item.clone()));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools(n: usize) -> Vec<String> {
+        (1..=n).map(|i| format!("tool_{i}")).collect()
+    }
+
+    fn named_tools() -> Vec<String> {
+        vec![
+            "builtin:get_current_time".into(),
+            "builtin:read_file".into(),
+            "builtin:list_directory".into(),
+            "builtin:grep_search".into(),
+            "tavily:search".into(),
+            "tavily:extract".into(),
+            "tavily:crawl".into(),
+            "tavily:map".into(),
+            "tavily:research".into(),
+        ]
+    }
+
+    // ── fast-path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert_eq!(parse_tool_filter("", &tools(5)).unwrap(), None);
+    }
+
+    #[test]
+    fn whitespace_only_returns_none() {
+        assert_eq!(parse_tool_filter("   ", &tools(5)).unwrap(), None);
+    }
+
+    #[test]
+    fn all_keyword_returns_none() {
+        assert_eq!(parse_tool_filter("all", &tools(5)).unwrap(), None);
+    }
+
+    #[test]
+    fn all_keyword_case_insensitive() {
+        assert_eq!(parse_tool_filter("ALL", &tools(5)).unwrap(), None);
+        assert_eq!(parse_tool_filter("All", &tools(5)).unwrap(), None);
+    }
+
+    // ── numeric single ───────────────────────────────────────────────────────
+
+    #[test]
+    fn numeric_single_index() {
+        let t = tools(9);
+        assert_eq!(
+            parse_tool_filter("5", &t).unwrap(),
+            Some(vec!["tool_5".into()])
+        );
+    }
+
+    #[test]
+    fn numeric_index_1() {
+        let t = tools(9);
+        assert_eq!(
+            parse_tool_filter("1", &t).unwrap(),
+            Some(vec!["tool_1".into()])
+        );
+    }
+
+    #[test]
+    fn numeric_index_last() {
+        let t = tools(9);
+        assert_eq!(
+            parse_tool_filter("9", &t).unwrap(),
+            Some(vec!["tool_9".into()])
+        );
+    }
+
+    // ── range ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn range_5_to_9() {
+        let t = tools(9);
+        let got = parse_tool_filter("5:9", &t).unwrap();
+        assert_eq!(
+            got,
+            Some(vec![
+                "tool_5".into(),
+                "tool_6".into(),
+                "tool_7".into(),
+                "tool_8".into(),
+                "tool_9".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn range_single_element() {
+        let t = tools(9);
+        assert_eq!(
+            parse_tool_filter("3:3", &t).unwrap(),
+            Some(vec!["tool_3".into()])
+        );
+    }
+
+    // ── exclusion only ───────────────────────────────────────────────────────
+
+    #[test]
+    fn exclusion_only_single() {
+        let t = tools(9);
+        let got = parse_tool_filter("!6", &t).unwrap().unwrap();
+        assert_eq!(got.len(), 8);
+        assert!(!got.contains(&"tool_6".to_string()));
+    }
+
+    #[test]
+    fn exclusion_only_range() {
+        let t = tools(9);
+        let got = parse_tool_filter("!5:9", &t).unwrap().unwrap();
+        assert_eq!(got, vec!["tool_1", "tool_2", "tool_3", "tool_4"]);
+    }
+
+    #[test]
+    fn exclusion_only_by_name() {
+        let t = named_tools();
+        let got = parse_tool_filter("!tavily:search", &t).unwrap().unwrap();
+        assert!(!got.contains(&"tavily:search".to_string()));
+        assert_eq!(got.len(), 8);
+    }
+
+    // ── mixed inclusion + exclusion ──────────────────────────────────────────
+
+    #[test]
+    fn range_with_exclusion() {
+        let t = tools(9);
+        // 5:9 minus 6 → [5, 7, 8, 9]
+        let got = parse_tool_filter("5:9,!6", &t).unwrap();
+        assert_eq!(
+            got,
+            Some(vec![
+                "tool_5".into(),
+                "tool_7".into(),
+                "tool_8".into(),
+                "tool_9".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn range_with_exclusion_range() {
+        let t = tools(9);
+        // 1:9 minus !5:9 → [1, 2, 3, 4]
+        let got = parse_tool_filter("1:9,!5:9", &t).unwrap();
+        assert_eq!(
+            got,
+            Some(vec![
+                "tool_1".into(),
+                "tool_2".into(),
+                "tool_3".into(),
+                "tool_4".into(),
+            ])
+        );
+    }
+
+    // ── exact names ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn exact_name_works() {
+        let t = named_tools();
+        let got = parse_tool_filter("tavily:search", &t).unwrap();
+        assert_eq!(got, Some(vec!["tavily:search".into()]));
+    }
+
+    #[test]
+    fn mixed_name_and_number() {
+        let t = named_tools();
+        // Index 1 = "builtin:get_current_time", plus named "tavily:search" (index 5)
+        let got = parse_tool_filter("1,tavily:search", &t).unwrap();
+        assert_eq!(
+            got,
+            Some(vec![
+                "builtin:get_current_time".into(),
+                "tavily:search".into(),
+            ])
+        );
+    }
+
+    // ── deduplication ────────────────────────────────────────────────────────
+
+    #[test]
+    fn duplicates_are_removed() {
+        let t = tools(9);
+        // "1,1,1:3" → [tool_1, tool_2, tool_3]
+        let got = parse_tool_filter("1,1,1:3", &t).unwrap();
+        assert_eq!(
+            got,
+            Some(vec!["tool_1".into(), "tool_2".into(), "tool_3".into()])
+        );
+    }
+
+    // ── result equals full set → None ────────────────────────────────────────
+
+    #[test]
+    fn selecting_all_explicitly_returns_none() {
+        let t = tools(3);
+        // 1:3 covers everything → equivalent to "all"
+        assert_eq!(parse_tool_filter("1:3", &t).unwrap(), None);
+    }
+
+    // ── error cases ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn out_of_range_index_is_error() {
+        let t = tools(5);
+        assert!(parse_tool_filter("6", &t).is_err());
+    }
+
+    #[test]
+    fn index_zero_is_error() {
+        let t = tools(5);
+        assert!(parse_tool_filter("0", &t).is_err());
+    }
+
+    #[test]
+    fn unknown_name_is_error() {
+        let t = tools(5);
+        assert!(parse_tool_filter("nonexistent_tool", &t).is_err());
+    }
+
+    #[test]
+    fn range_start_gt_end_is_error() {
+        let t = tools(9);
+        assert!(parse_tool_filter("9:5", &t).is_err());
+    }
+
+    #[test]
+    fn exclusion_unknown_name_is_error() {
+        let t = tools(5);
+        assert!(parse_tool_filter("!nonexistent_tool", &t).is_err());
+    }
+}

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -266,6 +266,23 @@ The interactive REPL editor supports these commands:
 | `run` | Accept and run the council |
 | `quit` | Abort without running |
 
+The `tools <N>` command accepts a rich filter expression:
+
+| Expression | Meaning |
+|------------|---------|
+| `all` | All available tools (clears the filter) |
+| `5` | Tool at position 5 in the numbered list |
+| `5:9` | Tools at positions 5 through 9 (inclusive) |
+| `name` | Tool whose name matches exactly |
+| `!6` | All tools *except* position 6 |
+| `!5:9` | All tools *except* positions 5–9 |
+| `!name` | All tools *except* the named one |
+| `5:9,!6` | Positions 5–9, excluding 6 → gives 5, 7, 8, 9 |
+
+Tokens are comma-separated; inclusion and exclusion tokens can be freely mixed.
+When only exclusions are given (e.g. `!6`), the implicit inclusion set is
+all available tools.
+
 The `refine` command sends your instruction to the LLM along with the current
 council as context, producing a targeted revision that preserves stable agent
 IDs and makes minimal changes. You can refine multiple times before running.

--- a/crates/gglib-cli/src/handlers/council/editor.rs
+++ b/crates/gglib-cli/src/handlers/council/editor.rs
@@ -6,6 +6,7 @@
 use anyhow::{Result, anyhow, bail};
 
 use gglib_agent::council::config::{CouncilAgent, CouncilConfig, clamp_contentiousness};
+use gglib_agent::council::parse_tool_filter;
 
 use crate::presentation::style::{BOLD, DIM, RESET};
 
@@ -43,34 +44,15 @@ pub fn apply_contentiousness(agent: &mut CouncilAgent, input: &str) -> Result<()
 
 /// Set the tool filter for a single agent.
 ///
-/// `available` is the full list of tool names from the executor — printed
-/// for the user before this function is called.  Passing `"all"` or an
-/// empty string clears the filter (agent gets all tools).
+/// Delegates to [`parse_tool_filter`] for the full supported syntax:
+/// exact names, 1-based numeric indices, `N:M` ranges, and `!`-prefixed
+/// exclusions.  Passing `"all"` or an empty string clears the filter.
 pub fn apply_tool_filter(
     agent: &mut CouncilAgent,
     input: &str,
     available: &[String],
 ) -> Result<()> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("all") {
-        agent.tool_filter = None;
-        return Ok(());
-    }
-
-    let selected: Vec<String> = trimmed
-        .split(',')
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
-        .collect();
-
-    // Validate every name exists in the available set
-    for name in &selected {
-        if !available.iter().any(|a| a == name) {
-            bail!("unknown tool: {name}");
-        }
-    }
-
-    agent.tool_filter = Some(selected);
+    agent.tool_filter = parse_tool_filter(input, available)?;
     Ok(())
 }
 

--- a/crates/gglib-cli/src/handlers/council/repl.rs
+++ b/crates/gglib-cli/src/handlers/council/repl.rs
@@ -152,7 +152,7 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
             "tools" => {
                 if let Some(idx) = parse_agent_idx(arg, config.agents.len()) {
                     editor::print_available_tools(available_tools);
-                    eprintln!("  Enter comma-separated tool names, or \"all\":");
+                    eprintln!("  Enter names, numbers (5), ranges (5:9), exclusions (!6, !5:9), or \"all\":");
                     let input = rl.readline("  ")?;
                     let res = editor::apply_tool_filter(
                         &mut config.agents[idx],

--- a/crates/gglib-cli/src/handlers/council/repl.rs
+++ b/crates/gglib-cli/src/handlers/council/repl.rs
@@ -152,7 +152,9 @@ pub fn edit_loop(config: &mut CouncilConfig, available_tools: &[String]) -> Resu
             "tools" => {
                 if let Some(idx) = parse_agent_idx(arg, config.agents.len()) {
                     editor::print_available_tools(available_tools);
-                    eprintln!("  Enter names, numbers (5), ranges (5:9), exclusions (!6, !5:9), or \"all\":");
+                    eprintln!(
+                        "  Enter names, numbers (5), ranges (5:9), exclusions (!6, !5:9), or \"all\":"
+                    );
                     let input = rl.readline("  ")?;
                     let res = editor::apply_tool_filter(
                         &mut config.agents[idx],


### PR DESCRIPTION
## Problem

The council editor `tools <N>` command only accepted exact tool names. Entering the displayed 1-based numbers (e.g. `5,6,7,8,9`) was rejected with `unknown tool: 5`.

## Solution

Extract a new shared parser module `gglib_agent::council::tool_filter_parser` with a rich filter expression syntax. All frontends (CLI, Axum API, Tauri GUI) import and call the same `parse_tool_filter()` function, guaranteeing 100% feature parity.

### New syntax

| Expression | Meaning |
|------------|---------|
| `5`        | Tool at 1-based position 5 in the displayed list |
| `5:9`      | Tools at positions 5–9 inclusive |
| `!6`       | All tools *except* position 6 |
| `!5:9`     | All tools *except* positions 5–9 |
| `5:9,!6`   | Positions 5–9, minus 6 → gives 5, 7, 8, 9 |
| `name`     | Tool whose name matches exactly (unchanged) |
| `all`      | All tools / clear the filter (unchanged) |

Tokens are comma-separated; inclusions and exclusions can be freely mixed. When only exclusion tokens are given (e.g. `!6`), the implicit inclusion set is the full available list.

Tool names containing `:` (e.g. `tavily:search`) continue to work — range detection only fires when *both* sides of `:` are numeric.

## Changes

### `gglib-agent` (new file)
- `crates/gglib-agent/src/council/tool_filter_parser.rs` — `parse_tool_filter()` with full module-level doc comment, syntax table, and 23 unit tests covering every token form and all error cases
- `council/mod.rs` — `pub mod tool_filter_parser` + `pub use parse_tool_filter`
- `README.md` — adds `council/tool_filter_parser` row to the module table

### `gglib-cli` (thinned down)
- `editor.rs` — `apply_tool_filter` reduced to a 2-line delegate; all parsing logic removed from this crate
- `repl.rs` — REPL hint updated: `Enter names, numbers (5), ranges (5:9), exclusions (!6, !5:9), or "all":`
- `README.md` — `tools <N>` command entry expanded with a full syntax reference table

## Notes

- `gglib-tauri` was **not** given the `gglib-agent` dep in this PR: the crate has `#![deny(unused_crate_dependencies)]` and has no council UI yet. The dep should be added in the Tauri council UI PR alongside the first actual usage.
- Docs workflow (`cargo doc --workspace`) will pick up the new `//!` module doc and the updated `README` automatically on the next release.

## Tests

```
cargo test -p gglib-agent --lib -- tool_filter_parser
# 23 passed; 0 failed
```