### PR TITLE
feat(core): Phase G — hierarchical subgraphs, role catalog, TaskNodeKind

### DIFF
--- a/crates/gglib-agent/src/orchestrator/director.rs
+++ b/crates/gglib-agent/src/orchestrator/director.rs
@@ -26,9 +26,8 @@ use tokio::sync::mpsc;
 
 use gglib_core::domain::agent::{AgentMessage, AssistantContent, ToolDefinition};
 use gglib_core::domain::orchestrator::events::OrchestratorEvent;
-use gglib_core::domain::orchestrator::task_graph::{
-    HitlMode, NodeId, NodeStatus, TaskGraph, TaskGraphError, TaskNode,
-};
+use gglib_core::domain::orchestrator::task_graph::
+    {HitlMode, NodeId, NodeStatus, TaskGraph, TaskGraphError, TaskNode, TaskNodeKind};
 use gglib_core::ports::LlmCompletionPort;
 
 use gglib_core::ports::StructuredOutputError;
@@ -243,6 +242,8 @@ pub async fn plan(
                 goal: n.goal.clone(),
                 depends_on: n.depends_on.iter().map(|d| NodeId(d.clone())).collect(),
                 tool_allowlist: n.tool_allowlist.clone(),
+                kind: TaskNodeKind::Leaf,
+                role: None,
                 status: NodeStatus::Pending,
                 output: None,
                 compacted_output: None,

--- a/crates/gglib-agent/src/orchestrator/executor.rs
+++ b/crates/gglib-agent/src/orchestrator/executor.rs
@@ -875,7 +875,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::build_predecessor_context;
     use gglib_core::domain::orchestrator::task_graph::{
-        HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode,
+        HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
     };
 
     fn make_node(id: &str, deps: &[&str]) -> TaskNode {
@@ -884,6 +884,8 @@ mod tests {
             goal: id.into(),
             depends_on: deps.iter().map(|d| NodeId((*d).to_string())).collect(),
             tool_allowlist: vec![],
+            kind: TaskNodeKind::Leaf,
+            role: None,
             status: NodeStatus::Pending,
             output: None,
             compacted_output: None,

--- a/crates/gglib-cli/src/handlers/orchestrate.rs
+++ b/crates/gglib-cli/src/handlers/orchestrate.rs
@@ -313,6 +313,12 @@ async fn render_event(
         OrchestratorEvent::OrchestratorError { message } => {
             eprintln!("{}Error: {message}{}", style::DANGER, style::RESET);
         }
+        OrchestratorEvent::TeamStarted { team_id, .. } => {
+            eprintln!("{}[{team_id}] ▶ team started{}", style::DIM, style::RESET);
+        }
+        OrchestratorEvent::TeamSynthesized { team_id, .. } => {
+            eprintln!("{}[{team_id}] ✓ team synthesized{}", style::DIM, style::RESET);
+        }
         OrchestratorEvent::NodeProgress { .. } | OrchestratorEvent::SynthesisProgress { .. } => {}
     }
 }

--- a/crates/gglib-core/src/domain/orchestrator/events.rs
+++ b/crates/gglib-core/src/domain/orchestrator/events.rs
@@ -23,6 +23,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::agent::{ToolCall, ToolResult};
+use crate::domain::orchestrator::role_catalog::RoleId;
 
 use super::task_graph::TaskGraph;
 
@@ -257,4 +258,30 @@ pub enum OrchestratorEvent {
 
     /// The orchestrator run failed with an unrecoverable error.
     OrchestratorError { message: String },
+
+    // ── team (v2) ────────────────────────────────────────────────────────
+    /// A [`TaskNodeKind::Team`] node has started executing its nested subgraph.
+    ///
+    /// Emitted by the executor before it begins scheduling the first wave of
+    /// the team's subgraph.  Paired with [`OrchestratorEvent::TeamSynthesized`]
+    /// when the subgraph completes.
+    TeamStarted {
+        /// The id of the `Team` node in the parent graph.
+        team_id: String,
+        /// The optional specialist role assigned to this team.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        role: Option<RoleId>,
+    },
+
+    /// A [`TaskNodeKind::Team`] node's subgraph has completed and its output
+    /// has been compacted for passing to downstream nodes in the parent graph.
+    ///
+    /// The `compacted_output` is what downstream nodes receive as context from
+    /// this team node — identical in shape to a leaf node's `compacted_output`.
+    TeamSynthesized {
+        /// The id of the `Team` node in the parent graph.
+        team_id: String,
+        /// Compacted summary of the team's synthesised output.
+        compacted_output: String,
+    },
 }

--- a/crates/gglib-core/src/domain/orchestrator/mod.rs
+++ b/crates/gglib-core/src/domain/orchestrator/mod.rs
@@ -7,16 +7,20 @@
 //!
 //! | Module | Contents |
 //! |--------|---------|
-//! | [`task_graph`] | [`TaskGraph`], [`TaskNode`], [`NodeId`], [`NodeStatus`], [`HitlMode`], [`TaskGraphError`] |
+//! | [`task_graph`] | [`TaskGraph`], [`TaskNode`], [`TaskNodeKind`], [`NodeId`], [`NodeStatus`], [`HitlMode`], [`TaskGraphError`] |
+//! | [`role_catalog`] | [`RoleId`], [`RoleSpec`], [`RoleCatalog`] — built-in specialist roles |
 //! | [`events`] | [`OrchestratorEvent`] — SSE event stream types |
 //! | [`run`] | [`OrchestratorRun`], [`OrchestratorRunStatus`], [`OrchestratorRunEvent`] |
 
 pub mod events;
+pub mod role_catalog;
 pub mod run;
 pub mod task_graph;
 
 pub use events::{ApprovalKind, OrchestratorEvent};
+pub use role_catalog::{RoleCatalog, RoleId, RoleSpec};
 pub use run::{OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus};
 pub use task_graph::{
-    HitlMode, MAX_DEPTH, MAX_NODES, NodeId, NodeStatus, TaskGraph, TaskGraphError, TaskNode,
+    HitlMode, MAX_DEPTH, MAX_NODES, MAX_TOTAL_NODES, NodeId, NodeStatus, TaskGraph, TaskGraphError,
+    TaskNode, TaskNodeKind,
 };

--- a/crates/gglib-core/src/domain/orchestrator/role_catalog.rs
+++ b/crates/gglib-core/src/domain/orchestrator/role_catalog.rs
@@ -1,0 +1,335 @@
+//! Built-in role catalog for the orchestrator v2 hierarchical planner.
+//!
+//! A [`RoleId`] identifies a specialist role that a [`TaskNode`] can adopt.
+//! The [`RoleCatalog`] maps role names to [`RoleSpec`] entries that carry the
+//! system-prompt fragment, default tool allowlist, suggested sampling
+//! temperature, and approval policy for that role.
+//!
+//! # Built-in roles
+//!
+//! | Role id | Purpose |
+//! |---------|---------|
+//! | `researcher` | Information gathering and source retrieval |
+//! | `red-team` | Adversarial challenge and stress-testing of plans |
+//! | `fact-checker` | Verification of claims against retrieved evidence |
+//! | `writer` | First-draft prose generation |
+//! | `editor` | Revision and polish of existing drafts |
+//! | `critic` | Structured critique and gap identification |
+//! | `synthesizer` | Final integration of multiple node outputs |
+//!
+//! YAML-overridable catalogs are deferred to a future phase.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// =============================================================================
+// RoleId
+// =============================================================================
+
+/// Opaque identifier for a specialist role within a task-force subgraph.
+///
+/// Short, kebab-case strings are recommended (e.g. `"researcher"`, `"red-team"`).
+///
+/// # Example
+///
+/// ```rust
+/// use gglib_core::domain::orchestrator::role_catalog::RoleId;
+///
+/// let id = RoleId::new("researcher");
+/// assert_eq!(id.as_str(), "researcher");
+/// assert_eq!(id.to_string(), "researcher");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RoleId(pub String);
+
+impl RoleId {
+    /// Create a new [`RoleId`] from any string-like value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gglib_core::domain::orchestrator::role_catalog::RoleId;
+    ///
+    /// let id = RoleId::new("synthesizer");
+    /// assert_eq!(id.as_str(), "synthesizer");
+    /// ```
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Return the inner string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for RoleId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// =============================================================================
+// RoleSpec
+// =============================================================================
+
+/// Specification for a single specialist role.
+///
+/// Carried inside [`RoleCatalog`] and resolved at planning time by the
+/// hierarchical director (Phase H).
+#[derive(Debug, Clone)]
+pub struct RoleSpec {
+    /// Short, human-readable display name (title-case).
+    pub display_name: &'static str,
+    /// One-paragraph system-prompt fragment injected before the worker's goal.
+    pub system_prompt_fragment: &'static str,
+    /// Tool names this role is permitted to call by default.
+    ///
+    /// The director may widen or narrow this list per-node at plan time.
+    pub default_tool_allowlist: &'static [&'static str],
+    /// Suggested sampling temperature for this role's LLM calls (0.0–1.0).
+    pub suggested_temperature: f32,
+    /// Whether this role's output requires human approval before being passed
+    /// downstream.
+    pub requires_approval: bool,
+}
+
+// =============================================================================
+// RoleCatalog
+// =============================================================================
+
+/// Immutable map of [`RoleId`] → [`RoleSpec`] for the built-in specialist roles.
+///
+/// Construct via [`RoleCatalog::default()`]; the seven built-in roles are
+/// always present.  YAML-overridable catalogs are deferred to a future phase.
+///
+/// # Example
+///
+/// ```rust
+/// use gglib_core::domain::orchestrator::role_catalog::{RoleCatalog, RoleId};
+///
+/// let catalog = RoleCatalog::default();
+/// assert_eq!(catalog.len(), 7);
+/// assert!(catalog.get(&RoleId::new("researcher")).is_some());
+/// assert!(catalog.get(&RoleId::new("unknown-role")).is_none());
+/// ```
+pub struct RoleCatalog {
+    roles: HashMap<RoleId, RoleSpec>,
+}
+
+impl Default for RoleCatalog {
+    fn default() -> Self {
+        let mut roles: HashMap<RoleId, RoleSpec> = HashMap::with_capacity(7);
+
+        roles.insert(
+            RoleId::new("researcher"),
+            RoleSpec {
+                display_name: "Researcher",
+                system_prompt_fragment: "You are a specialist researcher. Your job is to gather \
+                    accurate, relevant information from the sources available to you. Prefer \
+                    primary sources. Cite your evidence clearly. Do not synthesise or \
+                    editorialize — return facts and summaries of what you found.",
+                default_tool_allowlist: &["web_search", "read_file"],
+                suggested_temperature: 0.3,
+                requires_approval: false,
+            },
+        );
+
+        roles.insert(
+            RoleId::new("red-team"),
+            RoleSpec {
+                display_name: "Red Team",
+                system_prompt_fragment: "You are an adversarial critic. Your job is to find \
+                    weaknesses, edge cases, and failure modes in the plan or content presented \
+                    to you. Be specific and constructive. Do not simply disagree — provide \
+                    concrete counter-arguments and evidence where possible.",
+                default_tool_allowlist: &[],
+                suggested_temperature: 0.7,
+                requires_approval: false,
+            },
+        );
+
+        roles.insert(
+            RoleId::new("fact-checker"),
+            RoleSpec {
+                display_name: "Fact Checker",
+                system_prompt_fragment: "You are a rigorous fact-checker. Your job is to verify \
+                    every claim in the content presented to you. For each claim, determine whether \
+                    it is supported, unsupported, or contradicted by available evidence. Return a \
+                    structured list of verdicts with your evidence.",
+                default_tool_allowlist: &["web_search"],
+                suggested_temperature: 0.2,
+                requires_approval: false,
+            },
+        );
+
+        roles.insert(
+            RoleId::new("writer"),
+            RoleSpec {
+                display_name: "Writer",
+                system_prompt_fragment: "You are a skilled writer. Your job is to produce a \
+                    first draft of high-quality prose based on the research and outlines provided \
+                    to you. Write clearly and engagingly. Do not pad with filler. Follow any \
+                    specified format, tone, or length constraints precisely.",
+                default_tool_allowlist: &[],
+                suggested_temperature: 0.7,
+                requires_approval: false,
+            },
+        );
+
+        roles.insert(
+            RoleId::new("editor"),
+            RoleSpec {
+                display_name: "Editor",
+                system_prompt_fragment: "You are a professional editor. Your job is to revise \
+                    and polish the draft provided to you. Improve clarity, flow, grammar, and \
+                    conciseness without changing the author's voice or intent. Return the revised \
+                    full text.",
+                default_tool_allowlist: &[],
+                suggested_temperature: 0.4,
+                requires_approval: false,
+            },
+        );
+
+        roles.insert(
+            RoleId::new("critic"),
+            RoleSpec {
+                display_name: "Critic",
+                system_prompt_fragment: "You are a structured critic. Your job is to identify \
+                    gaps, logical inconsistencies, and areas for improvement in the content \
+                    provided. Return a numbered list of specific, actionable critiques. Do not \
+                    rewrite the content — only identify what needs changing and why.",
+                default_tool_allowlist: &[],
+                suggested_temperature: 0.5,
+                requires_approval: false,
+            },
+        );
+
+        roles.insert(
+            RoleId::new("synthesizer"),
+            RoleSpec {
+                display_name: "Synthesizer",
+                system_prompt_fragment: "You are a synthesis specialist. Your job is to \
+                    integrate the outputs from multiple preceding workers into a single coherent, \
+                    well-structured response. Eliminate redundancy. Resolve contradictions by \
+                    noting them explicitly. Return a unified, polished result.",
+                default_tool_allowlist: &[],
+                suggested_temperature: 0.5,
+                requires_approval: false,
+            },
+        );
+
+        Self { roles }
+    }
+}
+
+impl RoleCatalog {
+    /// Look up a role by id.
+    ///
+    /// Returns `None` if no role with the given id exists in the catalog.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gglib_core::domain::orchestrator::role_catalog::{RoleCatalog, RoleId};
+    ///
+    /// let catalog = RoleCatalog::default();
+    /// let spec = catalog.get(&RoleId::new("writer")).unwrap();
+    /// assert_eq!(spec.display_name, "Writer");
+    /// assert!(catalog.get(&RoleId::new("nonexistent")).is_none());
+    /// ```
+    pub fn get(&self, id: &RoleId) -> Option<&RoleSpec> {
+        self.roles.get(id)
+    }
+
+    /// Return the number of roles in the catalog.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gglib_core::domain::orchestrator::role_catalog::RoleCatalog;
+    ///
+    /// let catalog = RoleCatalog::default();
+    /// assert_eq!(catalog.len(), 7);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.roles.len()
+    }
+
+    /// Return `true` if the catalog contains no roles.
+    pub fn is_empty(&self) -> bool {
+        self.roles.is_empty()
+    }
+
+    /// Return an iterator over `(RoleId, RoleSpec)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&RoleId, &RoleSpec)> {
+        self.roles.iter()
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_catalog_has_seven_roles() {
+        let catalog = RoleCatalog::default();
+        assert_eq!(catalog.len(), 7);
+    }
+
+    #[test]
+    fn all_builtin_role_ids_resolve() {
+        let catalog = RoleCatalog::default();
+        for name in [
+            "researcher",
+            "red-team",
+            "fact-checker",
+            "writer",
+            "editor",
+            "critic",
+            "synthesizer",
+        ] {
+            assert!(
+                catalog.get(&RoleId::new(name)).is_some(),
+                "built-in role '{name}' missing from catalog"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_role_returns_none() {
+        let catalog = RoleCatalog::default();
+        assert!(catalog.get(&RoleId::new("unknown")).is_none());
+    }
+
+    #[test]
+    fn researcher_spec_has_web_search_in_allowlist() {
+        let catalog = RoleCatalog::default();
+        let spec = catalog.get(&RoleId::new("researcher")).unwrap();
+        assert!(spec.default_tool_allowlist.contains(&"web_search"));
+    }
+
+    #[test]
+    fn role_id_display_matches_inner_string() {
+        let id = RoleId::new("fact-checker");
+        assert_eq!(id.to_string(), "fact-checker");
+        assert_eq!(id.as_str(), "fact-checker");
+    }
+
+    #[test]
+    fn is_empty_returns_false_for_default_catalog() {
+        let catalog = RoleCatalog::default();
+        assert!(!catalog.is_empty());
+    }
+
+    #[test]
+    fn iter_yields_seven_entries() {
+        let catalog = RoleCatalog::default();
+        assert_eq!(catalog.iter().count(), 7);
+    }
+}

--- a/crates/gglib-core/src/domain/orchestrator/task_graph.rs
+++ b/crates/gglib-core/src/domain/orchestrator/task_graph.rs
@@ -21,7 +21,7 @@
 //! ```rust
 //! use std::collections::HashSet;
 //! use gglib_core::domain::orchestrator::task_graph::{
-//!     TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode,
+//!     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
 //! };
 //!
 //! let nodes = vec![
@@ -30,6 +30,8 @@
 //!         goal: "Research the topic".into(),
 //!         depends_on: vec![],
 //!         tool_allowlist: vec!["web_search".into()],
+//!         kind: TaskNodeKind::Leaf,
+//!         role: None,
 //!         status: NodeStatus::Pending,
 //!         output: None,
 //!         compacted_output: None,
@@ -40,6 +42,8 @@
 //!         goal: "Write the first draft".into(),
 //!         depends_on: vec![NodeId("research".into())],
 //!         tool_allowlist: vec![],
+//!         kind: TaskNodeKind::Leaf,
+//!         role: None,
 //!         status: NodeStatus::Pending,
 //!         output: None,
 //!         compacted_output: None,
@@ -58,21 +62,36 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::domain::agent::ToolDefinition;
+use crate::domain::orchestrator::role_catalog::RoleId;
 
 // =============================================================================
 // Size limits
 // =============================================================================
 
-/// Maximum number of nodes a [`TaskGraph`] may contain.
+/// Maximum number of nodes a [`TaskGraph`] may contain **per subgraph**.
 ///
-/// Prevents unbounded context growth: each node's output is injected into
-/// downstream nodes' context windows, so large graphs compound quickly.
+/// This limit applies independently to each nested subgraph (including the
+/// top-level graph and every [`TaskNodeKind::Team`] subgraph).  It does **not**
+/// constrain the aggregate node count across all subgraphs; see
+/// [`MAX_TOTAL_NODES`] for the soft aggregate budget (Phase J).
+///
+/// Keeping each subgraph small ensures that no single LLM planning call ever
+/// needs to reason about more than ~8 sibling nodes.
 pub const MAX_NODES: usize = 8;
 
-/// Maximum depth (longest root-to-leaf path) a [`TaskGraph`] may have.
+/// Maximum depth (longest root-to-leaf path) a [`TaskGraph`] may have **per subgraph**.
 ///
-/// Keeps total latency bounded even when nodes are forced to run serially.
+/// Applied independently inside each subgraph.  Keeps total latency bounded
+/// even when nodes are forced to run serially within a department.
 pub const MAX_DEPTH: usize = 3;
+
+/// Soft upper bound on the **total** node count across all subgraphs combined.
+///
+/// This constant is not enforced during validation in Phase G.  Starting from
+/// Phase J the executor consults `OrchestratorConfig::max_total_nodes` (which
+/// defaults to this value) and emits a warn-only cost-estimate event when the
+/// aggregate budget is exceeded.
+pub const MAX_TOTAL_NODES: usize = 32;
 
 // =============================================================================
 // NodeId
@@ -155,13 +174,52 @@ pub enum HitlMode {
 }
 
 // =============================================================================
+// TaskNodeKind
+// =============================================================================
+
+/// Determines whether a [`TaskNode`] is an isolated leaf worker or a
+/// sub-team that executes its own nested [`TaskGraph`].
+///
+/// Existing (Phase A–F) nodes all default to `Leaf` when deserialized from
+/// JSON that does not carry a `kind` field.
+///
+/// # Example
+///
+/// ```rust
+/// use gglib_core::domain::orchestrator::task_graph::TaskNodeKind;
+///
+/// // Missing `kind` in old JSON → defaults to `Leaf`.
+/// let kind: TaskNodeKind = serde_json::from_str("\"leaf\"").unwrap();
+/// assert!(matches!(kind, TaskNodeKind::Leaf));
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskNodeKind {
+    /// A standard single-worker node.  This is the default for all v1 nodes
+    /// and for any node deserialized from JSON that omits the `kind` field.
+    #[default]
+    Leaf,
+    /// A compound node that encapsulates a nested [`TaskGraph`] (a sub-team).
+    ///
+    /// The executor recurses into `subgraph` and runs it to completion before
+    /// marking this node done and passing its synthesised output downstream.
+    Team {
+        /// The nested task graph executed when this node runs.
+        subgraph: Box<TaskGraph>,
+    },
+}
+
+// =============================================================================
 // TaskNode
 // =============================================================================
 
 /// A single work unit in a [`TaskGraph`].
 ///
-/// Each node is executed as an isolated `AgentLoop` worker whose context is
-/// assembled from:
+/// Each node is either a [`TaskNodeKind::Leaf`] (executed as an isolated
+/// `AgentLoop` worker) or a [`TaskNodeKind::Team`] (a sub-team with its own
+/// nested [`TaskGraph`] that the executor recurses into).
+///
+/// Leaf node context is assembled from:
 ///
 /// 1. Its own `goal` as the system instruction.
 /// 2. Compacted outputs from each `depends_on` predecessor as additional
@@ -182,6 +240,19 @@ pub struct TaskNode {
     /// An empty list means no tools are available to this worker.  Names must
     /// match entries in the runtime tool catalog.
     pub tool_allowlist: Vec<String>,
+    /// Whether this node is a leaf worker or a sub-team.
+    ///
+    /// Defaults to [`TaskNodeKind::Leaf`] when absent in serialised JSON so
+    /// that all Phase A–F plans deserialise without modification.
+    #[serde(default)]
+    pub kind: TaskNodeKind,
+    /// Optional specialist role assigned to this node.
+    ///
+    /// When `Some`, the executor will inject the role's
+    /// `system_prompt_fragment` before the node's `goal`.  `None` means the
+    /// node runs as a generic worker.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub role: Option<RoleId>,
     /// Current lifecycle state (mutated by the executor as the node runs).
     pub status: NodeStatus,
     /// The worker's full output text (set after reaching [`NodeStatus::Done`]).
@@ -317,13 +388,15 @@ fn compute_depth(
 /// # Example
 ///
 /// ```rust
-/// use gglib_core::domain::orchestrator::task_graph::{TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode};
+/// use gglib_core::domain::orchestrator::task_graph::{TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode};
 ///
 /// let nodes = vec![TaskNode {
 ///     id: NodeId("only".into()),
 ///     goal: "Do the thing".into(),
 ///     depends_on: vec![],
 ///     tool_allowlist: vec![],
+///     kind: TaskNodeKind::Leaf,
+///     role: None,
 ///     status: NodeStatus::Pending,
 ///     output: None,
 ///     compacted_output: None,
@@ -352,7 +425,7 @@ impl TaskGraph {
     ///
     /// ```rust
     /// use gglib_core::domain::orchestrator::task_graph::{
-    ///     TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode,
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
     /// };
     ///
     /// let nodes = vec![TaskNode {
@@ -360,6 +433,8 @@ impl TaskGraph {
     ///     goal: "Do the thing".into(),
     ///     depends_on: vec![],
     ///     tool_allowlist: vec![],
+    ///     kind: TaskNodeKind::Leaf,
+    ///     role: None,
     ///     status: NodeStatus::Pending,
     ///     output: None,
     ///     compacted_output: None,
@@ -411,7 +486,7 @@ impl TaskGraph {
     /// ```rust
     /// use std::collections::HashMap;
     /// use gglib_core::domain::orchestrator::task_graph::{
-    ///     TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode, TaskGraphError,
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode, TaskGraphError,
     /// };
     ///
     /// let mut nodes = HashMap::new();
@@ -421,6 +496,8 @@ impl TaskGraph {
     ///         goal: id.into(),
     ///         depends_on: vec![NodeId(dep.into())],
     ///         tool_allowlist: vec![],
+    ///         kind: TaskNodeKind::Leaf,
+    ///         role: None,
     ///         status: NodeStatus::Pending,
     ///         output: None, compacted_output: None, error: None,
     ///     });
@@ -461,6 +538,16 @@ impl TaskGraph {
             }
         }
 
+        // Recurse into Team subgraphs.  Per-subgraph caps (MAX_NODES, MAX_DEPTH)
+        // are enforced independently inside each subgraph by the recursive call.
+        // Cycles spanning a team boundary surface here as errors from the
+        // nested validate_acyclic call with the offending node id reported.
+        for node in self.nodes.values() {
+            if let TaskNodeKind::Team { subgraph } = &node.kind {
+                subgraph.validate_acyclic()?;
+            }
+        }
+
         Ok(())
     }
 
@@ -474,7 +561,7 @@ impl TaskGraph {
     ///
     /// ```rust
     /// use gglib_core::domain::orchestrator::task_graph::{
-    ///     TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode, TaskGraphError,
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode, TaskGraphError,
     /// };
     /// use gglib_core::ToolDefinition;
     ///
@@ -489,6 +576,8 @@ impl TaskGraph {
     ///     goal: "research".into(),
     ///     depends_on: vec![],
     ///     tool_allowlist: vec!["nonexistent".into()],
+    ///     kind: TaskNodeKind::Leaf,
+    ///     role: None,
     ///     status: NodeStatus::Pending,
     ///     output: None, compacted_output: None, error: None,
     /// }];
@@ -522,16 +611,18 @@ impl TaskGraph {
     ///
     /// ```rust
     /// use gglib_core::domain::orchestrator::task_graph::{
-    ///     TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode,
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
     /// };
     ///
     /// let nodes = vec![
     ///     TaskNode { id: NodeId("root".into()), goal: "g".into(), depends_on: vec![],
-    ///                tool_allowlist: vec![], status: NodeStatus::Pending,
+    ///                tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///                status: NodeStatus::Pending,
     ///                output: None, compacted_output: None, error: None },
     ///     TaskNode { id: NodeId("child".into()), goal: "g".into(),
     ///                depends_on: vec![NodeId("root".into())],
-    ///                tool_allowlist: vec![], status: NodeStatus::Pending,
+    ///                tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///                status: NodeStatus::Pending,
     ///                output: None, compacted_output: None, error: None },
     /// ];
     /// let g = TaskGraph::new("goal".into(), HitlMode::None, nodes).unwrap();
@@ -563,16 +654,18 @@ impl TaskGraph {
     /// ```rust
     /// use std::collections::HashSet;
     /// use gglib_core::domain::orchestrator::task_graph::{
-    ///     TaskGraph, TaskNode, NodeId, NodeStatus, HitlMode,
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
     /// };
     ///
     /// let nodes = vec![
     ///     TaskNode { id: NodeId("a".into()), goal: "g".into(), depends_on: vec![],
-    ///                tool_allowlist: vec![], status: NodeStatus::Pending,
+    ///                tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///                status: NodeStatus::Pending,
     ///                output: None, compacted_output: None, error: None },
     ///     TaskNode { id: NodeId("b".into()), goal: "g".into(),
     ///                depends_on: vec![NodeId("a".into())],
-    ///                tool_allowlist: vec![], status: NodeStatus::Pending,
+    ///                tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///                status: NodeStatus::Pending,
     ///                output: None, compacted_output: None, error: None },
     /// ];
     /// let g = TaskGraph::new("goal".into(), HitlMode::None, nodes).unwrap();
@@ -604,6 +697,46 @@ impl TaskGraph {
         ready.sort_by(|a, b| a.0.cmp(&b.0));
         ready
     }
+
+    /// Return the total number of nodes across all subgraphs combined.
+    ///
+    /// Each [`TaskNodeKind::Leaf`] contributes 1.  Each [`TaskNodeKind::Team`]
+    /// contributes 1 (for itself) plus the recursive count of its subgraph.
+    ///
+    /// This is the aggregate tally consulted by the warn-only token-cost
+    /// estimator introduced in Phase J.  Validation never fails on this value
+    /// in Phase G; see [`MAX_TOTAL_NODES`] for the soft budget.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gglib_core::domain::orchestrator::task_graph::{
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
+    /// };
+    ///
+    /// let nodes = vec![
+    ///     TaskNode { id: NodeId("a".into()), goal: "g".into(), depends_on: vec![],
+    ///                tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///                status: NodeStatus::Pending,
+    ///                output: None, compacted_output: None, error: None },
+    ///     TaskNode { id: NodeId("b".into()), goal: "g".into(),
+    ///                depends_on: vec![NodeId("a".into())],
+    ///                tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///                status: NodeStatus::Pending,
+    ///                output: None, compacted_output: None, error: None },
+    /// ];
+    /// let g = TaskGraph::new("goal".into(), HitlMode::None, nodes).unwrap();
+    /// assert_eq!(g.total_node_count(), 2);
+    /// ```
+    pub fn total_node_count(&self) -> usize {
+        self.nodes
+            .values()
+            .map(|n| match &n.kind {
+                TaskNodeKind::Leaf => 1,
+                TaskNodeKind::Team { subgraph } => 1 + subgraph.total_node_count(),
+            })
+            .sum()
+    }
 }
 
 // =============================================================================
@@ -626,6 +759,8 @@ mod tests {
             goal: id.into(),
             depends_on: vec![],
             tool_allowlist: vec![],
+            kind: TaskNodeKind::Leaf,
+            role: None,
             status: NodeStatus::Pending,
             output: None,
             compacted_output: None,
@@ -639,6 +774,8 @@ mod tests {
             goal: id.into(),
             depends_on: deps.iter().map(|d| NodeId((*d).to_string())).collect(),
             tool_allowlist: vec![],
+            kind: TaskNodeKind::Leaf,
+            role: None,
             status: NodeStatus::Pending,
             output: None,
             compacted_output: None,
@@ -903,4 +1040,187 @@ mod tests {
             Err(TaskGraphError::UnknownTool { .. })
         ));
     }
+
+    // ------------------------------------------------------------------
+    // total_node_count
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn total_node_count_flat_graph() {
+        let g = TaskGraph::new(
+            "g".into(),
+            HitlMode::None,
+            vec![leaf("a"), leaf("b"), node("c", &["a", "b"])],
+        )
+        .unwrap();
+        assert_eq!(g.total_node_count(), 3);
+    }
+
+    #[test]
+    fn total_node_count_with_team_subgraph() {
+        // Build subgraph: researcher → writer (2 nodes).
+        let subgraph = TaskGraph::new(
+            "department".into(),
+            HitlMode::None,
+            vec![leaf("researcher"), node("writer", &["researcher"])],
+        )
+        .unwrap();
+
+        // Top-level: team_node + synthesizer (2 nodes at top level).
+        // total = 2 (top) + 2 (subgraph) = 4.
+        let team_node = TaskNode {
+            id: NodeId("dept".into()),
+            goal: "Run department".into(),
+            depends_on: vec![],
+            tool_allowlist: vec![],
+            kind: TaskNodeKind::Team {
+                subgraph: Box::new(subgraph),
+            },
+            role: None,
+            status: NodeStatus::Pending,
+            output: None,
+            compacted_output: None,
+            error: None,
+        };
+        let synth = leaf("synthesize");
+        // Build with raw map to bypass node-count limits at this level.
+        let mut nodes = HashMap::new();
+        nodes.insert(team_node.id.clone(), team_node);
+        nodes.insert(synth.id.clone(), synth);
+        let g = TaskGraph {
+            goal: "top".into(),
+            hitl_mode: HitlMode::None,
+            nodes,
+        };
+        assert_eq!(g.total_node_count(), 4);
+    }
+
+    // ------------------------------------------------------------------
+    // Team subgraph validation
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn team_subgraph_cycle_is_detected() {
+        // Build a subgraph with a cycle: x → y → x.
+        let mut sub_nodes = HashMap::new();
+        for (id, dep) in [("x", "y"), ("y", "x")] {
+            sub_nodes.insert(
+                NodeId(id.into()),
+                TaskNode {
+                    id: NodeId(id.into()),
+                    goal: id.into(),
+                    depends_on: vec![NodeId(dep.into())],
+                    tool_allowlist: vec![],
+                    kind: TaskNodeKind::Leaf,
+                    role: None,
+                    status: NodeStatus::Pending,
+                    output: None,
+                    compacted_output: None,
+                    error: None,
+                },
+            );
+        }
+        let cyclic_subgraph = TaskGraph {
+            goal: "sub".into(),
+            hitl_mode: HitlMode::None,
+            nodes: sub_nodes,
+        };
+
+        // Wrap in a team node at the top level.
+        let team_node = TaskNode {
+            id: NodeId("team".into()),
+            goal: "team".into(),
+            depends_on: vec![],
+            tool_allowlist: vec![],
+            kind: TaskNodeKind::Team {
+                subgraph: Box::new(cyclic_subgraph),
+            },
+            role: None,
+            status: NodeStatus::Pending,
+            output: None,
+            compacted_output: None,
+            error: None,
+        };
+        let mut top_nodes = HashMap::new();
+        top_nodes.insert(team_node.id.clone(), team_node);
+        let g = TaskGraph {
+            goal: "top".into(),
+            hitl_mode: HitlMode::None,
+            nodes: top_nodes,
+        };
+        assert!(matches!(g.validate_acyclic(), Err(TaskGraphError::Cycle(_))));
+    }
+
+    #[test]
+    fn team_subgraph_per_subgraph_node_cap_is_independent() {
+        // A top-level graph with 8 nodes is valid even if a Team node's
+        // subgraph also has 8 nodes (per-subgraph caps, not global).
+        let sub_nodes: Vec<TaskNode> =
+            (0..MAX_NODES).map(|i| leaf(&format!("sub_{i}"))).collect();
+        let subgraph = TaskGraph::new("sub".into(), HitlMode::None, sub_nodes).unwrap();
+        // Top-level has just 1 Team node — well under MAX_NODES.
+        let team_node = TaskNode {
+            id: NodeId("team".into()),
+            goal: "run dept".into(),
+            depends_on: vec![],
+            tool_allowlist: vec![],
+            kind: TaskNodeKind::Team {
+                subgraph: Box::new(subgraph),
+            },
+            role: None,
+            status: NodeStatus::Pending,
+            output: None,
+            compacted_output: None,
+            error: None,
+        };
+        let result = TaskGraph::new("top".into(), HitlMode::None, vec![team_node]);
+        assert!(result.is_ok(), "per-subgraph cap must not be global");
+    }
+
+    // ------------------------------------------------------------------
+    // Phase F regression fixture
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn phase_f_fixture_deserializes_and_validates() {
+        let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/orchestrator/phase_f_baseline.json");
+        let json = std::fs::read_to_string(&fixture_path)
+            .unwrap_or_else(|e| panic!("could not read fixture {}: {e}", fixture_path.display()));
+        let graph: TaskGraph =
+            serde_json::from_str(&json).expect("fixture must deserialize without error");
+        graph
+            .validate_acyclic()
+            .expect("fixture must pass validate_acyclic");
+        // Flat Phase F plan — all nodes are leaves.
+        assert!(
+            graph
+                .nodes
+                .values()
+                .all(|n| matches!(n.kind, TaskNodeKind::Leaf)),
+            "Phase F fixture must contain only Leaf nodes"
+        );
+        // Aggregate count equals top-level count (no subgraphs).
+        assert_eq!(graph.total_node_count(), graph.nodes.len());
+    }
+
+    // ------------------------------------------------------------------
+    // TaskNodeKind serde round-trip
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn task_node_kind_leaf_is_default_when_absent() {
+        // Old-format JSON node without a `kind` field must deserialise as Leaf.
+        let json = r#"{
+            "id": "x",
+            "goal": "do something",
+            "depends_on": [],
+            "tool_allowlist": [],
+            "status": "pending"
+        }"#;
+        let node: TaskNode = serde_json::from_str(json).unwrap();
+        assert!(matches!(node.kind, TaskNodeKind::Leaf));
+        assert!(node.role.is_none());
+    }
 }
+

--- a/crates/gglib-proxy/src/orchestrator_proxy.rs
+++ b/crates/gglib-proxy/src/orchestrator_proxy.rs
@@ -616,7 +616,9 @@ pub(crate) fn orchestrator_event_to_content(event: &OrchestratorEvent) -> Option
         | OrchestratorEvent::NodeCompacting { .. }
         | OrchestratorEvent::SynthesisProgress { .. }
         | OrchestratorEvent::SynthesisComplete { .. }
-        | OrchestratorEvent::OrchestratorComplete { .. } => None,
+        | OrchestratorEvent::OrchestratorComplete { .. }
+        | OrchestratorEvent::TeamStarted { .. }
+        | OrchestratorEvent::TeamSynthesized { .. } => None,
     }
 }
 

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -28,7 +28,7 @@ use gglib_core::domain::orchestrator::run::{
     OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus,
 };
 use gglib_core::domain::orchestrator::task_graph::{
-    HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode,
+    HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
 };
 use gglib_core::ports::{
     ApprovalDecision, CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError,
@@ -269,6 +269,8 @@ fn test_graph() -> TaskGraph {
             goal: "step one".to_string(),
             depends_on: vec![],
             tool_allowlist: vec![],
+            kind: TaskNodeKind::Leaf,
+            role: None,
             status: NodeStatus::Pending,
             output: None,
             compacted_output: None,

--- a/tests/fixtures/orchestrator/phase_f_baseline.json
+++ b/tests/fixtures/orchestrator/phase_f_baseline.json
@@ -1,0 +1,34 @@
+{
+  "goal": "Research the history of llama.cpp and write a summary",
+  "hitl_mode": "none",
+  "nodes": {
+    "research_origins": {
+      "id": "research_origins",
+      "goal": "Research the origins of llama.cpp: who created it, when it was first released, and what problem it was designed to solve",
+      "depends_on": [],
+      "tool_allowlist": ["web_search"],
+      "status": "pending"
+    },
+    "research_milestones": {
+      "id": "research_milestones",
+      "goal": "Research the key technical milestones and version history of llama.cpp, including major performance improvements and model format changes",
+      "depends_on": [],
+      "tool_allowlist": ["web_search"],
+      "status": "pending"
+    },
+    "research_ecosystem": {
+      "id": "research_ecosystem",
+      "goal": "Research the llama.cpp community and ecosystem: key contributors, related projects, and its influence on the local AI movement",
+      "depends_on": [],
+      "tool_allowlist": ["web_search"],
+      "status": "pending"
+    },
+    "synthesize": {
+      "id": "synthesize",
+      "goal": "Write a comprehensive, well-structured summary of the history of llama.cpp, integrating the origins, milestones, and ecosystem research",
+      "depends_on": ["research_origins", "research_milestones", "research_ecosystem"],
+      "tool_allowlist": [],
+      "status": "pending"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Phase G** of the v2 orchestrator architecture (closes #508): hierarchical task decomposition via `TaskNodeKind::Team { subgraph }`, a built-in role catalog, and team lifecycle SSE events.

---

## Changes

### `gglib-core` — domain types

**`role_catalog.rs`** (new)
- `RoleId` newtype (`pub struct RoleId(pub String)`) with `new()`, `as_str()`, `Display`, `Serialize/Deserialize`
- `RoleSpec` — display name, system prompt fragment, default tool allowlist, suggested temperature, requires_approval flag
- `RoleCatalog` — `HashMap<RoleId, RoleSpec>` with `Default` impl populating 7 built-in specialist roles: `researcher`, `red-team`, `fact-checker`, `writer`, `editor`, `critic`, `synthesizer`

**`task_graph.rs`**
- New `TaskNodeKind` enum: `Leaf` (default) | `Team { subgraph: Box<TaskGraph> }` — serde `snake_case`, `#[serde(default)]` on the field for backward compat
- `MAX_NODES` / `MAX_DEPTH` docs clarified as per-subgraph limits
- `MAX_TOTAL_NODES = 32` soft aggregate budget (not enforced yet — Phase H)
- `TaskNode.role: Option<RoleId>` — specialist role assignment
- `validate_acyclic()` recurses into `Team` subgraphs
- `TaskGraph::total_node_count()` — recursive aggregate count

**`events.rs`**
- `TeamStarted { team_id, role: Option<RoleId> }` — emitted before team subgraph begins
- `TeamSynthesized { team_id, compacted_output }` — emitted when team subgraph completes

**`mod.rs`**
- `pub mod role_catalog` added
- Re-exports: `RoleCatalog`, `RoleId`, `RoleSpec`, `TaskNodeKind`, `MAX_TOTAL_NODES`

### Caller updates
- `gglib-agent/orchestrator/director.rs` — `TaskNode` construction gains `kind: TaskNodeKind::Leaf, role: None`
- `gglib-agent/orchestrator/executor.rs` — `make_node()` test helper updated
- `gglib-proxy/src/orchestrator_proxy.rs` — new event variants added to exhaustive match
- `gglib-cli/src/handlers/orchestrate.rs` — `render_event()` handles `TeamStarted`/`TeamSynthesized`
- `gglib-proxy/tests/integration_virtual_models.rs` — `test_graph()` helper updated

### Test fixtures
- `tests/fixtures/orchestrator/phase_f_baseline.json` — Phase F regression fixture (flat graph without `kind`/`role` fields; verifies backward-compat deserialization)

---

## Tests

- 25 unit tests pass (`cargo test -p gglib-core`)
- All doc-tests pass (`cargo test --doc -p gglib-core`)
- `cargo clippy --all-targets -- -D warnings` — clean
- `./scripts/check_boundaries.sh` — all PASS

## Issue

Closes #508