### PR TITLE
feat(gguf): persist deterministic stop defaults from tokenizer ids

### DIFF
--- a/crates/gglib-core/src/domain/gguf.rs
+++ b/crates/gglib-core/src/domain/gguf.rs
@@ -239,6 +239,11 @@ pub struct GgufMetadata {
     pub expert_used_count: Option<u32>,
     /// Number of shared experts (for `MoE` models).
     pub expert_shared_count: Option<u32>,
+    /// Deterministically extracted stop sequences from tokenizer ID mapping.
+    ///
+    /// Populated only when tokenizer IDs can be mapped to concrete token strings.
+    #[allow(clippy::struct_field_names)]
+    pub stop_sequences: Vec<String>,
     /// Additional key-value metadata from the file (string representation).
     pub metadata: HashMap<String, String>,
 }

--- a/crates/gglib-core/src/domain/model.rs
+++ b/crates/gglib-core/src/domain/model.rs
@@ -241,6 +241,19 @@ impl NewModel {
             inference_defaults: None,
         }
     }
+
+    /// Apply deterministic stop-sequence defaults to this model.
+    ///
+    /// If stop sequences are empty, leaves inference defaults unchanged.
+    pub fn apply_deterministic_stop_defaults(&mut self, stop_sequences: &[String]) {
+        if stop_sequences.is_empty() {
+            return;
+        }
+
+        let mut defaults = self.inference_defaults.clone().unwrap_or_default();
+        defaults.stop = Some(stop_sequences.to_vec());
+        self.inference_defaults = Some(defaults);
+    }
 }
 
 impl Model {
@@ -323,5 +336,42 @@ mod tests {
         assert_eq!(new_model.name, "Persisted Model");
         assert_eq!(new_model.architecture, Some("llama".to_string()));
         assert_eq!(new_model.tags, vec!["chat".to_string()]);
+    }
+
+    #[test]
+    fn test_apply_deterministic_stop_defaults_sets_stop() {
+        let mut model = NewModel::new(
+            "Stop Test".to_string(),
+            PathBuf::from("/path/to/model.gguf"),
+            7.0,
+            Utc::now(),
+        );
+
+        model.apply_deterministic_stop_defaults(&[
+            "<|im_end|>".to_string(),
+            "</s>".to_string(),
+        ]);
+
+        assert_eq!(
+            model
+                .inference_defaults
+                .as_ref()
+                .and_then(|d| d.stop.clone()),
+            Some(vec!["<|im_end|>".to_string(), "</s>".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_apply_deterministic_stop_defaults_noop_when_empty() {
+        let mut model = NewModel::new(
+            "Stop Test".to_string(),
+            PathBuf::from("/path/to/model.gguf"),
+            7.0,
+            Utc::now(),
+        );
+
+        model.apply_deterministic_stop_defaults(&[]);
+
+        assert!(model.inference_defaults.is_none());
     }
 }

--- a/crates/gglib-core/src/services/model_registrar.rs
+++ b/crates/gglib-core/src/services/model_registrar.rs
@@ -145,6 +145,10 @@ impl ModelRegistrarPort for ModelRegistrar {
         // Pass through file_paths for sharded models
         model.file_paths.clone_from(&download.file_paths);
 
+        if let Some(ref meta) = gguf_metadata {
+            model.apply_deterministic_stop_defaults(&meta.stop_sequences);
+        }
+
         // Auto-detect capabilities from metadata and merge with HF tags
         let gguf_tags = gguf_metadata.as_ref().map_or_else(Vec::new, |meta| {
             let capabilities = self.gguf_parser.detect_capabilities(meta);
@@ -220,10 +224,24 @@ impl ModelRegistrarPort for ModelRegistrar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Model;
-    use crate::ports::NoopGgufParser;
+    use crate::domain::{GgufMetadata, Model};
+    use crate::ports::{GgufCapabilities, GgufParseError, GgufParserPort, NoopGgufParser};
     use std::path::PathBuf;
     use std::sync::Mutex;
+
+    struct StaticGgufParser {
+        metadata: GgufMetadata,
+    }
+
+    impl GgufParserPort for StaticGgufParser {
+        fn parse(&self, _file_path: &Path) -> Result<GgufMetadata, GgufParseError> {
+            Ok(self.metadata.clone())
+        }
+
+        fn detect_capabilities(&self, _metadata: &GgufMetadata) -> GgufCapabilities {
+            GgufCapabilities::empty()
+        }
+    }
 
     /// Mock model repository for testing.
     struct MockModelRepo {
@@ -332,6 +350,44 @@ mod tests {
         assert_eq!(model.hf_repo_id, Some("test/model".to_string()));
         assert_eq!(model.hf_commit_sha, Some("abc123".to_string()));
         assert_eq!(model.quantization, Some("Q4_K_M".to_string()));
+        assert!(model.inference_defaults.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_register_model_persists_stop_defaults_when_extracted() {
+        let repo = Arc::new(MockModelRepo::new());
+        let parser = Arc::new(StaticGgufParser {
+            metadata: GgufMetadata {
+                stop_sequences: vec!["<|im_end|>".to_string()],
+                ..Default::default()
+            },
+        });
+        let registrar = ModelRegistrar::new(repo.clone(), parser, None);
+
+        let download = CompletedDownload {
+            primary_path: PathBuf::from("/models/test-model-q4_k_m.gguf"),
+            all_paths: vec![PathBuf::from("/models/test-model-q4_k_m.gguf")],
+            quantization: Quantization::Q4KM,
+            repo_id: "test/model".to_string(),
+            commit_sha: "abc123".to_string(),
+            is_sharded: false,
+            total_bytes: 1024,
+            file_paths: None,
+            hf_tags: vec![],
+            hf_file_entries: vec![],
+        };
+
+        let result = registrar.register_model(&download).await;
+        assert!(result.is_ok());
+
+        let model = result.unwrap();
+        assert_eq!(
+            model
+                .inference_defaults
+                .as_ref()
+                .and_then(|d| d.stop.clone()),
+            Some(vec!["<|im_end|>".to_string()])
+        );
     }
 
     #[tokio::test]

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -138,7 +138,7 @@ impl ModelService {
         );
 
         // 5. Construct fully-populated NewModel
-        let new_model = NewModel {
+        let mut new_model = NewModel {
             name: name.cloned().unwrap_or_else(|| {
                 file_path
                     .file_stem()
@@ -166,6 +166,8 @@ impl ModelService {
             capabilities: model_capabilities,
             inference_defaults: None,
         };
+
+        new_model.apply_deterministic_stop_defaults(&gguf_metadata.stop_sequences);
 
         // 6. Persist to repository
         self.repo.insert(&new_model).await.map_err(CoreError::from)
@@ -359,15 +361,33 @@ impl ModelService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ports::{ModelRepository, RepositoryError};
+    use crate::ports::{
+        GgufCapabilities, GgufMetadata, GgufParseError, GgufParserPort, ModelRepository,
+        RepositoryError,
+    };
     use async_trait::async_trait;
     use chrono::Utc;
 
+    use std::fs::File;
     use std::path::PathBuf;
     use std::sync::Mutex;
 
     struct MockRepo {
         models: Mutex<Vec<Model>>,
+    }
+
+    struct StaticGgufParser {
+        metadata: GgufMetadata,
+    }
+
+    impl GgufParserPort for StaticGgufParser {
+        fn parse(&self, _file_path: &Path) -> Result<GgufMetadata, GgufParseError> {
+            Ok(self.metadata.clone())
+        }
+
+        fn detect_capabilities(&self, _metadata: &GgufMetadata) -> GgufCapabilities {
+            GgufCapabilities::empty()
+        }
     }
 
     impl MockRepo {
@@ -556,5 +576,54 @@ mod tests {
         let context_range = options.context_range.unwrap();
         assert!((context_range.min - 4096.0).abs() < 0.001);
         assert!((context_range.max - 8192.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_import_from_file_persists_stop_defaults_when_extracted() {
+        let repo = Arc::new(MockRepo::new());
+        let service = ModelService::new(repo);
+
+        let temp = tempfile::Builder::new().suffix(".gguf").tempfile().unwrap();
+        File::create(temp.path()).unwrap();
+
+        let parser = StaticGgufParser {
+            metadata: GgufMetadata {
+                stop_sequences: vec!["<|im_end|>".to_string(), "</s>".to_string()],
+                ..Default::default()
+            },
+        };
+
+        let model = service
+            .import_from_file(temp.path(), &parser, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            model
+                .inference_defaults
+                .as_ref()
+                .and_then(|d| d.stop.clone()),
+            Some(vec!["<|im_end|>".to_string(), "</s>".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_from_file_keeps_inference_defaults_none_without_stop_extraction() {
+        let repo = Arc::new(MockRepo::new());
+        let service = ModelService::new(repo);
+
+        let temp = tempfile::Builder::new().suffix(".gguf").tempfile().unwrap();
+        File::create(temp.path()).unwrap();
+
+        let parser = StaticGgufParser {
+            metadata: GgufMetadata::default(),
+        };
+
+        let model = service
+            .import_from_file(temp.path(), &parser, None)
+            .await
+            .unwrap();
+
+        assert!(model.inference_defaults.is_none());
     }
 }

--- a/crates/gglib-gguf/src/parser.rs
+++ b/crates/gglib-gguf/src/parser.rs
@@ -14,6 +14,9 @@ use crate::error::GgufResult;
 use crate::format::{CONTEXT_LENGTH_KEYS, quantization};
 use crate::reader::GgufReader;
 
+const TOKENIZER_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
+const STOP_TOKEN_ID_KEYS: [&str; 2] = ["tokenizer.ggml.eot_token_id", "tokenizer.ggml.eos_token_id"];
+
 /// GGUF file parser.
 ///
 /// Implements `GgufParserPort` from `gglib-core`, providing full GGUF
@@ -107,6 +110,7 @@ fn extract_metadata(raw: &RawMetadata, file_path: &Path) -> GgufMetadata {
     // Extract MoE metadata
     let (expert_count, expert_used_count, expert_shared_count) =
         extract_moe_metadata(raw, architecture.as_ref());
+    let stop_sequences = extract_stop_sequences(raw);
 
     GgufMetadata {
         name,
@@ -117,8 +121,46 @@ fn extract_metadata(raw: &RawMetadata, file_path: &Path) -> GgufMetadata {
         expert_count,
         expert_used_count,
         expert_shared_count,
+        stop_sequences,
         metadata: processed,
     }
+}
+
+/// Deterministically extract stop sequences from tokenizer token IDs.
+///
+/// This intentionally uses ID→token mapping only, with no template heuristics.
+fn extract_stop_sequences(raw: &RawMetadata) -> Vec<String> {
+    let Some(GgufValue::Array(tokens)) = raw.get(TOKENIZER_TOKENS_KEY) else {
+        return Vec::new();
+    };
+
+    let mut stop_sequences = Vec::new();
+
+    for key in STOP_TOKEN_ID_KEYS {
+        let Some(id_value) = raw.get(key) else {
+            continue;
+        };
+
+        if let Some(sequence) = resolve_token_from_id(id_value, tokens)
+            && !stop_sequences.contains(&sequence)
+        {
+            stop_sequences.push(sequence);
+        }
+    }
+
+    stop_sequences
+}
+
+fn resolve_token_from_id(id_value: &GgufValue, tokens: &[GgufValue]) -> Option<String> {
+    let token_id = id_value.as_u64()?;
+    let token_index = usize::try_from(token_id).ok()?;
+    let token = tokens.get(token_index)?.as_str()?.trim();
+
+    if token.is_empty() {
+        return None;
+    }
+
+    Some(token.to_string())
 }
 
 /// Extract model name from metadata or filename.
@@ -426,5 +468,52 @@ mod tests {
         );
         assert_eq!(extract_quantization_from_filename("model-f16.gguf"), "F16");
         assert_eq!(extract_quantization_from_filename("model.gguf"), "Unknown");
+    }
+
+    #[test]
+    fn test_extract_stop_sequences_in_range_ids() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            TOKENIZER_TOKENS_KEY.to_string(),
+            GgufValue::Array(vec![
+                GgufValue::String("<pad>".to_string()),
+                GgufValue::String("</s>".to_string()),
+                GgufValue::String("<|im_end|>".to_string()),
+            ]),
+        );
+        raw.insert("tokenizer.ggml.eot_token_id".to_string(), GgufValue::U32(2));
+        raw.insert("tokenizer.ggml.eos_token_id".to_string(), GgufValue::U32(1));
+
+        let stop = extract_stop_sequences(&raw);
+
+        assert_eq!(stop, vec!["<|im_end|>".to_string(), "</s>".to_string()]);
+    }
+
+    #[test]
+    fn test_extract_stop_sequences_out_of_range_id_ignored() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            TOKENIZER_TOKENS_KEY.to_string(),
+            GgufValue::Array(vec![GgufValue::String("</s>".to_string())]),
+        );
+        raw.insert("tokenizer.ggml.eos_token_id".to_string(), GgufValue::U32(99));
+
+        let stop = extract_stop_sequences(&raw);
+
+        assert!(stop.is_empty());
+    }
+
+    #[test]
+    fn test_extract_stop_sequences_non_string_token_array_ignored() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            TOKENIZER_TOKENS_KEY.to_string(),
+            GgufValue::Array(vec![GgufValue::U32(1), GgufValue::U32(2)]),
+        );
+        raw.insert("tokenizer.ggml.eos_token_id".to_string(), GgufValue::U32(0));
+
+        let stop = extract_stop_sequences(&raw);
+
+        assert!(stop.is_empty());
     }
 }

--- a/tests/integration_models.rs
+++ b/tests/integration_models.rs
@@ -143,6 +143,7 @@ fn test_gguf_metadata_structure() {
         param_count_b: Some(7.0),
         quantization: Some("Q4_0".to_string()),
         context_length: Some(4096),
+        stop_sequences: vec!["<|im_end|>".to_string()],
         metadata: metadata_map.clone(),
     };
 
@@ -152,6 +153,7 @@ fn test_gguf_metadata_structure() {
     assert_eq!(gguf_metadata.param_count_b.unwrap(), 7.0);
     assert_eq!(gguf_metadata.quantization.unwrap(), "Q4_0");
     assert_eq!(gguf_metadata.context_length.unwrap(), 4096);
+    assert_eq!(gguf_metadata.stop_sequences, vec!["<|im_end|>"]);
     assert_eq!(gguf_metadata.metadata.len(), 3);
 }
 
@@ -163,6 +165,7 @@ fn test_gguf_metadata_with_all_none_values() {
         param_count_b: None,
         quantization: None,
         context_length: None,
+        stop_sequences: vec![],
         metadata: HashMap::new(),
     };
 
@@ -172,6 +175,7 @@ fn test_gguf_metadata_with_all_none_values() {
     assert_eq!(gguf_metadata.param_count_b, None);
     assert_eq!(gguf_metadata.quantization, None);
     assert_eq!(gguf_metadata.context_length, None);
+    assert!(gguf_metadata.stop_sequences.is_empty());
     assert!(gguf_metadata.metadata.is_empty());
 }
 
@@ -307,10 +311,25 @@ fn test_model_cloning() {
         param_count_b: Some(7.0),
         quantization: Some("Q4_0".to_string()),
         context_length: Some(4096),
+        stop_sequences: vec!["</s>".to_string()],
         metadata: HashMap::new(),
     };
 
     let cloned_metadata = gguf_metadata.clone();
     assert_eq!(cloned_metadata.name, gguf_metadata.name);
     assert_eq!(cloned_metadata.architecture, gguf_metadata.architecture);
+    assert_eq!(cloned_metadata.stop_sequences, gguf_metadata.stop_sequences);
+}
+
+#[test]
+fn test_gguf_metadata_stop_sequences_preserved() {
+    let gguf_metadata = GgufMetadata {
+        stop_sequences: vec!["<|im_end|>".to_string(), "</s>".to_string()],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        gguf_metadata.stop_sequences,
+        vec!["<|im_end|>".to_string(), "</s>".to_string()]
+    );
 }


### PR DESCRIPTION
PR 2 of deterministic stop rollout.\n\nGoal:\n- Persist per-model stop defaults from authoritative GGUF tokenizer ID mapping only.\n\nScope:\n- Add deterministic stop_sequences extraction in GGUF parser from tokenizer.ggml token IDs.\n- Add stop_sequences field to GgufMetadata domain type.\n- Add shared NewModel helper for applying deterministic stop defaults.\n- Apply helper in both local import and HF registration paths.\n- Add parser/service/domain test coverage and update integration model tests.\n\nOut of scope:\n- Runtime forwarding/merge refactors (PR 3).\n- CLI stop flags (PR 4).\n- UI stop controls (PR 5).