### PR TITLE
feat(bootstrap): add gglib-bootstrap crate — consolidate shared infra wiring [Phase 1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gglib-bootstrap"
+version = "0.7.2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "gglib-core",
+ "gglib-db",
+ "gglib-download",
+ "gglib-gguf",
+ "gglib-hf",
+ "gglib-runtime",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "gglib-build-info"
 version = "0.7.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/gglib-db",
     "crates/gglib-download",
     "crates/gglib-gguf",
+    "crates/gglib-bootstrap",
     "crates/gglib-gui",
     "crates/gglib-hf",
     "crates/gglib-build-info",
@@ -90,6 +91,7 @@ tempfile = "3.8"
 mockall = "0.14"
 
 # Internal crates (for migration)
+gglib-bootstrap = { path = "crates/gglib-bootstrap" }
 gglib-core = { path = "crates/gglib-core" }
 gglib-db = { path = "crates/gglib-db", features = ["test-utils"] }
 gglib-download = { path = "crates/gglib-download" }

--- a/crates/gglib-bootstrap/Cargo.toml
+++ b/crates/gglib-bootstrap/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "gglib-bootstrap"
+version.workspace = true
+edition.workspace = true
+description = "Shared composition root for gglib adapters — wires infrastructure without adapter concerns"
+license.workspace = true
+publish = false
+build = "build.rs"
+
+[lib]
+name = "gglib_bootstrap"
+path = "src/lib.rs"
+
+[dependencies]
+# Internal crates — strictly infrastructure wiring only; no adapter crates (mcp, tauri, axum)
+gglib-core = { path = "../gglib-core" }
+gglib-db = { path = "../gglib-db" }
+gglib-download = { path = "../gglib-download" }
+gglib-gguf = { path = "../gglib-gguf" }
+gglib-hf = { path = "../gglib-hf" }
+gglib-runtime = { path = "../gglib-runtime" }
+
+# Async runtime — full features match the adapters that consume this crate
+tokio = { workspace = true }
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/gglib-bootstrap/README.md
+++ b/crates/gglib-bootstrap/README.md
@@ -1,0 +1,42 @@
+# gglib-bootstrap
+
+Shared composition root for gglib adapters.
+
+This crate consolidates the infrastructure-wiring steps that were previously duplicated
+across the CLI, Axum, and Tauri bootstrap modules into a single
+`CoreBootstrap::build(config, emitter) → BuiltCore` call.
+
+## What it wires
+
+1. SQLite database pool + repository set
+2. `LlamaServerRunner` (process runner)
+3. `GgufParser` + `ModelFilesRepository` + `ModelRegistrar`
+4. Download manager (using the injected `AppEventEmitter`)
+5. `DownloadTriggerAdapter` (bridges `DownloadManagerPort` → `DownloadTriggerPort`)
+6. `ModelVerificationService` + fully configured `AppCore`
+
+## Hexagonal boundary
+
+Depends **only** on infrastructure crates:
+`gglib-core`, `gglib-db`, `gglib-download`, `gglib-gguf`, `gglib-hf`, `gglib-runtime`.
+
+Does **not** depend on adapter crates (`gglib-mcp`, `gglib-axum`, `gglib-tauri`, `gglib-cli`).
+
+## Usage
+
+```rust
+use std::sync::Arc;
+use gglib_bootstrap::{BootstrapConfig, CoreBootstrap};
+use gglib_core::paths::{database_path, llama_server_path, resolve_models_dir};
+
+let emitter: Arc<dyn AppEventEmitter> = Arc::new(MyAdapterEmitter::new());
+let config = BootstrapConfig {
+    db_path: database_path()?,
+    llama_server_path: llama_server_path()?,
+    max_concurrent: 4,
+    models_dir: resolve_models_dir(None)?.path,
+    hf_token: std::env::var("HF_TOKEN").ok(),
+};
+let core = CoreBootstrap::build(config, emitter).await?;
+// core.app, core.runner, core.downloads, core.hf_client … all ready
+```

--- a/crates/gglib-bootstrap/build.rs
+++ b/crates/gglib-bootstrap/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+include!("../build_common.rs");
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    process_readme_for_rustdoc(&crate_dir);
+}

--- a/crates/gglib-bootstrap/src/lib.rs
+++ b/crates/gglib-bootstrap/src/lib.rs
@@ -1,0 +1,289 @@
+//! Shared composition root for gglib adapters.
+//!
+//! This crate consolidates the common infrastructure-wiring steps that were
+//! previously duplicated across the CLI, Axum, and Tauri bootstrap modules:
+//!
+//! 1. Database pool + repository set
+//! 2. Process runner (`LlamaServerRunner`)
+//! 3. GGUF parser + model-files repository + model registrar
+//! 4. Download manager (accepting an injected event emitter)
+//! 5. `DownloadTriggerAdapter` (bridges `DownloadManagerPort` → `DownloadTriggerPort`)
+//! 6. `ModelVerificationService` + fully wired `AppCore`
+//!
+//! Each adapter then adds its own concerns on top of the returned [`BuiltCore`]
+//! (MCP service, proxy supervisor, SSE broadcaster, etc.).
+//!
+//! # Hexagonal boundary
+//!
+//! This crate depends **only** on pure infrastructure crates
+//! (`gglib-core`, `gglib-db`, `gglib-download`, `gglib-gguf`, `gglib-hf`,
+//! `gglib-runtime`). It does **not** depend on adapter crates (`gglib-mcp`,
+//! `gglib-axum`, `gglib-tauri`, `gglib-cli`).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use gglib_bootstrap::{BootstrapConfig, CoreBootstrap};
+//! use gglib_core::ports::AppEventEmitter;
+//!
+//! let emitter: Arc<dyn AppEventEmitter> = Arc::new(MyEmitter::new());
+//! let config = BootstrapConfig {
+//!     db_path: database_path()?,
+//!     llama_server_path: llama_server_path()?,
+//!     max_concurrent: 4,
+//!     models_dir: resolve_models_dir(None)?.path,
+//!     hf_token: std::env::var("HF_TOKEN").ok(),
+//! };
+//! let core = CoreBootstrap::build(config, emitter).await?;
+//! // core.app, core.runner, core.downloads, core.hf_client, … all ready
+//! ```
+
+#![deny(unsafe_code)]
+#![deny(unused_crate_dependencies)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use gglib_core::ModelRegistrar;
+// tokio is a required runtime dependency (async fn build uses it transitively)
+use tokio as _;
+use gglib_core::download::DownloadError;
+use gglib_core::ports::{
+    AppEventBridge, AppEventEmitter, DownloadManagerConfig, DownloadManagerPort, GgufParserPort,
+    HfClientPort, ModelRegistrarPort, ModelRepository, ProcessRunner, Repos,
+};
+use gglib_core::services::{AppCore, ModelVerificationService};
+use gglib_db::{CoreFactory, ModelFilesRepository, setup_database};
+use gglib_download::{DownloadManagerDeps, build_download_manager};
+// GGUF_BOOTSTRAP_EXCEPTION: Parser injected at composition root only
+use gglib_gguf::GgufParser;
+use gglib_hf::{DefaultHfClient, HfClientConfig};
+use gglib_runtime::LlamaServerRunner;
+
+// ---------------------------------------------------------------------------
+// Public configuration types
+// ---------------------------------------------------------------------------
+
+/// Configuration required to run [`CoreBootstrap::build`].
+///
+/// All paths must be fully resolved by the caller before passing this struct.
+/// The path-resolution helpers (`database_path`, `llama_server_path`,
+/// `resolve_models_dir`) are deliberately kept in `gglib-core::paths` so
+/// that adapters own their own path strategies.
+#[derive(Debug, Clone)]
+pub struct BootstrapConfig {
+    /// Absolute path to the SQLite database file.
+    pub db_path: PathBuf,
+    /// Absolute path to the llama-server binary.
+    pub llama_server_path: PathBuf,
+    /// Maximum number of concurrently running llama-server processes.
+    pub max_concurrent: usize,
+    /// Absolute path to the directory where model files are stored.
+    pub models_dir: PathBuf,
+    /// Optional HuggingFace API token for authenticated downloads.
+    pub hf_token: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Output type
+// ---------------------------------------------------------------------------
+
+/// Fully wired infrastructure produced by [`CoreBootstrap::build`].
+///
+/// All fields are `pub` so adapter bootstrap modules can access every
+/// service they need to assemble their own context structs.
+pub struct BuiltCore {
+    /// Core application facade with verification service attached.
+    pub app: Arc<AppCore>,
+    /// Process runner for llama-server lifecycle management.
+    pub runner: Arc<dyn ProcessRunner>,
+    /// Download manager trait object.
+    pub downloads: Arc<dyn DownloadManagerPort>,
+    /// HuggingFace HTTP client.
+    pub hf_client: Arc<dyn HfClientPort>,
+    /// GGUF file parser for metadata extraction and capability detection.
+    pub gguf_parser: Arc<dyn GgufParserPort>,
+    /// Repository set (models, settings, MCP servers, chat history).
+    ///
+    /// Adapters need this to construct the MCP service and other
+    /// infrastructure that requires direct repository access.
+    pub repos: Repos,
+    /// Model registrar shared between the download manager and direct
+    /// registration code paths (e.g., CLI `model add` command).
+    pub model_registrar: Arc<dyn ModelRegistrarPort>,
+}
+
+// ---------------------------------------------------------------------------
+// DownloadTriggerAdapter (consolidated from CLI + Axum bootstrap copies)
+// ---------------------------------------------------------------------------
+
+/// Bridges [`DownloadManagerPort`] → [`DownloadTriggerPort`].
+///
+/// `ModelVerificationService` needs a `DownloadTriggerPort` to queue
+/// downloads, but the download manager implements the richer
+/// `DownloadManagerPort`. This adapter performs the conversion.
+struct DownloadTriggerAdapter {
+    download_manager: Arc<dyn DownloadManagerPort>,
+}
+
+#[async_trait]
+impl gglib_core::services::DownloadTriggerPort for DownloadTriggerAdapter {
+    async fn queue_download(
+        &self,
+        repo_id: String,
+        quantization: Option<String>,
+    ) -> anyhow::Result<String> {
+        use gglib_core::download::Quantization;
+        use gglib_core::ports::DownloadRequest;
+        use std::str::FromStr;
+
+        // Convert quantization string to enum; default to Q4_K_M when absent.
+        let quant = quantization
+            .as_ref()
+            .and_then(|q| Quantization::from_str(q).ok())
+            .unwrap_or(Quantization::Q4KM);
+
+        let request = DownloadRequest::new(repo_id, quant);
+        let id = self
+            .download_manager
+            .queue_download(request)
+            .await
+            .map_err(|e: DownloadError| anyhow::anyhow!("Failed to queue download: {e}"))?;
+
+        Ok(id.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CoreBootstrap
+// ---------------------------------------------------------------------------
+
+/// Shared composition root that wires common infrastructure for all adapters.
+///
+/// Call [`CoreBootstrap::build`] once at adapter startup. The returned
+/// [`BuiltCore`] contains every shared service; adapter-specific concerns
+/// (MCP service, SSE broadcaster, proxy supervisor, etc.) are added on top
+/// by the individual adapter bootstrap modules.
+pub struct CoreBootstrap;
+
+impl CoreBootstrap {
+    /// Build and wire all shared infrastructure.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` — Resolved paths and runtime parameters.
+    /// * `emitter` — Adapter-specific event emitter (SSE broadcaster for
+    ///   Axum/Tauri, `AppEventBridge` wrapping a `TauriEventEmitter`, or
+    ///   `NoopEmitter` for CLI). Download events flow through this emitter
+    ///   to the frontend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database cannot be opened, the schema
+    /// migration fails, or any infrastructure component cannot be
+    /// initialized.
+    pub async fn build(
+        config: BootstrapConfig,
+        emitter: Arc<dyn AppEventEmitter>,
+    ) -> Result<BuiltCore> {
+        // 1. Database pool + repositories
+        let pool = setup_database(&config.db_path).await?;
+        let repos = CoreFactory::build_repos(pool.clone());
+
+        // 2. Process runner
+        let runner: Arc<dyn ProcessRunner> = Arc::new(LlamaServerRunner::new(
+            config.llama_server_path,
+            config.max_concurrent,
+        ));
+
+        // 3. GGUF parser (shared: model registrar + capability detection)
+        let gguf_parser: Arc<dyn GgufParserPort> = Arc::new(GgufParser::new());
+
+        // 4. Model-files repository (used by registrar + verification service)
+        let model_files_repo = Arc::new(ModelFilesRepository::new(pool.clone()));
+
+        // 5. Model registrar — composes model repository + GGUF parser so
+        //    that both GUI and CLI download paths use the identical
+        //    registration logic.
+        // Keep the concrete type so it satisfies the Sized bound in
+        // DownloadManagerDeps<R, ..>; erased to trait object only in BuiltCore.
+        let model_registrar_concrete = Arc::new(ModelRegistrar::new(
+            repos.models.clone(),
+            gguf_parser.clone(),
+            Some(
+                Arc::clone(&model_files_repo)
+                    as Arc<dyn gglib_core::services::ModelFilesRepositoryPort>,
+            ),
+        ));
+        let model_registrar: Arc<dyn ModelRegistrarPort> = model_registrar_concrete.clone();
+
+        // 6. Download manager configuration
+        let download_config = {
+            let mut cfg = DownloadManagerConfig::new(config.models_dir);
+            if let Some(token) = config.hf_token {
+                cfg = cfg.with_hf_token(Some(token));
+            }
+            cfg
+        };
+
+        // 7. HuggingFace client
+        let hf_client_concrete = Arc::new(DefaultHfClient::new(&HfClientConfig::default()));
+        let hf_client: Arc<dyn HfClientPort> = hf_client_concrete.clone();
+
+        // 8. Download state repository
+        let download_repo = CoreFactory::download_state_repository(pool);
+
+        // 9. Download manager — `DownloadManagerDeps<R,..>` requires R: Sized,
+        //    so we pass the concrete registrar. The emitter is bridged from the
+        //    adapter's AppEventEmitter to satisfy DownloadEventEmitterPort.
+        let download_emitter = Arc::new(AppEventBridge::new(Arc::clone(&emitter)));
+        let downloads: Arc<dyn DownloadManagerPort> =
+            Arc::new(build_download_manager(DownloadManagerDeps {
+                model_registrar: model_registrar_concrete,
+                download_repo,
+                hf_client: hf_client_concrete,
+                event_emitter: download_emitter,
+                config: download_config,
+            }));
+
+        // 10. Download trigger adapter (bridges DownloadManagerPort →
+        //     DownloadTriggerPort for ModelVerificationService)
+        let download_trigger = Arc::new(DownloadTriggerAdapter {
+            download_manager: Arc::clone(&downloads),
+        });
+
+        // 11. Model verification service
+        let model_repo: Arc<dyn ModelRepository> = repos.models.clone();
+        let verification_service = Arc::new(ModelVerificationService::new(
+            Arc::clone(&model_repo),
+            Arc::clone(&model_files_repo)
+                as Arc<dyn gglib_core::services::ModelFilesReaderPort>,
+            hf_client.clone(),
+            download_trigger,
+        ));
+
+        // 12. AppCore — fully wired with verification
+        let app = Arc::new(AppCore::new(repos.clone(), Arc::clone(&runner)).with_verification(
+            verification_service,
+        ));
+
+        tracing::debug!(
+            db_path = %config.db_path.display(),
+            "CoreBootstrap: infrastructure wired successfully"
+        );
+
+        Ok(BuiltCore {
+            app,
+            runner,
+            downloads,
+            hf_client,
+            gguf_parser,
+            repos,
+            model_registrar,
+        })
+    }
+}


### PR DESCRIPTION
## Phase 1 — Add `gglib-bootstrap` crate

Part of epic #453 (`refactor/gui-backend-dissolution`).

### What this PR does

Creates a new `gglib-bootstrap` crate that consolidates the infrastructure-wiring steps previously duplicated verbatim across `gglib-cli`, `gglib-axum`, and `gglib-tauri` bootstrap modules.

**Consolidated steps:**
1. DB pool + `CoreFactory::build_repos`
2. `LlamaServerRunner` process runner
3. `GgufParser` + `ModelFilesRepository`  
4. `ModelRegistrar` (concrete type retained to satisfy `DownloadManagerDeps<R,..>` `Sized` bound)
5. `DownloadManager` — `AppEventBridge` wraps the adapter's `Arc<dyn AppEventEmitter>` to satisfy `DownloadEventEmitterPort`
6. `DownloadTriggerAdapter` (bridges `DownloadManagerPort` → `DownloadTriggerPort`) — previously copy-pasted in CLI **and** Axum
7. `ModelVerificationService` + `AppCore`

### Public API

```rust
pub struct BootstrapConfig { pub db_path, pub llama_server_path, pub max_concurrent, pub models_dir, pub hf_token }
pub struct BuiltCore { pub app, pub runner, pub downloads, pub hf_client, pub gguf_parser, pub repos, pub model_registrar }
pub struct CoreBootstrap;
impl CoreBootstrap { pub async fn build(config, emitter: Arc<dyn AppEventEmitter>) -> Result<BuiltCore> }
```

### Hexagonal boundary

`gglib-bootstrap` depends only on infrastructure crates (`gglib-core`, `gglib-db`, `gglib-download`, `gglib-gguf`, `gglib-hf`, `gglib-runtime`). Zero adapter crate dependencies.

### Validation

`cargo check -p gglib-bootstrap` passes clean (0 errors, 0 warnings).