### PR TITLE
feat: CLI interactive download queue with GUI parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "console 0.16.3",
  "crossterm",
  "dotenvy",
  "gglib-agent",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GGLib keeps a catalog of your GGUFs, handles downloading from HuggingFace, and s
 ## Quick look
 
 ```bash
-# Download a model from HuggingFace
+# Download a model from HuggingFace (interactive queue — press [a] to add more, [q] to cancel)
 gglib model download bartowski/Qwen2.5-7B-Instruct-GGUF
 
 # List what you have

--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -29,6 +29,11 @@ clap_complete = "4"
 indicatif = { workspace = true }
 termimad = { workspace = true }
 crossterm = { workspace = true }
+# `console` is the input-side companion to indicatif (same authors). Used by the
+# interactive download monitor for single-keystroke reads (`Term::read_key`) and
+# cooked-mode line input (`Term::read_line`). Importing directly (rather than
+# relying on indicatif's transitive dep) makes the dependency explicit.
+console = "0.16"
 chrono = { workspace = true }
 serde_json = { workspace = true }
 hf-hub = { workspace = true }

--- a/crates/gglib-cli/src/bootstrap.rs
+++ b/crates/gglib-cli/src/bootstrap.rs
@@ -19,8 +19,9 @@ use gglib_core::ModelRegistrar;
 use gglib_core::download::DownloadError;
 use gglib_core::ports::{
     DownloadManagerConfig, DownloadManagerPort, GgufParserPort, ModelRegistrarPort,
-    ModelRepository, NoopDownloadEmitter, NoopEmitter, ProcessRunner, Repos,
+    ModelRepository, NoopEmitter, ProcessRunner, Repos,
 };
+use gglib_download::CliDownloadEventEmitter;
 use gglib_core::services::{AppCore, ModelVerificationService};
 use gglib_db::{CoreFactory, setup_database};
 use gglib_download::{DownloadManagerDeps, build_download_manager};
@@ -122,6 +123,12 @@ pub struct CliContext {
     /// TCP connections to llama-server are pooled across REPL turns, matching
     /// the connection-pooling behaviour of the Axum handler.
     pub http_client: reqwest::Client,
+    /// Terminal progress emitter used by the interactive download monitor.
+    ///
+    /// Shared with the download manager so bar updates flow from manager events,
+    /// and with the interactive monitor so it can suspend rendering while
+    /// prompting for additional model IDs.
+    pub download_emitter: Arc<CliDownloadEventEmitter>,
 }
 
 /// Bootstrap the CLI application.
@@ -167,7 +174,9 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
 
     // 6. Create download manager with injected ports
     let models_dir_resolution = resolve_models_dir(None)?;
-    let download_config = DownloadManagerConfig::new(models_dir_resolution.path);
+    let hf_token = std::env::var("HF_TOKEN").ok();
+    let download_config = DownloadManagerConfig::new(models_dir_resolution.path)
+        .with_hf_token(hf_token);
 
     // Create the model registrar (composes over model repository + GGUF parser).
     // Stored on CliContext AND injected into the download manager so CLI
@@ -187,8 +196,9 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
     // Create the HuggingFace client
     let hf_client = Arc::new(DefaultHfClient::new(&HfClientConfig::default()));
 
-    // Create no-op event emitter (CLI doesn't need real-time events)
-    let event_emitter = Arc::new(NoopDownloadEmitter::new());
+    // Create CLI terminal emitter — renders indicatif progress bars and exposes
+    // the MultiProgress handle for interactive suspend/resume.
+    let download_emitter = Arc::new(CliDownloadEventEmitter::new());
 
     // Build the download manager
     let downloads: Arc<dyn DownloadManagerPort> =
@@ -196,7 +206,7 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
             model_registrar: model_registrar.clone(),
             download_repo,
             hf_client: hf_client.clone(),
-            event_emitter,
+            event_emitter: Arc::clone(&download_emitter),
             config: download_config,
         }));
 
@@ -223,6 +233,7 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
         llama_server_path: config.llama_server_path,
         base_port: config.base_port,
         http_client: reqwest::Client::new(),
+        download_emitter,
     })
 }
 
@@ -254,6 +265,7 @@ pub fn bootstrap_with(
         llama_server_path,
         base_port: 9000,
         http_client: reqwest::Client::new(),
+        download_emitter: Arc::new(CliDownloadEventEmitter::new()),
     }
 }
 

--- a/crates/gglib-cli/src/bootstrap.rs
+++ b/crates/gglib-cli/src/bootstrap.rs
@@ -21,9 +21,9 @@ use gglib_core::ports::{
     DownloadManagerConfig, DownloadManagerPort, GgufParserPort, ModelRegistrarPort,
     ModelRepository, NoopEmitter, ProcessRunner, Repos,
 };
-use gglib_download::CliDownloadEventEmitter;
 use gglib_core::services::{AppCore, ModelVerificationService};
 use gglib_db::{CoreFactory, setup_database};
+use gglib_download::CliDownloadEventEmitter;
 use gglib_download::{DownloadManagerDeps, build_download_manager};
 // GGUF_BOOTSTRAP_EXCEPTION: Parser injected at composition root only
 use gglib_gguf::GgufParser;
@@ -175,8 +175,8 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
     // 6. Create download manager with injected ports
     let models_dir_resolution = resolve_models_dir(None)?;
     let hf_token = std::env::var("HF_TOKEN").ok();
-    let download_config = DownloadManagerConfig::new(models_dir_resolution.path)
-        .with_hf_token(hf_token);
+    let download_config =
+        DownloadManagerConfig::new(models_dir_resolution.path).with_hf_token(hf_token);
 
     // Create the model registrar (composes over model repository + GGUF parser).
     // Stored on CliContext AND injected into the download manager so CLI

--- a/crates/gglib-cli/src/handlers/model/download/README.md
+++ b/crates/gglib-cli/src/handlers/model/download/README.md
@@ -11,7 +11,7 @@ HuggingFace Hub download command handlers for the CLI.
 
 ## Purpose
 
-This module handles all download-related commands that interact with HuggingFace Hub, including searching for models, browsing popular models, downloading GGUF files, checking for updates, and updating existing models.
+This module handles all download-related commands that interact with HuggingFace Hub, including searching for models, browsing popular models, downloading GGUF files with interactive queue management, checking for updates, and updating existing models.
 
 ## Architecture
 
@@ -20,18 +20,21 @@ This module handles all download-related commands that interact with HuggingFace
 │                    download Module                               │
 ├──────────────────────────────────────────────────────────────────┤
 │                                                                  │
-│  CLI → Handler → cli_exec → HF Client → Database Registration   │
-│       (this)     (download) (hf crate)   (db crate)             │
+│  CLI → exec.rs ──queue_smart()──► DownloadManagerPort           │
+│              └───────────────────► interactive.rs (TUI monitor) │
+│                                        ↕  [a]/[q] hotkeys        │
+│                                   CliDownloadEventEmitter        │
+│                                   (indicatif MultiProgress)      │
 │                                                                  │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
 **Key Flow:**
-1. User issues download command via CLI
-2. Handler validates and prepares arguments
-3. Delegates to `gglib-download::cli_exec` for actual download
-4. Automatically registers downloaded model in database (unless `--skip-db`)
-5. Displays progress and confirmation
+1. User issues `gglib model download <repo>` command
+2. `exec.rs` queues it via `DownloadManagerPort::queue_smart` (same code path as the GUI)
+3. `interactive.rs` renders progress via `CliDownloadEventEmitter` (indicatif bars)
+4. In TTY mode: `[a]` prompts for another model to add to the queue; `[q]` cancels all
+5. Model registration on completion is handled by the download manager (via `ModelRegistrarPort`)
 
 ## Modules
 
@@ -41,6 +44,7 @@ This module handles all download-related commands that interact with HuggingFace
 | [`browse.rs`](browse.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-browse-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-browse-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-browse-coverage.json) |
 | [`check_updates.rs`](check_updates.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-check_updates-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-check_updates-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-check_updates-coverage.json) |
 | [`exec.rs`](exec.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-exec-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-exec-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-exec-coverage.json) |
+| [`interactive.rs`](interactive.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-interactive-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-interactive-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-interactive-coverage.json) |
 | [`search.rs`](search.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-search-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-search-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-search-coverage.json) |
 | [`update_model.rs`](update_model.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-update_model-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-update_model-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-download-update_model-coverage.json) |
 <!-- module-table:end -->
@@ -82,35 +86,38 @@ gglib model browse popular --limit 10
 gglib model browse recent --size 7B
 ```
 
-### `download` (exec)
-Download a model from HuggingFace Hub.
+### `download` (exec + interactive)
+Download a model from HuggingFace Hub with interactive queue support.
 
-**Module:** `exec.rs`
+**Module:** `exec.rs` (orchestrator), `interactive.rs` (TUI monitor)
 
 **Options:**
 - `--quantization <QUANT>` / `-q` - Specific quantization (e.g., "Q4_K_M")
-- `--list-quants` - List available quantizations
-- `--skip-db` - Skip database registration
-- `--token <TOKEN>` - HuggingFace token for private models
+- `--list-quants` - List available quantizations (uses `--token` if provided)
+- `--token <TOKEN>` - HuggingFace token (for `--list-quants` only; use `HF_TOKEN` env var for downloads)
 - `--force` / `-f` - Skip confirmation prompt
 
+**Interactive mode (TTY):**
+- `[a]` — add another model to the queue while a download is running
+- `[q]` / Ctrl-C — cancel all pending downloads and exit cleanly
+- Falls back to a plain polling monitor when stdout is not a TTY (CI, pipes)
+
 **Flow:**
-1. Query HuggingFace Hub for repo info
-2. Show available quantizations (if `--list-quants`)
-3. Download GGUF file to models directory
-4. Parse GGUF metadata
-5. Register in database (unless `--skip-db`)
+1. Queue initial model via `DownloadManagerPort::queue_smart` (same path as GUI)
+2. Enter the interactive monitor loop
+3. Download manager handles progress events → `CliDownloadEventEmitter` renders indicatif bars
+4. On completion, model is registered automatically (via `ModelRegistrarPort`)
 
 **Example:**
 ```bash
 # List available quantizations
 gglib model download microsoft/DialoGPT-medium --list-quants
 
-# Download specific quantization
+# Download specific quantization — enters live queue monitor
 gglib model download microsoft/DialoGPT-medium -q Q4_K_M
 
-# Download without database registration
-gglib model download microsoft/DialoGPT-medium -q Q4_K_M --skip-db
+# Download with HF token for private repos (set env var for downloads)
+HF_TOKEN=hf_... gglib model download my-org/private-model -q Q4_K_M
 ```
 
 ### `check-updates`

--- a/crates/gglib-cli/src/handlers/model/download/exec.rs
+++ b/crates/gglib-cli/src/handlers/model/download/exec.rs
@@ -1,17 +1,22 @@
-//! Download handler.
+//! Download handler — lean orchestrator.
 //!
-//! Downloads models from HuggingFace Hub and registers them in the database
-//! via [`ModelRegistrarPort`], the same registration path used by the GUI.
+//! Queues the initial model via [`DownloadManagerPort::queue_smart`] (the same
+//! path used by the GUI) and then delegates to [`interactive::run_interactive_monitor`]
+//! for progress rendering and optional interactive queue management.
+//!
+//! Model registration after download is handled internally by the download
+//! manager via the shared [`ModelRegistrarPort`], giving full parity with
+//! the GUI registration path.
 
-use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::Result;
-use gglib_core::download::Quantization;
-use gglib_core::ports::CompletedDownload;
-use gglib_download::cli_exec::{self, CliDownloadRequest, CliDownloadResult, list_quantizations};
+use gglib_download::cli_exec::list_quantizations;
 
 use crate::bootstrap::CliContext;
 use gglib_core::paths::resolve_models_dir;
+
+use super::interactive;
 
 /// Download command arguments passed from CLI.
 pub struct DownloadArgs<'a> {
@@ -19,89 +24,48 @@ pub struct DownloadArgs<'a> {
     pub quantization: Option<&'a str>,
     pub list_quants: bool,
     pub force: bool,
+    /// HuggingFace token for private models.
+    ///
+    /// Used only for `--list-quants`. For downloads, prefer the `HF_TOKEN`
+    /// environment variable which is read at startup and wired into the
+    /// download manager config, mirroring how the GUI handles authentication.
     pub token: Option<&'a str>,
 }
 
 /// Execute the download command.
 ///
-/// Downloads a model from HuggingFace and registers it in the database.
+/// Queues `model_id` via the shared [`DownloadManagerPort`] and enters the
+/// interactive monitor loop. The monitor exits when all queued downloads
+/// complete or the user presses `[q]`.
 pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
     let models_dir = resolve_models_dir(None)?.path;
 
-    // If --list-quants, just show available quantizations and exit
+    // --list-quants: show available quantizations and exit (uses cli_exec directly).
     if args.list_quants {
         list_quantizations(args.model_id, &models_dir, args.token.map(String::from)).await?;
         return Ok(());
     }
 
-    // Build download request
-    let mut request = CliDownloadRequest::new(args.model_id, models_dir.clone())
-        .with_force(args.force)
-        .with_token(args.token.map(String::from));
+    // Queue the initial download via the shared manager (same code path as GUI).
+    let quant = args.quantization.map(String::from);
+    let (position, shard_count) = Arc::clone(&ctx.downloads)
+        .queue_smart(args.model_id.to_string(), quant)
+        .await?;
 
-    if let Some(quant) = args.quantization {
-        request = request.with_quantization(quant);
-    }
-
-    // Execute download (this handles progress display)
-    let result = cli_exec::download(request).await?;
-
-    // Register via the same ModelRegistrarPort that the GUI uses,
-    // ensuring full GGUF metadata extraction and parity.
-    let completed = build_completed_download(&result)?;
-
-    match ctx.model_registrar.register_model(&completed).await {
-        Ok(model) => {
-            println!("✓ Model registered in database:");
-            println!("  ID: {}", model.id);
-            println!("  Name: {}", model.name);
-            println!("  Path: {}", model.file_path.display());
-        }
-        Err(e) => {
-            // Don't fail - the download succeeded, just registration failed
-            println!(
-                "⚠️  Download succeeded but database registration failed: {}",
-                e
-            );
-            println!(
-                "  You can manually add the model with: gglib model add {}",
-                result.primary_path.display()
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// Map a [`CliDownloadResult`] to the [`CompletedDownload`] DTO that
-/// [`ModelRegistrarPort::register_model`] expects.
-fn build_completed_download(result: &CliDownloadResult) -> Result<CompletedDownload> {
-    let quantization = Quantization::from_str(&result.quantization).unwrap_or_default(); // falls back to Quantization::Unknown
-
-    let is_sharded = result.downloaded_paths.len() > 1;
-
-    let total_bytes = result
-        .downloaded_paths
-        .iter()
-        .map(|p| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
-        .sum();
-
-    let file_paths = if is_sharded {
-        Some(result.downloaded_paths.clone())
+    if shard_count > 1 {
+        println!(
+            "↳ queued at position {position} ({shard_count} shards)",
+        );
     } else {
-        None
-    };
+        println!("↳ queued at position {position}");
+    }
 
-    Ok(CompletedDownload {
-        primary_path: result.primary_path.clone(),
-        all_paths: result.downloaded_paths.clone(),
-        quantization,
-        repo_id: result.repo_id.clone(),
-        commit_sha: result.commit_sha.clone(),
-        is_sharded,
-        total_bytes,
-        file_paths,
-        hf_tags: vec![],
-        hf_file_entries: vec![],
-    })
+    // Hand off to the interactive monitor — all progress rendering, keypress
+    // handling, TTY/non-TTY detection, and failure reporting live there.
+    interactive::run_interactive_monitor(
+        Arc::clone(&ctx.downloads),
+        Arc::clone(&ctx.download_emitter),
+    )
+    .await
 }
+

--- a/crates/gglib-cli/src/handlers/model/download/exec.rs
+++ b/crates/gglib-cli/src/handlers/model/download/exec.rs
@@ -48,15 +48,9 @@ pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
 
     // Queue the initial download via the shared manager (same code path as GUI).
     let quant = args.quantization.map(String::from);
-    let (position, shard_count) = Arc::clone(&ctx.downloads)
+    Arc::clone(&ctx.downloads)
         .queue_smart(args.model_id.to_string(), quant)
         .await?;
-
-    if shard_count > 1 {
-        println!("↳ queued at position {position} ({shard_count} shards)",);
-    } else {
-        println!("↳ queued at position {position}");
-    }
 
     // Hand off to the interactive monitor — all progress rendering, keypress
     // handling, TTY/non-TTY detection, and failure reporting live there.

--- a/crates/gglib-cli/src/handlers/model/download/exec.rs
+++ b/crates/gglib-cli/src/handlers/model/download/exec.rs
@@ -53,9 +53,7 @@ pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
         .await?;
 
     if shard_count > 1 {
-        println!(
-            "↳ queued at position {position} ({shard_count} shards)",
-        );
+        println!("↳ queued at position {position} ({shard_count} shards)",);
     } else {
         println!("↳ queued at position {position}");
     }
@@ -68,4 +66,3 @@ pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
     )
     .await
 }
-

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -123,8 +123,9 @@ async fn run_tty_monitor(
                     ..
                 })) => {
                     handle_add_to_queue(&downloads, &mp, &mut raw).await;
-                    // Re-print so the hint is visible below any new bar.
-                    mp.println("[a] queue another  [q] quit").ok();
+                    // Reset so the polling loop reprints the hint cleanly on
+                    // the next tick, after the bars have fully re-rendered.
+                    hint_shown = false;
                 }
 
                 Ok(Event::Key(KeyEvent {
@@ -197,16 +198,19 @@ async fn handle_add_to_queue(
     // we block on stdin, ensuring background downloads keep progressing.
     let prompt_result = tokio::task::block_in_place(|| {
         mp.suspend(|| -> Result<Option<(String, Option<String>)>> {
-            let model_id = prompt_string("Model ID")?;
-            if model_id.is_empty() {
+            let model_id_raw = prompt_string("Model ID")?;
+            if model_id_raw.is_empty() {
                 return Ok(None);
             }
-            let quant_str =
-                prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
-            let quant = if quant_str.is_empty() {
-                None
+            // Accept inline `-q` flag so the user can paste a full
+            // command-line fragment, e.g. `owner/repo -q Q4_K_M`.
+            let (model_id, inline_quant) = parse_inline_quant(&model_id_raw);
+            let quant = if inline_quant.is_some() {
+                inline_quant
             } else {
-                Some(quant_str)
+                let quant_str =
+                    prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
+                if quant_str.is_empty() { None } else { Some(quant_str) }
             };
             Ok(Some((model_id, quant)))
         })
@@ -234,6 +238,23 @@ async fn handle_add_to_queue(
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Parse an optional inline `-q <quant>` suffix from a raw model ID string.
+///
+/// Accepts the fragment that a user might copy from a CLI invocation, e.g.
+/// `owner/repo -q Q4_K_M`. Splits on the first ` -q ` token (case-sensitive)
+/// and returns `(model_id, Some(quantization))`. If no flag is found, returns
+/// the original string unchanged and `None`.
+fn parse_inline_quant(s: &str) -> (String, Option<String>) {
+    if let Some((model, quant)) = s.split_once(" -q ") {
+        let model = model.trim().to_string();
+        let quant = quant.trim().to_string();
+        if !model.is_empty() && !quant.is_empty() {
+            return (model, Some(quant));
+        }
+    }
+    (s.trim().to_string(), None)
+}
 
 /// Returns `true` when there are no active or pending downloads.
 fn is_queue_finished(snapshot: &QueueSnapshot) -> bool {

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use indicatif::{ProgressBar, ProgressStyle};
 
 use gglib_core::download::QueueSnapshot;
 use gglib_core::ports::DownloadManagerPort;
@@ -110,8 +111,12 @@ async fn run_tty_monitor(
         Err(_) => return run_plain_monitor(downloads).await,
     };
 
+    // hint_bar: a static ProgressBar owned by the MultiProgress that holds
+    // the [a]/[q] hint text. Using a managed bar (rather than mp.println)
+    // keeps indicatif's line-count accurate, so suspend/resume never tears.
+    let mut hint_bar: Option<ProgressBar> = None;
     let mut seen_items = false;
-    let mut hint_shown = false;
+    let mut last_item_count: u32 = 0;
 
     loop {
         // ── Non-blocking keypress check (zero-timeout poll) ───────────────
@@ -122,10 +127,9 @@ async fn run_tty_monitor(
                     kind: KeyEventKind::Press,
                     ..
                 })) => {
+                    // suspend() inside handle_add_to_queue clears and redraws
+                    // all managed bars (including hint_bar) automatically.
                     handle_add_to_queue(&downloads, &mp, &mut raw).await;
-                    // Reset so the polling loop reprints the hint cleanly on
-                    // the next tick, after the bars have fully re-rendered.
-                    hint_shown = false;
                 }
 
                 Ok(Event::Key(KeyEvent {
@@ -156,15 +160,30 @@ async fn run_tty_monitor(
 
         // ── Completion / progress check ───────────────────────────────────
         let snapshot = downloads.get_queue_snapshot().await?;
+        let item_count = snapshot.active_count + snapshot.pending_count;
 
-        if snapshot.active_count > 0 || snapshot.pending_count > 0 {
+        if item_count > 0 {
             seen_items = true;
         }
 
-        // Show the hint once, anchored under the first progress bar.
-        if seen_items && !hint_shown {
-            mp.println("[a] queue another  [q] quit").ok();
-            hint_shown = true;
+        // Create the hint bar the first time we see activity.
+        if seen_items && hint_bar.is_none() {
+            let style = ProgressStyle::with_template("{msg}")
+                .unwrap_or_else(|_| ProgressStyle::default_bar());
+            let bar = ProgressBar::new(0);
+            bar.set_style(style);
+            bar.set_message("[a] queue another  [q] quit");
+            hint_bar = Some(mp.add(bar));
+            last_item_count = item_count;
+        }
+
+        // Re-anchor hint to the bottom whenever new items appear.
+        if item_count > last_item_count {
+            if let Some(bar) = &hint_bar {
+                mp.remove(bar);
+                mp.add(bar.clone());
+            }
+            last_item_count = item_count;
         }
 
         // Fast-fail: exit immediately if a failure appeared before we ever
@@ -177,6 +196,10 @@ async fn run_tty_monitor(
         }
     }
 
+    // Clear the hint bar cleanly before restoring the terminal.
+    if let Some(bar) = hint_bar {
+        bar.finish_and_clear();
+    }
     drop(raw);
     Ok(())
 }
@@ -210,7 +233,11 @@ async fn handle_add_to_queue(
             } else {
                 let quant_str =
                     prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
-                if quant_str.is_empty() { None } else { Some(quant_str) }
+                if quant_str.is_empty() {
+                    None
+                } else {
+                    Some(quant_str)
+                }
             };
             Ok(Some((model_id, quant)))
         })

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -27,11 +27,13 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressStyle};
 
 use gglib_core::download::QueueSnapshot;
 use gglib_core::ports::DownloadManagerPort;
 use gglib_download::CliDownloadEventEmitter;
+
+use crate::utils::input::{prompt_string, prompt_string_with_default};
 
 // ─── Public entry point ──────────────────────────────────────────────────────
 
@@ -104,7 +106,7 @@ async fn run_tty_monitor(
 ) -> Result<()> {
     let mp = emitter.multi_progress();
 
-    let _raw = match RawModeGuard::acquire() {
+    let mut raw = match RawModeGuard::acquire() {
         Ok(g) => g,
         Err(_) => return run_plain_monitor(downloads).await,
     };
@@ -125,9 +127,9 @@ async fn run_tty_monitor(
                     kind: KeyEventKind::Press,
                     ..
                 })) => {
-                    // Inline input via temporary ProgressBars — no stdin
-                    // prompts, so nothing leaks into the scrollback buffer.
-                    handle_add_to_queue(&downloads, &mp).await;
+                    // suspend() inside handle_add_to_queue clears and redraws
+                    // all managed bars (including hint_bar) automatically.
+                    handle_add_to_queue(&downloads, &mp, &mut raw).await;
                 }
 
                 Ok(Event::Key(KeyEvent {
@@ -164,19 +166,15 @@ async fn run_tty_monitor(
             seen_items = true;
         }
 
-        // Create the hint bar the first time we see activity, then keep
-        // its message in sync with the live queue counts on every tick.
-        let hint_msg = build_hint_message(snapshot.active_count, snapshot.pending_count);
+        // Create the hint bar the first time we see activity.
         if seen_items && hint_bar.is_none() {
             let style = ProgressStyle::with_template("{msg}")
                 .unwrap_or_else(|_| ProgressStyle::default_bar());
             let bar = ProgressBar::new(0);
             bar.set_style(style);
-            bar.set_message(hint_msg.clone());
+            bar.set_message("[a] queue another  [q] quit");
             hint_bar = Some(mp.add(bar));
             last_item_count = item_count;
-        } else if let Some(bar) = &hint_bar {
-            bar.set_message(hint_msg);
         }
 
         // Re-anchor hint to the bottom whenever new items appear.
@@ -202,132 +200,72 @@ async fn run_tty_monitor(
     if let Some(bar) = hint_bar {
         bar.finish_and_clear();
     }
-    drop(_raw);
+    drop(raw);
     Ok(())
 }
 
 /// Prompt the user for a new model ID and queue it.
 ///
-/// Uses [`prompt_in_bar`] for input — the prompt is rendered as a temporary
-/// managed `ProgressBar`, so keystrokes never reach stdout and there is no
-/// scrollback leakage. The terminal stays in raw mode throughout.
-async fn handle_add_to_queue(downloads: &Arc<dyn DownloadManagerPort>, mp: &MultiProgress) {
-    // — Model ID prompt —
-    let model_id_raw = match prompt_in_bar(mp, "Model ID").await {
-        Ok(Some(s)) if !s.is_empty() => s,
-        _ => return, // empty input, Esc, or Ctrl-C — silently abort
-    };
+/// Disables raw mode while reading stdin, wraps the blocking read in
+/// [`tokio::task::block_in_place`] so Tokio can keep running download tasks
+/// on other threads, then re-enables raw mode before returning.
+async fn handle_add_to_queue(
+    downloads: &Arc<dyn DownloadManagerPort>,
+    mp: &indicatif::MultiProgress,
+    raw: &mut RawModeGuard,
+) {
+    // Step off raw mode so the terminal echoes characters correctly.
+    raw.disable();
 
-    // Accept inline `-q` flag so the user can paste a full command-line
-    // fragment, e.g. `owner/repo -q Q4_K_M`.
-    let (model_id, inline_quant) = parse_inline_quant(&model_id_raw);
-
-    // — Quantization prompt (skipped if `-q` was inline) —
-    let quant = if inline_quant.is_some() {
-        inline_quant
-    } else {
-        match prompt_in_bar(mp, "Quantization (optional, e.g. Q4_K_M)").await {
-            Ok(Some(s)) if !s.is_empty() => Some(s),
-            Ok(_) => None,
-            Err(_) => return,
-        }
-    };
-
-    if let Err(e) = Arc::clone(downloads).queue_smart(model_id, quant).await {
-        // Show the error in a transient managed bar so it doesn't leak
-        // into the scrollback. Auto-clears after 3 seconds.
-        let style =
-            ProgressStyle::with_template("{msg}").unwrap_or_else(|_| ProgressStyle::default_bar());
-        let bar = mp.add(ProgressBar::new(0));
-        bar.set_style(style);
-        bar.set_message(format!("✗ Queue error: {e}"));
-        tokio::time::sleep(Duration::from_secs(3)).await;
-        bar.finish_and_clear();
-    }
-}
-
-/// Read a single line of user input from a temporary `ProgressBar`.
-///
-/// The bar is rendered as `{label}: {buffer}_` and updates live as the user
-/// types. Reads keystrokes via crossterm in raw mode, so nothing is echoed
-/// to stdout and no scrollback artifacts are produced.
-///
-/// # Returns
-/// - `Ok(Some(text))` on Enter (text may be empty if user pressed Enter immediately)
-/// - `Ok(None)` on Esc (user cancelled)
-/// - `Err(_)` on Ctrl-C (caller should treat as cancel)
-async fn prompt_in_bar(mp: &MultiProgress, label: &str) -> Result<Option<String>> {
-    let style = ProgressStyle::with_template("{prefix}: {msg}")
-        .unwrap_or_else(|_| ProgressStyle::default_bar());
-    let bar = mp.add(ProgressBar::new(0));
-    bar.set_style(style);
-    bar.set_prefix(label.to_string());
-    bar.set_message("_".to_string());
-
-    let mut buffer = String::new();
-
-    loop {
-        if crossterm::event::poll(Duration::ZERO).unwrap_or(false)
-            && let Ok(Event::Key(KeyEvent {
-                code,
-                modifiers,
-                kind: KeyEventKind::Press,
-                ..
-            })) = crossterm::event::read()
-        {
-            match code {
-                KeyCode::Enter => {
-                    bar.finish_and_clear();
-                    return Ok(Some(buffer.trim().to_string()));
-                }
-                KeyCode::Esc => {
-                    bar.finish_and_clear();
-                    return Ok(None);
-                }
-                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-                    bar.finish_and_clear();
-                    return Err(anyhow::anyhow!("input cancelled"));
-                }
-                KeyCode::Backspace => {
-                    buffer.pop();
-                    bar.set_message(format!("{buffer}_"));
-                }
-                KeyCode::Char(c) => {
-                    buffer.push(c);
-                    bar.set_message(format!("{buffer}_"));
-                }
-                _ => {}
+    // block_in_place: Tokio moves other tasks away from this thread while
+    // we block on stdin, ensuring background downloads keep progressing.
+    let prompt_result = tokio::task::block_in_place(|| {
+        mp.suspend(|| -> Result<Option<(String, Option<String>)>> {
+            let model_id_raw = prompt_string("Model ID")?;
+            if model_id_raw.is_empty() {
+                return Ok(None);
             }
-        }
+            // Accept inline `-q` flag so the user can paste a full
+            // command-line fragment, e.g. `owner/repo -q Q4_K_M`.
+            let (model_id, inline_quant) = parse_inline_quant(&model_id_raw);
+            let quant = if inline_quant.is_some() {
+                inline_quant
+            } else {
+                let quant_str =
+                    prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
+                if quant_str.is_empty() {
+                    None
+                } else {
+                    Some(quant_str)
+                }
+            };
+            Ok(Some((model_id, quant)))
+        })
+    });
 
-        // Yield to let Tokio run download tasks; their bars tick via
-        // their own enable_steady_tick from indicatif's draw thread.
-        tokio::time::sleep(Duration::from_millis(30)).await;
+    // Best-effort re-enable; if it fails the plain monitor loop continues.
+    let _ = raw.enable();
+
+    let entry = match prompt_result {
+        Ok(Some(entry)) => entry,
+        Ok(None) => return, // user pressed Enter with no input
+        Err(e) => {
+            mp.println(format!("✗ Input error: {e}")).ok();
+            return;
+        }
+    };
+
+    let (model_id, quant) = entry;
+    match Arc::clone(downloads).queue_smart(model_id, quant).await {
+        Ok(_) => {}
+        Err(e) => {
+            mp.println(format!("✗ Queue error: {e}")).ok();
+        }
     }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-/// Build the hint bar message including live queue counts.
-///
-/// Examples:
-/// - `[a] queue another  [q] quit  •  1 downloading`
-/// - `[a] queue another  [q] quit  •  2 downloading, 1 queued`
-fn build_hint_message(active: u32, pending: u32) -> String {
-    let mut msg = String::from("[a] queue another  [q] quit");
-    if active > 0 || pending > 0 {
-        msg.push_str("  •  ");
-        if active > 0 {
-            msg.push_str(&format!("{active} downloading"));
-        }
-        if pending > 0 {
-            if active > 0 {
-                msg.push_str(", ");
-            }
-            msg.push_str(&format!("{pending} queued"));
-        }
-    }
-    msg
-}
+
 /// Parse an optional inline `-q <quant>` suffix from a raw model ID string.
 ///
 /// Accepts the fragment that a user might copy from a CLI invocation, e.g.
@@ -362,19 +300,37 @@ fn print_failures(snapshot: &QueueSnapshot) {
 /// RAII guard that enables crossterm raw mode on construction and disables it
 /// on drop, ensuring the terminal is always restored even if the caller returns
 /// early via `?`.
-struct RawModeGuard;
+struct RawModeGuard {
+    active: bool,
+}
 
 impl RawModeGuard {
     /// Enable raw mode and return a guard. Returns an error if the terminal
     /// does not support raw mode.
     fn acquire() -> Result<Self> {
         enable_raw_mode()?;
-        Ok(Self)
+        Ok(Self { active: true })
+    }
+
+    /// Disable raw mode and mark the guard as inactive.
+    fn disable(&mut self) {
+        if self.active {
+            let _ = disable_raw_mode();
+            self.active = false;
+        }
+    }
+
+    /// Re-enable raw mode. Returns an error on failure; the guard stays
+    /// inactive so `Drop` won't attempt a double-disable.
+    fn enable(&mut self) -> Result<()> {
+        enable_raw_mode()?;
+        self.active = true;
+        Ok(())
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
-        let _ = disable_raw_mode();
+        self.disable();
     }
 }

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -226,10 +226,7 @@ async fn handle_add_to_queue(
 
     let (model_id, quant) = entry;
     match Arc::clone(downloads).queue_smart(model_id, quant).await {
-        Ok((pos, shards)) => {
-            mp.println(format!("↳ queued at position {pos} ({shards} shard(s))"))
-                .ok();
-        }
+        Ok(_) => {}
         Err(e) => {
             mp.println(format!("✗ Queue error: {e}")).ok();
         }

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -8,15 +8,45 @@
 //!
 //! | Environment | Behaviour |
 //! |---|---|
-//! | TTY (normal terminal) | Raw-mode keypress listener, `[a]` / `[q]` hotkeys |
+//! | TTY (normal terminal) | Single-keystroke `[a]` / `[q]` hotkeys via `console::Term` |
 //! | Non-TTY (CI, pipe)    | Plain 250 ms polling loop; exits when queue empties |
+//!
+//! # Why `console`, not `crossterm` raw mode
+//!
+//! Earlier iterations enabled `crossterm::terminal::enable_raw_mode()` to read
+//! single keypresses without Enter. That permanently disables the termios
+//! `OPOST` (output post-processing) flag for the duration of raw mode, which
+//! means newline characters (`\n`) are no longer translated to `\r\n` on
+//! output. `indicatif` emits a bare `\n` between each managed bar to separate
+//! them; without `OPOST` the cursor never returns to column 0, so every redraw
+//! drifts one column to the right and old frames remain on screen — bars
+//! appear to "scroll" instead of redrawing in place. The `crossterm` docs
+//! confirm this: *"New line character will not be processed therefore
+//! `println!` can't be used"* in raw mode.
+//!
+//! The `console` crate (same authors as `indicatif`, designed for exactly
+//! this scenario) provides `Term::read_key()` which briefly enters cbreak
+//! mode for a single byte read and then immediately restores cooked mode —
+//! `OPOST` stays enabled, so indicatif's redraws continue to work correctly.
+//! `Term::read_line()` reads a full line in cooked mode, perfect for the
+//! `[a]` "queue another" prompt when wrapped in `MultiProgress::suspend`.
+//!
+//! # Reader thread and rendezvous channels
+//!
+//! Because `Term::read_key()` is blocking, it runs on a dedicated thread
+//! (`tokio::task::spawn_blocking`). After every keystroke the reader thread
+//! parks on a *command* channel waiting for an explicit `Continue` from the
+//! main task. This rendezvous gives the main task a guaranteed window during
+//! which stdin is idle — necessary when the user presses `[a]` and we need
+//! to call `Term::read_line()` ourselves without racing the reader for
+//! input bytes.
 //!
 //! # Blocking stdin safety
 //!
-//! When the user presses `[a]`, stdin must be read synchronously inside
+//! When the user presses `[a]`, the line-input read happens inside
 //! `MultiProgress::suspend`, which takes a plain closure. To avoid starving
-//! the Tokio executor (and pausing background downloads), the entire suspend
-//! block is wrapped in [`tokio::task::block_in_place`], which signals to the
+//! the Tokio executor (and pausing background downloads) the suspend block
+//! is wrapped in `tokio::task::block_in_place`, which signals to the
 //! runtime that the current thread will block and allows other tasks to
 //! migrate to different threads.
 
@@ -25,15 +55,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use console::{Key, Term};
 use indicatif::{ProgressBar, ProgressStyle};
+use tokio::sync::mpsc;
 
 use gglib_core::download::QueueSnapshot;
 use gglib_core::ports::DownloadManagerPort;
 use gglib_download::CliDownloadEventEmitter;
-
-use crate::utils::input::{prompt_string, prompt_string_with_default};
 
 // ─── Public entry point ──────────────────────────────────────────────────────
 
@@ -95,156 +123,208 @@ async fn run_plain_monitor(downloads: Arc<dyn DownloadManagerPort>) -> Result<()
 
 // ─── TTY path ────────────────────────────────────────────────────────────────
 
+/// Command sent from the main task back to the keystroke reader thread,
+/// telling it whether to read another key or exit.
+enum ReaderCmd {
+    Continue,
+    Stop,
+}
+
 /// Interactive monitor for TTY environments.
 ///
-/// Enables raw mode so individual keypresses are detected without Enter.
-/// If raw mode fails (e.g., the platform doesn't support it), falls back
-/// gracefully to [`run_plain_monitor`].
+/// Spawns a dedicated keystroke reader thread (using `console::Term::read_key`)
+/// that ships keys to the main loop over an async mpsc channel, then awaits
+/// an explicit `Continue` command before reading the next key. The main loop
+/// `select!`s between the key channel, a 250 ms render tick, and Ctrl-C.
 async fn run_tty_monitor(
     downloads: Arc<dyn DownloadManagerPort>,
     emitter: Arc<CliDownloadEventEmitter>,
 ) -> Result<()> {
     let mp = emitter.multi_progress();
 
-    let mut raw = match RawModeGuard::acquire() {
-        Ok(g) => g,
-        Err(_) => return run_plain_monitor(downloads).await,
-    };
+    // ── Channels ───────────────────────────────────────────────────────────
+    // key_tx/key_rx: reader → main, one slot (rendezvous-ish; reader can
+    // queue a single key before blocking on the next cmd recv).
+    let (key_tx, mut key_rx) = mpsc::channel::<Key>(1);
+    // cmd_tx/cmd_rx: main → reader, capacity 1. Reader blocks on `recv()`
+    // after every key send, ensuring stdin is never read by the reader
+    // while the main task is doing line input.
+    let (cmd_tx, mut cmd_rx) = mpsc::channel::<ReaderCmd>(1);
 
-    // hint_bar: a static ProgressBar owned by the MultiProgress that holds
-    // the [a]/[q] hint text. Using a managed bar (rather than mp.println)
-    // keeps indicatif's line-count accurate, so suspend/resume never tears.
+    // ── Spawn the keystroke reader on a dedicated blocking thread ──────────
+    let reader_handle = tokio::task::spawn_blocking(move || {
+        let term = Term::stdout();
+        loop {
+            let key = match term.read_key() {
+                Ok(k) => k,
+                Err(_) => return, // stdin closed or unsupported
+            };
+            // If the channel is closed, main has exited — bail out.
+            if key_tx.blocking_send(key).is_err() {
+                return;
+            }
+            // Park until main tells us what to do next. This is the
+            // critical synchronization: while we're parked here, main
+            // can safely call `Term::read_line()` on stdin.
+            match cmd_rx.blocking_recv() {
+                Some(ReaderCmd::Continue) => {}
+                Some(ReaderCmd::Stop) | None => return,
+            }
+        }
+    });
+
+    // ── Render state ───────────────────────────────────────────────────────
     let mut hint_bar: Option<ProgressBar> = None;
     let mut seen_items = false;
     let mut last_item_count: u32 = 0;
 
-    loop {
-        // ── Non-blocking keypress check (zero-timeout poll) ───────────────
-        if crossterm::event::poll(Duration::ZERO).unwrap_or(false) {
-            match crossterm::event::read() {
-                Ok(Event::Key(KeyEvent {
-                    code: KeyCode::Char('a'),
-                    kind: KeyEventKind::Press,
-                    ..
-                })) => {
-                    // suspend() inside handle_add_to_queue clears and redraws
-                    // all managed bars (including hint_bar) automatically.
-                    handle_add_to_queue(&downloads, &mp, &mut raw).await;
+    let mut tick = tokio::time::interval(Duration::from_millis(250));
+    // Skip the initial fire-immediately tick so we don't redraw before
+    // the runner task has had a chance to populate the queue.
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    tick.tick().await;
+
+    let result: Result<()> = loop {
+        tokio::select! {
+            // ── Keystroke from reader thread ───────────────────────────────
+            maybe_key = key_rx.recv() => {
+                match maybe_key {
+                    Some(Key::Char('a')) => {
+                        // Reader is now parked on cmd_rx.recv() — stdin is
+                        // free for us to call Term::read_line() inside the
+                        // suspend block.
+                        handle_add_to_queue(&downloads, &mp).await;
+                        // Tell reader to resume reading keys.
+                        let _ = cmd_tx.send(ReaderCmd::Continue).await;
+                    }
+                    Some(Key::Char('q')) | Some(Key::Escape) => {
+                        downloads.cancel_all().await.ok();
+                        let _ = cmd_tx.send(ReaderCmd::Stop).await;
+                        break Ok(());
+                    }
+                    Some(_) => {
+                        // Ignore other keys; tell reader to keep going.
+                        let _ = cmd_tx.send(ReaderCmd::Continue).await;
+                    }
+                    None => {
+                        // Reader thread exited unexpectedly — fall through
+                        // to plain polling for the rest of the session.
+                        break run_plain_monitor(downloads.clone()).await;
+                    }
+                }
+            }
+
+            // ── Ctrl-C from terminal (signal, not a key) ──────────────────
+            _ = tokio::signal::ctrl_c() => {
+                downloads.cancel_all().await.ok();
+                let _ = cmd_tx.send(ReaderCmd::Stop).await;
+                break Ok(());
+            }
+
+            // ── 250 ms render / completion tick ────────────────────────────
+            _ = tick.tick() => {
+                let snapshot = downloads.get_queue_snapshot().await?;
+                let item_count = snapshot.active_count + snapshot.pending_count;
+
+                if item_count > 0 {
+                    seen_items = true;
                 }
 
-                Ok(Event::Key(KeyEvent {
-                    code: KeyCode::Char('q'),
-                    kind: KeyEventKind::Press,
-                    ..
-                })) => {
-                    downloads.cancel_all().await.ok();
-                    break;
+                // Create the hint bar the first time we see activity.
+                if seen_items && hint_bar.is_none() {
+                    let style = ProgressStyle::with_template("{msg}")
+                        .unwrap_or_else(|_| ProgressStyle::default_bar());
+                    let bar = ProgressBar::new(0);
+                    bar.set_style(style);
+                    bar.set_message(build_hint_message(
+                        snapshot.active_count,
+                        snapshot.pending_count,
+                    ));
+                    hint_bar = Some(mp.add(bar));
+                    last_item_count = item_count;
                 }
 
-                Ok(Event::Key(KeyEvent {
-                    code: KeyCode::Char('c'),
-                    modifiers,
-                    kind: KeyEventKind::Press,
-                    ..
-                })) if modifiers.contains(KeyModifiers::CONTROL) => {
-                    downloads.cancel_all().await.ok();
-                    break;
+                // Update live counts in the hint message every tick.
+                if let Some(bar) = &hint_bar {
+                    bar.set_message(build_hint_message(
+                        snapshot.active_count,
+                        snapshot.pending_count,
+                    ));
                 }
 
-                _ => {}
+                // Re-anchor hint to the bottom whenever new items appear.
+                if item_count > last_item_count {
+                    if let Some(bar) = &hint_bar {
+                        mp.remove(bar);
+                        mp.add(bar.clone());
+                    }
+                    last_item_count = item_count;
+                }
+
+                // Fast-fail: exit if a failure appeared before any activity.
+                let has_failure = !snapshot.recent_failures.is_empty();
+                if (seen_items || has_failure) && is_queue_finished(&snapshot) {
+                    print_failures(&snapshot);
+                    let _ = cmd_tx.send(ReaderCmd::Stop).await;
+                    break Ok(());
+                }
             }
         }
+    };
 
-        // ── Async yield — lets Tokio run download worker tasks ────────────
-        tokio::time::sleep(Duration::from_millis(250)).await;
-
-        // ── Completion / progress check ───────────────────────────────────
-        let snapshot = downloads.get_queue_snapshot().await?;
-        let item_count = snapshot.active_count + snapshot.pending_count;
-
-        if item_count > 0 {
-            seen_items = true;
-        }
-
-        // Create the hint bar the first time we see activity.
-        if seen_items && hint_bar.is_none() {
-            let style = ProgressStyle::with_template("{msg}")
-                .unwrap_or_else(|_| ProgressStyle::default_bar());
-            let bar = ProgressBar::new(0);
-            bar.set_style(style);
-            bar.set_message("[a] queue another  [q] quit");
-            hint_bar = Some(mp.add(bar));
-            last_item_count = item_count;
-        }
-
-        // Re-anchor hint to the bottom whenever new items appear.
-        if item_count > last_item_count {
-            if let Some(bar) = &hint_bar {
-                mp.remove(bar);
-                mp.add(bar.clone());
-            }
-            last_item_count = item_count;
-        }
-
-        // Fast-fail: exit immediately if a failure appeared before we ever
-        // saw any activity (instant auth error, missing Python helper, etc.).
-        let has_failure = !snapshot.recent_failures.is_empty();
-
-        if (seen_items || has_failure) && is_queue_finished(&snapshot) {
-            print_failures(&snapshot);
-            break;
-        }
-    }
-
-    // Clear the hint bar cleanly before restoring the terminal.
+    // Clear the hint bar cleanly before returning.
     if let Some(bar) = hint_bar {
         bar.finish_and_clear();
     }
-    drop(raw);
-    Ok(())
+    // Best-effort: wait briefly for the reader thread to exit so the
+    // terminal isn't left with a half-read pending. read_key() is blocking,
+    // so if we've already sent Stop the reader will exit on the next key —
+    // we don't actually wait for it (would block on stdin) and rely on
+    // the channel close + process exit to clean up.
+    drop(reader_handle);
+    result
 }
 
-/// Prompt the user for a new model ID and queue it.
-///
-/// Disables raw mode while reading stdin, wraps the blocking read in
-/// [`tokio::task::block_in_place`] so Tokio can keep running download tasks
-/// on other threads, then re-enables raw mode before returning.
+/// Prompt the user (via `console::Term::read_line`) for a new model ID
+/// and queue it. Runs entirely in cooked mode inside `MultiProgress::suspend`,
+/// so termios `OPOST` stays enabled and indicatif resumes cleanly afterward.
 async fn handle_add_to_queue(
     downloads: &Arc<dyn DownloadManagerPort>,
     mp: &indicatif::MultiProgress,
-    raw: &mut RawModeGuard,
 ) {
-    // Step off raw mode so the terminal echoes characters correctly.
-    raw.disable();
-
     // block_in_place: Tokio moves other tasks away from this thread while
     // we block on stdin, ensuring background downloads keep progressing.
     let prompt_result = tokio::task::block_in_place(|| {
         mp.suspend(|| -> Result<Option<(String, Option<String>)>> {
-            let model_id_raw = prompt_string("Model ID")?;
+            let term = Term::stdout();
+
+            // Print prompts to the same Term we read from so they line up
+            // with the input cursor when bars are suspended.
+            term.write_line("Model ID:")?;
+            let model_id_raw = term.read_line()?;
+            let model_id_raw = model_id_raw.trim();
             if model_id_raw.is_empty() {
                 return Ok(None);
             }
+
             // Accept inline `-q` flag so the user can paste a full
             // command-line fragment, e.g. `owner/repo -q Q4_K_M`.
-            let (model_id, inline_quant) = parse_inline_quant(&model_id_raw);
+            let (model_id, inline_quant) = parse_inline_quant(model_id_raw);
             let quant = if inline_quant.is_some() {
                 inline_quant
             } else {
-                let quant_str =
-                    prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
-                if quant_str.is_empty() {
+                term.write_line("Quantization (optional, e.g. Q4_K_M):")?;
+                let q = term.read_line()?;
+                let q = q.trim();
+                if q.is_empty() {
                     None
                 } else {
-                    Some(quant_str)
+                    Some(q.to_string())
                 }
             };
             Ok(Some((model_id, quant)))
         })
     });
-
-    // Best-effort re-enable; if it fails the plain monitor loop continues.
-    let _ = raw.enable();
 
     let entry = match prompt_result {
         Ok(Some(entry)) => entry,
@@ -257,7 +337,9 @@ async fn handle_add_to_queue(
 
     let (model_id, quant) = entry;
     match Arc::clone(downloads).queue_smart(model_id, quant).await {
-        Ok(_) => {}
+        Ok(_) => {
+            mp.println("✓ Queued").ok();
+        }
         Err(e) => {
             mp.println(format!("✗ Queue error: {e}")).ok();
         }
@@ -265,6 +347,11 @@ async fn handle_add_to_queue(
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Build the hint bar message including live queue counts.
+fn build_hint_message(active: u32, pending: u32) -> String {
+    format!("[a] queue another  [q] quit   ({active} active, {pending} queued)")
+}
 
 /// Parse an optional inline `-q <quant>` suffix from a raw model ID string.
 ///
@@ -292,45 +379,5 @@ fn is_queue_finished(snapshot: &QueueSnapshot) -> bool {
 fn print_failures(snapshot: &QueueSnapshot) {
     for failure in &snapshot.recent_failures {
         eprintln!("✗ {}: {}", failure.display_name, failure.error);
-    }
-}
-
-// ─── RawModeGuard ─────────────────────────────────────────────────────────────
-
-/// RAII guard that enables crossterm raw mode on construction and disables it
-/// on drop, ensuring the terminal is always restored even if the caller returns
-/// early via `?`.
-struct RawModeGuard {
-    active: bool,
-}
-
-impl RawModeGuard {
-    /// Enable raw mode and return a guard. Returns an error if the terminal
-    /// does not support raw mode.
-    fn acquire() -> Result<Self> {
-        enable_raw_mode()?;
-        Ok(Self { active: true })
-    }
-
-    /// Disable raw mode and mark the guard as inactive.
-    fn disable(&mut self) {
-        if self.active {
-            let _ = disable_raw_mode();
-            self.active = false;
-        }
-    }
-
-    /// Re-enable raw mode. Returns an error on failure; the guard stays
-    /// inactive so `Drop` won't attempt a double-disable.
-    fn enable(&mut self) -> Result<()> {
-        enable_raw_mode()?;
-        self.active = true;
-        Ok(())
-    }
-}
-
-impl Drop for RawModeGuard {
-    fn drop(&mut self) {
-        self.disable();
     }
 }

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -1,0 +1,254 @@
+//! Interactive download monitor for the CLI.
+//!
+//! Runs a monitoring loop while the download manager is active, rendering
+//! progress bars and — in TTY environments — listening for keypresses so
+//! the user can queue additional models without restarting the command.
+//!
+//! # TTY vs. non-TTY
+//!
+//! | Environment | Behaviour |
+//! |---|---|
+//! | TTY (normal terminal) | Raw-mode keypress listener, `[a]` / `[q]` hotkeys |
+//! | Non-TTY (CI, pipe)    | Plain 250 ms polling loop; exits when queue empties |
+//!
+//! # Blocking stdin safety
+//!
+//! When the user presses `[a]`, stdin must be read synchronously inside
+//! `MultiProgress::suspend`, which takes a plain closure. To avoid starving
+//! the Tokio executor (and pausing background downloads), the entire suspend
+//! block is wrapped in [`tokio::task::block_in_place`], which signals to the
+//! runtime that the current thread will block and allows other tasks to
+//! migrate to different threads.
+
+use std::io::IsTerminal;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+use gglib_core::download::QueueSnapshot;
+use gglib_core::ports::DownloadManagerPort;
+use gglib_download::CliDownloadEventEmitter;
+
+use crate::utils::input::{prompt_string, prompt_string_with_default};
+
+// ─── Public entry point ──────────────────────────────────────────────────────
+
+/// Run the interactive download monitor.
+///
+/// Blocks until all queued downloads complete, fail, or are cancelled.
+/// Failures encountered during the session are printed to stderr on exit.
+///
+/// The calling `execute()` handler simply awaits this future — all queue
+/// interaction and progress rendering is encapsulated here.
+pub async fn run_interactive_monitor(
+    downloads: Arc<dyn DownloadManagerPort>,
+    emitter: Arc<CliDownloadEventEmitter>,
+) -> Result<()> {
+    if std::io::stdout().is_terminal() {
+        run_tty_monitor(downloads, emitter).await
+    } else {
+        run_plain_monitor(downloads).await
+    }
+}
+
+// ─── Non-TTY path ────────────────────────────────────────────────────────────
+
+/// Plain polling loop for non-interactive environments (CI, pipes).
+///
+/// indicatif degrades gracefully on non-TTY stdout, so progress bars
+/// still emit periodic lines. We just poll for completion.
+async fn run_plain_monitor(downloads: Arc<dyn DownloadManagerPort>) -> Result<()> {
+    let mut interval = tokio::time::interval(Duration::from_millis(250));
+    loop {
+        interval.tick().await;
+        let snapshot = downloads.get_queue_snapshot().await?;
+        if is_queue_finished(&snapshot) {
+            print_failures(&snapshot);
+            return Ok(());
+        }
+    }
+}
+
+// ─── TTY path ────────────────────────────────────────────────────────────────
+
+/// Interactive monitor for TTY environments.
+///
+/// Enables raw mode so individual keypresses are detected without Enter.
+/// If raw mode fails (e.g., the platform doesn't support it), falls back
+/// gracefully to [`run_plain_monitor`].
+async fn run_tty_monitor(
+    downloads: Arc<dyn DownloadManagerPort>,
+    emitter: Arc<CliDownloadEventEmitter>,
+) -> Result<()> {
+    let mp = emitter.multi_progress();
+
+    let mut raw = match RawModeGuard::acquire() {
+        Ok(g) => g,
+        Err(_) => return run_plain_monitor(downloads).await,
+    };
+
+    mp.println("[a] add to queue  [q] quit").ok();
+
+    loop {
+        // ── Non-blocking keypress check (zero-timeout poll) ───────────────
+        if crossterm::event::poll(Duration::ZERO).unwrap_or(false) {
+            match crossterm::event::read() {
+                Ok(Event::Key(KeyEvent {
+                    code: KeyCode::Char('a'),
+                    kind: KeyEventKind::Press,
+                    ..
+                })) => {
+                    handle_add_to_queue(&downloads, &mp, &mut raw).await;
+                    mp.println("[a] add to queue  [q] quit").ok();
+                }
+
+                Ok(Event::Key(KeyEvent {
+                    code: KeyCode::Char('q'),
+                    kind: KeyEventKind::Press,
+                    ..
+                })) => {
+                    downloads.cancel_all().await.ok();
+                    break;
+                }
+
+                Ok(Event::Key(KeyEvent {
+                    code: KeyCode::Char('c'),
+                    modifiers,
+                    kind: KeyEventKind::Press,
+                    ..
+                })) if modifiers.contains(KeyModifiers::CONTROL) => {
+                    downloads.cancel_all().await.ok();
+                    break;
+                }
+
+                _ => {}
+            }
+        }
+
+        // ── Async yield — lets Tokio run download worker tasks ────────────
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        // ── Completion check ──────────────────────────────────────────────
+        let snapshot = downloads.get_queue_snapshot().await?;
+        if is_queue_finished(&snapshot) {
+            print_failures(&snapshot);
+            break;
+        }
+    }
+
+    drop(raw);
+    Ok(())
+}
+
+/// Prompt the user for a new model ID and queue it.
+///
+/// Disables raw mode while reading stdin, wraps the blocking read in
+/// [`tokio::task::block_in_place`] so Tokio can keep running download tasks
+/// on other threads, then re-enables raw mode before returning.
+async fn handle_add_to_queue(
+    downloads: &Arc<dyn DownloadManagerPort>,
+    mp: &indicatif::MultiProgress,
+    raw: &mut RawModeGuard,
+) {
+    // Step off raw mode so the terminal echoes characters correctly.
+    raw.disable();
+
+    // block_in_place: Tokio moves other tasks away from this thread while
+    // we block on stdin, ensuring background downloads keep progressing.
+    let prompt_result = tokio::task::block_in_place(|| {
+        mp.suspend(|| -> Result<Option<(String, Option<String>)>> {
+            let model_id = prompt_string("Model ID")?;
+            if model_id.is_empty() {
+                return Ok(None);
+            }
+            let quant_str =
+                prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
+            let quant = if quant_str.is_empty() {
+                None
+            } else {
+                Some(quant_str)
+            };
+            Ok(Some((model_id, quant)))
+        })
+    });
+
+    // Best-effort re-enable; if it fails the plain monitor loop continues.
+    let _ = raw.enable();
+
+    let entry = match prompt_result {
+        Ok(Some(entry)) => entry,
+        Ok(None) => return, // user pressed Enter with no input
+        Err(e) => {
+            mp.println(format!("✗ Input error: {e}")).ok();
+            return;
+        }
+    };
+
+    let (model_id, quant) = entry;
+    match Arc::clone(downloads).queue_smart(model_id, quant).await {
+        Ok((pos, shards)) => {
+            mp.println(format!("↳ queued at position {pos} ({shards} shard(s))"))
+                .ok();
+        }
+        Err(e) => {
+            mp.println(format!("✗ Queue error: {e}")).ok();
+        }
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Returns `true` when there are no active or pending downloads.
+fn is_queue_finished(snapshot: &QueueSnapshot) -> bool {
+    snapshot.active_count == 0 && snapshot.pending_count == 0
+}
+
+/// Print any recorded failures to stderr.
+fn print_failures(snapshot: &QueueSnapshot) {
+    for failure in &snapshot.recent_failures {
+        eprintln!("✗ {}: {}", failure.display_name, failure.error);
+    }
+}
+
+// ─── RawModeGuard ─────────────────────────────────────────────────────────────
+
+/// RAII guard that enables crossterm raw mode on construction and disables it
+/// on drop, ensuring the terminal is always restored even if the caller returns
+/// early via `?`.
+struct RawModeGuard {
+    active: bool,
+}
+
+impl RawModeGuard {
+    /// Enable raw mode and return a guard. Returns an error if the terminal
+    /// does not support raw mode.
+    fn acquire() -> Result<Self> {
+        enable_raw_mode()?;
+        Ok(Self { active: true })
+    }
+
+    /// Disable raw mode and mark the guard as inactive.
+    fn disable(&mut self) {
+        if self.active {
+            let _ = disable_raw_mode();
+            self.active = false;
+        }
+    }
+
+    /// Re-enable raw mode. Returns an error on failure; the guard stays
+    /// inactive so `Drop` won't attempt a double-disable.
+    fn enable(&mut self) -> Result<()> {
+        enable_raw_mode()?;
+        self.active = true;
+        Ok(())
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        self.disable();
+    }
+}

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -193,7 +193,7 @@ async fn run_tty_monitor(
                         // Reader is now parked on cmd_rx.recv() — stdin is
                         // free for us to call Term::read_line() inside the
                         // suspend block.
-                        handle_add_to_queue(&downloads, &mp).await;
+                        handle_add_to_queue(&downloads, &emitter, &mp).await;
                         // Tell reader to resume reading keys.
                         let _ = cmd_tx.send(ReaderCmd::Continue).await;
                     }
@@ -288,10 +288,19 @@ async fn run_tty_monitor(
 /// Prompt the user (via `console::Term::read_line`) for a new model ID
 /// and queue it. Runs entirely in cooked mode inside `MultiProgress::suspend`,
 /// so termios `OPOST` stays enabled and indicatif resumes cleanly afterward.
+///
+/// Steady-tick animation on all active bars is paused for the duration of the
+/// prompt. Without this, indicatif's per-bar background ticker can race with
+/// `suspend` and emit one last redraw frame just as suspend is clearing the
+/// region, leaving that frame stranded in scrollback above the prompt.
 async fn handle_add_to_queue(
     downloads: &Arc<dyn DownloadManagerPort>,
+    emitter: &Arc<CliDownloadEventEmitter>,
     mp: &indicatif::MultiProgress,
 ) {
+    // Quiesce indicatif's animation threads so suspend has exclusive control.
+    emitter.pause_animation();
+
     // block_in_place: Tokio moves other tasks away from this thread while
     // we block on stdin, ensuring background downloads keep progressing.
     let prompt_result = tokio::task::block_in_place(|| {
@@ -325,6 +334,9 @@ async fn handle_add_to_queue(
             Ok(Some((model_id, quant)))
         })
     });
+
+    // Restart steady-tick now that suspend has returned and bars are back.
+    emitter.resume_animation();
 
     let entry = match prompt_result {
         Ok(Some(entry)) => entry,

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -27,13 +27,11 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 use gglib_core::download::QueueSnapshot;
 use gglib_core::ports::DownloadManagerPort;
 use gglib_download::CliDownloadEventEmitter;
-
-use crate::utils::input::{prompt_string, prompt_string_with_default};
 
 // ─── Public entry point ──────────────────────────────────────────────────────
 
@@ -106,7 +104,7 @@ async fn run_tty_monitor(
 ) -> Result<()> {
     let mp = emitter.multi_progress();
 
-    let mut raw = match RawModeGuard::acquire() {
+    let _raw = match RawModeGuard::acquire() {
         Ok(g) => g,
         Err(_) => return run_plain_monitor(downloads).await,
     };
@@ -127,9 +125,9 @@ async fn run_tty_monitor(
                     kind: KeyEventKind::Press,
                     ..
                 })) => {
-                    // suspend() inside handle_add_to_queue clears and redraws
-                    // all managed bars (including hint_bar) automatically.
-                    handle_add_to_queue(&downloads, &mp, &mut raw).await;
+                    // Inline input via temporary ProgressBars — no stdin
+                    // prompts, so nothing leaks into the scrollback buffer.
+                    handle_add_to_queue(&downloads, &mp).await;
                 }
 
                 Ok(Event::Key(KeyEvent {
@@ -166,15 +164,19 @@ async fn run_tty_monitor(
             seen_items = true;
         }
 
-        // Create the hint bar the first time we see activity.
+        // Create the hint bar the first time we see activity, then keep
+        // its message in sync with the live queue counts on every tick.
+        let hint_msg = build_hint_message(snapshot.active_count, snapshot.pending_count);
         if seen_items && hint_bar.is_none() {
             let style = ProgressStyle::with_template("{msg}")
                 .unwrap_or_else(|_| ProgressStyle::default_bar());
             let bar = ProgressBar::new(0);
             bar.set_style(style);
-            bar.set_message("[a] queue another  [q] quit");
+            bar.set_message(hint_msg.clone());
             hint_bar = Some(mp.add(bar));
             last_item_count = item_count;
+        } else if let Some(bar) = &hint_bar {
+            bar.set_message(hint_msg);
         }
 
         // Re-anchor hint to the bottom whenever new items appear.
@@ -200,72 +202,132 @@ async fn run_tty_monitor(
     if let Some(bar) = hint_bar {
         bar.finish_and_clear();
     }
-    drop(raw);
+    drop(_raw);
     Ok(())
 }
 
 /// Prompt the user for a new model ID and queue it.
 ///
-/// Disables raw mode while reading stdin, wraps the blocking read in
-/// [`tokio::task::block_in_place`] so Tokio can keep running download tasks
-/// on other threads, then re-enables raw mode before returning.
-async fn handle_add_to_queue(
-    downloads: &Arc<dyn DownloadManagerPort>,
-    mp: &indicatif::MultiProgress,
-    raw: &mut RawModeGuard,
-) {
-    // Step off raw mode so the terminal echoes characters correctly.
-    raw.disable();
+/// Uses [`prompt_in_bar`] for input — the prompt is rendered as a temporary
+/// managed `ProgressBar`, so keystrokes never reach stdout and there is no
+/// scrollback leakage. The terminal stays in raw mode throughout.
+async fn handle_add_to_queue(downloads: &Arc<dyn DownloadManagerPort>, mp: &MultiProgress) {
+    // — Model ID prompt —
+    let model_id_raw = match prompt_in_bar(mp, "Model ID").await {
+        Ok(Some(s)) if !s.is_empty() => s,
+        _ => return, // empty input, Esc, or Ctrl-C — silently abort
+    };
 
-    // block_in_place: Tokio moves other tasks away from this thread while
-    // we block on stdin, ensuring background downloads keep progressing.
-    let prompt_result = tokio::task::block_in_place(|| {
-        mp.suspend(|| -> Result<Option<(String, Option<String>)>> {
-            let model_id_raw = prompt_string("Model ID")?;
-            if model_id_raw.is_empty() {
-                return Ok(None);
-            }
-            // Accept inline `-q` flag so the user can paste a full
-            // command-line fragment, e.g. `owner/repo -q Q4_K_M`.
-            let (model_id, inline_quant) = parse_inline_quant(&model_id_raw);
-            let quant = if inline_quant.is_some() {
-                inline_quant
-            } else {
-                let quant_str =
-                    prompt_string_with_default("Quantization (optional, e.g. Q4_K_M)", None)?;
-                if quant_str.is_empty() {
-                    None
-                } else {
-                    Some(quant_str)
-                }
-            };
-            Ok(Some((model_id, quant)))
-        })
-    });
+    // Accept inline `-q` flag so the user can paste a full command-line
+    // fragment, e.g. `owner/repo -q Q4_K_M`.
+    let (model_id, inline_quant) = parse_inline_quant(&model_id_raw);
 
-    // Best-effort re-enable; if it fails the plain monitor loop continues.
-    let _ = raw.enable();
-
-    let entry = match prompt_result {
-        Ok(Some(entry)) => entry,
-        Ok(None) => return, // user pressed Enter with no input
-        Err(e) => {
-            mp.println(format!("✗ Input error: {e}")).ok();
-            return;
+    // — Quantization prompt (skipped if `-q` was inline) —
+    let quant = if inline_quant.is_some() {
+        inline_quant
+    } else {
+        match prompt_in_bar(mp, "Quantization (optional, e.g. Q4_K_M)").await {
+            Ok(Some(s)) if !s.is_empty() => Some(s),
+            Ok(_) => None,
+            Err(_) => return,
         }
     };
 
-    let (model_id, quant) = entry;
-    match Arc::clone(downloads).queue_smart(model_id, quant).await {
-        Ok(_) => {}
-        Err(e) => {
-            mp.println(format!("✗ Queue error: {e}")).ok();
+    if let Err(e) = Arc::clone(downloads).queue_smart(model_id, quant).await {
+        // Show the error in a transient managed bar so it doesn't leak
+        // into the scrollback. Auto-clears after 3 seconds.
+        let style =
+            ProgressStyle::with_template("{msg}").unwrap_or_else(|_| ProgressStyle::default_bar());
+        let bar = mp.add(ProgressBar::new(0));
+        bar.set_style(style);
+        bar.set_message(format!("✗ Queue error: {e}"));
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        bar.finish_and_clear();
+    }
+}
+
+/// Read a single line of user input from a temporary `ProgressBar`.
+///
+/// The bar is rendered as `{label}: {buffer}_` and updates live as the user
+/// types. Reads keystrokes via crossterm in raw mode, so nothing is echoed
+/// to stdout and no scrollback artifacts are produced.
+///
+/// # Returns
+/// - `Ok(Some(text))` on Enter (text may be empty if user pressed Enter immediately)
+/// - `Ok(None)` on Esc (user cancelled)
+/// - `Err(_)` on Ctrl-C (caller should treat as cancel)
+async fn prompt_in_bar(mp: &MultiProgress, label: &str) -> Result<Option<String>> {
+    let style = ProgressStyle::with_template("{prefix}: {msg}")
+        .unwrap_or_else(|_| ProgressStyle::default_bar());
+    let bar = mp.add(ProgressBar::new(0));
+    bar.set_style(style);
+    bar.set_prefix(label.to_string());
+    bar.set_message("_".to_string());
+
+    let mut buffer = String::new();
+
+    loop {
+        if crossterm::event::poll(Duration::ZERO).unwrap_or(false)
+            && let Ok(Event::Key(KeyEvent {
+                code,
+                modifiers,
+                kind: KeyEventKind::Press,
+                ..
+            })) = crossterm::event::read()
+        {
+            match code {
+                KeyCode::Enter => {
+                    bar.finish_and_clear();
+                    return Ok(Some(buffer.trim().to_string()));
+                }
+                KeyCode::Esc => {
+                    bar.finish_and_clear();
+                    return Ok(None);
+                }
+                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    bar.finish_and_clear();
+                    return Err(anyhow::anyhow!("input cancelled"));
+                }
+                KeyCode::Backspace => {
+                    buffer.pop();
+                    bar.set_message(format!("{buffer}_"));
+                }
+                KeyCode::Char(c) => {
+                    buffer.push(c);
+                    bar.set_message(format!("{buffer}_"));
+                }
+                _ => {}
+            }
         }
+
+        // Yield to let Tokio run download tasks; their bars tick via
+        // their own enable_steady_tick from indicatif's draw thread.
+        tokio::time::sleep(Duration::from_millis(30)).await;
     }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
+/// Build the hint bar message including live queue counts.
+///
+/// Examples:
+/// - `[a] queue another  [q] quit  •  1 downloading`
+/// - `[a] queue another  [q] quit  •  2 downloading, 1 queued`
+fn build_hint_message(active: u32, pending: u32) -> String {
+    let mut msg = String::from("[a] queue another  [q] quit");
+    if active > 0 || pending > 0 {
+        msg.push_str("  •  ");
+        if active > 0 {
+            msg.push_str(&format!("{active} downloading"));
+        }
+        if pending > 0 {
+            if active > 0 {
+                msg.push_str(", ");
+            }
+            msg.push_str(&format!("{pending} queued"));
+        }
+    }
+    msg
+}
 /// Parse an optional inline `-q <quant>` suffix from a raw model ID string.
 ///
 /// Accepts the fragment that a user might copy from a CLI invocation, e.g.
@@ -300,37 +362,19 @@ fn print_failures(snapshot: &QueueSnapshot) {
 /// RAII guard that enables crossterm raw mode on construction and disables it
 /// on drop, ensuring the terminal is always restored even if the caller returns
 /// early via `?`.
-struct RawModeGuard {
-    active: bool,
-}
+struct RawModeGuard;
 
 impl RawModeGuard {
     /// Enable raw mode and return a guard. Returns an error if the terminal
     /// does not support raw mode.
     fn acquire() -> Result<Self> {
         enable_raw_mode()?;
-        Ok(Self { active: true })
-    }
-
-    /// Disable raw mode and mark the guard as inactive.
-    fn disable(&mut self) {
-        if self.active {
-            let _ = disable_raw_mode();
-            self.active = false;
-        }
-    }
-
-    /// Re-enable raw mode. Returns an error on failure; the guard stays
-    /// inactive so `Drop` won't attempt a double-disable.
-    fn enable(&mut self) -> Result<()> {
-        enable_raw_mode()?;
-        self.active = true;
-        Ok(())
+        Ok(Self)
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
-        self.disable();
+        let _ = disable_raw_mode();
     }
 }

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -60,12 +60,32 @@ pub async fn run_interactive_monitor(
 ///
 /// indicatif degrades gracefully on non-TTY stdout, so progress bars
 /// still emit periodic lines. We just poll for completion.
+///
+/// The loop will not exit until it has observed at least one non-empty
+/// snapshot (`seen_items`), which prevents a premature exit caused by
+/// the Tokio runner task not yet being scheduled when the first poll
+/// fires. Fast-fail exits early if `recent_failures` appears before any
+/// items were ever seen active (e.g. instant auth error).
 async fn run_plain_monitor(downloads: Arc<dyn DownloadManagerPort>) -> Result<()> {
+    // Brief initial yield so the async runner task can be scheduled and
+    // move the queued item from pending → active before we first poll.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
     let mut interval = tokio::time::interval(Duration::from_millis(250));
+    let mut seen_items = false;
     loop {
         interval.tick().await;
         let snapshot = downloads.get_queue_snapshot().await?;
-        if is_queue_finished(&snapshot) {
+
+        if snapshot.active_count > 0 || snapshot.pending_count > 0 {
+            seen_items = true;
+        }
+
+        // Fast-fail: a failure appeared before we ever saw activity.
+        // This covers instant errors (auth, missing Python helper, etc.).
+        let has_failure = !snapshot.recent_failures.is_empty();
+
+        if (seen_items || has_failure) && is_queue_finished(&snapshot) {
             print_failures(&snapshot);
             return Ok(());
         }
@@ -90,7 +110,8 @@ async fn run_tty_monitor(
         Err(_) => return run_plain_monitor(downloads).await,
     };
 
-    mp.println("[a] add to queue  [q] quit").ok();
+    let mut seen_items = false;
+    let mut hint_shown = false;
 
     loop {
         // ── Non-blocking keypress check (zero-timeout poll) ───────────────
@@ -102,7 +123,8 @@ async fn run_tty_monitor(
                     ..
                 })) => {
                     handle_add_to_queue(&downloads, &mp, &mut raw).await;
-                    mp.println("[a] add to queue  [q] quit").ok();
+                    // Re-print so the hint is visible below any new bar.
+                    mp.println("[a] queue another  [q] quit").ok();
                 }
 
                 Ok(Event::Key(KeyEvent {
@@ -131,9 +153,24 @@ async fn run_tty_monitor(
         // ── Async yield — lets Tokio run download worker tasks ────────────
         tokio::time::sleep(Duration::from_millis(250)).await;
 
-        // ── Completion check ──────────────────────────────────────────────
+        // ── Completion / progress check ───────────────────────────────────
         let snapshot = downloads.get_queue_snapshot().await?;
-        if is_queue_finished(&snapshot) {
+
+        if snapshot.active_count > 0 || snapshot.pending_count > 0 {
+            seen_items = true;
+        }
+
+        // Show the hint once, anchored under the first progress bar.
+        if seen_items && !hint_shown {
+            mp.println("[a] queue another  [q] quit").ok();
+            hint_shown = true;
+        }
+
+        // Fast-fail: exit immediately if a failure appeared before we ever
+        // saw any activity (instant auth error, missing Python helper, etc.).
+        let has_failure = !snapshot.recent_failures.is_empty();
+
+        if (seen_items || has_failure) && is_queue_finished(&snapshot) {
             print_failures(&snapshot);
             break;
         }

--- a/crates/gglib-cli/src/handlers/model/download/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/download/mod.rs
@@ -9,6 +9,7 @@
 mod browse;
 mod check_updates;
 mod exec;
+mod interactive;
 mod search;
 mod update_model;
 

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -105,9 +105,16 @@ pub enum ModelCommand {
         force: bool,
     },
 
-    /// Download a GGUF model from HuggingFace Hub
+    /// Download a GGUF model from HuggingFace Hub.
+    ///
+    /// Routes through the shared download queue (same path as the GUI), so
+    /// progress is rendered in the terminal and multiple models can be added
+    /// interactively while a download is in flight.
+    ///
+    /// In a TTY, press **[a]** to add another model to the queue or **[q]** / Ctrl-C
+    /// to cancel all pending downloads.
     Download {
-        /// HuggingFace model repository (e.g., "microsoft/DialoGPT-medium")
+        /// HuggingFace model repository (e.g., "bartowski/Qwen2.5-7B-Instruct-GGUF")
         model_id: String,
         /// Specific quantization to download (e.g., "Q4_K_M", "F16")
         #[arg(short, long)]
@@ -118,7 +125,11 @@ pub enum ModelCommand {
         /// Skip adding to database after download (models are registered by default)
         #[arg(long)]
         skip_db: bool,
-        /// HuggingFace token for private models
+        /// HuggingFace token for private models (for `--list-quants` only).
+        ///
+        /// For downloads, set the `HF_TOKEN` environment variable instead.
+        /// It is read at startup and wired into the download manager config,
+        /// mirroring how the GUI handles authentication.
         #[arg(long)]
         token: Option<String>,
         /// Skip confirmation prompt

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -57,6 +57,35 @@ impl CliDownloadEventEmitter {
     pub fn multi_progress(&self) -> Arc<MultiProgress> {
         Arc::clone(&self.multi_progress)
     }
+
+    /// Pause the steady-tick animation thread on every active bar.
+    ///
+    /// indicatif's `enable_steady_tick` spawns a background thread that
+    /// redraws the bar at a fixed interval to keep spinners animating.
+    /// That thread can race with [`MultiProgress::suspend`]: if it fires
+    /// in the narrow window between suspend acquiring its draw lock and
+    /// the user's prompt closure starting, the extra frame can be left in
+    /// scrollback as a visual artifact above the prompts. Callers that are
+    /// about to suspend the display for blocking input should call this
+    /// first and [`Self::resume_animation`] when done.
+    pub fn pause_animation(&self) {
+        if let Ok(bars) = self.bars.lock() {
+            for bar in bars.values() {
+                bar.disable_steady_tick();
+            }
+        }
+    }
+
+    /// Re-enable the steady-tick animation thread on every active bar.
+    ///
+    /// Pairs with [`Self::pause_animation`].
+    pub fn resume_animation(&self) {
+        if let Ok(bars) = self.bars.lock() {
+            for bar in bars.values() {
+                bar.enable_steady_tick(TICK_INTERVAL);
+            }
+        }
+    }
 }
 
 impl Default for CliDownloadEventEmitter {

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -19,7 +19,17 @@ use gglib_core::ports::DownloadEventEmitterPort;
 
 // ─── Style constants ─────────────────────────────────────────────────────────
 
-const SPINNER_TEMPLATE: &str = "{spinner:.cyan} {wide_msg}";
+// A single unified template is used for the entire lifetime of the bar.
+//
+// Earlier iterations switched between a spinner-only template and a bar
+// template once the first `ShardProgress` event arrived with a known total
+// size. That `set_style` call could race with the steady-tick redraw and
+// indicatif's draw-target line tracking, leaving the spinner frame stranded
+// in scrollback while the new template drew fresh one line below it.
+//
+// The unified template renders fine even when the bar's length is unknown
+// (the bar widget appears empty until `set_length` is called with a real
+// total) and avoids the mid-stream style switch entirely.
 const BAR_TEMPLATE: &str = "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {bytes_per_sec} eta {eta}";
 const TICK_INTERVAL: Duration = Duration::from_millis(120);
 
@@ -109,12 +119,18 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                     _ => id.clone(),
                 };
 
-                let spinner_style = ProgressStyle::with_template(SPINNER_TEMPLATE)
-                    .unwrap_or_else(|_| ProgressStyle::default_spinner())
+                // Always create the bar with the unified BAR_TEMPLATE — see
+                // module-level comment on `BAR_TEMPLATE` for why we never
+                // switch styles mid-stream. Length 0 is a sentinel meaning
+                // "total not yet known"; the bar widget renders empty until
+                // a Progress/ShardProgress event supplies a real length.
+                let style = ProgressStyle::with_template(BAR_TEMPLATE)
+                    .unwrap_or_else(|_| ProgressStyle::default_bar())
+                    .progress_chars("█▓░")
                     .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
 
-                let bar = self.multi_progress.add(ProgressBar::new_spinner());
-                bar.set_style(spinner_style);
+                let bar = self.multi_progress.add(ProgressBar::new(0));
+                bar.set_style(style);
                 bar.enable_steady_tick(TICK_INTERVAL);
                 bar.set_message(label);
 
@@ -133,11 +149,10 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
             } => {
                 if let Ok(bars) = self.bars.lock() {
                     if let Some(bar) = bars.get(&id) {
+                        // First time we see a real total, set length. No
+                        // set_style — the unified template is already in
+                        // place from DownloadStarted.
                         if total > 0 && bar.length().unwrap_or(0) == 0 {
-                            let bar_style = ProgressStyle::with_template(BAR_TEMPLATE)
-                                .unwrap_or_else(|_| ProgressStyle::default_bar())
-                                .progress_chars("█▓░");
-                            bar.set_style(bar_style);
                             bar.set_length(total);
                         }
                         bar.set_position(downloaded);
@@ -156,11 +171,10 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
             } => {
                 if let Ok(bars) = self.bars.lock() {
                     if let Some(bar) = bars.get(&id) {
+                        // Update length on first real total or whenever the
+                        // total changes (e.g. final shard size resolved).
+                        // No set_style — unified template stays in place.
                         if aggregate_total > 0 && bar.length().unwrap_or(0) != aggregate_total {
-                            let bar_style = ProgressStyle::with_template(BAR_TEMPLATE)
-                                .unwrap_or_else(|_| ProgressStyle::default_bar())
-                                .progress_chars("█▓░");
-                            bar.set_style(bar_style);
                             bar.set_length(aggregate_total);
                         }
                         bar.set_position(aggregate_downloaded);

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -1,0 +1,185 @@
+//! CLI download event emitter.
+//!
+//! Implements [`DownloadEventEmitterPort`] using `indicatif` [`MultiProgress`] bars,
+//! rendering live download progress in the terminal. This is the concrete emitter
+//! wired into the download manager when running as a CLI process.
+//!
+//! A shared [`Arc<MultiProgress>`] handle is exposed so the interactive monitor
+//! can call [`MultiProgress::suspend`] while prompting for user input.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::Arc;
+use std::time::Duration;
+
+use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
+
+use gglib_core::download::DownloadEvent;
+use gglib_core::ports::DownloadEventEmitterPort;
+
+// ─── Style constants ─────────────────────────────────────────────────────────
+
+const SPINNER_TEMPLATE: &str = "{spinner:.cyan} {wide_msg}";
+const BAR_TEMPLATE: &str =
+    "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {bytes_per_sec} eta {eta}";
+const TICK_INTERVAL: Duration = Duration::from_millis(120);
+
+// ─── CliDownloadEventEmitter ─────────────────────────────────────────────────
+
+/// Terminal-rendering download event emitter for CLI contexts.
+///
+/// Wraps an `indicatif` [`MultiProgress`] and maintains one [`ProgressBar`] per
+/// active download, keyed by the canonical download ID string. Events emitted by
+/// the [`DownloadManagerPort`] are translated into bar updates synchronously (the
+/// `emit` method does not block on I/O).
+///
+/// The inner [`MultiProgress`] is shared via [`Arc`] so the interactive monitor
+/// can suspend rendering while collecting user input without tearing the display.
+pub struct CliDownloadEventEmitter {
+    multi_progress: Arc<MultiProgress>,
+    bars: Mutex<HashMap<String, ProgressBar>>,
+}
+
+impl CliDownloadEventEmitter {
+    /// Create a new emitter backed by a fresh [`MultiProgress`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            multi_progress: Arc::new(MultiProgress::new()),
+            bars: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return a clone of the shared [`MultiProgress`] handle.
+    ///
+    /// The interactive monitor uses this to call [`MultiProgress::suspend`]
+    /// while prompting for additional model IDs.
+    #[must_use]
+    pub fn multi_progress(&self) -> Arc<MultiProgress> {
+        Arc::clone(&self.multi_progress)
+    }
+}
+
+impl Default for CliDownloadEventEmitter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DownloadEventEmitterPort for CliDownloadEventEmitter {
+    fn emit(&self, event: DownloadEvent) {
+        match event {
+            DownloadEvent::DownloadStarted {
+                id,
+                shard_index,
+                total_shards,
+            } => {
+                let label = match (shard_index, total_shards) {
+                    (Some(idx), Some(total)) => {
+                        format!("{id} [shard {}/{total}]", idx + 1)
+                    }
+                    _ => id.clone(),
+                };
+
+                let spinner_style = ProgressStyle::with_template(SPINNER_TEMPLATE)
+                    .unwrap_or_else(|_| ProgressStyle::default_spinner())
+                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
+
+                let bar = self.multi_progress.add(ProgressBar::new_spinner());
+                bar.set_style(spinner_style);
+                bar.enable_steady_tick(TICK_INTERVAL);
+                bar.set_message(label);
+
+                if let Ok(mut bars) = self.bars.lock() {
+                    bars.insert(id, bar);
+                }
+            }
+
+            DownloadEvent::DownloadProgress {
+                id,
+                downloaded,
+                total,
+                speed_bps: _,
+                eta_seconds: _,
+                percentage: _,
+            } => {
+                if let Ok(bars) = self.bars.lock() {
+                    if let Some(bar) = bars.get(&id) {
+                        if total > 0 && bar.length().unwrap_or(0) == 0 {
+                            let bar_style = ProgressStyle::with_template(BAR_TEMPLATE)
+                                .unwrap_or_else(|_| ProgressStyle::default_bar())
+                                .progress_chars("█▓░");
+                            bar.set_style(bar_style);
+                            bar.set_length(total);
+                        }
+                        bar.set_position(downloaded);
+                        bar.set_message(format!(
+                            "{id} {}",
+                            HumanBytes(downloaded)
+                        ));
+                    }
+                }
+            }
+
+            DownloadEvent::ShardProgress {
+                id,
+                shard_index,
+                total_shards,
+                aggregate_downloaded,
+                aggregate_total,
+                ..
+            } => {
+                if let Ok(bars) = self.bars.lock() {
+                    if let Some(bar) = bars.get(&id) {
+                        if aggregate_total > 0 && bar.length().unwrap_or(0) != aggregate_total {
+                            let bar_style = ProgressStyle::with_template(BAR_TEMPLATE)
+                                .unwrap_or_else(|_| ProgressStyle::default_bar())
+                                .progress_chars("█▓░");
+                            bar.set_style(bar_style);
+                            bar.set_length(aggregate_total);
+                        }
+                        bar.set_position(aggregate_downloaded);
+                        bar.set_message(format!(
+                            "{id} [shard {}/{total_shards}] {}",
+                            shard_index + 1,
+                            HumanBytes(aggregate_downloaded),
+                        ));
+                    }
+                }
+            }
+
+            DownloadEvent::DownloadCompleted { id, .. } => {
+                if let Ok(mut bars) = self.bars.lock() {
+                    if let Some(bar) = bars.remove(&id) {
+                        bar.finish_with_message(format!("✓ {id}"));
+                    }
+                }
+            }
+
+            DownloadEvent::DownloadFailed { id, error } => {
+                if let Ok(mut bars) = self.bars.lock() {
+                    if let Some(bar) = bars.remove(&id) {
+                        bar.abandon_with_message(format!("✗ {id}: {error}"));
+                    }
+                }
+            }
+
+            DownloadEvent::DownloadCancelled { id } => {
+                if let Ok(mut bars) = self.bars.lock() {
+                    if let Some(bar) = bars.remove(&id) {
+                        bar.abandon_with_message(format!("✗ {id}: cancelled"));
+                    }
+                }
+            }
+
+            // Queue-level events don't need bar updates in the CLI emitter.
+            DownloadEvent::QueueSnapshot { .. } | DownloadEvent::QueueRunComplete { .. } => {}
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn DownloadEventEmitterPort> {
+        // CliDownloadEventEmitter is not Clone (Mutex), so we return a NoopDownloadEmitter
+        // for the rare code path that needs a boxed clone. The real emitter is shared via Arc.
+        Box::new(gglib_core::ports::NoopDownloadEmitter::new())
+    }
+}

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -8,8 +8,8 @@
 //! can call [`MultiProgress::suspend`] while prompting for user input.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
@@ -20,8 +20,7 @@ use gglib_core::ports::DownloadEventEmitterPort;
 // ─── Style constants ─────────────────────────────────────────────────────────
 
 const SPINNER_TEMPLATE: &str = "{spinner:.cyan} {wide_msg}";
-const BAR_TEMPLATE: &str =
-    "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {bytes_per_sec} eta {eta}";
+const BAR_TEMPLATE: &str = "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {bytes_per_sec} eta {eta}";
 const TICK_INTERVAL: Duration = Duration::from_millis(120);
 
 // ─── CliDownloadEventEmitter ─────────────────────────────────────────────────
@@ -113,10 +112,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                             bar.set_length(total);
                         }
                         bar.set_position(downloaded);
-                        bar.set_message(format!(
-                            "{id} {}",
-                            HumanBytes(downloaded)
-                        ));
+                        bar.set_message(format!("{id} {}", HumanBytes(downloaded)));
                     }
                 }
             }

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -21,14 +21,10 @@ pub use python_bridge::{FastDownloadRequest, run_fast_download};
 
 /// Execute a download request and return the result.
 ///
-/// This function:
-/// 1. Resolves the quantization files from `HuggingFace`
-/// 2. Downloads the files using the Python helper
-/// 3. Returns the paths for the handler to register
-///
-/// Note: This does NOT register the model in the database - that's the
-/// handler's responsibility using `ctx.app().models().add()`.
-pub async fn download(request: CliDownloadRequest) -> Result<CliDownloadResult> {
+/// Used internally by [`update_model`] for the force-redownload path.
+/// Interactive CLI downloads now route through [`DownloadManagerPort::queue_smart`]
+/// instead of calling this function directly.
+pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadResult> {
     let quant = request.quantization.as_ref().ok_or_else(|| {
         anyhow!("Please specify a quantization. Use --list-quants to see available options.")
     })?;

--- a/crates/gglib-download/src/cli_exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/mod.rs
@@ -1,32 +1,20 @@
-//! CLI download execution layer.
+//! CLI download utility layer.
 //!
-//! This module provides the download execution logic for CLI commands.
-//! It is intentionally separated from the async queue-based `DownloadManagerPort`
-//! which is designed for GUI/background downloads.
+//! This module provides utilities used by CLI commands that are intentionally
+//! separated from the queue-based [`DownloadManagerPort`] path.
 //!
-//! # Architecture
+//! # What lives here
 //!
-//! The CLI execution layer:
-//! - Uses synchronous/blocking patterns suitable for CLI UX
-//! - Shows progress bars directly in terminal
-//! - Returns results for the handler to register in the database
+//! - [`list_quantizations`] — HuggingFace quant listing for `--list-quants`
+//! - [`check_update`] / [`update_model`] — update path for `model upgrade`
+//! - Python bridge helpers ([`ensure_fast_helper_ready`], [`run_fast_download`]) shared
+//!   with the async download manager
 //!
-//! # Usage
+//! # What moved out
 //!
-//! ```ignore
-//! use gglib_download::cli_exec::{CliDownloadRequest, download};
-//!
-//! let request = CliDownloadRequest::new("unsloth/Llama-3-GGUF", models_dir)
-//!     .with_quantization("Q4_K_M");
-//!
-//! let result = download(request).await?;
-//! // Handler then calls ctx.app().models().add(...) with result
-//! ```
-//!
-//! # No `AppCore`
-//!
-//! This module does NOT import or use `AppCore`. Database registration
-//! is the responsibility of the CLI handler layer.
+//! Interactive downloads (the `model download` command) now route through
+//! [`DownloadManagerPort::queue_smart`], giving the CLI the same queue,
+//! progress events, and model registration path as the GUI.
 
 mod api;
 mod exec;
@@ -34,7 +22,7 @@ mod types;
 mod utils;
 
 pub use api::{browse_models, create_hf_api, list_quantizations, search_models};
-pub use exec::{check_update, download, update_model};
+pub use exec::{check_update, update_model};
 pub use types::*;
 
 // Re-export Python bridge for use by the async manager

--- a/crates/gglib-download/src/cli_exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # What lives here
 //!
-//! - [`list_quantizations`] — HuggingFace quant listing for `--list-quants`
+//! - [`list_quantizations`] — `HuggingFace` quant listing for `--list-quants`
 //! - [`check_update`] / [`update_model`] — update path for `model upgrade`
 //! - Python bridge helpers ([`ensure_fast_helper_ready`], [`run_fast_download`]) shared
 //!   with the async download manager

--- a/crates/gglib-download/src/lib.rs
+++ b/crates/gglib-download/src/lib.rs
@@ -30,8 +30,12 @@ pub use resolver::HfQuantizationResolver;
 mod quant_selector;
 pub use quant_selector::{QuantizationSelection, QuantizationSelector, SelectionError};
 
-// CLI execution module (transitional - synchronous CLI downloads)
+// CLI execution module (list_quantizations + Python bridge helpers)
 pub mod cli_exec;
+
+// CLI terminal progress emitter
+mod cli_emitter;
+pub use cli_emitter::CliDownloadEventEmitter;
 
 // Public API - modular download manager
 mod manager;

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -145,14 +145,22 @@ gglib proxy --host 0.0.0.0 --port 8080 --llama-port 5500
 ### HuggingFace Hub Integration
 
 #### `model download <repo_id> [OPTIONS]`
-Download a model from HuggingFace Hub.
+Download a model from HuggingFace Hub with interactive queue support.
 
 **Options:**
 - `--quantization <QUANT>`, `-q`: Specific quantization to download (e.g., "Q4_K_M", "F16")
 - `--list-quants`: List available quantizations for the model
-- `--skip-db`: Skip adding to database after download (models are registered by default)
-- `--token <TOKEN>`: HuggingFace token for private models
+- `--token <TOKEN>`: HuggingFace token (for `--list-quants` only; use `HF_TOKEN` env var for downloads)
 - `--force`, `-f`: Skip confirmation prompt
+
+**Interactive mode (TTY):**
+- After queuing a download, the terminal enters a live progress monitor
+- **[a]** — add another model to the queue while the current one is downloading
+- **[q]** / Ctrl-C — cancel all pending downloads and exit
+- Non-TTY environments (CI, pipes) automatically fall back to a plain monitor
+
+**Authentication:**
+For downloading private models, set the `HF_TOKEN` environment variable. It is read at startup and wired into the download manager, mirroring how the GUI handles authentication.
 
 **Example:**
 ```bash
@@ -162,8 +170,8 @@ gglib model download microsoft/DialoGPT-medium --list-quants
 # Download specific quantization (auto-registered in database)
 gglib model download microsoft/DialoGPT-medium --quantization Q4_K_M
 
-# Download without registering in database
-gglib model download microsoft/DialoGPT-medium -q Q4_K_M --skip-db
+# Download a private model using HF_TOKEN
+HF_TOKEN=hf_... gglib model download my-org/private-model -q Q4_K_M
 ```
 
 #### `model search <query> [OPTIONS]`


### PR DESCRIPTION
## Summary

Brings the CLI `model download` command to full parity with the GUI download queue.

Previously the CLI called `cli_exec::download()` directly — a single blocking download with no queue, no progress bars wired to the shared event system, and separate model registration logic duplicated from the GUI path.

Now the CLI routes through `DownloadManagerPort::queue_smart`, the same code path as the GUI, and enters an interactive terminal monitor while downloads run.

---

## Changes

### New: `CliDownloadEventEmitter` (`gglib-download`)
Implements `DownloadEventEmitterPort` using `indicatif` `MultiProgress` bars. Maps `DownloadEvent` variants to spinner → byte-bar progression with shard-aware labelling, clean finish/abandon messages, and exposes `Arc<MultiProgress>` so the monitor can suspend rendering while prompting for input.

### New: `interactive.rs` (`gglib-cli`)
TUI monitor module. Branches on TTY detection:
- **TTY**: raw-mode `[a]`/`[q]` hotkey loop with `RawModeGuard` RAII, `crossterm::event::poll(Duration::ZERO)` non-blocking keypress check, and `tokio::task::block_in_place` inside `MultiProgress::suspend` for safe stdin reads
- **Non-TTY** (CI, pipes): plain 250ms polling loop — indicatif degrades naturally

### Rewritten: `exec.rs` (`gglib-cli`)
Replaced ~75 lines of blocking download + manual registration with:
1. `Arc::clone(&ctx.downloads).queue_smart(...)` — enqueue via shared manager
2. `interactive::run_interactive_monitor(...)` — hand off to the TUI loop

Model registration on completion is handled internally by the download manager (via `ModelRegistrarPort`), removing the duplicated `build_completed_download` helper.

### Narrowed: `cli_exec::download` visibility
`download()` is still used internally by `update_model()`, so it was not deleted — instead narrowed to `pub(super)` and removed from the public re-exports. Updated module doc to reflect the new role.

### Bootstrap wiring
- `CliDownloadEventEmitter` replaces `NoopDownloadEmitter` in `bootstrap.rs`
- `HF_TOKEN` env var is read at startup into `DownloadManagerConfig`
- `CliContext` gains `download_emitter: Arc<CliDownloadEventEmitter>` field

### Documentation
- `model_commands.rs`: improved `Download` variant docstring with interactive queue description and `HF_TOKEN` guidance
- `handlers/model/download/README.md`: updated architecture diagram, module table, command docs
- `src/commands/README.md`: expanded `model download` section with interactive mode and auth docs
- `README.md`: Quick look example annotated

---

## Commits

```
bebf2ed feat(download): add CliDownloadEventEmitter with indicatif MultiProgress
e368443 feat(cli): wire CliDownloadEventEmitter into bootstrap, read HF_TOKEN env var
1443c47 feat(cli): add interactive download monitor module
dc255f7 feat(cli): rewrite exec.rs as lean orchestrator over DownloadManagerPort
9e7c9e8 refactor(download): narrow cli_exec::download to pub(super), update module docs
1268c0e docs: update model download docs for interactive queue parity
```

---

## UX

```
$ gglib model download bartowski/Qwen2.5-7B-Instruct-GGUF -q Q4_K_M
↳ queued at position 0

  bartowski/Qwen2.5-7B-Instruct-GGUF  [████████████░░░░░░░░]  2.1 GB/5.4 GB  3.8 MB/s

[a] add model  [q] quit
```

Press `[a]` to add another model while the current one downloads. Press `[q]` or Ctrl-C to cancel all.