### PR TITLE
PR 3: Unify inference precedence and stop propagation

### DIFF
--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -175,6 +175,7 @@ impl ServerOps {
         request: &StartServerRequest,
         base_port: u16,
         default_context_size: Option<u64>,
+        global_inference_defaults: Option<gglib_core::domain::InferenceConfig>,
     ) -> ServerConfig {
         let mut config = ServerConfig::new(
             model.id,
@@ -212,9 +213,12 @@ impl ServerOps {
             }
         }
 
-        if let Some(ref params) = request.inference_params {
-            config = config.with_inference_config(params.clone());
-        }
+        let resolved_inference = gglib_core::domain::InferenceConfig::resolve_with_hierarchy(
+            request.inference_params.as_ref(),
+            model.inference_defaults.as_ref(),
+            global_inference_defaults.as_ref(),
+        );
+        config = config.with_inference_config(resolved_inference);
 
         config
     }
@@ -259,7 +263,13 @@ impl ServerOps {
             "Resolved llama-server base port for model serving"
         );
 
-        let config = Self::build_config(&model, &request, base_port, settings.default_context_size);
+        let config = Self::build_config(
+            &model,
+            &request,
+            base_port,
+            settings.default_context_size,
+            settings.inference_defaults.clone(),
+        );
         let handle = self.deps.runner.start(config).await.map_err(|e| {
             // Emit error event before mapping the error
             let error_summary = ServerSummary {
@@ -596,6 +606,8 @@ impl ServerOps {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
     use tokio::time::{Duration, timeout};
 
     /// Helper to check if registry contains a server_id
@@ -604,6 +616,78 @@ mod tests {
         fn contains(&self, server_id: i64) -> bool {
             self.monitors.contains_key(&server_id)
         }
+    }
+
+    fn sample_model() -> Model {
+        Model {
+            id: 1,
+            name: "test-model".to_string(),
+            file_path: PathBuf::from("/tmp/test-model.gguf"),
+            param_count_b: 7.0,
+            architecture: None,
+            quantization: None,
+            context_length: Some(4096),
+            expert_count: None,
+            expert_used_count: None,
+            expert_shared_count: None,
+            metadata: HashMap::new(),
+            added_at: "2026-01-01T00:00:00Z".parse().unwrap(),
+            hf_repo_id: None,
+            hf_commit_sha: None,
+            hf_filename: None,
+            download_date: None,
+            last_update_check: None,
+            tags: vec![],
+            capabilities: gglib_core::domain::ModelCapabilities::default(),
+            inference_defaults: None,
+        }
+    }
+
+    #[test]
+    fn test_build_config_resolves_inference_precedence_with_stop() {
+        let mut model = sample_model();
+        model.inference_defaults = Some(gglib_core::domain::InferenceConfig {
+            temperature: Some(0.35),
+            stop: Some(vec!["<|model|>".to_string()]),
+            ..Default::default()
+        });
+
+        let request = StartServerRequest {
+            inference_params: Some(gglib_core::domain::InferenceConfig {
+                top_p: Some(0.71),
+                stop: Some(vec!["<|request|>".to_string()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let global_defaults = Some(gglib_core::domain::InferenceConfig {
+            top_p: Some(0.95),
+            top_k: Some(88),
+            stop: Some(vec!["<|global|>".to_string()]),
+            ..Default::default()
+        });
+
+        let config = ServerOps::build_config(&model, &request, 9000, Some(8192), global_defaults);
+        let resolved = config.inference_config.expect("resolved inference config");
+
+        assert_eq!(resolved.stop, Some(vec!["<|request|>".to_string()]));
+        assert_eq!(resolved.top_p, Some(0.71));
+        assert_eq!(resolved.temperature, Some(0.35));
+        assert_eq!(resolved.top_k, Some(88));
+        assert_eq!(resolved.max_tokens, Some(2048));
+    }
+
+    #[test]
+    fn test_build_config_keeps_stop_none_when_unspecified() {
+        let model = sample_model();
+        let request = StartServerRequest::default();
+
+        let config = ServerOps::build_config(&model, &request, 9000, None, None);
+        let resolved = config.inference_config.expect("resolved inference config");
+
+        assert!(resolved.stop.is_none());
+        assert_eq!(resolved.temperature, Some(0.7));
     }
 
     #[tokio::test]

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -363,6 +363,46 @@ fn apply_tools_to_body(
     }
 }
 
+fn resolve_chat_inference_config(
+    request: &ChatProxyRequest,
+    model_defaults: Option<&gglib_core::domain::InferenceConfig>,
+    global_defaults: Option<&gglib_core::domain::InferenceConfig>,
+) -> gglib_core::domain::InferenceConfig {
+    let request_override = gglib_core::domain::InferenceConfig {
+        temperature: request.temperature,
+        top_p: request.top_p,
+        top_k: request.top_k,
+        max_tokens: request.max_tokens,
+        repeat_penalty: request.repeat_penalty,
+        stop: request.stop.clone(),
+    };
+
+    gglib_core::domain::InferenceConfig::resolve_with_hierarchy(
+        Some(&request_override),
+        model_defaults,
+        global_defaults,
+    )
+}
+
+fn build_forward_body(
+    model: &str,
+    messages: Vec<ChatMessage>,
+    stream: bool,
+    resolved: &gglib_core::domain::InferenceConfig,
+) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "messages": messages,
+        "stream": stream,
+        "max_tokens": resolved.max_tokens,
+        "temperature": resolved.temperature,
+        "top_p": resolved.top_p,
+        "top_k": resolved.top_k,
+        "repeat_penalty": resolved.repeat_penalty,
+        "stop": resolved.stop,
+    })
+}
+
 /// Proxy chat completion requests to a running llama-server.
 ///
 /// POST /api/chat
@@ -436,29 +476,8 @@ pub async fn proxy_chat(
         .ok()
         .and_then(|s| s.inference_defaults);
 
-    // Resolve inference parameters using hierarchy:
-    // Request → Model → Global → Hardcoded defaults
-    let mut resolved = gglib_core::domain::InferenceConfig {
-        temperature: request.temperature,
-        top_p: request.top_p,
-        top_k: request.top_k,
-        max_tokens: request.max_tokens,
-        repeat_penalty: request.repeat_penalty,
-        stop: request.stop.clone(),
-    };
-
-    // Apply model defaults (if missing)
-    if let Some(model_defaults) = model_defaults {
-        resolved.merge_with(&model_defaults);
-    }
-
-    // Apply global settings defaults (if missing)
-    if let Some(global_defaults) = global_defaults {
-        resolved.merge_with(&global_defaults);
-    }
-
-    // Apply hardcoded defaults for any still-missing values
-    resolved.merge_with(&gglib_core::domain::InferenceConfig::with_hardcoded_defaults());
+    let resolved =
+        resolve_chat_inference_config(&request, model_defaults.as_ref(), global_defaults.as_ref());
 
     tracing::debug!(
         port = request.port,
@@ -528,17 +547,8 @@ pub async fn proxy_chat(
     let server_url = format!("http://127.0.0.1:{}/v1/chat/completions", request.port);
 
     // Build the forwarded request body with resolved inference parameters
-    let mut forward_body = serde_json::json!({
-        "model": request.model,
-        "messages": final_messages,
-        "stream": request.stream,
-        "max_tokens": resolved.max_tokens,
-        "temperature": resolved.temperature,
-        "top_p": resolved.top_p,
-        "top_k": resolved.top_k,
-        "repeat_penalty": resolved.repeat_penalty,
-        "stop": resolved.stop,
-    });
+    let mut forward_body =
+        build_forward_body(&request.model, final_messages, request.stream, &resolved);
 
     // Inject tools only when the model supports them.
     // Note: request.messages was consumed above, so we pass fields individually.
@@ -629,6 +639,28 @@ mod tests {
     use super::*;
     use gglib_core::domain::ModelCapabilities;
 
+    fn sample_request() -> ChatProxyRequest {
+        ChatProxyRequest {
+            port: 8080,
+            model: "test-model".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            stream: false,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            repeat_penalty: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
     #[test]
     fn test_tools_stripped_when_not_supported() {
         let tools = Some(vec![
@@ -693,5 +725,62 @@ mod tests {
         assert!(body_no_cap.get("tool_choice").is_none());
         assert!(body_with_cap.get("tools").is_none());
         assert!(body_with_cap.get("tool_choice").is_none());
+    }
+
+    #[test]
+    fn test_resolve_chat_inference_config_precedence_for_stop() {
+        let mut request = sample_request();
+        request.top_p = Some(0.72);
+        request.stop = Some(vec!["<|request|>".to_string()]);
+
+        let model_defaults = gglib_core::domain::InferenceConfig {
+            temperature: Some(0.4),
+            stop: Some(vec!["<|model|>".to_string()]),
+            ..Default::default()
+        };
+        let global_defaults = gglib_core::domain::InferenceConfig {
+            top_p: Some(0.95),
+            top_k: Some(88),
+            stop: Some(vec!["<|global|>".to_string()]),
+            ..Default::default()
+        };
+
+        let resolved =
+            resolve_chat_inference_config(&request, Some(&model_defaults), Some(&global_defaults));
+
+        assert_eq!(resolved.stop, Some(vec!["<|request|>".to_string()]));
+        assert_eq!(resolved.top_p, Some(0.72));
+        assert_eq!(resolved.temperature, Some(0.4));
+        assert_eq!(resolved.top_k, Some(88));
+    }
+
+    #[test]
+    fn test_resolve_chat_inference_config_stop_none_when_unspecified() {
+        let request = sample_request();
+
+        let resolved = resolve_chat_inference_config(&request, None, None);
+
+        assert!(resolved.stop.is_none());
+    }
+
+    #[test]
+    fn test_build_forward_body_includes_resolved_stop() {
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: Some("hello".to_string()),
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let resolved = gglib_core::domain::InferenceConfig {
+            stop: Some(vec!["<|im_end|>".to_string(), "</s>".to_string()]),
+            ..Default::default()
+        };
+
+        let body = build_forward_body("test-model", messages, false, &resolved);
+        assert_eq!(
+            body.get("stop"),
+            Some(&serde_json::json!(["<|im_end|>", "</s>"]))
+        );
     }
 }

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -99,16 +99,48 @@ pub async fn compose(
     banner: &BannerInfo,
 ) -> Result<(Arc<dyn AgentLoopPort>, Option<ProcessHandle>)> {
     // 1. Resolve the LLM port — reuse or auto-start.
-    let (port, maybe_handle) = resolve_port(ctx, params, banner).await?;
+    let (port, maybe_handle, started_model) = resolve_port(ctx, params, banner).await?;
 
-    // 2. Initialise MCP servers (CLI bootstrap intentionally skips this).
+    // 2. Resolve sampling through the shared hierarchy:
+    // request override -> model defaults -> global defaults -> hardcoded fallback.
+    let settings = ctx
+        .app
+        .settings()
+        .get()
+        .await
+        .context("failed to load settings for inference resolution")?;
+
+    let mut model_defaults = started_model
+        .as_ref()
+        .and_then(|m| m.inference_defaults.clone());
+    if model_defaults.is_none() && !params.model_identifier.is_empty() {
+        match ctx.app.models().get(&params.model_identifier).await {
+            Ok(Some(model)) => {
+                model_defaults = model.inference_defaults;
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!(
+                model = %params.model_identifier,
+                error = %e,
+                "Failed to load model defaults for inference resolution"
+            ),
+        }
+    }
+
+    let resolved_sampling = Some(InferenceConfig::resolve_with_hierarchy(
+        sampling.as_ref(),
+        model_defaults.as_ref(),
+        settings.inference_defaults.as_ref(),
+    ));
+
+    // 3. Initialise MCP servers (CLI bootstrap intentionally skips this).
     //    A failure is logged as a warning rather than aborting the session:
     //    the agent can still run without tools.
     if let Err(e) = ctx.mcp.initialize().await {
         tracing::warn!("MCP initialisation failed — tools may be unavailable: {e}");
     }
 
-    // 3. Compose the agent loop.  When tools are specified the loop is
+    // 4. Compose the agent loop.  When tools are specified the loop is
     //    restricted to the named allowlist; otherwise all MCP tools are visible.
     let tool_filter = if params.tools.is_empty() {
         None
@@ -123,7 +155,7 @@ pub async fn compose(
         Arc::clone(&ctx.mcp),
         tool_filter,
         sandbox_root,
-        sampling,
+        resolved_sampling,
     );
 
     Ok((agent, maybe_handle))
@@ -143,10 +175,10 @@ async fn resolve_port(
     ctx: &CliContext,
     params: &AgentSessionParams,
     banner: &BannerInfo,
-) -> Result<(u16, Option<ProcessHandle>)> {
+) -> Result<(u16, Option<ProcessHandle>, Option<gglib_core::Model>)> {
     if let Some(port) = params.port {
         tracing::debug!("reusing user-supplied llama-server on port {port}");
-        return Ok((port, None));
+        return Ok((port, None, None));
     }
 
     // Auto-start: look up the model, then ask the process runner to start it.
@@ -223,7 +255,7 @@ async fn resolve_port(
         style::print_banner_close();
     }
 
-    Ok((handle.port, Some(handle)))
+    Ok((handle.port, Some(handle), Some(model)))
 }
 
 /// Print non-default sampling parameter lines in the info banner.

--- a/crates/gglib-cli/src/handlers/inference/shared.rs
+++ b/crates/gglib-cli/src/handlers/inference/shared.rs
@@ -17,24 +17,16 @@ use gglib_runtime::llama::{ContextResolution, ContextResolutionSource};
 /// defaults → hardcoded defaults. Each layer fills in only `None` fields.
 pub async fn resolve_inference_config(
     ctx: &CliContext,
-    mut config: InferenceConfig,
+    config: InferenceConfig,
     model: &gglib_core::Model,
 ) -> Result<InferenceConfig> {
-    // Apply model defaults
-    if let Some(ref model_defaults) = model.inference_defaults {
-        config.merge_with(model_defaults);
-    }
-
-    // Apply global defaults
     let settings = ctx.app.settings().get().await?;
-    if let Some(ref global_defaults) = settings.inference_defaults {
-        config.merge_with(global_defaults);
-    }
 
-    // Apply hardcoded defaults
-    config.merge_with(&InferenceConfig::with_hardcoded_defaults());
-
-    Ok(config)
+    Ok(InferenceConfig::resolve_with_hierarchy(
+        Some(&config),
+        model.inference_defaults.as_ref(),
+        settings.inference_defaults.as_ref(),
+    ))
 }
 
 /// Resolve the maximum agent iterations via a 3-level fallback chain.

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -134,6 +134,30 @@ impl InferenceConfig {
         }
     }
 
+    /// Resolve inference values through the standard precedence chain.
+    ///
+    /// Order: request override -> model defaults -> global defaults -> hardcoded fallback.
+    ///
+    /// Note: hardcoded fallback intentionally leaves `stop` as `None`.
+    #[must_use]
+    pub fn resolve_with_hierarchy(
+        request_override: Option<&Self>,
+        model_defaults: Option<&Self>,
+        global_defaults: Option<&Self>,
+    ) -> Self {
+        let mut resolved = request_override.cloned().unwrap_or_default();
+
+        if let Some(model_defaults) = model_defaults {
+            resolved.merge_with(model_defaults);
+        }
+        if let Some(global_defaults) = global_defaults {
+            resolved.merge_with(global_defaults);
+        }
+
+        resolved.merge_with(&Self::with_hardcoded_defaults());
+        resolved
+    }
+
     /// Create a new config with all fields set to sensible defaults.
     ///
     /// These are the hardcoded fallback values used when no other
@@ -199,6 +223,12 @@ impl InferenceConfig {
         if let Some(repeat_penalty) = self.repeat_penalty {
             args.push("--repeat-penalty".to_string());
             args.push(repeat_penalty.to_string());
+        }
+        if let Some(stop) = &self.stop {
+            for sequence in stop {
+                args.push("--stop".to_string());
+                args.push(sequence.clone());
+            }
         }
 
         args
@@ -272,6 +302,68 @@ mod tests {
         assert_eq!(config.max_tokens, Some(2048));
         assert_eq!(config.repeat_penalty, Some(1.0));
         assert!(config.stop.is_none());
+    }
+
+    #[test]
+    fn test_resolve_with_hierarchy_precedence_for_stop() {
+        let request = InferenceConfig {
+            top_p: Some(0.77),
+            stop: Some(vec!["<|request|>".to_string()]),
+            ..Default::default()
+        };
+        let model_defaults = InferenceConfig {
+            temperature: Some(0.42),
+            stop: Some(vec!["<|model|>".to_string()]),
+            ..Default::default()
+        };
+        let global_defaults = InferenceConfig {
+            top_p: Some(0.95),
+            top_k: Some(99),
+            stop: Some(vec!["<|global|>".to_string()]),
+            ..Default::default()
+        };
+
+        let resolved = InferenceConfig::resolve_with_hierarchy(
+            Some(&request),
+            Some(&model_defaults),
+            Some(&global_defaults),
+        );
+
+        assert_eq!(resolved.stop, Some(vec!["<|request|>".to_string()]));
+        assert_eq!(resolved.top_p, Some(0.77));
+        assert_eq!(resolved.temperature, Some(0.42));
+        assert_eq!(resolved.top_k, Some(99));
+    }
+
+    #[test]
+    fn test_resolve_with_hierarchy_keeps_stop_none_without_defaults() {
+        let resolved = InferenceConfig::resolve_with_hierarchy(None, None, None);
+
+        assert_eq!(resolved.temperature, Some(0.7));
+        assert_eq!(resolved.top_p, Some(0.95));
+        assert_eq!(resolved.top_k, Some(40));
+        assert_eq!(resolved.max_tokens, Some(2048));
+        assert_eq!(resolved.repeat_penalty, Some(1.0));
+        assert!(resolved.stop.is_none());
+    }
+
+    #[test]
+    fn test_to_cli_args_includes_repeated_stop_flags() {
+        let config = InferenceConfig {
+            stop: Some(vec!["<|im_end|>".to_string(), "</s>".to_string()]),
+            ..Default::default()
+        };
+
+        let args = config.to_cli_args();
+        assert_eq!(
+            args,
+            vec![
+                "--stop".to_string(),
+                "<|im_end|>".to_string(),
+                "--stop".to_string(),
+                "</s>".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -267,4 +267,52 @@ mod tests {
             "build_and_spawn should succeed with valid bootstrap path"
         );
     }
+
+    /// Test that stop sequences are forwarded as repeated --stop flags.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_build_and_spawn_forwards_stop_flags() {
+        let temp_dir = TempDir::new().unwrap();
+        let binary_path = temp_dir.path().join("llama-server");
+        let args_path = temp_dir.path().join("args.txt");
+
+        // Fake binary records argv to args_path and exits.
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\nexit 0\n",
+            args_path.display()
+        );
+        fs::write(&binary_path, script).unwrap();
+        fs::set_permissions(&binary_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let config = ServerConfig {
+            model_id: 1,
+            model_name: "test-model".to_string(),
+            model_path: PathBuf::from("/tmp/test.gguf"),
+            base_port: 9000,
+            port: Some(8080),
+            context_size: None,
+            gpu_layers: None,
+            jinja: false,
+            reasoning_format: None,
+            inference_config: Some(gglib_core::domain::InferenceConfig {
+                stop: Some(vec!["<|im_end|>".to_string(), "</s>".to_string()]),
+                ..Default::default()
+            }),
+            extra_args: vec![],
+        };
+
+        let mut child = build_and_spawn(Some(&binary_path), &config, 8080).unwrap();
+        let status = child.wait().await.unwrap();
+        assert!(status.success());
+
+        let args_text = fs::read_to_string(&args_path).unwrap();
+        let args: Vec<&str> = args_text.lines().collect();
+        let stop_values: Vec<&str> = args
+            .windows(2)
+            .filter(|w| w[0] == "--stop")
+            .map(|w| w[1])
+            .collect();
+
+        assert_eq!(stop_values, vec!["<|im_end|>", "</s>"]);
+    }
 }

--- a/crates/gglib-runtime/src/llama/invocation.rs
+++ b/crates/gglib-runtime/src/llama/invocation.rs
@@ -318,4 +318,35 @@ mod tests {
             Some(ContextResolutionSource::ExplicitFlag)
         );
     }
+
+    #[test]
+    fn builder_adds_repeated_stop_flags_from_inference_config() {
+        let inference = InferenceConfig {
+            stop: Some(vec!["<|im_end|>".to_string(), "</s>".to_string()]),
+            ..Default::default()
+        };
+
+        let cmd = LlamaCommandBuilder::new("/usr/bin/llama-server", "/models/test.gguf")
+            .inference_config(inference)
+            .build();
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+
+        let stop_pairs: Vec<(String, String)> = args
+            .windows(2)
+            .filter(|w| w[0] == "--stop")
+            .map(|w| (w[0].clone(), w[1].clone()))
+            .collect();
+
+        assert_eq!(
+            stop_pairs,
+            vec![
+                ("--stop".to_string(), "<|im_end|>".to_string()),
+                ("--stop".to_string(), "</s>".to_string()),
+            ]
+        );
+    }
 }

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -218,6 +218,52 @@ fn tool_def_to_openai(def: &ToolDefinition) -> Value {
     })
 }
 
+fn apply_sampling_to_body(body: &mut Value, sampling: &InferenceConfig) {
+    if let Some(t) = sampling.temperature {
+        body["temperature"] = json!(t);
+    }
+    if let Some(p) = sampling.top_p {
+        body["top_p"] = json!(p);
+    }
+    if let Some(k) = sampling.top_k {
+        body["top_k"] = json!(k);
+    }
+    if let Some(m) = sampling.max_tokens {
+        body["max_tokens"] = json!(m);
+    }
+    if let Some(r) = sampling.repeat_penalty {
+        body["repeat_penalty"] = json!(r);
+    }
+    if let Some(stop) = &sampling.stop {
+        body["stop"] = json!(stop);
+    }
+}
+
+fn build_chat_request_body(
+    model: &str,
+    openai_messages: Vec<Value>,
+    openai_tools: Vec<Value>,
+    sampling: Option<&InferenceConfig>,
+) -> Value {
+    let mut body = json!({
+        "model": model,
+        "messages": openai_messages,
+        "stream": true,
+        "return_progress": true,
+    });
+
+    if !openai_tools.is_empty() {
+        body["tools"] = json!(openai_tools);
+        body["tool_choice"] = json!("auto");
+    }
+
+    if let Some(sampling) = sampling {
+        apply_sampling_to_body(&mut body, sampling);
+    }
+
+    body
+}
+
 // =============================================================================
 // LlmCompletionPort implementation
 // =============================================================================
@@ -231,34 +277,12 @@ impl LlmCompletionPort for LlmCompletionAdapter {
     ) -> Result<Pin<Box<dyn Stream<Item = Result<LlmStreamEvent>> + Send>>> {
         let openai_messages: Vec<Value> = messages.iter().map(message_to_openai).collect();
         let openai_tools: Vec<Value> = tools.iter().map(tool_def_to_openai).collect();
-
-        let mut body = json!({
-            "model": self.model,
-            "messages": openai_messages,
-            "stream": true,
-            "return_progress": true,
-        });
-        if !openai_tools.is_empty() {
-            body["tools"] = json!(openai_tools);
-            body["tool_choice"] = json!("auto");
-        }
-        if let Some(ref s) = self.sampling {
-            if let Some(t) = s.temperature {
-                body["temperature"] = json!(t);
-            }
-            if let Some(p) = s.top_p {
-                body["top_p"] = json!(p);
-            }
-            if let Some(k) = s.top_k {
-                body["top_k"] = json!(k);
-            }
-            if let Some(m) = s.max_tokens {
-                body["max_tokens"] = json!(m);
-            }
-            if let Some(r) = s.repeat_penalty {
-                body["repeat_penalty"] = json!(r);
-            }
-        }
+        let body = build_chat_request_body(
+            &self.model,
+            openai_messages,
+            openai_tools,
+            self.sampling.as_ref(),
+        );
 
         // Gate the connect + first-byte phase with a hard timeout so a
         // stalled or unresponsive llama-server doesn't hang the agent task
@@ -314,5 +338,48 @@ impl LlmCompletionPort for LlmCompletionAdapter {
         };
 
         Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_chat_request_body_includes_stop_sampling() {
+        let sampling = InferenceConfig {
+            stop: Some(vec!["<|im_end|>".to_string(), "</s>".to_string()]),
+            ..Default::default()
+        };
+
+        let body = build_chat_request_body(
+            "test-model",
+            vec![json!({"role":"user","content":"hello"})],
+            Vec::new(),
+            Some(&sampling),
+        );
+
+        assert_eq!(
+            body.get("stop"),
+            Some(&json!(["<|im_end|>", "</s>"])),
+            "resolved stop sequences must be present in outbound LLM payload"
+        );
+    }
+
+    #[test]
+    fn test_build_chat_request_body_omits_stop_when_none() {
+        let sampling = InferenceConfig {
+            temperature: Some(0.8),
+            ..Default::default()
+        };
+
+        let body = build_chat_request_body(
+            "test-model",
+            vec![json!({"role":"user","content":"hello"})],
+            Vec::new(),
+            Some(&sampling),
+        );
+
+        assert!(body.get("stop").is_none());
     }
 }


### PR DESCRIPTION
## Summary\n- centralize inference precedence resolution in gglib-core via InferenceConfig::resolve_with_hierarchy\n- switch CLI shared resolver, agent chat compose flow, axum chat proxy, and app-services server config to use the centralized hierarchy\n- forward resolved stop sequences end-to-end in runtime payload and llama CLI args\n- add targeted tests for stop precedence, stop-none baseline, and outbound stop propagation\n\n## Scope Guardrails\n- includes PR 3 only\n- no CLI user-flag surface changes (PR 4)\n- no frontend UI changes (PR 5)\n\n## Validation\n- cargo test -p gglib-core\n- cargo test -p gglib-core domain::inference::tests::test_resolve_with_hierarchy_precedence_for_stop\n- cargo test -p gglib-axum\n- cargo test -p gglib-axum chat_api::tests::test_build_forward_body_includes_resolved_stop\n- cargo test -p gglib-app-services -F gglib-runtime/cli test_build_config_\n- cargo test -p gglib-runtime -F cli stop\n- cargo test -p gglib-cli --no-run\n