### PR TITLE
chore(phase-4): CI, badges, coverage, and docs rigor for gglib-app-services + gglib-bootstrap

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -20,8 +20,8 @@ concurrency:
 env:
   ALL_CRATES: >-
     gglib-core gglib-db gglib-gguf gglib-hf gglib-download gglib-mcp
-    gglib-agent gglib-proxy gglib-runtime gglib-gui gglib-cli gglib-axum
-    gglib-tauri gglib-build-info
+    gglib-agent gglib-proxy gglib-runtime gglib-app-services gglib-bootstrap
+    gglib-cli gglib-axum gglib-tauri gglib-build-info
 
 jobs:
   # =============================================================================
@@ -268,11 +268,17 @@ jobs:
             extract_module_tests "$AGENT_TEST" "$MODULE" "gglib-agent-$MODULE"
           done
           
-          # gglib-gui modules
-          GUI_TEST="$(find artifacts -name 'rust-test-gglib-gui.txt' -type f 2>/dev/null | head -1)"
-          for MODULE in backend deps error downloads models servers settings mcp proxy types; do
-            extract_module_tests "$GUI_TEST" "$MODULE" "gglib-gui-$MODULE"
+          # gglib-app-services modules
+          APP_SVC_TEST="$(find artifacts -name 'rust-test-gglib-app-services.txt' -type f 2>/dev/null | head -1)"
+          for MODULE in error downloads models servers settings mcp proxy types setup; do
+            extract_module_tests "$APP_SVC_TEST" "$MODULE" "gglib-app-services-$MODULE"
           done
+          
+          # gglib-bootstrap (no sub-modules — single composition root file)
+          BOOTSTRAP_TEST="$(find artifacts -name 'rust-test-gglib-bootstrap.txt' -type f 2>/dev/null | head -1)"
+          if [ -n "$BOOTSTRAP_TEST" ] && [ -f "$BOOTSTRAP_TEST" ]; then
+            extract_module_tests "$BOOTSTRAP_TEST" "bootstrap" "gglib-bootstrap-bootstrap"
+          fi
           
           # --- Boundary badge ---
           # Download boundary results from separate artifact
@@ -557,11 +563,15 @@ jobs:
             extract_module_cov "$AGENT_LCOV" "src/$MODULE/" "gglib-agent-$MODULE"
           done
           
-          # gglib-gui modules
-          GUI_LCOV="$(find artifacts -name 'gglib-gui-lcov.info' -type f 2>/dev/null | head -1)"
-          for MODULE in backend deps error downloads models servers settings mcp proxy types; do
-            extract_module_cov "$GUI_LCOV" "src/$MODULE.rs" "gglib-gui-$MODULE"
+          # gglib-app-services modules
+          APP_SVC_LCOV="$(find artifacts -name 'gglib-app-services-lcov.info' -type f 2>/dev/null | head -1)"
+          for MODULE in error downloads models servers settings mcp proxy types setup; do
+            extract_module_cov "$APP_SVC_LCOV" "src/$MODULE.rs" "gglib-app-services-$MODULE"
           done
+          
+          # gglib-bootstrap (single composition root)
+          BOOTSTRAP_LCOV="$(find artifacts -name 'gglib-bootstrap-lcov.info' -type f 2>/dev/null | head -1)"
+          extract_module_cov "$BOOTSTRAP_LCOV" "src/bootstrap.rs" "gglib-bootstrap-bootstrap"
           
           # =============================================================================
           # Per-file coverage extraction (dynamic discovery)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,8 @@ jobs:
           cargo test -p gglib-agent --verbose 2>&1 | tee rust-test-gglib-agent.txt
           cargo test -p gglib-proxy --verbose 2>&1 | tee rust-test-gglib-proxy.txt
           cargo test -p gglib-runtime --verbose 2>&1 | tee rust-test-gglib-runtime.txt
-          cargo test -p gglib-gui --verbose 2>&1 | tee rust-test-gglib-gui.txt
+          cargo test -p gglib-app-services --verbose 2>&1 | tee rust-test-gglib-app-services.txt
+          cargo test -p gglib-bootstrap --verbose 2>&1 | tee rust-test-gglib-bootstrap.txt
           cargo test -p gglib-cli --verbose 2>&1 | tee rust-test-gglib-cli.txt
           cargo test -p gglib-axum --verbose 2>&1 | tee rust-test-gglib-axum.txt
           cargo test -p gglib-tauri --verbose 2>&1 | tee rust-test-gglib-tauri.txt
@@ -160,7 +161,8 @@ jobs:
             rust-test-gglib-agent.txt
             rust-test-gglib-proxy.txt
             rust-test-gglib-runtime.txt
-            rust-test-gglib-gui.txt
+            rust-test-gglib-app-services.txt
+            rust-test-gglib-bootstrap.txt
             rust-test-gglib-cli.txt
             rust-test-gglib-axum.txt
             rust-test-gglib-tauri.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,7 +71,8 @@ jobs:
             -p gglib-agent \
             -p gglib-proxy \
             -p gglib-runtime \
-            -p gglib-gui \
+            -p gglib-app-services \
+            -p gglib-bootstrap \
             -p gglib-cli \
             -p gglib-axum \
             --lcov --output-path lcov.info 2>&1 | tee rust-test-output.txt
@@ -94,7 +95,8 @@ jobs:
           cargo llvm-cov report --package gglib-agent --lcov --output-path gglib-agent-lcov.info
           cargo llvm-cov report --package gglib-proxy --lcov --output-path gglib-proxy-lcov.info
           cargo llvm-cov report --package gglib-runtime --lcov --output-path gglib-runtime-lcov.info
-          cargo llvm-cov report --package gglib-gui --lcov --output-path gglib-gui-lcov.info
+          cargo llvm-cov report --package gglib-app-services --lcov --output-path gglib-app-services-lcov.info
+          cargo llvm-cov report --package gglib-bootstrap --lcov --output-path gglib-bootstrap-lcov.info
           cargo llvm-cov report --package gglib-cli --lcov --output-path gglib-cli-lcov.info
           cargo llvm-cov report --package gglib-axum --lcov --output-path gglib-axum-lcov.info
 
@@ -113,7 +115,8 @@ jobs:
             --package gglib-agent \
             --package gglib-proxy \
             --package gglib-runtime \
-            --package gglib-gui \
+            --package gglib-app-services \
+            --package gglib-bootstrap \
             --package gglib-cli \
             --package gglib-axum \
             --html
@@ -135,7 +138,8 @@ jobs:
             gglib-agent-lcov.info
             gglib-proxy-lcov.info
             gglib-runtime-lcov.info
-            gglib-gui-lcov.info
+            gglib-app-services-lcov.info
+            gglib-bootstrap-lcov.info
             gglib-cli-lcov.info
             gglib-axum-lcov.info
             coverage/

--- a/README.md
+++ b/README.md
@@ -125,8 +125,12 @@ Cargo workspace with compile-time enforced boundaries. Adapters → infrastructu
 │                                   Facade Layer                                      │
 │                                                                                     │
 │   ┌─────────────────────────────────────────────────────────────────────────────┐   │
-│   │                              gglib-app-services                                      │   │
-│   │         Shared GUI backend (ensures feature parity across adapters)         │   │
+│   │                              gglib-app-services                             │   │
+│   │         Shared service ops (ensures feature parity across adapters)         │   │
+│   └─────────────────────────────────────────────────────────────────────────────┘   │
+│   ┌─────────────────────────────────────────────────────────────────────────────┐   │
+│   │                              gglib-bootstrap                                │   │
+│   │         Shared composition root (infra wiring for all adapters)             │   │
 │   └─────────────────────────────────────────────────────────────────────────────┘   │
 │                                                                                     │
 └─────────────────────────────────────────────────────────────────────────────────────┘
@@ -215,6 +219,7 @@ Only `gglib-runtime` spawns llama-server processes; only `gglib-download` talks 
 | Crate | Tests | Coverage | LOC | Complexity |
 |-------|-------|----------|-----|------------|
 | [gglib-app-services](crates/gglib-app-services) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-complexity.json) |
+| [gglib-bootstrap](crates/gglib-bootstrap) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-complexity.json) |
 
 #### Adapter Layer
 | Crate | Tests | Coverage | LOC | Complexity |
@@ -248,7 +253,8 @@ Each crate has its own README with architecture diagrams, module breakdowns, and
 | **Infra** | [gglib-mcp](crates/gglib-mcp/README.md) | MCP server management |
 | **Infra** | [gglib-proxy](crates/gglib-proxy/README.md) | OpenAI-compatible proxy server |
 | **Infra** | [gglib-runtime](crates/gglib-runtime/README.md) | Process manager & system probes |
-| **Facade** | [gglib-app-services](crates/gglib-app-services/README.md) | Shared GUI backend (feature parity) |
+| **Facade** | [gglib-app-services](crates/gglib-app-services/README.md) | Shared application service ops (feature parity) |
+| **Facade** | [gglib-bootstrap](crates/gglib-bootstrap/README.md) | Shared composition root (infra wiring) |
 | **Adapter** | [gglib-cli](crates/gglib-cli/README.md) | CLI interface |
 | **Adapter** | [gglib-axum](crates/gglib-axum/README.md) | HTTP API server |
 | **Adapter** | [gglib-tauri](crates/gglib-tauri/README.md) | Desktop GUI (Tauri + React) |
@@ -304,10 +310,10 @@ Download from the [Releases page](https://github.com/mmogr/gglib/releases):
 
 | Platform | Archive | Post-install |
 |----------|---------|--------------|
-| **macOS (Apple Silicon)** | `gglib-app-services-*-aarch64-apple-darwin.tar.gz` | Run `macos-install.command` to remove quarantine |
-| **macOS (Intel)** | `gglib-app-services-*-x86_64-apple-darwin.tar.gz` | Same as above |
-| **Linux** | `gglib-app-services-*-x86_64-unknown-linux-gnu.tar.gz` | Run `gglib-app-services` |
-| **Windows** | `gglib-app-services-*-x86_64-pc-windows-msvc.zip` | Run `gglib-app-services.exe` |
+| **macOS (Apple Silicon)** | `gglib-gui-*-aarch64-apple-darwin.tar.gz` | Run `macos-install.command` to remove quarantine |
+| **macOS (Intel)** | `gglib-gui-*-x86_64-apple-darwin.tar.gz` | Same as above |
+| **Linux** | `gglib-gui-*-x86_64-unknown-linux-gnu.tar.gz` | Run `gglib-gui` |
+| **Windows** | `gglib-gui-*-x86_64-pc-windows-msvc.zip` | Run `gglib-gui.exe` |
 
 ### From Source
 

--- a/src/services/transport/mappers.ts
+++ b/src/services/transport/mappers.ts
@@ -10,7 +10,7 @@ import type { CreateConversationParams, SaveMessageParams } from '../transport/t
 
 /**
  * Request shape matching Rust's StartServerRequest.
- * Must stay in sync with gglib-gui/src/types.rs::StartServerRequest
+ * Must stay in sync with gglib-app-services/src/types.rs::StartServerRequest
  */
 export interface StartServerRequest {
   contextLength?: number;


### PR DESCRIPTION
## Phase 4 — CI, Docs, and README Rigor

Final phase of the `GuiBackend` dissolution epic. Synchronizes CI pipelines, badge workflows, coverage reports, and documentation with the crate renames from Phases 1–3.

### Changes

**`.github/workflows/badges.yml`**
- `ALL_CRATES`: `gglib-gui` → `gglib-app-services`, `gglib-bootstrap` added
- Per-module test badge block: artifact `rust-test-gglib-gui.txt` → `rust-test-gglib-app-services.txt`; module list drops `backend`/`deps` (deleted in Phase 2), adds `setup`; badge names updated
- Per-module LCOV coverage block: same fixes as test block
- `gglib-bootstrap` test and coverage blocks added (single composition root, no sub-modules)

**`.github/workflows/ci.yml`**
- `cargo test -p gglib-gui` → `cargo test -p gglib-app-services`
- `cargo test -p gglib-bootstrap` added
- Artifact upload list updated accordingly

**`.github/workflows/coverage.yml`**
- `-p gglib-gui` → `-p gglib-app-services` in all 4 sections (run, report, HTML, archive)
- `-p gglib-bootstrap` added in all 4 sections

**`src/services/transport/mappers.ts`**
- Stale comment `gglib-gui/src/types.rs` → `gglib-app-services/src/types.rs`

**`README.md`**
- Facade Layer metrics table: `gglib-bootstrap` row added
- Crate Documentation table: `gglib-bootstrap` row added with description
- Architecture ASCII diagram: `gglib-bootstrap` composition-root box added; label cleaned up
- Release archive table: restored `gglib-gui-*` distribution filenames (Phase 3 sed incorrectly renamed user-facing artifact names)

### Notes
- `release.yml` intentionally unchanged — `gglib-gui-*.tar.gz` are user-facing distribution filenames, not crate names (same rationale as `package.json`)
- No Rust source changes; `cargo check --workspace` not required