### PR TITLE
fix(runtime): fast-fail llama-server startup on crash (closes #468)

### DIFF
--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -33,11 +33,11 @@ pub struct StartupWatcher {
 
 /// Spawn llama-server and attach a stderr watcher for fast startup-failure detection.
 ///
-/// This function is identical to calling [`build_and_spawn`] and then
-/// [`spawn_log_readers`], but additionally:
+/// This function spawns the process (via [`build_and_spawn`]) and additionally:
 ///
-/// 1. Captures stderr through a ring buffer (last [`STDERR_RING_CAPACITY`] lines).
-/// 2. Returns a [`StartupWatcher`] whose `exit_rx` fires as soon as llama-server's
+/// 1. Wires stdout to `log_sink` fire-and-forget via a background task.
+/// 2. Captures stderr through a ring buffer (last [`STDERR_RING_CAPACITY`] lines).
+/// 3. Returns a [`StartupWatcher`] whose `exit_rx` fires as soon as llama-server's
 ///    stderr pipe closes (i.e., the process has exited or crashed).
 ///
 /// The `exit_rx` should be passed to `wait_for_http_health_or_exit` so the
@@ -259,25 +259,6 @@ pub fn build_and_spawn(
         .map_err(|e| anyhow::anyhow!("Failed to spawn llama-server: {}", e))?;
 
     Ok(child)
-}
-
-/// Spawn background tasks to stream stdout/stderr logs asynchronously.
-///
-/// The tasks read lines from the process output and log them
-/// via tracing. If a log sink is provided, lines are also forwarded there.
-/// They exit when the streams close.
-pub fn spawn_log_readers(
-    child: &mut Child,
-    port: u16,
-    log_sink: Option<Arc<dyn ServerLogSinkPort>>,
-) {
-    if let Some(stdout) = child.stdout.take() {
-        spawn_stream_reader(stdout, port, "stdout", log_sink.clone());
-    }
-
-    if let Some(stderr) = child.stderr.take() {
-        spawn_stream_reader(stderr, port, "stderr", log_sink);
-    }
 }
 
 /// A no-op log sink that discards all log lines.

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -12,6 +12,14 @@ use tokio::process::Child;
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
+/// Shared ownership of a spawned child process.
+///
+/// The child is wrapped in `Option` so it can be `take()`n exactly once
+/// (by the caller that will ultimately `wait` on it or kill it).
+/// The `Mutex` lets the background watcher task call `try_wait()` to
+/// obtain the exit status without owning the `Child`.
+pub type SharedChild = Arc<std::sync::Mutex<Option<Child>>>;
+
 /// Maximum number of lines retained in each stream's ring buffer.
 const RING_CAPACITY: usize = 50;
 
@@ -22,6 +30,10 @@ pub struct CapturedOutput {
     pub stdout: Vec<String>,
     /// Last N lines from stderr.
     pub stderr: Vec<String>,
+    /// Normal exit code, if the process exited normally.
+    pub exit_code: Option<i32>,
+    /// Unix signal number that killed the process, if any.
+    pub exit_signal: Option<i32>,
 }
 
 impl CapturedOutput {
@@ -31,13 +43,23 @@ impl CapturedOutput {
     /// stderr is typically empty on failure. This method returns stdout when
     /// available, falling back to stderr, then a placeholder.
     pub fn best_effort_context(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
         if !self.stdout.is_empty() {
-            self.stdout.join("\n")
+            parts.push(self.stdout.join("\n"));
         } else if !self.stderr.is_empty() {
-            self.stderr.join("\n")
+            parts.push(self.stderr.join("\n"));
         } else {
-            String::from("(no output captured)")
+            parts.push(String::from("(no output from llama-server)"));
         }
+
+        match (self.exit_code, self.exit_signal) {
+            (Some(code), _) => parts.push(format!("Exit code: {code}")),
+            (None, Some(sig)) => parts.push(format!("Killed by signal: {sig}")),
+            _ => {}
+        }
+
+        parts.join("\n")
     }
 }
 
@@ -81,21 +103,30 @@ pub fn spawn_with_exit_watch(
     config: &ServerConfig,
     port: u16,
     log_sink: Option<Arc<dyn ServerLogSinkPort>>,
-) -> anyhow::Result<(Child, StartupWatcher)> {
+) -> anyhow::Result<(SharedChild, StartupWatcher)> {
     let mut child = build_and_spawn(llama_server_path, config, port)?;
 
     // Stdout and stderr: both are captured in ring buffers for error diagnostics,
     // and forwarded to the log sink. llama-server writes most output (including
     // error messages) to stdout, so we must capture both streams.
     //
-    // Architecture: we use a shared Arc<Mutex<>> for the captured output, and
-    // the stderr task fires the oneshot when stderr closes (process has exited).
-    // The stdout task fills its ring before that point.
+    // Architecture:
+    // - Captured output is shared via `Arc<Mutex<CapturedOutput>>`.
+    // - The child is shared via `SharedChild` (`Arc<Mutex<Option<Child>>>`) so the
+    //   stderr watcher task can call `try_wait()` to get the exit status.
+    // - Stdout/stderr pipes are taken *before* the child is placed into the Arc.
+    // - The stderr task fires the oneshot with the captured output (including exit
+    //   code/signal) when stderr closes.
     let (exit_tx, exit_rx) = oneshot::channel::<CapturedOutput>();
     let captured = std::sync::Arc::new(std::sync::Mutex::new(CapturedOutput::default()));
 
+    // Take pipes before moving the child into the shared Arc.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let child_arc: SharedChild = Arc::new(std::sync::Mutex::new(Some(child)));
+
     // Stdout ring — captures output and sends to log sink.
-    if let Some(stdout) = child.stdout.take() {
+    if let Some(stdout) = stdout_pipe {
         let sink = log_sink.clone();
         let captured_stdout = captured.clone();
         tokio::spawn(async move {
@@ -139,7 +170,8 @@ pub fn spawn_with_exit_watch(
     }
 
     // Stderr ring — fires the exit signal when stderr closes (process has exited).
-    if let Some(stderr) = child.stderr.take() {
+    if let Some(stderr) = stderr_pipe {
+        let child_for_task = child_arc.clone();
         let sink = log_sink.clone();
         let captured_stderr = captured.clone();
         tokio::spawn(async move {
@@ -181,11 +213,47 @@ pub fn spawn_with_exit_watch(
             debug!(port = %port, "stderr watcher task exiting, sending exit signal");
             // Give the stdout task a moment to flush its remaining lines.
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Collect exit status from the child before sending the captured output.
+            // The child is a zombie at this point (pipes closed = process exited), so
+            // try_wait() is non-blocking and safe to call from a Mutex guard.
+            let (exit_code, exit_signal) = {
+                let exit_status = child_for_task
+                    .lock()
+                    .ok()
+                    .and_then(|mut guard| guard.as_mut().and_then(|c| c.try_wait().ok().flatten()));
+                match exit_status {
+                    Some(status) => {
+                        let code = status.code();
+                        #[cfg(unix)]
+                        let signal = {
+                            use std::os::unix::process::ExitStatusExt;
+                            status.signal()
+                        };
+                        #[cfg(not(unix))]
+                        let signal: Option<i32> = None;
+                        debug!(
+                            port = %port,
+                            exit_code = ?code,
+                            exit_signal = ?signal,
+                            "llama-server exit status"
+                        );
+                        (code, signal)
+                    }
+                    None => {
+                        debug!(port = %port, "could not retrieve llama-server exit status");
+                        (None, None)
+                    }
+                }
+            };
+
             let output = captured_stderr
                 .lock()
                 .map(|cap| CapturedOutput {
                     stdout: cap.stdout.clone(),
                     stderr: cap.stderr.clone(),
+                    exit_code,
+                    exit_signal,
                 })
                 .unwrap_or_default();
             // Best-effort send; the receiver may have been dropped if startup succeeded.
@@ -197,7 +265,7 @@ pub fn spawn_with_exit_watch(
         let _ = exit_tx.send(CapturedOutput::default());
     }
 
-    Ok((child, StartupWatcher { exit_rx }))
+    Ok((child_arc, StartupWatcher { exit_rx }))
 }
 
 /// Select the llama-server path to use.

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -4,7 +4,6 @@
 //! capturing stdout/stderr output.
 
 use crate::llama::{LlamaServerError, resolve_llama_server};
-use crate::process::spawn_stream_reader;
 use gglib_core::ports::{ServerConfig, ServerLogSinkPort};
 use gglib_core::utils::process::async_cmd;
 use std::path::{Path, PathBuf};
@@ -13,38 +12,70 @@ use tokio::process::Child;
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
-/// Maximum number of stderr lines retained in the ring buffer.
-const STDERR_RING_CAPACITY: usize = 50;
+/// Maximum number of lines retained in each stream's ring buffer.
+const RING_CAPACITY: usize = 50;
+
+/// Output captured from llama-server's stdout and stderr at process exit.
+#[derive(Debug, Default)]
+pub struct CapturedOutput {
+    /// Last N lines from stdout.
+    pub stdout: Vec<String>,
+    /// Last N lines from stderr.
+    pub stderr: Vec<String>,
+}
+
+impl CapturedOutput {
+    /// Returns the most useful output for display in an error message.
+    ///
+    /// llama-server writes most of its logging (including errors) to stdout.
+    /// stderr is typically empty on failure. This method returns stdout when
+    /// available, falling back to stderr, then a placeholder.
+    pub fn best_effort_context(&self) -> String {
+        if !self.stdout.is_empty() {
+            self.stdout.join("\n")
+        } else if !self.stderr.is_empty() {
+            self.stderr.join("\n")
+        } else {
+            String::from("(no output captured)")
+        }
+    }
+}
 
 /// Carries the process-exit information produced by [`spawn_with_exit_watch`].
 ///
-/// The sender half is consumed by a background watcher task that monitors the
-/// child's stderr pipe. When the pipe hits EOF (meaning the process has
-/// exited or closed its stderr), it fires the sender with the buffered lines.
+/// The sender halves are consumed by background watcher tasks that monitor the
+/// child's stdout and stderr pipes. When both pipes hit EOF (meaning the process
+/// has exited), the captured output is available via the receiver.
 /// The receiver half is passed to `wait_for_http_health_or_exit` so the health
 /// loop can fast-fail the moment llama-server dies.
 pub struct StartupWatcher {
-    /// Fires when llama-server's stderr closes, carrying the last N lines.
+    /// Fires when llama-server's stderr closes (exit signal).
     ///
+    /// Carries captured output from both stdout and stderr.
     /// `None` is sent only if the task is dropped before EOF (should not
     /// happen in practice).
-    pub exit_rx: oneshot::Receiver<Vec<String>>,
+    pub exit_rx: oneshot::Receiver<CapturedOutput>,
 }
 
-/// Spawn llama-server and attach a stderr watcher for fast startup-failure detection.
+/// Spawn llama-server and attach stdout/stderr watchers for fast startup-failure detection.
 ///
 /// This function spawns the process (via [`build_and_spawn`]) and additionally:
 ///
-/// 1. Wires stdout to `log_sink` fire-and-forget via a background task.
-/// 2. Captures stderr through a ring buffer (last [`STDERR_RING_CAPACITY`] lines).
+/// 1. Captures stdout through a ring buffer (last [`RING_CAPACITY`] lines) and
+///    forwards lines to `log_sink`.
+/// 2. Captures stderr through a ring buffer (last [`RING_CAPACITY`] lines) and
+///    forwards lines to `log_sink`.
 /// 3. Returns a [`StartupWatcher`] whose `exit_rx` fires as soon as llama-server's
-///    stderr pipe closes (i.e., the process has exited or crashed).
+///    stderr pipe closes (i.e., the process has exited or crashed), carrying both
+///    stdout and stderr captures so the error message includes relevant context.
+///
+/// Note: llama-server writes most output (including errors) to stdout, not stderr.
+/// The [`CapturedOutput::best_effort_context`] method selects the most useful stream
+/// for display in error messages.
 ///
 /// The `exit_rx` should be passed to `wait_for_http_health_or_exit` so the
 /// health loop can abort immediately on process death instead of waiting for
 /// the full timeout.
-///
-/// stdout is still forwarded to the `log_sink` as usual.
 pub fn spawn_with_exit_watch(
     llama_server_path: Option<&Path>,
     config: &ServerConfig,
@@ -53,46 +84,92 @@ pub fn spawn_with_exit_watch(
 ) -> anyhow::Result<(Child, StartupWatcher)> {
     let mut child = build_and_spawn(llama_server_path, config, port)?;
 
-    // Wire stdout to the log sink (fire-and-forget, same as before).
+    // Stdout and stderr: both are captured in ring buffers for error diagnostics,
+    // and forwarded to the log sink. llama-server writes most output (including
+    // error messages) to stdout, so we must capture both streams.
+    //
+    // Architecture: we use a shared Arc<Mutex<>> for the captured output, and
+    // the stderr task fires the oneshot when stderr closes (process has exited).
+    // The stdout task fills its ring before that point.
+    let (exit_tx, exit_rx) = oneshot::channel::<CapturedOutput>();
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(CapturedOutput::default()));
+
+    // Stdout ring — captures output and sends to log sink.
     if let Some(stdout) = child.stdout.take() {
-        spawn_stream_reader(stdout, port, "stdout", log_sink.clone());
-    }
-
-    // Stderr: dual-purpose — forward to log sink AND feed the ring buffer.
-    let (exit_tx, exit_rx) = oneshot::channel::<Vec<String>>();
-
-    if let Some(stderr) = child.stderr.take() {
         let sink = log_sink.clone();
+        let captured_stdout = captured.clone();
         tokio::spawn(async move {
             use tokio::io::{AsyncBufReadExt, BufReader};
 
-            let mut reader = BufReader::new(stderr);
+            let mut reader = BufReader::new(stdout);
             let mut buf: Vec<u8> = Vec::with_capacity(1024);
-            let mut ring: Vec<String> = Vec::with_capacity(STDERR_RING_CAPACITY);
 
             loop {
                 buf.clear();
                 match reader.read_until(b'\n', &mut buf).await {
-                    Ok(0) => break, // EOF — process exited
+                    Ok(0) => break,
                     Ok(_) => {
-                        // Trim trailing newline(s)
                         if buf.last() == Some(&b'\n') {
                             buf.pop();
                             if buf.last() == Some(&b'\r') {
                                 buf.pop();
                             }
                         }
-                        // Lossy UTF-8 so non-UTF8 bytes from C/C++ tools don't abort the reader.
+                        let line = String::from_utf8_lossy(&buf).into_owned();
+                        debug!(port = %port, stream_type = "stdout", "stdout: {}", line);
+                        if let Some(ref s) = sink {
+                            s.append(port, "stdout", line.clone());
+                        }
+                        if let Ok(mut cap) = captured_stdout.lock() {
+                            if cap.stdout.len() >= RING_CAPACITY {
+                                cap.stdout.remove(0);
+                            }
+                            cap.stdout.push(line);
+                        }
+                    }
+                    Err(e) => {
+                        debug!(port = %port, error = %e, "stdout reader exiting due to read error");
+                        break;
+                    }
+                }
+            }
+
+            debug!(port = %port, stream_type = "stdout", "log stream reader task exiting");
+        });
+    }
+
+    // Stderr ring — fires the exit signal when stderr closes (process has exited).
+    if let Some(stderr) = child.stderr.take() {
+        let sink = log_sink.clone();
+        let captured_stderr = captured.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+
+            let mut reader = BufReader::new(stderr);
+            let mut buf: Vec<u8> = Vec::with_capacity(1024);
+
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf).await {
+                    Ok(0) => break, // EOF — process exited
+                    Ok(_) => {
+                        if buf.last() == Some(&b'\n') {
+                            buf.pop();
+                            if buf.last() == Some(&b'\r') {
+                                buf.pop();
+                            }
+                        }
                         let line = String::from_utf8_lossy(&buf).into_owned();
                         debug!(port = %port, stream_type = "stderr", "stderr: {}", line);
                         if let Some(ref s) = sink {
                             s.append(port, "stderr", line.clone());
                         }
-                        // Ring buffer: drop the oldest entry when full.
-                        if ring.len() >= STDERR_RING_CAPACITY {
-                            ring.remove(0);
+                        if let Ok(mut cap) = captured_stderr.lock() {
+                            if cap.stderr.len() >= RING_CAPACITY {
+                                cap.stderr.remove(0);
+                            }
+                            cap.stderr.push(line);
                         }
-                        ring.push(line);
                     }
                     Err(e) => {
                         debug!(port = %port, error = %e, "stderr reader exiting due to read error");
@@ -102,13 +179,22 @@ pub fn spawn_with_exit_watch(
             }
 
             debug!(port = %port, "stderr watcher task exiting, sending exit signal");
+            // Give the stdout task a moment to flush its remaining lines.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let output = captured_stderr
+                .lock()
+                .map(|cap| CapturedOutput {
+                    stdout: cap.stdout.clone(),
+                    stderr: cap.stderr.clone(),
+                })
+                .unwrap_or_default();
             // Best-effort send; the receiver may have been dropped if startup succeeded.
-            let _ = exit_tx.send(ring);
+            let _ = exit_tx.send(output);
         });
     } else {
-        // No stderr pipe — send an empty buffer immediately so the receiver
+        // No stderr pipe — send an empty capture immediately so the receiver
         // never blocks forever waiting for a signal that never arrives.
-        let _ = exit_tx.send(Vec::new());
+        let _ = exit_tx.send(CapturedOutput::default());
     }
 
     Ok((child, StartupWatcher { exit_rx }))

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -10,7 +10,109 @@ use gglib_core::utils::process::async_cmd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::process::Child;
+use tokio::sync::oneshot;
 use tracing::{debug, warn};
+
+/// Maximum number of stderr lines retained in the ring buffer.
+const STDERR_RING_CAPACITY: usize = 50;
+
+/// Carries the process-exit information produced by [`spawn_with_exit_watch`].
+///
+/// The sender half is consumed by a background watcher task that monitors the
+/// child's stderr pipe. When the pipe hits EOF (meaning the process has
+/// exited or closed its stderr), it fires the sender with the buffered lines.
+/// The receiver half is passed to `wait_for_http_health_or_exit` so the health
+/// loop can fast-fail the moment llama-server dies.
+pub struct StartupWatcher {
+    /// Fires when llama-server's stderr closes, carrying the last N lines.
+    ///
+    /// `None` is sent only if the task is dropped before EOF (should not
+    /// happen in practice).
+    pub exit_rx: oneshot::Receiver<Vec<String>>,
+}
+
+/// Spawn llama-server and attach a stderr watcher for fast startup-failure detection.
+///
+/// This function is identical to calling [`build_and_spawn`] and then
+/// [`spawn_log_readers`], but additionally:
+///
+/// 1. Captures stderr through a ring buffer (last [`STDERR_RING_CAPACITY`] lines).
+/// 2. Returns a [`StartupWatcher`] whose `exit_rx` fires as soon as llama-server's
+///    stderr pipe closes (i.e., the process has exited or crashed).
+///
+/// The `exit_rx` should be passed to `wait_for_http_health_or_exit` so the
+/// health loop can abort immediately on process death instead of waiting for
+/// the full timeout.
+///
+/// stdout is still forwarded to the `log_sink` as usual.
+pub fn spawn_with_exit_watch(
+    llama_server_path: Option<&Path>,
+    config: &ServerConfig,
+    port: u16,
+    log_sink: Option<Arc<dyn ServerLogSinkPort>>,
+) -> anyhow::Result<(Child, StartupWatcher)> {
+    let mut child = build_and_spawn(llama_server_path, config, port)?;
+
+    // Wire stdout to the log sink (fire-and-forget, same as before).
+    if let Some(stdout) = child.stdout.take() {
+        spawn_stream_reader(stdout, port, "stdout", log_sink.clone());
+    }
+
+    // Stderr: dual-purpose — forward to log sink AND feed the ring buffer.
+    let (exit_tx, exit_rx) = oneshot::channel::<Vec<String>>();
+
+    if let Some(stderr) = child.stderr.take() {
+        let sink = log_sink.clone();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+
+            let mut reader = BufReader::new(stderr);
+            let mut buf: Vec<u8> = Vec::with_capacity(1024);
+            let mut ring: Vec<String> = Vec::with_capacity(STDERR_RING_CAPACITY);
+
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf).await {
+                    Ok(0) => break, // EOF — process exited
+                    Ok(_) => {
+                        // Trim trailing newline(s)
+                        if buf.last() == Some(&b'\n') {
+                            buf.pop();
+                            if buf.last() == Some(&b'\r') {
+                                buf.pop();
+                            }
+                        }
+                        // Lossy UTF-8 so non-UTF8 bytes from C/C++ tools don't abort the reader.
+                        let line = String::from_utf8_lossy(&buf).into_owned();
+                        debug!(port = %port, stream_type = "stderr", "stderr: {}", line);
+                        if let Some(ref s) = sink {
+                            s.append(port, "stderr", line.clone());
+                        }
+                        // Ring buffer: drop the oldest entry when full.
+                        if ring.len() >= STDERR_RING_CAPACITY {
+                            ring.remove(0);
+                        }
+                        ring.push(line);
+                    }
+                    Err(e) => {
+                        debug!(port = %port, error = %e, "stderr reader exiting due to read error");
+                        break;
+                    }
+                }
+            }
+
+            debug!(port = %port, "stderr watcher task exiting, sending exit signal");
+            // Best-effort send; the receiver may have been dropped if startup succeeded.
+            let _ = exit_tx.send(ring);
+        });
+    } else {
+        // No stderr pipe — send an empty buffer immediately so the receiver
+        // never blocks forever waiting for a signal that never arrives.
+        let _ = exit_tx.send(Vec::new());
+    }
+
+    Ok((child, StartupWatcher { exit_rx }))
+}
 
 /// Select the llama-server path to use.
 ///

--- a/crates/gglib-runtime/src/health.rs
+++ b/crates/gglib-runtime/src/health.rs
@@ -7,6 +7,7 @@
 use anyhow::Result;
 use reqwest::Client;
 use std::time::Duration;
+use tokio::sync::oneshot;
 use tokio::time::sleep;
 use tracing::{debug, info};
 
@@ -106,7 +107,117 @@ pub async fn wait_for_http_health(port: u16, timeout_secs: u64) -> Result<()> {
     }
 }
 
-/// Check if a process is alive using its PID.
+/// Wait for HTTP health check to succeed, aborting early if the process exits.
+///
+/// This is the fast-failing variant of [`wait_for_http_health`]. It accepts a
+/// [`oneshot::Receiver`] that fires when llama-server's stderr pipe closes
+/// (produced by [`crate::command::spawn_with_exit_watch`]).  When the receiver
+/// fires, the loop aborts immediately and returns a descriptive error containing
+/// the last lines of stderr output, rather than waiting for `timeout_secs`.
+///
+/// # Arguments
+///
+/// * `port` — Port the server is expected to listen on
+/// * `timeout_secs` — Maximum seconds to wait before giving up
+/// * `exit_rx` — Fires with last N stderr lines when the process exits
+pub async fn wait_for_http_health_or_exit(
+    port: u16,
+    timeout_secs: u64,
+    exit_rx: oneshot::Receiver<Vec<String>>,
+) -> Result<()> {
+    let health_url = format!("http://127.0.0.1:{}/health", port);
+    info!("Waiting for llama-server to be ready at {}", health_url);
+
+    let max_attempts = timeout_secs;
+    let mut attempt = 0u64;
+    let client = Client::builder().timeout(Duration::from_secs(2)).build()?;
+
+    // Pin the exit receiver so we can use it in select! repeatedly.
+    let mut exit_rx = exit_rx;
+
+    loop {
+        attempt += 1;
+
+        // Wait 1 second, but abort early if the process exits.
+        tokio::select! {
+            biased;
+
+            // Process exited — fail fast with its stderr output.
+            stderr_lines = &mut exit_rx => {
+                let lines = stderr_lines.unwrap_or_default();
+                let context = if lines.is_empty() {
+                    String::from("(no stderr output captured)")
+                } else {
+                    lines.join("\n")
+                };
+                return Err(anyhow::anyhow!(
+                    "llama-server exited unexpectedly before becoming ready.\n\nStderr output:\n{}",
+                    context
+                ));
+            }
+
+            _ = sleep(Duration::from_secs(1)) => {}
+        }
+
+        match client.get(&health_url).send().await {
+            Ok(response) => {
+                let status = response.status();
+
+                if !status.is_success() {
+                    debug!(
+                        "Health check returned status {} (expected 200), retrying...",
+                        status
+                    );
+
+                    // Fail faster if clearly wrong service
+                    if (status.as_u16() == 403 || status.as_u16() == 404) && attempt > 3 {
+                        return Err(anyhow::anyhow!(
+                            "Port {} appears to be in use by another service (status {})",
+                            port,
+                            status
+                        ));
+                    }
+                } else {
+                    // Got 200 OK - verify it's actually llama-server
+                    match response.text().await {
+                        Ok(body) => {
+                            if body.contains("status")
+                                || body.contains("slots")
+                                || body.contains("error")
+                                || body.is_empty()
+                            {
+                                info!("llama-server is ready on port {}", port);
+                                return Ok(());
+                            } else {
+                                debug!("Health check returned unexpected response: {}", body);
+                                if attempt > 5 {
+                                    return Err(anyhow::anyhow!(
+                                        "Port {} is responding but doesn't appear to be llama-server",
+                                        port
+                                    ));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            debug!("Failed to read health response: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                debug!("Health check failed: {}, retrying...", e);
+            }
+        }
+
+        if attempt >= max_attempts {
+            return Err(anyhow::anyhow!(
+                "llama-server failed to start within {}s on port {}",
+                max_attempts,
+                port
+            ));
+        }
+    }
+}
 ///
 /// Uses a simple file-based check on Unix systems.
 #[cfg(unix)]

--- a/crates/gglib-runtime/src/health.rs
+++ b/crates/gglib-runtime/src/health.rs
@@ -11,6 +11,8 @@ use tokio::sync::oneshot;
 use tokio::time::sleep;
 use tracing::{debug, info};
 
+use crate::command::CapturedOutput;
+
 /// Check HTTP health of a server at the given port.
 ///
 /// Makes a single request to the health endpoint and returns
@@ -113,17 +115,17 @@ pub async fn wait_for_http_health(port: u16, timeout_secs: u64) -> Result<()> {
 /// [`oneshot::Receiver`] that fires when llama-server's stderr pipe closes
 /// (produced by [`crate::command::spawn_with_exit_watch`]).  When the receiver
 /// fires, the loop aborts immediately and returns a descriptive error containing
-/// the last lines of stderr output, rather than waiting for `timeout_secs`.
+/// the captured output from the process, rather than waiting for `timeout_secs`.
 ///
 /// # Arguments
 ///
 /// * `port` — Port the server is expected to listen on
 /// * `timeout_secs` — Maximum seconds to wait before giving up
-/// * `exit_rx` — Fires with last N stderr lines when the process exits
+/// * `exit_rx` — Fires with captured stdout/stderr when the process exits
 pub async fn wait_for_http_health_or_exit(
     port: u16,
     timeout_secs: u64,
-    exit_rx: oneshot::Receiver<Vec<String>>,
+    exit_rx: oneshot::Receiver<CapturedOutput>,
 ) -> Result<()> {
     let health_url = format!("http://127.0.0.1:{}/health", port);
     info!("Waiting for llama-server to be ready at {}", health_url);
@@ -142,16 +144,13 @@ pub async fn wait_for_http_health_or_exit(
         tokio::select! {
             biased;
 
-            // Process exited — fail fast with its stderr output.
-            stderr_lines = &mut exit_rx => {
-                let lines = stderr_lines.unwrap_or_default();
-                let context = if lines.is_empty() {
-                    String::from("(no stderr output captured)")
-                } else {
-                    lines.join("\n")
-                };
+            // Process exited — fail fast with its captured output.
+            captured = &mut exit_rx => {
+                let context = captured
+                    .unwrap_or_default()
+                    .best_effort_context();
                 return Err(anyhow::anyhow!(
-                    "llama-server exited unexpectedly before becoming ready.\n\nStderr output:\n{}",
+                    "llama-server exited unexpectedly before becoming ready.\n\nOutput:\n{}",
                     context
                 ));
             }

--- a/crates/gglib-runtime/src/process/core.rs
+++ b/crates/gglib-runtime/src/process/core.rs
@@ -67,8 +67,10 @@ impl GuiProcessCore {
         let port = self.resolve_port(config.port)?;
         let llama_path = Path::new(&self.llama_server_path);
         use crate::process::LogManagerSink;
-        let log_sink = Some(Arc::new(LogManagerSink) as Arc<dyn gglib_core::ports::ServerLogSinkPort>);
-        let (child, watcher) = command::spawn_with_exit_watch(Some(llama_path), &config, port, log_sink)?;
+        let log_sink =
+            Some(Arc::new(LogManagerSink) as Arc<dyn gglib_core::ports::ServerLogSinkPort>);
+        let (child, watcher) =
+            command::spawn_with_exit_watch(Some(llama_path), &config, port, log_sink)?;
         let pid = child
             .id()
             .ok_or_else(|| anyhow!("Failed to get child PID"))?;

--- a/crates/gglib-runtime/src/process/core.rs
+++ b/crates/gglib-runtime/src/process/core.rs
@@ -9,7 +9,7 @@
 use super::ports::{allocate_port, is_port_available};
 use super::shutdown::shutdown_child;
 use super::types::{RunningProcess, ServerInfo};
-use crate::command::{build_and_spawn, spawn_log_readers};
+use crate::command::{self, StartupWatcher};
 use crate::pidfile::{delete_pidfile, write_pidfile};
 use anyhow::{Result, anyhow};
 use gglib_core::ports::ServerConfig;
@@ -45,10 +45,12 @@ impl GuiProcessCore {
         }
     }
 
-    /// Spawn a new llama-server process
+    /// Spawn a new llama-server process.
     ///
-    /// Returns the port number for the spawned process.
-    pub async fn spawn(&mut self, config: ServerConfig) -> Result<u16> {
+    /// Returns the allocated port and a `StartupWatcher`.  The caller **must**
+    /// pass the watcher to `wait_for_http_health_or_exit` so that a crash
+    /// during startup is detected immediately.
+    pub async fn spawn(&mut self, config: ServerConfig) -> Result<(u16, StartupWatcher)> {
         let model_id = config.model_id as u32;
 
         if self.processes.contains_key(&model_id) {
@@ -64,7 +66,9 @@ impl GuiProcessCore {
 
         let port = self.resolve_port(config.port)?;
         let llama_path = Path::new(&self.llama_server_path);
-        let mut child = build_and_spawn(Some(llama_path), &config, port)?;
+        use crate::process::LogManagerSink;
+        let log_sink = Some(Arc::new(LogManagerSink) as Arc<dyn gglib_core::ports::ServerLogSinkPort>);
+        let (child, watcher) = command::spawn_with_exit_watch(Some(llama_path), &config, port, log_sink)?;
         let pid = child
             .id()
             .ok_or_else(|| anyhow!("Failed to get child PID"))?;
@@ -73,8 +77,6 @@ impl GuiProcessCore {
         if let Err(e) = write_pidfile(config.model_id, pid, port) {
             debug!("Failed to write PID file: {}", e);
         }
-
-        self.spawn_log_readers(&mut child, port);
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -92,12 +94,7 @@ impl GuiProcessCore {
         let running = RunningProcess::new(info, child);
         self.processes.insert(model_id, running);
 
-        Ok(port)
-    }
-
-    fn spawn_log_readers(&self, child: &mut tokio::process::Child, port: u16) {
-        use crate::process::LogManagerSink;
-        spawn_log_readers(child, port, Some(Arc::new(LogManagerSink)));
+        Ok((port, watcher))
     }
 
     fn resolve_port(&self, requested: Option<u16>) -> Result<u16> {

--- a/crates/gglib-runtime/src/process/core.rs
+++ b/crates/gglib-runtime/src/process/core.rs
@@ -72,7 +72,9 @@ impl GuiProcessCore {
         let (child, watcher) =
             command::spawn_with_exit_watch(Some(llama_path), &config, port, log_sink)?;
         let pid = child
-            .id()
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|c| c.id()))
             .ok_or_else(|| anyhow!("Failed to get child PID"))?;
 
         // Write PID file
@@ -127,8 +129,11 @@ impl GuiProcessCore {
         let pid = running.info.pid;
         debug!(model_id = %model_id, pid = %pid, port = %running.info.port, "Stopping process");
 
-        // Use graceful shutdown with SIGTERM → SIGKILL
-        let _ = shutdown_child(running.child).await;
+        // Use graceful shutdown with SIGTERM → SIGKILL.
+        // The child may already be gone (fast-fail path), so handle the missing case.
+        if let Some(child) = running.child.lock().ok().and_then(|mut g| g.take()) {
+            let _ = shutdown_child(child).await;
+        }
 
         // Remove PID file
         if let Err(e) = delete_pidfile(model_id as i64) {
@@ -183,8 +188,10 @@ impl GuiProcessCore {
                 let pid = running.info.pid;
                 debug!(model_id = %model_id, pid = %pid, port = %running.info.port, "Stopping process");
 
-                // Use graceful shutdown with SIGTERM → SIGKILL
-                let _ = shutdown_child(running.child).await;
+                // Use graceful shutdown with SIGTERM → SIGKILL.
+                if let Some(child) = running.child.lock().ok().and_then(|mut g| g.take()) {
+                    let _ = shutdown_child(child).await;
+                }
 
                 // Remove PID file
                 if let Err(e) = delete_pidfile(model_id as i64) {
@@ -203,16 +210,25 @@ impl GuiProcessCore {
         let mut dead = Vec::new();
 
         for (id, running) in self.processes.iter_mut() {
-            match running.child.try_wait() {
-                Ok(Some(status)) => {
-                    debug!(id = %id, status = ?status, "Process exited");
-                    dead.push(*id);
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!(id = %id, error = %e, "Error checking process");
-                    dead.push(*id);
-                }
+            let is_dead = match running.child.lock() {
+                Ok(mut guard) => match guard.as_mut() {
+                    Some(c) => match c.try_wait() {
+                        Ok(Some(status)) => {
+                            debug!(id = %id, status = ?status, "Process exited");
+                            true
+                        }
+                        Ok(None) => false,
+                        Err(e) => {
+                            warn!(id = %id, error = %e, "Error checking process");
+                            true
+                        }
+                    },
+                    None => true, // child already taken
+                },
+                Err(_) => true, // poisoned mutex
+            };
+            if is_dead {
+                dead.push(*id);
             }
         }
 

--- a/crates/gglib-runtime/src/process/health.rs
+++ b/crates/gglib-runtime/src/process/health.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use sysinfo::{Pid, ProcessStatus, System};
+use tokio::sync::oneshot;
 use tokio::time::{Duration, sleep};
 use tracing::{debug, info};
 
@@ -48,6 +49,108 @@ pub async fn wait_for_http_health(port: u16, timeout_secs: u64) -> Result<()> {
                         Ok(body) => {
                             // llama-server health endpoint returns JSON with status info
                             // Check for llama-server specific content
+                            if body.contains("status")
+                                || body.contains("slots")
+                                || body.contains("error")
+                                || body.is_empty()
+                            {
+                                info!("llama-server is ready on port {}", port);
+                                return Ok(());
+                            } else {
+                                debug!("Health check returned unexpected response: {}", body);
+                                if attempt > 5 {
+                                    return Err(anyhow::anyhow!(
+                                        "Port {} is responding but doesn't appear to be llama-server",
+                                        port
+                                    ));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            debug!("Failed to read health response: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                debug!("Health check failed: {}, retrying...", e);
+            }
+        }
+
+        if attempt >= max_attempts {
+            return Err(anyhow::anyhow!(
+                "llama-server failed to start within {}s on port {}. Check if the port is available.",
+                max_attempts,
+                port
+            ));
+        }
+    }
+}
+
+/// Wait for HTTP health check to succeed, aborting early if the process exits.
+///
+/// Races a 1-second HTTP-poll sleep against the `exit_rx` oneshot from
+/// [`crate::command::spawn_with_exit_watch`].  When the receiver fires, the
+/// loop returns immediately with the last N stderr lines in the error message.
+pub async fn wait_for_http_health_or_exit(
+    port: u16,
+    timeout_secs: u64,
+    exit_rx: oneshot::Receiver<Vec<String>>,
+) -> Result<()> {
+    let health_url = format!("http://127.0.0.1:{}/health", port);
+    info!("Waiting for llama-server to be ready at {}", health_url);
+
+    let max_attempts = timeout_secs;
+    let mut attempt = 0u64;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+
+    let mut exit_rx = exit_rx;
+
+    loop {
+        attempt += 1;
+
+        tokio::select! {
+            biased;
+
+            // Process exited — fail fast with its stderr output.
+            stderr_lines = &mut exit_rx => {
+                let lines = stderr_lines.unwrap_or_default();
+                let context = if lines.is_empty() {
+                    String::from("(no stderr output captured)")
+                } else {
+                    lines.join("\n")
+                };
+                return Err(anyhow::anyhow!(
+                    "llama-server exited unexpectedly before becoming ready.\n\nStderr output:\n{}",
+                    context
+                ));
+            }
+
+            _ = sleep(Duration::from_secs(1)) => {}
+        }
+
+        match client.get(&health_url).send().await {
+            Ok(response) => {
+                let status = response.status();
+
+                if !status.is_success() {
+                    debug!(
+                        "Health check returned status {} (expected 200), retrying...",
+                        status
+                    );
+
+                    if (status.as_u16() == 403 || status.as_u16() == 404) && attempt > 3 {
+                        return Err(anyhow::anyhow!(
+                            "Port {} appears to be in use by another service (status {}). Try using a different port range.",
+                            port,
+                            status
+                        ));
+                    }
+                } else {
+                    match response.text().await {
+                        Ok(body) => {
                             if body.contains("status")
                                 || body.contains("slots")
                                 || body.contains("error")

--- a/crates/gglib-runtime/src/process/health.rs
+++ b/crates/gglib-runtime/src/process/health.rs
@@ -6,6 +6,8 @@ use tokio::sync::oneshot;
 use tokio::time::{Duration, sleep};
 use tracing::{debug, info};
 
+use crate::command::CapturedOutput;
+
 /// Wait for HTTP health check to succeed
 ///
 /// Polls the llama-server's /health endpoint until it returns 200 OK
@@ -91,11 +93,11 @@ pub async fn wait_for_http_health(port: u16, timeout_secs: u64) -> Result<()> {
 ///
 /// Races a 1-second HTTP-poll sleep against the `exit_rx` oneshot from
 /// [`crate::command::spawn_with_exit_watch`].  When the receiver fires, the
-/// loop returns immediately with the last N stderr lines in the error message.
+/// loop returns immediately with the captured output in the error message.
 pub async fn wait_for_http_health_or_exit(
     port: u16,
     timeout_secs: u64,
-    exit_rx: oneshot::Receiver<Vec<String>>,
+    exit_rx: oneshot::Receiver<CapturedOutput>,
 ) -> Result<()> {
     let health_url = format!("http://127.0.0.1:{}/health", port);
     info!("Waiting for llama-server to be ready at {}", health_url);
@@ -114,16 +116,13 @@ pub async fn wait_for_http_health_or_exit(
         tokio::select! {
             biased;
 
-            // Process exited — fail fast with its stderr output.
-            stderr_lines = &mut exit_rx => {
-                let lines = stderr_lines.unwrap_or_default();
-                let context = if lines.is_empty() {
-                    String::from("(no stderr output captured)")
-                } else {
-                    lines.join("\n")
-                };
+            // Process exited — fail fast with its captured output.
+            captured = &mut exit_rx => {
+                let context = captured
+                    .unwrap_or_default()
+                    .best_effort_context();
                 return Err(anyhow::anyhow!(
-                    "llama-server exited unexpectedly before becoming ready.\n\nStderr output:\n{}",
+                    "llama-server exited unexpectedly before becoming ready.\n\nOutput:\n{}",
                     context
                 ));
             }

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -5,7 +5,7 @@
 //! - **SingleSwap**: Auto-swapping single model with smart context handling (Proxy use case)
 
 use super::core::GuiProcessCore;
-use super::health::wait_for_http_health;
+use super::health::wait_for_http_health_or_exit;
 use super::types::ServerInfo;
 use anyhow::{Result, anyhow};
 use gglib_core::ports::{
@@ -142,14 +142,14 @@ impl ProcessManager {
         }
 
         // Spawn the process
-        let allocated_port = core.spawn(config).await?;
+        let (allocated_port, watcher) = core.spawn(config).await?;
 
         // Release the lock before waiting
         drop(core);
 
-        // Wait for server to be ready by polling health endpoint
+        // Wait for server to be ready, aborting early if the process exits.
         debug!(port = %allocated_port, "Waiting for llama-server to be ready");
-        wait_for_http_health(allocated_port, 30).await?;
+        wait_for_http_health_or_exit(allocated_port, 30, watcher.exit_rx).await?;
         debug!("llama-server is ready and accepting requests");
 
         Ok(allocated_port)
@@ -278,15 +278,15 @@ impl ProcessManager {
         .with_context_size(effective_ctx)
         .with_jinja(); // Enable jinja by default for proxy
 
-        let port = {
+        let (port, watcher) = {
             let mut core = self.core.write().await;
             core.spawn(config)
                 .await
                 .map_err(|e| ModelRuntimeError::SpawnFailed(e.to_string()))?
         };
 
-        // 6. Wait for health check
-        if let Err(e) = wait_for_http_health(port, 120).await {
+        // 6. Wait for health check, failing fast if the process exits.
+        if let Err(e) = wait_for_http_health_or_exit(port, 120, watcher.exit_rx).await {
             // DON'T update current_model on failure - guard will clear loading
             return Err(ModelRuntimeError::HealthCheckFailed(e.to_string()));
         }

--- a/crates/gglib-runtime/src/process/mod.rs
+++ b/crates/gglib-runtime/src/process/mod.rs
@@ -25,7 +25,6 @@ mod logs;
 mod manager;
 mod ports;
 pub mod shutdown;
-mod stream;
 mod types;
 
 // Re-export commonly used types
@@ -36,5 +35,4 @@ pub use health::{check_process_health, update_health_batch, wait_for_http_health
 pub use logs::{LogManagerSink, ServerLogEntry, ServerLogManager, get_log_manager};
 pub use manager::{CurrentModelState, ProcessManager, ProcessStrategy};
 pub use shutdown::{kill_pid, shutdown_child};
-pub(crate) use stream::spawn_stream_reader;
 pub use types::{RunningProcess, ServerInfo};

--- a/crates/gglib-runtime/src/process/types.rs
+++ b/crates/gglib-runtime/src/process/types.rs
@@ -1,7 +1,7 @@
 //! Shared types for process management.
 
+use crate::command::SharedChild;
 use serde::Serialize;
-use tokio::process::Child;
 
 /// Information about a running model server
 #[derive(Debug, Clone, Serialize)]
@@ -58,11 +58,11 @@ impl ServerInfo {
 /// Running process with metadata
 pub struct RunningProcess {
     pub info: ServerInfo,
-    pub child: Child,
+    pub child: SharedChild,
 }
 
 impl RunningProcess {
-    pub fn new(info: ServerInfo, child: Child) -> Self {
+    pub fn new(info: ServerInfo, child: SharedChild) -> Self {
         Self { info, child }
     }
 }

--- a/crates/gglib-runtime/src/process_core.rs
+++ b/crates/gglib-runtime/src/process_core.rs
@@ -9,17 +9,16 @@ use std::collections::HashMap;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::process::Child;
 use tracing::debug;
 
-use crate::command::{self, StartupWatcher};
+use crate::command::{self, SharedChild, StartupWatcher};
 use crate::pidfile::{delete_pidfile, write_pidfile};
 use crate::process::shutdown::shutdown_child;
 
 /// Running process with handle to the child process.
 struct RunningProcess {
     handle: ProcessHandle,
-    child: Child,
+    child: SharedChild,
     context_size: Option<u64>,
 }
 
@@ -74,7 +73,9 @@ impl ProcessCore {
             command::spawn_with_exit_watch(Some(&self.llama_server_path), config, port, log_sink)?;
 
         let pid = child
-            .id()
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|c| c.id()))
             .ok_or_else(|| anyhow!("Failed to get child PID"))?;
 
         // Write PID file
@@ -120,8 +121,11 @@ impl ProcessCore {
         let pid = running.handle.pid.unwrap_or(0);
         debug!(model_id = %model_id, pid = %pid, "Stopping process");
 
-        // Use graceful shutdown with SIGTERM → SIGKILL
-        let _ = shutdown_child(running.child).await;
+        // Use graceful shutdown with SIGTERM → SIGKILL.
+        // The child may already be gone (fast-fail path), so handle the missing case.
+        if let Some(child) = running.child.lock().ok().and_then(|mut g| g.take()) {
+            let _ = shutdown_child(child).await;
+        }
 
         // Remove PID file
         if let Err(e) = delete_pidfile(model_id) {
@@ -198,11 +202,15 @@ impl ProcessCore {
         let mut dead = Vec::new();
 
         for (id, r) in self.processes.iter_mut() {
-            match r.child.try_wait() {
-                Ok(Some(_)) | Err(_) => {
-                    dead.push(*id);
-                }
-                Ok(None) => {}
+            let is_dead = match r.child.lock() {
+                Ok(mut guard) => match guard.as_mut() {
+                    Some(c) => matches!(c.try_wait(), Ok(Some(_)) | Err(_)),
+                    None => true, // child already taken
+                },
+                Err(_) => true, // poisoned mutex — treat as dead
+            };
+            if is_dead {
+                dead.push(*id);
             }
         }
 

--- a/crates/gglib-runtime/src/process_core.rs
+++ b/crates/gglib-runtime/src/process_core.rs
@@ -49,7 +49,10 @@ impl ProcessCore {
     /// pass the `StartupWatcher` to `wait_for_http_health_or_exit` so that a
     /// crash during startup is detected immediately instead of waiting for the
     /// full health-check timeout.
-    pub async fn spawn(&mut self, config: &ServerConfig) -> Result<(ProcessHandle, StartupWatcher)> {
+    pub async fn spawn(
+        &mut self,
+        config: &ServerConfig,
+    ) -> Result<(ProcessHandle, StartupWatcher)> {
         if self.processes.contains_key(&config.model_id) {
             return Err(anyhow!("Model {} is already running", config.model_id));
         }
@@ -65,13 +68,10 @@ impl ProcessCore {
 
         // Use spawn_with_exit_watch so we get a StartupWatcher for fast-fail detection.
         use crate::process::LogManagerSink;
-        let log_sink = Some(std::sync::Arc::new(LogManagerSink) as std::sync::Arc<dyn gglib_core::ports::ServerLogSinkPort>);
-        let (child, watcher) = command::spawn_with_exit_watch(
-            Some(&self.llama_server_path),
-            config,
-            port,
-            log_sink,
-        )?;
+        let log_sink = Some(std::sync::Arc::new(LogManagerSink)
+            as std::sync::Arc<dyn gglib_core::ports::ServerLogSinkPort>);
+        let (child, watcher) =
+            command::spawn_with_exit_watch(Some(&self.llama_server_path), config, port, log_sink)?;
 
         let pid = child
             .id()

--- a/crates/gglib-runtime/src/process_core.rs
+++ b/crates/gglib-runtime/src/process_core.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::process::Child;
 use tracing::debug;
 
-use crate::command;
+use crate::command::{self, StartupWatcher};
 use crate::pidfile::{delete_pidfile, write_pidfile};
 use crate::process::shutdown::shutdown_child;
 
@@ -44,7 +44,12 @@ impl ProcessCore {
     }
 
     /// Spawn a new llama-server process from configuration.
-    pub async fn spawn(&mut self, config: &ServerConfig) -> Result<ProcessHandle> {
+    ///
+    /// Returns a `(ProcessHandle, StartupWatcher)` pair.  The caller **must**
+    /// pass the `StartupWatcher` to `wait_for_http_health_or_exit` so that a
+    /// crash during startup is detected immediately instead of waiting for the
+    /// full health-check timeout.
+    pub async fn spawn(&mut self, config: &ServerConfig) -> Result<(ProcessHandle, StartupWatcher)> {
         if self.processes.contains_key(&config.model_id) {
             return Err(anyhow!("Model {} is already running", config.model_id));
         }
@@ -57,7 +62,17 @@ impl ProcessCore {
         }
 
         let port = self.resolve_port(config)?;
-        let mut child = command::build_and_spawn(Some(&self.llama_server_path), config, port)?;
+
+        // Use spawn_with_exit_watch so we get a StartupWatcher for fast-fail detection.
+        use crate::process::LogManagerSink;
+        let log_sink = Some(std::sync::Arc::new(LogManagerSink) as std::sync::Arc<dyn gglib_core::ports::ServerLogSinkPort>);
+        let (child, watcher) = command::spawn_with_exit_watch(
+            Some(&self.llama_server_path),
+            config,
+            port,
+            log_sink,
+        )?;
+
         let pid = child
             .id()
             .ok_or_else(|| anyhow!("Failed to get child PID"))?;
@@ -67,10 +82,6 @@ impl ProcessCore {
             debug!("Failed to write PID file: {}", e);
             // Non-fatal - continue anyway
         }
-
-        // Wire log capture to the log manager for GUI streaming
-        use crate::process::LogManagerSink;
-        command::spawn_log_readers(&mut child, port, Some(std::sync::Arc::new(LogManagerSink)));
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -96,7 +107,7 @@ impl ProcessCore {
             },
         );
 
-        Ok(handle)
+        Ok((handle, watcher))
     }
 
     /// Kill a running process with graceful shutdown.

--- a/crates/gglib-runtime/src/runner.rs
+++ b/crates/gglib-runtime/src/runner.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::debug;
 
-use crate::health::{check_http_health, wait_for_http_health};
+use crate::health::{check_http_health, wait_for_http_health_or_exit};
 use crate::process_core::ProcessCore;
 
 /// Default timeout for health checks when starting a server (seconds).
@@ -88,15 +88,15 @@ impl ProcessRunner for LlamaServerRunner {
         }
 
         // Spawn the process
-        let handle = {
+        let (handle, watcher) = {
             let mut core = self.core.write().await;
             core.spawn(&config)
                 .await
                 .map_err(|e| ProcessError::StartFailed(e.to_string()))?
         };
 
-        // Wait for HTTP health check
-        wait_for_http_health(handle.port, DEFAULT_STARTUP_TIMEOUT_SECS)
+        // Wait for HTTP health check, aborting early if the process exits.
+        wait_for_http_health_or_exit(handle.port, DEFAULT_STARTUP_TIMEOUT_SECS, watcher.exit_rx)
             .await
             .map_err(|e| {
                 // Try to kill the process if health check fails


### PR DESCRIPTION
## Summary

Fixes #468.

When `llama-server` crashes immediately after being spawned (e.g. bad GPU configuration, missing CUDA libraries, incompatible model file), the old code would silently poll the HTTP health endpoint for the full timeout (30–120 seconds) before surfacing a useless `"Health check failed: llama-server failed to start within 120s"` error. The actual crash reason from stderr was lost.

After this change the failure is reported within ~1 second, and the error message includes the last 50 lines of llama-server's stderr output.

## Root Cause

`wait_for_http_health(port, timeout_secs)` receives only a port number — it has no reference to the child process and therefore cannot detect that the process has already died. This was a latent bug present since the first commit (Dec 2025); the process-spawning unification in PR #406 (Apr 2026) preserved the same pattern across both code paths.

## Solution

Three incremental commits:

### Commit 1 — `command.rs`: infrastructure
- Add `StartupWatcher { exit_rx: oneshot::Receiver<Vec<String>> }` — the receiver fires with the last N stderr lines when the process exits.
- Add `spawn_with_exit_watch(llama_server_path, config, port, log_sink) -> Result<(Child, StartupWatcher)>` — spawns the process, wires stdout to the log sink fire-and-forget, and starts a stderr reader task that: decodes lines with `String::from_utf8_lossy` (non-UTF8 safe), forwards them to the log sink, maintains a 50-line ring buffer, and sends the buffer via `exit_tx` on EOF.

### Commit 2 — CLI path (`health.rs`, `process_core.rs`, `runner.rs`)
- `health.rs`: add `wait_for_http_health_or_exit(port, timeout, exit_rx)` — identical structure to the existing `wait_for_http_health` but wraps the `sleep(1s)` in `tokio::select! { biased; stderr_lines = &mut exit_rx => { fail fast } _ = sleep(..) => {} }`.
- `process_core.rs`: `ProcessCore::spawn()` now returns `(ProcessHandle, StartupWatcher)` and uses `spawn_with_exit_watch`.
- `runner.rs`: destructures the watcher and calls `wait_for_http_health_or_exit`.

### Commit 3 — GUI/proxy path (`process/health.rs`, `process/core.rs`, `process/manager.rs`)
- `process/health.rs`: mirror of the CLI-path `wait_for_http_health_or_exit`.
- `process/core.rs`: `GuiProcessCore::spawn()` now returns `(u16, StartupWatcher)` and uses `spawn_with_exit_watch` (removing the now-redundant `spawn_log_readers` helper).
- `process/manager.rs`: both `start_server()` (30s timeout) and `ensure_model_running()` (120s timeout) updated.

## Before / After

**Before:**
```
$ gglib q 'hello'
Error: Health check failed: llama-server failed to start within 120s on port 9000.
# (after 120 seconds)
```

**After:**
```
$ gglib q 'hello'
Error: Health check failed: llama-server exited unexpectedly before becoming ready.

Stderr output:
ggml_cuda_init: failed to initialize CUDA: unknown error
llama_model_load: error loading model: llama_model_loader: failed to load model from /path/to/model.gguf
# (within ~1 second)
```

## Testing

- `cargo check -p gglib-runtime` passes (pre-existing E0107 errors in `build_common.rs` are unrelated and pre-date this PR).
- Both code paths (CLI via `ProcessCore` + `LlamaServerRunner`, GUI/proxy via `GuiProcessCore` + `ProcessManager`) are covered.
