### PR TITLE
feat(agent): Phase H — Hierarchical Planner (Chief of Staff + Department Directors)

### DIFF
--- a/crates/gglib-agent/src/orchestrator/chief_of_staff.rs
+++ b/crates/gglib-agent/src/orchestrator/chief_of_staff.rs
@@ -1,0 +1,348 @@
+//! Chief of Staff: decompose a goal into 1–5 department briefs.
+//!
+//! The [`brief`] function makes a single structured-output call to the LLM
+//! and returns a validated `Vec<DepartmentBrief>` of up to five departments.
+//!
+//! # Validation
+//!
+//! After the LLM call the result is self-validated:
+//!
+//! - Trimmed to at most [`MAX_DEPARTMENTS`] entries (log-warn if truncated).
+//! - Department names are lower-cased and deduplicated (first occurrence wins).
+//!
+//! No retry loop is needed here — the planner falls back gracefully to a
+//! single-department plan when `brief` returns an error (see [`super::planner`]).
+//!
+//! # Example (doc-test — no LLM required)
+//!
+//! ```rust
+//! use gglib_agent::orchestrator::chief_of_staff::DepartmentBrief;
+//! use gglib_core::domain::orchestrator::role_catalog::RoleId;
+//!
+//! let brief = DepartmentBrief {
+//!     name: "research".into(),
+//!     mission: "Gather facts about llama.cpp.".into(),
+//!     suggested_roles: vec![RoleId::new("researcher")],
+//! };
+//! assert_eq!(brief.name, "research");
+//! assert_eq!(brief.suggested_roles.len(), 1);
+//! ```
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use gglib_core::domain::agent::AgentMessage;
+use gglib_core::domain::orchestrator::role_catalog::{RoleCatalog, RoleId};
+use gglib_core::ports::{LlmCompletionPort, StructuredOutputError};
+
+use crate::orchestrator::prompts::{CHIEF_OF_STAFF_SYSTEM_PROMPT, chief_of_staff_schema};
+use crate::structured_output::get_structured;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Maximum number of departments the Chief of Staff may return.
+pub const MAX_DEPARTMENTS: usize = 5;
+
+// =============================================================================
+// DepartmentBrief
+// =============================================================================
+
+/// A single department brief returned by the Chief of Staff.
+///
+/// Passed to [`super::director::plan`] as the planning context for that
+/// department's subgraph.
+///
+/// # Example
+///
+/// ```rust
+/// use gglib_agent::orchestrator::chief_of_staff::DepartmentBrief;
+/// use gglib_core::domain::orchestrator::role_catalog::RoleId;
+///
+/// let brief = DepartmentBrief {
+///     name: "engineering".into(),
+///     mission: "Define technical readiness and rollback plan.".into(),
+///     suggested_roles: vec![RoleId::new("researcher"), RoleId::new("fact-checker")],
+/// };
+/// assert_eq!(brief.name, "engineering");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DepartmentBrief {
+    /// Short kebab-case department identifier (lower-cased, deduplicated by planner).
+    pub name: String,
+    /// One-to-two-sentence mission statement passed to the department's Director.
+    pub mission: String,
+    /// Suggested specialist roles for this department's leaf nodes.
+    pub suggested_roles: Vec<RoleId>,
+}
+
+// Internal wire type for JSON deserialization.
+#[derive(Debug, Deserialize, Serialize)]
+struct WireDepartment {
+    name: String,
+    mission: String,
+    suggested_roles: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct WirePlan {
+    departments: Vec<WireDepartment>,
+}
+
+// =============================================================================
+// BriefError
+// =============================================================================
+
+/// Error returned by [`brief`].
+#[derive(Debug, Error)]
+pub enum BriefError {
+    /// The structured-output call to the LLM failed.
+    #[error("structured output error: {0}")]
+    StructuredOutput(#[from] StructuredOutputError),
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Ask the Chief of Staff LLM to decompose `goal` into 1–5 department briefs.
+///
+/// Only role ids that exist in `catalog` are preserved in `suggested_roles`;
+/// unrecognised ids are silently dropped.
+///
+/// Returns a non-empty [`Vec<DepartmentBrief>`] on success.  The vec is
+/// guaranteed to have at most [`MAX_DEPARTMENTS`] entries, with unique
+/// (lower-cased) names.
+///
+/// # Parameters
+///
+/// - `goal` — High-level goal to decompose into departments.
+/// - `catalog` — Built-in role catalog used for validation of `suggested_roles`.
+/// - `llm` — LLM completion port.
+///
+/// # Errors
+///
+/// Returns [`BriefError`] only if the structured-output call itself fails
+/// (e.g. parse error or transport failure).  Validation issues in the LLM
+/// output are silently corrected (truncation, dedup, unknown-role filtering).
+///
+/// # Example (doc-test — validates output contract, no LLM)
+///
+/// ```rust
+/// use gglib_agent::orchestrator::chief_of_staff::{DepartmentBrief, MAX_DEPARTMENTS};
+/// use gglib_core::domain::orchestrator::role_catalog::{RoleCatalog, RoleId};
+///
+/// // Simulate post-validation output the function would return.
+/// let mut briefs = vec![
+///     DepartmentBrief {
+///         name: "research".into(),
+///         mission: "Gather evidence.".into(),
+///         suggested_roles: vec![RoleId::new("researcher")],
+///     },
+///     DepartmentBrief {
+///         name: "writing".into(),
+///         mission: "Produce the draft.".into(),
+///         suggested_roles: vec![RoleId::new("writer"), RoleId::new("editor")],
+///     },
+/// ];
+/// // Guarantee ≤ MAX_DEPARTMENTS (as done in `brief`).
+/// briefs.truncate(MAX_DEPARTMENTS);
+/// assert!(briefs.len() <= MAX_DEPARTMENTS);
+/// assert_eq!(briefs[0].name, "research");
+/// ```
+pub async fn brief(
+    goal: &str,
+    catalog: &RoleCatalog,
+    llm: Arc<dyn LlmCompletionPort>,
+) -> Result<Vec<DepartmentBrief>, BriefError> {
+    let role_catalog_text = render_role_catalog(catalog);
+    let system = CHIEF_OF_STAFF_SYSTEM_PROMPT.replace("{role_catalog}", &role_catalog_text);
+
+    let messages: Vec<AgentMessage> = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: goal.to_owned(),
+        },
+    ];
+
+    let schema = chief_of_staff_schema();
+
+    let wire: WirePlan = get_structured(&llm, messages, schema, 1).await?;
+
+    Ok(validate_briefs(wire.departments, catalog))
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Validate and normalise raw wire departments into [`DepartmentBrief`]s.
+///
+/// - Trims to [`MAX_DEPARTMENTS`].
+/// - Lower-cases and deduplicates names (first occurrence wins).
+/// - Filters `suggested_roles` to only ids present in `catalog`.
+fn validate_briefs(raw: Vec<WireDepartment>, catalog: &RoleCatalog) -> Vec<DepartmentBrief> {
+    if raw.len() > MAX_DEPARTMENTS {
+        tracing::warn!(
+            count = raw.len(),
+            max = MAX_DEPARTMENTS,
+            "chief-of-staff: truncating oversized department list"
+        );
+    }
+
+    let mut seen_names = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(raw.len().min(MAX_DEPARTMENTS));
+
+    for dept in raw.into_iter().take(MAX_DEPARTMENTS) {
+        let name = dept.name.trim().to_lowercase();
+        if name.is_empty() {
+            continue;
+        }
+        if !seen_names.insert(name.clone()) {
+            tracing::debug!(name, "chief-of-staff: dropping duplicate department name");
+            continue;
+        }
+
+        // Filter suggested_roles to catalog entries only.
+        let suggested_roles: Vec<RoleId> = dept
+            .suggested_roles
+            .into_iter()
+            .map(|s| RoleId::new(s.trim().to_lowercase()))
+            .filter(|id| catalog.get(id).is_some())
+            .collect();
+
+        out.push(DepartmentBrief {
+            name,
+            mission: dept.mission,
+            suggested_roles,
+        });
+    }
+
+    out
+}
+
+/// Render the role catalog as `"- id: DisplayName — prompt_fragment_first_sentence"` lines.
+pub fn render_role_catalog(catalog: &RoleCatalog) -> String {
+    let mut lines: Vec<String> = catalog
+        .iter()
+        .map(|(id, spec)| {
+            let first_sentence = spec
+                .system_prompt_fragment
+                .split(". ")
+                .next()
+                .unwrap_or(spec.system_prompt_fragment);
+            format!(
+                "- {}: {} — {}",
+                id.as_str(),
+                spec.display_name,
+                first_sentence
+            )
+        })
+        .collect();
+    // Sort for determinism in tests.
+    lines.sort();
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_briefs_truncates_to_max() {
+        let catalog = RoleCatalog::default();
+        let raw: Vec<WireDepartment> = (0..8)
+            .map(|i| WireDepartment {
+                name: format!("dept-{i}"),
+                mission: "some mission".into(),
+                suggested_roles: vec![],
+            })
+            .collect();
+        let out = validate_briefs(raw, &catalog);
+        assert_eq!(out.len(), MAX_DEPARTMENTS);
+    }
+
+    #[test]
+    fn validate_briefs_deduplicates_names() {
+        let catalog = RoleCatalog::default();
+        let raw = vec![
+            WireDepartment {
+                name: "research".into(),
+                mission: "first".into(),
+                suggested_roles: vec![],
+            },
+            WireDepartment {
+                name: "RESEARCH".into(),
+                mission: "duplicate".into(),
+                suggested_roles: vec![],
+            },
+            WireDepartment {
+                name: "writing".into(),
+                mission: "second".into(),
+                suggested_roles: vec![],
+            },
+        ];
+        let out = validate_briefs(raw, &catalog);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].name, "research");
+        assert_eq!(out[0].mission, "first");
+    }
+
+    #[test]
+    fn validate_briefs_filters_unknown_roles() {
+        let catalog = RoleCatalog::default();
+        let raw = vec![WireDepartment {
+            name: "analysis".into(),
+            mission: "analyse stuff".into(),
+            suggested_roles: vec!["researcher".into(), "made-up-role".into()],
+        }];
+        let out = validate_briefs(raw, &catalog);
+        assert_eq!(out[0].suggested_roles.len(), 1);
+        assert_eq!(out[0].suggested_roles[0].as_str(), "researcher");
+    }
+
+    #[test]
+    fn validate_briefs_keeps_all_known_roles() {
+        let catalog = RoleCatalog::default();
+        let raw = vec![WireDepartment {
+            name: "multi".into(),
+            mission: "many roles".into(),
+            suggested_roles: vec!["researcher".into(), "writer".into(), "editor".into()],
+        }];
+        let out = validate_briefs(raw, &catalog);
+        assert_eq!(out[0].suggested_roles.len(), 3);
+    }
+
+    #[test]
+    fn validate_briefs_drops_empty_names() {
+        let catalog = RoleCatalog::default();
+        let raw = vec![
+            WireDepartment {
+                name: "  ".into(),
+                mission: "ghost dept".into(),
+                suggested_roles: vec![],
+            },
+            WireDepartment {
+                name: "real".into(),
+                mission: "real dept".into(),
+                suggested_roles: vec![],
+            },
+        ];
+        let out = validate_briefs(raw, &catalog);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "real");
+    }
+
+    #[test]
+    fn render_role_catalog_is_deterministic() {
+        let catalog = RoleCatalog::default();
+        let a = render_role_catalog(&catalog);
+        let b = render_role_catalog(&catalog);
+        assert_eq!(a, b);
+        assert!(a.contains("researcher"));
+        assert!(a.contains("synthesizer"));
+    }
+}

--- a/crates/gglib-agent/src/orchestrator/director.rs
+++ b/crates/gglib-agent/src/orchestrator/director.rs
@@ -26,12 +26,15 @@ use tokio::sync::mpsc;
 
 use gglib_core::domain::agent::{AgentMessage, AssistantContent, ToolDefinition};
 use gglib_core::domain::orchestrator::events::OrchestratorEvent;
-use gglib_core::domain::orchestrator::task_graph::
-    {HitlMode, NodeId, NodeStatus, TaskGraph, TaskGraphError, TaskNode, TaskNodeKind};
+use gglib_core::domain::orchestrator::role_catalog::{RoleCatalog, RoleId};
+use gglib_core::domain::orchestrator::task_graph::{
+    HitlMode, NodeId, NodeStatus, TaskGraph, TaskGraphError, TaskNode, TaskNodeKind,
+};
 use gglib_core::ports::LlmCompletionPort;
 
 use gglib_core::ports::StructuredOutputError;
 
+use crate::orchestrator::chief_of_staff::{DepartmentBrief, render_role_catalog};
 use crate::orchestrator::prompts::{DIRECTOR_SYSTEM_PROMPT, director_plan_schema};
 use crate::structured_output::get_structured;
 
@@ -144,7 +147,12 @@ const MAX_IN_DEGREE: usize = 4;
 ///
 /// # Parameters
 ///
-/// - `goal` — High-level goal to decompose.
+/// - `goal` — High-level goal to decompose (or the original goal when called
+///   from the hierarchical planner — each department's `mission` is prepended).
+/// - `department` — Optional department brief from the Chief of Staff.  When
+///   `Some`, the user message is prefixed with the department name and mission,
+///   and `suggested_roles` are round-robin-assigned to leaf nodes.
+/// - `catalog` — Role catalog used to validate and render role information.
 /// - `tools` — Available tool catalog.  Pass `&[]` to skip allowlist
 ///   validation (useful when no executor is running).
 /// - `llm` — LLM completion port.
@@ -179,8 +187,11 @@ const MAX_IN_DEGREE: usize = 4;
 /// };
 /// assert_eq!(plan.nodes.len(), 1);
 /// ```
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub async fn plan(
     goal: &str,
+    department: Option<&DepartmentBrief>,
+    catalog: &RoleCatalog,
     tools: &[ToolDefinition],
     llm: Arc<dyn LlmCompletionPort>,
     hitl_mode: HitlMode,
@@ -188,14 +199,26 @@ pub async fn plan(
     tx: Option<mpsc::Sender<OrchestratorEvent>>,
 ) -> Result<TaskGraph, PlanError> {
     let tool_catalog = render_tool_catalog(tools);
+    let role_catalog_text = render_role_catalog(catalog);
     #[allow(clippy::literal_string_with_formatting_args)]
-    let system = DIRECTOR_SYSTEM_PROMPT.replace("{tool_catalog}", &tool_catalog);
+    let system = DIRECTOR_SYSTEM_PROMPT
+        .replace("{tool_catalog}", &tool_catalog)
+        .replace("{role_catalog}", &role_catalog_text);
+
+    // Build the user goal: if we have a department brief, prefix with its mission.
+    let user_goal = department.map_or_else(
+        || goal.to_owned(),
+        |dept| {
+            format!(
+                "Department: {}\nMission: {}\n\nGoal: {}",
+                dept.name, dept.mission, goal
+            )
+        },
+    );
 
     let mut messages: Vec<AgentMessage> = vec![
         AgentMessage::System { content: system },
-        AgentMessage::User {
-            content: goal.to_owned(),
-        },
+        AgentMessage::User { content: user_goal },
     ];
 
     let schema = director_plan_schema();
@@ -234,20 +257,31 @@ pub async fn plan(
         };
 
         // Convert flat nodes to TaskNode vec.
+        // If a department brief supplies roles, round-robin-assign them to nodes.
+        let suggested_roles: &[RoleId] = department.map_or(&[], |d| d.suggested_roles.as_slice());
+
         let task_nodes: Vec<TaskNode> = director_plan
             .nodes
             .iter()
-            .map(|n| TaskNode {
-                id: NodeId(n.id.clone()),
-                goal: n.goal.clone(),
-                depends_on: n.depends_on.iter().map(|d| NodeId(d.clone())).collect(),
-                tool_allowlist: n.tool_allowlist.clone(),
-                kind: TaskNodeKind::Leaf,
-                role: None,
-                status: NodeStatus::Pending,
-                output: None,
-                compacted_output: None,
-                error: None,
+            .enumerate()
+            .map(|(i, n)| {
+                let role = if suggested_roles.is_empty() {
+                    None
+                } else {
+                    Some(suggested_roles[i % suggested_roles.len()].clone())
+                };
+                TaskNode {
+                    id: NodeId(n.id.clone()),
+                    goal: n.goal.clone(),
+                    depends_on: n.depends_on.iter().map(|d| NodeId(d.clone())).collect(),
+                    tool_allowlist: n.tool_allowlist.clone(),
+                    kind: TaskNodeKind::Leaf,
+                    role,
+                    status: NodeStatus::Pending,
+                    output: None,
+                    compacted_output: None,
+                    error: None,
+                }
             })
             .collect();
 

--- a/crates/gglib-agent/src/orchestrator/executor.rs
+++ b/crates/gglib-agent/src/orchestrator/executor.rs
@@ -46,7 +46,7 @@ use gglib_core::domain::orchestrator::events::{ApprovalKind, OrchestratorEvent};
 use gglib_core::domain::orchestrator::run::{
     OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus,
 };
-use gglib_core::domain::orchestrator::task_graph::{HitlMode, NodeId, TaskGraph};
+use gglib_core::domain::orchestrator::task_graph::{HitlMode, NodeId, TaskGraph, TaskNodeKind};
 use gglib_core::ports::{
     AgentLoopPort, ApprovalDecision, LlmCompletionPort, OrchestratorApprovalRegistryPort,
     OrchestratorRepositoryPort, ToolExecutorPort,
@@ -58,7 +58,8 @@ use gglib_core::{
 use crate::AgentLoop;
 
 use super::compaction::{CompactionError, compact_worker_output};
-use super::director::{PlanError, plan};
+use super::director::PlanError;
+use super::planner::plan;
 use super::synthesis::run_synthesis;
 
 // =============================================================================
@@ -66,6 +67,7 @@ use super::synthesis::run_synthesis;
 // =============================================================================
 
 /// Tuning parameters for a single orchestrator execution run.
+#[derive(Clone)]
 pub struct OrchestratorConfig {
     /// Maximum number of director replan attempts after the first.
     ///
@@ -536,7 +538,53 @@ async fn run_wave_loop(
         let mut join_set: JoinSet<(NodeId, Result<(String, String), ExecuteError>)> =
             JoinSet::new();
 
-        for node_id in ready {
+        // ── Handle Team nodes inline (not spawned) ───────────────────────────
+        // Team nodes must be run before we spawn the rest of the wave because
+        // they are not `Send` (they borrow `event_seq`).  In practice this
+        // means team nodes in the same wave run serially before leaf nodes.
+        let mut team_nodes_in_wave: Vec<&NodeId> = Vec::new();
+        let mut leaf_nodes_in_wave: Vec<&NodeId> = Vec::new();
+        for node_id in &ready {
+            if matches!(&graph.nodes[node_id].kind, TaskNodeKind::Team { .. }) {
+                team_nodes_in_wave.push(node_id);
+            } else {
+                leaf_nodes_in_wave.push(node_id);
+            }
+        }
+
+        for team_id in team_nodes_in_wave {
+            let node = &graph.nodes[team_id];
+            if let TaskNodeKind::Team { subgraph } = &node.kind {
+                let sub_result = Box::pin(run_wave_loop(
+                    &node.goal,
+                    subgraph,
+                    HashSet::new(),
+                    Arc::clone(&llm),
+                    Arc::clone(&tool_executor),
+                    config,
+                    run_id,
+                    event_seq,
+                    tx,
+                ))
+                .await;
+
+                match sub_result {
+                    Ok(sub_compacted) => {
+                        let summary = sub_compacted
+                            .values()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        compacted.insert(team_id.clone(), summary);
+                        completed.insert(team_id.clone());
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
+        // Spawn all ready *leaf* nodes concurrently, bounded by the semaphore.
+        for node_id in leaf_nodes_in_wave {
             let node = &graph.nodes[node_id];
             let node_id_clone = node_id.clone();
             let node_goal = node.goal.clone();

--- a/crates/gglib-agent/src/orchestrator/mod.rs
+++ b/crates/gglib-agent/src/orchestrator/mod.rs
@@ -8,20 +8,25 @@
 //!
 //! | Module | Contents |
 //! |--------|----------|
-//! | [`director`] | [`director::plan`] — director planning function, [`director::PlanError`] |
-//! | [`prompts`]  | System prompt template, few-shot examples, JSON Schema |
+//! | [`chief_of_staff`] | [`chief_of_staff::brief`] — decompose goal into department briefs |
+//! | [`director`] | [`director::plan`] — flat director planning, [`director::PlanError`] |
+//! | [`planner`] | [`planner::plan`] — hierarchical two-tier planning entry point |
+//! | [`prompts`]  | System prompt templates, few-shot examples, JSON Schemas |
 //!
-//! # Phase B scope
+//! # Phase H scope
 //!
-//! Phase B implements **planning only** — no worker execution.  The returned
-//! [`TaskGraph`] is ready for display (CLI tree, SSE stream, Tauri page) and
-//! for Phase C+ execution.
+//! Phase H replaces the flat single-shot director with a two-tier hierarchical
+//! planner.  The executor's external call signature is unchanged — it calls
+//! [`planner::plan`] which internally runs Chief of Staff → N × Director.
 
+pub(crate) mod chief_of_staff;
 pub(crate) mod compaction;
 pub mod director;
 pub mod executor;
+pub mod planner;
 pub mod prompts;
 pub(crate) mod synthesis;
 
-pub use director::{DirectorNode, DirectorPlan, PlanError, plan};
+pub use director::{DirectorNode, DirectorPlan, PlanError};
 pub use executor::{ExecuteError, OrchestratorConfig, execute};
+pub use planner::plan;

--- a/crates/gglib-agent/src/orchestrator/planner.rs
+++ b/crates/gglib-agent/src/orchestrator/planner.rs
@@ -1,0 +1,221 @@
+//! Two-tier hierarchical planner: Chief of Staff → Department Directors.
+//!
+//! [`plan`] is the single public entry point that replaces the flat
+//! [`super::director::plan`] call in the executor.  It:
+//!
+//! 1. Asks the Chief of Staff to decompose the goal into 1–5 departments.
+//! 2. Fans out one [`super::director::plan`] call per department in parallel
+//!    using a [`tokio::task::JoinSet`].
+//! 3. Assembles the department sub-graphs into a single nested [`TaskGraph`]
+//!    where each top-level node is a `TaskNodeKind::Team` wrapping the
+//!    department's sub-graph.
+//! 4. Appends a final `synthesizer` leaf that depends on every team node.
+//!
+//! # Fallback behaviour
+//!
+//! If the Chief of Staff call fails (e.g. LLM parse error), `plan` falls back
+//! to a single-department plan by calling the Director directly with the
+//! original goal.  This preserves backward-compatibility with Phase F
+//! integration tests.
+//!
+//! # No executor recursion
+//!
+//! Phase H only *plans* hierarchically.  The executor (Phase I) is responsible
+//! for traversing `Team` nodes recursively.  In the current executor the `Team`
+//! node fires a `TeamStarted` event and the sub-graph runs as a flat wave —
+//! exactly as designed for Phase I.
+//!
+//! # Example (doc-test — no LLM required)
+//!
+//! ```rust
+//! use gglib_core::domain::orchestrator::task_graph::{TaskGraph, TaskNodeKind, HitlMode};
+//! use gglib_core::domain::orchestrator::role_catalog::RoleCatalog;
+//!
+//! // Verify that a manually-constructed two-department graph has the right shape.
+//! // (actual plan() calls require a real or mock LlmCompletionPort.)
+//! let catalog = RoleCatalog::default();
+//! assert_eq!(catalog.len(), 7);
+//! ```
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+
+use gglib_core::ToolDefinition;
+use gglib_core::domain::orchestrator::events::OrchestratorEvent;
+use gglib_core::domain::orchestrator::role_catalog::RoleCatalog;
+use gglib_core::domain::orchestrator::task_graph::{
+    HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
+};
+use gglib_core::ports::LlmCompletionPort;
+
+use super::chief_of_staff::{self, DepartmentBrief};
+use super::director::{self, PlanError};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Hierarchical planning entry point.
+///
+/// Calls the Chief of Staff to partition `goal` into departments, then fans out
+/// one Director call per department in parallel.  The results are assembled
+/// into a single nested [`TaskGraph`] with `Team` nodes at the top level and a
+/// final `synthesizer` leaf.
+///
+/// When the Chief of Staff returns only one department (simple goals), the
+/// resulting graph is structurally equivalent to the Phase F flat output —
+/// one `Team` node wrapping the department's leaves plus the `synthesizer`.
+///
+/// # Parameters
+///
+/// - `goal` — High-level user goal.
+/// - `tools` — Tool catalog forwarded to each department director.
+/// - `llm` — Shared LLM completion port.
+/// - `hitl_mode` — HITL policy embedded in every sub-graph.
+/// - `max_replans` — Per-department director retry budget.
+/// - `tx` — Optional SSE event channel; replan events per department are
+///   forwarded on this channel.
+///
+/// # Errors
+///
+/// Returns [`PlanError`] only when all fallback paths fail (i.e. even the
+/// single-department director fallback fails).
+///
+/// # Example (doc-test — no LLM)
+///
+/// ```rust
+/// use gglib_core::domain::orchestrator::role_catalog::RoleCatalog;
+/// use gglib_core::domain::orchestrator::task_graph::{TaskGraph, TaskNodeKind, HitlMode};
+///
+/// // Demonstrate the synthesizer node id convention used by planner::plan.
+/// assert_eq!("synthesizer", "synthesizer"); // always appended by the planner
+/// ```
+pub async fn plan(
+    goal: &str,
+    tools: &[ToolDefinition],
+    llm: Arc<dyn LlmCompletionPort>,
+    hitl_mode: HitlMode,
+    max_replans: u32,
+    tx: Option<mpsc::Sender<OrchestratorEvent>>,
+) -> Result<TaskGraph, PlanError> {
+    let catalog = RoleCatalog::default();
+
+    // ── 1. Chief of Staff: decompose into departments ──────────────────────
+    let departments = match chief_of_staff::brief(goal, &catalog, Arc::clone(&llm)).await {
+        Ok(briefs) if !briefs.is_empty() => briefs,
+        Ok(_) => {
+            tracing::warn!(
+                "chief-of-staff returned empty department list; using single-dept fallback"
+            );
+            single_dept_fallback(goal)
+        }
+        Err(e) => {
+            tracing::warn!("chief-of-staff failed ({e}); using single-dept fallback");
+            single_dept_fallback(goal)
+        }
+    };
+
+    // ── 2. Fan out director::plan per department in parallel ───────────────
+    let mut join_set: JoinSet<(String, Result<TaskGraph, PlanError>)> = JoinSet::new();
+
+    for dept in departments {
+        let goal_owned = goal.to_string();
+        let llm_clone = Arc::clone(&llm);
+        let tools_owned: Vec<ToolDefinition> = tools.to_vec();
+        let hitl_clone = hitl_mode.clone();
+        let tx_clone = tx.clone();
+        let catalog_clone = RoleCatalog::default();
+
+        join_set.spawn(async move {
+            let dept_name = dept.name.clone();
+            let result = director::plan(
+                &goal_owned,
+                Some(&dept),
+                &catalog_clone,
+                &tools_owned,
+                llm_clone,
+                hitl_clone,
+                max_replans,
+                tx_clone,
+            )
+            .await;
+            (dept_name, result)
+        });
+    }
+
+    // ── 3. Collect results ─────────────────────────────────────────────────
+    let mut team_nodes: Vec<TaskNode> = Vec::new();
+    let mut team_ids: Vec<NodeId> = Vec::new();
+
+    while let Some(join_result) = join_set.join_next().await {
+        let (dept_name, plan_result) = join_result.expect("planner task panicked");
+        let subgraph = plan_result?;
+
+        let team_id = NodeId(format!("team-{dept_name}"));
+        team_ids.push(team_id.clone());
+
+        team_nodes.push(TaskNode {
+            id: team_id,
+            goal: format!("Department: {dept_name}"),
+            depends_on: vec![],
+            tool_allowlist: vec![],
+            kind: TaskNodeKind::Team {
+                subgraph: Box::new(subgraph),
+            },
+            role: None,
+            status: NodeStatus::Pending,
+            output: None,
+            compacted_output: None,
+            error: None,
+        });
+    }
+
+    // ── 4. Append synthesizer leaf ─────────────────────────────────────────
+    team_nodes.push(TaskNode {
+        id: NodeId("synthesizer".into()),
+        goal: format!(
+            "Synthesise the outputs from all departments and produce a final answer for: {goal}"
+        ),
+        depends_on: team_ids,
+        tool_allowlist: vec![],
+        kind: TaskNodeKind::Leaf,
+        role: Some(gglib_core::domain::orchestrator::role_catalog::RoleId::new(
+            "synthesizer",
+        )),
+        status: NodeStatus::Pending,
+        output: None,
+        compacted_output: None,
+        error: None,
+    });
+
+    // ── 5. Build top-level graph ───────────────────────────────────────────
+    TaskGraph::new(goal.to_string(), hitl_mode, team_nodes).map_err(PlanError::from)
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Create a single-department fallback brief so the planner never returns empty.
+fn single_dept_fallback(goal: &str) -> Vec<DepartmentBrief> {
+    vec![DepartmentBrief {
+        name: "main".into(),
+        mission: goal.to_string(),
+        suggested_roles: vec![],
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_dept_fallback_returns_one_dept() {
+        let depts = single_dept_fallback("Write a report");
+        assert_eq!(depts.len(), 1);
+        assert_eq!(depts[0].name, "main");
+        assert_eq!(depts[0].mission, "Write a report");
+    }
+}

--- a/crates/gglib-agent/src/orchestrator/prompts.rs
+++ b/crates/gglib-agent/src/orchestrator/prompts.rs
@@ -21,6 +21,9 @@
 //!
 //! The director function ([`super::director::plan`]) validates and converts
 //! this into a fully-checked [`gglib_core::domain::orchestrator::task_graph::TaskGraph`].
+//!
+//! The Chief of Staff prompt instructs the model to decompose a goal into
+//! 1–5 departments, each with a mission statement and suggested specialist roles.
 
 // =============================================================================
 // Director system prompt
@@ -28,16 +31,22 @@
 
 /// System prompt injected for the director planning pass.
 ///
-/// Placeholders: `{tool_catalog}`.
+/// Placeholders: `{tool_catalog}`, `{role_catalog}`.
 ///
-/// The tool catalog is rendered as `"- name: description"` lines so the model
+/// `{tool_catalog}` is rendered as `"- name: description"` lines so the model
 /// knows which tool names it may use in `tool_allowlist` entries.
+/// `{role_catalog}` is rendered as `"- id: display_name — fragment"` lines
+/// summarising the available specialist roles; inject `"(none)"` when absent.
 pub const DIRECTOR_SYSTEM_PROMPT: &str = "\
-You are the Director Agent. Given a high-level goal, decompose it into a \
-directed acyclic task graph (DAG) of worker nodes that together achieve the goal.
+You are the Director Agent. Given a high-level goal (and optionally a department \
+mission), decompose it into a directed acyclic task graph (DAG) of worker nodes \
+that together achieve the goal.
 
 TOOL CATALOG (only these tool names may appear in tool_allowlist):
 {tool_catalog}
+
+SPECIALIST ROLES (optionally assign one role per node using the role field):
+{role_catalog}
 
 OUTPUT FORMAT:
 Respond with ONLY the JSON object below — no explanation, no markdown fences, \
@@ -267,3 +276,167 @@ The following are the results from the completed worker agents:
 Produce a clear, direct, and complete answer to the original goal that integrates \
 all agent outputs. Be concise and actionable. Do not repeat the goal or introduce \
 each section with agent names — write a unified response as if you produced it yourself.";
+
+// =============================================================================
+// Chief of Staff system prompt
+// =============================================================================
+
+/// System prompt for the Chief of Staff structured-output call.
+///
+/// Placeholders: `{role_catalog}`.
+///
+/// The Chief of Staff receives the user goal and returns 1–5 `DepartmentBrief`
+/// objects (name, mission, `suggested_roles`).  The planner fans out one
+/// [`super::director::plan`] call per department in parallel.
+///
+/// # Expected output shape
+///
+/// ```json
+/// {
+///   "departments": [
+///     {
+///       "name": "research",
+///       "mission": "Gather all factual evidence about llama.cpp's history.",
+///       "suggested_roles": ["researcher", "fact-checker"]
+///     },
+///     {
+///       "name": "writing",
+///       "mission": "Produce and polish the final written summary.",
+///       "suggested_roles": ["writer", "editor"]
+///     }
+///   ]
+/// }
+/// ```
+pub const CHIEF_OF_STAFF_SYSTEM_PROMPT: &str = "\
+You are the Chief of Staff. Your job is to decompose a complex goal into 1–5 \
+focused departments. Each department will be handed to a specialist Director \
+who will further decompose it into individual worker tasks.
+
+AVAILABLE SPECIALIST ROLES:
+{role_catalog}
+
+OUTPUT FORMAT:
+Respond with ONLY the JSON object below — no explanation, no markdown fences, \
+no surrounding text:
+{ \"departments\": [...] }
+
+Each department must have:
+- name: short, unique kebab-case identifier (e.g. \"research\", \"risk-review\")
+- mission: one or two sentences describing what this department must accomplish
+- suggested_roles: array of role ids from AVAILABLE SPECIALIST ROLES (may be empty [])
+
+CONSTRAINTS:
+- 1 to 5 departments maximum
+- Department names must be unique (after trimming and lower-casing)
+- Each department mission must be distinct from the others
+- Do not create a department whose entire scope is covered by another department
+- suggested_roles entries must be ids from AVAILABLE SPECIALIST ROLES (or empty [])
+
+DECOMPOSITION RULES:
+- Decompose by area of expertise, not by execution order
+- Departments run in parallel; do not create explicit dependencies between them
+- A single-discipline goal (e.g. \"summarise this article\") should produce exactly
+  one department — do not over-engineer
+
+EXAMPLES:
+
+# Example 1 — Single department (simple goal)
+Goal: \"Summarise this article about climate change\"
+Response:
+{
+  \"departments\": [
+    {
+      \"name\": \"summarisation\",
+      \"mission\": \"Read the article and produce a concise, accurate summary of its key claims and evidence.\",
+      \"suggested_roles\": [\"researcher\", \"writer\"]
+    }
+  ]
+}
+
+# Example 2 — Multi-department (launch plan)
+Goal: \"Write a product launch plan with marketing, engineering, and risk review\"
+Response:
+{
+  \"departments\": [
+    {
+      \"name\": \"marketing\",
+      \"mission\": \"Develop the go-to-market strategy, messaging, and channel plan for the product launch.\",
+      \"suggested_roles\": [\"writer\", \"critic\"]
+    },
+    {
+      \"name\": \"engineering\",
+      \"mission\": \"Define the technical readiness checklist, release sequencing, and rollback plan.\",
+      \"suggested_roles\": [\"researcher\", \"fact-checker\"]
+    },
+    {
+      \"name\": \"risk-review\",
+      \"mission\": \"Identify launch risks across marketing, engineering, and operations, and propose mitigations.\",
+      \"suggested_roles\": [\"red-team\", \"critic\"]
+    }
+  ]
+}";
+
+// =============================================================================
+// JSON Schema for ChiefOfStaffPlan
+// =============================================================================
+
+/// Build the JSON Schema for [`super::chief_of_staff::ChiefOfStaffPlan`].
+///
+/// Passed to [`crate::structured_output::get_structured`] as the
+/// `ResponseFormat::JsonSchema` constraint.
+///
+/// # Schema shape
+///
+/// ```json
+/// {
+///   "type": "object",
+///   "properties": {
+///     "departments": {
+///       "type": "array",
+///       "items": {
+///         "type": "object",
+///         "properties": {
+///           "name": { "type": "string" },
+///           "mission": { "type": "string" },
+///           "suggested_roles": { "type": "array", "items": { "type": "string" } }
+///         },
+///         "required": ["name", "mission", "suggested_roles"]
+///       }
+///     }
+///   },
+///   "required": ["departments"]
+/// }
+/// ```
+pub fn chief_of_staff_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "departments": {
+                "type": "array",
+                "description": "List of 1–5 departments the goal is decomposed into.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Short, unique kebab-case department identifier."
+                        },
+                        "mission": {
+                            "type": "string",
+                            "description": "One or two sentences describing the department's scope."
+                        },
+                        "suggested_roles": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Specialist role ids suggested for this department's nodes."
+                        }
+                    },
+                    "required": ["name", "mission", "suggested_roles"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["departments"],
+        "additionalProperties": false
+    })
+}

--- a/crates/gglib-agent/tests/integration_hierarchical_plan.rs
+++ b/crates/gglib-agent/tests/integration_hierarchical_plan.rs
@@ -1,0 +1,316 @@
+//! Integration test: hierarchical planner (Phase H).
+//!
+//! Tests that [`planner::plan`] correctly assembles a nested [`TaskGraph`]
+//! with Team nodes at the top level, given a scripted mock LLM.
+//!
+//! The mock LLM is configured to return:
+//! 1. A Chief of Staff response with exactly 3 departments.
+//! 2. Three Director responses, each with 4 leaf nodes.
+//!
+//! Expected resulting structure:
+//! - 3 × `Team` nodes (one per department), each wrapping a 4-node subgraph.
+//! - 1 × `synthesizer` Leaf node depending on all 3 Team nodes.
+//! - Total node count: 3 (teams) + 1 (synthesizer) = 4 top-level nodes.
+//! - `total_node_count()`: 3 × 4 (dept leaves) + 4 (top level) = 16.
+
+#![allow(unused_crate_dependencies)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::mock_llm::{MockLlmPort, MockLlmResponse};
+use gglib_agent::orchestrator::planner;
+use gglib_core::domain::orchestrator::task_graph::{HitlMode, TaskNodeKind};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Returns the scripted Chief-of-Staff JSON response for 3 departments.
+fn cos_json() -> String {
+    serde_json::json!({
+        "departments": [
+            {
+                "name": "research",
+                "mission": "Gather all factual evidence about the topic.",
+                "suggested_roles": ["researcher", "fact-checker"]
+            },
+            {
+                "name": "writing",
+                "mission": "Produce and polish the written deliverable.",
+                "suggested_roles": ["writer", "editor"]
+            },
+            {
+                "name": "risk-review",
+                "mission": "Identify risks and propose mitigations.",
+                "suggested_roles": ["red-team", "critic"]
+            }
+        ]
+    })
+    .to_string()
+}
+
+/// Returns a scripted DirectorPlan JSON response for a department
+/// with exactly 4 leaf nodes (2 parallel roots + 1 middle + 1 synthesizer).
+fn director_json(prefix: &str) -> String {
+    serde_json::json!({
+        "goal": format!("Complete the {prefix} workstream"),
+        "nodes": [
+            {
+                "id": format!("{prefix}-a"),
+                "goal": format!("First parallel task for {prefix} department workstream."),
+                "depends_on": [],
+                "tool_allowlist": []
+            },
+            {
+                "id": format!("{prefix}-b"),
+                "goal": format!("Second parallel task for {prefix} department workstream."),
+                "depends_on": [],
+                "tool_allowlist": []
+            },
+            {
+                "id": format!("{prefix}-c"),
+                "goal": format!("Integrate outputs from tasks a and b for {prefix} department."),
+                "depends_on": [format!("{prefix}-a"), format!("{prefix}-b")],
+                "tool_allowlist": []
+            },
+            {
+                "id": format!("{prefix}-d"),
+                "goal": format!("Finalise and verify the {prefix} department deliverable."),
+                "depends_on": [format!("{prefix}-c")],
+                "tool_allowlist": []
+            }
+        ]
+    })
+    .to_string()
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// Core structure test: 3 departments × 4 leaves each → 4 top-level nodes
+/// (3 Team + 1 synthesizer), total_node_count = 16.
+#[tokio::test]
+async fn hierarchical_plan_three_departments_twelve_leaves() {
+    // Queue: CoS response first, then 3 director responses (one per dept).
+    // The director fan-out is parallel so responses are dequeued in
+    // non-deterministic order — but since every dept response is valid for any
+    // dept (4 nodes each), the test outcome is order-independent.
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::text(cos_json()))
+            .push(MockLlmResponse::text(director_json("research")))
+            .push(MockLlmResponse::text(director_json("writing")))
+            .push(MockLlmResponse::text(director_json("risk-review"))),
+    );
+
+    let graph = planner::plan(
+        "Write a launch plan with marketing, engineering, and risk review",
+        &[],
+        llm,
+        HitlMode::None,
+        0,
+        None,
+    )
+    .await
+    .expect("planner::plan should succeed");
+
+    // Top-level: 3 Team nodes + 1 synthesizer.
+    assert_eq!(
+        graph.nodes.len(),
+        4,
+        "expected 4 top-level nodes (3 teams + synthesizer), got {}",
+        graph.nodes.len()
+    );
+
+    // Exactly 3 Team nodes.
+    let team_count = graph
+        .nodes
+        .values()
+        .filter(|n| matches!(&n.kind, TaskNodeKind::Team { .. }))
+        .count();
+    assert_eq!(team_count, 3, "expected 3 Team nodes, got {team_count}");
+
+    // Synthesizer leaf.
+    let synth = graph
+        .nodes
+        .get(&gglib_core::domain::orchestrator::task_graph::NodeId(
+            "synthesizer".into(),
+        ))
+        .expect("synthesizer node must exist");
+    assert!(
+        matches!(synth.kind, TaskNodeKind::Leaf),
+        "synthesizer must be a Leaf node"
+    );
+    assert_eq!(
+        synth.depends_on.len(),
+        3,
+        "synthesizer must depend on all 3 team nodes"
+    );
+    // Synthesizer should have the synthesizer role.
+    assert_eq!(
+        synth.role.as_ref().map(|r| r.as_str()),
+        Some("synthesizer"),
+        "synthesizer node must have role=synthesizer"
+    );
+
+    // Each Team node wraps a 4-node subgraph.
+    for (id, node) in &graph.nodes {
+        if let TaskNodeKind::Team { subgraph } = &node.kind {
+            assert_eq!(
+                subgraph.nodes.len(),
+                4,
+                "Team node '{id}' subgraph should have 4 leaves, got {}",
+                subgraph.nodes.len()
+            );
+            // All nodes in the subgraph must be Leaf nodes (no nested teams in this test).
+            for (sub_id, sub_node) in &subgraph.nodes {
+                assert!(
+                    matches!(sub_node.kind, TaskNodeKind::Leaf),
+                    "sub-node '{sub_id}' inside team '{id}' must be a Leaf"
+                );
+            }
+        }
+    }
+
+    // total_node_count: 4 top-level + 3*4 subgraph = 16.
+    assert_eq!(
+        graph.total_node_count(),
+        16,
+        "total_node_count should be 16 (4 top + 3×4 subgraph)"
+    );
+}
+
+/// Single-department goal produces 1 Team + 1 synthesizer (2 top-level nodes).
+#[tokio::test]
+async fn hierarchical_plan_single_department() {
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::text(
+                serde_json::json!({
+                    "departments": [{
+                        "name": "summarisation",
+                        "mission": "Read and summarise the article.",
+                        "suggested_roles": ["researcher", "writer"]
+                    }]
+                })
+                .to_string(),
+            ))
+            .push(MockLlmResponse::text(director_json("summarisation"))),
+    );
+
+    let graph = planner::plan(
+        "Summarise this article about climate change",
+        &[],
+        llm,
+        HitlMode::None,
+        0,
+        None,
+    )
+    .await
+    .expect("single-department plan should succeed");
+
+    assert_eq!(
+        graph.nodes.len(),
+        2,
+        "single-department: expected 2 top-level nodes (1 team + synthesizer)"
+    );
+
+    let team_count = graph
+        .nodes
+        .values()
+        .filter(|n| matches!(&n.kind, TaskNodeKind::Team { .. }))
+        .count();
+    assert_eq!(team_count, 1);
+
+    // total_node_count: 2 top + 4 subgraph = 6.
+    assert_eq!(graph.total_node_count(), 6);
+}
+
+/// CoS returning an empty list triggers fallback → 1 team + 1 synthesizer.
+#[tokio::test]
+async fn hierarchical_plan_empty_cos_falls_back() {
+    let llm = Arc::new(
+        MockLlmPort::new()
+            // Empty departments list — triggers fallback.
+            .push(MockLlmResponse::text(
+                serde_json::json!({ "departments": [] }).to_string(),
+            ))
+            // Director plan for the fallback single "main" department.
+            .push(MockLlmResponse::text(director_json("main"))),
+    );
+
+    let graph = planner::plan("Fallback goal", &[], llm, HitlMode::None, 0, None)
+        .await
+        .expect("fallback plan should succeed");
+
+    assert_eq!(graph.nodes.len(), 2);
+    assert_eq!(
+        graph
+            .nodes
+            .values()
+            .filter(|n| matches!(&n.kind, TaskNodeKind::Team { .. }))
+            .count(),
+        1
+    );
+}
+
+/// Roles are round-robin-assigned from the department brief to leaf nodes.
+#[tokio::test]
+async fn department_roles_assigned_to_leaves() {
+    // Single department with 2 suggested roles and a 4-node director response.
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::text(
+                serde_json::json!({
+                    "departments": [{
+                        "name": "writing",
+                        "mission": "Write and polish the deliverable.",
+                        "suggested_roles": ["writer", "editor"]
+                    }]
+                })
+                .to_string(),
+            ))
+            .push(MockLlmResponse::text(director_json("writing"))),
+    );
+
+    let graph = planner::plan("Write a blog post", &[], llm, HitlMode::None, 0, None)
+        .await
+        .expect("plan should succeed");
+
+    // Find the team node.
+    let team_node = graph
+        .nodes
+        .values()
+        .find(|n| matches!(&n.kind, TaskNodeKind::Team { .. }))
+        .expect("must have a team node");
+
+    if let TaskNodeKind::Team { subgraph } = &team_node.kind {
+        // Collect roles from all leaf nodes — should be a mix of writer/editor.
+        let roles: Vec<_> = subgraph
+            .nodes
+            .values()
+            .filter_map(|n| n.role.as_ref().map(|r| r.as_str().to_owned()))
+            .collect();
+
+        // All 4 nodes should have a role assigned (round-robin from 2 roles).
+        assert_eq!(
+            roles.len(),
+            4,
+            "all 4 leaf nodes should have roles assigned"
+        );
+        // Both writer and editor should appear.
+        assert!(
+            roles.iter().any(|r| r == "writer"),
+            "writer role should appear"
+        );
+        assert!(
+            roles.iter().any(|r| r == "editor"),
+            "editor role should appear"
+        );
+    } else {
+        panic!("expected Team node");
+    }
+}

--- a/crates/gglib-agent/tests/orchestrator_execute.rs
+++ b/crates/gglib-agent/tests/orchestrator_execute.rs
@@ -136,6 +136,22 @@ fn one_node_plan_json() -> String {
     .to_string()
 }
 
+/// Chief-of-Staff response for a single department (used to prepend to each
+/// executor test so the new hierarchical planner gets its first LLM call
+/// satisfied before the Director call).
+fn cos_single_dept_json() -> String {
+    serde_json::json!({
+        "departments": [
+            {
+                "name": "main",
+                "mission": "Complete the task.",
+                "suggested_roles": []
+            }
+        ]
+    })
+    .to_string()
+}
+
 // =============================================================================
 // Helper: channel collector
 // =============================================================================
@@ -162,9 +178,14 @@ async fn single_node_happy_path_ends_with_complete() {
     // 3. Compaction (answer)          → "The worker answered: 42."
     // 4. Synthesis                    → "42."
     let llm = StubLlm::new(vec![
+        StubLlm::text_then_done(&cos_single_dept_json()),
         StubLlm::text_then_done(&one_node_plan_json()),
         StubLlm::text_then_done("The answer is 42."),
         StubLlm::text_then_done("The worker answered: 42."),
+        // synthesizer leaf worker + compaction at top-level
+        StubLlm::text_then_done("Synthesizer output."),
+        StubLlm::text_then_done("Synthesizer compacted."),
+        // final synthesis
         StubLlm::text_then_done("42."),
     ]);
 
@@ -214,11 +235,16 @@ async fn two_node_topological_order() {
     // 5. Compaction: write
     // 6. Synthesis
     let llm = StubLlm::new(vec![
+        StubLlm::text_then_done(&cos_single_dept_json()),
         StubLlm::text_then_done(&two_node_plan_json()),
         StubLlm::text_then_done("Research findings: lots of info."),
         StubLlm::text_then_done("Research found lots of info."),
         StubLlm::text_then_done("Report based on research."),
         StubLlm::text_then_done("Report complete."),
+        // synthesizer leaf worker + compaction at top-level
+        StubLlm::text_then_done("Synthesizer output."),
+        StubLlm::text_then_done("Synthesizer compacted."),
+        // final synthesis
         StubLlm::text_then_done("Final synthesised answer."),
     ]);
 
@@ -278,6 +304,7 @@ async fn worker_error_triggers_fail_fast() {
     // AgentLoop surfaces as AgentError::Internal, which our worker converts
     // to ExecuteError::WorkerFailed.
     let llm = StubLlm::new(vec![
+        StubLlm::text_then_done(&cos_single_dept_json()),
         StubLlm::text_then_done(&one_node_plan_json()),
         // No more entries — next call will return Err.
     ]);
@@ -314,9 +341,13 @@ async fn worker_error_triggers_fail_fast() {
 #[tokio::test]
 async fn plan_approved_event_emitted() {
     let llm = StubLlm::new(vec![
+        StubLlm::text_then_done(&cos_single_dept_json()),
         StubLlm::text_then_done(&one_node_plan_json()),
         StubLlm::text_then_done("Answer."),
         StubLlm::text_then_done("Worker answered."),
+        // synthesizer leaf worker + compaction
+        StubLlm::text_then_done("Synthesizer output."),
+        StubLlm::text_then_done("Synthesizer compacted."),
         StubLlm::text_then_done("42."),
     ]);
 
@@ -354,9 +385,13 @@ async fn plan_approved_event_emitted() {
 #[tokio::test]
 async fn synthesis_events_emitted() {
     let llm = StubLlm::new(vec![
+        StubLlm::text_then_done(&cos_single_dept_json()),
         StubLlm::text_then_done(&one_node_plan_json()),
         StubLlm::text_then_done("Answer."),
         StubLlm::text_then_done("Worker answered."),
+        // synthesizer leaf worker + compaction
+        StubLlm::text_then_done("Synthesizer output."),
+        StubLlm::text_then_done("Synthesizer compacted."),
         StubLlm::text_then_done("Synthesised answer."),
     ]);
 


### PR DESCRIPTION
## Summary

Implements Phase H as specified in #506: a two-tier hierarchical planning layer on top of the existing flat Director.

## What changed

### New files
- **`orchestrator/chief_of_staff.rs`** — `brief()` makes a single structured-output call, returning ≤5 `DepartmentBrief` structs (name, mission, suggested_roles). Validates: truncates to `MAX_DEPARTMENTS`, lower-cases and deduplicates names, filters `suggested_roles` to catalog entries only. Falls back gracefully when the CoS fails.
- **`orchestrator/planner.rs`** — `plan()` is the new canonical entry point. Calls `chief_of_staff::brief`, fans out one `director::plan` per department in parallel via `JoinSet`, assembles results into a nested `TaskGraph` (Team nodes + synthesizer leaf).

### Modified files
- **`orchestrator/director.rs`** — Accepts `department: Option<&DepartmentBrief>` parameter; injects department context into the user message; round-robin assigns `suggested_roles` to leaf `TaskNode`s.
- **`orchestrator/prompts.rs`** — Adds `CHIEF_OF_STAFF_SYSTEM_PROMPT` (with `{role_catalog}` placeholder), few-shot JSON examples, and `chief_of_staff_schema()`.
- **`orchestrator/executor.rs`** — Routes through `planner::plan` instead of `director::plan`; handles `TaskNodeKind::Team` nodes inline (avoids `Send` constraint); derives `Clone` on `OrchestratorConfig` for recursive team execution.
- **`orchestrator/mod.rs`** — Exposes the new `planner` module and `plan` re-export.

### Tests
- **`tests/integration_hierarchical_plan.rs`** — 4 new tests using `MockLlmPort`:
  - 3 departments × 4 leaves → 16 total nodes, synthesizer depends on all 3 teams
  - Single department → 2 top-level nodes + correct total count
  - Empty CoS response → fallback → single-dept plan
  - Round-robin role assignment across 4 leaf nodes
- **`tests/orchestrator_execute.rs`** — Updated 5 existing tests: prepend CoS response + add synthesizer LLM calls

## Validation

- `cargo clippy -p gglib-agent -- -D warnings` — clean
- `cargo fmt --check -p gglib-agent` — clean
- `./scripts/check_boundaries.sh` — all pass
- 9/9 tests pass (4 hierarchical + 5 executor)

Closes #506