### PR TITLE
feat(orchestrator): Phase F — native frontend polish, DAG visualization, HITL modals, run management

### DIFF
--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -250,8 +250,10 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
         model_repo,
         mcp: mcp.clone(),
         core: Arc::clone(&core),
-        approval_registry: Arc::clone(&approval_registry) as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
-        orchestrator_repo: Arc::clone(&orchestrator_repo) as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
+        approval_registry: Arc::clone(&approval_registry)
+            as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
+        orchestrator_repo: Arc::clone(&orchestrator_repo)
+            as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
     }));
 
     let setup = Arc::new(SetupOps::new(SetupDeps {

--- a/crates/gglib-proxy/src/lib.rs
+++ b/crates/gglib-proxy/src/lib.rs
@@ -7,5 +7,5 @@ pub mod models;
 pub mod orchestrator_proxy;
 pub mod server;
 
-pub use orchestrator_proxy::{OrchestratorDeps, OrchestratorRunnerPort, OrchestratorRunParams};
+pub use orchestrator_proxy::{OrchestratorDeps, OrchestratorRunParams, OrchestratorRunnerPort};
 pub use server::serve;

--- a/crates/gglib-proxy/src/orchestrator_proxy.rs
+++ b/crates/gglib-proxy/src/orchestrator_proxy.rs
@@ -45,8 +45,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use futures_util::StreamExt as _;
 use serde::Deserialize;
@@ -63,9 +63,7 @@ use gglib_core::domain::orchestrator::run::OrchestratorRunStatus;
 use gglib_core::domain::orchestrator::task_graph::{HitlMode, NodeStatus, TaskGraph};
 use gglib_core::ports::{OrchestratorApprovalRegistryPort, OrchestratorRepositoryPort};
 
-use crate::models::{
-    ChatChunkChoice, ChatCompletionChunk, ChatDelta, ErrorResponse, ModelInfo,
-};
+use crate::models::{ChatChunkChoice, ChatCompletionChunk, ChatDelta, ErrorResponse, ModelInfo};
 
 // =============================================================================
 // Virtual model constants
@@ -192,32 +190,28 @@ pub(crate) async fn handle_virtual_model(
 ) -> Response {
     match model_name {
         VIRTUAL_MODEL_NATIVE => handle_native_mode(),
-        VIRTUAL_MODEL_AUTO => {
-            match serde_json::from_slice::<OrchestratorRequest>(body) {
-                Ok(req) => handle_auto_mode(deps, req).await,
-                Err(e) => (
-                    StatusCode::BAD_REQUEST,
-                    axum::Json(ErrorResponse::new(
-                        format!("Invalid request body: {e}"),
-                        "invalid_request",
-                    )),
-                )
-                    .into_response(),
-            }
-        }
-        VIRTUAL_MODEL_INTERACTIVE => {
-            match serde_json::from_slice::<OrchestratorRequest>(body) {
-                Ok(req) => handle_interactive_mode(deps, req).await,
-                Err(e) => (
-                    StatusCode::BAD_REQUEST,
-                    axum::Json(ErrorResponse::new(
-                        format!("Invalid request body: {e}"),
-                        "invalid_request",
-                    )),
-                )
-                    .into_response(),
-            }
-        }
+        VIRTUAL_MODEL_AUTO => match serde_json::from_slice::<OrchestratorRequest>(body) {
+            Ok(req) => handle_auto_mode(deps, req).await,
+            Err(e) => (
+                StatusCode::BAD_REQUEST,
+                axum::Json(ErrorResponse::new(
+                    format!("Invalid request body: {e}"),
+                    "invalid_request",
+                )),
+            )
+                .into_response(),
+        },
+        VIRTUAL_MODEL_INTERACTIVE => match serde_json::from_slice::<OrchestratorRequest>(body) {
+            Ok(req) => handle_interactive_mode(deps, req).await,
+            Err(e) => (
+                StatusCode::BAD_REQUEST,
+                axum::Json(ErrorResponse::new(
+                    format!("Invalid request body: {e}"),
+                    "invalid_request",
+                )),
+            )
+                .into_response(),
+        },
         _ => (
             StatusCode::NOT_FOUND,
             axum::Json(ErrorResponse::new(
@@ -447,10 +441,7 @@ async fn resume_interactive_run(
             let runner = Arc::clone(&deps.runner);
             let goal_for_log = run_id.clone();
             tokio::spawn(async move {
-                if let Err(e) = runner
-                    .run(&goal_for_log, params, tx, cancel_for_task)
-                    .await
-                {
+                if let Err(e) = runner.run(&goal_for_log, params, tx, cancel_for_task).await {
                     error!(run_id = %goal_for_log, error = %e, "orchestrator proxy: resume run failed");
                 }
             });
@@ -519,7 +510,9 @@ fn build_sse_stream(
         yield done_event();
     };
 
-    Sse::new(sse_stream).keep_alive(KeepAlive::default()).into_response()
+    Sse::new(sse_stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 /// Build a static single-chunk SSE stream (for rejection messages, etc.).
@@ -535,7 +528,9 @@ fn build_static_sse(content: &str, model: &str) -> Response {
         yield done_event();
     };
 
-    Sse::new(sse_stream).keep_alive(KeepAlive::default()).into_response()
+    Sse::new(sse_stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 // =============================================================================
@@ -567,9 +562,9 @@ pub(crate) fn orchestrator_event_to_content(event: &OrchestratorEvent) -> Option
             Some(buf)
         }
 
-        OrchestratorEvent::NodeStarted { goal, node_id } => {
-            Some(format!("\n\n## 🔧 Working on: {goal}\n\n<!-- node:{node_id} -->\n"))
-        }
+        OrchestratorEvent::NodeStarted { goal, node_id } => Some(format!(
+            "\n\n## 🔧 Working on: {goal}\n\n<!-- node:{node_id} -->\n"
+        )),
 
         OrchestratorEvent::NodeTextDelta { delta, .. } => Some(delta.clone()),
 
@@ -602,9 +597,7 @@ pub(crate) fn orchestrator_event_to_content(event: &OrchestratorEvent) -> Option
             Some(format!("\n\n**❌ Node `{node_id}` failed:** {error}\n\n"))
         }
 
-        OrchestratorEvent::SynthesisStart => {
-            Some("\n\n## 📝 Synthesizing\n\n".to_string())
-        }
+        OrchestratorEvent::SynthesisStart => Some("\n\n## 📝 Synthesizing\n\n".to_string()),
 
         OrchestratorEvent::SynthesisTextDelta { delta } => Some(delta.clone()),
 

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -25,7 +25,9 @@ use crate::forward::forward_chat_completion;
 use crate::mcp::handlers::{delete_mcp, get_mcp, post_mcp};
 use crate::mcp::session::SessionManager;
 use crate::models::{ChatRoutingEnvelope, ErrorResponse, ModelInfo, ModelsResponse};
-use crate::orchestrator_proxy::{OrchestratorDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info};
+use crate::orchestrator_proxy::{
+    OrchestratorDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info,
+};
 
 /// Shared application state for the proxy server.
 #[derive(Clone)]

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -11,40 +11,79 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use gglib_core::domain::orchestrator::{
+    OrchestratorEvent, OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus,
+};
+use gglib_core::ports::{
+    ApprovalDecision, OrchestratorApprovalRegistryPort, OrchestratorRepositoryPort, RepositoryError,
+};
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,
 };
 use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
 use gglib_mcp::McpService;
-use gglib_proxy::{OrchestratorDeps, OrchestratorRunnerPort, OrchestratorRunParams};
-use gglib_core::domain::orchestrator::{OrchestratorEvent, OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus};
-use gglib_core::ports::{ApprovalDecision, OrchestratorApprovalRegistryPort, OrchestratorRepositoryPort, RepositoryError};
+use gglib_proxy::{OrchestratorDeps, OrchestratorRunParams, OrchestratorRunnerPort};
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
 struct NoopRunner;
 #[async_trait::async_trait]
 impl OrchestratorRunnerPort for NoopRunner {
-    async fn run(&self, _: &str, _: OrchestratorRunParams, _: mpsc::Sender<OrchestratorEvent>, _: CancellationToken) -> anyhow::Result<()> { Ok(()) }
+    async fn run(
+        &self,
+        _: &str,
+        _: OrchestratorRunParams,
+        _: mpsc::Sender<OrchestratorEvent>,
+        _: CancellationToken,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 struct NoopApprovalRegistry;
 impl OrchestratorApprovalRegistryPort for NoopApprovalRegistry {
     fn register(&self, _: String, _: oneshot::Sender<ApprovalDecision>) {}
-    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool { false }
-    fn is_pending(&self, _: &str) -> bool { false }
+    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool {
+        false
+    }
+    fn is_pending(&self, _: &str) -> bool {
+        false
+    }
 }
 struct NoopOrchestratorRepo;
 #[async_trait::async_trait]
 impl OrchestratorRepositoryPort for NoopOrchestratorRepo {
-    async fn create_run(&self, _: OrchestratorRun) -> Result<(), RepositoryError> { Ok(()) }
-    async fn update_run_status(&self, _: &str, _: OrchestratorRunStatus) -> Result<(), RepositoryError> { Ok(()) }
-    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> { Ok(()) }
-    async fn append_event(&self, _: OrchestratorRunEvent) -> Result<(), RepositoryError> { Ok(()) }
-    async fn get_run(&self, _: &str) -> Result<Option<OrchestratorRun>, RepositoryError> { Ok(None) }
-    async fn list_runs(&self, _: Option<OrchestratorRunStatus>) -> Result<Vec<OrchestratorRun>, RepositoryError> { Ok(vec![]) }
-    async fn list_events(&self, _: &str) -> Result<Vec<OrchestratorRunEvent>, RepositoryError> { Ok(vec![]) }
-    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> { Ok(0) }
+    async fn create_run(&self, _: OrchestratorRun) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn update_run_status(
+        &self,
+        _: &str,
+        _: OrchestratorRunStatus,
+    ) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn append_event(&self, _: OrchestratorRunEvent) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn get_run(&self, _: &str) -> Result<Option<OrchestratorRun>, RepositoryError> {
+        Ok(None)
+    }
+    async fn list_runs(
+        &self,
+        _: Option<OrchestratorRunStatus>,
+    ) -> Result<Vec<OrchestratorRun>, RepositoryError> {
+        Ok(vec![])
+    }
+    async fn list_events(&self, _: &str) -> Result<Vec<OrchestratorRunEvent>, RepositoryError> {
+        Ok(vec![])
+    }
+    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
+        Ok(0)
+    }
 }
 fn make_orchestrator_deps() -> OrchestratorDeps {
     OrchestratorDeps {
@@ -142,9 +181,17 @@ async fn start_proxy() -> (String, CancellationToken) {
     let cancel_clone = cancel.clone();
 
     tokio::spawn(async move {
-        gglib_proxy::serve(listener, 4096, runtime, catalog, mcp, make_orchestrator_deps(), cancel_clone)
-            .await
-            .ok();
+        gglib_proxy::serve(
+            listener,
+            4096,
+            runtime,
+            catalog,
+            mcp,
+            make_orchestrator_deps(),
+            cancel_clone,
+        )
+        .await
+        .ok();
     });
 
     // Give the server a moment to start

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -29,40 +29,79 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use gglib_core::domain::orchestrator::{
+    OrchestratorEvent, OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus,
+};
+use gglib_core::ports::{
+    ApprovalDecision, OrchestratorApprovalRegistryPort, OrchestratorRepositoryPort, RepositoryError,
+};
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,
 };
 use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
 use gglib_mcp::McpService;
-use gglib_proxy::{OrchestratorDeps, OrchestratorRunnerPort, OrchestratorRunParams};
-use gglib_core::domain::orchestrator::{OrchestratorEvent, OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus};
-use gglib_core::ports::{ApprovalDecision, OrchestratorApprovalRegistryPort, OrchestratorRepositoryPort, RepositoryError};
+use gglib_proxy::{OrchestratorDeps, OrchestratorRunParams, OrchestratorRunnerPort};
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
 struct NoopRunner;
 #[async_trait]
 impl OrchestratorRunnerPort for NoopRunner {
-    async fn run(&self, _: &str, _: OrchestratorRunParams, _: mpsc::Sender<OrchestratorEvent>, _: CancellationToken) -> anyhow::Result<()> { Ok(()) }
+    async fn run(
+        &self,
+        _: &str,
+        _: OrchestratorRunParams,
+        _: mpsc::Sender<OrchestratorEvent>,
+        _: CancellationToken,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 struct NoopApprovalRegistry;
 impl OrchestratorApprovalRegistryPort for NoopApprovalRegistry {
     fn register(&self, _: String, _: oneshot::Sender<ApprovalDecision>) {}
-    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool { false }
-    fn is_pending(&self, _: &str) -> bool { false }
+    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool {
+        false
+    }
+    fn is_pending(&self, _: &str) -> bool {
+        false
+    }
 }
 struct NoopOrchestratorRepo;
 #[async_trait]
 impl OrchestratorRepositoryPort for NoopOrchestratorRepo {
-    async fn create_run(&self, _: OrchestratorRun) -> Result<(), RepositoryError> { Ok(()) }
-    async fn update_run_status(&self, _: &str, _: OrchestratorRunStatus) -> Result<(), RepositoryError> { Ok(()) }
-    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> { Ok(()) }
-    async fn append_event(&self, _: OrchestratorRunEvent) -> Result<(), RepositoryError> { Ok(()) }
-    async fn get_run(&self, _: &str) -> Result<Option<OrchestratorRun>, RepositoryError> { Ok(None) }
-    async fn list_runs(&self, _: Option<OrchestratorRunStatus>) -> Result<Vec<OrchestratorRun>, RepositoryError> { Ok(vec![]) }
-    async fn list_events(&self, _: &str) -> Result<Vec<OrchestratorRunEvent>, RepositoryError> { Ok(vec![]) }
-    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> { Ok(0) }
+    async fn create_run(&self, _: OrchestratorRun) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn update_run_status(
+        &self,
+        _: &str,
+        _: OrchestratorRunStatus,
+    ) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn append_event(&self, _: OrchestratorRunEvent) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+    async fn get_run(&self, _: &str) -> Result<Option<OrchestratorRun>, RepositoryError> {
+        Ok(None)
+    }
+    async fn list_runs(
+        &self,
+        _: Option<OrchestratorRunStatus>,
+    ) -> Result<Vec<OrchestratorRun>, RepositoryError> {
+        Ok(vec![])
+    }
+    async fn list_events(&self, _: &str) -> Result<Vec<OrchestratorRunEvent>, RepositoryError> {
+        Ok(vec![])
+    }
+    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
+        Ok(0)
+    }
 }
 fn make_orchestrator_deps() -> OrchestratorDeps {
     OrchestratorDeps {
@@ -260,9 +299,17 @@ async fn spawn_proxy(
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
-        gglib_proxy::serve(listener, 4096, runtime, catalog, mcp, make_orchestrator_deps(), cancel_clone)
-            .await
-            .ok();
+        gglib_proxy::serve(
+            listener,
+            4096,
+            runtime,
+            catalog,
+            mcp,
+            make_orchestrator_deps(),
+            cancel_clone,
+        )
+        .await
+        .ok();
     });
 
     tokio::time::sleep(Duration::from_millis(30)).await;

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -249,10 +249,10 @@ async fn collect_sse_data(resp: reqwest::Response) -> Vec<String> {
         while let Some(pos) = buf.find("\n\n") {
             let frame = buf[..pos].trim().to_string();
             buf = buf[pos + 2..].to_string();
-            if let Some(data) = frame.strip_prefix("data: ") {
-                if data != "[DONE]" {
-                    frames.push(data.to_string());
-                }
+            if let Some(data) = frame.strip_prefix("data: ")
+                && data != "[DONE]"
+            {
+                frames.push(data.to_string());
             }
         }
     }
@@ -430,14 +430,11 @@ async fn test_auto_mode_streams_events_as_markdown() {
     );
 
     // The last data frame with a finish_reason must be "stop".
-    let stop_frame = frames
-        .iter()
-        .rev()
-        .find_map(|f| {
-            let v: Value = serde_json::from_str(f).ok()?;
-            let reason = v["choices"][0]["finish_reason"].as_str()?.to_string();
-            Some(reason)
-        });
+    let stop_frame = frames.iter().rev().find_map(|f| {
+        let v: Value = serde_json::from_str(f).ok()?;
+        let reason = v["choices"][0]["finish_reason"].as_str()?.to_string();
+        Some(reason)
+    });
     assert_eq!(
         stop_frame.as_deref(),
         Some("stop"),

--- a/crates/gglib-runtime/src/orchestrator_runner.rs
+++ b/crates/gglib-runtime/src/orchestrator_runner.rs
@@ -81,16 +81,12 @@ impl OrchestratorRunnerPort for OrchestratorRunnerAdapter {
         cancel: CancellationToken,
     ) -> anyhow::Result<()> {
         // Find the currently loaded model.
-        let target = self
-            .runtime_port
-            .current_model()
-            .await
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "No model is currently loaded. \
+        let target = self.runtime_port.current_model().await.ok_or_else(|| {
+            anyhow::anyhow!(
+                "No model is currently loaded. \
                      Start a model with `gglib model run <name>` or select one in the UI."
-                )
-            })?;
+            )
+        })?;
 
         debug!(
             model = %target.model_name,

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -162,11 +162,7 @@ impl OrchestratorRepositoryPort for InMemoryOrchestratorRepository {
         let guard = self.runs.lock().unwrap_or_else(|p| p.into_inner());
         let runs: Vec<OrchestratorRun> = guard
             .values()
-            .filter(|r| {
-                status_filter
-                    .as_ref()
-                    .is_none_or(|s| &r.status == s)
-            })
+            .filter(|r| status_filter.as_ref().is_none_or(|s| &r.status == s))
             .cloned()
             .collect();
         Ok(runs)
@@ -322,4 +318,3 @@ pub async fn start_proxy_standalone(
 
     Ok(())
 }
-

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -365,16 +365,18 @@ mod tests {
     use async_trait::async_trait;
     use gglib_core::NoopEmitter;
     use gglib_core::domain::mcp::{McpServer, NewMcpServer};
-    use gglib_core::ports::{
-        CatalogError, ModelLaunchSpec, ModelRuntimeError, ModelSummary, RunningTarget,
+    use gglib_core::domain::orchestrator::{
+        OrchestratorEvent, OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus,
     };
-    use gglib_core::ports::{McpRepositoryError, McpServerRepository};
-    use gglib_proxy::{OrchestratorDeps, OrchestratorRunnerPort, OrchestratorRunParams};
-    use gglib_core::domain::orchestrator::{OrchestratorEvent, OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus};
     use gglib_core::ports::{
         ApprovalDecision, OrchestratorApprovalRegistryPort, OrchestratorRepositoryPort,
         RepositoryError,
     };
+    use gglib_core::ports::{
+        CatalogError, ModelLaunchSpec, ModelRuntimeError, ModelSummary, RunningTarget,
+    };
+    use gglib_core::ports::{McpRepositoryError, McpServerRepository};
+    use gglib_proxy::{OrchestratorDeps, OrchestratorRunParams, OrchestratorRunnerPort};
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::sync::CancellationToken;
 
@@ -398,21 +400,48 @@ mod tests {
     struct NoopApprovalRegistry;
     impl OrchestratorApprovalRegistryPort for NoopApprovalRegistry {
         fn register(&self, _id: String, _tx: oneshot::Sender<ApprovalDecision>) {}
-        fn resolve(&self, _id: &str, _decision: ApprovalDecision) -> bool { false }
-        fn is_pending(&self, _id: &str) -> bool { false }
+        fn resolve(&self, _id: &str, _decision: ApprovalDecision) -> bool {
+            false
+        }
+        fn is_pending(&self, _id: &str) -> bool {
+            false
+        }
     }
 
     struct NoopOrchestratorRepo;
     #[async_trait]
     impl OrchestratorRepositoryPort for NoopOrchestratorRepo {
-        async fn create_run(&self, _: OrchestratorRun) -> Result<(), RepositoryError> { Ok(()) }
-        async fn update_run_status(&self, _: &str, _: OrchestratorRunStatus) -> Result<(), RepositoryError> { Ok(()) }
-        async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> { Ok(()) }
-        async fn append_event(&self, _: OrchestratorRunEvent) -> Result<(), RepositoryError> { Ok(()) }
-        async fn get_run(&self, _: &str) -> Result<Option<OrchestratorRun>, RepositoryError> { Ok(None) }
-        async fn list_runs(&self, _: Option<OrchestratorRunStatus>) -> Result<Vec<OrchestratorRun>, RepositoryError> { Ok(vec![]) }
-        async fn list_events(&self, _: &str) -> Result<Vec<OrchestratorRunEvent>, RepositoryError> { Ok(vec![]) }
-        async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> { Ok(0) }
+        async fn create_run(&self, _: OrchestratorRun) -> Result<(), RepositoryError> {
+            Ok(())
+        }
+        async fn update_run_status(
+            &self,
+            _: &str,
+            _: OrchestratorRunStatus,
+        ) -> Result<(), RepositoryError> {
+            Ok(())
+        }
+        async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
+            Ok(())
+        }
+        async fn append_event(&self, _: OrchestratorRunEvent) -> Result<(), RepositoryError> {
+            Ok(())
+        }
+        async fn get_run(&self, _: &str) -> Result<Option<OrchestratorRun>, RepositoryError> {
+            Ok(None)
+        }
+        async fn list_runs(
+            &self,
+            _: Option<OrchestratorRunStatus>,
+        ) -> Result<Vec<OrchestratorRun>, RepositoryError> {
+            Ok(vec![])
+        }
+        async fn list_events(&self, _: &str) -> Result<Vec<OrchestratorRunEvent>, RepositoryError> {
+            Ok(vec![])
+        }
+        async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
+            Ok(0)
+        }
     }
 
     fn make_orchestrator() -> OrchestratorDeps {
@@ -530,7 +559,13 @@ mod tests {
         let (runtime, catalog) = make_ports();
         let mcp = make_mcp();
         let addr = supervisor
-            .start(config.clone(), runtime.clone(), catalog.clone(), mcp, make_orchestrator())
+            .start(
+                config.clone(),
+                runtime.clone(),
+                catalog.clone(),
+                mcp,
+                make_orchestrator(),
+            )
             .await
             .unwrap();
         assert_ne!(addr.port(), 0);
@@ -576,7 +611,13 @@ mod tests {
         // Start
         let (runtime, catalog) = make_ports();
         let addr1 = supervisor
-            .start(config.clone(), runtime, catalog, make_mcp(), make_orchestrator())
+            .start(
+                config.clone(),
+                runtime,
+                catalog,
+                make_mcp(),
+                make_orchestrator(),
+            )
             .await
             .unwrap();
 

--- a/crates/gglib-tauri/src/bootstrap.rs
+++ b/crates/gglib-tauri/src/bootstrap.rs
@@ -218,8 +218,10 @@ pub async fn bootstrap(config: TauriConfig, app_handle: AppHandle) -> Result<Tau
         model_repo: model_repo.clone(),
         mcp: mcp.clone(),
         core: Arc::clone(&app),
-        approval_registry: Arc::clone(&approval_registry) as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
-        orchestrator_repo: Arc::clone(&orchestrator_repo) as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
+        approval_registry: Arc::clone(&approval_registry)
+            as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
+        orchestrator_repo: Arc::clone(&orchestrator_repo)
+            as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
     }));
     let setup = Arc::new(SetupOps::new(SetupDeps {
         core: Arc::clone(&app),
@@ -308,8 +310,10 @@ pub fn bootstrap_with(
         model_repo: model_repo.clone(),
         mcp: mcp.clone(),
         core: Arc::clone(&app),
-        approval_registry: Arc::clone(&approval_registry_w) as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
-        orchestrator_repo: Arc::clone(&orch_repo_w) as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
+        approval_registry: Arc::clone(&approval_registry_w)
+            as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
+        orchestrator_repo: Arc::clone(&orch_repo_w)
+            as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
     }));
     let setup_ops = Arc::new(SetupOps::new(SetupDeps {
         core: Arc::clone(&app),
@@ -434,8 +438,10 @@ pub async fn bootstrap_early(config: TauriConfig) -> Result<TauriContext> {
         model_repo: model_repo.clone(),
         mcp: mcp.clone(),
         core: Arc::clone(&app),
-        approval_registry: Arc::clone(&approval_registry_e) as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
-        orchestrator_repo: Arc::clone(&orchestrator_repo) as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
+        approval_registry: Arc::clone(&approval_registry_e)
+            as Arc<dyn gglib_core::ports::OrchestratorApprovalRegistryPort>,
+        orchestrator_repo: Arc::clone(&orchestrator_repo)
+            as Arc<dyn gglib_core::ports::OrchestratorRepositoryPort>,
     }));
     let setup = Arc::new(SetupOps::new(SetupDeps {
         core: Arc::clone(&app),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import { startProxy, stopProxy } from "./services/clients/servers";
 import { getSetupStatus } from "./services/transport/api/setup";
 import { syncBuiltinTools } from "./services/tools";
 import OrchestratorPlanPreview from "./pages/OrchestratorPlanPreview";
+import OrchestratorPage from "./pages/Orchestrator";
+import { OrchestratorProvider } from "./contexts/OrchestratorContext";
 
 /**
  * Inner app component that consumes ToastContext.
@@ -28,9 +30,15 @@ function AppContent() {
   const [showPlanPage, setShowPlanPage] = useState(
     () => window.location.hash === '#plan'
   );
+  const [showOrchestratorPage, setShowOrchestratorPage] = useState(
+    () => window.location.hash === '#orchestrator'
+  );
 
   useEffect(() => {
-    const onHashChange = () => setShowPlanPage(window.location.hash === '#plan');
+    const onHashChange = () => {
+      setShowPlanPage(window.location.hash === '#plan');
+      setShowOrchestratorPage(window.location.hash === '#orchestrator');
+    };
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
@@ -176,7 +184,16 @@ function AppContent() {
           onRefreshServers={loadServers}
         />
         <div className="flex-1 min-h-0 overflow-hidden flex">
-          {showPlanPage ? (
+          {showOrchestratorPage ? (
+            <OrchestratorProvider>
+              <OrchestratorPage
+                onBack={() => {
+                  window.location.hash = '';
+                  setShowOrchestratorPage(false);
+                }}
+              />
+            </OrchestratorProvider>
+          ) : showPlanPage ? (
             <OrchestratorPlanPreview
               onBack={() => {
                 window.location.hash = '';

--- a/src/contexts/OrchestratorContext.tsx
+++ b/src/contexts/OrchestratorContext.tsx
@@ -1,0 +1,315 @@
+/**
+ * Orchestrator session context.
+ *
+ * Holds the current `OrchestratorSession` state and exposes dispatch actions
+ * to the component tree. The heavy lifting (SSE streaming, API calls)
+ * belongs in `useOrchestrator` — this context is a thin state container.
+ *
+ * @module contexts/OrchestratorContext
+ */
+
+import { createContext, useContext, useReducer, type Dispatch, type ReactNode } from 'react';
+import type {
+  TaskGraph,
+  OrchestratorRun,
+  ApprovalKind,
+} from '../types/orchestrator';
+
+// ─── Session state ────────────────────────────────────────────────────────────
+
+export type OrchestratorPhase =
+  | 'idle'
+  | 'planning'
+  | 'running'
+  | 'awaiting_approval'
+  | 'synthesizing'
+  | 'complete'
+  | 'error';
+
+export type NodePhase = 'pending' | 'running' | 'compacting' | 'done' | 'failed';
+
+export interface NodeToolEntry {
+  displayName: string;
+  argsSummary: string;
+  durationDisplay?: string;
+  done: boolean;
+}
+
+export interface NodeState {
+  phase: NodePhase;
+  goal: string;
+  text: string;
+  toolLog: NodeToolEntry[];
+  outputPreview?: string;
+  error?: string;
+}
+
+export interface PendingApproval {
+  approvalId: string;
+  kind: ApprovalKind;
+  submitting: boolean;
+}
+
+export interface OrchestratorSession {
+  phase: OrchestratorPhase;
+  graph: TaskGraph | null;
+  nodeStates: Record<string, NodeState>;
+  synthesisText: string;
+  finalAnswer: string | null;
+  pendingApproval: PendingApproval | null;
+  error: string | null;
+  /** Runs loaded from GET /api/orchestrator/runs */
+  runs: OrchestratorRun[];
+  runsLoading: boolean;
+}
+
+function createEmptySession(): OrchestratorSession {
+  return {
+    phase: 'idle',
+    graph: null,
+    nodeStates: {},
+    synthesisText: '',
+    finalAnswer: null,
+    pendingApproval: null,
+    error: null,
+    runs: [],
+    runsLoading: false,
+  };
+}
+
+// ─── Actions ──────────────────────────────────────────────────────────────────
+
+export type OrchestratorAction =
+  // Lifecycle
+  | { type: 'START_RUN'; goal: string }
+  | { type: 'RESET' }
+  // Planning
+  | { type: 'PLAN_PROPOSED'; graph: TaskGraph }
+  | { type: 'PLAN_APPROVED' }
+  | { type: 'PLAN_REJECTED'; reason?: string | null }
+  | { type: 'REPLAN_ATTEMPT'; attempt: number; reason: string }
+  // Node lifecycle
+  | { type: 'NODE_STARTED'; nodeId: string; goal: string }
+  | { type: 'NODE_TEXT_DELTA'; nodeId: string; delta: string }
+  | { type: 'NODE_TOOL_CALL_START'; nodeId: string; displayName: string; argsSummary: string }
+  | { type: 'NODE_TOOL_CALL_COMPLETE'; nodeId: string; toolName: string; displayName: string; durationDisplay: string }
+  | { type: 'NODE_COMPACTING'; nodeId: string }
+  | { type: 'NODE_COMPLETE'; nodeId: string; outputPreview: string }
+  | { type: 'NODE_FAILED'; nodeId: string; error: string }
+  // Synthesis
+  | { type: 'SYNTHESIS_START' }
+  | { type: 'SYNTHESIS_TEXT_DELTA'; delta: string }
+  | { type: 'SYNTHESIS_COMPLETE'; content: string }
+  // HITL approval
+  | { type: 'AWAITING_APPROVAL'; approvalId: string; kind: ApprovalKind }
+  | { type: 'APPROVAL_SUBMITTING' }
+  | { type: 'APPROVAL_DONE' }
+  // Terminal
+  | { type: 'ORCHESTRATOR_COMPLETE'; answer: string }
+  | { type: 'ORCHESTRATOR_ERROR'; message: string }
+  // Runs list
+  | { type: 'RUNS_LOADING' }
+  | { type: 'RUNS_LOADED'; runs: OrchestratorRun[] }
+  | { type: 'RUNS_ERROR' };
+
+// ─── Reducer ──────────────────────────────────────────────────────────────────
+
+export function orchestratorReducer(
+  state: OrchestratorSession,
+  action: OrchestratorAction,
+): OrchestratorSession {
+  switch (action.type) {
+    case 'START_RUN':
+      return {
+        ...createEmptySession(),
+        phase: 'running',
+        runs: state.runs,
+        runsLoading: state.runsLoading,
+      };
+
+    case 'RESET':
+      return {
+        ...createEmptySession(),
+        runs: state.runs,
+        runsLoading: state.runsLoading,
+      };
+
+    case 'PLAN_PROPOSED':
+      return { ...state, graph: action.graph };
+
+    case 'PLAN_APPROVED':
+      return { ...state, pendingApproval: null };
+
+    case 'PLAN_REJECTED':
+      return { ...state, pendingApproval: null };
+
+    case 'REPLAN_ATTEMPT':
+      return state;
+
+    case 'NODE_STARTED':
+      return {
+        ...state,
+        nodeStates: {
+          ...state.nodeStates,
+          [action.nodeId]: {
+            phase: 'running',
+            goal: action.goal,
+            text: '',
+            toolLog: [],
+          },
+        },
+      };
+
+    case 'NODE_TEXT_DELTA': {
+      const ns = state.nodeStates[action.nodeId];
+      if (!ns) return state;
+      return {
+        ...state,
+        nodeStates: {
+          ...state.nodeStates,
+          [action.nodeId]: { ...ns, text: ns.text + action.delta },
+        },
+      };
+    }
+
+    case 'NODE_TOOL_CALL_START': {
+      const ns = state.nodeStates[action.nodeId];
+      if (!ns) return state;
+      return {
+        ...state,
+        nodeStates: {
+          ...state.nodeStates,
+          [action.nodeId]: {
+            ...ns,
+            toolLog: [
+              ...ns.toolLog,
+              { displayName: action.displayName, argsSummary: action.argsSummary, done: false },
+            ],
+          },
+        },
+      };
+    }
+
+    case 'NODE_TOOL_CALL_COMPLETE': {
+      const ns = state.nodeStates[action.nodeId];
+      if (!ns) return state;
+      // Mark the last entry with this displayName as done
+      const toolLog = [...ns.toolLog];
+      const idx = toolLog.map((t) => t.displayName).lastIndexOf(action.displayName);
+      if (idx !== -1) {
+        toolLog[idx] = { ...toolLog[idx], done: true, durationDisplay: action.durationDisplay };
+      }
+      return {
+        ...state,
+        nodeStates: { ...state.nodeStates, [action.nodeId]: { ...ns, toolLog } },
+      };
+    }
+
+    case 'NODE_COMPACTING': {
+      const ns = state.nodeStates[action.nodeId];
+      if (!ns) return state;
+      return {
+        ...state,
+        nodeStates: { ...state.nodeStates, [action.nodeId]: { ...ns, phase: 'compacting' } },
+      };
+    }
+
+    case 'NODE_COMPLETE': {
+      const ns = state.nodeStates[action.nodeId];
+      if (!ns) return state;
+      return {
+        ...state,
+        nodeStates: {
+          ...state.nodeStates,
+          [action.nodeId]: { ...ns, phase: 'done', outputPreview: action.outputPreview },
+        },
+      };
+    }
+
+    case 'NODE_FAILED': {
+      const ns = state.nodeStates[action.nodeId];
+      if (!ns) return state;
+      return {
+        ...state,
+        nodeStates: {
+          ...state.nodeStates,
+          [action.nodeId]: { ...ns, phase: 'failed', error: action.error },
+        },
+      };
+    }
+
+    case 'SYNTHESIS_START':
+      return { ...state, phase: 'synthesizing', synthesisText: '' };
+
+    case 'SYNTHESIS_TEXT_DELTA':
+      return { ...state, synthesisText: state.synthesisText + action.delta };
+
+    case 'SYNTHESIS_COMPLETE':
+      return { ...state, synthesisText: action.content };
+
+    case 'AWAITING_APPROVAL':
+      return {
+        ...state,
+        phase: 'awaiting_approval',
+        pendingApproval: { approvalId: action.approvalId, kind: action.kind, submitting: false },
+      };
+
+    case 'APPROVAL_SUBMITTING':
+      if (!state.pendingApproval) return state;
+      return {
+        ...state,
+        pendingApproval: { ...state.pendingApproval, submitting: true },
+      };
+
+    case 'APPROVAL_DONE':
+      return { ...state, phase: 'running', pendingApproval: null };
+
+    case 'ORCHESTRATOR_COMPLETE':
+      return { ...state, phase: 'complete', finalAnswer: action.answer };
+
+    case 'ORCHESTRATOR_ERROR':
+      return { ...state, phase: 'error', error: action.message };
+
+    case 'RUNS_LOADING':
+      return { ...state, runsLoading: true };
+
+    case 'RUNS_LOADED':
+      return { ...state, runs: action.runs, runsLoading: false };
+
+    case 'RUNS_ERROR':
+      return { ...state, runsLoading: false };
+
+    default:
+      return state;
+  }
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+interface OrchestratorContextValue {
+  session: OrchestratorSession;
+  dispatch: Dispatch<OrchestratorAction>;
+}
+
+const OrchestratorContext = createContext<OrchestratorContextValue | null>(null);
+
+export function OrchestratorProvider({ children }: { children: ReactNode }) {
+  const [session, dispatch] = useReducer(orchestratorReducer, undefined, createEmptySession);
+
+  return (
+    <OrchestratorContext.Provider value={{ session, dispatch }}>
+      {children}
+    </OrchestratorContext.Provider>
+  );
+}
+
+/**
+ * Access orchestrator session state and dispatch.
+ *
+ * Must be used within an `<OrchestratorProvider>`.
+ */
+export function useOrchestratorContext(): OrchestratorContextValue {
+  const ctx = useContext(OrchestratorContext);
+  if (!ctx) throw new Error('useOrchestratorContext must be used within <OrchestratorProvider>');
+  return ctx;
+}

--- a/src/hooks/useOrchestrator/index.ts
+++ b/src/hooks/useOrchestrator/index.ts
@@ -1,0 +1,2 @@
+export { useOrchestrator } from './useOrchestrator';
+export type { UseOrchestratorOptions, UseOrchestratorReturn } from './useOrchestrator';

--- a/src/hooks/useOrchestrator/useOrchestrator.ts
+++ b/src/hooks/useOrchestrator/useOrchestrator.ts
@@ -1,0 +1,224 @@
+/**
+ * Orchestrator hook.
+ *
+ * Bridges `runOrchestrator` / `resumeOrchestratorRun` SSE events to the
+ * `OrchestratorContext` reducer. Manages AbortController lifecycle so the
+ * user can cancel mid-stream.
+ *
+ * @module hooks/useOrchestrator
+ */
+
+import { useCallback, useRef } from 'react';
+import { useOrchestratorContext, type OrchestratorAction } from '../../contexts/OrchestratorContext';
+import {
+  runOrchestrator,
+  approveOrchestrator,
+  listOrchestratorRuns,
+  resumeOrchestratorRun,
+} from '../../services/clients/orchestrator';
+import type { OrchestratorEvent, ApprovalDecisionPayload, OrchestratorRunStatus } from '../../types/orchestrator';
+import { appLogger } from '../../services/platform';
+
+export interface UseOrchestratorOptions {
+  serverPort: number;
+  model?: string;
+}
+
+export interface UseOrchestratorReturn {
+  session: ReturnType<typeof useOrchestratorContext>['session'];
+  run: (goal: string, hitlMode?: string, maxWorkerConcurrency?: number) => Promise<void>;
+  resume: (runId: string) => Promise<void>;
+  cancel: () => void;
+  reset: () => void;
+  approve: (payload: ApprovalDecisionPayload) => Promise<void>;
+  loadRuns: (status?: OrchestratorRunStatus) => Promise<void>;
+  isStreaming: boolean;
+}
+
+/** Map a raw SSE OrchestratorEvent to a typed OrchestratorAction. */
+function eventToAction(event: OrchestratorEvent): OrchestratorAction | null {
+  switch (event.type) {
+    case 'plan_proposed':
+      return { type: 'PLAN_PROPOSED', graph: event.graph };
+    case 'plan_approved':
+      return { type: 'PLAN_APPROVED' };
+    case 'plan_rejected':
+      return { type: 'PLAN_REJECTED', reason: event.reason };
+    case 'replan_attempt':
+      return { type: 'REPLAN_ATTEMPT', attempt: event.attempt, reason: event.reason };
+    case 'awaiting_approval':
+      return { type: 'AWAITING_APPROVAL', approvalId: event.approval_id, kind: event.kind };
+    case 'node_started':
+      return { type: 'NODE_STARTED', nodeId: event.node_id, goal: event.goal };
+    case 'node_text_delta':
+      return { type: 'NODE_TEXT_DELTA', nodeId: event.node_id, delta: event.delta };
+    case 'node_tool_call_start':
+      return {
+        type: 'NODE_TOOL_CALL_START',
+        nodeId: event.node_id,
+        displayName: event.display_name,
+        argsSummary: event.args_summary,
+      };
+    case 'node_tool_call_complete':
+      return {
+        type: 'NODE_TOOL_CALL_COMPLETE',
+        nodeId: event.node_id,
+        toolName: event.tool_name,
+        displayName: event.display_name,
+        durationDisplay: event.duration_display,
+      };
+    case 'node_compacting':
+      return { type: 'NODE_COMPACTING', nodeId: event.node_id };
+    case 'node_complete':
+      return { type: 'NODE_COMPLETE', nodeId: event.node_id, outputPreview: event.output_preview };
+    case 'node_failed':
+      return { type: 'NODE_FAILED', nodeId: event.node_id, error: event.error };
+    case 'synthesis_start':
+      return { type: 'SYNTHESIS_START' };
+    case 'synthesis_text_delta':
+      return { type: 'SYNTHESIS_TEXT_DELTA', delta: event.delta };
+    case 'synthesis_complete':
+      return { type: 'SYNTHESIS_COMPLETE', content: event.content };
+    case 'orchestrator_complete':
+      return { type: 'ORCHESTRATOR_COMPLETE', answer: event.answer };
+    case 'orchestrator_error':
+      return { type: 'ORCHESTRATOR_ERROR', message: event.message };
+    // Informational events — no reducer action needed
+    case 'node_reasoning_delta':
+    case 'node_progress':
+    case 'node_system_warning':
+    case 'synthesis_progress':
+      return null;
+    default:
+      return null;
+  }
+}
+
+export function useOrchestrator({ serverPort, model }: UseOrchestratorOptions): UseOrchestratorReturn {
+  const { session, dispatch } = useOrchestratorContext();
+  const abortRef = useRef<AbortController | null>(null);
+  const streamingRef = useRef(false);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    streamingRef.current = false;
+  }, []);
+
+  const reset = useCallback(() => {
+    cancel();
+    dispatch({ type: 'RESET' });
+  }, [cancel, dispatch]);
+
+  const run = useCallback(
+    async (goal: string, hitlMode?: string, maxWorkerConcurrency?: number) => {
+      cancel();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      streamingRef.current = true;
+
+      dispatch({ type: 'START_RUN', goal });
+
+      try {
+        await runOrchestrator(
+          {
+            goal,
+            port: serverPort,
+            model: model ?? undefined,
+            hitl_mode: hitlMode && hitlMode !== 'none' ? hitlMode : undefined,
+            max_worker_concurrency: maxWorkerConcurrency,
+          },
+          (event: OrchestratorEvent) => {
+            const action = eventToAction(event);
+            if (action) dispatch(action);
+          },
+          ctrl.signal,
+        );
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          dispatch({ type: 'ORCHESTRATOR_ERROR', message: err.message });
+          appLogger.error('hook', 'Orchestrator run failed', { error: err.message });
+        }
+      } finally {
+        streamingRef.current = false;
+      }
+    },
+    [cancel, dispatch, serverPort, model],
+  );
+
+  const resume = useCallback(
+    async (runId: string) => {
+      cancel();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      streamingRef.current = true;
+
+      dispatch({ type: 'START_RUN', goal: '' });
+
+      try {
+        await resumeOrchestratorRun(
+          runId,
+          serverPort,
+          model ?? undefined,
+          (event: OrchestratorEvent) => {
+            const action = eventToAction(event);
+            if (action) dispatch(action);
+          },
+          ctrl.signal,
+        );
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          dispatch({ type: 'ORCHESTRATOR_ERROR', message: err.message });
+          appLogger.error('hook', 'Orchestrator resume failed', { error: err.message });
+        }
+      } finally {
+        streamingRef.current = false;
+      }
+    },
+    [cancel, dispatch, serverPort, model],
+  );
+
+  const approve = useCallback(
+    async (payload: ApprovalDecisionPayload) => {
+      if (!session.pendingApproval) return;
+      const { approvalId } = session.pendingApproval;
+
+      dispatch({ type: 'APPROVAL_SUBMITTING' });
+      try {
+        await approveOrchestrator(approvalId, payload);
+        dispatch({ type: 'APPROVAL_DONE' });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Approval failed';
+        dispatch({ type: 'ORCHESTRATOR_ERROR', message });
+        appLogger.error('hook', 'Orchestrator approval failed', { error: message });
+      }
+    },
+    [session.pendingApproval, dispatch],
+  );
+
+  const loadRuns = useCallback(
+    async (status?: OrchestratorRunStatus) => {
+      dispatch({ type: 'RUNS_LOADING' });
+      try {
+        const runs = await listOrchestratorRuns(status);
+        dispatch({ type: 'RUNS_LOADED', runs });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to load runs';
+        appLogger.error('hook', 'Failed to load orchestrator runs', { error: message });
+        dispatch({ type: 'RUNS_ERROR' });
+      }
+    },
+    [dispatch],
+  );
+
+  return {
+    session,
+    run,
+    resume,
+    cancel,
+    reset,
+    approve,
+    loadRuns,
+    isStreaming: streamingRef.current,
+  };
+}

--- a/src/pages/Orchestrator/components/DagView.tsx
+++ b/src/pages/Orchestrator/components/DagView.tsx
@@ -1,0 +1,132 @@
+/**
+ * DagView — Simple indented-tree visualization of a TaskGraph.
+ *
+ * Renders each TaskNode with its status badge and dependency structure
+ * using pure CSS — no external graph library required.
+ */
+
+import { FC } from 'react';
+import { CheckCircle, Circle, Loader, AlertCircle, Clock } from 'lucide-react';
+import { cn } from '../../../utils/cn';
+import type { TaskGraph } from '../../../types/orchestrator';
+import type { NodeState, NodePhase } from '../../../contexts/OrchestratorContext';
+
+interface DagViewProps {
+  graph: TaskGraph;
+  nodeStates: Record<string, NodeState>;
+  onSelectNode?: (nodeId: string) => void;
+  selectedNodeId?: string | null;
+}
+
+function phaseIcon(phase: NodePhase) {
+  switch (phase) {
+    case 'running':
+      return <Loader size={14} className="text-primary animate-spin" />;
+    case 'compacting':
+      return <Loader size={14} className="text-warning animate-spin" />;
+    case 'done':
+      return <CheckCircle size={14} className="text-success" />;
+    case 'failed':
+      return <AlertCircle size={14} className="text-danger" />;
+    default:
+      return <Circle size={14} className="text-text-muted" />;
+  }
+}
+
+function phaseBadge(phase: NodePhase) {
+  const base = 'text-xs px-xs py-[2px] rounded-sm font-medium';
+  switch (phase) {
+    case 'running':
+      return <span className={cn(base, 'bg-primary/15 text-primary')}>Running</span>;
+    case 'compacting':
+      return <span className={cn(base, 'bg-warning/15 text-warning')}>Compacting</span>;
+    case 'done':
+      return <span className={cn(base, 'bg-success/15 text-success')}>Done</span>;
+    case 'failed':
+      return <span className={cn(base, 'bg-danger/15 text-danger')}>Failed</span>;
+    default:
+      return <span className={cn(base, 'bg-surface-elevated text-text-muted')}>Pending</span>;
+  }
+}
+
+/** Topological sort of node ids so roots come first. */
+function topoSort(nodes: TaskGraph['nodes']): string[] {
+  const visited = new Set<string>();
+  const result: string[] = [];
+
+  function visit(id: string) {
+    if (visited.has(id)) return;
+    visited.add(id);
+    const node = nodes[id];
+    if (node) {
+      for (const dep of node.depends_on) visit(dep);
+    }
+    result.push(id);
+  }
+
+  for (const id of Object.keys(nodes)) {
+    visit(id);
+  }
+  return result;
+}
+
+const DagView: FC<DagViewProps> = ({ graph, nodeStates, onSelectNode, selectedNodeId }) => {
+  const sortedIds = topoSort(graph.nodes);
+
+  return (
+    <div className="flex flex-col gap-xs">
+      {sortedIds.map((id) => {
+        const node = graph.nodes[id];
+        if (!node) return null;
+        const ns = nodeStates[id];
+        const phase: NodePhase = ns?.phase ?? 'pending';
+        const isSelected = selectedNodeId === id;
+        const hasDeps = node.depends_on.length > 0;
+
+        return (
+          <div key={id}>
+            {hasDeps && (
+              <div className="flex items-center gap-xs ml-md mb-xs">
+                {node.depends_on.map((dep) => (
+                  <span key={dep} className="text-xs text-text-muted flex items-center gap-xs">
+                    <Clock size={10} />
+                    <span>after <span className="font-medium text-text-secondary">{dep}</span></span>
+                  </span>
+                ))}
+              </div>
+            )}
+            <button
+              className={cn(
+                'w-full text-left flex items-start gap-sm p-sm rounded-base border transition-all cursor-pointer bg-transparent',
+                isSelected
+                  ? 'border-primary/40 bg-primary/5'
+                  : 'border-border hover:border-border-hover hover:bg-surface-hover',
+              )}
+              onClick={() => onSelectNode?.(id)}
+            >
+              <span className="mt-[2px] shrink-0">{phaseIcon(phase)}</span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-sm flex-wrap">
+                  <span className="text-sm font-semibold text-text font-mono">{id}</span>
+                  {phaseBadge(phase)}
+                </div>
+                <p className="text-sm text-text-secondary mt-xs leading-relaxed truncate">{node.goal}</p>
+                {node.tool_allowlist.length > 0 && (
+                  <div className="flex flex-wrap gap-xs mt-xs">
+                    {node.tool_allowlist.map((t) => (
+                      <span key={t} className="text-xs bg-surface-elevated text-text-muted px-xs py-[1px] rounded-sm font-mono">
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default DagView;

--- a/src/pages/Orchestrator/components/HitlApprovalModal.tsx
+++ b/src/pages/Orchestrator/components/HitlApprovalModal.tsx
@@ -1,0 +1,217 @@
+/**
+ * HitlApprovalModal — Human-in-the-loop approval modal.
+ *
+ * Renders one of three variants based on ApprovalKind:
+ *   - plan:  shows the full graph JSON with an optional edit textarea.
+ *   - node:  shows node goal and tool allowlist.
+ *   - tool:  shows the pending tool name and node context.
+ *
+ * On approve, calls onApprove with the appropriate ApprovalDecisionPayload.
+ * On reject, calls onReject with an optional reason.
+ */
+
+import { FC, useState } from 'react';
+import { Modal } from '../../../components/ui/Modal';
+import { Button } from '../../../components/ui/Button';
+import { Textarea } from '../../../components/ui/Textarea';
+import type {
+  ApprovalKind,
+  ApprovalDecisionPayload,
+  TaskGraph,
+} from '../../../types/orchestrator';
+
+interface HitlApprovalModalProps {
+  open: boolean;
+  kind: ApprovalKind;
+  graph: TaskGraph | null;
+  submitting: boolean;
+  onApprove: (payload: ApprovalDecisionPayload) => void;
+  onReject: (reason?: string) => void;
+}
+
+const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
+  open,
+  kind,
+  graph,
+  submitting,
+  onApprove,
+  onReject,
+}) => {
+  const [rejectReason, setRejectReason] = useState('');
+  const [showReject, setShowReject] = useState(false);
+  const [graphEditJson, setGraphEditJson] = useState('');
+  const [graphEditError, setGraphEditError] = useState<string | null>(null);
+  const [showEdit, setShowEdit] = useState(false);
+
+  function handleApprove() {
+    if (showEdit && graphEditJson.trim()) {
+      try {
+        const editedGraph = JSON.parse(graphEditJson) as TaskGraph;
+        onApprove({ decision: 'approve_with_edits', edited_graph: editedGraph });
+      } catch {
+        setGraphEditError('Invalid JSON — please fix before approving with edits.');
+        return;
+      }
+    } else {
+      onApprove({ decision: 'approve' });
+    }
+  }
+
+  function handleReject() {
+    onReject(rejectReason.trim() || undefined);
+    setRejectReason('');
+    setShowReject(false);
+  }
+
+  function handleStartEdit() {
+    setShowEdit(true);
+    setGraphEditJson(JSON.stringify(graph, null, 2));
+    setGraphEditError(null);
+  }
+
+  const title =
+    kind.kind === 'plan'
+      ? 'Approve proposed plan?'
+      : kind.kind === 'node'
+        ? `Approve node: ${kind.node_id}`
+        : `Approve tool call: ${kind.tool_name}`;
+
+  const description =
+    kind.kind === 'plan'
+      ? 'Review the task graph and approve or reject the plan before execution begins.'
+      : kind.kind === 'node'
+        ? `The orchestrator wants to execute node "${kind.node_id}". Approve to allow it to run.`
+        : `The orchestrator wants to call "${kind.tool_name}" inside node "${kind.node_id}".`;
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => !submitting && onReject()}
+      title={title}
+      description={description}
+      size="lg"
+      preventClose={submitting}
+      footer={
+        showReject ? (
+          <>
+            <Button variant="secondary" size="md" onClick={() => setShowReject(false)} disabled={submitting}>
+              Back
+            </Button>
+            <Button variant="danger" size="md" onClick={handleReject} isLoading={submitting}>
+              Confirm Reject
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="danger" size="md" onClick={() => setShowReject(true)} disabled={submitting}>
+              Reject
+            </Button>
+            {kind.kind === 'plan' && !showEdit && (
+              <Button variant="secondary" size="md" onClick={handleStartEdit} disabled={submitting}>
+                Approve with Edits
+              </Button>
+            )}
+            <Button variant="primary" size="md" onClick={handleApprove} isLoading={submitting}>
+              {showEdit ? 'Approve with Edits' : 'Approve'}
+            </Button>
+          </>
+        )
+      }
+    >
+      <div className="flex flex-col gap-md">
+        {showReject && (
+          <div className="flex flex-col gap-sm">
+            <label className="text-sm font-medium text-text">Rejection reason (optional)</label>
+            <Textarea
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              placeholder="Why are you rejecting this?"
+              rows={3}
+            />
+          </div>
+        )}
+
+        {!showReject && kind.kind === 'plan' && graph && (
+          <div className="flex flex-col gap-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-text">Task graph</span>
+              {!showEdit && (
+                <span className="text-xs text-text-muted">
+                  {Object.keys(graph.nodes).length} nodes · hitl_mode: {graph.hitl_mode}
+                </span>
+              )}
+            </div>
+
+            {showEdit ? (
+              <>
+                <Textarea
+                  value={graphEditJson}
+                  onChange={(e) => {
+                    setGraphEditJson(e.target.value);
+                    setGraphEditError(null);
+                  }}
+                  rows={16}
+                  className="font-mono text-xs"
+                  aria-label="Edited graph JSON"
+                />
+                {graphEditError && (
+                  <p className="text-xs text-danger">{graphEditError}</p>
+                )}
+              </>
+            ) : (
+              <pre className="text-xs text-text-secondary bg-surface rounded-base p-sm overflow-x-auto max-h-[320px] overflow-y-auto scrollbar-thin font-mono">
+                {JSON.stringify(graph, null, 2)}
+              </pre>
+            )}
+          </div>
+        )}
+
+        {!showReject && kind.kind === 'node' && graph && (
+          <div className="flex flex-col gap-sm">
+            {graph.nodes[kind.node_id] && (
+              <>
+                <div>
+                  <p className="text-xs text-text-muted font-medium mb-xs">Goal</p>
+                  <p className="text-sm text-text">{graph.nodes[kind.node_id].goal}</p>
+                </div>
+                {graph.nodes[kind.node_id].tool_allowlist.length > 0 && (
+                  <div>
+                    <p className="text-xs text-text-muted font-medium mb-xs">Allowed tools</p>
+                    <div className="flex flex-wrap gap-xs">
+                      {graph.nodes[kind.node_id].tool_allowlist.map((t) => (
+                        <span key={t} className="text-xs bg-surface-elevated text-text-secondary px-xs py-[2px] rounded-sm font-mono">
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {!showReject && kind.kind === 'tool' && (
+          <div className="flex flex-col gap-sm">
+            <div>
+              <p className="text-xs text-text-muted font-medium mb-xs">Tool</p>
+              <p className="text-sm font-mono text-text">{kind.tool_name}</p>
+            </div>
+            <div>
+              <p className="text-xs text-text-muted font-medium mb-xs">Node</p>
+              <p className="text-sm font-mono text-text-secondary">{kind.node_id}</p>
+            </div>
+            {graph?.nodes[kind.node_id] && (
+              <div>
+                <p className="text-xs text-text-muted font-medium mb-xs">Node goal</p>
+                <p className="text-sm text-text">{graph.nodes[kind.node_id].goal}</p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default HitlApprovalModal;

--- a/src/pages/Orchestrator/components/NodePanel.tsx
+++ b/src/pages/Orchestrator/components/NodePanel.tsx
@@ -1,0 +1,154 @@
+/**
+ * NodePanel — Collapsible panel for a single orchestrator task node.
+ *
+ * Shows: goal, tool allowlist, streaming text, tool calls, final output,
+ * and status badge. Expands/collapses on click.
+ */
+
+import { FC, useState } from 'react';
+import { ChevronDown, ChevronRight, Wrench, CheckCircle, XCircle, Loader } from 'lucide-react';
+import { cn } from '../../../utils/cn';
+import type { NodeState, NodePhase } from '../../../contexts/OrchestratorContext';
+import type { TaskNode } from '../../../types/orchestrator';
+
+interface NodePanelProps {
+  nodeId: string;
+  node: TaskNode;
+  nodeState: NodeState | undefined;
+  defaultOpen?: boolean;
+}
+
+function statusColor(phase: NodePhase): string {
+  switch (phase) {
+    case 'running':
+    case 'compacting':
+      return 'border-primary/40 bg-primary/5';
+    case 'done':
+      return 'border-success/40 bg-success/5';
+    case 'failed':
+      return 'border-danger/40 bg-danger/5';
+    default:
+      return 'border-border bg-surface';
+  }
+}
+
+function statusLabel(phase: NodePhase) {
+  const base = 'text-xs font-medium px-xs py-[2px] rounded-sm';
+  switch (phase) {
+    case 'running':
+      return <span className={cn(base, 'bg-primary/15 text-primary')}>Running</span>;
+    case 'compacting':
+      return <span className={cn(base, 'bg-warning/15 text-warning')}>Compacting</span>;
+    case 'done':
+      return <span className={cn(base, 'bg-success/15 text-success')}>Done</span>;
+    case 'failed':
+      return <span className={cn(base, 'bg-danger/15 text-danger')}>Failed</span>;
+    default:
+      return <span className={cn(base, 'bg-surface-elevated text-text-muted')}>Pending</span>;
+  }
+}
+
+const NodePanel: FC<NodePanelProps> = ({ nodeId, node, nodeState, defaultOpen = false }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const phase: NodePhase = nodeState?.phase ?? 'pending';
+
+  return (
+    <div className={cn('rounded-base border transition-colors', statusColor(phase))}>
+      {/* Header */}
+      <button
+        className="w-full flex items-center gap-sm p-sm text-left bg-transparent border-none cursor-pointer"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="text-text-secondary shrink-0">
+          {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+        <span className="font-mono text-sm font-semibold text-text flex-1 truncate">{nodeId}</span>
+        {phase === 'running' || phase === 'compacting' ? (
+          <Loader size={12} className="text-primary animate-spin shrink-0" />
+        ) : phase === 'done' ? (
+          <CheckCircle size={12} className="text-success shrink-0" />
+        ) : phase === 'failed' ? (
+          <XCircle size={12} className="text-danger shrink-0" />
+        ) : null}
+        {statusLabel(phase)}
+      </button>
+
+      {/* Body */}
+      {open && (
+        <div className="px-sm pb-sm flex flex-col gap-sm border-t border-border/50">
+          {/* Goal */}
+          <div className="pt-sm">
+            <p className="text-xs text-text-muted mb-xs font-medium uppercase tracking-wide">Goal</p>
+            <p className="text-sm text-text leading-relaxed">{node.goal}</p>
+          </div>
+
+          {/* Tool allowlist */}
+          {node.tool_allowlist.length > 0 && (
+            <div>
+              <p className="text-xs text-text-muted mb-xs font-medium uppercase tracking-wide">Allowed tools</p>
+              <div className="flex flex-wrap gap-xs">
+                {node.tool_allowlist.map((t) => (
+                  <span key={t} className="flex items-center gap-xs text-xs bg-surface-elevated text-text-secondary px-xs py-[2px] rounded-sm font-mono">
+                    <Wrench size={10} />
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Tool calls log */}
+          {nodeState && nodeState.toolLog.length > 0 && (
+            <div>
+              <p className="text-xs text-text-muted mb-xs font-medium uppercase tracking-wide">Tool calls</p>
+              <div className="flex flex-col gap-xs">
+                {nodeState.toolLog.map((tc, i) => (
+                  <div key={i} className="flex items-start gap-xs text-xs bg-surface-elevated rounded-sm px-sm py-xs">
+                    {tc.done ? (
+                      <CheckCircle size={10} className="text-success mt-[2px] shrink-0" />
+                    ) : (
+                      <Loader size={10} className="text-primary animate-spin mt-[2px] shrink-0" />
+                    )}
+                    <span className="font-medium text-text font-mono">{tc.displayName}</span>
+                    <span className="text-text-muted flex-1 truncate">{tc.argsSummary}</span>
+                    {tc.durationDisplay && (
+                      <span className="text-text-muted shrink-0">{tc.durationDisplay}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Streaming text */}
+          {nodeState && nodeState.text && (
+            <div>
+              <p className="text-xs text-text-muted mb-xs font-medium uppercase tracking-wide">Output</p>
+              <pre className="text-sm text-text whitespace-pre-wrap font-mono leading-relaxed bg-surface rounded-sm p-sm max-h-[200px] overflow-y-auto scrollbar-thin">
+                {nodeState.text}
+              </pre>
+            </div>
+          )}
+
+          {/* Final output preview (collapsed text) */}
+          {nodeState?.outputPreview && nodeState.phase === 'done' && !nodeState.text && (
+            <div>
+              <p className="text-xs text-text-muted mb-xs font-medium uppercase tracking-wide">Output preview</p>
+              <p className="text-sm text-text-secondary leading-relaxed">{nodeState.outputPreview}</p>
+            </div>
+          )}
+
+          {/* Error */}
+          {nodeState?.error && (
+            <div className="rounded-sm bg-danger/10 border border-danger/20 p-sm">
+              <p className="text-xs text-danger font-medium">{nodeState.error}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NodePanel;

--- a/src/pages/Orchestrator/components/RunsList.tsx
+++ b/src/pages/Orchestrator/components/RunsList.tsx
@@ -1,0 +1,131 @@
+/**
+ * RunsList — Sidebar entry showing resumable orchestrator runs.
+ *
+ * Lists runs from GET /api/orchestrator/runs, with status filter tabs.
+ * Clicking a run fires onSelectRun so the parent page can resume it.
+ */
+
+import { FC, useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { cn } from '../../../utils/cn';
+import { Button } from '../../../components/ui/Button';
+import { Icon } from '../../../components/ui/Icon';
+import type { OrchestratorRun, OrchestratorRunStatus } from '../../../types/orchestrator';
+
+interface RunsListProps {
+  runs: OrchestratorRun[];
+  loading: boolean;
+  onRefresh: () => void;
+  onSelectRun: (run: OrchestratorRun) => void;
+}
+
+const STATUS_FILTERS: Array<{ label: string; value: OrchestratorRunStatus | 'all' }> = [
+  { label: 'All', value: 'all' },
+  { label: 'Running', value: 'running' },
+  { label: 'Paused', value: 'awaiting_approval' },
+  { label: 'Done', value: 'completed' },
+  { label: 'Failed', value: 'failed' },
+];
+
+function statusBadge(status: OrchestratorRunStatus) {
+  const base = 'text-xs px-xs py-[2px] rounded-sm font-medium';
+  switch (status) {
+    case 'running':
+      return <span className={cn(base, 'bg-primary/15 text-primary')}>Running</span>;
+    case 'awaiting_approval':
+      return <span className={cn(base, 'bg-warning/15 text-warning')}>Awaiting approval</span>;
+    case 'interrupted':
+      return <span className={cn(base, 'bg-warning/15 text-warning')}>Interrupted</span>;
+    case 'completed':
+      return <span className={cn(base, 'bg-success/15 text-success')}>Completed</span>;
+    case 'failed':
+      return <span className={cn(base, 'bg-danger/15 text-danger')}>Failed</span>;
+    default:
+      return <span className={cn(base, 'bg-surface-elevated text-text-muted')}>{status}</span>;
+  }
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+const RunsList: FC<RunsListProps> = ({ runs, loading, onRefresh, onSelectRun }) => {
+  const [filter, setFilter] = useState<OrchestratorRunStatus | 'all'>('all');
+
+  // Auto-refresh once on mount if runs is empty
+  useEffect(() => {
+    if (runs.length === 0 && !loading) {
+      onRefresh();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const filtered = filter === 'all' ? runs : runs.filter((r) => r.status === filter);
+
+  return (
+    <div className="flex flex-col gap-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-text">Previous runs</span>
+        <Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading} iconOnly title="Refresh runs">
+          <Icon icon={RefreshCw} size={13} className={cn(loading && 'animate-spin')} />
+        </Button>
+      </div>
+
+      {/* Status filter tabs */}
+      <div className="flex gap-xs flex-wrap">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setFilter(f.value)}
+            className={cn(
+              'text-xs px-sm py-xs rounded-sm border transition-colors bg-transparent cursor-pointer',
+              filter === f.value
+                ? 'border-primary/40 text-primary bg-primary/10'
+                : 'border-border text-text-muted hover:border-border-hover hover:text-text',
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Runs list */}
+      {loading && filtered.length === 0 && (
+        <p className="text-sm text-text-muted text-center py-md">Loading…</p>
+      )}
+
+      {!loading && filtered.length === 0 && (
+        <p className="text-sm text-text-muted text-center py-md">No runs found.</p>
+      )}
+
+      <div className="flex flex-col gap-xs">
+        {filtered.map((run) => (
+          <button
+            key={run.id}
+            className="w-full text-left flex flex-col gap-xs p-sm rounded-base border border-border hover:border-border-hover hover:bg-surface-hover transition-colors cursor-pointer bg-transparent"
+            onClick={() => onSelectRun(run)}
+          >
+            <div className="flex items-center justify-between gap-sm">
+              <span className="text-xs font-mono text-text-muted truncate flex-1">{run.id.slice(0, 12)}…</span>
+              {statusBadge(run.status)}
+            </div>
+            <p className="text-sm text-text leading-snug line-clamp-2">{run.goal}</p>
+            <span className="text-xs text-text-muted">{formatDate(run.updated_at)}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RunsList;

--- a/src/pages/Orchestrator/index.tsx
+++ b/src/pages/Orchestrator/index.tsx
@@ -1,0 +1,325 @@
+/**
+ * Orchestrator page — Phase F native frontend.
+ *
+ * Provides:
+ *   - Goal input form + run/cancel buttons
+ *   - DAG visualization with clickable nodes
+ *   - Per-node collapsible NodePanel components
+ *   - Synthesis streaming output
+ *   - HITL approval modals (plan / node / tool)
+ *   - Resumable runs sidebar via RunsList
+ *
+ * Uses the OrchestratorContext + useOrchestrator hook.
+ * HTTP transport only — no tauri::command, no isTauriApp branching.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { ArrowLeft, Play, Square, RotateCcw, ChevronDown, ChevronRight } from 'lucide-react';
+import { Button } from '../../components/ui/Button';
+import { Input } from '../../components/ui/Input';
+import { Select } from '../../components/ui/Select';
+import { Icon } from '../../components/ui/Icon';
+import { useOrchestrator } from '../../hooks/useOrchestrator';
+import { useSettingsContext } from '../../contexts/SettingsContext';
+import type { OrchestratorRun } from '../../types/orchestrator';
+import DagView from './components/DagView';
+import NodePanel from './components/NodePanel';
+import HitlApprovalModal from './components/HitlApprovalModal';
+import RunsList from './components/RunsList';
+
+const HITL_MODE_OPTIONS = [
+  { value: 'none', label: 'No approval' },
+  { value: 'approve_plan', label: 'Approve plan' },
+  { value: 'approve_each_node', label: 'Approve each node' },
+  { value: 'approve_tools', label: 'Approve tool calls' },
+];
+
+interface OrchestratorPageProps {
+  onBack?: () => void;
+}
+
+export default function OrchestratorPage({ onBack }: OrchestratorPageProps) {
+  const { settings } = useSettingsContext();
+  const serverPort = settings?.llamaBasePort ?? 9000;
+
+  const { session, run, resume, cancel, reset, approve, loadRuns, isStreaming } = useOrchestrator({
+    serverPort,
+  });
+
+  const [goal, setGoal] = useState('');
+  const [hitlMode, setHitlMode] = useState('none');
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [showRuns, setShowRuns] = useState(false);
+  const [showNodes, setShowNodes] = useState(true);
+
+  const isActive = session.phase === 'running' || session.phase === 'awaiting_approval' || session.phase === 'synthesizing';
+
+  // Load runs on mount
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!goal.trim() || isActive) return;
+      await run(goal.trim(), hitlMode);
+    },
+    [goal, hitlMode, isActive, run],
+  );
+
+  const handleResume = useCallback(
+    async (r: OrchestratorRun) => {
+      setGoal(r.goal);
+      setShowRuns(false);
+      await resume(r.id);
+    },
+    [resume],
+  );
+
+  const handleApproveWithPayload = useCallback(
+    (payload: Parameters<typeof approve>[0]) => {
+      approve(payload);
+    },
+    [approve],
+  );
+
+  const handleReject = useCallback(
+    (reason?: string) => {
+      approve({ decision: 'reject', reason });
+    },
+    [approve],
+  );
+
+  // Auto-open nodes section when run starts
+  useEffect(() => {
+    if (session.phase === 'running') setShowNodes(true);
+  }, [session.phase]);
+
+  const nodeIds = session.graph ? Object.keys(session.graph.nodes) : [];
+
+  return (
+    <div className="flex h-full overflow-hidden bg-background">
+      {/* ── Sidebar ────────────────────────────────────────────────────── */}
+      <aside className="hidden md:flex flex-col w-[280px] shrink-0 border-r border-border bg-surface overflow-y-auto p-md gap-md scrollbar-thin">
+        {onBack && (
+          <Button variant="ghost" size="sm" onClick={onBack} className="self-start -ml-xs">
+            <Icon icon={ArrowLeft} size={14} />
+            Back
+          </Button>
+        )}
+
+        <div>
+          <p className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-sm">Orchestrator</p>
+          <p className="text-xs text-text-secondary leading-relaxed">
+            Multi-node task execution with a director planner and parallel workers.
+          </p>
+        </div>
+
+        {/* Runs toggle */}
+        <button
+          className="flex items-center gap-xs text-sm font-medium text-text bg-transparent border-none cursor-pointer p-0 hover:text-primary transition-colors"
+          onClick={() => setShowRuns((v) => !v)}
+        >
+          <Icon icon={showRuns ? ChevronDown : ChevronRight} size={13} />
+          Previous runs
+        </button>
+
+        {showRuns && (
+          <RunsList
+            runs={session.runs}
+            loading={session.runsLoading}
+            onRefresh={() => loadRuns()}
+            onSelectRun={handleResume}
+          />
+        )}
+      </aside>
+
+      {/* ── Main content ───────────────────────────────────────────────── */}
+      <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center gap-sm px-md py-sm border-b border-border shrink-0">
+          {onBack && (
+            <Button variant="ghost" size="sm" onClick={onBack} className="md:hidden -ml-xs" iconOnly title="Back">
+              <Icon icon={ArrowLeft} size={14} />
+            </Button>
+          )}
+          <h1 className="text-lg font-semibold text-text flex-1">Orchestrator</h1>
+          {(session.phase === 'complete' || session.phase === 'error') && (
+            <Button variant="secondary" size="sm" onClick={reset}>
+              <Icon icon={RotateCcw} size={13} />
+              New run
+            </Button>
+          )}
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto p-md flex flex-col gap-lg scrollbar-thin">
+          {/* Goal input form */}
+          <form onSubmit={handleSubmit} className="flex flex-col gap-sm">
+            <div className="flex gap-sm">
+              <Input
+                value={goal}
+                onChange={(e) => setGoal(e.target.value)}
+                placeholder="Describe the goal for the orchestrator…"
+                disabled={isActive}
+                className="flex-1"
+              />
+              {isActive ? (
+                <Button type="button" variant="danger" size="md" onClick={cancel} iconOnly title="Cancel">
+                  <Icon icon={Square} size={14} />
+                </Button>
+              ) : (
+                <Button type="submit" variant="primary" size="md" disabled={!goal.trim()}>
+                  <Icon icon={Play} size={14} />
+                  Run
+                </Button>
+              )}
+            </div>
+
+            <div className="flex items-center gap-sm">
+              <label className="text-sm text-text-secondary shrink-0">HITL mode:</label>
+              <Select
+                value={hitlMode}
+                onChange={(e) => setHitlMode(e.target.value)}
+                disabled={isActive}
+                size="sm"
+              >
+                {HITL_MODE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </Select>
+            </div>
+          </form>
+
+          {/* Error banner */}
+          {session.error && (
+            <div className="rounded-base border border-danger/30 bg-danger/10 px-md py-sm">
+              <p className="text-sm text-danger">{session.error}</p>
+            </div>
+          )}
+
+          {/* Phase indicator */}
+          {isActive && (
+            <div className="flex items-center gap-sm text-sm text-text-secondary">
+              <span className="inline-block w-2 h-2 rounded-full bg-primary animate-pulse" />
+              {session.phase === 'synthesizing'
+                ? 'Synthesizing final answer…'
+                : session.phase === 'awaiting_approval'
+                  ? 'Waiting for your approval…'
+                  : 'Running…'}
+            </div>
+          )}
+
+          {/* DAG visualization */}
+          {session.graph && (
+            <section className="flex flex-col gap-sm">
+              <button
+                className="flex items-center gap-xs text-sm font-semibold text-text bg-transparent border-none cursor-pointer p-0 hover:text-primary transition-colors"
+                onClick={() => setShowNodes((v) => !v)}
+              >
+                <Icon icon={showNodes ? ChevronDown : ChevronRight} size={14} />
+                Task graph
+                <span className="ml-xs text-xs text-text-muted font-normal">
+                  ({nodeIds.length} nodes)
+                </span>
+              </button>
+
+              {showNodes && (
+                <>
+                  <DagView
+                    graph={session.graph}
+                    nodeStates={session.nodeStates}
+                    selectedNodeId={selectedNodeId}
+                    onSelectNode={(id) => setSelectedNodeId((prev) => (prev === id ? null : id))}
+                  />
+
+                  {/* Node panels */}
+                  {nodeIds.length > 0 && (
+                    <div className="flex flex-col gap-xs mt-xs">
+                      {nodeIds.map((id) => (
+                        <NodePanel
+                          key={id}
+                          nodeId={id}
+                          node={session.graph!.nodes[id]}
+                          nodeState={session.nodeStates[id]}
+                          defaultOpen={
+                            id === selectedNodeId ||
+                            session.nodeStates[id]?.phase === 'running' ||
+                            session.nodeStates[id]?.phase === 'failed'
+                          }
+                        />
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+            </section>
+          )}
+
+          {/* Synthesis streaming output */}
+          {(session.synthesisText || session.phase === 'synthesizing') && (
+            <section className="flex flex-col gap-sm">
+              <h2 className="text-sm font-semibold text-text">Synthesis</h2>
+              <div className="rounded-base border border-border bg-surface p-md">
+                <pre className="text-sm text-text whitespace-pre-wrap font-sans leading-relaxed">
+                  {session.synthesisText}
+                  {session.phase === 'synthesizing' && (
+                    <span className="inline-block w-[2px] h-[1em] bg-primary align-text-bottom animate-blink ml-[1px]" />
+                  )}
+                </pre>
+              </div>
+            </section>
+          )}
+
+          {/* Final answer */}
+          {session.phase === 'complete' && session.finalAnswer && (
+            <section className="flex flex-col gap-sm">
+              <h2 className="text-sm font-semibold text-success">Answer</h2>
+              <div className="rounded-base border border-success/30 bg-success/5 p-md">
+                <pre className="text-sm text-text whitespace-pre-wrap font-sans leading-relaxed">
+                  {session.finalAnswer}
+                </pre>
+              </div>
+            </section>
+          )}
+
+          {/* Mobile: previous runs */}
+          <section className="flex flex-col gap-sm md:hidden">
+            <button
+              className="flex items-center gap-xs text-sm font-semibold text-text bg-transparent border-none cursor-pointer p-0 hover:text-primary transition-colors"
+              onClick={() => setShowRuns((v) => !v)}
+            >
+              <Icon icon={showRuns ? ChevronDown : ChevronRight} size={14} />
+              Previous runs
+            </button>
+
+            {showRuns && (
+              <RunsList
+                runs={session.runs}
+                loading={session.runsLoading}
+                onRefresh={() => loadRuns()}
+                onSelectRun={handleResume}
+              />
+            )}
+          </section>
+        </div>
+      </main>
+
+      {/* HITL approval modal */}
+      {session.pendingApproval && (
+        <HitlApprovalModal
+          open={true}
+          kind={session.pendingApproval.kind}
+          graph={session.graph}
+          submitting={session.pendingApproval.submitting}
+          onApprove={handleApproveWithPayload}
+          onReject={handleReject}
+        />
+      )}
+
+      {/* suppress unused warning */}
+      {void isStreaming}
+    </div>
+  );
+}

--- a/tests/ts/hooks/OrchestratorContext.test.ts
+++ b/tests/ts/hooks/OrchestratorContext.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for OrchestratorContext reducer state transitions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  orchestratorReducer,
+  type OrchestratorSession,
+  type OrchestratorAction,
+} from '../../../src/contexts/OrchestratorContext';
+import type { TaskGraph, ApprovalKind } from '../../../src/types/orchestrator';
+
+const EMPTY_GRAPH: TaskGraph = {
+  goal: 'test goal',
+  hitl_mode: 'none',
+  nodes: {
+    t1: { id: 't1', goal: 'do task 1', depends_on: [], tool_allowlist: [], status: 'pending' },
+    t2: { id: 't2', goal: 'do task 2', depends_on: ['t1'], tool_allowlist: ['search'], status: 'pending' },
+  },
+};
+
+function emptySession(): OrchestratorSession {
+  return makeSession();
+}
+
+// Build an initial idle session via RESET from a fabricated state
+function makeSession(overrides: Partial<OrchestratorSession> = {}): OrchestratorSession {
+  return {
+    phase: 'idle',
+    graph: null,
+    nodeStates: {},
+    synthesisText: '',
+    finalAnswer: null,
+    pendingApproval: null,
+    error: null,
+    runs: [],
+    runsLoading: false,
+    ...overrides,
+  };
+}
+
+describe('orchestratorReducer', () => {
+  it('RESET returns idle session', () => {
+    const state = makeSession({ phase: 'complete', finalAnswer: 'answer', graph: EMPTY_GRAPH });
+    const next = orchestratorReducer(state, { type: 'RESET' });
+    expect(next.phase).toBe('idle');
+    expect(next.graph).toBeNull();
+    expect(next.finalAnswer).toBeNull();
+  });
+
+  it('START_RUN moves phase to running and clears session', () => {
+    const state = makeSession({ phase: 'idle', runs: [{ id: 'r1', goal: 'g', graph_json: null, status: 'completed', hitl_mode: 'none', conversation_id: null, created_at: '', updated_at: '' }] });
+    const next = orchestratorReducer(state, { type: 'START_RUN', goal: 'new goal' });
+    expect(next.phase).toBe('running');
+    expect(next.graph).toBeNull();
+    expect(next.synthesisText).toBe('');
+    // preserves runs
+    expect(next.runs).toHaveLength(1);
+  });
+
+  it('PLAN_PROPOSED sets graph', () => {
+    const state = makeSession({ phase: 'running' });
+    const next = orchestratorReducer(state, { type: 'PLAN_PROPOSED', graph: EMPTY_GRAPH });
+    expect(next.graph).toEqual(EMPTY_GRAPH);
+  });
+
+  it('NODE_STARTED creates node state', () => {
+    const state = makeSession({ phase: 'running' });
+    const next = orchestratorReducer(state, { type: 'NODE_STARTED', nodeId: 't1', goal: 'do task 1' });
+    expect(next.nodeStates['t1']).toEqual({ phase: 'running', goal: 'do task 1', text: '', toolLog: [] });
+  });
+
+  it('NODE_TEXT_DELTA accumulates text', () => {
+    const state = makeSession({
+      nodeStates: { t1: { phase: 'running', goal: 'g', text: 'Hello', toolLog: [] } },
+    });
+    const next = orchestratorReducer(state, { type: 'NODE_TEXT_DELTA', nodeId: 't1', delta: ' World' });
+    expect(next.nodeStates['t1'].text).toBe('Hello World');
+  });
+
+  it('NODE_TEXT_DELTA ignores unknown node', () => {
+    const state = makeSession({ nodeStates: {} });
+    const next = orchestratorReducer(state, { type: 'NODE_TEXT_DELTA', nodeId: 'unknown', delta: 'x' });
+    expect(next).toBe(state);
+  });
+
+  it('NODE_TOOL_CALL_START appends to toolLog', () => {
+    const state = makeSession({
+      nodeStates: { t1: { phase: 'running', goal: 'g', text: '', toolLog: [] } },
+    });
+    const next = orchestratorReducer(state, {
+      type: 'NODE_TOOL_CALL_START',
+      nodeId: 't1',
+      displayName: 'search',
+      argsSummary: 'query=foo',
+    });
+    expect(next.nodeStates['t1'].toolLog).toHaveLength(1);
+    expect(next.nodeStates['t1'].toolLog[0].done).toBe(false);
+    expect(next.nodeStates['t1'].toolLog[0].displayName).toBe('search');
+  });
+
+  it('NODE_TOOL_CALL_COMPLETE marks tool done', () => {
+    const state = makeSession({
+      nodeStates: {
+        t1: {
+          phase: 'running', goal: 'g', text: '',
+          toolLog: [{ displayName: 'search', argsSummary: 'q', done: false }],
+        },
+      },
+    });
+    const next = orchestratorReducer(state, {
+      type: 'NODE_TOOL_CALL_COMPLETE',
+      nodeId: 't1',
+      toolName: 'search',
+      displayName: 'search',
+      durationDisplay: '1.2s',
+    });
+    expect(next.nodeStates['t1'].toolLog[0].done).toBe(true);
+    expect(next.nodeStates['t1'].toolLog[0].durationDisplay).toBe('1.2s');
+  });
+
+  it('NODE_COMPLETE sets phase done and outputPreview', () => {
+    const state = makeSession({
+      nodeStates: { t1: { phase: 'running', goal: 'g', text: 'some text', toolLog: [] } },
+    });
+    const next = orchestratorReducer(state, {
+      type: 'NODE_COMPLETE',
+      nodeId: 't1',
+      outputPreview: 'preview here',
+    });
+    expect(next.nodeStates['t1'].phase).toBe('done');
+    expect(next.nodeStates['t1'].outputPreview).toBe('preview here');
+  });
+
+  it('NODE_FAILED sets phase failed and error', () => {
+    const state = makeSession({
+      nodeStates: { t1: { phase: 'running', goal: 'g', text: '', toolLog: [] } },
+    });
+    const next = orchestratorReducer(state, { type: 'NODE_FAILED', nodeId: 't1', error: 'timeout' });
+    expect(next.nodeStates['t1'].phase).toBe('failed');
+    expect(next.nodeStates['t1'].error).toBe('timeout');
+  });
+
+  it('NODE_COMPACTING sets phase compacting', () => {
+    const state = makeSession({
+      nodeStates: { t1: { phase: 'running', goal: 'g', text: 'long text', toolLog: [] } },
+    });
+    const next = orchestratorReducer(state, { type: 'NODE_COMPACTING', nodeId: 't1' });
+    expect(next.nodeStates['t1'].phase).toBe('compacting');
+  });
+
+  it('SYNTHESIS_START sets phase synthesizing and clears text', () => {
+    const state = makeSession({ synthesisText: 'old', phase: 'running' });
+    const next = orchestratorReducer(state, { type: 'SYNTHESIS_START' });
+    expect(next.phase).toBe('synthesizing');
+    expect(next.synthesisText).toBe('');
+  });
+
+  it('SYNTHESIS_TEXT_DELTA accumulates synthesis text', () => {
+    const state = makeSession({ phase: 'synthesizing', synthesisText: 'Hello' });
+    const next = orchestratorReducer(state, { type: 'SYNTHESIS_TEXT_DELTA', delta: ' world' });
+    expect(next.synthesisText).toBe('Hello world');
+  });
+
+  it('ORCHESTRATOR_COMPLETE sets phase complete and finalAnswer', () => {
+    const state = makeSession({ phase: 'synthesizing' });
+    const next = orchestratorReducer(state, { type: 'ORCHESTRATOR_COMPLETE', answer: 'the answer' });
+    expect(next.phase).toBe('complete');
+    expect(next.finalAnswer).toBe('the answer');
+  });
+
+  it('ORCHESTRATOR_ERROR sets phase error and error message', () => {
+    const state = makeSession({ phase: 'running' });
+    const next = orchestratorReducer(state, { type: 'ORCHESTRATOR_ERROR', message: 'something went wrong' });
+    expect(next.phase).toBe('error');
+    expect(next.error).toBe('something went wrong');
+  });
+
+  it('AWAITING_APPROVAL sets phase and pendingApproval', () => {
+    const state = makeSession({ phase: 'running' });
+    const kind: ApprovalKind = { kind: 'plan' };
+    const next = orchestratorReducer(state, { type: 'AWAITING_APPROVAL', approvalId: 'abc', kind });
+    expect(next.phase).toBe('awaiting_approval');
+    expect(next.pendingApproval).toEqual({ approvalId: 'abc', kind, submitting: false });
+  });
+
+  it('APPROVAL_SUBMITTING marks submitting true', () => {
+    const state = makeSession({
+      pendingApproval: { approvalId: 'abc', kind: { kind: 'plan' }, submitting: false },
+    });
+    const next = orchestratorReducer(state, { type: 'APPROVAL_SUBMITTING' });
+    expect(next.pendingApproval?.submitting).toBe(true);
+  });
+
+  it('APPROVAL_DONE clears pendingApproval and resumes running', () => {
+    const state = makeSession({
+      phase: 'awaiting_approval',
+      pendingApproval: { approvalId: 'abc', kind: { kind: 'plan' }, submitting: true },
+    });
+    const next = orchestratorReducer(state, { type: 'APPROVAL_DONE' });
+    expect(next.phase).toBe('running');
+    expect(next.pendingApproval).toBeNull();
+  });
+
+  it('RUNS_LOADED stores runs and clears loading', () => {
+    const state = makeSession({ runsLoading: true, runs: [] });
+    const runs = [{ id: 'r1', goal: 'g', graph_json: null, status: 'completed' as const, hitl_mode: 'none' as const, conversation_id: null, created_at: '', updated_at: '' }];
+    const next = orchestratorReducer(state, { type: 'RUNS_LOADED', runs });
+    expect(next.runs).toHaveLength(1);
+    expect(next.runsLoading).toBe(false);
+  });
+
+  describe('session preserved across RESET', () => {
+    it('RESET preserves runs from previous state', () => {
+      const runs = [{ id: 'r1', goal: 'g', graph_json: null, status: 'completed' as const, hitl_mode: 'none' as const, conversation_id: null, created_at: '', updated_at: '' }];
+      const state = makeSession({ phase: 'complete', runs });
+      const next = orchestratorReducer(state, { type: 'RESET' });
+      expect(next.runs).toHaveLength(1);
+    });
+  });
+});
+
+// Ensure emptySession utility doesn't throw
+describe('emptySession helper', () => {
+  it('returns idle phase', () => {
+    const s = emptySession();
+    expect(s.phase).toBe('idle');
+  });
+});


### PR DESCRIPTION
## Phase F — Native Frontend Polish, DAG Visualization, HITL Modals, Run Management

Closes #495

This PR completes Phase F of the Orchestrator epic, adding a full native frontend for the orchestrator backend built across Phases A–E.

---

### What's included

#### `src/contexts/OrchestratorContext.tsx` (new)
Reducer-based context following the `CouncilContext` pattern exactly.

- **State shape**: `{ phase, graph, nodeStates, synthesisText, finalAnswer, pendingApproval, error, runs, runsLoading }`
- **Phases**: `idle | planning | running | awaiting_approval | synthesizing | complete | error`
- **NodeState**: per-node `phase`, `goal`, `text`, `toolLog`, `outputPreview`, `error`
- **All actions**: `START_RUN`, `RESET`, `PLAN_PROPOSED`, `NODE_STARTED`, `NODE_TEXT_DELTA`, `NODE_TOOL_CALL_START`, `NODE_TOOL_CALL_COMPLETE`, `NODE_COMPACTING`, `NODE_COMPLETE`, `NODE_FAILED`, `SYNTHESIS_START`, `SYNTHESIS_TEXT_DELTA`, `SYNTHESIS_COMPLETE`, `AWAITING_APPROVAL`, `APPROVAL_SUBMITTING`, `APPROVAL_DONE`, `ORCHESTRATOR_COMPLETE`, `ORCHESTRATOR_ERROR`, `RUNS_LOADING`, `RUNS_LOADED`, `RUNS_ERROR`
- `RESET` and `START_RUN` preserve `runs` and `runsLoading` from previous state.

#### `src/hooks/useOrchestrator/` (new)
Bridges SSE events → context dispatch. Manages `AbortController` lifecycle.

- `run(goal, hitlMode?, maxWorkerConcurrency?)` — streams events from `runOrchestrator()`
- `resume(runId)` — resumes a paused run via `resumeOrchestratorRun()`
- `approve(payload)` — submits an approval decision via `approveOrchestrator()`
- `loadRuns(status?)` — fetches the run list via `listOrchestratorRuns()`

#### `src/pages/Orchestrator/components/DagView.tsx` (new)
Topologically-sorted indented tree of `TaskGraph` nodes. No external graph library.

- Phase badges: running / done / failed / compacting (Tailwind v4 tokens)
- Clickable nodes with selection highlight
- Dependency labels shown inline

#### `src/pages/Orchestrator/components/NodePanel.tsx` (new)
Collapsible per-node panel. Auto-opens for `running` or `failed` nodes.

- Goal, tool allowlist badges, streaming text, tool call log with timing, output preview, error box

#### `src/pages/Orchestrator/components/HitlApprovalModal.tsx` (new)
HITL approval modal for `plan | node | tool` kinds.

- **Plan**: full graph JSON viewer + optional "Approve with Edits" (editable JSON with parse validation) + reject-with-reason
- **Node**: shows node goal and tool allowlist
- **Tool**: shows tool name, node ID, and node goal
- Uses existing `Modal` (Radix Dialog) component; `preventClose` while submitting

#### `src/pages/Orchestrator/components/RunsList.tsx` (new)
Resumable runs entry with status filter tabs (All / Running / Paused / Done / Failed), formatted timestamps, and click-to-resume.

#### `src/pages/Orchestrator/index.tsx` (new)
Main Orchestrator page.

- Sidebar (hidden on mobile): Back button, description, collapsible "Previous runs" with `RunsList`
- Main area: goal input + HITL mode selector (`none | approve_plan | approve_each_node | approve_tools`), live phase indicator, collapsible DAG section, `NodePanel` list, synthesis streaming output with blinking cursor, final answer panel (green)
- `serverPort` sourced from `useSettingsContext().settings?.llamaBasePort ?? 9000`

#### `src/App.tsx` (modified)
- Added `#orchestrator` hash routing
- Wraps `OrchestratorPage` in `<OrchestratorProvider>` (resets on navigate-away)

#### `tests/ts/hooks/OrchestratorContext.test.ts` (new)
21 reducer tests covering every major state transition. All pass.

---

### Constraints respected

- No `isTauriApp` branching — HTTP transport only
- No new `#[tauri::command]` — uses existing backend endpoints from Phases C/D
- Tailwind v4 design tokens throughout — no hardcoded hex colors
- All 606 frontend tests pass; zero TypeScript errors
