### PR TITLE
feat(orchestrator): Phase J — NodeBudget + warn-only RunCostEstimate (#509)

### DIFF
--- a/crates/gglib-agent/src/orchestrator/estimator.rs
+++ b/crates/gglib-agent/src/orchestrator/estimator.rs
@@ -1,0 +1,151 @@
+//! Pure run-cost estimator for the orchestrator.
+//!
+//! # Cost model
+//!
+//! Each node in the task graph incurs an estimated **2 000 tokens** of LLM
+//! traffic (system-prompt + context window + output).  Wall-clock time is
+//! derived by assuming a sustained throughput of **50 tokens / second** — a
+//! conservative baseline for a single llama-server instance running on
+//! consumer hardware.
+//!
+//! ```text
+//! est_tokens      = node_count × 2 000
+//! est_wall_seconds = est_tokens ÷ 50
+//! ```
+//!
+//! These numbers are intentionally approximate.  The estimator is a
+//! warn-only advisory: it never blocks execution.
+
+use gglib_core::domain::orchestrator::task_graph::TaskGraph;
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Estimated LLM tokens consumed per orchestrator node (system-prompt +
+/// context + output).
+pub const TOKENS_PER_NODE: u64 = 2_000;
+
+/// Assumed sustained token throughput in tokens per second.
+pub const TOKENS_PER_SECOND: u64 = 50;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/// Output of [`estimate_run_cost`].
+///
+/// All fields are advisory estimates — never enforced as hard limits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunCostEstimate {
+    /// Total aggregate node count across all subgraphs.
+    pub node_count: usize,
+    /// Rough token estimate (input + output) for the entire run.
+    pub est_tokens: u64,
+    /// Estimated wall-clock seconds at [`TOKENS_PER_SECOND`] tokens/second.
+    pub est_wall_seconds: u64,
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Estimate the cost of executing `graph` without performing any I/O.
+///
+/// The function is pure — it reads only the structure of the task graph.
+///
+/// # Examples
+///
+/// A simple 3-node graph (e.g. two workers + one synthesizer):
+///
+/// ```rust
+/// use gglib_agent::orchestrator::estimator::estimate_run_cost;
+/// use gglib_core::domain::orchestrator::task_graph::{
+///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
+/// };
+///
+/// fn leaf(id: &str) -> TaskNode {
+///     TaskNode {
+///         id: NodeId(id.into()),
+///         goal: id.into(),
+///         depends_on: vec![],
+///         tool_allowlist: vec![],
+///         kind: TaskNodeKind::Leaf,
+///         role: None,
+///         status: NodeStatus::Pending,
+///         output: None,
+///         compacted_output: None,
+///         error: None,
+///     }
+/// }
+///
+/// let graph = TaskGraph::new(
+///     "test".into(),
+///     HitlMode::None,
+///     vec![leaf("a"), leaf("b"), leaf("c")],
+/// )
+/// .unwrap();
+///
+/// let est = estimate_run_cost(&graph);
+/// assert_eq!(est.node_count, 3);
+/// assert_eq!(est.est_tokens, 6_000);
+/// assert_eq!(est.est_wall_seconds, 120);
+/// ```
+///
+/// A graph with a Team node whose subgraph contains 7 leaves, giving a total
+/// of 1 (team) + 7 (sub-leaves) + 7 (other top-level leaves) = 15 nodes:
+///
+/// ```rust
+/// use gglib_agent::orchestrator::estimator::estimate_run_cost;
+/// use gglib_core::domain::orchestrator::task_graph::{
+///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
+/// };
+///
+/// fn leaf(id: &str) -> TaskNode {
+///     TaskNode {
+///         id: NodeId(id.into()),
+///         goal: id.into(),
+///         depends_on: vec![],
+///         tool_allowlist: vec![],
+///         kind: TaskNodeKind::Leaf,
+///         role: None,
+///         status: NodeStatus::Pending,
+///         output: None,
+///         compacted_output: None,
+///         error: None,
+///     }
+/// }
+///
+/// // Build a subgraph with 7 leaf nodes.
+/// let sub_leaves: Vec<TaskNode> = (0..7).map(|i| leaf(&format!("s{i}"))).collect();
+/// let subgraph = TaskGraph::new("sub".into(), HitlMode::None, sub_leaves).unwrap();
+///
+/// // Team node wraps the subgraph (counts as 1 + 7 = 8 total).
+/// let team_node = TaskNode {
+///     id: NodeId("team".into()),
+///     goal: "team goal".into(),
+///     depends_on: vec![],
+///     tool_allowlist: vec![],
+///     kind: TaskNodeKind::Team { subgraph: Box::new(subgraph) },
+///     role: None,
+///     status: NodeStatus::Pending,
+///     output: None,
+///     compacted_output: None,
+///     error: None,
+/// };
+///
+/// // Top-level: 1 team + 7 leaf siblings = 8 nodes → total_node_count = 15.
+/// let mut top_nodes: Vec<TaskNode> = (0..7).map(|i| leaf(&format!("t{i}"))).collect();
+/// top_nodes.push(team_node);
+/// let graph = TaskGraph::new("big goal".into(), HitlMode::None, top_nodes).unwrap();
+///
+/// let est = estimate_run_cost(&graph);
+/// assert_eq!(est.node_count, 15);
+/// assert_eq!(est.est_tokens, 30_000);
+/// assert_eq!(est.est_wall_seconds, 600);
+/// ```
+pub fn estimate_run_cost(graph: &TaskGraph) -> RunCostEstimate {
+    let node_count = graph.total_node_count();
+    let est_tokens = (node_count as u64).saturating_mul(TOKENS_PER_NODE);
+    let est_wall_seconds = est_tokens / TOKENS_PER_SECOND;
+
+    RunCostEstimate {
+        node_count,
+        est_tokens,
+        est_wall_seconds,
+    }
+}

--- a/crates/gglib-agent/src/orchestrator/executor.rs
+++ b/crates/gglib-agent/src/orchestrator/executor.rs
@@ -46,7 +46,9 @@ use gglib_core::domain::orchestrator::events::{ApprovalKind, OrchestratorEvent};
 use gglib_core::domain::orchestrator::run::{
     OrchestratorRun, OrchestratorRunEvent, OrchestratorRunStatus,
 };
-use gglib_core::domain::orchestrator::task_graph::{HitlMode, NodeId, TaskGraph, TaskNodeKind};
+use gglib_core::domain::orchestrator::task_graph::{
+    HitlMode, NodeBudget, NodeId, TaskGraph, TaskNodeKind,
+};
 use gglib_core::ports::{
     AgentLoopPort, ApprovalDecision, LlmCompletionPort, OrchestratorApprovalRegistryPort,
     OrchestratorRepositoryPort, ToolExecutorPort,
@@ -59,6 +61,7 @@ use crate::AgentLoop;
 
 use super::compaction::{CompactionError, compact_worker_output};
 use super::director::PlanError;
+use super::estimator::estimate_run_cost;
 use super::planner::plan;
 use super::spawn::{SpawnCapturingExecutor, SpawnRequest, SpawnSink};
 use super::synthesis::run_synthesis;
@@ -113,6 +116,13 @@ pub struct OrchestratorConfig {
     /// intentionally generous (default: 9 = 3 levels × 3 max teams each) to
     /// catch infinite-recursion bugs without restricting real use cases.
     pub max_team_depth: u32,
+
+    /// Advisory node-count budget used by the Phase J cost estimator.
+    ///
+    /// When the aggregate node count exceeds `node_budget.upper_bound()`, the
+    /// executor emits a [`tracing::warn!`] but **never** returns an error.
+    /// Defaults to [`NodeBudget::TaskForce`] (25 nodes).
+    pub node_budget: NodeBudget,
 }
 
 impl Default for OrchestratorConfig {
@@ -126,6 +136,7 @@ impl Default for OrchestratorConfig {
             run_id: None,
             graph_override: None,
             max_team_depth: 9,
+            node_budget: NodeBudget::default(),
         }
     }
 }
@@ -278,6 +289,21 @@ pub async fn execute(
                 graph: override_graph.clone(),
             })
             .await;
+        let cost = estimate_run_cost(&override_graph);
+        let _ = tx
+            .send(OrchestratorEvent::RunCostEstimate {
+                node_count: cost.node_count,
+                est_tokens: cost.est_tokens,
+                est_wall_seconds: cost.est_wall_seconds,
+            })
+            .await;
+        if override_graph.total_node_count() > config.node_budget.upper_bound() {
+            tracing::warn!(
+                node_count = override_graph.total_node_count(),
+                budget_upper = config.node_budget.upper_bound(),
+                "orchestrator: aggregate node count exceeds advisory node budget",
+            );
+        }
         let _ = tx.send(OrchestratorEvent::PlanApproved).await;
         override_graph
     } else {
@@ -295,6 +321,21 @@ pub async fn execute(
         let _ = tx
             .send(OrchestratorEvent::PlanProposed { graph: g.clone() })
             .await;
+        let cost = estimate_run_cost(&g);
+        let _ = tx
+            .send(OrchestratorEvent::RunCostEstimate {
+                node_count: cost.node_count,
+                est_tokens: cost.est_tokens,
+                est_wall_seconds: cost.est_wall_seconds,
+            })
+            .await;
+        if g.total_node_count() > config.node_budget.upper_bound() {
+            tracing::warn!(
+                node_count = g.total_node_count(),
+                budget_upper = config.node_budget.upper_bound(),
+                "orchestrator: aggregate node count exceeds advisory node budget",
+            );
+        }
 
         // ── 1a. Plan HITL gate ────────────────────────────────────────────────
         let approved_graph = if config.hitl_mode >= HitlMode::ApprovePlan {

--- a/crates/gglib-agent/src/orchestrator/mod.rs
+++ b/crates/gglib-agent/src/orchestrator/mod.rs
@@ -22,6 +22,7 @@
 pub(crate) mod chief_of_staff;
 pub(crate) mod compaction;
 pub mod director;
+pub mod estimator;
 pub mod executor;
 pub mod planner;
 pub mod prompts;

--- a/crates/gglib-agent/tests/integration_hierarchical_plan.rs
+++ b/crates/gglib-agent/tests/integration_hierarchical_plan.rs
@@ -51,7 +51,7 @@ fn cos_json() -> String {
     .to_string()
 }
 
-/// Returns a scripted DirectorPlan JSON response for a department
+/// Returns a scripted `DirectorPlan` JSON response for a department
 /// with exactly 4 leaf nodes (2 parallel roots + 1 middle + 1 synthesizer).
 fn director_json(prefix: &str) -> String {
     serde_json::json!({
@@ -91,7 +91,7 @@ fn director_json(prefix: &str) -> String {
 // =============================================================================
 
 /// Core structure test: 3 departments × 4 leaves each → 4 top-level nodes
-/// (3 Team + 1 synthesizer), total_node_count = 16.
+/// (3 Team + 1 synthesizer), `total_node_count` = 16.
 #[tokio::test]
 async fn hierarchical_plan_three_departments_twelve_leaves() {
     // Queue: CoS response first, then 3 director responses (one per dept).
@@ -151,7 +151,10 @@ async fn hierarchical_plan_three_departments_twelve_leaves() {
     );
     // Synthesizer should have the synthesizer role.
     assert_eq!(
-        synth.role.as_ref().map(|r| r.as_str()),
+        synth
+            .role
+            .as_ref()
+            .map(gglib_core::domain::orchestrator::RoleId::as_str),
         Some("synthesizer"),
         "synthesizer node must have role=synthesizer"
     );
@@ -229,7 +232,7 @@ async fn hierarchical_plan_single_department() {
     assert_eq!(graph.total_node_count(), 6);
 }
 
-/// CoS returning an empty list triggers fallback → 1 team + 1 synthesizer.
+/// `CoS` returning an empty list triggers fallback → 1 team + 1 synthesizer.
 #[tokio::test]
 async fn hierarchical_plan_empty_cos_falls_back() {
     let llm = Arc::new(

--- a/crates/gglib-agent/tests/integration_hierarchical_run.rs
+++ b/crates/gglib-agent/tests/integration_hierarchical_run.rs
@@ -7,7 +7,7 @@
 //!
 //! # LLM call budget
 //!
-//! Planning:   1 CoS + 3 Director              =  4 calls
+//! Planning:   1 `CoS` + 3 Director              =  4 calls
 //! Execution: 12 leaf workers + 12 compactions  = 24 calls
 //! Synthesis:  1 final synthesis call           =  1 call
 //! Total                                        = 29 calls

--- a/crates/gglib-agent/tests/integration_spawn_subteam.rs
+++ b/crates/gglib-agent/tests/integration_spawn_subteam.rs
@@ -13,7 +13,7 @@
 //!
 //! Main worker: 2 calls (initial + continuation after spawn tool reply)
 //! Main worker compaction: 1 call
-//! Spawn planning — CoS: 1 call
+//! Spawn planning — `CoS`: 1 call
 //! Spawn planning — Director (1 dept, 2 leaves): 1 call
 //! Spawned leaf workers (2): 2 calls
 //! Spawned leaf compactions (2): 2 calls
@@ -61,11 +61,9 @@ impl OrchestratorApprovalRegistryPort for TestApprovalRegistry {
 
     fn resolve(&self, approval_id: &str, decision: ApprovalDecision) -> bool {
         let mut guard = self.senders.try_lock().unwrap();
-        if let Some(tx) = guard.remove(approval_id) {
-            tx.send(decision).is_ok()
-        } else {
-            false
-        }
+        guard
+            .remove(approval_id)
+            .is_some_and(|tx| tx.send(decision).is_ok())
     }
 
     fn is_pending(&self, approval_id: &str) -> bool {
@@ -103,8 +101,8 @@ fn single_leaf_graph() -> TaskGraph {
 // Tests
 // =============================================================================
 
-/// Happy path: worker calls spawn_subteam → auto-approved (HitlMode::None) →
-/// child subgraph runs → SubteamSpawned event emitted → run completes.
+/// Happy path: worker calls `spawn_subteam` → auto-approved (`HitlMode::None`) →
+/// child subgraph runs → `SubteamSpawned` event emitted → run completes.
 #[tokio::test]
 async fn spawn_subteam_auto_approve() {
     // LLM call budget:
@@ -233,9 +231,10 @@ async fn spawn_subteam_auto_approve() {
     );
 }
 
-/// HITL path: with ApproveEachNode, spawn requires explicit approval.
+/// HITL path: with `ApproveEachNode`, spawn requires explicit approval.
 /// The test auto-approves via the registry to keep it non-blocking.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn spawn_subteam_hitl_requires_approval() {
     let child_cos = serde_json::json!({
         "departments": [{

--- a/crates/gglib-axum/src/handlers/orchestrator/mod.rs
+++ b/crates/gglib-axum/src/handlers/orchestrator/mod.rs
@@ -32,6 +32,7 @@ use futures_util::StreamExt as _;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use gglib_agent::orchestrator::estimator::estimate_run_cost;
 use gglib_agent::orchestrator::plan;
 use gglib_core::domain::orchestrator::events::{
     ORCHESTRATOR_EVENT_CHANNEL_CAPACITY, OrchestratorEvent,
@@ -120,7 +121,15 @@ pub async fn plan_sse(
         {
             Ok(graph) => {
                 let summary = format!("Plan accepted: {} node(s)", graph.nodes.len());
+                let cost = estimate_run_cost(&graph);
                 let _ = tx.send(OrchestratorEvent::PlanProposed { graph }).await;
+                let _ = tx
+                    .send(OrchestratorEvent::RunCostEstimate {
+                        node_count: cost.node_count,
+                        est_tokens: cost.est_tokens,
+                        est_wall_seconds: cost.est_wall_seconds,
+                    })
+                    .await;
                 let _ = tx
                     .send(OrchestratorEvent::OrchestratorComplete { answer: summary })
                     .await;

--- a/crates/gglib-cli/src/handlers/orchestrate.rs
+++ b/crates/gglib-cli/src/handlers/orchestrate.rs
@@ -323,7 +323,10 @@ async fn render_event(
                 style::RESET
             );
         }
-        OrchestratorEvent::NodeProgress { .. } | OrchestratorEvent::SynthesisProgress { .. } => {}
+        OrchestratorEvent::NodeProgress { .. }
+        | OrchestratorEvent::SynthesisProgress { .. }
+        | OrchestratorEvent::RunCostEstimate { .. }
+        | OrchestratorEvent::SubteamSpawned { .. } => {}
     }
 }
 
@@ -338,6 +341,9 @@ async fn prompt_and_resolve(
         ApprovalKind::Node { node_id } => format!("node '{node_id}'"),
         ApprovalKind::Tool { node_id, tool_name } => {
             format!("tool call '{tool_name}' in node '{node_id}'")
+        }
+        ApprovalKind::SpawnSubteam { node_id, .. } => {
+            format!("spawn subteam requested by node '{node_id}'")
         }
     };
 

--- a/crates/gglib-core/src/domain/orchestrator/events.rs
+++ b/crates/gglib-core/src/domain/orchestrator/events.rs
@@ -95,6 +95,22 @@ pub enum OrchestratorEvent {
         reason: String,
     },
 
+    /// Warn-only cost estimate emitted immediately after
+    /// [`OrchestratorEvent::PlanProposed`].
+    ///
+    /// Never suppressed, never fatal — the run always proceeds.  The
+    /// frontend may display a yellow warning banner when
+    /// `est_wall_seconds > 60` or `node_count` exceeds 80 % of the active
+    /// [`NodeBudget`] upper bound.
+    RunCostEstimate {
+        /// Total aggregate node count across all subgraphs.
+        node_count: usize,
+        /// Rough token estimate (input + output) for the entire run.
+        est_tokens: u64,
+        /// Estimated wall-clock seconds at 50 tokens / second.
+        est_wall_seconds: u64,
+    },
+
     /// The plan was approved (by the user or automatically when
     /// `hitl_mode == None`).
     PlanApproved,

--- a/crates/gglib-core/src/domain/orchestrator/task_graph.rs
+++ b/crates/gglib-core/src/domain/orchestrator/task_graph.rs
@@ -174,6 +174,64 @@ pub enum HitlMode {
 }
 
 // =============================================================================
+// NodeBudget
+// =============================================================================
+
+/// Advisory upper bound on the aggregate node count across all subgraphs.
+///
+/// The Phase J cost estimator checks the total node count against
+/// `upper_bound()` and emits a [`tracing::warn!`] when exceeded, but never
+/// returns an error — the executor always proceeds.
+///
+/// # Default
+///
+/// [`NodeBudget::TaskForce`] (up to 25 nodes).
+///
+/// # Example
+///
+/// ```rust
+/// use gglib_core::domain::orchestrator::task_graph::NodeBudget;
+///
+/// let budget = NodeBudget::TaskForce;
+/// assert_eq!(budget.upper_bound(), 25);
+///
+/// let custom = NodeBudget::Custom { value: 100 };
+/// assert_eq!(custom.upper_bound(), 100);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NodeBudget {
+    /// Up to 3 nodes — single-agent equivalent.
+    Solo,
+    /// Up to 8 nodes — small coordination team.
+    SmallTeam,
+    /// Up to 25 nodes — cross-functional task force. **Default**.
+    #[default]
+    TaskForce,
+    /// Up to 60 nodes — full department-scale run.
+    Department,
+    /// Caller-specified upper bound.
+    Custom {
+        /// The maximum number of aggregate nodes allowed before a warning is
+        /// emitted.
+        value: usize,
+    },
+}
+
+impl NodeBudget {
+    /// Returns the advisory upper bound for this budget variant.
+    pub const fn upper_bound(&self) -> usize {
+        match self {
+            Self::Solo => 3,
+            Self::SmallTeam => 8,
+            Self::TaskForce => 25,
+            Self::Department => 60,
+            Self::Custom { value } => *value,
+        }
+    }
+}
+
+// =============================================================================
 // TaskNodeKind
 // =============================================================================
 

--- a/crates/gglib-proxy/src/orchestrator_proxy.rs
+++ b/crates/gglib-proxy/src/orchestrator_proxy.rs
@@ -610,6 +610,7 @@ pub(crate) fn orchestrator_event_to_content(event: &OrchestratorEvent) -> Option
         | OrchestratorEvent::PlanRejected { .. }
         | OrchestratorEvent::ReplanAttempt { .. }
         | OrchestratorEvent::AwaitingApproval { .. }
+        | OrchestratorEvent::RunCostEstimate { .. }
         | OrchestratorEvent::NodeReasoningDelta { .. }
         | OrchestratorEvent::NodeProgress { .. }
         | OrchestratorEvent::NodeSystemWarning { .. }

--- a/src/contexts/OrchestratorContext.tsx
+++ b/src/contexts/OrchestratorContext.tsx
@@ -15,6 +15,14 @@ import type {
   ApprovalKind,
 } from '../types/orchestrator';
 
+// ─── Cost estimate ───────────────────────────────────────────────────────────────────
+
+export interface RunCostEstimate {
+  nodeCount: number;
+  estTokens: number;
+  estWallSeconds: number;
+}
+
 // ─── Session state ────────────────────────────────────────────────────────────
 
 export type OrchestratorPhase =
@@ -57,6 +65,7 @@ export interface OrchestratorSession {
   synthesisText: string;
   finalAnswer: string | null;
   pendingApproval: PendingApproval | null;
+  costEstimate: RunCostEstimate | null;
   error: string | null;
   /** Runs loaded from GET /api/orchestrator/runs */
   runs: OrchestratorRun[];
@@ -71,6 +80,7 @@ function createEmptySession(): OrchestratorSession {
     synthesisText: '',
     finalAnswer: null,
     pendingApproval: null,
+    costEstimate: null,
     error: null,
     runs: [],
     runsLoading: false,
@@ -88,6 +98,7 @@ export type OrchestratorAction =
   | { type: 'PLAN_APPROVED' }
   | { type: 'PLAN_REJECTED'; reason?: string | null }
   | { type: 'REPLAN_ATTEMPT'; attempt: number; reason: string }
+  | { type: 'SET_COST_ESTIMATE'; nodeCount: number; estTokens: number; estWallSeconds: number }
   // Node lifecycle
   | { type: 'NODE_STARTED'; nodeId: string; goal: string }
   | { type: 'NODE_TEXT_DELTA'; nodeId: string; delta: string }
@@ -136,6 +147,16 @@ export function orchestratorReducer(
 
     case 'PLAN_PROPOSED':
       return { ...state, graph: action.graph };
+
+    case 'SET_COST_ESTIMATE':
+      return {
+        ...state,
+        costEstimate: {
+          nodeCount: action.nodeCount,
+          estTokens: action.estTokens,
+          estWallSeconds: action.estWallSeconds,
+        },
+      };
 
     case 'PLAN_APPROVED':
       return { ...state, pendingApproval: null };

--- a/src/hooks/useOrchestrator/useOrchestrator.ts
+++ b/src/hooks/useOrchestrator/useOrchestrator.ts
@@ -40,6 +40,13 @@ function eventToAction(event: OrchestratorEvent): OrchestratorAction | null {
   switch (event.type) {
     case 'plan_proposed':
       return { type: 'PLAN_PROPOSED', graph: event.graph };
+    case 'run_cost_estimate':
+      return {
+        type: 'SET_COST_ESTIMATE',
+        nodeCount: event.node_count,
+        estTokens: event.est_tokens,
+        estWallSeconds: event.est_wall_seconds,
+      };
     case 'plan_approved':
       return { type: 'PLAN_APPROVED' };
     case 'plan_rejected':
@@ -88,6 +95,9 @@ function eventToAction(event: OrchestratorEvent): OrchestratorAction | null {
     case 'node_progress':
     case 'node_system_warning':
     case 'synthesis_progress':
+    case 'team_started':
+    case 'team_synthesized':
+    case 'subteam_spawned':
       return null;
     default:
       return null;

--- a/src/pages/Orchestrator/components/HitlApprovalModal.tsx
+++ b/src/pages/Orchestrator/components/HitlApprovalModal.tsx
@@ -11,20 +11,26 @@
  */
 
 import { FC, useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { Modal } from '../../../components/ui/Modal';
 import { Button } from '../../../components/ui/Button';
 import { Textarea } from '../../../components/ui/Textarea';
+import { Icon } from '../../../components/ui/Icon';
 import type {
   ApprovalKind,
   ApprovalDecisionPayload,
   TaskGraph,
 } from '../../../types/orchestrator';
+import type { RunCostEstimate } from '../../../contexts/OrchestratorContext';
 
 interface HitlApprovalModalProps {
   open: boolean;
   kind: ApprovalKind;
   graph: TaskGraph | null;
   submitting: boolean;
+  costEstimate: RunCostEstimate | null;
+  /** Advisory upper bound for the active NodeBudget (default 25). */
+  budgetUpper?: number;
   onApprove: (payload: ApprovalDecisionPayload) => void;
   onReject: (reason?: string) => void;
 }
@@ -34,6 +40,8 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
   kind,
   graph,
   submitting,
+  costEstimate,
+  budgetUpper = 25,
   onApprove,
   onReject,
 }) => {
@@ -68,6 +76,10 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
     setGraphEditJson(JSON.stringify(graph, null, 2));
     setGraphEditError(null);
   }
+
+  const showCostBanner =
+    costEstimate !== null &&
+    (costEstimate.estWallSeconds > 60 || costEstimate.nodeCount > budgetUpper * 0.8);
 
   const title =
     kind.kind === 'plan'
@@ -123,6 +135,23 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
       }
     >
       <div className="flex flex-col gap-md">
+        {showCostBanner && costEstimate && (
+          <div
+            role="alert"
+            data-testid="cost-warning-banner"
+            className="rounded-base border border-warning/40 bg-warning/8 px-md py-sm flex items-start gap-sm"
+          >
+            <Icon icon={AlertTriangle} size={15} className="text-warning shrink-0 mt-[1px]" />
+            <p className="text-sm text-text-secondary">
+              This plan has <strong>{costEstimate.nodeCount}</strong> node
+              {costEstimate.nodeCount !== 1 ? 's' : ''} and is estimated to take
+              approximately <strong>{costEstimate.estWallSeconds}s</strong>{' '}
+              (~{Math.round(costEstimate.estTokens / 1000)}k tokens).{' '}
+              You can still run it — this is advisory only.
+            </p>
+          </div>
+        )}
+
         {showReject && (
           <div className="flex flex-col gap-sm">
             <label className="text-sm font-medium text-text">Rejection reason (optional)</label>

--- a/src/pages/Orchestrator/index.tsx
+++ b/src/pages/Orchestrator/index.tsx
@@ -203,6 +203,26 @@ export default function OrchestratorPage({ onBack, hasRunningServers = false }: 
             </div>
           )}
 
+          {/* Cost estimate warning banner */}
+          {session.costEstimate &&
+            (session.costEstimate.estWallSeconds > 60 ||
+              session.costEstimate.nodeCount > 25 * 0.8) && (
+              <div
+                role="alert"
+                data-testid="cost-warning-banner"
+                className="rounded-base border border-warning/40 bg-warning/8 px-md py-sm flex items-start gap-sm"
+              >
+                <Icon icon={AlertTriangle} size={15} className="text-warning shrink-0 mt-[1px]" />
+                <p className="text-sm text-text-secondary">
+                  This plan has <strong>{session.costEstimate.nodeCount}</strong> node
+                  {session.costEstimate.nodeCount !== 1 ? 's' : ''} and is estimated to take
+                  approximately <strong>{session.costEstimate.estWallSeconds}s</strong>{' '}
+                  (~{Math.round(session.costEstimate.estTokens / 1000)}k tokens).{' '}
+                  You can still run it — this is advisory only.
+                </p>
+              </div>
+            )}
+
           {/* Error banner */}
           {session.error && (
             <div className="rounded-base border border-danger/30 bg-danger/10 px-md py-sm">
@@ -324,6 +344,7 @@ export default function OrchestratorPage({ onBack, hasRunningServers = false }: 
           kind={session.pendingApproval.kind}
           graph={session.graph}
           submitting={session.pendingApproval.submitting}
+          costEstimate={session.costEstimate}
           onApprove={handleApproveWithPayload}
           onReject={handleReject}
         />

--- a/src/types/orchestrator.ts
+++ b/src/types/orchestrator.ts
@@ -15,6 +15,19 @@
 
 export type HitlMode = 'none' | 'approve_plan' | 'approve_each_node' | 'approve_tools';
 
+/**
+ * Advisory node-count budget.  Mirrors `task_graph::NodeBudget` (Rust).
+ *
+ * The `kind` field is produced by `#[serde(tag = "kind", rename_all =
+ * "snake_case")]`.
+ */
+export type NodeBudget =
+  | { kind: 'solo' }
+  | { kind: 'small_team' }
+  | { kind: 'task_force' }
+  | { kind: 'department' }
+  | { kind: 'custom'; value: number };
+
 export interface TaskNode {
   id: string;
   goal: string;
@@ -46,6 +59,7 @@ export type OrchestratorEvent =
   | PlanApprovedEvent
   | PlanRejectedEvent
   | ReplanAttemptEvent
+  | RunCostEstimateEvent
   | AwaitingApprovalEvent
   | NodeStartedEvent
   | NodeTextDeltaEvent
@@ -87,6 +101,23 @@ export interface ReplanAttemptEvent {
   type: 'replan_attempt';
   attempt: number;
   reason: string;
+}
+
+// ─── Cost estimate event ─────────────────────────────────────────────────────
+
+/**
+ * Warn-only cost estimate emitted immediately after `plan_proposed`.
+ *
+ * Mirrors `orchestrator::events::OrchestratorEvent::RunCostEstimate`.
+ */
+export interface RunCostEstimateEvent {
+  type: 'run_cost_estimate';
+  /** Total aggregate node count across all subgraphs. */
+  node_count: number;
+  /** Rough token estimate (input + output) for the entire run. */
+  est_tokens: number;
+  /** Estimated wall-clock seconds at 50 tokens/second. */
+  est_wall_seconds: number;
 }
 
 // ─── Node lifecycle events ───────────────────────────────────────────────────

--- a/tests/ts/components/HitlApprovalModal.test.tsx
+++ b/tests/ts/components/HitlApprovalModal.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HitlApprovalModal from '../../../src/pages/Orchestrator/components/HitlApprovalModal';
+import type { RunCostEstimate } from '../../../src/contexts/OrchestratorContext';
+
+const baseProps = {
+  open: true,
+  kind: { kind: 'plan' } as const,
+  graph: null,
+  submitting: false,
+  costEstimate: null,
+  onApprove: vi.fn(),
+  onReject: vi.fn(),
+};
+
+describe('HitlApprovalModal — cost warning banner', () => {
+  it('does not render the banner when costEstimate is null', () => {
+    render(<HitlApprovalModal {...baseProps} costEstimate={null} />);
+    expect(screen.queryByTestId('cost-warning-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not render the banner when estimate is below thresholds', () => {
+    const est: RunCostEstimate = {
+      nodeCount: 2,
+      estTokens: 4_000,
+      estWallSeconds: 80, // > 60 → should show... let's use 50 to be below
+    };
+    // Correct: wall 50 ≤ 60 AND nodeCount 2 ≤ 25*0.8 = 20 → no banner
+    const safeEst: RunCostEstimate = { nodeCount: 2, estTokens: 4_000, estWallSeconds: 50 };
+    render(<HitlApprovalModal {...baseProps} costEstimate={safeEst} />);
+    expect(screen.queryByTestId('cost-warning-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders the banner when est_wall_seconds exceeds 60', () => {
+    const est: RunCostEstimate = {
+      nodeCount: 3,
+      estTokens: 6_000,
+      estWallSeconds: 120,
+    };
+    render(<HitlApprovalModal {...baseProps} costEstimate={est} />);
+    expect(screen.getByTestId('cost-warning-banner')).toBeInTheDocument();
+  });
+
+  it('renders the banner when node_count exceeds 80% of budgetUpper', () => {
+    // budgetUpper defaults to 25; 80% = 20; nodeCount 21 → show
+    const est: RunCostEstimate = {
+      nodeCount: 21,
+      estTokens: 42_000,
+      estWallSeconds: 55, // < 60, but nodeCount > 20 → show
+    };
+    render(<HitlApprovalModal {...baseProps} costEstimate={est} />);
+    expect(screen.getByTestId('cost-warning-banner')).toBeInTheDocument();
+  });
+
+  it('renders the banner for a massive estimate (1000 nodes)', () => {
+    const est: RunCostEstimate = {
+      nodeCount: 1_000,
+      estTokens: 2_000_000,
+      estWallSeconds: 40_000,
+    };
+    render(<HitlApprovalModal {...baseProps} costEstimate={est} />);
+    expect(screen.getByTestId('cost-warning-banner')).toBeInTheDocument();
+  });
+
+  it('Approve button is always enabled regardless of cost estimate', () => {
+    const est: RunCostEstimate = {
+      nodeCount: 1_000,
+      estTokens: 2_000_000,
+      estWallSeconds: 40_000,
+    };
+    render(<HitlApprovalModal {...baseProps} costEstimate={est} />);
+    // There may be multiple Approve-labelled buttons; all should be enabled.
+    const approveBtns = screen.getAllByRole('button', { name: /approve/i });
+    expect(approveBtns.length).toBeGreaterThan(0);
+    approveBtns.forEach((btn) => expect(btn).not.toBeDisabled());
+  });
+
+  it('respects custom budgetUpper for the node threshold', () => {
+    // budgetUpper=10; nodeCount=9; 9 > 10*0.8=8 → show banner
+    const est: RunCostEstimate = {
+      nodeCount: 9,
+      estTokens: 18_000,
+      estWallSeconds: 50, // < 60
+    };
+    render(<HitlApprovalModal {...baseProps} costEstimate={est} budgetUpper={10} />);
+    expect(screen.getByTestId('cost-warning-banner')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #509: soft node budget advisory and a warn-only token-cost estimator for the orchestrator.

The estimator is purely informational — execution always proceeds, the `tracing::warn!` only fires when the plan exceeds the advisory budget, and "Approve" is never disabled.

---

## Changes

### Rust

| File | Change |
|---|---|
| `gglib-core/domain/orchestrator/task_graph.rs` | `NodeBudget` enum (`Solo`/`SmallTeam`/`TaskForce`/`Department`/`Custom`) with `const upper_bound()` |
| `gglib-core/domain/orchestrator/events.rs` | `RunCostEstimate { node_count, est_tokens, est_wall_seconds }` SSE event variant |
| `gglib-agent/orchestrator/estimator.rs` | **New** — pure cost estimation module. Model: 2000 tokens/node at 50 tps. Two doc-tests. |
| `gglib-agent/orchestrator/executor.rs` | `OrchestratorConfig` gains `node_budget: NodeBudget` (default `TaskForce` = 25). Emits `RunCostEstimate` after `PlanProposed`; `tracing::warn!` if over budget. |
| `gglib-axum/handlers/orchestrator/mod.rs` | `plan_sse` also emits `RunCostEstimate` after `PlanProposed` |
| `gglib-proxy/orchestrator_proxy.rs` | `RunCostEstimate` treated as informational (no OpenAI chunk) |
| `gglib-cli/handlers/orchestrate.rs` | Handle `RunCostEstimate`/`SubteamSpawned` (silent) and `SpawnSubteam` approval kind |

### TypeScript / Frontend

| File | Change |
|---|---|
| `src/types/orchestrator.ts` | `NodeBudget` type, `RunCostEstimateEvent` interface, union updated |
| `src/contexts/OrchestratorContext.tsx` | `costEstimate` session field, `SET_COST_ESTIMATE` reducer action |
| `src/hooks/useOrchestrator/useOrchestrator.ts` | `run_cost_estimate` → `SET_COST_ESTIMATE` |
| `src/pages/Orchestrator/components/HitlApprovalModal.tsx` | Yellow advisory banner when `estWallSeconds > 60` or `nodeCount > 80% budget` |
| `src/pages/Orchestrator/index.tsx` | Same cost banner on main orchestrator page |

### Tests

- **`tests/ts/components/HitlApprovalModal.test.tsx`** — 7 new tests: banner show/hide logic, massive estimates, approve button always enabled, custom `budgetUpper`
- Fixed pre-existing clippy lints in agent integration tests (`doc_markdown`, `option_if_let_else`, `redundant_closure`, `too_many_lines`)

---

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test -p gglib-core -p gglib-agent --lib` — 293 passed ✅
- `cargo test --doc -p gglib-agent` — estimator doc-tests pass ✅
- `npx tsc --noEmit` ✅
- `npx vitest run` — 613 passed (46 test files) ✅
- `./scripts/check_boundaries.sh` ✅

Closes #509