### PR TITLE
chore: switch license from GPLv3 to AGPL-3.0 with dual licensing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
 dependencies = [
  "clap",
 ]
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-agent"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-app"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-app-services"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "dirs",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-axum"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-bootstrap"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1958,14 +1958,14 @@ dependencies = [
 
 [[package]]
 name = "gglib-build-info"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "vergen-gix",
 ]
 
 [[package]]
 name = "gglib-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-db"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-download"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-gguf"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "gglib-core",
  "memmap2",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-hf"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "gglib-core",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-mcp"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-proxy"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-runtime"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-tauri"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "gglib-app-services",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 [workspace.package]
 version = "0.7.4"
 edition = "2024"
-license = "GPLv3"
+license = "AGPL-3.0"
 repository = "https://github.com/mmogr/gglib"
 authors = ["mmogr"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 # Shared package metadata for all workspace crates
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mmogr/gglib"

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,17 +7,15 @@
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Affero General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage](https://github.com/mmogr/gglib/actions/workflows/coverage.yml/badge.svg)](https://github.com/mmogr/gglib/actions/workflows/coverage.yml)
 [![Release](https://github.com/mmogr/gglib/actions/workflows/release.yml/badge.svg)](https://github.com/mmogr/gglib/actions/workflows/release.yml)
 ![Version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/version.json)
-[![License](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 
 <!-- crate-docs:start -->
 
@@ -506,3 +506,12 @@ Auto-generated from source and updated with every release.
 ### Integrations
 ![HuggingFace](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Hub-yellow?style=flat-square)
 ![Llama.cpp](https://img.shields.io/badge/Llama.cpp-Inference-lightgrey?style=flat-square)
+
+## License
+
+GGLib is open source under the [GNU Affero General Public License v3.0](LICENSE) (AGPL-3.0).
+
+- **Personal and open source use** is free.
+- **Commercial use** — building a product, running a SaaS, or embedding GGLib in paid software — requires a commercial license.
+
+For commercial licensing enquiries, contact [@mmogr](https://github.com/mmogr) on GitHub.

--- a/crates/gglib-axum/Cargo.toml
+++ b/crates/gglib-axum/Cargo.toml
@@ -3,7 +3,7 @@ name = "gglib-axum"
 version.workspace = true
 edition.workspace = true
 description = "Axum web server adapter for gglib"
-license = "GPLv3"
+license.workspace = true
 publish = false
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gglib-gui",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Modern GUI for GGLib GGUF Model Manager",
   "author": "mmogr",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.4",
   "description": "Modern GUI for GGLib GGUF Model Manager",
   "author": "mmogr",
-  "license": "GPLv3",
+  "license": "AGPL-3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mmogr/gglib.git"

--- a/src-tauri/src/menu/build.rs
+++ b/src-tauri/src/menu/build.rs
@@ -19,7 +19,7 @@ pub fn build_app_menu(app: &AppHandle) -> Result<(Menu<Wry>, AppMenu), tauri::Er
         .version(Some(gglib_build_info::SEMVER))
         .short_version(Some(gglib_build_info::ABOUT_SHORT_VERSION))
         .authors(Some(vec!["mmogr".to_string()]))
-        .license(Some("GPLv3"))
+        .license(Some("AGPL-3.0"))
         .website(Some("https://github.com/mmogr/gglib"))
         .website_label(Some("GitHub"))
         .build();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "GGLib GUI",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "identifier": "com.gglib.gui",
   "build": {
     "beforeBuildCommand": "npm run build:tauri",


### PR DESCRIPTION
## Summary

Switches the project license from GPLv3 to **AGPL-3.0**, and establishes a dual-licensing model (open source + commercial).

### Why AGPL-3.0?

GPLv3 has a well-known SaaS loophole: a company can run the software as a hosted service and distribute no source code, owing nothing. AGPL-3.0 closes this — anyone running GGLib as a network-accessible service must open-source their modifications or obtain a commercial license.

As sole copyright holder, the dual-licensing model means:
- **Personal and open source use** remains free forever under AGPL-3.0
- **Commercial use** (SaaS, embedded products, proprietary forks) requires a commercial license from the copyright holder

### Changes

| File | Change |
|---|---|
| `LICENSE` | Replaced with official GNU Affero General Public License v3.0 text |
| `Cargo.toml` | `license = "GPLv3"` → `license = "AGPL-3.0"` (workspace, propagates to all 15 crates) |
| `crates/gglib-axum/Cargo.toml` | Hardcoded `license = "GPLv3"` → `license.workspace = true` (consistent with all other crates) |
| `package.json` | `"license": "GPLv3"` → `"license": "AGPL-3.0"` |
| `src-tauri/src/menu/build.rs` | Tauri about menu metadata: `"GPLv3"` → `"AGPL-3.0"` |
| `README.md` | Updated license badge; added `## License` section explaining dual licensing and commercial contact |

### Notes

- AGPL-3.0 is OSI-approved and accepted by crates.io, so publishing crates remains possible
- No contributor CLA issues — sole author
- Commercial licensing enquiries directed to [@mmogr](https://github.com/mmogr)