### PR TITLE
test(gglib-db): add CRUD tests for all SQLite repositories

### DIFF
--- a/crates/gglib-db/README.md
+++ b/crates/gglib-db/README.md
@@ -102,3 +102,40 @@ async fn example() {
 1. **Port Pattern** — Repositories implement traits from `gglib-core`, not local traits
 2. **No Domain Logic** — Pure data access; business logic stays in `gglib-core::services`
 3. **Pooled Connections** — All adapters share a connection pool for efficiency
+
+## Testing
+
+All tests are inline `#[cfg(test)]` blocks living alongside their respective implementations.
+
+### Test harness
+
+Use `setup_test_database()` (feature-gated under `test-utils`) rather than `TestDb::new()`.
+`setup_test_database()` creates an in-memory `SQLite` database and runs the full production schema
+via `create_schema()`, so every test exercises the real schema including all columns and CHECK
+constraints.
+
+```rust,no_run
+#[cfg(test)]
+mod tests {
+    use crate::setup::setup_test_database;
+    use super::*;
+
+    #[tokio::test]
+    async fn example() {
+        let pool = setup_test_database().await.unwrap();
+        let repo = SqliteModelRepository::new(pool);
+        // ...
+    }
+}
+```
+
+### Coverage at a glance
+
+| Repository | Tests |
+|---|---|
+| `SqliteModelRepository` | insert/list, get_by_id, get_by_name, update, delete, not-found errors, upsert dedup |
+| `SqliteChatHistoryRepository` | create/list conversations, get by id, count, update title, delete, messages round-trip, update/delete messages |
+| `SqliteDownloadStateRepository` | enqueue, update status, mark failed, remove, prune completed |
+| `SqliteMcpRepository` | insert/get/list/update/delete servers, SSE server, duplicate name conflict |
+| `SqliteSettingsRepository` | load empty, save and load, clear individual fields |
+

--- a/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
@@ -353,7 +353,10 @@ mod tests {
     #[tokio::test]
     async fn get_conversation_by_id() {
         let repo = repo().await;
-        let id = repo.create_conversation(make_conv("Explore")).await.unwrap();
+        let id = repo
+            .create_conversation(make_conv("Explore"))
+            .await
+            .unwrap();
         let conv = repo.get_conversation(id).await.unwrap();
         assert_eq!(conv.unwrap().title, "Explore");
     }
@@ -370,9 +373,15 @@ mod tests {
     async fn update_conversation_title() {
         let repo = repo().await;
         let id = repo.create_conversation(make_conv("Old")).await.unwrap();
-        let update = ConversationUpdate { title: Some("New".to_string()), ..Default::default() };
+        let update = ConversationUpdate {
+            title: Some("New".to_string()),
+            ..Default::default()
+        };
         repo.update_conversation(id, update).await.unwrap();
-        assert_eq!(repo.get_conversation(id).await.unwrap().unwrap().title, "New");
+        assert_eq!(
+            repo.get_conversation(id).await.unwrap().unwrap().title,
+            "New"
+        );
     }
 
     #[tokio::test]
@@ -397,7 +406,9 @@ mod tests {
         let repo = repo().await;
         let cid = repo.create_conversation(make_conv("Count")).await.unwrap();
         for i in 0..3 {
-            repo.save_message(make_msg(cid, &format!("m{i}"))).await.unwrap();
+            repo.save_message(make_msg(cid, &format!("m{i}")))
+                .await
+                .unwrap();
         }
         assert_eq!(repo.get_message_count(cid).await.unwrap(), 3);
     }
@@ -407,7 +418,9 @@ mod tests {
         let repo = repo().await;
         let cid = repo.create_conversation(make_conv("Edit")).await.unwrap();
         let mid = repo.save_message(make_msg(cid, "original")).await.unwrap();
-        repo.update_message(mid, "updated".to_string(), None).await.unwrap();
+        repo.update_message(mid, "updated".to_string(), None)
+            .await
+            .unwrap();
         assert_eq!(repo.get_messages(cid).await.unwrap()[0].content, "updated");
     }
 

--- a/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs
@@ -306,3 +306,120 @@ impl ChatHistoryRepository for SqliteChatHistoryRepository {
         Ok(row.get("count"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use gglib_core::domain::chat::{ConversationUpdate, MessageRole, NewConversation, NewMessage};
+    use gglib_core::ports::chat_history::ChatHistoryRepository;
+
+    use crate::setup::setup_test_database;
+
+    use super::*;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn make_conv(title: &str) -> NewConversation {
+        NewConversation {
+            title: title.to_string(),
+            model_id: None,
+            system_prompt: None,
+            settings: None,
+        }
+    }
+
+    fn make_msg(conversation_id: i64, content: &str) -> NewMessage {
+        NewMessage {
+            conversation_id,
+            role: MessageRole::User,
+            content: content.to_string(),
+            metadata: None,
+        }
+    }
+
+    async fn repo() -> SqliteChatHistoryRepository {
+        let pool = setup_test_database().await.expect("setup_test_database");
+        SqliteChatHistoryRepository::new(pool)
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_and_list_conversations() {
+        let repo = repo().await;
+        repo.create_conversation(make_conv("Chat 1")).await.unwrap();
+        assert_eq!(repo.list_conversations().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_conversation_by_id() {
+        let repo = repo().await;
+        let id = repo.create_conversation(make_conv("Explore")).await.unwrap();
+        let conv = repo.get_conversation(id).await.unwrap();
+        assert_eq!(conv.unwrap().title, "Explore");
+    }
+
+    #[tokio::test]
+    async fn get_conversation_count() {
+        let repo = repo().await;
+        repo.create_conversation(make_conv("A")).await.unwrap();
+        repo.create_conversation(make_conv("B")).await.unwrap();
+        assert_eq!(repo.get_conversation_count().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_conversation_title() {
+        let repo = repo().await;
+        let id = repo.create_conversation(make_conv("Old")).await.unwrap();
+        let update = ConversationUpdate { title: Some("New".to_string()), ..Default::default() };
+        repo.update_conversation(id, update).await.unwrap();
+        assert_eq!(repo.get_conversation(id).await.unwrap().unwrap().title, "New");
+    }
+
+    #[tokio::test]
+    async fn delete_conversation() {
+        let repo = repo().await;
+        let id = repo.create_conversation(make_conv("Tmp")).await.unwrap();
+        repo.delete_conversation(id).await.unwrap();
+        assert!(repo.list_conversations().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn save_and_get_messages_round_trip() {
+        let repo = repo().await;
+        let cid = repo.create_conversation(make_conv("Msgs")).await.unwrap();
+        repo.save_message(make_msg(cid, "Hello")).await.unwrap();
+        repo.save_message(make_msg(cid, "World")).await.unwrap();
+        assert_eq!(repo.get_messages(cid).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn get_message_count() {
+        let repo = repo().await;
+        let cid = repo.create_conversation(make_conv("Count")).await.unwrap();
+        for i in 0..3 {
+            repo.save_message(make_msg(cid, &format!("m{i}"))).await.unwrap();
+        }
+        assert_eq!(repo.get_message_count(cid).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn update_message_content() {
+        let repo = repo().await;
+        let cid = repo.create_conversation(make_conv("Edit")).await.unwrap();
+        let mid = repo.save_message(make_msg(cid, "original")).await.unwrap();
+        repo.update_message(mid, "updated".to_string(), None).await.unwrap();
+        assert_eq!(repo.get_messages(cid).await.unwrap()[0].content, "updated");
+    }
+
+    #[tokio::test]
+    async fn delete_message_and_subsequent_removes_tail() {
+        let repo = repo().await;
+        let cid = repo.create_conversation(make_conv("Tail")).await.unwrap();
+        repo.save_message(make_msg(cid, "A")).await.unwrap();
+        let mid_b = repo.save_message(make_msg(cid, "B")).await.unwrap();
+        repo.save_message(make_msg(cid, "C")).await.unwrap();
+        let removed = repo.delete_message_and_subsequent(mid_b).await.unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(repo.get_messages(cid).await.unwrap().len(), 1);
+    }
+}

--- a/crates/gglib-db/src/repositories/sqlite_download_state_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_download_state_repository.rs
@@ -336,4 +336,23 @@ mod tests {
         let queue = repo.load_queue().await.unwrap();
         assert!(queue.is_empty());
     }
+
+    #[tokio::test]
+    async fn prune_completed_removes_completed_entries() {
+        let pool = setup_test_db().await;
+        let repo = SqliteDownloadStateRepository::new(pool.clone());
+
+        let download = QueuedDownload::new("prune-test", "org/model", "Model", 1, 1234567890);
+        repo.enqueue(&download).await.unwrap();
+        // mark_failed sets completed_at = datetime('now'); backdate so prune_completed(0) matches.
+        let id = DownloadId::from_model("prune-test");
+        repo.mark_failed(&id, "err").await.unwrap();
+        sqlx::query("UPDATE download_queue SET completed_at = '1990-01-01 00:00:00' WHERE id = ?")
+            .bind(id.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(repo.prune_completed(0).await.unwrap(), 1);
+    }
 }

--- a/crates/gglib-db/src/repositories/sqlite_model_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_model_repository.rs
@@ -238,3 +238,105 @@ impl ModelRepository for SqliteModelRepository {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use chrono::Utc;
+    use gglib_core::{NewModel, RepositoryError};
+
+    use crate::setup::setup_test_database;
+
+    use super::*;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Return a minimal valid [`NewModel`] with a unique-by-`name` path so each
+    /// test has an independent model key.
+    fn make_model(name: &str) -> NewModel {
+        NewModel::new(
+            name.to_string(),
+            PathBuf::from(format!("/models/{name}.gguf")),
+            7.0,
+            Utc::now(),
+        )
+    }
+
+    async fn repo() -> SqliteModelRepository {
+        let pool = setup_test_database().await.expect("setup_test_database");
+        SqliteModelRepository::new(pool)
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn insert_and_list() {
+        let repo = repo().await;
+        repo.insert(&make_model("Alpha")).await.unwrap();
+        assert_eq!(repo.list().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_by_id_returns_inserted_model() {
+        let repo = repo().await;
+        let inserted = repo.insert(&make_model("Beta")).await.unwrap();
+        let fetched = repo.get_by_id(inserted.id).await.unwrap();
+        assert_eq!(fetched.name, "Beta");
+    }
+
+    #[tokio::test]
+    async fn get_by_id_not_found_returns_error() {
+        let repo = repo().await;
+        let err = repo.get_by_id(999).await.unwrap_err();
+        assert!(matches!(err, RepositoryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn get_by_name_returns_inserted_model() {
+        let repo = repo().await;
+        repo.insert(&make_model("Gamma")).await.unwrap();
+        let fetched = repo.get_by_name("Gamma").await.unwrap();
+        assert_eq!(fetched.name, "Gamma");
+    }
+
+    #[tokio::test]
+    async fn get_by_name_not_found_returns_error() {
+        let repo = repo().await;
+        let err = repo.get_by_name("ghost").await.unwrap_err();
+        assert!(matches!(err, RepositoryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn update_changes_model_fields() {
+        let repo = repo().await;
+        let mut model = repo.insert(&make_model("Delta")).await.unwrap();
+        model.name = "Delta-v2".to_string();
+        repo.update(&model).await.unwrap();
+        assert_eq!(repo.get_by_id(model.id).await.unwrap().name, "Delta-v2");
+    }
+
+    #[tokio::test]
+    async fn delete_removes_model_from_list() {
+        let repo = repo().await;
+        let model = repo.insert(&make_model("Epsilon")).await.unwrap();
+        repo.delete(model.id).await.unwrap();
+        assert!(repo.list().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_not_found_returns_error() {
+        let repo = repo().await;
+        let err = repo.delete(999).await.unwrap_err();
+        assert!(matches!(err, RepositoryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn upsert_deduplicates_same_model_key() {
+        let repo = repo().await;
+        // Two inserts of the same path → same local model_key → UPSERT updates in place.
+        repo.insert(&make_model("Zeta")).await.unwrap();
+        repo.insert(&make_model("Zeta")).await.unwrap();
+        assert_eq!(repo.list().await.unwrap().len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline `#[cfg(test)]` test blocks for the three previously untested (or undertested) repository implementations in `gglib-db`.

### Changes

| File | Tests added |
|---|---|
| `sqlite_model_repository.rs` | 9 new tests (0 → 9) |
| `sqlite_chat_history_repository.rs` | 9 new tests (0 → 9) |
| `sqlite_download_state_repository.rs` | 1 new test (4 → 5) |
| `README.md` | `## Testing` section documenting harness and coverage |

**Total: +19 tests, all green (38/38 passing)**

### Test harness

All new tests use `setup_test_database()` (in-memory SQLite, full production schema via `create_schema()`), not `TestDb::new()`. Each test file uses a small `make_*` / `repo()` helper to keep individual test bodies to 3–5 lines.

### Coverage at a glance

- `SqliteModelRepository` — insert/list, get_by_id, get_by_name, update, delete, not-found errors, upsert deduplication
- `SqliteChatHistoryRepository` — create/list conversations, get by id, count, update title, delete, messages round-trip, update message, delete-and-subsequent tail removal
- `SqliteDownloadStateRepository` — gap fill: `prune_completed` (enqueue → mark_failed → backdate → prune → assert count)

### Commits

```
test(gglib-db): SqliteModelRepository CRUD tests
test(gglib-db): SqliteChatHistoryRepository CRUD tests
test(gglib-db): SqliteDownloadStateRepository prune_completed test
docs(gglib-db): add testing strategy documentation
```
