### PR TITLE
PR6: proxy stop compatibility + pass-through invariants

### DIFF
--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -109,6 +109,16 @@ pub(crate) struct ChatRoutingEnvelope {
     pub num_ctx: Option<u64>,
 }
 
+/// OpenAI-compatible `stop` field representation.
+///
+/// The OpenAI API accepts either a single string or an array of strings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum StopSequences {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
 /// Full OpenAI-compatible chat completion request.
 ///
 /// This type is kept for response construction, testing, and documentation
@@ -143,9 +153,9 @@ pub struct ChatCompletionRequest {
     /// Number of completions to generate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<u32>,
-    /// Stop sequences.
+    /// Stop sequences (`"END"` or `["END", "STOP"]`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop: Option<Vec<String>>,
+    pub stop: Option<StopSequences>,
     /// Context window size (Ollama-compatible parameter).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_ctx: Option<u64>,
@@ -661,10 +671,24 @@ mod tests {
         assert_eq!(req.top_p, Some(0.9));
         assert_eq!(req.max_tokens, Some(512));
         assert_eq!(req.n, Some(1));
-        assert_eq!(req.stop.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            req.stop,
+            Some(StopSequences::Multiple(vec!["END".to_string()]))
+        );
         assert_eq!(req.num_ctx, Some(8192));
         assert_eq!(req.tools.as_ref().unwrap().len(), 1);
         assert_eq!(req.tools.as_ref().unwrap()[0].function.name, "get_weather");
+    }
+
+    #[test]
+    fn chat_request_accepts_stop_as_bare_string() {
+        let json = r#"{
+            "model": "llama-3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": "END"
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.stop, Some(StopSequences::Single("END".to_string())));
     }
 
     #[test]

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -144,7 +144,7 @@ async fn chat_completions(
     // all other fields are ignored by serde and the raw bytes are forwarded
     // unchanged. This makes the proxy immune to content-array messages,
     // stop as a bare string, and any future OpenAI request extensions.
-    let envelope: ChatRoutingEnvelope = match serde_json::from_slice(&body) {
+    let envelope: ChatRoutingEnvelope = match parse_routing_envelope(&body) {
         Ok(env) => env,
         Err(e) => {
             error!("Failed to parse request: {e}");
@@ -195,6 +195,10 @@ async fn chat_completions(
     forward_chat_completion(&state.client, &upstream_url, &headers, body, is_streaming).await
 }
 
+fn parse_routing_envelope(body: &[u8]) -> Result<ChatRoutingEnvelope, serde_json::Error> {
+    serde_json::from_slice(body)
+}
+
 /// Convert ModelRuntimeError to HTTP response with appropriate status code.
 fn handle_runtime_error(err: ModelRuntimeError) -> Response {
     let (status, error_response) = match &err {
@@ -229,5 +233,31 @@ mod tests {
     async fn test_health_check() {
         let response = health_check().await.into_response();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn parse_routing_envelope_accepts_stop_string_without_body_mutation() {
+        let payload = br#"{"model":"llama-3","messages":[],"stop":"END"}"#.to_vec();
+        let original = payload.clone();
+
+        let env = parse_routing_envelope(&payload).unwrap();
+        assert_eq!(env.model, "llama-3");
+        assert_eq!(payload, original);
+
+        let raw: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(raw["stop"], serde_json::Value::String("END".to_string()));
+    }
+
+    #[test]
+    fn parse_routing_envelope_accepts_stop_array_without_body_mutation() {
+        let payload = br#"{"model":"llama-3","messages":[],"stop":["END","STOP"]}"#.to_vec();
+        let original = payload.clone();
+
+        let env = parse_routing_envelope(&payload).unwrap();
+        assert_eq!(env.model, "llama-3");
+        assert_eq!(payload, original);
+
+        let raw: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(raw["stop"], serde_json::json!(["END", "STOP"]));
     }
 }

--- a/crates/gglib-runtime/src/proxy/models.rs
+++ b/crates/gglib-runtime/src/proxy/models.rs
@@ -93,6 +93,16 @@ pub struct ChatRoutingEnvelope {
     pub num_ctx: Option<u64>,
 }
 
+/// OpenAI-compatible `stop` field representation.
+///
+/// The OpenAI API accepts either a single string or an array of strings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum StopSequences {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
 /// Request to /v1/chat/completions endpoint
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChatCompletionRequest {
@@ -115,9 +125,9 @@ pub struct ChatCompletionRequest {
     /// Number of completions to generate
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<u32>,
-    /// Stop sequences
+    /// Stop sequences (`"END"` or `["END", "STOP"]`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop: Option<Vec<String>>,
+    pub stop: Option<StopSequences>,
     /// Context window size (Ollama-compatible parameter)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_ctx: Option<u64>,

--- a/tests/unit/proxy/test_models.rs
+++ b/tests/unit/proxy/test_models.rs
@@ -127,9 +127,69 @@ fn test_chat_completion_request_deserialize_full() {
     assert_eq!(request.n, Some(1));
     assert_eq!(
         request.stop,
-        Some(vec!["END".to_string(), "STOP".to_string()])
+        Some(gglib_runtime::proxy::models::StopSequences::Multiple(vec![
+            "END".to_string(),
+            "STOP".to_string(),
+        ]))
     );
     assert_eq!(request.num_ctx, Some(8192));
+}
+
+#[test]
+fn test_chat_completion_request_deserialize_stop_as_string() {
+    let json_str = r#"{
+        "model": "mistral-7b",
+        "messages": [
+            {"role": "user", "content": "What is Rust?"}
+        ],
+        "stop": "END"
+    }"#;
+
+    let request: gglib_runtime::proxy::models::ChatCompletionRequest =
+        serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(
+        request.stop,
+        Some(gglib_runtime::proxy::models::StopSequences::Single(
+            "END".to_string(),
+        ))
+    );
+}
+
+/// Regression lock: extracting routing fields must not normalize pass-through
+/// fields such as stop string/array shape.
+#[test]
+fn test_routing_envelope_keeps_stop_string_shape_in_raw_body() {
+    let json_str = r#"{
+        "model": "llama-3",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stop": "END"
+    }"#;
+
+    let env: gglib_runtime::proxy::models::ChatRoutingEnvelope =
+        serde_json::from_str(json_str).unwrap();
+    assert_eq!(env.model, "llama-3");
+
+    let raw: serde_json::Value = serde_json::from_str(json_str).unwrap();
+    assert_eq!(raw["stop"], serde_json::Value::String("END".to_string()));
+}
+
+/// Regression lock: stop arrays keep their original structure through routing
+/// envelope extraction.
+#[test]
+fn test_routing_envelope_keeps_stop_array_shape_in_raw_body() {
+    let json_str = r#"{
+        "model": "llama-3",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stop": ["END", "STOP"]
+    }"#;
+
+    let env: gglib_runtime::proxy::models::ChatRoutingEnvelope =
+        serde_json::from_str(json_str).unwrap();
+    assert_eq!(env.model, "llama-3");
+
+    let raw: serde_json::Value = serde_json::from_str(json_str).unwrap();
+    assert_eq!(raw["stop"], serde_json::json!(["END", "STOP"]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a `StopSequences` untagged enum in proxy chat request models to accept both OpenAI-compatible forms of `stop` (`"END"` and `["END"]`)
- mirror the same stop representation in runtime proxy models for contract parity
- route chat envelope parsing through a small helper in proxy server and add tests that lock raw request-body shape invariants for stop string/array forms
- extend proxy model tests to cover full request deserialization with bare-string stop values

## Scope
- proxy/runtime proxy model compatibility only
- proxy invariants and regression tests only
- no UI/serve-session/axum/cli behavior changes

## Validation
- `cargo test -p gglib-proxy` (all passing)
- `cargo test -p gglib-runtime` currently fails due unrelated pre-existing compile errors in `crates/gglib-runtime/src/llama/detect/cuda.rs` (`Result<T, E>` generic arity)
