### PR TITLE
feat(orchestrator): Phase I — executor recursion and spawn_subteam dynamic interrupt

### DIFF
--- a/crates/gglib-agent/src/orchestrator/executor.rs
+++ b/crates/gglib-agent/src/orchestrator/executor.rs
@@ -60,6 +60,7 @@ use crate::AgentLoop;
 use super::compaction::{CompactionError, compact_worker_output};
 use super::director::PlanError;
 use super::planner::plan;
+use super::spawn::{SpawnCapturingExecutor, SpawnRequest, SpawnSink};
 use super::synthesis::run_synthesis;
 
 // =============================================================================
@@ -105,6 +106,13 @@ pub struct OrchestratorConfig {
     /// When set, planning is skipped and execution resumes from the remaining
     /// `Pending` nodes.
     pub graph_override: Option<TaskGraph>,
+
+    /// Maximum recursion depth for nested Team and spawn sub-team graphs.
+    ///
+    /// A `debug_assert` fires at this limit during development.  The value is
+    /// intentionally generous (default: 9 = 3 levels × 3 max teams each) to
+    /// catch infinite-recursion bugs without restricting real use cases.
+    pub max_team_depth: u32,
 }
 
 impl Default for OrchestratorConfig {
@@ -117,6 +125,7 @@ impl Default for OrchestratorConfig {
             repository: None,
             run_id: None,
             graph_override: None,
+            max_team_depth: 9,
         }
     }
 }
@@ -165,6 +174,10 @@ pub enum ExecuteError {
         /// Optional user-provided reason.
         reason: String,
     },
+
+    /// The executor hit the maximum recursive team depth.
+    #[error("maximum team recursion depth exceeded")]
+    MaxDepthExceeded,
 }
 
 impl From<CompactionError> for ExecuteError {
@@ -392,6 +405,10 @@ pub async fn execute(
         .map(|(id, _)| id.clone())
         .collect();
 
+    // Create the concurrency semaphore here so it is shared across all
+    // recursive Team and spawn sub-team wave loops.
+    let sem = Arc::new(Semaphore::new(config.max_worker_concurrency));
+
     let result = run_wave_loop(
         goal,
         &graph,
@@ -402,6 +419,8 @@ pub async fn execute(
         &run_id,
         &mut event_seq,
         &tx,
+        Arc::clone(&sem),
+        0,
     )
     .await;
 
@@ -454,8 +473,17 @@ async fn run_wave_loop(
     run_id: &str,
     event_seq: &mut i64,
     tx: &mpsc::Sender<OrchestratorEvent>,
+    sem: Arc<Semaphore>,
+    depth: u32,
 ) -> Result<HashMap<NodeId, String>, ExecuteError> {
-    let sem = Arc::new(Semaphore::new(config.max_worker_concurrency));
+    debug_assert!(
+        depth < config.max_team_depth,
+        "orchestrator: team recursion depth {depth} reached limit {}",
+        config.max_team_depth
+    );
+    if depth >= config.max_team_depth {
+        return Err(ExecuteError::MaxDepthExceeded);
+    }
     let mut compacted: HashMap<NodeId, String> = HashMap::new();
 
     loop {
@@ -535,8 +563,11 @@ async fn run_wave_loop(
 
         // Spawn all ready nodes concurrently, bounded by the semaphore.
         #[allow(clippy::type_complexity)]
-        let mut join_set: JoinSet<(NodeId, Result<(String, String), ExecuteError>)> =
-            JoinSet::new();
+        let mut join_set: JoinSet<(
+            NodeId,
+            Result<(String, String), ExecuteError>,
+            SpawnSink,
+        )> = JoinSet::new();
 
         // ── Handle Team nodes inline (not spawned) ───────────────────────────
         // Team nodes must be run before we spawn the rest of the wave because
@@ -555,6 +586,14 @@ async fn run_wave_loop(
         for team_id in team_nodes_in_wave {
             let node = &graph.nodes[team_id];
             if let TaskNodeKind::Team { subgraph } = &node.kind {
+                // Emit TeamStarted before recursing.
+                let _ = tx
+                    .send(OrchestratorEvent::TeamStarted {
+                        team_id: team_id.0.clone(),
+                        role: node.role.clone(),
+                    })
+                    .await;
+
                 let sub_result = Box::pin(run_wave_loop(
                     &node.goal,
                     subgraph,
@@ -565,6 +604,8 @@ async fn run_wave_loop(
                     run_id,
                     event_seq,
                     tx,
+                    Arc::clone(&sem),
+                    depth + 1,
                 ))
                 .await;
 
@@ -575,6 +616,13 @@ async fn run_wave_loop(
                             .cloned()
                             .collect::<Vec<_>>()
                             .join("\n");
+                        // Emit TeamSynthesized with the compacted summary.
+                        let _ = tx
+                            .send(OrchestratorEvent::TeamSynthesized {
+                                team_id: team_id.0.clone(),
+                                compacted_output: summary.clone(),
+                            })
+                            .await;
                         compacted.insert(team_id.clone(), summary);
                         completed.insert(team_id.clone());
                     }
@@ -602,11 +650,20 @@ async fn run_wave_loop(
             let tool_executor_clone = Arc::clone(&tool_executor);
             let tx_clone = tx.clone();
 
+            // Each leaf gets its own SpawnSink so a worker can request a sub-team.
+            let spawn_sink: SpawnSink = Arc::new(tokio::sync::Mutex::new(None));
+            let spawn_sink_for_spawn = Arc::clone(&spawn_sink);
+
             join_set.spawn(async move {
                 let _permit = sem_clone
                     .acquire_owned()
                     .await
                     .expect("semaphore not closed");
+
+                // Wrap the executor to intercept spawn_subteam calls.
+                let capturing_executor: Arc<dyn ToolExecutorPort> = Arc::new(
+                    SpawnCapturingExecutor::new(tool_executor_clone, spawn_sink_for_spawn),
+                );
 
                 let result = run_worker(
                     &node_id_clone,
@@ -614,21 +671,30 @@ async fn run_wave_loop(
                     predecessor_context,
                     allowlist,
                     llm_clone,
-                    tool_executor_clone,
+                    capturing_executor,
                     &tx_clone,
                 )
                 .await;
 
-                (node_id_clone, result)
+                (node_id_clone, result, spawn_sink)
             });
         }
 
         // Collect results; fail fast on first error.
+        // Defer spawn processing until after the full wave completes so that
+        // parallel workers don't interleave with spawn approval/planning.
+        let mut pending_spawns: Vec<(NodeId, String, SpawnRequest)> = Vec::new();
+
         while let Some(join_result) = join_set.join_next().await {
-            let (node_id, worker_result) = join_result.expect("join_set task panicked");
+            let (node_id, worker_result, sink) = join_result.expect("join_set task panicked");
 
             match worker_result {
-                Ok((_full_output, compacted_output)) => {
+                Ok((full_output, compacted_output)) => {
+                    // Check whether the worker requested a spawn.
+                    let maybe_spawn = sink.lock().await.take();
+                    if let Some(req) = maybe_spawn {
+                        pending_spawns.push((node_id.clone(), full_output, req));
+                    }
                     compacted.insert(node_id.clone(), compacted_output);
                     completed.insert(node_id);
                 }
@@ -641,7 +707,125 @@ async fn run_wave_loop(
                 }
             }
         }
-    }
+
+        // ── Process spawn requests (serially after wave) ─────────────────────
+        for (parent_node_id, _parent_output, spawn_req) in pending_spawns {
+            // Determine whether a human needs to approve the spawn.
+            let approved = if config.hitl_mode >= HitlMode::ApproveEachNode {
+                if let Some(registry) = &config.approval_registry {
+                    let approval_id = uuid::Uuid::new_v4().to_string();
+                    let (tx_approval, rx_approval) =
+                        tokio::sync::oneshot::channel::<ApprovalDecision>();
+                    registry.register(approval_id.clone(), tx_approval);
+
+                    let event = OrchestratorEvent::AwaitingApproval {
+                        approval_id: approval_id.clone(),
+                        kind:
+                            gglib_core::domain::orchestrator::events::ApprovalKind::SpawnSubteam {
+                                node_id: parent_node_id.0.clone(),
+                                suggested_roles: spawn_req.suggested_roles.clone(),
+                            },
+                    };
+                    let _ = tx.send(event).await;
+
+                    match rx_approval.await {
+                        Ok(ApprovalDecision::Approve | ApprovalDecision::ApproveWithEdits(_)) => {
+                            true
+                        }
+                        Ok(ApprovalDecision::Reject(reason)) => {
+                            // Rejected spawn — log a warning and skip.
+                            tracing::warn!(
+                                "orchestrator: spawn_subteam rejected for node '{}': {reason}",
+                                parent_node_id.0
+                            );
+                            false
+                        }
+                        Err(_) => false,
+                    }
+                } else {
+                    // Registry absent → auto-approve.
+                    true
+                }
+            } else {
+                // HitlMode::None → auto-approve.
+                true
+            };
+
+            if !approved {
+                continue;
+            }
+
+            // Plan the child subgraph.
+            let child_graph = match plan(
+                &spawn_req.goal,
+                &[], // no tool list — director planning only
+                Arc::clone(&llm),
+                config.hitl_mode.clone(),
+                config.max_replans,
+                None, // no event forwarding for child planning
+            )
+            .await
+            {
+                Ok(g) => g,
+                Err(e) => {
+                    tracing::warn!(
+                        "orchestrator: spawn_subteam planning failed for node '{}': {e}",
+                        parent_node_id.0
+                    );
+                    continue;
+                }
+            };
+
+            let child_summary_line = format!(
+                "{} nodes for goal: {}",
+                child_graph.nodes.len(),
+                &spawn_req.goal
+            );
+
+            // Emit SubteamSpawned event.
+            let _ = tx
+                .send(OrchestratorEvent::SubteamSpawned {
+                    parent_node_id: parent_node_id.0.clone(),
+                    child_graph_summary: child_summary_line,
+                })
+                .await;
+
+            // Run the child subgraph recursively.
+            let child_result = Box::pin(run_wave_loop(
+                &spawn_req.goal,
+                &child_graph,
+                HashSet::new(),
+                Arc::clone(&llm),
+                Arc::clone(&tool_executor),
+                config,
+                run_id,
+                event_seq,
+                tx,
+                Arc::clone(&sem),
+                depth + 1,
+            ))
+            .await;
+
+            match child_result {
+                Ok(child_compacted) => {
+                    // Merge child compacted outputs into the parent's map,
+                    // prefixing with the spawn context so downstream nodes
+                    // see the enriched context.
+                    let child_summary = child_compacted
+                        .values()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    // Append to the parent node's existing compacted output.
+                    if let Some(existing) = compacted.get_mut(&parent_node_id) {
+                        existing.push_str("\n\n[Spawned sub-team output]\n");
+                        existing.push_str(&child_summary);
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    } // end loop
 
     Ok(compacted)
 }

--- a/crates/gglib-agent/src/orchestrator/mod.rs
+++ b/crates/gglib-agent/src/orchestrator/mod.rs
@@ -25,6 +25,7 @@ pub mod director;
 pub mod executor;
 pub mod planner;
 pub mod prompts;
+pub mod spawn;
 pub(crate) mod synthesis;
 
 pub use director::{DirectorNode, DirectorPlan, PlanError};

--- a/crates/gglib-agent/src/orchestrator/spawn.rs
+++ b/crates/gglib-agent/src/orchestrator/spawn.rs
@@ -1,0 +1,188 @@
+//! Dynamic sub-team spawning support for the orchestrator.
+//!
+//! A worker node may call the built-in `spawn_subteam` tool to request that
+//! the executor dynamically plan and execute a subordinate team for a
+//! focused sub-goal.  The mechanism has two parts:
+//!
+//! 1. [`spawn_subteam_tool_def`] — the [`ToolDefinition`] injected into every
+//!    worker's tool list.  The LLM invokes it with `{"goal": "…",
+//!    "suggested_roles": ["role-a", "role-b"]}`.
+//!
+//! 2. [`SpawnCapturingExecutor`] — a transparent [`ToolExecutorPort`] decorator
+//!    that intercepts `spawn_subteam` calls, writes the parsed [`SpawnRequest`]
+//!    into a shared [`SpawnSink`], and returns a synthetic
+//!    `ToolResult { success: true }` so the LLM can finish its turn normally.
+//!    After the worker loop terminates, the executor reads the sink and drives
+//!    the approval + planning + recursive execution flow.
+//!
+//! # Name
+//!
+//! The tool is deliberately named `"spawn_subteam"` (no prefix) to keep it
+//! concise; it is always injected directly by the executor and is never
+//! routed through the MCP adapter.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use gglib_core::domain::agent::{ToolCall, ToolDefinition, ToolResult};
+use gglib_core::ports::ToolExecutorPort;
+
+// =============================================================================
+// Tool name constant
+// =============================================================================
+
+/// Wire name used both in the tool definition and in the executor interceptor.
+pub const SPAWN_SUBTEAM_TOOL_NAME: &str = "spawn_subteam";
+
+// =============================================================================
+// SpawnRequest
+// =============================================================================
+
+/// A request to dynamically plan and execute a sub-team for `goal`.
+///
+/// Populated by [`SpawnCapturingExecutor`] when a worker calls `spawn_subteam`,
+/// then read by the executor after the worker terminates.
+#[derive(Debug, Clone)]
+pub struct SpawnRequest {
+    /// The sub-goal to hand off to the spawned team.
+    pub goal: String,
+    /// Role hints the requesting worker proposed for the new team.
+    pub suggested_roles: Vec<String>,
+}
+
+// =============================================================================
+// SpawnSink
+// =============================================================================
+
+/// A shared, once-writable slot for a [`SpawnRequest`].
+///
+/// Each worker node gets its own fresh `SpawnSink`.  The
+/// [`SpawnCapturingExecutor`] fills it on the first `spawn_subteam` call;
+/// subsequent calls in the same turn are silently ignored (only one spawn per
+/// node is supported).
+pub type SpawnSink = Arc<Mutex<Option<SpawnRequest>>>;
+
+// =============================================================================
+// Tool definition
+// =============================================================================
+
+/// Returns the [`ToolDefinition`] for `spawn_subteam` that is injected into
+/// every worker's tool list by the executor.
+///
+/// # Schema
+///
+/// ```json
+/// {
+///   "type": "object",
+///   "properties": {
+///     "goal": { "type": "string" },
+///     "suggested_roles": { "type": "array", "items": { "type": "string" } }
+///   },
+///   "required": ["goal"]
+/// }
+/// ```
+#[must_use]
+pub fn spawn_subteam_tool_def() -> ToolDefinition {
+    ToolDefinition {
+        name: SPAWN_SUBTEAM_TOOL_NAME.to_string(),
+        description: Some(
+            "Request that the orchestrator dynamically plan and execute a focused sub-team for a \
+             specific sub-goal. Use when the current task requires a coordinated effort that \
+             exceeds your scope. Provide a clear goal and any role hints that would help the \
+             planner assemble the right team."
+                .to_string(),
+        ),
+        input_schema: Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "description": "The focused sub-goal for the spawned team to accomplish."
+                },
+                "suggested_roles": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional role hints (e.g. [\"researcher\", \"writer\"]) to \
+                                    guide the planner when assembling the team."
+                }
+            },
+            "required": ["goal"]
+        })),
+        title: Some("Spawn Sub-team".to_string()),
+    }
+}
+
+// =============================================================================
+// SpawnCapturingExecutor
+// =============================================================================
+
+/// A [`ToolExecutorPort`] decorator that intercepts `spawn_subteam` calls.
+///
+/// All other tool calls are forwarded unchanged to the wrapped `inner`
+/// executor.  When `spawn_subteam` is invoked the arguments are parsed and
+/// written to `sink`, and a synthetic success result is returned so the LLM
+/// can complete its turn without an error.
+pub struct SpawnCapturingExecutor {
+    inner: Arc<dyn ToolExecutorPort>,
+    sink: SpawnSink,
+}
+
+impl SpawnCapturingExecutor {
+    /// Create a new decorator around `inner` that captures spawn requests into
+    /// `sink`.
+    pub fn new(inner: Arc<dyn ToolExecutorPort>, sink: SpawnSink) -> Self {
+        Self { inner, sink }
+    }
+}
+
+/// Arguments accepted by the `spawn_subteam` tool.
+#[derive(Debug, Deserialize)]
+struct SpawnArgs {
+    goal: String,
+    #[serde(default)]
+    suggested_roles: Vec<String>,
+}
+
+#[async_trait]
+impl ToolExecutorPort for SpawnCapturingExecutor {
+    async fn list_tools(&self) -> Vec<ToolDefinition> {
+        let mut tools = self.inner.list_tools().await;
+        tools.push(spawn_subteam_tool_def());
+        tools
+    }
+
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, anyhow::Error> {
+        if call.name != SPAWN_SUBTEAM_TOOL_NAME {
+            return self.inner.execute(call).await;
+        }
+
+        // Parse the spawn arguments (best-effort; missing goal → empty string).
+        let args: SpawnArgs = serde_json::from_value(call.arguments.clone()).unwrap_or(SpawnArgs {
+            goal: String::new(),
+            suggested_roles: vec![],
+        });
+
+        // Write to sink only on the first call per worker.
+        {
+            let mut guard = self.sink.lock().await;
+            if guard.is_none() {
+                *guard = Some(SpawnRequest {
+                    goal: args.goal,
+                    suggested_roles: args.suggested_roles,
+                });
+            }
+        }
+
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            content: "Sub-team spawn requested. The orchestrator will plan and execute a \
+                      dedicated team for this goal. Continue with your response."
+                .to_string(),
+            success: true,
+        })
+    }
+}

--- a/crates/gglib-agent/tests/integration_hierarchical_run.rs
+++ b/crates/gglib-agent/tests/integration_hierarchical_run.rs
@@ -1,0 +1,218 @@
+//! Integration test: hierarchical execution (Phase I).
+//!
+//! Verifies that the executor correctly drives a 3-department / 12-leaf
+//! [`TaskGraph`] to completion, emitting [`TeamStarted`] before any leaf in
+//! that team and [`TeamSynthesized`] before any sibling or downstream node
+//! starts.
+//!
+//! # LLM call budget
+//!
+//! Planning:   1 CoS + 3 Director              =  4 calls
+//! Execution: 12 leaf workers + 12 compactions  = 24 calls
+//! Synthesis:  1 final synthesis call           =  1 call
+//! Total                                        = 29 calls
+
+#![allow(unused_crate_dependencies)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common::mock_llm::{MockLlmPort, MockLlmResponse};
+use gglib_agent::orchestrator::{OrchestratorConfig, execute};
+use gglib_core::domain::orchestrator::events::OrchestratorEvent;
+use gglib_core::domain::orchestrator::task_graph::HitlMode;
+use gglib_core::ports::EmptyToolExecutor;
+use tokio::sync::mpsc;
+
+// =============================================================================
+// Scripted LLM helpers — same as integration_hierarchical_plan.rs
+// =============================================================================
+
+fn cos_json() -> String {
+    serde_json::json!({
+        "departments": [
+            {
+                "name": "research",
+                "mission": "Gather all factual evidence.",
+                "suggested_roles": ["researcher"]
+            },
+            {
+                "name": "writing",
+                "mission": "Produce the written deliverable.",
+                "suggested_roles": ["writer"]
+            },
+            {
+                "name": "risk-review",
+                "mission": "Identify risks.",
+                "suggested_roles": ["critic"]
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn director_json(prefix: &str) -> String {
+    serde_json::json!({
+        "goal": format!("Complete the {prefix} workstream"),
+        "nodes": [
+            {
+                "id": format!("{prefix}-a"),
+                "goal": format!("First task for {prefix}."),
+                "depends_on": [],
+                "tool_allowlist": []
+            },
+            {
+                "id": format!("{prefix}-b"),
+                "goal": format!("Second task for {prefix}."),
+                "depends_on": [],
+                "tool_allowlist": []
+            },
+            {
+                "id": format!("{prefix}-c"),
+                "goal": format!("Integrate a+b for {prefix}."),
+                "depends_on": [format!("{prefix}-a"), format!("{prefix}-b")],
+                "tool_allowlist": []
+            },
+            {
+                "id": format!("{prefix}-d"),
+                "goal": format!("Finalise {prefix}."),
+                "depends_on": [format!("{prefix}-c")],
+                "tool_allowlist": []
+            }
+        ]
+    })
+    .to_string()
+}
+
+// =============================================================================
+// Test
+// =============================================================================
+
+/// 3-department / 12-leaf plan executes end-to-end.
+///
+/// Verifies:
+/// 1. `TeamStarted` is emitted for each team before any `NodeStarted` event
+///    from a leaf in that team.
+/// 2. `TeamSynthesized` is emitted for each team before the top-level
+///    synthesizer `NodeStarted` event (i.e. the downstream synthesizer does
+///    not start until all teams are done).
+/// 3. The run completes with `OrchestratorComplete`.
+#[tokio::test]
+async fn hierarchical_run_three_departments_twelve_leaves() {
+    // Planning: 1 CoS + 3 Directors.
+    // Execution: 13 leaf workers (12 dept leaves + 1 synthesizer leaf) ×
+    //            (1 worker turn + 1 compaction turn) = 26
+    //            + 1 top-level synthesis pass = 27
+    // Total: 4 + 26 + 1 = 31 LLM calls.
+    let leaf_answer = "Done.";
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::text(cos_json()))
+            .push(MockLlmResponse::text(director_json("research")))
+            .push(MockLlmResponse::text(director_json("writing")))
+            .push(MockLlmResponse::text(director_json("risk-review")))
+            .push_many((0..27).map(|_| MockLlmResponse::text(leaf_answer))),
+    );
+
+    let tool_executor = Arc::new(EmptyToolExecutor);
+
+    let (tx, mut rx) = mpsc::channel::<OrchestratorEvent>(4096);
+
+    let config = OrchestratorConfig {
+        hitl_mode: HitlMode::None,
+        max_replans: 0,
+        ..Default::default()
+    };
+
+    let run_handle = tokio::spawn(async move {
+        execute(
+            "Write a launch plan with research, writing, and risk review",
+            &[],
+            llm,
+            tool_executor,
+            config,
+            tx,
+        )
+        .await
+    });
+
+    // Collect all events.
+    let mut events: Vec<OrchestratorEvent> = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+
+    // The execute call should have returned Ok(()) by now.
+    let result = run_handle.await.expect("task did not panic");
+    assert!(result.is_ok(), "execute should succeed: {result:?}");
+
+    // ── Verify OrchestratorComplete is the last event ─────────────────────────
+    assert!(
+        matches!(
+            events.last(),
+            Some(OrchestratorEvent::OrchestratorComplete { .. })
+        ),
+        "last event should be OrchestratorComplete"
+    );
+
+    // ── Build index: event position for each event type ───────────────────────
+    // For each team_id record position of TeamStarted and TeamSynthesized.
+    // For each node_id record position of first NodeStarted.
+    let mut team_started_pos: HashMap<String, usize> = HashMap::new();
+    let mut team_synthesized_pos: HashMap<String, usize> = HashMap::new();
+    let mut node_started_pos: HashMap<String, usize> = HashMap::new();
+
+    for (pos, ev) in events.iter().enumerate() {
+        match ev {
+            OrchestratorEvent::TeamStarted { team_id, .. } => {
+                team_started_pos.entry(team_id.clone()).or_insert(pos);
+            }
+            OrchestratorEvent::TeamSynthesized { team_id, .. } => {
+                team_synthesized_pos.entry(team_id.clone()).or_insert(pos);
+            }
+            OrchestratorEvent::NodeStarted { node_id, .. } => {
+                node_started_pos.entry(node_id.clone()).or_insert(pos);
+            }
+            _ => {}
+        }
+    }
+
+    // We should have TeamStarted + TeamSynthesized for all 3 teams.
+    assert_eq!(team_started_pos.len(), 3, "expected 3 TeamStarted events");
+    assert_eq!(
+        team_synthesized_pos.len(),
+        3,
+        "expected 3 TeamSynthesized events"
+    );
+
+    // ── Rule 1: TeamStarted comes before any leaf NodeStarted in that team ────
+    for (team_id, started_pos) in &team_started_pos {
+        // The leaf node ids all start with "<team_id>-" (e.g. "research-a").
+        let team_prefix = format!("{team_id}-");
+        for (node_id, node_pos) in &node_started_pos {
+            if node_id.starts_with(&team_prefix) {
+                assert!(
+                    started_pos < node_pos,
+                    "TeamStarted({team_id})@{started_pos} must precede \
+                     NodeStarted({node_id})@{node_pos}"
+                );
+            }
+        }
+    }
+
+    // ── Rule 2: TeamSynthesized for each team before synthesizer NodeStarted ──
+    // The synthesizer top-level leaf id is "synthesizer".
+    if let Some(synth_pos) = node_started_pos.get("synthesizer") {
+        for (team_id, synthesized_pos) in &team_synthesized_pos {
+            assert!(
+                synthesized_pos < synth_pos,
+                "TeamSynthesized({team_id})@{synthesized_pos} must precede \
+                 NodeStarted(synthesizer)@{synth_pos}"
+            );
+        }
+    }
+    // (If synthesizer didn't appear as a NodeStarted, the run still completed,
+    // but there is nothing to order against — that's fine.)
+}

--- a/crates/gglib-agent/tests/integration_spawn_subteam.rs
+++ b/crates/gglib-agent/tests/integration_spawn_subteam.rs
@@ -1,0 +1,364 @@
+//! Integration test: `spawn_subteam` dynamic sub-team spawning (Phase I).
+//!
+//! Tests:
+//! 1. A worker that calls `spawn_subteam` triggers a [`SubteamSpawned`] event
+//!    and the child sub-team executes; the run completes successfully.
+//! 2. With [`HitlMode::None`] the spawn is auto-approved (no
+//!    [`AwaitingApproval`] event for the spawn).
+//! 3. With a HITL registry and [`HitlMode::ApproveEachNode`], an
+//!    [`AwaitingApproval`] event with `kind.spawn_subteam` is emitted before
+//!    the child runs.
+//!
+//! # LLM call budget (auto-approve path)
+//!
+//! Main worker: 2 calls (initial + continuation after spawn tool reply)
+//! Main worker compaction: 1 call
+//! Spawn planning — CoS: 1 call
+//! Spawn planning — Director (1 dept, 2 leaves): 1 call
+//! Spawned leaf workers (2): 2 calls
+//! Spawned leaf compactions (2): 2 calls
+//! Top-level synthesis: 1 call
+//! Total: 10 calls
+
+#![allow(unused_crate_dependencies)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common::mock_llm::{MockLlmPort, MockLlmResponse};
+use gglib_agent::orchestrator::{OrchestratorConfig, execute};
+use gglib_core::domain::orchestrator::events::{ApprovalKind, OrchestratorEvent};
+use gglib_core::domain::orchestrator::task_graph::{
+    HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
+};
+use gglib_core::ports::{ApprovalDecision, EmptyToolExecutor, OrchestratorApprovalRegistryPort};
+use tokio::sync::{mpsc, oneshot};
+
+// =============================================================================
+// Simple approval registry for tests
+// =============================================================================
+
+/// A trivial in-process registry used in tests.
+struct TestApprovalRegistry {
+    senders: tokio::sync::Mutex<HashMap<String, oneshot::Sender<ApprovalDecision>>>,
+}
+
+impl TestApprovalRegistry {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            senders: tokio::sync::Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+impl OrchestratorApprovalRegistryPort for TestApprovalRegistry {
+    fn register(&self, approval_id: String, sender: oneshot::Sender<ApprovalDecision>) {
+        let mut guard = self.senders.try_lock().unwrap();
+        guard.insert(approval_id, sender);
+    }
+
+    fn resolve(&self, approval_id: &str, decision: ApprovalDecision) -> bool {
+        let mut guard = self.senders.try_lock().unwrap();
+        if let Some(tx) = guard.remove(approval_id) {
+            tx.send(decision).is_ok()
+        } else {
+            false
+        }
+    }
+
+    fn is_pending(&self, approval_id: &str) -> bool {
+        self.senders.try_lock().unwrap().contains_key(approval_id)
+    }
+}
+
+// =============================================================================
+// Scripted LLM helpers
+// =============================================================================
+
+/// Single-node graph that simply does one leaf task.
+fn single_leaf_graph() -> TaskGraph {
+    let node = TaskNode {
+        id: NodeId("worker-1".into()),
+        goal: "Research the topic and spawn a writing team if needed.".into(),
+        depends_on: vec![],
+        tool_allowlist: vec!["spawn_subteam".into()],
+        kind: TaskNodeKind::Leaf,
+        role: None,
+        status: NodeStatus::Pending,
+        output: None,
+        compacted_output: None,
+        error: None,
+    };
+    TaskGraph::new(
+        "Research and spawn writing.".into(),
+        HitlMode::None,
+        vec![node],
+    )
+    .expect("single-node graph must be valid")
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// Happy path: worker calls spawn_subteam → auto-approved (HitlMode::None) →
+/// child subgraph runs → SubteamSpawned event emitted → run completes.
+#[tokio::test]
+async fn spawn_subteam_auto_approve() {
+    // LLM call budget:
+    // [0]  initial worker turn → tool call for spawn_subteam
+    // [1]  continuation after spawn tool returns
+    // [2]  main worker compaction
+    // [3]  CoS for child planning (1 dept)
+    // [4]  Director for child planning (2 leaf nodes: write-a, write-b)
+    // [5]  write-a worker
+    // [6]  write-a compaction
+    // [7]  write-b worker
+    // [8]  write-b compaction
+    // [9]  synthesizer leaf worker (appended by planner)
+    // [10] synthesizer leaf compaction
+    // [11] top-level synthesis
+    let child_cos = serde_json::json!({
+        "departments": [{
+            "name": "writing",
+            "mission": "Write the deliverable.",
+            "suggested_roles": ["writer"]
+        }]
+    })
+    .to_string();
+
+    let child_director = serde_json::json!({
+        "goal": "Write the deliverable",
+        "nodes": [
+            {
+                "id": "write-a",
+                "goal": "Draft the document.",
+                "depends_on": [],
+                "tool_allowlist": []
+            },
+            {
+                "id": "write-b",
+                "goal": "Proofread the document.",
+                "depends_on": ["write-a"],
+                "tool_allowlist": []
+            }
+        ]
+    })
+    .to_string();
+
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::tool_call(
+                "tc-spawn-1",
+                "spawn_subteam",
+                serde_json::json!({
+                    "goal": "Write a polished document based on the research.",
+                    "suggested_roles": ["writer", "proofreader"]
+                }),
+            ))
+            .push(MockLlmResponse::text(
+                "Research complete, spawning writing team.",
+            ))
+            .push(MockLlmResponse::text("Done.")) // [2] main worker compaction
+            .push(MockLlmResponse::text(child_cos)) // [3] CoS
+            .push(MockLlmResponse::text(child_director)) // [4] Director
+            .push_many((0..7).map(|_| MockLlmResponse::text("Done."))), // [5..11]
+    );
+
+    let tool_executor = Arc::new(EmptyToolExecutor);
+
+    let (tx, mut rx) = mpsc::channel::<OrchestratorEvent>(4096);
+
+    let config = OrchestratorConfig {
+        hitl_mode: HitlMode::None,
+        max_replans: 0,
+        graph_override: Some(single_leaf_graph()),
+        ..Default::default()
+    };
+
+    let run_handle = tokio::spawn(async move {
+        execute(
+            "Research and write a comprehensive analysis.",
+            &[],
+            llm,
+            tool_executor,
+            config,
+            tx,
+        )
+        .await
+    });
+
+    let mut events: Vec<OrchestratorEvent> = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+
+    let result = run_handle.await.expect("task did not panic");
+    assert!(result.is_ok(), "execute should succeed: {result:?}");
+
+    // ── Verify SubteamSpawned was emitted ─────────────────────────────────────
+    let subteam_spawned = events.iter().any(|e| {
+        matches!(e, OrchestratorEvent::SubteamSpawned { parent_node_id, .. }
+            if parent_node_id == "worker-1")
+    });
+    assert!(
+        subteam_spawned,
+        "SubteamSpawned event should be emitted for worker-1"
+    );
+
+    // ── Verify no AwaitingApproval with spawn_subteam kind ────────────────────
+    let spawn_approval = events.iter().any(|e| {
+        matches!(
+            e,
+            OrchestratorEvent::AwaitingApproval {
+                kind: ApprovalKind::SpawnSubteam { .. },
+                ..
+            }
+        )
+    });
+    assert!(
+        !spawn_approval,
+        "HitlMode::None should not emit AwaitingApproval for spawn"
+    );
+
+    // ── Verify run completed ──────────────────────────────────────────────────
+    assert!(
+        matches!(
+            events.last(),
+            Some(OrchestratorEvent::OrchestratorComplete { .. })
+        ),
+        "last event should be OrchestratorComplete"
+    );
+}
+
+/// HITL path: with ApproveEachNode, spawn requires explicit approval.
+/// The test auto-approves via the registry to keep it non-blocking.
+#[tokio::test]
+async fn spawn_subteam_hitl_requires_approval() {
+    let child_cos = serde_json::json!({
+        "departments": [{
+            "name": "writing",
+            "mission": "Write the deliverable.",
+            "suggested_roles": ["writer"]
+        }]
+    })
+    .to_string();
+
+    let child_director = serde_json::json!({
+        "goal": "Write the deliverable",
+        "nodes": [
+            {
+                "id": "write-a",
+                "goal": "Draft the document.",
+                "depends_on": [],
+                "tool_allowlist": []
+            },
+            {
+                "id": "write-b",
+                "goal": "Proofread the document.",
+                "depends_on": ["write-a"],
+                "tool_allowlist": []
+            }
+        ]
+    })
+    .to_string();
+
+    let llm = Arc::new(
+        MockLlmPort::new()
+            .push(MockLlmResponse::tool_call(
+                "tc-spawn-2",
+                "spawn_subteam",
+                serde_json::json!({
+                    "goal": "Write a polished document.",
+                    "suggested_roles": ["writer"]
+                }),
+            ))
+            .push(MockLlmResponse::text("Research complete."))
+            .push(MockLlmResponse::text("Done.")) // main worker compaction
+            .push(MockLlmResponse::text(child_cos)) // CoS
+            .push(MockLlmResponse::text(child_director)) // Director
+            .push_many((0..7).map(|_| MockLlmResponse::text("Done."))),
+    );
+
+    let tool_executor = Arc::new(EmptyToolExecutor);
+    let registry = TestApprovalRegistry::new();
+    let registry_for_resolver = Arc::clone(&registry);
+
+    let (tx, mut rx) = mpsc::channel::<OrchestratorEvent>(4096);
+
+    let config = OrchestratorConfig {
+        hitl_mode: HitlMode::ApproveEachNode,
+        max_replans: 0,
+        graph_override: Some(single_leaf_graph()),
+        approval_registry: Some(registry),
+        ..Default::default()
+    };
+
+    // Spawn the executor.
+    let run_handle = tokio::spawn(async move {
+        execute(
+            "Research and write a comprehensive analysis.",
+            &[],
+            llm,
+            tool_executor,
+            config,
+            tx,
+        )
+        .await
+    });
+
+    // Consume events; whenever we see AwaitingApproval, approve it immediately.
+    let mut events: Vec<OrchestratorEvent> = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        if let OrchestratorEvent::AwaitingApproval { approval_id, .. } = &ev {
+            let id = approval_id.clone();
+            let reg = Arc::clone(&registry_for_resolver);
+            tokio::spawn(async move {
+                reg.resolve(&id, ApprovalDecision::Approve);
+            });
+        }
+        events.push(ev);
+    }
+
+    let result = run_handle.await.expect("task did not panic");
+    assert!(
+        result.is_ok(),
+        "execute should succeed with approved spawn: {result:?}"
+    );
+
+    // ── Verify AwaitingApproval with SpawnSubteam kind was emitted ────────────
+    let spawn_approval_event = events.iter().find(|e| {
+        matches!(
+            e,
+            OrchestratorEvent::AwaitingApproval {
+                kind: ApprovalKind::SpawnSubteam { node_id, .. },
+                ..
+            } if node_id == "worker-1"
+        )
+    });
+    assert!(
+        spawn_approval_event.is_some(),
+        "ApproveEachNode should emit AwaitingApproval(SpawnSubteam) for worker-1"
+    );
+
+    // ── Verify SubteamSpawned was emitted ─────────────────────────────────────
+    let subteam_spawned = events.iter().any(|e| {
+        matches!(e, OrchestratorEvent::SubteamSpawned { parent_node_id, .. }
+            if parent_node_id == "worker-1")
+    });
+    assert!(
+        subteam_spawned,
+        "SubteamSpawned should be emitted after approval"
+    );
+
+    // ── Verify run completed ──────────────────────────────────────────────────
+    assert!(
+        matches!(
+            events.last(),
+            Some(OrchestratorEvent::OrchestratorComplete { .. })
+        ),
+        "last event should be OrchestratorComplete"
+    );
+}

--- a/crates/gglib-cli/src/handlers/orchestrate.rs
+++ b/crates/gglib-cli/src/handlers/orchestrate.rs
@@ -317,7 +317,11 @@ async fn render_event(
             eprintln!("{}[{team_id}] ▶ team started{}", style::DIM, style::RESET);
         }
         OrchestratorEvent::TeamSynthesized { team_id, .. } => {
-            eprintln!("{}[{team_id}] ✓ team synthesized{}", style::DIM, style::RESET);
+            eprintln!(
+                "{}[{team_id}] ✓ team synthesized{}",
+                style::DIM,
+                style::RESET
+            );
         }
         OrchestratorEvent::NodeProgress { .. } | OrchestratorEvent::SynthesisProgress { .. } => {}
     }

--- a/crates/gglib-core/src/domain/orchestrator/events.rs
+++ b/crates/gglib-core/src/domain/orchestrator/events.rs
@@ -57,6 +57,13 @@ pub enum ApprovalKind {
         /// The tool name being called.
         tool_name: String,
     },
+    /// Approval before dynamically spawning a sub-team from within a worker node.
+    SpawnSubteam {
+        /// The worker node that requested the spawn.
+        node_id: String,
+        /// Roles suggested by the requesting worker for the new team.
+        suggested_roles: Vec<String>,
+    },
 }
 
 // =============================================================================
@@ -283,5 +290,18 @@ pub enum OrchestratorEvent {
         team_id: String,
         /// Compacted summary of the team's synthesised output.
         compacted_output: String,
+    },
+
+    // ── spawn (Phase I) ──────────────────────────────────────────────────
+    /// A worker node requested dynamic team spawning and the executor approved
+    /// it; the child sub-team subgraph has been planned and is about to run.
+    ///
+    /// `parent_node_id` is the leaf node that triggered the spawn.  The child
+    /// graph runs as a nested [`run_wave_loop`] inside the parent's wave.
+    SubteamSpawned {
+        /// The leaf node that triggered the spawn.
+        parent_node_id: String,
+        /// One-line summary of the child graph that was planned.
+        child_graph_summary: String,
     },
 }

--- a/crates/gglib-core/src/domain/orchestrator/task_graph.rs
+++ b/crates/gglib-core/src/domain/orchestrator/task_graph.rs
@@ -1148,15 +1148,17 @@ mod tests {
             hitl_mode: HitlMode::None,
             nodes: top_nodes,
         };
-        assert!(matches!(g.validate_acyclic(), Err(TaskGraphError::Cycle(_))));
+        assert!(matches!(
+            g.validate_acyclic(),
+            Err(TaskGraphError::Cycle(_))
+        ));
     }
 
     #[test]
     fn team_subgraph_per_subgraph_node_cap_is_independent() {
         // A top-level graph with 8 nodes is valid even if a Team node's
         // subgraph also has 8 nodes (per-subgraph caps, not global).
-        let sub_nodes: Vec<TaskNode> =
-            (0..MAX_NODES).map(|i| leaf(&format!("sub_{i}"))).collect();
+        let sub_nodes: Vec<TaskNode> = (0..MAX_NODES).map(|i| leaf(&format!("sub_{i}"))).collect();
         let subgraph = TaskGraph::new("sub".into(), HitlMode::None, sub_nodes).unwrap();
         // Top-level has just 1 Team node — well under MAX_NODES.
         let team_node = TaskNode {
@@ -1223,4 +1225,3 @@ mod tests {
         assert!(node.role.is_none());
     }
 }
-

--- a/crates/gglib-proxy/src/orchestrator_proxy.rs
+++ b/crates/gglib-proxy/src/orchestrator_proxy.rs
@@ -618,7 +618,8 @@ pub(crate) fn orchestrator_event_to_content(event: &OrchestratorEvent) -> Option
         | OrchestratorEvent::SynthesisComplete { .. }
         | OrchestratorEvent::OrchestratorComplete { .. }
         | OrchestratorEvent::TeamStarted { .. }
-        | OrchestratorEvent::TeamSynthesized { .. } => None,
+        | OrchestratorEvent::TeamSynthesized { .. }
+        | OrchestratorEvent::SubteamSpawned { .. } => None,
     }
 }
 

--- a/src/pages/Orchestrator/components/HitlApprovalModal.tsx
+++ b/src/pages/Orchestrator/components/HitlApprovalModal.tsx
@@ -74,14 +74,18 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
       ? 'Approve proposed plan?'
       : kind.kind === 'node'
         ? `Approve node: ${kind.node_id}`
-        : `Approve tool call: ${kind.tool_name}`;
+        : kind.kind === 'tool'
+          ? `Approve tool call: ${kind.tool_name}`
+          : `Approve spawn subteam for node: ${kind.node_id}`;
 
   const description =
     kind.kind === 'plan'
       ? 'Review the task graph and approve or reject the plan before execution begins.'
       : kind.kind === 'node'
         ? `The orchestrator wants to execute node "${kind.node_id}". Approve to allow it to run.`
-        : `The orchestrator wants to call "${kind.tool_name}" inside node "${kind.node_id}".`;
+        : kind.kind === 'tool'
+          ? `The orchestrator wants to call "${kind.tool_name}" inside node "${kind.node_id}".`
+          : `The orchestrator wants to spawn a sub-team for node "${kind.node_id}" with roles: ${kind.suggested_roles.join(', ')}.`;
 
   return (
     <Modal

--- a/src/pages/OrchestratorPlanPreview.tsx
+++ b/src/pages/OrchestratorPlanPreview.tsx
@@ -169,7 +169,9 @@ export default function OrchestratorPlanPreview({ onBack }: Props) {
                   ? 'the proposed plan'
                   : e.kind.kind === 'node'
                     ? `node '${e.kind.node_id}'`
-                    : `tool '${e.kind.tool_name}' in node '${e.kind.node_id}'`;
+                    : e.kind.kind === 'tool'
+                      ? `tool '${e.kind.tool_name}' in node '${e.kind.node_id}'`
+                      : `spawn sub-team for node '${e.kind.node_id}'`;
               setPendingApproval({ approvalId: e.approval_id, description: kindDesc, submitting: false });
               break;
             }

--- a/src/types/orchestrator.ts
+++ b/src/types/orchestrator.ts
@@ -62,7 +62,10 @@ export type OrchestratorEvent =
   | SynthesisTextDeltaEvent
   | SynthesisCompleteEvent
   | OrchestratorCompleteEvent
-  | OrchestratorErrorEvent;
+  | OrchestratorErrorEvent
+  | TeamStartedEvent
+  | TeamSynthesizedEvent
+  | SubteamSpawnedEvent;
 
 // ─── Planning events ─────────────────────────────────────────────────────────
 
@@ -191,12 +194,33 @@ export interface OrchestratorErrorEvent {
   message: string;
 }
 
+// ─── Team events (Phase G / Phase I) ─────────────────────────────────────────
+
+export interface TeamStartedEvent {
+  type: 'team_started';
+  team_id: string;
+  role?: string | null;
+}
+
+export interface TeamSynthesizedEvent {
+  type: 'team_synthesized';
+  team_id: string;
+  compacted_output: string;
+}
+
+export interface SubteamSpawnedEvent {
+  type: 'subteam_spawned';
+  parent_node_id: string;
+  child_graph_summary: string;
+}
+
 // ─── HITL / approval types ───────────────────────────────────────────────────
 
 export type ApprovalKind =
   | { kind: 'plan' }
   | { kind: 'node'; node_id: string }
-  | { kind: 'tool'; node_id: string; tool_name: string };
+  | { kind: 'tool'; node_id: string; tool_name: string }
+  | { kind: 'spawn_subteam'; node_id: string; suggested_roles: string[] };
 
 export interface AwaitingApprovalEvent {
   type: 'awaiting_approval';


### PR DESCRIPTION
Closes #504

## Summary

Implements Phase I of the orchestrator: **executor recursion** and the **`spawn_subteam` dynamic interrupt**.

A worker node can now call the `spawn_subteam` tool during execution to dynamically request a new sub-team. The executor intercepts this call, optionally gates it through HITL approval, plans the child graph via the existing `plan()` pipeline, emits `SubteamSpawned`, then recurses into `run_wave_loop` to execute the child graph before continuing. A `max_team_depth` guard (default: 9) prevents infinite recursion.

## Changes

### Core domain (`gglib-core`)
- `events.rs`: Added `ApprovalKind::SpawnSubteam { node_id, suggested_roles }` and `OrchestratorEvent::SubteamSpawned { parent_node_id, child_graph_summary }`

### Orchestrator (`gglib-agent`)
- **`spawn.rs`** (new): `SpawnRequest`, `SpawnSink`, `SpawnCapturingExecutor` (wraps any `ToolExecutorPort`, intercepts `spawn_subteam` calls into a per-worker sink), and `spawn_subteam_tool_def()` (tool schema for LLM)
- **`executor.rs`**: Shared `Arc<Semaphore>` passed through all recursive `run_wave_loop` calls; `depth` parameter added; post-wave spawn-request processing loop with HITL gate, `plan()` call, `SubteamSpawned` event, and recursive execution; `MaxDepthExceeded` error variant; `max_team_depth` config field

### Proxy (`gglib-proxy`)
- `orchestrator_proxy.rs`: Added `SubteamSpawned` arm to non-exhaustive match

### Frontend (`src/`)
- `types/orchestrator.ts`: `SpawnSubteam` approval kind, `SubteamSpawnedEvent` type, union extension
- `HitlApprovalModal.tsx` / `OrchestratorPlanPreview.tsx`: Narrowed `ApprovalKind` discriminated union to handle `spawn_subteam` case (fixes TS2339)

## Tests

| Test file | What it covers |
|---|---|
| `integration_hierarchical_run.rs` | 3-department / 12-leaf graph completes; `TeamStarted` before leaves, `TeamSynthesized` before top-level synthesis, `OrchestratorComplete` at end |
| `integration_spawn_subteam.rs` | Auto-approve path: worker calls `spawn_subteam` → `SubteamSpawned` emitted, child runs, no `AwaitingApproval` for `HitlMode::None` |
| `integration_spawn_subteam.rs` | HITL path: `AwaitingApproval(SpawnSubteam)` emitted before child runs; approved via registry; `SubteamSpawned` and `OrchestratorComplete` follow |

All 3 new tests pass. `cargo clippy`, `cargo fmt --check`, `./scripts/check_boundaries.sh`, and `npx tsc --noEmit` are all clean.