### PR TITLE
fix(agent): soft-recover from parallel-tool-limit overflow

### DIFF
--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -272,12 +272,71 @@ impl AgentLoopPort for AgentLoop {
             let response = self.call_and_collect(&messages, &tools, &tx).await?;
 
             if response.tool_calls.len() > config.max_parallel_tools {
-                let error = AgentError::ParallelToolLimitExceeded {
-                    count: response.tool_calls.len(),
-                    limit: config.max_parallel_tools,
-                };
-                emit_error_event(&tx, &error.to_string()).await;
-                return Err(error);
+                // Soft recovery (was: hard `Err(ParallelToolLimitExceeded)`).
+                //
+                // Modern reasoning models occasionally request very large
+                // parallel batches; aborting the entire turn made the council
+                // appear to "stall" with no visible cause.  Instead we:
+                //
+                // 1. Emit a visible `SystemWarning` to the SSE stream so the
+                //    user sees what happened and gets an actionable hint.
+                // 2. Synthesise tool-result messages that report the overflow
+                //    back to the model as a tool error, so it can self-correct
+                //    by retrying with a smaller batch.
+                // 3. Append assistant + synthetic results to history and
+                //    continue the loop.
+                let count = response.tool_calls.len();
+                let limit = config.max_parallel_tools;
+
+                let synthetic_error = format!(
+                    "ERROR: You requested {count} tool calls in a single batch, but the \
+                     parallel tool-call limit is {limit}.  None of the {count} calls were \
+                     executed.  Please retry your request, issuing at most {limit} tool \
+                     calls per turn (you can split a large batch across multiple turns)."
+                );
+                let synthetic_results: Vec<ToolResult> = response
+                    .tool_calls
+                    .iter()
+                    .map(|tc| ToolResult {
+                        tool_call_id: tc.id.clone(),
+                        content: synthetic_error.clone(),
+                        success: false,
+                    })
+                    .collect();
+
+                let suggested_action = format!(
+                    "To permanently raise this limit, run: \
+                     `gglib config settings set --max-parallel-tools <N>` \
+                     (current: {limit}, ceiling: {ceiling})",
+                    ceiling = gglib_core::MAX_PARALLEL_TOOLS_CEILING,
+                );
+                let warning_message = format!(
+                    "Agent attempted {count} parallel tool calls (limit is {limit}). \
+                     Auto-recovering: the model will retry in smaller batches."
+                );
+                warn!(count, limit, "parallel tool limit exceeded; soft-recovering");
+                let _ = tx
+                    .send(AgentEvent::SystemWarning {
+                        message: warning_message,
+                        suggested_action: Some(suggested_action),
+                    })
+                    .await;
+
+                append_iteration_messages(
+                    &mut messages,
+                    response.content,
+                    response.tool_calls,
+                    synthetic_results,
+                );
+                messages = prune_for_budget(std::mem::take(&mut messages), &config);
+
+                let _ = tx
+                    .send(AgentEvent::IterationComplete {
+                        iteration: iteration + 1,
+                        tool_calls: count,
+                    })
+                    .await;
+                continue;
             }
 
             debug!(

--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -314,7 +314,10 @@ impl AgentLoopPort for AgentLoop {
                     "Agent attempted {count} parallel tool calls (limit is {limit}). \
                      Auto-recovering: the model will retry in smaller batches."
                 );
-                warn!(count, limit, "parallel tool limit exceeded; soft-recovering");
+                warn!(
+                    count,
+                    limit, "parallel tool limit exceeded; soft-recovering"
+                );
                 let _ = tx
                     .send(AgentEvent::SystemWarning {
                         message: warning_message,

--- a/crates/gglib-agent/src/council/events.rs
+++ b/crates/gglib-agent/src/council/events.rs
@@ -75,6 +75,22 @@ pub enum CouncilEvent {
         duration_display: String,
     },
 
+    /// A non-fatal warning surfaced by the agent loop during this turn.
+    ///
+    /// Used to inform the user that the loop encountered a recoverable
+    /// condition (e.g. parallel-tool-limit overflow that triggered an
+    /// auto-retry).  The CLI/GUI should render this prominently but the
+    /// council deliberation continues normally.
+    ///
+    /// `suggested_action` is an optional, user-facing actionable hint
+    /// (e.g. a CLI command to permanently raise a limit).
+    AgentSystemWarning {
+        agent_id: String,
+        message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        suggested_action: Option<String>,
+    },
+
     /// The current agent's turn is finished.
     ///
     /// `core_claim` is extracted from a `CORE CLAIM: ...` marker in the

--- a/crates/gglib-agent/src/council/stream_bridge.rs
+++ b/crates/gglib-agent/src/council/stream_bridge.rs
@@ -87,6 +87,15 @@ pub async fn bridge_agent_events(
                 duration_display,
             },
 
+            AgentEvent::SystemWarning {
+                message,
+                suggested_action,
+            } => CouncilEvent::AgentSystemWarning {
+                agent_id: id.clone(),
+                message,
+                suggested_action,
+            },
+
             AgentEvent::FinalAnswer { content } => {
                 final_content = Some(content);
                 // Don't emit a council event here — the orchestrator emits

--- a/crates/gglib-agent/tests/integration_guards.rs
+++ b/crates/gglib-agent/tests/integration_guards.rs
@@ -305,9 +305,8 @@ async fn test_too_many_tool_calls_integration() {
         } => Some((message.clone(), suggested_action.clone())),
         _ => None,
     });
-    let (warn_msg, warn_action) = warning.expect(
-        "AgentEvent::SystemWarning must be emitted when parallel tool limit is exceeded",
-    );
+    let (warn_msg, warn_action) = warning
+        .expect("AgentEvent::SystemWarning must be emitted when parallel tool limit is exceeded");
     assert!(
         warn_msg.contains('3') && warn_msg.contains('2'),
         "warning must mention attempted count (3) and limit (2): {warn_msg}"

--- a/crates/gglib-agent/tests/integration_guards.rs
+++ b/crates/gglib-agent/tests/integration_guards.rs
@@ -12,7 +12,7 @@
 //! | [`test_loop_detection`]                 | Repeated tool-call batch → [`AgentError::LoopDetected`] |
 //! | [`test_stagnation_detected_integration`] | Repeated text response → [`AgentError::StagnationDetected`] |
 //! | [`test_stagnation_fires_before_finalize`] | Stagnation catches repeated final answer |
-//! | [`test_too_many_tool_calls_integration`] | Oversized tool-call batch → [`AgentError::ParallelToolLimitExceeded`] |
+//! | [`test_too_many_tool_calls_integration`] | Oversized tool-call batch → soft-recovery via synthetic tool error + [`AgentEvent::SystemWarning`] |
 
 mod common;
 
@@ -219,16 +219,23 @@ async fn test_stagnation_detected_integration() {
     );
 }
 
-/// **Too many tool calls**: when the LLM returns more tool calls in a single
-/// batch than `max_parallel_tools` allows, the loop must terminate immediately
-/// with [`AgentError::ParallelToolLimitExceeded`] and emit [`AgentEvent::Error`].
+/// **Too many tool calls (soft recovery)**: when the LLM returns more tool
+/// calls in a single batch than `max_parallel_tools` allows, the loop must
+/// **not** terminate.  Instead it:
 ///
-/// The batch is rejected *before* any tool is executed — this is checked by
-/// asserting that the tool executor is never called.
+/// 1. Emits an [`AgentEvent::SystemWarning`] with an actionable hint so the
+///    user sees what happened (rather than a silent stall).
+/// 2. Synthesises one tool-result-shaped error per requested tool call,
+///    feeding the overflow back to the model so it can self-correct.
+/// 3. Continues the loop without executing any of the over-budget calls.
+///
+/// On the second iteration the model returns a normal answer; the run must
+/// complete successfully.
 #[tokio::test]
 async fn test_too_many_tool_calls_integration() {
-    // LLM emits 3 tool calls in one response; limit is 2.
-    let batch = MockLlmResponse {
+    // First response: 3 tool calls (over the limit of 2) — must trigger
+    // soft recovery, NOT abort.
+    let overflow_batch = MockLlmResponse {
         reasoning: None,
         content: None,
         tool_calls: vec![
@@ -250,7 +257,15 @@ async fn test_too_many_tool_calls_integration() {
         ],
         finish_reason: "tool_calls".into(),
     };
-    let llm = Arc::new(MockLlmPort::new().push(batch));
+    // Second response: a normal final answer the model produces after seeing
+    // the synthetic "batch limit exceeded" tool-result.
+    let recovery = MockLlmResponse {
+        reasoning: None,
+        content: Some("retried with smaller batches".into()),
+        tool_calls: vec![],
+        finish_reason: "stop".into(),
+    };
+    let llm = Arc::new(MockLlmPort::new().push(overflow_batch).push(recovery));
     let executor = MockToolExecutorPort::new().with_tool(
         ToolDefinition::new("search"),
         MockToolBehavior::Immediate {
@@ -267,7 +282,7 @@ async fn test_too_many_tool_calls_integration() {
                 content: "search for things".into(),
             }],
             common::for_test(|c| {
-                c.max_parallel_tools = 2; // 3 calls > 2 → rejected
+                c.max_parallel_tools = 2; // 3 calls > 2 → soft-recovered
                 c.max_repeated_batch_steps = None;
             }),
             tx,
@@ -276,25 +291,42 @@ async fn test_too_many_tool_calls_integration() {
 
     let events = collect_events(rx).await;
 
-    // Must produce the dedicated error variant.
+    // Must complete normally (no hard error).
     assert!(
-        matches!(
-            result,
-            Err(AgentError::ParallelToolLimitExceeded { count: 3, limit: 2 })
-        ),
-        "expected ParallelToolLimitExceeded {{ count: 3, limit: 2 }}, got: {result:?}"
+        result.is_ok(),
+        "expected Ok after soft-recovery, got: {result:?}"
     );
 
-    // An AgentEvent::Error must have been emitted before the stream closes.
+    // A SystemWarning must have been emitted with both fields populated.
+    let warning = events.iter().find_map(|e| match e {
+        AgentEvent::SystemWarning {
+            message,
+            suggested_action,
+        } => Some((message.clone(), suggested_action.clone())),
+        _ => None,
+    });
+    let (warn_msg, warn_action) = warning.expect(
+        "AgentEvent::SystemWarning must be emitted when parallel tool limit is exceeded",
+    );
     assert!(
-        has_error_event(&events),
-        "AgentEvent::Error must be emitted on ParallelToolLimitExceeded"
+        warn_msg.contains('3') && warn_msg.contains('2'),
+        "warning must mention attempted count (3) and limit (2): {warn_msg}"
+    );
+    assert!(
+        warn_action.is_some_and(|a| a.contains("max-parallel-tools")),
+        "warning must include an actionable suggestion referencing the setting key"
     );
 
-    // The tool must never have been called — the batch is rejected before execution.
+    // The hard-error path must NOT have fired.
     assert!(
-        !has_final_answer(&events),
-        "FinalAnswer must not be emitted when the batch is rejected"
+        !has_error_event(&events),
+        "AgentEvent::Error must not be emitted when soft-recovering"
+    );
+
+    // The final answer from the second LLM response must have been produced.
+    assert!(
+        has_final_answer(&events),
+        "FinalAnswer must be emitted after soft-recovery completes"
     );
 }
 

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -29,7 +29,7 @@ use std::io::{self, Write as _};
 
 use gglib_core::domain::agent::AgentEvent;
 
-use crate::presentation::style::{BOLD, DANGER, DIM, RESET, SUCCESS};
+use crate::presentation::style::{BOLD, DANGER, DIM, RESET, SUCCESS, WARNING};
 
 use super::tool_format::format_tool_result;
 
@@ -125,6 +125,18 @@ pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_del
 
         AgentEvent::Error { message } => {
             eprintln!("\n  ❌  {message}");
+        }
+
+        AgentEvent::SystemWarning {
+            message,
+            suggested_action,
+        } => {
+            if !quiet {
+                eprintln!("\n  {WARNING}⚠  {BOLD}{message}{RESET}");
+                if let Some(action) = suggested_action {
+                    eprintln!("  {DIM}→ {action}{RESET}");
+                }
+            }
         }
 
         AgentEvent::PromptProgress { .. } => {

--- a/crates/gglib-cli/src/handlers/council/stream.rs
+++ b/crates/gglib-cli/src/handlers/council/stream.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 
 use gglib_agent::council::events::CouncilEvent;
 
-use crate::presentation::style::{BOLD, DIM, RESET};
+use crate::presentation::style::{BOLD, DIM, RESET, WARNING};
 
 // ─── Temperature colours (contentiousness → ANSI 256-colour) ────────────────
 
@@ -90,6 +90,18 @@ pub async fn render_council_stream(rx: &mut mpsc::Receiver<CouncilEvent>) {
                 eprintln!(
                     "  {icon_color}{icon}{RESET}  {BOLD}{display_name}{RESET}  {DIM}{duration_display}{RESET}"
                 );
+            }
+
+            CouncilEvent::AgentSystemWarning {
+                message,
+                suggested_action,
+                ..
+            } => {
+                // Yellow ⚠ on stderr, prominent so it isn't lost in deltas.
+                eprintln!("\n  {WARNING}⚠  {BOLD}{message}{RESET}");
+                if let Some(action) = suggested_action {
+                    eprintln!("  {DIM}→ {action}{RESET}");
+                }
             }
 
             CouncilEvent::AgentTurnComplete { core_claim, .. } => {

--- a/crates/gglib-core/src/domain/agent/config.rs
+++ b/crates/gglib-core/src/domain/agent/config.rs
@@ -19,9 +19,12 @@ pub const MAX_ITERATIONS_CEILING: usize = 50;
 
 /// Hard ceiling on `max_parallel_tools` accepted from external callers.
 ///
-/// 20 concurrent tools per iteration is far beyond any practical need and
-/// prevents thread-pool saturation from crafted requests.
-pub const MAX_PARALLEL_TOOLS_CEILING: usize = 20;
+/// 50 concurrent tools per iteration is far beyond any practical need and
+/// prevents thread-pool saturation from crafted requests.  Modern reasoning
+/// models occasionally request large parallel batches (10–25 calls); the
+/// ceiling must comfortably exceed the default to leave headroom for users
+/// who legitimately want to raise the limit.
+pub const MAX_PARALLEL_TOOLS_CEILING: usize = 50;
 
 /// Hard ceiling on `tool_timeout_ms` accepted from external callers (60 s).
 ///
@@ -51,10 +54,16 @@ pub const DEFAULT_MAX_ITERATIONS: usize = 25;
 
 /// Default value for [`AgentConfig::max_parallel_tools`].
 ///
-/// Mirrors `MAX_PARALLEL_TOOLS = 5` from the TypeScript frontend.
+/// Set to 25 to comfortably accommodate modern reasoning models (Qwen3-MoE,
+/// DeepSeek-R1, etc.) that routinely request 6–10 parallel tool calls per
+/// turn during exploration-heavy tasks (e.g. codebase reviews).  An overflow
+/// is no longer fatal — the loop now soft-recovers by injecting a synthetic
+/// tool error and asking the model to retry with a smaller batch — but a
+/// generous default avoids triggering that recovery path under normal load.
+///
 /// Used both in [`AgentConfig::default`] and in [`super::events::AGENT_EVENT_CHANNEL_CAPACITY`]
 /// so the channel size accounts for the correct number of concurrent tool events.
-pub const DEFAULT_MAX_PARALLEL_TOOLS: usize = 5;
+pub const DEFAULT_MAX_PARALLEL_TOOLS: usize = 25;
 
 /// Default value for [`AgentConfig::max_stagnation_steps`].
 ///

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -95,6 +95,25 @@ pub enum AgentEvent {
         time_ms: u64,
     },
 
+    /// A non-fatal system-level warning surfaced by the loop itself.
+    ///
+    /// Unlike [`AgentEvent::Error`], a `SystemWarning` does **not** terminate
+    /// the loop — it informs the user that the loop encountered a recoverable
+    /// condition (e.g. the model requested more parallel tool calls than the
+    /// configured limit, and the loop is auto-retrying with a synthetic
+    /// error fed back to the model).
+    ///
+    /// `suggested_action`, when present, contains an actionable hint the UI
+    /// can render verbatim (e.g. a CLI command to permanently raise a limit).
+    SystemWarning {
+        /// Human-readable description of the recoverable condition.
+        message: String,
+        /// Optional actionable hint (e.g. CLI command) the UI can show to the
+        /// user to permanently address the cause.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        suggested_action: Option<String>,
+    },
+
     /// A fatal error has terminated the loop.
     Error {
         /// Human-readable description of the failure.
@@ -187,20 +206,23 @@ pub enum LlmStreamEvent {
 /// [`tokio::sync::mpsc`] channel capacity for streaming [`AgentEvent`]s
 /// produced by a single [`crate::ports::AgentLoopPort::run`] call.
 ///
-/// Set to a generous static ceiling (4 096) rather than a formula tied to
-/// default config values.  The formula-based value (~532 for default config)
-/// is too small for callers that use non-default settings such as
-/// `max_iterations = 50` + `max_parallel_tools = 20`, which would produce
-/// up to ~2 061 structural events per run before any `TextDelta` headroom.
-/// Filling the channel causes `tx.send().await` to back-pressure on every
-/// token in the hot streaming path, with measurable latency impact.
+/// Sized so that a full run at the **maximum ceiling configuration**
+/// (`MAX_ITERATIONS_CEILING` × (`MAX_PARALLEL_TOOLS_CEILING` × 2 + 1) + 1
+/// structural events ≈ 5 051 with `MAX_ITERATIONS_CEILING = 50` and
+/// `MAX_PARALLEL_TOOLS_CEILING = 50`) fits without back-pressure on the hot
+/// streaming path.  Any value ≥ 5 051 satisfies the structural ceiling test;
+/// 8 192 leaves comfortable headroom for `TextDelta` bursts.
 ///
-/// 4 096 fits comfortably in a few hundred kilobytes of memory per active
-/// agent session and is sufficient for any realistic configuration.
+/// Filling the channel causes `tx.send().await` to back-pressure on every
+/// token, with measurable latency impact, so the constant is set well above
+/// the hard floor.
+///
+/// 8 192 fits comfortably in under a megabyte of memory per active agent
+/// session.
 ///
 /// All callers (SSE handlers, CLI REPL) should use this constant instead of
 /// a magic literal.
-pub const AGENT_EVENT_CHANNEL_CAPACITY: usize = 4_096;
+pub const AGENT_EVENT_CHANNEL_CAPACITY: usize = 8_192;
 
 #[cfg(test)]
 mod tests {

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -82,6 +82,17 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
         displayName: event.display_name,
         durationDisplay: event.duration_display,
       };
+    case 'agent_system_warning':
+      // Surface the recoverable warning to the user.  No reducer action yet —
+      // wire into UI surface (banner / toast / inline note) when the council
+      // pages add a warning track.  Logging at warn level ensures the message
+      // is visible in DevTools and the appLogger transport.
+      appLogger.warn('[council] system warning', {
+        agentId: event.agent_id,
+        message: event.message,
+        suggestedAction: event.suggested_action,
+      });
+      return null;
     case 'agent_turn_complete':
       return {
         type: 'AGENT_TURN_COMPLETE',

--- a/src/hooks/useCouncil/useCouncil.ts
+++ b/src/hooks/useCouncil/useCouncil.ts
@@ -87,7 +87,7 @@ function eventToAction(event: CouncilEvent): CouncilAction | null {
       // wire into UI surface (banner / toast / inline note) when the council
       // pages add a warning track.  Logging at warn level ensures the message
       // is visible in DevTools and the appLogger transport.
-      appLogger.warn('[council] system warning', {
+      appLogger.warn('hook', 'council: parallel-tool-limit soft-recovery', {
         agentId: event.agent_id,
         message: event.message,
         suggestedAction: event.suggested_action,

--- a/src/types/council.ts
+++ b/src/types/council.ts
@@ -34,6 +34,7 @@ export type CouncilEvent =
   | AgentReasoningDeltaEvent
   | AgentToolCallStartEvent
   | AgentToolCallCompleteEvent
+  | AgentSystemWarningEvent
   | AgentTurnCompleteEvent
   | RoundSeparatorEvent
   | JudgeStartEvent
@@ -85,6 +86,24 @@ export interface AgentToolCallCompleteEvent {
   result: { content: string; is_error: boolean };
   display_name: string;
   duration_display: string;
+}
+
+/**
+ * Non-fatal warning surfaced by the agent loop during a turn.
+ *
+ * Mirrors `CouncilEvent::AgentSystemWarning` (Rust).  Currently emitted when
+ * the model requests more parallel tool calls than the configured limit and
+ * the loop auto-recovers by feeding a synthetic error back to the model.
+ *
+ * Render this prominently (e.g. as a banner attached to the agent's bubble);
+ * the council deliberation continues normally.
+ */
+export interface AgentSystemWarningEvent {
+  type: 'agent_system_warning';
+  agent_id: string;
+  message: string;
+  /** Optional actionable hint (e.g. a CLI command to raise a limit). */
+  suggested_action?: string;
 }
 
 export interface AgentTurnCompleteEvent {


### PR DESCRIPTION
## Problem

The agent loop aborted the entire agent turn with a hard `ParallelToolLimitExceeded` error when the LLM requested more tool calls in a single batch than `max_parallel_tools` (default: 5) allowed.

Modern reasoning models — Qwen3-MoE in particular — routinely batch 6–10+ tool calls per turn during exploration-heavy tasks (codebase reviews, multi-file analysis). The old default of 5 turned a normal model behaviour into a **silent council stall**: agents appeared to stop after 2–3 iterations with no visible explanation. The error was swallowed by the SSE bridge and never surfaced to the user.

Confirmed via `RUST_LOG=debug` A/B capture across both branches. On the branch run, 5 of 6 agents hit the cap (batch sizes 6, 8, 6, 6, 6) and aborted silently. On the main run the same prompt happened to draw smaller batches (≤5) due to model non-determinism — pure luck, not a real fix.

## Changes

### Config defaults raised
- `DEFAULT_MAX_PARALLEL_TOOLS`: 5 → **25** — comfortably above Qwen3-MoE's practical ceiling under exploration prompts
- `MAX_PARALLEL_TOOLS_CEILING`: 20 → **50** — ceiling must exceed the new default
- `AGENT_EVENT_CHANNEL_CAPACITY`: 4096 → **8192** — required to satisfy the structural-events ceiling test under the new caps

### Soft recovery in `agent_loop.rs`
When the model requests more tool calls than the limit:
1. Emits `AgentEvent::SystemWarning` (new variant) with an actionable hint so the user sees what happened
2. Synthesises a `ToolResult`-shaped error for every over-budget call, fed back into the LLM context so it can self-correct by retrying with a smaller batch
3. **Continues the loop** instead of aborting

### New `AgentEvent::SystemWarning { message, suggested_action }`
Non-fatal event variant for recoverable loop conditions. The `suggested_action` field carries a user-facing CLI command (e.g. `gglib config settings set --max-parallel-tools <N>`).

### Council event plumbing
- New `CouncilEvent::AgentSystemWarning` variant + bridge mapping
- Rendered as a prominent yellow ⚠ in the CLI council stream and single-agent renderer

### Frontend
- New `AgentSystemWarningEvent` TS type mirroring the Rust variant
- `useCouncil` hook dispatches to `appLogger.warn('hook', ...)` (UI surface — banner/toast — to be wired in a follow-up)

### Test updated
`integration_guards::test_too_many_tool_calls_integration` rewritten to assert the new soft-recovery contract:
- `AgentEvent::SystemWarning` emitted with count + limit in the message and `max-parallel-tools` in the suggested action
- No `AgentEvent::Error`
- `FinalAnswer` reached on the recovery iteration (model given a second chance)

## Verification

End-to-end council run on `fix/agent-tool-batch-limit` with the codebase-review prompt that previously stalled every agent:
- **Zero** `agent turn ended early` in 3053 log lines
- Batch sizes of **6 and 7** observed with no abort
- First agent ran **19 full iterations** and produced a complete `CORE CLAIM`
- Second agent ran **9 full iterations** and produced a complete `CORE CLAIM`
- All `cargo test -p gglib-agent -p gglib-core -p gglib-cli` green (520+ tests)
- `cargo clippy --workspace --tests --all-features -- -D warnings` clean