### PR TITLE
fix(#466): complete download progress visibility and registration reliability

### DIFF
--- a/crates/gglib-cli/src/handlers/model/download/README.md
+++ b/crates/gglib-cli/src/handlers/model/download/README.md
@@ -33,8 +33,26 @@ This module handles all download-related commands that interact with HuggingFace
 1. User issues `gglib model download <repo>` command
 2. `exec.rs` queues it via `DownloadManagerPort::queue_smart` (same code path as the GUI)
 3. `interactive.rs` renders progress via `CliDownloadEventEmitter` (indicatif bars)
-4. In TTY mode: `[a]` prompts for another model to add to the queue; `[q]` cancels all
-5. Model registration on completion is handled by the download manager (via `ModelRegistrarPort`)
+4. In TTY mode: `[a]` prompts for another model to add to the queue.
+   `[q]` (or `Esc` / `Ctrl-C`) is **two-step**:
+   - First press → arms drain mode (hint becomes
+     `Draining... press q again to force quit`); active downloads
+     continue running until they finish naturally and the queue auto-
+     exits when it empties.
+   - Second press → calls `cancel_all()`, which signals cancel tokens
+     and waits up to 5 s for in-flight Python helpers to actually
+     finalize before returning.
+5. Lifecycle states surfaced on the bar:
+   `Downloading` → `Finalizing` (gathering HF metadata) →
+   `Registering` (writing model row) → terminal `Completed` /
+   `Failed` / `Cancelled`. The `Finalizing` / `Registering` labels
+   keep the UI from looking frozen at 100 %.
+6. When the Python helper uses the `hf-xet` transport (which bypasses
+   tqdm), a stat-based fallback poller emits synthetic progress events
+   so the bar still ticks. See
+   [`gglib-download/src/cli_exec/exec/xet_poller.rs`](../../../../../gglib-download/src/cli_exec/exec/xet_poller.rs).
+7. Model registration on completion is handled by the download manager
+   (via `ModelRegistrarPort`).
 
 ## Modules
 

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -152,7 +152,19 @@ async fn run_tty_monitor(
     let (cmd_tx, mut cmd_rx) = mpsc::channel::<ReaderCmd>(1);
 
     // ── Spawn the keystroke reader on a dedicated blocking thread ──────────
-    let reader_handle = tokio::task::spawn_blocking(move || {
+    // Spawn as a plain OS thread rather than `tokio::task::spawn_blocking`.
+    //
+    // `spawn_blocking` registers the thread with Tokio's blocking pool.  When
+    // the pool shuts down (after the async main returns) it waits up to
+    // `blocking_shutdown_timeout` (default: 10 s) for all blocking tasks to
+    // finish.  Because `term.read_key()` blocks indefinitely on stdin, the
+    // thread never exits on its own — causing a 10-second hang every time the
+    // download completes without the user pressing a key.
+    //
+    // A plain `std::thread` is *not* tracked by Tokio's blocking pool, so
+    // dropping the handle here is truly fire-and-forget: Tokio shuts down
+    // immediately and the OS kills the thread when the process exits.
+    let reader_handle = std::thread::spawn(move || {
         let term = Term::stdout();
         loop {
             let key = match term.read_key() {
@@ -307,11 +319,10 @@ async fn run_tty_monitor(
     if let Some(bar) = hint_bar {
         bar.finish_and_clear();
     }
-    // Best-effort: wait briefly for the reader thread to exit so the
-    // terminal isn't left with a half-read pending. read_key() is blocking,
-    // so if we've already sent Stop the reader will exit on the next key —
-    // we don't actually wait for it (would block on stdin) and rely on
-    // the channel close + process exit to clean up.
+    // Detach the reader thread.  We already sent ReaderCmd::Stop so it will
+    // exit as soon as the user presses the next key (or when the process
+    // terminates and the OS kills it).  We must not join here — that would
+    // block the async task on stdin forever.
     drop(reader_handle);
     result
 }

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -177,6 +177,10 @@ async fn run_tty_monitor(
     let mut hint_bar: Option<ProgressBar> = None;
     let mut seen_items = false;
     let mut last_item_count: u32 = 0;
+    // Two-step quit: first `q`/Ctrl-C arms `quitting=true` and lets active
+    // downloads drain naturally; the second press calls `cancel_all()`.
+    // Auto-exit fires when the queue empties on its own.
+    let mut quitting = false;
 
     let mut tick = tokio::time::interval(Duration::from_millis(250));
     // Skip the initial fire-immediately tick so we don't redraw before
@@ -198,9 +202,20 @@ async fn run_tty_monitor(
                         let _ = cmd_tx.send(ReaderCmd::Continue).await;
                     }
                     Some(Key::Char('q')) | Some(Key::Escape) => {
-                        downloads.cancel_all().await.ok();
-                        let _ = cmd_tx.send(ReaderCmd::Stop).await;
-                        break Ok(());
+                        if quitting {
+                            // Second press → force quit.
+                            downloads.cancel_all().await.ok();
+                            let _ = cmd_tx.send(ReaderCmd::Stop).await;
+                            break Ok(());
+                        }
+                        // First press → arm drain mode and update the hint.
+                        quitting = true;
+                        if let Some(bar) = &hint_bar {
+                            bar.set_message(
+                                "Draining... press q again to force quit".to_string(),
+                            );
+                        }
+                        let _ = cmd_tx.send(ReaderCmd::Continue).await;
                     }
                     Some(_) => {
                         // Ignore other keys; tell reader to keep going.
@@ -216,9 +231,17 @@ async fn run_tty_monitor(
 
             // ── Ctrl-C from terminal (signal, not a key) ──────────────────
             _ = tokio::signal::ctrl_c() => {
-                downloads.cancel_all().await.ok();
-                let _ = cmd_tx.send(ReaderCmd::Stop).await;
-                break Ok(());
+                if quitting {
+                    downloads.cancel_all().await.ok();
+                    let _ = cmd_tx.send(ReaderCmd::Stop).await;
+                    break Ok(());
+                }
+                quitting = true;
+                if let Some(bar) = &hint_bar {
+                    bar.set_message(
+                        "Draining... press q again to force quit".to_string(),
+                    );
+                }
             }
 
             // ── 250 ms render / completion tick ────────────────────────────
@@ -245,11 +268,19 @@ async fn run_tty_monitor(
                 }
 
                 // Update live counts in the hint message every tick.
+                // While quitting, keep the drain hint pinned so the user
+                // doesn't lose the "press q again" instruction.
                 if let Some(bar) = &hint_bar {
-                    bar.set_message(build_hint_message(
-                        snapshot.active_count,
-                        snapshot.pending_count,
-                    ));
+                    if quitting {
+                        bar.set_message(
+                            "Draining... press q again to force quit".to_string(),
+                        );
+                    } else {
+                        bar.set_message(build_hint_message(
+                            snapshot.active_count,
+                            snapshot.pending_count,
+                        ));
+                    }
                 }
 
                 // Re-anchor hint to the bottom whenever new items appear.

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -111,8 +111,14 @@ pub enum ModelCommand {
     /// progress is rendered in the terminal and multiple models can be added
     /// interactively while a download is in flight.
     ///
-    /// In a TTY, press **[a]** to add another model to the queue or **[q]** / Ctrl-C
-    /// to cancel all pending downloads.
+    /// In a TTY, press **[a]** to add another model to the queue. Press
+    /// **[q]** / `Esc` / `Ctrl-C` once to drain (active downloads keep
+    /// running, hint becomes `Draining... press q again to force quit`);
+    /// press it again to cancel all in-flight jobs and exit.
+    ///
+    /// While a download is in flight the bar surfaces the lifecycle phase:
+    /// `Downloading` → `Finalizing` (gathering HF metadata) → `Registering`
+    /// (writing model row) → terminal `Completed` / `Failed` / `Cancelled`.
     Download {
         /// HuggingFace model repository (e.g., "bartowski/Qwen2.5-7B-Instruct-GGUF")
         model_id: String,

--- a/crates/gglib-core/src/download/events.rs
+++ b/crates/gglib-core/src/download/events.rs
@@ -34,6 +34,10 @@ pub enum DownloadStatus {
     Queued,
     /// Currently being downloaded.
     Downloading,
+    /// Bytes are on disk; verifying / collecting metadata before registration.
+    Finalizing,
+    /// Registering the completed download in the model database.
+    Registering,
     /// Completed successfully.
     Completed,
     /// Failed with an error.
@@ -49,6 +53,8 @@ impl DownloadStatus {
         match self {
             Self::Queued => "queued",
             Self::Downloading => "downloading",
+            Self::Finalizing => "finalizing",
+            Self::Registering => "registering",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
@@ -60,11 +66,27 @@ impl DownloadStatus {
     pub fn parse(s: &str) -> Self {
         match s {
             "downloading" => Self::Downloading,
+            "finalizing" => Self::Finalizing,
+            "registering" => Self::Registering,
             "completed" => Self::Completed,
             "failed" => Self::Failed,
             "cancelled" => Self::Cancelled,
             // "queued" or unknown values default to Queued
             _ => Self::Queued,
+        }
+    }
+
+    /// Human-readable label for UI display.
+    #[must_use]
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Queued => "Queued",
+            Self::Downloading => "Downloading",
+            Self::Finalizing => "Finalizing",
+            Self::Registering => "Registering",
+            Self::Completed => "Completed",
+            Self::Failed => "Failed",
+            Self::Cancelled => "Cancelled",
         }
     }
 }
@@ -169,6 +191,20 @@ pub enum DownloadEvent {
     DownloadCancelled {
         /// Canonical ID of the download.
         id: String,
+    },
+
+    /// Lifecycle status transition for a download (e.g.
+    /// `Downloading` → `Finalizing` → `Registering`).
+    ///
+    /// Emitted at the boundaries between phases so transports can render a
+    /// non-frozen state while the manager is verifying bytes and writing the
+    /// model row to the database. Terminal states (`Completed`, `Failed`,
+    /// `Cancelled`) keep their dedicated event variants.
+    DownloadStatusChanged {
+        /// Canonical ID of the download.
+        id: String,
+        /// New status of the download.
+        status: DownloadStatus,
     },
 
     /// Queue run completed (all downloads in the queue finished).
@@ -293,6 +329,14 @@ impl DownloadEvent {
         Self::DownloadCancelled { id: id.into() }
     }
 
+    /// Create a status-changed event for non-terminal lifecycle transitions.
+    pub fn status_changed(id: impl Into<String>, status: DownloadStatus) -> Self {
+        Self::DownloadStatusChanged {
+            id: id.into(),
+            status,
+        }
+    }
+
     /// Create a queue run complete event.
     pub const fn queue_run_complete(summary: QueueRunSummary) -> Self {
         Self::QueueRunComplete { summary }
@@ -308,7 +352,8 @@ impl DownloadEvent {
             | Self::ShardProgress { id, .. }
             | Self::DownloadCompleted { id, .. }
             | Self::DownloadFailed { id, .. }
-            | Self::DownloadCancelled { id } => Some(id),
+            | Self::DownloadCancelled { id }
+            | Self::DownloadStatusChanged { id, .. } => Some(id),
         }
     }
 
@@ -326,6 +371,7 @@ impl DownloadEvent {
             Self::DownloadCompleted { .. } => "download:completed",
             Self::DownloadFailed { .. } => "download:failed",
             Self::DownloadCancelled { .. } => "download:cancelled",
+            Self::DownloadStatusChanged { .. } => "download:status_changed",
             Self::QueueRunComplete { .. } => "download:queue_run_complete",
         }
     }

--- a/crates/gglib-download/README.md
+++ b/crates/gglib-download/README.md
@@ -86,11 +86,20 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 ## Features
 
 - **Queued Downloads** — Multiple concurrent downloads with priority ordering
-- **Progress Tracking** — Real-time progress events for UI updates
+- **Progress Tracking** — Real-time progress events for UI updates, including
+  non-terminal `Finalizing` and `Registering` lifecycle transitions emitted
+  between the last byte hitting disk and the model row being written.
 - **Automatic Model Registration** — Downloads are automatically registered in the database with parsed GGUF metadata
 - **Resume Support** — Partial download resumption on failure
 - **Shard Handling** — Automatic detection and download of sharded models
-- **Fast-Path Downloads** — Uses `hf_xet` Python helper for multi-gigabyte files
+- **Fast-Path Downloads** — Uses `hf_xet` Python helper for multi-gigabyte files.
+  When the `hf-xet` transport bypasses Python `tqdm`, a stat-based fallback
+  poller (`cli_exec/exec/xet_poller.rs`) emits synthetic progress events so
+  the bar keeps moving instead of freezing at `0 B / 0 B`.
+- **Bounded Drain on Cancel** — `cancel_all()` signals cancel tokens and
+  then waits up to 5 s for in-flight jobs to finalize before returning,
+  so callers (CLI, Tauri, Axum) don't exit while Python helper subprocesses
+  are still cleaning up.
 - **Retry Logic** — Automatic retry with exponential backoff
 
 ## Usage

--- a/crates/gglib-download/scripts/hf_xet_downloader.py
+++ b/crates/gglib-download/scripts/hf_xet_downloader.py
@@ -99,7 +99,14 @@ class JsonProgressBar(tqdm):
         # tqdm 4.67 tightened attribute slots, so guard access to desc.
         self._label = getattr(self, "desc", None) or desc or ""
         self._last_emit = 0.0
-        self._emit(force=True)
+        # Skip the initial forced emit when the total is unknown — emitting
+        # `progress {0,0}` at construction misleads the Rust bridge into
+        # showing "0 B/0 B" for the entire transfer on the hf-xet path
+        # (where tqdm is never driven). The Rust-side stat fallback
+        # (`xet_poller`) handles this case; only emit here when we actually
+        # have a non-zero total to advertise.
+        if self.total:
+            self._emit(force=True)
 
     def update(self, n=1):  # type: ignore[override]
         if getattr(self, "disable", False):

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -212,6 +212,18 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                 }
             }
 
+            DownloadEvent::DownloadStatusChanged { id, status } => {
+                // Surface non-terminal lifecycle transitions (Finalizing,
+                // Registering) on the existing bar so the user sees that
+                // work is still happening between "100% downloaded" and
+                // the final completion event.
+                if let Ok(bars) = self.bars.lock() {
+                    if let Some(bar) = bars.get(&id) {
+                        bar.set_message(format!("{id} — {}…", status.label()));
+                    }
+                }
+            }
+
             // Queue-level events don't need bar updates in the CLI emitter.
             DownloadEvent::QueueSnapshot { .. } | DownloadEvent::QueueRunComplete { .. } => {}
         }

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -7,6 +7,7 @@ mod progress;
 pub mod python_bridge;
 mod python_env;
 mod python_protocol;
+mod xet_poller;
 
 use std::fs;
 
@@ -82,6 +83,7 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         token: request.token.as_deref(),
         force: request.force,
         progress: None,
+        expected_total: None,
         cancel_token: None,
     };
 

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -9,7 +9,7 @@
 //! and dispatches progress events to callbacks or CLI display.
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use gglib_core::utils::process::async_cmd;
 use thiserror::Error;
@@ -194,27 +194,38 @@ async fn run_download_process(
         buf
     });
 
-    // CLI progress if no callback provided
-    let mut cli_progress = if request.progress.is_none() {
-        Some(CliProgressPrinter::new())
-    } else {
-        None
-    };
+    // Scoped poller targets: per-file final paths (covers already-renamed
+    // shards) plus the .cache subdir (covers in-flight .incomplete temp files
+    // written by huggingface_hub during hf-xet transfers). Avoids counting
+    // unrelated files that happen to share the same destination directory.
+    let poller_targets: Vec<_> = request
+        .files
+        .iter()
+        .map(|f| request.destination.join(f))
+        .chain(std::iter::once(request.destination.join(".cache")))
+        .collect();
 
-    // Spawn the xet stat-fallback poller. It only emits synthetic progress
-    // events when the Python helper goes silent (typical of the hf-xet fast
-    // path); while real `tqdm` events are flowing it stays dormant.
-    //
-    // We hand the poller the destination *directory* (not the per-file
-    // final paths) because `huggingface_hub` streams bytes into a
-    // `<dest>/.cache/huggingface/download/<filename>.incomplete` temp file
-    // while the transfer is in flight and only renames to the final path on
-    // completion. The poller walks the directory recursively so the
-    // in-progress bytes are accounted for.
-    let xet_poller = request.progress.as_ref().map(|cb| {
-        let targets = vec![request.destination.to_path_buf()];
-        XetPoller::spawn(targets, request.expected_total, Arc::clone(cb))
-    });
+    // Always spawn the xet stat-fallback poller — it stays dormant while real
+    // tqdm events flow, then emits synthetic progress from on-disk byte counts
+    // once they go quiet. Covers both the callback path (worker queue) and the
+    // no-callback path (direct exec, e.g. `model upgrade`).
+    let (cli_progress, xet_poller) = if let Some(cb) = request.progress.as_ref() {
+        // Callback path: external sink handles both real and synthetic events.
+        let poller = XetPoller::spawn(poller_targets, request.expected_total, Arc::clone(cb));
+        (None, Some(poller))
+    } else {
+        // No-callback path: wrap the CLI printer so the XetPoller background
+        // task can call .update() without a mutable borrow of the local.
+        let printer = Arc::new(Mutex::new(CliProgressPrinter::new()));
+        let printer_clone = Arc::clone(&printer);
+        let cb: ProgressCallback = Arc::new(move |d, t| {
+            if let Ok(mut g) = printer_clone.try_lock() {
+                g.update(None, d, t);
+            }
+        });
+        let poller = XetPoller::spawn(poller_targets, request.expected_total, cb);
+        (Some(printer), Some(poller))
+    };
 
     let mut ctrl_c = Box::pin(signal::ctrl_c());
     let cancel_token = request.cancel_token.clone();
@@ -231,7 +242,7 @@ async fn run_download_process(
                 }
             } => {
                 let _ = child.kill().await;
-                finish_progress(&mut cli_progress);
+                finish_progress(cli_progress.as_ref());
                 if let Some(p) = xet_poller { p.shutdown(); }
                 return Err(PythonBridgeError::Cancelled);
             }
@@ -239,7 +250,7 @@ async fn run_download_process(
             // Ctrl+C from terminal
             _ = &mut ctrl_c => {
                 let _ = child.kill().await;
-                finish_progress(&mut cli_progress);
+                finish_progress(cli_progress.as_ref());
                 if let Some(p) = xet_poller { p.shutdown(); }
                 return Err(PythonBridgeError::Cancelled);
             }
@@ -254,18 +265,18 @@ async fn run_download_process(
                 }
 
                 if let Ok(event) = parse_line(&line) {
-                    match handle_event(event, request, &mut cli_progress, xet_poller.as_ref()) {
+                    match handle_event(event, request, cli_progress.as_ref(), xet_poller.as_ref()) {
                         Ok(()) => {}
                         Err(e) => {
                             let _ = child.kill().await;
-                            finish_progress(&mut cli_progress);
+                            finish_progress(cli_progress.as_ref());
                             if let Some(p) = xet_poller { p.shutdown(); }
                             return Err(e);
                         }
                     }
                 } else {
                     // Non-protocol line — print to console
-                    finish_progress(&mut cli_progress);
+                    finish_progress(cli_progress.as_ref());
                     println!("[fast-path] {line}");
                 }
             }
@@ -278,7 +289,7 @@ async fn run_download_process(
         .await
         .map_err(|e| PythonBridgeError::ProcessFailed(e.to_string()))?;
 
-    finish_progress(&mut cli_progress);
+    finish_progress(cli_progress.as_ref());
     if let Some(p) = xet_poller {
         p.shutdown();
     }
@@ -305,7 +316,7 @@ async fn run_download_process(
 fn handle_event(
     event: PythonEvent,
     request: &FastDownloadRequest<'_>,
-    cli_progress: &mut Option<CliProgressPrinter>,
+    cli_progress: Option<&Arc<Mutex<CliProgressPrinter>>>,
     xet_poller: Option<&XetPoller>,
 ) -> Result<(), PythonBridgeError> {
     match event {
@@ -320,8 +331,10 @@ fn handle_event(
             }
             if let Some(cb) = request.progress.as_ref() {
                 cb(downloaded, total);
-            } else if let Some(printer) = cli_progress.as_mut() {
-                printer.update(file.as_deref(), downloaded, total);
+            } else if let Some(printer) = cli_progress {
+                if let Ok(mut g) = printer.lock() {
+                    g.update(file.as_deref(), downloaded, total);
+                }
             }
             Ok(())
         }
@@ -334,8 +347,10 @@ fn handle_event(
     }
 }
 
-fn finish_progress(printer: &mut Option<CliProgressPrinter>) {
-    if let Some(p) = printer.as_mut() {
-        p.finish();
+fn finish_progress(printer: Option<&Arc<Mutex<CliProgressPrinter>>>) {
+    if let Some(p) = printer {
+        if let Ok(mut g) = p.lock() {
+            g.finish();
+        }
     }
 }

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -8,7 +8,8 @@
 //! The orchestrator spawns a Python subprocess, streams its output,
 //! and dispatches progress events to callbacks or CLI display.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use gglib_core::utils::process::async_cmd;
 use thiserror::Error;
@@ -19,13 +20,18 @@ use tokio_util::sync::CancellationToken;
 use super::progress::CliProgressPrinter;
 use super::python_env::{EnvSetupError, PythonEnvironment};
 use super::python_protocol::{ProtocolError, PythonEvent, parse_line};
+use super::xet_poller::XetPoller;
 
 // ============================================================================
 // Types
 // ============================================================================
 
-/// Callback for download progress: (`downloaded_bytes`, `total_bytes`)
-pub type ProgressCallback = Box<dyn Fn(u64, u64) + Send + Sync>;
+/// Callback for download progress: (`downloaded_bytes`, `total_bytes`).
+///
+/// Wrapped in an `Arc` so the bridge can share the same callback with the
+/// [`XetPoller`] background task (which needs `'static` ownership) without
+/// boxing through extra channels.
+pub type ProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
 
 // ============================================================================
 // Constants
@@ -69,7 +75,14 @@ pub struct FastDownloadRequest<'a> {
     pub files: &'a [String],
     pub token: Option<&'a str>,
     pub force: bool,
-    pub progress: Option<&'a ProgressCallback>,
+    /// Progress sink for `(downloaded, total)` byte updates. Shared with the
+    /// xet stat-fallback poller so synthetic progress events surface through
+    /// the same channel as real Python `tqdm` events.
+    pub progress: Option<ProgressCallback>,
+    /// Optional total size hint forwarded to synthetic progress events when
+    /// the Python helper goes silent. `None` means "unknown" — the bar will
+    /// display downloaded bytes without a percentage.
+    pub expected_total: Option<u64>,
     /// Cancellation token for external cancellation.
     pub cancel_token: Option<CancellationToken>,
 }
@@ -188,6 +201,18 @@ async fn run_download_process(
         None
     };
 
+    // Spawn the xet stat-fallback poller. It only emits synthetic progress
+    // events when the Python helper goes silent (typical of the hf-xet fast
+    // path); while real `tqdm` events are flowing it stays dormant.
+    let xet_poller = request.progress.as_ref().map(|cb| {
+        let targets: Vec<PathBuf> = request
+            .files
+            .iter()
+            .map(|f| request.destination.join(f))
+            .collect();
+        XetPoller::spawn(targets, request.expected_total, Arc::clone(cb))
+    });
+
     let mut ctrl_c = Box::pin(signal::ctrl_c());
     let cancel_token = request.cancel_token.clone();
 
@@ -204,6 +229,7 @@ async fn run_download_process(
             } => {
                 let _ = child.kill().await;
                 finish_progress(&mut cli_progress);
+                if let Some(p) = xet_poller { p.shutdown(); }
                 return Err(PythonBridgeError::Cancelled);
             }
 
@@ -211,6 +237,7 @@ async fn run_download_process(
             _ = &mut ctrl_c => {
                 let _ = child.kill().await;
                 finish_progress(&mut cli_progress);
+                if let Some(p) = xet_poller { p.shutdown(); }
                 return Err(PythonBridgeError::Cancelled);
             }
 
@@ -224,11 +251,12 @@ async fn run_download_process(
                 }
 
                 if let Ok(event) = parse_line(&line) {
-                    match handle_event(event, request, &mut cli_progress) {
+                    match handle_event(event, request, &mut cli_progress, xet_poller.as_ref()) {
                         Ok(()) => {}
                         Err(e) => {
                             let _ = child.kill().await;
                             finish_progress(&mut cli_progress);
+                            if let Some(p) = xet_poller { p.shutdown(); }
                             return Err(e);
                         }
                     }
@@ -248,6 +276,9 @@ async fn run_download_process(
         .map_err(|e| PythonBridgeError::ProcessFailed(e.to_string()))?;
 
     finish_progress(&mut cli_progress);
+    if let Some(p) = xet_poller {
+        p.shutdown();
+    }
 
     let stderr_buf = stderr_task.await.unwrap_or_default();
     let stderr_text = String::from_utf8_lossy(&stderr_buf).trim().to_string();
@@ -272,6 +303,7 @@ fn handle_event(
     event: PythonEvent,
     request: &FastDownloadRequest<'_>,
     cli_progress: &mut Option<CliProgressPrinter>,
+    xet_poller: Option<&XetPoller>,
 ) -> Result<(), PythonBridgeError> {
     match event {
         PythonEvent::Progress {
@@ -279,7 +311,11 @@ fn handle_event(
             downloaded,
             total,
         } => {
-            if let Some(cb) = request.progress {
+            // A real Python event arrived — keep the stat fallback dormant.
+            if let Some(p) = xet_poller {
+                p.note_real_event();
+            }
+            if let Some(cb) = request.progress.as_ref() {
                 cb(downloaded, total);
             } else if let Some(printer) = cli_progress.as_mut() {
                 printer.update(file.as_deref(), downloaded, total);

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -8,7 +8,7 @@
 //! The orchestrator spawns a Python subprocess, streams its output,
 //! and dispatches progress events to callbacks or CLI display.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use gglib_core::utils::process::async_cmd;
@@ -204,12 +204,15 @@ async fn run_download_process(
     // Spawn the xet stat-fallback poller. It only emits synthetic progress
     // events when the Python helper goes silent (typical of the hf-xet fast
     // path); while real `tqdm` events are flowing it stays dormant.
+    //
+    // We hand the poller the destination *directory* (not the per-file
+    // final paths) because `huggingface_hub` streams bytes into a
+    // `<dest>/.cache/huggingface/download/<filename>.incomplete` temp file
+    // while the transfer is in flight and only renames to the final path on
+    // completion. The poller walks the directory recursively so the
+    // in-progress bytes are accounted for.
     let xet_poller = request.progress.as_ref().map(|cb| {
-        let targets: Vec<PathBuf> = request
-            .files
-            .iter()
-            .map(|f| request.destination.join(f))
-            .collect();
+        let targets = vec![request.destination.to_path_buf()];
         XetPoller::spawn(targets, request.expected_total, Arc::clone(cb))
     });
 

--- a/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
+++ b/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
@@ -18,7 +18,7 @@
 //! it is a pure stat-and-callback utility that the [`super::python_bridge`]
 //! layer composes.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -139,13 +139,54 @@ async fn is_stale(last_real: &Arc<Mutex<Instant>>) -> bool {
     guard.elapsed() >= STALE_AFTER
 }
 
-/// Sum the on-disk sizes of every existing target, treating missing files as
-/// zero-length (they may simply not have been created yet).
+/// Sum the on-disk sizes of every existing target.
+///
+/// Each target may be either a file or a directory:
+/// * **File** — its length is added directly. Missing files contribute zero
+///   (they may simply not have been created yet).
+/// * **Directory** — every regular file beneath it is summed recursively.
+///   This is required for the hf-xet path because `huggingface_hub` writes
+///   bytes to `<dest>/.cache/huggingface/download/<filename>.incomplete`
+///   while the transfer is in flight and only renames to `<dest>/<filename>`
+///   on completion. Stat'ing the final path alone would report 0 B for the
+///   entire transfer.
 async fn sum_sizes(targets: &[PathBuf]) -> u64 {
     let mut total: u64 = 0;
     for path in targets {
-        if let Ok(metadata) = tokio::fs::metadata(path).await {
+        let Ok(metadata) = tokio::fs::metadata(path).await else {
+            continue;
+        };
+        if metadata.is_file() {
             total = total.saturating_add(metadata.len());
+        } else if metadata.is_dir() {
+            total = total.saturating_add(sum_dir_size(path).await);
+        }
+    }
+    total
+}
+
+/// Recursively sum the sizes of every regular file under `dir`.
+///
+/// Symlinks are followed for size accounting only when the entry's metadata
+/// reports `is_file()` (i.e. the symlink points at a regular file). Errors
+/// reading individual entries are silently treated as zero so a transient
+/// `EACCES` or a vanishing temp file doesn't poison the running total.
+async fn sum_dir_size(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let Ok(mut entries) = tokio::fs::read_dir(&current).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let Ok(metadata) = entry.metadata().await else {
+                continue;
+            };
+            if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            } else if metadata.is_dir() {
+                stack.push(entry.path());
+            }
         }
     }
     total
@@ -255,9 +296,46 @@ mod tests {
             entries.len() <= 1,
             "expected ≤1 synthetic event for a static file, got {entries:?}"
         );
-        if let Some((d, t)) = entries.first() {
-            assert_eq!(*d, 2048);
-            assert_eq!(*t, 0, "total=0 when expected_total is None");
-        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn walks_directory_targets_recursively() {
+        // Mirrors the real hf-xet layout: bytes live under
+        // `<dest>/.cache/huggingface/download/<file>.incomplete` while the
+        // transfer is in flight, and only the directory itself exists at
+        // the spawned target path.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join(".cache/huggingface/download");
+        tokio::fs::create_dir_all(&cache).await.unwrap();
+        let temp_file = cache.join("model.gguf.incomplete");
+        tokio::fs::write(&temp_file, vec![0u8; 4096]).await.unwrap();
+
+        let (cb, log) = recording_callback();
+        let poller = XetPoller::spawn(vec![dir.path().to_path_buf()], Some(8192), cb);
+
+        // Wait past the staleness threshold so synthetic events kick in.
+        tokio::time::sleep(STALE_AFTER + Duration::from_millis(50)).await;
+
+        // Grow the in-flight temp file; the poller should observe the
+        // change via the recursive walk even though the final path
+        // (`<dest>/model.gguf`) doesn't exist yet.
+        let mut f = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&temp_file)
+            .await
+            .unwrap();
+        f.write_all(&[0u8; 2048]).await.unwrap();
+        f.flush().await.unwrap();
+        drop(f);
+
+        tokio::time::sleep(POLL_INTERVAL * 3).await;
+
+        poller.shutdown();
+
+        let entries = log.lock().unwrap().clone();
+        assert!(
+            entries.iter().any(|(d, t)| *d == 6144 && *t == 8192),
+            "expected synthetic event with downloaded=6144 total=8192, got {entries:?}"
+        );
     }
 }

--- a/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
+++ b/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
@@ -1,0 +1,263 @@
+//! File-stat fallback for hf-xet downloads.
+//!
+//! `huggingface_hub` does not drive `tqdm` when the underlying transfer is
+//! handled by the `hf_xet` Rust client, so [`JsonProgressBar`] (in the Python
+//! helper) never receives `update()` calls. Without intervention the Rust
+//! bridge would only ever see the initial `progress {0,0}` event followed
+//! eventually by `complete` — leaving the user staring at a frozen
+//! `0 B/0 B` progress bar for the entire transfer.
+//!
+//! This module spawns a small Tokio task that periodically `stat`s the
+//! destination files and emits a synthetic `(downloaded, total)` event
+//! whenever no real progress event has arrived for [`STALE_AFTER`]. Real
+//! events take precedence: callers must invoke [`XetPoller::note_real_event`]
+//! whenever a Python-side `Progress` message is observed, and the poller
+//! stays dormant for as long as those events keep flowing.
+//!
+//! The poller has no knowledge of the Python protocol or process lifecycle —
+//! it is a pure stat-and-callback utility that the [`super::python_bridge`]
+//! layer composes.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+use super::python_bridge::ProgressCallback;
+
+/// How often the poller wakes up to stat the destination files.
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Minimum age of the most recent real event before synthetic events kick in.
+///
+/// While Python-side `tqdm` updates are flowing, the poller stays silent.
+/// Once real events go quiet for longer than this threshold the poller
+/// assumes hf-xet is driving the transfer directly and starts reporting
+/// on-disk byte counts.
+const STALE_AFTER: Duration = Duration::from_secs(1);
+
+/// Background file-stat fallback that emits synthetic progress events when
+/// the Python helper goes silent (typical of the hf-xet fast path).
+pub struct XetPoller {
+    /// Last time a real Python `Progress` event was observed.
+    last_real_event_at: Arc<Mutex<Instant>>,
+    /// Last synthetic byte count we reported. Used to suppress no-change emits.
+    last_synthetic_bytes: Arc<AtomicU64>,
+    /// Handle to the polling task; aborted on [`XetPoller::shutdown`].
+    handle: JoinHandle<()>,
+}
+
+impl XetPoller {
+    /// Spawn a background poller for the given destination files.
+    ///
+    /// `targets` are absolute paths (`dest_root.join(file)` for each file the
+    /// downloader was asked to fetch). `expected_total`, when known, is
+    /// forwarded as the `total` field on synthetic progress events; pass
+    /// `None` if the size is unknown (the bar will display downloaded bytes
+    /// only).
+    ///
+    /// The poller invokes `on_progress(downloaded_sum, expected_total)`
+    /// whenever the on-disk size changes **and** no real event has been
+    /// reported for at least [`STALE_AFTER`].
+    pub fn spawn(
+        targets: Vec<PathBuf>,
+        expected_total: Option<u64>,
+        on_progress: ProgressCallback,
+    ) -> Self {
+        let last_real_event_at = Arc::new(Mutex::new(Instant::now()));
+        let last_synthetic_bytes = Arc::new(AtomicU64::new(0));
+
+        let last_real = Arc::clone(&last_real_event_at);
+        let last_bytes = Arc::clone(&last_synthetic_bytes);
+        let total = expected_total.unwrap_or(0);
+
+        let handle = tokio::spawn(async move {
+            let mut tick = tokio::time::interval(POLL_INTERVAL);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // The first tick fires immediately — skip it so we don't race the
+            // child process to its first byte on disk.
+            tick.tick().await;
+
+            loop {
+                tick.tick().await;
+
+                if !is_stale(&last_real).await {
+                    continue;
+                }
+
+                let downloaded = sum_sizes(&targets).await;
+                if downloaded == 0 {
+                    // Nothing on disk yet — wait for the next tick.
+                    continue;
+                }
+                if downloaded == last_bytes.load(Ordering::Relaxed) {
+                    continue;
+                }
+
+                last_bytes.store(downloaded, Ordering::Relaxed);
+                on_progress(downloaded, total);
+            }
+        });
+
+        Self {
+            last_real_event_at,
+            last_synthetic_bytes,
+            handle,
+        }
+    }
+
+    /// Record that a real Python `Progress` event was just observed.
+    ///
+    /// This bumps the staleness timer back to "now", causing the poller to
+    /// stay dormant for as long as real events keep arriving regularly. Safe
+    /// to call from synchronous code that is already inside a Tokio runtime.
+    pub fn note_real_event(&self) {
+        // Optimistic non-blocking update. If the lock is contended (the
+        // poller task is holding it for a stale-check) the next call will
+        // pick up the slack — at worst we miss one staleness reset, which
+        // is harmless.
+        if let Ok(mut guard) = self.last_real_event_at.try_lock() {
+            *guard = Instant::now();
+        }
+    }
+
+    /// Stop the background poller. Idempotent; consumes the handle.
+    pub fn shutdown(self) {
+        self.handle.abort();
+        // Reset counters so the type behaves as a one-shot resource.
+        self.last_synthetic_bytes.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Returns `true` when the most recent real event is older than [`STALE_AFTER`].
+async fn is_stale(last_real: &Arc<Mutex<Instant>>) -> bool {
+    let guard = last_real.lock().await;
+    guard.elapsed() >= STALE_AFTER
+}
+
+/// Sum the on-disk sizes of every existing target, treating missing files as
+/// zero-length (they may simply not have been created yet).
+async fn sum_sizes(targets: &[PathBuf]) -> u64 {
+    let mut total: u64 = 0;
+    for path in targets {
+        if let Ok(metadata) = tokio::fs::metadata(path).await {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    total
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+    use tokio::io::AsyncWriteExt;
+
+    type ProgressLog = Arc<StdMutex<Vec<(u64, u64)>>>;
+
+    /// Build a `ProgressCallback` that records every `(downloaded, total)`
+    /// pair into a shared vector.
+    fn recording_callback() -> (ProgressCallback, ProgressLog) {
+        let log = Arc::new(StdMutex::new(Vec::new()));
+        let log_clone = Arc::clone(&log);
+        let cb: ProgressCallback = Arc::new(move |d, t| {
+            log_clone.lock().unwrap().push((d, t));
+        });
+        (cb, log)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn emits_synthetic_progress_when_python_is_silent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.gguf");
+        tokio::fs::write(&path, b"").await.unwrap();
+
+        let (cb, log) = recording_callback();
+        let poller = XetPoller::spawn(vec![path.clone()], Some(1024), cb);
+
+        // Wait past the staleness threshold without any real events arriving,
+        // then grow the file and let the poller observe the change.
+        tokio::time::sleep(STALE_AFTER + Duration::from_millis(50)).await;
+
+        let mut f = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap();
+        f.write_all(&[0u8; 512]).await.unwrap();
+        f.flush().await.unwrap();
+        drop(f);
+
+        // Give the poller a couple of stat ticks to notice.
+        tokio::time::sleep(POLL_INTERVAL * 3).await;
+
+        poller.shutdown();
+
+        let entries = log.lock().unwrap().clone();
+        assert!(
+            entries.iter().any(|(d, t)| *d == 512 && *t == 1024),
+            "expected synthetic event with downloaded=512 total=1024, got {entries:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stays_dormant_while_real_events_are_flowing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.gguf");
+        tokio::fs::write(&path, vec![0u8; 4096]).await.unwrap();
+
+        let (cb, log) = recording_callback();
+        let poller = XetPoller::spawn(vec![path.clone()], Some(8192), cb);
+
+        // Simulate a steady stream of real Python events. Each call resets
+        // the staleness timer well before STALE_AFTER elapses.
+        for _ in 0..6 {
+            poller.note_real_event();
+            tokio::time::advance(Duration::from_millis(300)).await;
+            tokio::task::yield_now().await;
+        }
+
+        poller.shutdown();
+
+        assert!(
+            log.lock().unwrap().is_empty(),
+            "expected no synthetic events while real events were flowing"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn coalesces_repeated_no_change_polls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.gguf");
+        tokio::fs::write(&path, vec![0u8; 2048]).await.unwrap();
+
+        let (cb, log) = recording_callback();
+        let poller = XetPoller::spawn(vec![path.clone()], None, cb);
+
+        // Wait past staleness + several poll intervals.
+        tokio::time::sleep(STALE_AFTER + POLL_INTERVAL * 5).await;
+
+        poller.shutdown();
+
+        // The file size never changes after the first observation, so we
+        // should see at most one synthetic event regardless of how many
+        // poll intervals elapse.
+        let entries = log.lock().unwrap().clone();
+        assert!(
+            entries.len() <= 1,
+            "expected ≤1 synthetic event for a static file, got {entries:?}"
+        );
+        if let Some((d, t)) = entries.first() {
+            assert_eq!(*d, 2048);
+            assert_eq!(*t, 0, "total=0 when expected_total is None");
+        }
+    }
+}

--- a/crates/gglib-download/src/cli_exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/mod.rs
@@ -27,6 +27,6 @@ pub use types::*;
 
 // Re-export Python bridge for use by the async manager
 pub use exec::python_bridge::{
-    FastDownloadRequest, PythonBridgeError, ensure_fast_helper_ready, preflight_fast_helper,
-    run_fast_download,
+    FastDownloadRequest, ProgressCallback, PythonBridgeError, ensure_fast_helper_ready,
+    preflight_fast_helper, run_fast_download,
 };

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -819,10 +819,11 @@ impl DownloadManagerImpl {
         // Phase 1 of finalization: bytes are on disk, we are about to gather
         // metadata (HF tags etc.). Emit a status transition so the UI shows
         // "Finalizing" instead of looking frozen at 100%.
-        self.event_emitter.emit(DownloadEvent::DownloadStatusChanged {
-            id: event_id.clone(),
-            status: gglib_core::download::DownloadStatus::Finalizing,
-        });
+        self.event_emitter
+            .emit(DownloadEvent::DownloadStatusChanged {
+                id: event_id.clone(),
+                status: gglib_core::download::DownloadStatus::Finalizing,
+            });
 
         // Fetch HF model info to get tags (soft fail if unavailable)
         let hf_tags = self
@@ -851,10 +852,11 @@ impl DownloadManagerImpl {
         };
 
         // Phase 2 of finalization: writing the model row to the database.
-        self.event_emitter.emit(DownloadEvent::DownloadStatusChanged {
-            id: event_id.clone(),
-            status: gglib_core::download::DownloadStatus::Registering,
-        });
+        self.event_emitter
+            .emit(DownloadEvent::DownloadStatusChanged {
+                id: event_id.clone(),
+                status: gglib_core::download::DownloadStatus::Registering,
+            });
 
         // Register model (soft-fail)
         match self.model_registrar.register_model(&completed).await {
@@ -1517,8 +1519,7 @@ impl DownloadManagerPort for DownloadManagerImpl {
         // are still cleaning up. Without this the CLI would exit with
         // partially-written files and no DB row — exactly the symptom
         // tracked in #466.
-        let drain_deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        let drain_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         let mut poll = tokio::time::interval(std::time::Duration::from_millis(50));
         poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -810,6 +810,20 @@ impl DownloadManagerImpl {
             .first()
             .expect("GroupComplete should have at least one path");
 
+        // Canonical event ID matches the one used for progress / completion.
+        let event_id = format!(
+            "{}:{}",
+            complete.metadata.repo_id, complete.metadata.quantization
+        );
+
+        // Phase 1 of finalization: bytes are on disk, we are about to gather
+        // metadata (HF tags etc.). Emit a status transition so the UI shows
+        // "Finalizing" instead of looking frozen at 100%.
+        self.event_emitter.emit(DownloadEvent::DownloadStatusChanged {
+            id: event_id.clone(),
+            status: gglib_core::download::DownloadStatus::Finalizing,
+        });
+
         // Fetch HF model info to get tags (soft fail if unavailable)
         let hf_tags = self
             .hf_client
@@ -836,6 +850,12 @@ impl DownloadManagerImpl {
             hf_file_entries: complete.metadata.file_entries,
         };
 
+        // Phase 2 of finalization: writing the model row to the database.
+        self.event_emitter.emit(DownloadEvent::DownloadStatusChanged {
+            id: event_id.clone(),
+            status: gglib_core::download::DownloadStatus::Registering,
+        });
+
         // Register model (soft-fail)
         match self.model_registrar.register_model(&completed).await {
             Ok(model) => {
@@ -848,10 +868,7 @@ impl DownloadManagerImpl {
 
                 // Emit completion event
                 self.event_emitter.emit(DownloadEvent::DownloadCompleted {
-                    id: format!(
-                        "{}:{}",
-                        complete.metadata.repo_id, complete.metadata.quantization
-                    ),
+                    id: event_id,
                     message: Some(format!(
                         "Downloaded {} to {}",
                         if completed.is_sharded {
@@ -869,6 +886,12 @@ impl DownloadManagerImpl {
                     path = %primary_path.display(),
                     "Failed to register model - files downloaded but won't appear in library"
                 );
+                // Surface the failure as a terminal event so the UI doesn't
+                // sit on "Registering" forever when registration soft-fails.
+                self.event_emitter.emit(DownloadEvent::DownloadFailed {
+                    id: event_id,
+                    error: format!("Registration failed: {e}"),
+                });
             }
         }
     }

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -259,6 +259,11 @@ pub struct DownloadManagerImpl {
     /// Event emitter for download events.
     event_emitter: Arc<dyn DownloadEventEmitterPort>,
     /// `HuggingFace` client for fetching model metadata.
+    ///
+    /// Currently retained for future use (e.g. lazy tag refresh).
+    /// Not invoked during finalization to keep registration fast and
+    /// avoid blocking on a slow/stalled HTTP call.
+    #[allow(dead_code)]
     hf_client: Arc<dyn HfClientPort>,
     /// File resolver.
     resolver: HfQuantizationResolver,
@@ -439,6 +444,11 @@ impl DownloadManagerImpl {
                     revision: item.revision.clone(),
                     cancel: cancel.clone(),
                     progress_tx,
+                    // Plumb the per-shard file size from HF metadata so the
+                    // stat-fallback poller (`xet_poller`) can emit synthetic
+                    // progress events with a real total. Without this the
+                    // hf-xet fast path leaves the CLI bar stuck at `0 B/0 B`.
+                    expected_total: item.shard_info.as_ref().and_then(|s| s.file_size),
                 };
 
                 // Emit started event (include shard info if this is a sharded download)
@@ -825,14 +835,14 @@ impl DownloadManagerImpl {
                 status: gglib_core::download::DownloadStatus::Finalizing,
             });
 
-        // Fetch HF model info to get tags (soft fail if unavailable)
-        let hf_tags = self
-            .hf_client
-            .get_model_info(&complete.metadata.repo_id)
-            .await
-            .ok()
-            .map(|info| info.tags)
-            .unwrap_or_default();
+        // Tags are nice-to-have metadata fetched lazily elsewhere; we
+        // intentionally do NOT make a network call here. Any synchronous
+        // HF API call during finalization risks wedging registration on
+        // a slow/stalled connection (the underlying HTTP client has no
+        // robust read timeout). Falling back to an empty tag list keeps
+        // finalization fast and predictable; tags can be refreshed later
+        // by a model rescan.
+        let hf_tags: Vec<String> = Vec::new();
 
         let completed = CompletedDownload {
             primary_path: primary_path.clone(),

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -1508,9 +1508,32 @@ impl DownloadManagerPort for DownloadManagerImpl {
             }
         }
 
-        // Clear queue
+        // Clear queue (drops everything still pending).
         self.queue.write().await.clear();
         self.emit_queue_snapshot().await;
+
+        // Bounded drain: wait up to 5s for active downloads to actually
+        // finalize so we don't return while the Python helper subprocesses
+        // are still cleaning up. Without this the CLI would exit with
+        // partially-written files and no DB row — exactly the symptom
+        // tracked in #466.
+        let drain_deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut poll = tokio::time::interval(std::time::Duration::from_millis(50));
+        poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            poll.tick().await;
+            if self.active.lock().await.is_empty() {
+                break;
+            }
+            if tokio::time::Instant::now() >= drain_deadline {
+                tracing::warn!(
+                    "cancel_all drain deadline exceeded; returning while jobs still draining"
+                );
+                break;
+            }
+        }
+
         tracing::info!("Cancelled all downloads");
         Ok(())
     }

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -258,12 +258,7 @@ pub struct DownloadManagerImpl {
     _download_repo: Arc<dyn DownloadStateRepositoryPort>,
     /// Event emitter for download events.
     event_emitter: Arc<dyn DownloadEventEmitterPort>,
-    /// `HuggingFace` client for fetching model metadata.
-    ///
-    /// Currently retained for future use (e.g. lazy tag refresh).
-    /// Not invoked during finalization to keep registration fast and
-    /// avoid blocking on a slow/stalled HTTP call.
-    #[allow(dead_code)]
+    /// `HuggingFace` client for fetching model metadata (e.g. tags at registration time).
     hf_client: Arc<dyn HfClientPort>,
     /// File resolver.
     resolver: HfQuantizationResolver,
@@ -620,7 +615,16 @@ impl DownloadManagerImpl {
 
     /// Finalize a job after it completes or fails.
     ///
-    /// Verifies the lease to prevent stale commits.
+    /// Verifies the lease first (to prevent double-finalization), then runs
+    /// `handle_job_result` (which includes model registration) while the item
+    /// is **still present** in the active map. Only after that completes is the
+    /// item removed from `active` and the snapshot emitted.
+    ///
+    /// This ordering is critical: the CLI interactive monitor exits as soon as
+    /// `active_count == 0`. Removing the item before registration completes
+    /// would allow the CLI to exit mid-insert, dropping the tokio runtime and
+    /// silently losing the DB row.
+    ///
     /// Lock order: active → queue.
     async fn finalize_job(
         &self,
@@ -628,27 +632,31 @@ impl DownloadManagerImpl {
         lease: LeaseId,
         result: Result<CompletedJob, DownloadError>,
     ) {
-        // Verify lease and remove from active
-        if !self.verify_and_remove_lease(&item.id, lease).await {
+        // Step 1 — verify lease (guards against stale/duplicate finalization)
+        // without yet removing the item from the active map.
+        if !self.verify_lease(&item.id, lease).await {
             tracing::debug!(id = %item.id, "Ignoring stale finalize (lease mismatch)");
             return;
         }
 
-        // Handle the result with shard coordination
+        // Step 2 — run registration while still in the active map so the
+        // CLI monitor cannot race past registration.
         self.handle_job_result(item, result).await;
 
-        // Emit updated snapshot
+        // Step 3 — now safe to remove from active map and notify watchers.
+        self.remove_from_active(&item.id).await;
         self.emit_queue_snapshot().await;
     }
 
-    /// Verify lease matches and remove from active map.
-    async fn verify_and_remove_lease(&self, id: &DownloadId, lease: LeaseId) -> bool {
-        let mut active = self.active.lock().await;
-        active
-            .get(id)
-            .is_some_and(|job| job.lease == lease)
-            .then(|| active.remove(id))
-            .is_some()
+    /// Check that the stored lease matches `lease` without removing the entry.
+    async fn verify_lease(&self, id: &DownloadId, lease: LeaseId) -> bool {
+        let active = self.active.lock().await;
+        active.get(id).is_some_and(|job| job.lease == lease)
+    }
+
+    /// Remove an entry from the active map unconditionally.
+    async fn remove_from_active(&self, id: &DownloadId) {
+        self.active.lock().await.remove(id);
     }
 
     /// Handle the result of a completed job.
@@ -835,14 +843,33 @@ impl DownloadManagerImpl {
                 status: gglib_core::download::DownloadStatus::Finalizing,
             });
 
-        // Tags are nice-to-have metadata fetched lazily elsewhere; we
-        // intentionally do NOT make a network call here. Any synchronous
-        // HF API call during finalization risks wedging registration on
-        // a slow/stalled connection (the underlying HTTP client has no
-        // robust read timeout). Falling back to an empty tag list keeps
-        // finalization fast and predictable; tags can be refreshed later
-        // by a model rescan.
-        let hf_tags: Vec<String> = Vec::new();
+        // Fetch HF model tags (nice-to-have metadata). Bounded by a strict
+        // 5-second timeout: a stalled/slow connection must never delay the
+        // DB insert. On timeout or error we log a warning and proceed with
+        // an empty tag list — a failed tag fetch is never a hard failure.
+        let hf_tags = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.hf_client.get_model_info(&complete.metadata.repo_id),
+        )
+        .await
+        {
+            Ok(Ok(info)) => info.tags,
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    error = %e,
+                    repo_id = %complete.metadata.repo_id,
+                    "Failed to fetch HF tags during finalization; registering without tags",
+                );
+                Vec::new()
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    repo_id = %complete.metadata.repo_id,
+                    "Timed out fetching HF tags (5 s); registering without tags",
+                );
+                Vec::new()
+            }
+        };
 
         let completed = CompletedDownload {
             primary_path: primary_path.clone(),

--- a/crates/gglib-download/src/manager/worker.rs
+++ b/crates/gglib-download/src/manager/worker.rs
@@ -50,6 +50,13 @@ pub struct DownloadJob {
     pub cancel: CancellationToken,
     /// Progress sender for this job.
     pub progress_tx: watch::Sender<ProgressUpdate>,
+    /// Expected total bytes from HF metadata, if known.
+    ///
+    /// Used by the stat-fallback poller (`xet_poller`) so synthetic progress
+    /// events carry a real total. Without it the CLI bar renders `0 B/0 B`
+    /// for the entire transfer because the hf-xet fast path never drives
+    /// tqdm to publish a `(0, total)` initial event.
+    pub expected_total: Option<u64>,
 }
 
 /// Progress update sent through the watch channel.
@@ -206,11 +213,7 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
         token: deps.config.hf_token.as_deref(),
         force: false,
         progress: Some(Arc::clone(&progress_callback)),
-        // TODO(#466 follow-up): plumb shard_info.file_size from the manager so
-        // synthetic progress events from `xet_poller` can show a real % bar.
-        // For now an unknown total is acceptable \u2014 the bar will display
-        // downloaded bytes and is no longer frozen at 0/0.
-        expected_total: None,
+        expected_total: job.expected_total,
         cancel_token: Some(job.cancel.clone()),
     };
 

--- a/crates/gglib-download/src/manager/worker.rs
+++ b/crates/gglib-download/src/manager/worker.rs
@@ -185,8 +185,8 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
     // Create progress callback that updates watch channel
     let progress_tx = job.progress_tx.clone();
     let seq_clone = Arc::clone(&seq);
-    let progress_callback: Box<dyn Fn(u64, u64) + Send + Sync> =
-        Box::new(move |downloaded: u64, total: u64| {
+    let progress_callback: crate::cli_exec::ProgressCallback =
+        Arc::new(move |downloaded: u64, total: u64| {
             let current_seq = seq_clone.fetch_add(1, Ordering::Relaxed);
             // send_modify avoids clone and is infallible
             progress_tx.send_modify(|state| {
@@ -205,7 +205,12 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
         files: &job.destination.files,
         token: deps.config.hf_token.as_deref(),
         force: false,
-        progress: Some(&progress_callback),
+        progress: Some(Arc::clone(&progress_callback)),
+        // TODO(#466 follow-up): plumb shard_info.file_size from the manager so
+        // synthetic progress events from `xet_poller` can show a real % bar.
+        // For now an unknown total is acceptable \u2014 the bar will display
+        // downloaded bytes and is no longer frozen at 0/0.
+        expected_total: None,
         cancel_token: Some(job.cancel.clone()),
     };
 

--- a/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
+++ b/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
@@ -132,6 +132,14 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
   const percentage = progress?.percentage ?? undefined;
   const shard = progress?.shard;
   const isSharded = !!(shard && shard.total > 1);
+  // Lifecycle label: surfaces Finalizing/Registering between bytes-on-disk
+  // and the terminal Completed event so the UI doesn't look frozen at 100%.
+  const phaseLabel = (() => {
+    if (progress?.status === 'finalizing') return 'Finalizing';
+    if (progress?.status === 'registering') return 'Registering';
+    if (isSharded && shard) return `Downloading shard ${shard.index + 1}/${shard.total}`;
+    return 'Downloading';
+  })();
 
   return (
     <div className="bg-background border-b border-border rounded-none p-base mb-0">
@@ -142,7 +150,7 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
               <Icon icon={Download} size={16} />
             </span>
             <span className="text-sm font-medium text-text">
-              {isSharded && shard ? `Downloading shard ${shard.index + 1}/${shard.total}` : 'Downloading'}
+              {phaseLabel}
             </span>
             {queueCount > 0 && (
               <div className="relative">

--- a/src/hooks/useDownloadManager.ts
+++ b/src/hooks/useDownloadManager.ts
@@ -19,7 +19,7 @@ function snapshotIsBusy(items: DownloadSummary[]): boolean {
   return items.some(i => i.status === 'queued' || i.status === 'downloading');
 }
 
-export type DownloadProgressStatus = 'started' | 'progress' | 'completed' | 'error';
+export type DownloadProgressStatus = 'started' | 'progress' | 'finalizing' | 'registering' | 'completed' | 'error';
 
 export interface DownloadProgressView {
   status: DownloadProgressStatus;
@@ -159,6 +159,18 @@ function eventToProgress(event: DownloadEvent): DownloadProgressView | null {
       return { status: 'error', id: event.id, message: event.error };
     case 'download_cancelled':
       return { status: 'error', id: event.id, message: 'Cancelled' };
+    case 'download_status_changed':
+      // Non-terminal lifecycle transitions (Finalizing, Registering) emitted
+      // after bytes are on disk but before the model row is written. Treated
+      // as progress so the UI keeps the download card mounted with a clear
+      // status label instead of looking frozen at 100%.
+      if (event.status === 'finalizing') {
+        return { status: 'finalizing', id: event.id, message: 'Finalizing…' };
+      }
+      if (event.status === 'registering') {
+        return { status: 'registering', id: event.id, message: 'Registering…' };
+      }
+      return null;
     default:
       return null;
   }

--- a/src/services/decoders/downloadEvent.ts
+++ b/src/services/decoders/downloadEvent.ts
@@ -26,6 +26,7 @@ const KNOWN_DOWNLOAD_EVENT_TYPES = new Set([
   'download_completed',
   'download_failed',
   'download_cancelled',
+  'download_status_changed',
   'queue_run_complete',
 ]);
 

--- a/src/services/transport/types/downloads.ts
+++ b/src/services/transport/types/downloads.ts
@@ -8,7 +8,7 @@ import type { DownloadId, HfModelId } from './ids';
 /**
  * Download status.
  */
-export type DownloadStatus = 'queued' | 'downloading' | 'completed' | 'failed' | 'cancelled';
+export type DownloadStatus = 'queued' | 'downloading' | 'finalizing' | 'registering' | 'completed' | 'failed' | 'cancelled';
 
 /**
  * Shard information for multi-file downloads.

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -119,6 +119,7 @@ export type DownloadEvent =
   | { type: 'download_completed'; id: DownloadId; message?: string | null }
   | { type: 'download_failed'; id: DownloadId; error: string }
   | { type: 'download_cancelled'; id: DownloadId }
+  | { type: 'download_status_changed'; id: DownloadId; status: import('./downloads').DownloadStatus }
   | { type: 'queue_run_complete'; summary: QueueRunSummary };
 
 // ============================================================================


### PR DESCRIPTION
Fixes #466.

## What was broken

`gglib model download <repo> -q <quant>` had three distinct failures:

1. **Frozen `0 B/0 B` bar** — When `huggingface_hub` uses the `hf-xet` transport, Python tqdm is bypassed entirely. No progress events reached Rust, so the CLI bar read `0 B/0 B` for the whole transfer while bytes flowed on disk.

2. **Model silently not registered** — The command exited 0 but wrote no row to the database. The model file was on disk; `gglib model list` showed nothing.

3. **10-second hang after completion** — The command would freeze for ~10 seconds after the download finished before returning the prompt.

## Root cause (bugs 2 & 3)

Two independent PRs created a fatal interaction:

**PR #165** (Feb 2026, ec149f7) added `hf_client.get_model_info()` inside `register_completed_model` to import HF tags at registration time. Fine in the long-running GUI, but the call had no hard timeout and could stall on a slow connection.

**PR #452** (Apr 2026, f62f671) introduced the interactive CLI monitor: a 250 ms poll loop that exits as soon as `active_count == 0`. The problem: `finalize_job` removed the job from the `active` map (via `verify_and_remove_lease`) **before** calling `handle_job_result` / `register_completed_model`. The moment step 1 ran, the poll loop saw an empty queue, called `return Ok(())`, dropped the tokio runtime, and killed the in-flight `get_model_info` future and DB insert with it. Exit code: 0. Model: missing.

**Bug 3** came from using `tokio::task::spawn_blocking` for the stdin keystroke reader. Tokio's blocking pool waits up to `blocking_shutdown_timeout` (default 10 s) for all blocking tasks to finish. Since `term.read_key()` blocks indefinitely on stdin, the process hung after every unattended completion.

## Changes

### Structural fix: hold active lease until registration completes (f029285)
`crates/gglib-download/src/manager/mod.rs`

Split `verify_and_remove_lease` into two separate operations:
- `verify_lease` — checks the lease without removing the map entry
- `remove_from_active` — called only **after** `handle_job_result` returns

New ordering in `finalize_job`: `verify_lease → handle_job_result (GGUF parse + DB insert) → remove_from_active → emit_snapshot`. The CLI monitor can only see `active_count == 0` after registration is fully complete, closing the race for all future work inside `handle_job_result`.

### HF tags with 5-second timeout (f029285)
`crates/gglib-download/src/manager/mod.rs`

Restored `hf_client.get_model_info()` inside `register_completed_model` behind `tokio::time::timeout(5s)`. Timeout or error logs a warning and falls back to an empty tag list; the DB insert always proceeds.

### Fix 10-second post-completion hang (4394b44)
`crates/gglib-cli/src/handlers/model/download/interactive.rs`

Replaced `tokio::task::spawn_blocking` with `std::thread::spawn` for the keystroke reader. OS threads are not tracked by Tokio's blocking pool, so the runtime shuts down immediately when the async main returns.

### stat-based fallback poller for hf-xet (fdc62f4, 534e5a9)
New: `crates/gglib-download/src/cli_exec/exec/xet_poller.rs`

When the hf-xet transport bypasses tqdm, a background task wakes every 250 ms, sums on-disk bytes (recursively walking the destination directory to catch `.incomplete` temp files in `.cache/huggingface/download/`), and emits synthetic progress events when no real Python event has arrived for 1 s. Dormant while real tqdm events flow. 4 unit tests.

### Plumb shard file size into the worker (f84a82f)
`DownloadJob.expected_total` now populated from `shard_info.file_size` so the xet_poller's synthetic events carry a real byte total. Previously a `TODO(#466)` left this as `None`, keeping the bar at `0 B/0 B` even after the poller was wired in.

### Finalizing/Registering lifecycle states (78ab9bb)
`crates/gglib-core/src/download/events.rs`, `crates/gglib-download/src/cli_emitter.rs`, frontend types/decoder/hook/component

New `DownloadStatusChanged` event and `Finalizing`/`Registering` status variants. The CLI bar message updates to `— Finalizing…` / `Registering…` between bytes-on-disk and the terminal `Completed` event. The GUI component renders the same lifecycle label. Closes the "frozen at 100%" UX gap.

### Two-step quit and bounded drain (484b435)
`crates/gglib-cli/src/handlers/model/download/interactive.rs`, `crates/gglib-download/src/manager/mod.rs`

First `q`/Ctrl-C arms drain mode (hint: `Draining... press q again to force quit`); active downloads finish naturally. Second press calls `cancel_all()`. `cancel_all()` waits up to 5 s for in-flight jobs to finalize (bounded drain) before returning.

### Python helper: suppress misleading `{0,0}` event (fdc62f4)
`crates/gglib-download/scripts/hf_xet_downloader.py`

`JsonProgressBar.__init__` no longer emits `progress {0,0}` when the total is unknown, eliminating the false signal that made the bridge show `0 B/0 B` before the xet_poller could kick in.

## Verification

```
cargo test --workspace          # 92/92 download, 65/65 CLI
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo fmt --check               # clean
```

Manual end-to-end with `unsloth/Qwen3.5-9B-GGUF -q Q6_K` (cache-hit path):
- Bar ticks with real byte counts (no frozen `0 B/0 B`)
- Bar transitions: `Downloading` → `Finalizing…` → `Registering…` → `✓`
- Prompt returns within ~2 s of completion (no 10-second hang)
- `sqlite3 data/gglib.db "SELECT name, quantization FROM models"` shows the row
