### PR TITLE
PR7: docs + CI deterministic stop parity closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,11 @@ jobs:
           cargo test -p gglib-axum --verbose 2>&1 | tee rust-test-gglib-axum.txt
           cargo test -p gglib-tauri --verbose 2>&1 | tee rust-test-gglib-tauri.txt
 
+      - name: Run stop-focused Rust regressions
+        run: |
+          cargo test -p gglib-core stop --verbose 2>&1 | tee rust-test-stop-core.txt
+          cargo test -p gglib-proxy stop --verbose 2>&1 | tee rust-test-stop-proxy.txt
+
       - name: Run doctests
         run: cargo test --doc --verbose
 
@@ -166,6 +171,8 @@ jobs:
             rust-test-gglib-cli.txt
             rust-test-gglib-axum.txt
             rust-test-gglib-tauri.txt
+            rust-test-stop-core.txt
+            rust-test-stop-proxy.txt
           retention-days: 30
 
   test-frontend:
@@ -187,6 +194,9 @@ jobs:
       - name: Run TypeScript tests
         run: npm run test:run -- --reporter=json --reporter=default --outputFile=ts-test-results.json 2>&1 | tee ts-test-output.txt
 
+      - name: Run stop-focused TypeScript regressions
+        run: npm run test:run -- tests/ts/components/InferenceParametersForm.test.tsx tests/ts/contracts/tauri-serve-model.test.ts 2>&1 | tee ts-test-stop-output.txt
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -195,6 +205,7 @@ jobs:
           path: |
             ts-test-output.txt
             ts-test-results.json
+            ts-test-stop-output.txt
           retention-days: 30
 
   clippy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,17 @@ When adding a new long-running operation:
 
 ---
 
+## Deterministic Stop Contract
+
+`stop` behavior is a cross-surface contract and must remain uniform.
+
+- Do not implement stop precedence separately in adapters. Use the shared inference resolution path in core/runtime.
+- Keep request-level overrides (`--stop`, API `stop`, UI serve overrides) higher priority than model and global defaults.
+- Proxy remains transport-only: parse only routing envelope fields and forward raw request bytes unchanged.
+- Any stop-shape/schema change requires synchronized updates across Rust + TypeScript transport types and regression tests.
+
+---
+
 ## Concurrency Model
 
 The codebase uses Tokio for the async runtime. Understanding the boundary between async Tokio tasks and OS threads is critical.
@@ -419,6 +430,7 @@ Every PR must pass the following gates in order. They are not advisory.
 | **Architecture** | `./scripts/check-tauri-commands.sh`, `check-frontend-ipc.sh`, `check_transport_branching.sh` | Tauri policy; no IPC in product routes; no frontend transport branching |
 | **Clippy** | `cargo clippy --all-targets --all-features -- -D warnings` | No warnings, ever |
 | **Rust tests** | `cargo test` (aggregate + per-crate) | Correctness |
+| **Stop-focused regressions** | `cargo test -p gglib-core stop`, `cargo test -p gglib-proxy stop`, `npm run test:run -- tests/ts/components/InferenceParametersForm.test.tsx tests/ts/contracts/tauri-serve-model.test.ts` | Deterministic stop parity across CLI, Axum/Tauri transport, and proxy |
 | **Doc tests** | `cargo test --doc --verbose` | Doc examples compile and run |
 | **Frontend tests** | `npm run test:run` | TypeScript correctness |
 | **Cross-OS check** | `cargo check` on Linux/macOS/Windows | No platform-specific breakage |
@@ -444,5 +456,6 @@ Before requesting review, confirm each item:
 - [ ] Environment variable merging uses read-then-append, not a bare `.env()` that overwrites.
 - [ ] Any feature gated behind `#[cfg(feature = "...")]` is declared correctly in all consuming `Cargo.toml` files.
 - [ ] If the change adds a new long-running operation, all three surfaces (CLI, Axum, Tauri) are wired up.
+- [ ] If the change touches stop behavior, stop-focused Rust and TypeScript regressions pass and surface parity remains intact.
 - [ ] `Cargo.lock` is up to date and committed.
 - [ ] No new dependency has been introduced from a higher layer to a lower layer.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,15 @@ All interfaces share the same database and model directory. Pick whichever fits 
 | **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `0.0.0.0:9887` |
 | **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — works with OpenWebUI, any OpenAI SDK |
 
+### Deterministic Stop Behavior
+
+- Deterministic model-level stop defaults are extracted from GGUF tokenizer metadata at registration time when authoritative keys are present.
+- Stop resolution is consistent across CLI, Axum API, and Tauri/web UI:
+        1. request/command override (`--stop`, UI serve override, API `stop`)
+        2. per-model inference defaults
+        3. global inference defaults
+- The OpenAI proxy stays pass-through and accepts both valid OpenAI stop shapes (`"stop": "END"` and `"stop": ["END", "STOP"]`).
+
 **Shell completions** — enable tab completion for your shell:
 
 | Shell | Setup |

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -178,6 +178,13 @@ gglib q "Summarize this" --stop "<|im_end|>" --stop "</s>"
 
 Inference commands accept repeatable `--stop` flags, matching runtime CLI forwarding:
 
+- `q`, `chat`, and `serve` all use the same shared inference resolver.
+- Effective stop precedence is:
+  1. explicit `--stop` on the current command
+  2. model defaults (including deterministic GGUF-derived defaults captured at registration)
+  3. global inference defaults from settings
+- Per-model defaults can be edited without touching other inference fields using `gglib model update --stop ...` and `gglib model update --clear-stop`.
+
 ```bash
 # Serve with explicit stop sequences
 gglib serve 1 --stop "<|im_end|>" --stop "</s>"


### PR DESCRIPTION
## Summary
- document deterministic stop behavior in the root README, including cross-surface precedence and proxy shape compatibility
- expand CLI README stop docs with shared resolver precedence and deterministic GGUF default behavior
- add contributor guidance for the deterministic stop contract plus CI/checklist expectations in CONTRIBUTING
- add focused CI regression steps and artifacts for stop behavior in Rust (`gglib-core`, `gglib-proxy`) and TypeScript (`InferenceParametersForm`, `tauri-serve-model`)

## Scope
- docs and CI workflow only
- no runtime/model/adapter logic changes

## Validation
- `cargo test -p gglib-core stop`
- `cargo test -p gglib-proxy stop`
- `npm run test:run -- tests/ts/components/InferenceParametersForm.test.tsx tests/ts/contracts/tauri-serve-model.test.ts`
