### PR TITLE
feat(inference): add stop sequences to shared contract

### DIFF
--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -79,6 +79,8 @@ pub struct ChatProxyRequest {
     pub top_k: Option<i32>,
     /// Optional repeat_penalty (inference parameter - will be resolved via hierarchy).
     pub repeat_penalty: Option<f32>,
+    /// Optional stop sequences (inference parameter - will be resolved via hierarchy).
+    pub stop: Option<Vec<String>>,
     /// Optional tools for function calling.
     #[serde(default)]
     pub tools: Option<Vec<serde_json::Value>>,
@@ -442,6 +444,7 @@ pub async fn proxy_chat(
         top_k: request.top_k,
         max_tokens: request.max_tokens,
         repeat_penalty: request.repeat_penalty,
+        stop: request.stop.clone(),
     };
 
     // Apply model defaults (if missing)
@@ -464,6 +467,7 @@ pub async fn proxy_chat(
         resolved_top_k = resolved.top_k,
         resolved_max_tokens = resolved.max_tokens,
         resolved_repeat_penalty = resolved.repeat_penalty,
+        resolved_stop = ?resolved.stop,
         "Resolved inference parameters via hierarchy"
     );
 
@@ -533,6 +537,7 @@ pub async fn proxy_chat(
         "top_p": resolved.top_p,
         "top_k": resolved.top_k,
         "repeat_penalty": resolved.repeat_penalty,
+        "stop": resolved.stop,
     });
 
     // Inject tools only when the model supports them.

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -50,6 +50,7 @@ impl SamplingArgs {
             top_k: self.top_k,
             max_tokens: self.max_tokens,
             repeat_penalty: self.repeat_penalty,
+            stop: None,
         }
     }
 }

--- a/crates/gglib-core/src/domain/chat.rs
+++ b/crates/gglib-core/src/domain/chat.rs
@@ -183,6 +183,9 @@ pub struct ConversationSettings {
     /// Repetition penalty.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repeat_penalty: Option<f32>,
+    /// Stop sequences that terminate generation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
     /// Context window size (numeric or "max").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ctx_size: Option<String>,
@@ -204,4 +207,32 @@ pub struct ConversationSettings {
     /// Whether tools were disabled entirely.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_tools: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ConversationSettings;
+
+    #[test]
+    fn conversation_settings_deserializes_without_stop() {
+        let json = r#"{"model_name":"qwen","temperature":0.7}"#;
+        let settings: ConversationSettings = serde_json::from_str(json).unwrap();
+
+        assert_eq!(settings.model_name.as_deref(), Some("qwen"));
+        assert!(settings.stop.is_none());
+    }
+
+    #[test]
+    fn conversation_settings_round_trips_with_stop() {
+        let settings = ConversationSettings {
+            model_name: Some("qwen".to_string()),
+            stop: Some(vec!["<|im_end|>".to_string(), "</s>".to_string()]),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_string(&settings).unwrap();
+        let deserialized: ConversationSettings = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.stop, settings.stop);
+    }
 }

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -1,7 +1,7 @@
 //! Inference configuration types.
 //!
 //! Defines shared types for configuring LLM inference parameters
-//! (temperature, `top_p`, `top_k`, `max_tokens`, `repeat_penalty`).
+//! (temperature, `top_p`, `top_k`, `max_tokens`, `repeat_penalty`, `stop`).
 //!
 //! This module provides the core `InferenceConfig` type that is reused across:
 //! - Per-model defaults (`Model.inference_defaults`)
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 ///     top_k: Some(40),
 ///     max_tokens: Some(2048),
 ///     repeat_penalty: Some(1.1),
+///     stop: Some(vec!["<|im_end|>".to_string()]),
 /// };
 ///
 /// // Creative writing settings
@@ -79,6 +80,11 @@ pub struct InferenceConfig {
     /// - 1.1-1.3: Moderate penalty
     /// - > 1.3: Strong penalty (may hurt coherence)
     pub repeat_penalty: Option<f32>,
+
+    /// Stop sequences that terminate generation when encountered.
+    ///
+    /// If omitted, model/global/hardcoded fallback resolution applies.
+    pub stop: Option<Vec<String>>,
 }
 
 impl InferenceConfig {
@@ -107,7 +113,7 @@ impl InferenceConfig {
     /// assert_eq!(request.temperature, Some(0.8)); // Request value wins
     /// assert_eq!(request.top_p, Some(0.9));      // Fallback to model default
     /// ```
-    pub const fn merge_with(&mut self, other: &Self) {
+    pub fn merge_with(&mut self, other: &Self) {
         if self.temperature.is_none() {
             self.temperature = other.temperature;
         }
@@ -123,6 +129,9 @@ impl InferenceConfig {
         if self.repeat_penalty.is_none() {
             self.repeat_penalty = other.repeat_penalty;
         }
+        if self.stop.is_none() {
+            self.stop = other.stop.clone();
+        }
     }
 
     /// Create a new config with all fields set to sensible defaults.
@@ -137,6 +146,7 @@ impl InferenceConfig {
             top_k: Some(40),
             max_tokens: Some(2048),
             repeat_penalty: Some(1.0),
+            stop: None,
         }
     }
 
@@ -160,6 +170,7 @@ impl InferenceConfig {
     ///     top_k: None,
     ///     max_tokens: Some(1024),
     ///     repeat_penalty: None,
+    ///     stop: None,
     /// };
     ///
     /// let args = config.to_cli_args();
@@ -206,6 +217,7 @@ mod tests {
         assert!(config.top_k.is_none());
         assert!(config.max_tokens.is_none());
         assert!(config.repeat_penalty.is_none());
+        assert!(config.stop.is_none());
     }
 
     #[test]
@@ -213,6 +225,7 @@ mod tests {
         let mut request = InferenceConfig {
             temperature: Some(0.8),
             top_p: None,
+            stop: None,
             ..Default::default()
         };
 
@@ -220,6 +233,7 @@ mod tests {
             temperature: Some(0.5),
             top_p: Some(0.9),
             top_k: Some(50),
+            stop: Some(vec!["<|im_end|>".to_string()]),
             ..Default::default()
         };
 
@@ -228,7 +242,25 @@ mod tests {
         assert_eq!(request.temperature, Some(0.8)); // Request wins
         assert_eq!(request.top_p, Some(0.9)); // Fallback to model
         assert_eq!(request.top_k, Some(50)); // Fallback to model
+        assert_eq!(request.stop, Some(vec!["<|im_end|>".to_string()])); // Fallback to model
         assert!(request.max_tokens.is_none()); // Still None
+    }
+
+    #[test]
+    fn test_merge_with_preserves_request_stop() {
+        let mut request = InferenceConfig {
+            stop: Some(vec!["<|custom_stop|>".to_string()]),
+            ..Default::default()
+        };
+
+        let model_defaults = InferenceConfig {
+            stop: Some(vec!["<|im_end|>".to_string()]),
+            ..Default::default()
+        };
+
+        request.merge_with(&model_defaults);
+
+        assert_eq!(request.stop, Some(vec!["<|custom_stop|>".to_string()]));
     }
 
     #[test]
@@ -239,6 +271,7 @@ mod tests {
         assert_eq!(config.top_k, Some(40));
         assert_eq!(config.max_tokens, Some(2048));
         assert_eq!(config.repeat_penalty, Some(1.0));
+        assert!(config.stop.is_none());
     }
 
     #[test]
@@ -249,6 +282,7 @@ mod tests {
             top_k: None,
             max_tokens: Some(1024),
             repeat_penalty: None,
+            stop: Some(vec!["<|im_end|>".to_string()]),
         };
 
         let json = serde_json::to_string(&config).unwrap();

--- a/crates/gglib-core/src/ports/process_runner.rs
+++ b/crates/gglib-core/src/ports/process_runner.rs
@@ -103,7 +103,7 @@ impl ServerConfig {
 
     /// Set inference sampling parameters.
     #[must_use]
-    pub const fn with_inference_config(mut self, config: InferenceConfig) -> Self {
+    pub fn with_inference_config(mut self, config: InferenceConfig) -> Self {
         self.inference_config = Some(config);
         self
     }

--- a/crates/gglib-core/src/settings.rs
+++ b/crates/gglib-core/src/settings.rs
@@ -16,6 +16,12 @@ pub const DEFAULT_LLAMA_BASE_PORT: u16 = 9000;
 /// Default context size for models when not specified by the user.
 pub const DEFAULT_CONTEXT_SIZE: u64 = 4096;
 
+/// Maximum number of configured stop sequences.
+pub const MAX_STOP_SEQUENCES: usize = 16;
+
+/// Maximum length of a single stop sequence.
+pub const MAX_STOP_SEQUENCE_LENGTH: usize = 256;
+
 /// Application settings structure.
 ///
 /// All fields are optional to support partial updates and graceful defaults.
@@ -278,6 +284,30 @@ pub fn validate_inference_config(config: &InferenceConfig) -> Result<(), String>
         ));
     }
 
+    if let Some(stop) = &config.stop {
+        if stop.is_empty() {
+            return Err("Stop sequences must not be empty when provided".to_string());
+        }
+        if stop.len() > MAX_STOP_SEQUENCES {
+            return Err(format!(
+                "Stop sequences must contain at most {MAX_STOP_SEQUENCES} entries, got {}",
+                stop.len()
+            ));
+        }
+
+        for sequence in stop {
+            if sequence.trim().is_empty() {
+                return Err("Stop sequences must not contain blank values".to_string());
+            }
+            if sequence.len() > MAX_STOP_SEQUENCE_LENGTH {
+                return Err(format!(
+                    "Stop sequence must be at most {MAX_STOP_SEQUENCE_LENGTH} characters, got {}",
+                    sequence.len()
+                ));
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -358,8 +388,49 @@ mod tests {
             top_k: Some(40),
             max_tokens: Some(2048),
             repeat_penalty: Some(1.1),
+            stop: Some(vec!["<|im_end|>".to_string()]),
         };
         assert!(validate_inference_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_inference_config_stop_empty_list() {
+        let config = InferenceConfig {
+            stop: Some(vec![]),
+            ..Default::default()
+        };
+
+        assert!(validate_inference_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_inference_config_stop_blank_entry() {
+        let config = InferenceConfig {
+            stop: Some(vec!["   ".to_string()]),
+            ..Default::default()
+        };
+
+        assert!(validate_inference_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_inference_config_stop_too_many_entries() {
+        let config = InferenceConfig {
+            stop: Some(vec!["x".to_string(); MAX_STOP_SEQUENCES + 1]),
+            ..Default::default()
+        };
+
+        assert!(validate_inference_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_inference_config_stop_entry_too_long() {
+        let config = InferenceConfig {
+            stop: Some(vec!["x".repeat(MAX_STOP_SEQUENCE_LENGTH + 1)]),
+            ..Default::default()
+        };
+
+        assert!(validate_inference_config(&config).is_err());
     }
 
     #[test]

--- a/src/services/transport/mappers.ts
+++ b/src/services/transport/mappers.ts
@@ -25,6 +25,7 @@ export interface StartServerRequest {
     topK?: number;
     maxTokens?: number;
     repeatPenalty?: number;
+    stop?: string[];
   };
 }
 
@@ -72,7 +73,8 @@ export function toStartServerRequest(config: ServeConfig): StartServerRequest {
     config.topP !== undefined || 
     config.topK !== undefined || 
     config.maxTokens !== undefined || 
-    config.repeatPenalty !== undefined;
+    config.repeatPenalty !== undefined ||
+    config.stop !== undefined;
   
   const inferenceParams = hasInferenceParams ? {
     temperature: config.temperature,
@@ -80,6 +82,7 @@ export function toStartServerRequest(config: ServeConfig): StartServerRequest {
     topK: config.topK,
     maxTokens: config.maxTokens,
     repeatPenalty: config.repeatPenalty,
+    stop: config.stop,
   } : undefined;
 
   return {
@@ -89,7 +92,7 @@ export function toStartServerRequest(config: ServeConfig): StartServerRequest {
     jinja: config.jinja,
     // reasoning_format is auto-detected from model tags on backend when omitted
     reasoningFormat: undefined,
-    inferenceParams,
+    ...(inferenceParams !== undefined ? { inferenceParams } : {}),
   };
 }
 

--- a/src/services/transport/types/chat.ts
+++ b/src/services/transport/types/chat.ts
@@ -20,6 +20,7 @@ export interface ConversationSettings {
   top_k?: number | null;
   max_tokens?: number | null;
   repeat_penalty?: number | null;
+  stop?: string[] | null;
   ctx_size?: number | null;
   mlock?: boolean | null;
   tools?: string[] | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,8 @@ export interface InferenceConfig {
   maxTokens?: number;
   /** Repetition penalty (> 0.0, typically 1.0 - 1.3). */
   repeatPenalty?: number;
+  /** Stop sequences that terminate generation when encountered. */
+  stop?: string[];
 }
 
 // ============================================================================
@@ -67,6 +69,7 @@ export interface ServeConfig {
   topK?: number;
   maxTokens?: number;
   repeatPenalty?: number;
+  stop?: string[];
 }
 
 export interface ServerInfo {

--- a/tests/ts/contracts/tauri-serve-model.test.ts
+++ b/tests/ts/contracts/tauri-serve-model.test.ts
@@ -70,6 +70,12 @@ describe('Tauri serve_model IPC Contract', () => {
       port: 9090,
       mlock: true,
       jinja: false,
+      temperature: 0.8,
+      topP: 0.92,
+      topK: 64,
+      maxTokens: 1024,
+      repeatPenalty: 1.05,
+      stop: ['<|im_end|>', '</s>'],
     };
 
     const payload = {
@@ -83,6 +89,42 @@ describe('Tauri serve_model IPC Contract', () => {
       mlock: true,
       jinja: false,
       reasoningFormat: undefined,
+      inferenceParams: {
+        temperature: 0.8,
+        topP: 0.92,
+        topK: 64,
+        maxTokens: 1024,
+        repeatPenalty: 1.05,
+        stop: ['<|im_end|>', '</s>'],
+      },
+    });
+  });
+
+  it('should include stop-only inferenceParams when only stop is provided', () => {
+    const config: ServeConfig = {
+      id: 790,
+      stop: ['<|im_end|>'],
+    };
+
+    const payload = {
+      id: config.id,
+      request: toStartServerRequest(config),
+    };
+
+    expect(payload.request).toEqual({
+      contextLength: undefined,
+      port: undefined,
+      mlock: false,
+      jinja: undefined,
+      reasoningFormat: undefined,
+      inferenceParams: {
+        temperature: undefined,
+        topP: undefined,
+        topK: undefined,
+        maxTokens: undefined,
+        repeatPenalty: undefined,
+        stop: ['<|im_end|>'],
+      },
     });
   });
 


### PR DESCRIPTION
PR 1 of deterministic stop rollout.\n\nScope:\n- Add stop to shared inference contract and fallback merge behavior.\n- Persist stop in conversation settings and validate stop defaults.\n- Wire stop through Axum and frontend transport contracts/mappers.\n- Add focused Rust and TypeScript contract tests.\n\nOut of scope:\n- GGUF extraction changes.\n- CLI command surface changes for stop flags.