### PR TITLE
feat(orchestrator): Phase K — Conversational Steering + GraphDiff Preview

### DIFF
--- a/crates/gglib-agent/src/orchestrator/executor.rs
+++ b/crates/gglib-agent/src/orchestrator/executor.rs
@@ -64,6 +64,7 @@ use super::director::PlanError;
 use super::estimator::estimate_run_cost;
 use super::planner::plan;
 use super::spawn::{SpawnCapturingExecutor, SpawnRequest, SpawnSink};
+use super::steering::NoteQueue;
 use super::synthesis::run_synthesis;
 
 // =============================================================================
@@ -123,6 +124,17 @@ pub struct OrchestratorConfig {
     /// executor emits a [`tracing::warn!`] but **never** returns an error.
     /// Defaults to [`NodeBudget::TaskForce`] (25 nodes).
     pub node_budget: NodeBudget,
+
+    /// Optional per-run steering note queue.
+    ///
+    /// When set, the executor drains this queue at each wave boundary
+    /// (depth 0 only).  For each queued instruction it calls the steering LLM,
+    /// applies the returned [`GraphDiff`], and emits a
+    /// [`OrchestratorEvent::SteeringApplied`] event.  Instructions are
+    /// silently discarded on parse or validation failure (a warning is logged).
+    ///
+    /// `None` disables steering (backward-compatible).
+    pub note_queue: Option<NoteQueue>,
 }
 
 impl Default for OrchestratorConfig {
@@ -137,6 +149,7 @@ impl Default for OrchestratorConfig {
             graph_override: None,
             max_team_depth: 9,
             node_budget: NodeBudget::default(),
+            note_queue: None,
         }
     }
 }
@@ -282,7 +295,7 @@ pub async fn execute(
     };
 
     // ── 1. Planning (or graph override for resume) ────────────────────────────
-    let graph = if let Some(override_graph) = config.graph_override.clone() {
+    let mut graph = if let Some(override_graph) = config.graph_override.clone() {
         // Resume path: skip the director entirely.
         let _ = tx
             .send(OrchestratorEvent::PlanProposed {
@@ -452,7 +465,7 @@ pub async fn execute(
 
     let result = run_wave_loop(
         goal,
-        &graph,
+        &mut graph,
         pre_completed,
         Arc::clone(&llm),
         Arc::clone(&tool_executor),
@@ -506,7 +519,7 @@ pub async fn execute(
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn run_wave_loop(
     _goal: &str,
-    graph: &TaskGraph,
+    graph: &mut TaskGraph,
     mut completed: HashSet<NodeId>,
     llm: Arc<dyn LlmCompletionPort>,
     tool_executor: Arc<dyn ToolExecutorPort>,
@@ -526,9 +539,46 @@ async fn run_wave_loop(
         return Err(ExecuteError::MaxDepthExceeded);
     }
     let mut compacted: HashMap<NodeId, String> = HashMap::new();
+    let mut wave_number: u32 = 0;
 
     loop {
-        let ready = graph.ready_nodes(&completed);
+        // ── Steering note drain (depth 0 only, before each wave) ─────────────
+        if depth == 0 {
+            if let Some(queue) = &config.note_queue {
+                let notes: Vec<String> = {
+                    let mut q = queue.lock().await;
+                    std::mem::take(&mut *q)
+                };
+                for note in notes {
+                    match super::steering::steering_call(graph, &note, &llm).await {
+                        Ok(diff) => match graph.apply_diff(&diff) {
+                            Ok(()) => {
+                                let _ = tx
+                                    .send(OrchestratorEvent::SteeringApplied {
+                                        diff,
+                                        applied_at_wave: wave_number,
+                                    })
+                                    .await;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "orchestrator: steering diff invalid, skipping: {e}"
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            tracing::warn!("orchestrator: steering call failed, skipping: {e}");
+                        }
+                    }
+                }
+            }
+        }
+
+        let ready: Vec<NodeId> = graph
+            .ready_nodes(&completed)
+            .into_iter()
+            .cloned()
+            .collect();
         if ready.is_empty() {
             break;
         }
@@ -614,66 +664,74 @@ async fn run_wave_loop(
         // Team nodes must be run before we spawn the rest of the wave because
         // they are not `Send` (they borrow `event_seq`).  In practice this
         // means team nodes in the same wave run serially before leaf nodes.
-        let mut team_nodes_in_wave: Vec<&NodeId> = Vec::new();
-        let mut leaf_nodes_in_wave: Vec<&NodeId> = Vec::new();
+        let mut team_nodes_in_wave: Vec<NodeId> = Vec::new();
+        let mut leaf_nodes_in_wave: Vec<NodeId> = Vec::new();
         for node_id in &ready {
             if matches!(&graph.nodes[node_id].kind, TaskNodeKind::Team { .. }) {
-                team_nodes_in_wave.push(node_id);
+                team_nodes_in_wave.push(node_id.clone());
             } else {
-                leaf_nodes_in_wave.push(node_id);
+                leaf_nodes_in_wave.push(node_id.clone());
             }
         }
 
-        for team_id in team_nodes_in_wave {
-            let node = &graph.nodes[team_id];
-            if let TaskNodeKind::Team { subgraph } = &node.kind {
-                // Emit TeamStarted before recursing.
-                let _ = tx
-                    .send(OrchestratorEvent::TeamStarted {
-                        team_id: team_id.0.clone(),
-                        role: node.role.clone(),
-                    })
-                    .await;
+        for team_id in &team_nodes_in_wave {
+            // Clone the node data to release the immutable borrow before the
+            // recursive mutable call.
+            let (team_goal, team_role, mut sub_graph) = {
+                let node = &graph.nodes[team_id];
+                let sub = match &node.kind {
+                    TaskNodeKind::Team { subgraph } => (**subgraph).clone(),
+                    TaskNodeKind::Leaf => unreachable!("expected Team node"),
+                };
+                (node.goal.clone(), node.role.clone(), sub)
+            };
 
-                let sub_result = Box::pin(run_wave_loop(
-                    &node.goal,
-                    subgraph,
-                    HashSet::new(),
-                    Arc::clone(&llm),
-                    Arc::clone(&tool_executor),
-                    config,
-                    run_id,
-                    event_seq,
-                    tx,
-                    Arc::clone(&sem),
-                    depth + 1,
-                ))
+            // Emit TeamStarted before recursing.
+            let _ = tx
+                .send(OrchestratorEvent::TeamStarted {
+                    team_id: team_id.0.clone(),
+                    role: team_role,
+                })
                 .await;
 
-                match sub_result {
-                    Ok(sub_compacted) => {
-                        let summary = sub_compacted
-                            .values()
-                            .cloned()
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        // Emit TeamSynthesized with the compacted summary.
-                        let _ = tx
-                            .send(OrchestratorEvent::TeamSynthesized {
-                                team_id: team_id.0.clone(),
-                                compacted_output: summary.clone(),
-                            })
-                            .await;
-                        compacted.insert(team_id.clone(), summary);
-                        completed.insert(team_id.clone());
-                    }
-                    Err(e) => return Err(e),
+            let sub_result = Box::pin(run_wave_loop(
+                &team_goal,
+                &mut sub_graph,
+                HashSet::new(),
+                Arc::clone(&llm),
+                Arc::clone(&tool_executor),
+                config,
+                run_id,
+                event_seq,
+                tx,
+                Arc::clone(&sem),
+                depth + 1,
+            ))
+            .await;
+
+            match sub_result {
+                Ok(sub_compacted) => {
+                    let summary = sub_compacted
+                        .values()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    // Emit TeamSynthesized with the compacted summary.
+                    let _ = tx
+                        .send(OrchestratorEvent::TeamSynthesized {
+                            team_id: team_id.0.clone(),
+                            compacted_output: summary.clone(),
+                        })
+                        .await;
+                    compacted.insert(team_id.clone(), summary);
+                    completed.insert(team_id.clone());
                 }
+                Err(e) => return Err(e),
             }
         }
 
         // Spawn all ready *leaf* nodes concurrently, bounded by the semaphore.
-        for node_id in leaf_nodes_in_wave {
+        for node_id in &leaf_nodes_in_wave {
             let node = &graph.nodes[node_id];
             let node_id_clone = node_id.clone();
             let node_goal = node.goal.clone();
@@ -832,9 +890,10 @@ async fn run_wave_loop(
                 .await;
 
             // Run the child subgraph recursively.
+            let mut child_graph_mut = child_graph;
             let child_result = Box::pin(run_wave_loop(
                 &spawn_req.goal,
-                &child_graph,
+                &mut child_graph_mut,
                 HashSet::new(),
                 Arc::clone(&llm),
                 Arc::clone(&tool_executor),
@@ -866,6 +925,8 @@ async fn run_wave_loop(
                 Err(e) => return Err(e),
             }
         }
+
+        wave_number += 1;
     } // end loop
 
     Ok(compacted)

--- a/crates/gglib-agent/src/orchestrator/mod.rs
+++ b/crates/gglib-agent/src/orchestrator/mod.rs
@@ -27,6 +27,7 @@ pub mod executor;
 pub mod planner;
 pub mod prompts;
 pub mod spawn;
+pub mod steering;
 pub(crate) mod synthesis;
 
 pub use director::{DirectorNode, DirectorPlan, PlanError};

--- a/crates/gglib-agent/src/orchestrator/prompts.rs
+++ b/crates/gglib-agent/src/orchestrator/prompts.rs
@@ -440,3 +440,72 @@ pub fn chief_of_staff_schema() -> serde_json::Value {
         "additionalProperties": false
     })
 }
+
+// =============================================================================
+// Steering prompt + schema (Phase K)
+// =============================================================================
+
+/// System prompt for the steering LLM call.
+///
+/// The placeholder `<GRAPH_JSON>` is replaced with the current task graph
+/// serialised as pretty-printed JSON before the call is made.
+pub const STEERING_SYSTEM_PROMPT: &str = "\
+You are a task-graph planner assistant.
+The user will describe one change to make to the current execution plan.
+Respond with exactly one JSON object that conforms to the GraphDiff schema.
+
+Current task graph (JSON):
+<GRAPH_JSON>
+
+Available operations (use exactly one):
+  add_node      — add a new node.
+                  Fields: op, node (object with id, goal, depends_on, tool_allowlist, kind, status)
+  remove_node   — remove an existing node and its edges.
+                  Fields: op, id
+  split_node    — replace one node with multiple nodes.
+                  Fields: op, id, into (array of node objects)
+  reroute_edge  — change one dependency edge.
+                  Fields: op, node_id, old_dep, new_dep
+  set_role      — set or clear a node's specialist role.
+                  Fields: op, id, role (string or null)
+  set_tools     — replace a node's tool allowlist.
+                  Fields: op, id, tool_allowlist (array of strings)
+  wrap_in_team  — wrap several nodes into a new Team node.
+                  Fields: op, ids (array), team_id, team_goal
+
+Rules:
+- All node ids must be short, unique, lowercase identifiers (e.g. \"research\", \"review\").
+- The op field must be exactly one of the names listed above.
+- Return only the JSON object, no prose.
+";
+
+/// JSON Schema for a single [`gglib_core::domain::orchestrator::task_graph::GraphDiff`].
+///
+/// Deliberately flat (no `oneOf` / discriminated union) so that small models
+/// can satisfy the constraint reliably.  The `op` field acts as a discriminant.
+pub fn graph_diff_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "op": {
+                "type": "string",
+                "enum": [
+                    "add_node", "remove_node", "split_node",
+                    "reroute_edge", "set_role", "set_tools", "wrap_in_team"
+                ]
+            },
+            "node":           { "type": "object" },
+            "id":             { "type": "string" },
+            "into":           { "type": "array", "items": { "type": "object" } },
+            "node_id":        { "type": "string" },
+            "old_dep":        { "type": "string" },
+            "new_dep":        { "type": "string" },
+            "role":           {},
+            "tool_allowlist": { "type": "array", "items": { "type": "string" } },
+            "ids":            { "type": "array", "items": { "type": "string" } },
+            "team_id":        { "type": "string" },
+            "team_goal":      { "type": "string" }
+        },
+        "required": ["op"]
+    })
+}

--- a/crates/gglib-agent/src/orchestrator/steering.rs
+++ b/crates/gglib-agent/src/orchestrator/steering.rs
@@ -1,0 +1,79 @@
+//! Steering LLM call: produce a [`GraphDiff`] from a natural-language
+//! instruction.
+//!
+//! [`steering_call`] wraps [`crate::structured_output::get_structured`] with
+//! the steering system prompt and JSON schema so the LLM returns a single,
+//! typed [`GraphDiff`] that the executor can immediately apply.
+//!
+//! # Usage in the executor
+//!
+//! At each wave boundary (depth 0 only) the executor drains the per-run
+//! [`NoteQueue`], calls [`steering_call`] once per queued instruction, and
+//! applies the returned diff via
+//! [`TaskGraph::apply_diff`](gglib_core::domain::orchestrator::task_graph::TaskGraph::apply_diff).
+
+use std::sync::Arc;
+
+use gglib_core::domain::orchestrator::task_graph::{GraphDiff, TaskGraph};
+use gglib_core::ports::LlmCompletionPort;
+use gglib_core::{AgentMessage, StructuredOutputError};
+
+use crate::structured_output::get_structured;
+
+use super::prompts::{STEERING_SYSTEM_PROMPT, graph_diff_schema};
+
+// =============================================================================
+// NoteQueue
+// =============================================================================
+
+/// A shared, per-run queue of pending steering instructions.
+///
+/// The HTTP note endpoint appends instructions; the executor drains them at
+/// each wave boundary (depth 0 only).
+pub type NoteQueue = Arc<tokio::sync::Mutex<Vec<String>>>;
+
+// =============================================================================
+// SteeringError
+// =============================================================================
+
+/// Error returned by [`steering_call`].
+#[derive(Debug, thiserror::Error)]
+pub enum SteeringError {
+    /// The structured LLM call failed or returned unparseable output.
+    #[error("steering LLM call failed: {0}")]
+    Llm(#[from] StructuredOutputError),
+}
+
+// =============================================================================
+// steering_call
+// =============================================================================
+
+/// Ask the LLM to produce a single [`GraphDiff`] from a natural-language
+/// instruction given the current task graph.
+///
+/// # Parameters
+///
+/// - `graph` — the current task graph (serialised as context).
+/// - `instruction` — the user's change request in plain language.
+/// - `llm` — the LLM completion port to use.
+///
+/// # Retries
+///
+/// Delegates to [`get_structured`] with 2 retries on parse failure.
+pub async fn steering_call(
+    graph: &TaskGraph,
+    instruction: &str,
+    llm: &Arc<dyn LlmCompletionPort>,
+) -> Result<GraphDiff, SteeringError> {
+    let graph_json = serde_json::to_string_pretty(graph).unwrap_or_default();
+    // Use a placeholder string that doesn't look like a Rust format specifier.
+    let system = STEERING_SYSTEM_PROMPT.replace("<GRAPH_JSON>", &graph_json);
+    let messages = vec![
+        AgentMessage::System { content: system },
+        AgentMessage::User {
+            content: instruction.to_string(),
+        },
+    ];
+    let diff: GraphDiff = get_structured(llm, messages, graph_diff_schema(), 2).await?;
+    Ok(diff)
+}

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -7,6 +7,7 @@
 //! `AppEventEmitter` for the shared bootstrap), the MCP service with SSE
 //! emission, the seven domain ops, and the proxy crash watcher.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -138,6 +139,13 @@ pub struct AxumContext {
     pub approval_registry: Arc<OrchestratorApprovalRegistry>,
     /// Repository for persisting orchestrator run records and events.
     pub orchestrator_repo: Arc<SqliteOrchestratorRepository>,
+    /// Per-run queues for conversational steering notes (keyed by run_id).
+    #[allow(clippy::type_complexity)]
+    pub steering_note_queues: Arc<
+        tokio::sync::Mutex<
+            HashMap<String, Arc<tokio::sync::Mutex<Vec<String>>>>,
+        >,
+    >,
 }
 
 /// Bootstrap the Axum server with all services.
@@ -305,6 +313,7 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
         )),
         approval_registry,
         orchestrator_repo,
+        steering_note_queues: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
     })
 }
 

--- a/crates/gglib-axum/src/handlers/orchestrator/mod.rs
+++ b/crates/gglib-axum/src/handlers/orchestrator/mod.rs
@@ -18,9 +18,11 @@
 //! closes.
 
 pub mod approve;
+pub mod note;
 pub mod resume;
 pub mod run;
 pub mod runs;
+pub mod steer;
 
 use std::convert::Infallible;
 

--- a/crates/gglib-axum/src/handlers/orchestrator/note.rs
+++ b/crates/gglib-axum/src/handlers/orchestrator/note.rs
@@ -1,0 +1,47 @@
+//! `POST /api/orchestrator/runs/{run_id}/note` — enqueue a natural-language
+//! steering instruction for a live orchestrator run.
+//!
+//! The instruction is appended to the run's [`NoteQueue`].  At the next wave
+//! boundary the executor drains the queue, calls the steering LLM, applies
+//! the resulting [`GraphDiff`], and emits a
+//! [`OrchestratorEvent::SteeringApplied`] event on the SSE stream.
+//!
+//! Returns `202 Accepted` on success, or `404 Not Found` when no run with
+//! the given `run_id` is currently active.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::state::AppState;
+
+// ─── DTO ─────────────────────────────────────────────────────────────────────
+
+/// Request body for `POST /api/orchestrator/runs/{run_id}/note`.
+#[derive(Debug, serde::Deserialize)]
+pub struct NoteRequest {
+    /// Natural-language steering instruction to enqueue.
+    pub instruction: String,
+}
+
+// ─── POST /api/orchestrator/runs/{run_id}/note ───────────────────────────────
+
+/// Enqueue a steering note for the specified live run.
+///
+/// Returns `202 Accepted` when the note was enqueued, or `404 Not Found`
+/// when the run_id does not correspond to an active run.
+pub async fn post_note(
+    State(state): State<AppState>,
+    Path(run_id): Path<String>,
+    Json(req): Json<NoteRequest>,
+) -> impl IntoResponse {
+    let queues = state.steering_note_queues.lock().await;
+    match queues.get(&run_id) {
+        Some(queue) => {
+            queue.lock().await.push(req.instruction);
+            StatusCode::ACCEPTED
+        }
+        None => StatusCode::NOT_FOUND,
+    }
+}

--- a/crates/gglib-axum/src/handlers/orchestrator/run.rs
+++ b/crates/gglib-axum/src/handlers/orchestrator/run.rs
@@ -124,8 +124,27 @@ pub async fn run_sse(
         ..OrchestratorConfig::default()
     };
 
+    // Pre-generate run_id and register a steering note queue for this run.
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let note_queue: Arc<tokio::sync::Mutex<Vec<String>>> =
+        Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    {
+        state
+            .steering_note_queues
+            .lock()
+            .await
+            .insert(run_id.clone(), Arc::clone(&note_queue));
+    }
+
+    let config = OrchestratorConfig {
+        run_id: Some(run_id.clone()),
+        note_queue: Some(Arc::clone(&note_queue)),
+        ..config
+    };
+
     let (tx, rx) = mpsc::channel::<OrchestratorEvent>(ORCHESTRATOR_EVENT_CHANNEL_CAPACITY);
     let goal = req.goal.clone();
+    let steering_queues = Arc::clone(&state.steering_note_queues);
 
     tokio::spawn(async move {
         let _permit = permit;
@@ -144,6 +163,9 @@ pub async fn run_sse(
             // returning Err, so we only log here for server-side observability.
             tracing::error!(error = %e, goal, "orchestrator: run failed");
         }
+
+        // Clean up the steering note queue for this run.
+        steering_queues.lock().await.remove(&run_id);
     });
 
     let sse_stream = ReceiverStream::new(rx).filter_map(|event| {

--- a/crates/gglib-axum/src/handlers/orchestrator/steer.rs
+++ b/crates/gglib-axum/src/handlers/orchestrator/steer.rs
@@ -1,0 +1,75 @@
+//! `POST /api/orchestrator/steer` — apply a natural-language steering
+//! instruction to a [`TaskGraph`] preview and return the resulting
+//! [`GraphDiff`].
+//!
+//! This is a **stateless, preview-only** endpoint: it does not mutate any
+//! running orchestrator.  Callers may inspect the diff and, if satisfied,
+//! submit it to a live run via `POST /api/orchestrator/runs/{run_id}/note`.
+
+use axum::Json;
+use axum::extract::State;
+use std::sync::Arc;
+
+use gglib_agent::orchestrator::steering::steering_call;
+use gglib_core::domain::orchestrator::task_graph::{GraphDiff, TaskGraph};
+use gglib_runtime::compose_council_ports;
+
+use crate::error::HttpError;
+use crate::handlers::port_utils::validate_port;
+use crate::state::AppState;
+
+// ─── DTO ─────────────────────────────────────────────────────────────────────
+
+/// Request body for `POST /api/orchestrator/steer`.
+#[derive(Debug, serde::Deserialize)]
+pub struct SteerRequest {
+    /// The current task graph to steer.
+    pub graph: TaskGraph,
+    /// Natural-language instruction describing the desired modification.
+    pub instruction: String,
+    /// Port of the llama-server to use for the steering LLM call.
+    pub port: u16,
+    /// Optional model name override.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+/// Response body for `POST /api/orchestrator/steer`.
+#[derive(Debug, serde::Serialize)]
+pub struct SteerResponse {
+    /// The diff produced by the steering LLM call.
+    pub diff: GraphDiff,
+}
+
+// ─── POST /api/orchestrator/steer ────────────────────────────────────────────
+
+/// Preview a steering instruction against a graph and return the diff.
+///
+/// # Errors
+///
+/// Returns an HTTP error when the port is invalid or the LLM call fails.
+pub async fn steer(
+    State(state): State<AppState>,
+    Json(req): Json<SteerRequest>,
+) -> Result<Json<SteerResponse>, HttpError> {
+    validate_port(&state, req.port).await?;
+
+    let tags = match req.model.as_deref() {
+        Some(name) => state.core.models().tags_for(name).await,
+        None => Vec::new(),
+    };
+    let ports = compose_council_ports(
+        format!("http://127.0.0.1:{}", req.port),
+        state.http_client.clone(),
+        req.model.clone(),
+        tags,
+        state.mcp.clone(),
+        None,
+    );
+
+    let diff = steering_call(&req.graph, &req.instruction, &Arc::clone(&ports.llm))
+        .await
+        .map_err(|e| HttpError::Internal(e.to_string()))?;
+
+    Ok(Json(SteerResponse { diff }))
+}

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -131,6 +131,15 @@ pub(crate) fn api_routes() -> Router<AppState> {
             "/orchestrator/runs/{run_id}/resume",
             post(handlers::orchestrator::resume::resume_run),
         )
+        // Orchestrator Phase K: conversational steering
+        .route(
+            "/orchestrator/steer",
+            post(handlers::orchestrator::steer::steer),
+        )
+        .route(
+            "/orchestrator/runs/{run_id}/note",
+            post(handlers::orchestrator::note::post_note),
+        )
         // Chat routes (merged without prefix since we're already building /api)
         .merge(chat_routes_no_prefix())
 }

--- a/crates/gglib-cli/src/handlers/orchestrate.rs
+++ b/crates/gglib-cli/src/handlers/orchestrate.rs
@@ -327,6 +327,17 @@ async fn render_event(
         | OrchestratorEvent::SynthesisProgress { .. }
         | OrchestratorEvent::RunCostEstimate { .. }
         | OrchestratorEvent::SubteamSpawned { .. } => {}
+        OrchestratorEvent::SteeringApplied {
+            applied_at_wave,
+            diff,
+        } => {
+            eprintln!(
+                "{}[wave {applied_at_wave}] ↩ steering applied: {:?}{}",
+                style::DIM,
+                diff,
+                style::RESET,
+            );
+        }
     }
 }
 

--- a/crates/gglib-core/src/domain/orchestrator/events.rs
+++ b/crates/gglib-core/src/domain/orchestrator/events.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::domain::agent::{ToolCall, ToolResult};
 use crate::domain::orchestrator::role_catalog::RoleId;
 
-use super::task_graph::TaskGraph;
+use super::task_graph::{GraphDiff, TaskGraph};
 
 /// Channel capacity for the orchestrator event sender.
 ///
@@ -319,5 +319,17 @@ pub enum OrchestratorEvent {
         parent_node_id: String,
         /// One-line summary of the child graph that was planned.
         child_graph_summary: String,
+    },
+
+    // ── steering (Phase K) ───────────────────────────────────────────────
+    /// A [`GraphDiff`] was applied to the task graph at a wave boundary.
+    ///
+    /// Emitted after [`super::task_graph::TaskGraph::apply_diff`] succeeds.
+    /// Informational only — execution continues with the updated graph.
+    SteeringApplied {
+        /// The diff that was applied.
+        diff: GraphDiff,
+        /// Zero-based wave index at which the diff was applied.
+        applied_at_wave: u32,
     },
 }

--- a/crates/gglib-core/src/domain/orchestrator/task_graph.rs
+++ b/crates/gglib-core/src/domain/orchestrator/task_graph.rs
@@ -376,6 +376,102 @@ pub enum TaskGraphError {
         /// The tool name that was not found in the catalog.
         tool: String,
     },
+
+    /// A referenced node id was not found in the graph.
+    #[error("node not found: {0}")]
+    NodeNotFound(String),
+
+    /// The diff is structurally invalid (e.g. would leave an empty graph).
+    #[error("invalid diff: {0}")]
+    DiffInvalid(String),
+}
+
+// =============================================================================
+// GraphDiff
+// =============================================================================
+
+/// A single mutation to apply to a [`TaskGraph`] at runtime.
+///
+/// Produced by the steering LLM (`gglib_agent::orchestrator::steering`) and
+/// applied via [`TaskGraph::apply_diff`].  Each variant mutates the graph and
+/// then triggers re-validation to ensure the graph stays well-formed.
+///
+/// The `#[non_exhaustive]` attribute allows new variants to be added in future
+/// minor versions without breaking match arms in external crates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GraphDiff {
+    /// Add a new node.
+    ///
+    /// The node's `depends_on` carries all its incoming edges.
+    AddNode {
+        /// Node to insert.
+        node: TaskNode,
+    },
+
+    /// Remove a node and strip all edges that pointed to it.
+    ///
+    /// Any node whose `depends_on` contains `id` will have that entry removed.
+    RemoveNode {
+        /// Id of the node to remove.
+        id: NodeId,
+    },
+
+    /// Replace one node with multiple nodes.
+    ///
+    /// The original is removed; each entry in `into` is inserted.  Any node
+    /// that depended on the original will be updated to depend on all
+    /// replacements.
+    SplitNode {
+        /// Id of the node to replace.
+        id: NodeId,
+        /// Replacement nodes (at least one entry required).
+        into: Vec<TaskNode>,
+    },
+
+    /// Redirect one dependency edge.
+    ///
+    /// In `node_id`'s `depends_on` list, replaces `old_dep` with `new_dep`.
+    RerouteEdge {
+        /// Node whose dependency is being changed.
+        node_id: NodeId,
+        /// Dependency to remove.
+        old_dep: NodeId,
+        /// Dependency to add in its place.
+        new_dep: NodeId,
+    },
+
+    /// Set or clear a node's specialist role.
+    SetRole {
+        /// Target node id.
+        id: NodeId,
+        /// New role (`None` clears the current role).
+        role: Option<RoleId>,
+    },
+
+    /// Replace a node's entire tool allowlist.
+    SetTools {
+        /// Target node id.
+        id: NodeId,
+        /// New tool allowlist (replaces the current list entirely).
+        tool_allowlist: Vec<String>,
+    },
+
+    /// Wrap a set of nodes into a new [`TaskNodeKind::Team`] node.
+    ///
+    /// The wrapped nodes become the team's subgraph.  The `team_id` node
+    /// inherits all external in-edges (from nodes NOT in `ids`) and any
+    /// node outside `ids` that depended on a wrapped node will be updated
+    /// to depend on `team_id` instead.
+    WrapInTeam {
+        /// Ids of the nodes to wrap (all must exist in the graph).
+        ids: Vec<NodeId>,
+        /// Unique id for the new `Team` wrapper node.
+        team_id: NodeId,
+        /// High-level goal text for the new `Team` node.
+        team_goal: String,
+    },
 }
 
 // =============================================================================
@@ -794,6 +890,256 @@ impl TaskGraph {
                 TaskNodeKind::Team { subgraph } => 1 + subgraph.total_node_count(),
             })
             .sum()
+    }
+
+    /// Apply a [`GraphDiff`] mutation in-place, then re-validate.
+    ///
+    /// If either the mutation itself or the subsequent [`validate_acyclic`]
+    /// call fails, the graph is restored to its pre-call state (clone-and-swap
+    /// rollback) and the error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`TaskGraphError`] encountered (pre-condition checks
+    /// or post-mutation validation).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gglib_core::domain::orchestrator::task_graph::{
+    ///     TaskGraph, TaskNode, TaskNodeKind, NodeId, NodeStatus, HitlMode,
+    ///     GraphDiff,
+    /// };
+    ///
+    /// let nodes = vec![TaskNode {
+    ///     id: NodeId("a".into()), goal: "a".into(), depends_on: vec![],
+    ///     tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///     status: NodeStatus::Pending, output: None,
+    ///     compacted_output: None, error: None,
+    /// }];
+    /// let mut g = TaskGraph::new("goal".into(), HitlMode::None, nodes).unwrap();
+    ///
+    /// let new_node = TaskNode {
+    ///     id: NodeId("b".into()), goal: "b".into(),
+    ///     depends_on: vec![NodeId("a".into())],
+    ///     tool_allowlist: vec![], kind: TaskNodeKind::Leaf, role: None,
+    ///     status: NodeStatus::Pending, output: None,
+    ///     compacted_output: None, error: None,
+    /// };
+    /// g.apply_diff(&GraphDiff::AddNode { node: new_node }).unwrap();
+    /// assert_eq!(g.nodes.len(), 2);
+    /// ```
+    pub fn apply_diff(&mut self, diff: &GraphDiff) -> Result<(), TaskGraphError> {
+        let saved = self.clone();
+        match self.apply_diff_inner(diff) {
+            Ok(()) => match self.validate_acyclic() {
+                Ok(()) => Ok(()),
+                Err(e) => {
+                    *self = saved;
+                    Err(e)
+                }
+            },
+            Err(e) => {
+                *self = saved;
+                Err(e)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn apply_diff_inner(&mut self, diff: &GraphDiff) -> Result<(), TaskGraphError> {
+        match diff {
+            GraphDiff::AddNode { node } => {
+                if self.nodes.contains_key(&node.id) {
+                    return Err(TaskGraphError::DuplicateNodeId(node.id.0.clone()));
+                }
+                if self.nodes.len() >= MAX_NODES {
+                    return Err(TaskGraphError::TooManyNodes {
+                        count: self.nodes.len() + 1,
+                        max: MAX_NODES,
+                    });
+                }
+                self.nodes.insert(node.id.clone(), node.clone());
+            }
+
+            GraphDiff::RemoveNode { id } => {
+                if !self.nodes.contains_key(id) {
+                    return Err(TaskGraphError::NodeNotFound(id.0.clone()));
+                }
+                if self.nodes.len() == 1 {
+                    return Err(TaskGraphError::DiffInvalid(
+                        "cannot remove the only node in a graph".into(),
+                    ));
+                }
+                self.nodes.remove(id);
+                for node in self.nodes.values_mut() {
+                    node.depends_on.retain(|dep| dep != id);
+                }
+            }
+
+            GraphDiff::SplitNode { id, into } => {
+                if !self.nodes.contains_key(id) {
+                    return Err(TaskGraphError::NodeNotFound(id.0.clone()));
+                }
+                if into.is_empty() {
+                    return Err(TaskGraphError::DiffInvalid(
+                        "split_node: replacement list must not be empty".into(),
+                    ));
+                }
+                // Check for id conflicts among replacements (excluding the original id).
+                for n in into {
+                    if &n.id != id && self.nodes.contains_key(&n.id) {
+                        return Err(TaskGraphError::DuplicateNodeId(n.id.0.clone()));
+                    }
+                }
+                let new_count = self.nodes.len() - 1 + into.len();
+                if new_count > MAX_NODES {
+                    return Err(TaskGraphError::TooManyNodes {
+                        count: new_count,
+                        max: MAX_NODES,
+                    });
+                }
+                let replacement_ids: Vec<NodeId> = into.iter().map(|n| n.id.clone()).collect();
+                self.nodes.remove(id);
+                for n in into {
+                    self.nodes.insert(n.id.clone(), n.clone());
+                }
+                // Repoint any node that depended on the split node.
+                for node in self.nodes.values_mut() {
+                    if node.depends_on.contains(id) {
+                        node.depends_on.retain(|dep| dep != id);
+                        for rid in &replacement_ids {
+                            if !node.depends_on.contains(rid) {
+                                node.depends_on.push(rid.clone());
+                            }
+                        }
+                    }
+                }
+            }
+
+            GraphDiff::RerouteEdge {
+                node_id,
+                old_dep,
+                new_dep,
+            } => {
+                if !self.nodes.contains_key(node_id) {
+                    return Err(TaskGraphError::NodeNotFound(node_id.0.clone()));
+                }
+                if !self.nodes.contains_key(new_dep) {
+                    return Err(TaskGraphError::NodeNotFound(new_dep.0.clone()));
+                }
+                let node = self.nodes.get_mut(node_id).expect("checked above");
+                let pos = node
+                    .depends_on
+                    .iter()
+                    .position(|d| d == old_dep)
+                    .ok_or_else(|| {
+                        TaskGraphError::DiffInvalid(format!(
+                            "node '{}' does not depend on '{}'",
+                            node_id.0, old_dep.0
+                        ))
+                    })?;
+                node.depends_on[pos] = new_dep.clone();
+            }
+
+            GraphDiff::SetRole { id, role } => {
+                let node = self
+                    .nodes
+                    .get_mut(id)
+                    .ok_or_else(|| TaskGraphError::NodeNotFound(id.0.clone()))?;
+                node.role.clone_from(role);
+            }
+
+            GraphDiff::SetTools { id, tool_allowlist } => {
+                let node = self
+                    .nodes
+                    .get_mut(id)
+                    .ok_or_else(|| TaskGraphError::NodeNotFound(id.0.clone()))?;
+                node.tool_allowlist.clone_from(tool_allowlist);
+            }
+
+            GraphDiff::WrapInTeam {
+                ids,
+                team_id,
+                team_goal,
+            } => {
+                if ids.is_empty() {
+                    return Err(TaskGraphError::DiffInvalid(
+                        "wrap_in_team: ids list must not be empty".into(),
+                    ));
+                }
+                if self.nodes.contains_key(team_id) {
+                    return Err(TaskGraphError::DuplicateNodeId(team_id.0.clone()));
+                }
+                for id in ids {
+                    if !self.nodes.contains_key(id) {
+                        return Err(TaskGraphError::NodeNotFound(id.0.clone()));
+                    }
+                }
+
+                let wrapped_set: HashSet<NodeId> = ids.iter().cloned().collect();
+
+                // Team node inherits all external deps of the wrapped nodes.
+                let mut team_deps: Vec<NodeId> = Vec::new();
+                for id in ids {
+                    for dep in &self.nodes[id].depends_on {
+                        if !wrapped_set.contains(dep) && !team_deps.contains(dep) {
+                            team_deps.push(dep.clone());
+                        }
+                    }
+                }
+
+                // Extract wrapped nodes into the subgraph (stripping external deps).
+                let mut sub_nodes: HashMap<NodeId, TaskNode> = HashMap::new();
+                for id in ids {
+                    let mut node = self.nodes.remove(id).expect("checked above");
+                    node.depends_on.retain(|dep| wrapped_set.contains(dep));
+                    sub_nodes.insert(id.clone(), node);
+                }
+
+                // Repoint external nodes that depended on any wrapped node.
+                for node in self.nodes.values_mut() {
+                    let had_dep = node.depends_on.iter().any(|d| wrapped_set.contains(d));
+                    if had_dep {
+                        node.depends_on.retain(|d| !wrapped_set.contains(d));
+                        if !node.depends_on.contains(team_id) {
+                            node.depends_on.push(team_id.clone());
+                        }
+                    }
+                }
+
+                // Size guard for the parent graph (after removals, before insertion).
+                if self.nodes.len() >= MAX_NODES {
+                    return Err(TaskGraphError::TooManyNodes {
+                        count: self.nodes.len() + 1,
+                        max: MAX_NODES,
+                    });
+                }
+
+                let subgraph = Self {
+                    goal: team_goal.clone(),
+                    hitl_mode: self.hitl_mode.clone(),
+                    nodes: sub_nodes,
+                };
+
+                let team_node = TaskNode {
+                    id: team_id.clone(),
+                    goal: team_goal.clone(),
+                    depends_on: team_deps,
+                    tool_allowlist: vec![],
+                    kind: TaskNodeKind::Team {
+                        subgraph: Box::new(subgraph),
+                    },
+                    role: None,
+                    status: NodeStatus::Pending,
+                    output: None,
+                    compacted_output: None,
+                    error: None,
+                };
+                self.nodes.insert(team_id.clone(), team_node);
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/gglib-core/tests/apply_diff.rs
+++ b/crates/gglib-core/tests/apply_diff.rs
@@ -1,0 +1,171 @@
+//! Unit tests for [`TaskGraph::apply_diff`] covering all seven [`GraphDiff`]
+//! variants (happy-path) and two invalid-diff error cases.
+
+use gglib_core::domain::orchestrator::task_graph::{
+    GraphDiff, HitlMode, NodeId, NodeStatus, TaskGraph, TaskGraphError, TaskNode, TaskNodeKind,
+};
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+fn leaf(id: &str, depends_on: &[&str]) -> TaskNode {
+    TaskNode {
+        id: NodeId(id.into()),
+        goal: format!("goal for {id}"),
+        depends_on: depends_on.iter().map(|s| NodeId((*s).into())).collect(),
+        tool_allowlist: vec![],
+        kind: TaskNodeKind::Leaf,
+        role: None,
+        status: NodeStatus::Pending,
+        output: None,
+        compacted_output: None,
+        error: None,
+    }
+}
+
+fn simple_graph() -> TaskGraph {
+    TaskGraph::new(
+        "test graph".into(),
+        HitlMode::None,
+        vec![leaf("a", &[]), leaf("b", &["a"])],
+    )
+    .expect("valid graph")
+}
+
+// ─── AddNode (happy path) ──────────────────────────────────────────────────
+
+#[test]
+fn add_node_appends_node() {
+    let mut g = simple_graph();
+    let new_node = leaf("c", &["b"]);
+    g.apply_diff(&GraphDiff::AddNode { node: new_node }).unwrap();
+    assert!(g.nodes.contains_key(&NodeId("c".into())));
+}
+
+// ─── RemoveNode (happy path) ───────────────────────────────────────────────
+
+#[test]
+fn remove_node_removes_and_strips_edges() {
+    let mut g = simple_graph();
+    // Remove "a"; "b" depends on "a", so "b"'s depends_on should be cleared.
+    g.apply_diff(&GraphDiff::RemoveNode {
+        id: NodeId("a".into()),
+    })
+    .unwrap();
+    assert!(!g.nodes.contains_key(&NodeId("a".into())));
+    assert!(g.nodes[&NodeId("b".into())].depends_on.is_empty());
+}
+
+// ─── SplitNode (happy path) ───────────────────────────────────────────────
+
+#[test]
+fn split_node_replaces_original_and_updates_dependents() {
+    let mut g = simple_graph();
+    let a1 = leaf("a1", &[]);
+    let a2 = leaf("a2", &[]);
+    g.apply_diff(&GraphDiff::SplitNode {
+        id: NodeId("a".into()),
+        into: vec![a1, a2],
+    })
+    .unwrap();
+    assert!(!g.nodes.contains_key(&NodeId("a".into())));
+    assert!(g.nodes.contains_key(&NodeId("a1".into())));
+    assert!(g.nodes.contains_key(&NodeId("a2".into())));
+    let b_deps = &g.nodes[&NodeId("b".into())].depends_on;
+    assert!(b_deps.contains(&NodeId("a1".into())));
+    assert!(b_deps.contains(&NodeId("a2".into())));
+}
+
+// ─── RerouteEdge (happy path) ─────────────────────────────────────────────
+
+#[test]
+fn reroute_edge_updates_depends_on() {
+    let mut g = TaskGraph::new(
+        "reroute test".into(),
+        HitlMode::None,
+        vec![leaf("x", &[]), leaf("y", &[]), leaf("z", &["x"])],
+    )
+    .unwrap();
+    g.apply_diff(&GraphDiff::RerouteEdge {
+        node_id: NodeId("z".into()),
+        old_dep: NodeId("x".into()),
+        new_dep: NodeId("y".into()),
+    })
+    .unwrap();
+    let z_deps = &g.nodes[&NodeId("z".into())].depends_on;
+    assert!(!z_deps.contains(&NodeId("x".into())));
+    assert!(z_deps.contains(&NodeId("y".into())));
+}
+
+// ─── SetRole (happy path) ─────────────────────────────────────────────────
+
+#[test]
+fn set_role_updates_node_role() {
+    use gglib_core::domain::orchestrator::role_catalog::RoleId;
+    let mut g = simple_graph();
+    let role = RoleId("analyst".into());
+    g.apply_diff(&GraphDiff::SetRole {
+        id: NodeId("a".into()),
+        role: Some(role.clone()),
+    })
+    .unwrap();
+    assert_eq!(g.nodes[&NodeId("a".into())].role, Some(role));
+}
+
+// ─── SetTools (happy path) ────────────────────────────────────────────────
+
+#[test]
+fn set_tools_replaces_allowlist() {
+    let mut g = simple_graph();
+    g.apply_diff(&GraphDiff::SetTools {
+        id: NodeId("a".into()),
+        tool_allowlist: vec!["search".into(), "calc".into()],
+    })
+    .unwrap();
+    assert_eq!(
+        g.nodes[&NodeId("a".into())].tool_allowlist,
+        vec!["search".to_string(), "calc".to_string()]
+    );
+}
+
+// ─── WrapInTeam (happy path) ──────────────────────────────────────────────
+
+#[test]
+fn wrap_in_team_creates_team_node() {
+    let mut g = simple_graph();
+    g.apply_diff(&GraphDiff::WrapInTeam {
+        ids: vec![NodeId("a".into()), NodeId("b".into())],
+        team_id: NodeId("team_ab".into()),
+        team_goal: "team goal".into(),
+    })
+    .unwrap();
+    let team = &g.nodes[&NodeId("team_ab".into())];
+    assert!(matches!(team.kind, TaskNodeKind::Team { .. }));
+}
+
+// ─── Error: AddNode with duplicate id ────────────────────────────────────
+
+#[test]
+fn add_node_duplicate_id_returns_error_and_leaves_graph_unchanged() {
+    let mut g = simple_graph();
+    let original_len = g.nodes.len();
+    let dup = leaf("a", &[]);
+    let err = g
+        .apply_diff(&GraphDiff::AddNode { node: dup })
+        .unwrap_err();
+    assert!(matches!(err, TaskGraphError::DuplicateNodeId(_)));
+    // Graph must be rolled back.
+    assert_eq!(g.nodes.len(), original_len);
+}
+
+// ─── Error: RemoveNode that doesn't exist ────────────────────────────────
+
+#[test]
+fn remove_nonexistent_node_returns_not_found() {
+    let mut g = simple_graph();
+    let err = g
+        .apply_diff(&GraphDiff::RemoveNode {
+            id: NodeId("does_not_exist".into()),
+        })
+        .unwrap_err();
+    assert!(matches!(err, TaskGraphError::NodeNotFound(_)));
+}

--- a/crates/gglib-proxy/src/orchestrator_proxy.rs
+++ b/crates/gglib-proxy/src/orchestrator_proxy.rs
@@ -611,6 +611,7 @@ pub(crate) fn orchestrator_event_to_content(event: &OrchestratorEvent) -> Option
         | OrchestratorEvent::ReplanAttempt { .. }
         | OrchestratorEvent::AwaitingApproval { .. }
         | OrchestratorEvent::RunCostEstimate { .. }
+        | OrchestratorEvent::SteeringApplied { .. }
         | OrchestratorEvent::NodeReasoningDelta { .. }
         | OrchestratorEvent::NodeProgress { .. }
         | OrchestratorEvent::NodeSystemWarning { .. }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,6 +118,7 @@ fn main() {
                 agent_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
                 approval_registry: ctx.approval_registry.clone(),
                 orchestrator_repo: ctx.orchestrator_repo.clone(),
+                steering_note_queues: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             };
 
             // Start embedded API server with auth and ephemeral port

--- a/src/contexts/OrchestratorContext.tsx
+++ b/src/contexts/OrchestratorContext.tsx
@@ -13,6 +13,7 @@ import type {
   TaskGraph,
   OrchestratorRun,
   ApprovalKind,
+  GraphDiff,
 } from '../types/orchestrator';
 
 // ─── Cost estimate ───────────────────────────────────────────────────────────────────
@@ -67,6 +68,8 @@ export interface OrchestratorSession {
   pendingApproval: PendingApproval | null;
   costEstimate: RunCostEstimate | null;
   error: string | null;
+  /** Most recent steering diff received from a steering_applied event. */
+  pendingDiff: GraphDiff | null;
   /** Runs loaded from GET /api/orchestrator/runs */
   runs: OrchestratorRun[];
   runsLoading: boolean;
@@ -82,6 +85,7 @@ function createEmptySession(): OrchestratorSession {
     pendingApproval: null,
     costEstimate: null,
     error: null,
+    pendingDiff: null,
     runs: [],
     runsLoading: false,
   };
@@ -121,7 +125,9 @@ export type OrchestratorAction =
   // Runs list
   | { type: 'RUNS_LOADING' }
   | { type: 'RUNS_LOADED'; runs: OrchestratorRun[] }
-  | { type: 'RUNS_ERROR' };
+  | { type: 'RUNS_ERROR' }
+  // Steering (Phase K)
+  | { type: 'SET_PENDING_DIFF'; diff: GraphDiff | null };
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────
 
@@ -299,6 +305,9 @@ export function orchestratorReducer(
 
     case 'RUNS_ERROR':
       return { ...state, runsLoading: false };
+
+    case 'SET_PENDING_DIFF':
+      return { ...state, pendingDiff: action.diff };
 
     default:
       return state;

--- a/src/hooks/useOrchestrator/useOrchestrator.ts
+++ b/src/hooks/useOrchestrator/useOrchestrator.ts
@@ -99,6 +99,8 @@ function eventToAction(event: OrchestratorEvent): OrchestratorAction | null {
     case 'team_synthesized':
     case 'subteam_spawned':
       return null;
+    case 'steering_applied':
+      return { type: 'SET_PENDING_DIFF', diff: event.diff };
     default:
       return null;
   }

--- a/src/pages/Orchestrator/components/HitlApprovalModal.tsx
+++ b/src/pages/Orchestrator/components/HitlApprovalModal.tsx
@@ -22,6 +22,7 @@ import type {
   TaskGraph,
 } from '../../../types/orchestrator';
 import type { RunCostEstimate } from '../../../contexts/OrchestratorContext';
+import SteeringPanel from './SteeringPanel';
 
 interface HitlApprovalModalProps {
   open: boolean;
@@ -31,6 +32,10 @@ interface HitlApprovalModalProps {
   costEstimate: RunCostEstimate | null;
   /** Advisory upper bound for the active NodeBudget (default 25). */
   budgetUpper?: number;
+  /** Port for the steering LLM (required for plan edits via SteeringPanel). */
+  port?: number;
+  /** Optional model name for the steering LLM. */
+  model?: string;
   onApprove: (payload: ApprovalDecisionPayload) => void;
   onReject: (reason?: string) => void;
 }
@@ -42,24 +47,20 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
   submitting,
   costEstimate,
   budgetUpper = 25,
+  port,
+  model,
   onApprove,
   onReject,
 }) => {
   const [rejectReason, setRejectReason] = useState('');
   const [showReject, setShowReject] = useState(false);
-  const [graphEditJson, setGraphEditJson] = useState('');
-  const [graphEditError, setGraphEditError] = useState<string | null>(null);
   const [showEdit, setShowEdit] = useState(false);
+  // Tracks the current working graph (possibly modified via SteeringPanel).
+  const [editedGraph, setEditedGraph] = useState<TaskGraph | null>(null);
 
   function handleApprove() {
-    if (showEdit && graphEditJson.trim()) {
-      try {
-        const editedGraph = JSON.parse(graphEditJson) as TaskGraph;
-        onApprove({ decision: 'approve_with_edits', edited_graph: editedGraph });
-      } catch {
-        setGraphEditError('Invalid JSON — please fix before approving with edits.');
-        return;
-      }
+    if (showEdit && editedGraph) {
+      onApprove({ decision: 'approve_with_edits', edited_graph: editedGraph });
     } else {
       onApprove({ decision: 'approve' });
     }
@@ -73,8 +74,7 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
 
   function handleStartEdit() {
     setShowEdit(true);
-    setGraphEditJson(JSON.stringify(graph, null, 2));
-    setGraphEditError(null);
+    setEditedGraph(graph);
   }
 
   const showCostBanner =
@@ -177,18 +177,17 @@ const HitlApprovalModal: FC<HitlApprovalModalProps> = ({
 
             {showEdit ? (
               <>
-                <Textarea
-                  value={graphEditJson}
-                  onChange={(e) => {
-                    setGraphEditJson(e.target.value);
-                    setGraphEditError(null);
-                  }}
-                  rows={16}
-                  className="font-mono text-xs"
-                  aria-label="Edited graph JSON"
-                />
-                {graphEditError && (
-                  <p className="text-xs text-danger">{graphEditError}</p>
+                {port != null && (editedGraph ?? graph) ? (
+                  <SteeringPanel
+                    graph={(editedGraph ?? graph)!}
+                    port={port}
+                    model={model}
+                    onGraphChange={(g) => setEditedGraph(g)}
+                  />
+                ) : (
+                  <p className="text-xs text-text-muted">
+                    No server port available for steering edits.
+                  </p>
                 )}
               </>
             ) : (

--- a/src/pages/Orchestrator/components/SteeringPanel.tsx
+++ b/src/pages/Orchestrator/components/SteeringPanel.tsx
@@ -1,0 +1,314 @@
+/**
+ * SteeringPanel — chat-style input for conversational graph steering.
+ *
+ * Accepts a natural-language instruction, sends it to
+ * `POST /api/orchestrator/steer` for a diff preview, renders the diff with
+ * visual encoding (green = add, red = remove, amber = reroute/modify), and
+ * provides an "Apply diff" button that calls `onGraphChange`.
+ *
+ * @module pages/Orchestrator/components/SteeringPanel
+ */
+
+import { FC, useState } from 'react';
+import { Button } from '../../../components/ui/Button';
+import { Textarea } from '../../../components/ui/Textarea';
+import type { TaskGraph, GraphDiff, TaskNode } from '../../../types/orchestrator';
+
+// ─── Pure helper: apply a GraphDiff to a TaskGraph ───────────────────────────
+
+/**
+ * Apply `diff` to `graph` and return the updated graph.
+ * This is a best-effort client-side application for preview; the authoritative
+ * application happens in the Rust `apply_diff` implementation.
+ */
+export function applyDiff(graph: TaskGraph, diff: GraphDiff): TaskGraph {
+  const nodes = { ...graph.nodes };
+
+  switch (diff.op) {
+    case 'add_node': {
+      nodes[diff.node.id] = diff.node;
+      break;
+    }
+    case 'remove_node': {
+      delete nodes[diff.id];
+      // Strip edges pointing to removed node.
+      for (const id of Object.keys(nodes)) {
+        nodes[id] = {
+          ...nodes[id],
+          depends_on: nodes[id].depends_on.filter((d) => d !== diff.id),
+        };
+      }
+      break;
+    }
+    case 'split_node': {
+      delete nodes[diff.id];
+      for (const n of diff.into) {
+        nodes[n.id] = n;
+      }
+      // Repoint dependants.
+      for (const id of Object.keys(nodes)) {
+        if (nodes[id].depends_on.includes(diff.id)) {
+          nodes[id] = {
+            ...nodes[id],
+            depends_on: [
+              ...nodes[id].depends_on.filter((d) => d !== diff.id),
+              ...diff.into.map((n) => n.id),
+            ],
+          };
+        }
+      }
+      break;
+    }
+    case 'reroute_edge': {
+      const node = nodes[diff.node_id];
+      if (node) {
+        nodes[diff.node_id] = {
+          ...node,
+          depends_on: node.depends_on.map((d) => (d === diff.old_dep ? diff.new_dep : d)),
+        };
+      }
+      break;
+    }
+    case 'set_role': {
+      // Role is not part of the TaskNode TS interface but keep for completeness.
+      break;
+    }
+    case 'set_tools': {
+      const node = nodes[diff.id];
+      if (node) {
+        nodes[diff.id] = { ...node, tool_allowlist: diff.tool_allowlist };
+      }
+      break;
+    }
+    case 'wrap_in_team': {
+      // Simplified: remove wrapped ids and add team node.
+      for (const id of diff.ids) {
+        delete nodes[id];
+      }
+      const teamNode: TaskNode = {
+        id: diff.team_id,
+        goal: diff.team_goal,
+        depends_on: [],
+        tool_allowlist: [],
+        status: 'pending',
+      };
+      nodes[diff.team_id] = teamNode;
+      break;
+    }
+  }
+
+  return { ...graph, nodes };
+}
+
+// ─── Diff summary rendering ───────────────────────────────────────────────────
+
+interface DiffBadgeProps {
+  label: string;
+  color: 'green' | 'red' | 'amber';
+}
+
+const DiffBadge: FC<DiffBadgeProps> = ({ label, color }) => {
+  const cls =
+    color === 'green'
+      ? 'bg-success/15 text-success border-success/30'
+      : color === 'red'
+        ? 'bg-danger/15 text-danger border-danger/30'
+        : 'bg-warning/15 text-warning border-warning/30';
+
+  return (
+    <span
+      className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium border ${cls}`}
+    >
+      {label}
+    </span>
+  );
+};
+
+function DiffPreview({ diff }: { diff: GraphDiff }) {
+  switch (diff.op) {
+    case 'add_node':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="ADD" color="green" />
+          <span className="text-sm text-text-secondary">
+            Node <code className="font-mono">{diff.node.id}</code>: {diff.node.goal}
+          </span>
+        </div>
+      );
+    case 'remove_node':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="REMOVE" color="red" />
+          <span className="text-sm text-text-secondary">
+            Node <code className="font-mono">{diff.id}</code>
+          </span>
+        </div>
+      );
+    case 'split_node':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="SPLIT" color="amber" />
+          <span className="text-sm text-text-secondary">
+            Node <code className="font-mono">{diff.id}</code> →{' '}
+            {diff.into.map((n) => n.id).join(', ')}
+          </span>
+        </div>
+      );
+    case 'reroute_edge':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="REROUTE" color="amber" />
+          <span className="text-sm text-text-secondary">
+            <code className="font-mono">{diff.node_id}</code> dep{' '}
+            <code className="font-mono">{diff.old_dep}</code> →{' '}
+            <code className="font-mono">{diff.new_dep}</code>
+          </span>
+        </div>
+      );
+    case 'set_role':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="ROLE" color="amber" />
+          <span className="text-sm text-text-secondary">
+            Node <code className="font-mono">{diff.id}</code> role →{' '}
+            {diff.role ?? 'none'}
+          </span>
+        </div>
+      );
+    case 'set_tools':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="TOOLS" color="amber" />
+          <span className="text-sm text-text-secondary">
+            Node <code className="font-mono">{diff.id}</code> allowlist →{' '}
+            [{diff.tool_allowlist.join(', ')}]
+          </span>
+        </div>
+      );
+    case 'wrap_in_team':
+      return (
+        <div className="flex items-start gap-sm">
+          <DiffBadge label="WRAP TEAM" color="green" />
+          <span className="text-sm text-text-secondary">
+            [{diff.ids.join(', ')}] →{' '}
+            <code className="font-mono">{diff.team_id}</code>: {diff.team_goal}
+          </span>
+        </div>
+      );
+    default:
+      return <span className="text-xs text-text-muted">(unknown diff op)</span>;
+  }
+}
+
+// ─── SteeringPanel ────────────────────────────────────────────────────────────
+
+export interface SteeringPanelProps {
+  graph: TaskGraph;
+  port: number;
+  model?: string;
+  onGraphChange: (newGraph: TaskGraph) => void;
+}
+
+const SteeringPanel: FC<SteeringPanelProps> = ({ graph, port, model, onGraphChange }) => {
+  const [instruction, setInstruction] = useState('');
+  const [pendingDiff, setPendingDiff] = useState<GraphDiff | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handlePreview() {
+    const trimmed = instruction.trim();
+    if (!trimmed) return;
+
+    setLoading(true);
+    setError(null);
+    setPendingDiff(null);
+
+    try {
+      const res = await fetch('/api/orchestrator/steer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ graph, instruction: trimmed, port, model }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        setError(`Request failed (${res.status}): ${text}`);
+        return;
+      }
+
+      const body = (await res.json()) as { diff: GraphDiff };
+      setPendingDiff(body.diff);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleApply() {
+    if (!pendingDiff) return;
+    onGraphChange(applyDiff(graph, pendingDiff));
+    setPendingDiff(null);
+    setInstruction('');
+  }
+
+  return (
+    <div className="flex flex-col gap-md" data-testid="steering-panel">
+      <div className="flex flex-col gap-sm">
+        <label className="text-sm font-medium text-text">Steering instruction</label>
+        <Textarea
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+          placeholder="e.g. Split the 'research' node into two parallel sub-tasks…"
+          rows={3}
+          aria-label="Steering instruction"
+        />
+      </div>
+
+      <div className="flex items-center gap-sm">
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handlePreview}
+          isLoading={loading}
+          disabled={!instruction.trim() || loading}
+        >
+          Preview diff
+        </Button>
+        {pendingDiff && (
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={() => setPendingDiff(null)}
+            disabled={loading}
+          >
+            Discard
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-sm text-danger" role="alert">
+          {error}
+        </p>
+      )}
+
+      {pendingDiff && (
+        <div
+          className="flex flex-col gap-sm rounded-base border border-border bg-surface p-md"
+          data-testid="diff-preview"
+        >
+          <span className="text-xs font-medium text-text-muted uppercase tracking-wide">
+            Proposed diff
+          </span>
+          <DiffPreview diff={pendingDiff} />
+          <Button variant="primary" size="sm" onClick={handleApply}>
+            Apply diff
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SteeringPanel;

--- a/src/types/orchestrator.ts
+++ b/src/types/orchestrator.ts
@@ -60,6 +60,7 @@ export type OrchestratorEvent =
   | PlanRejectedEvent
   | ReplanAttemptEvent
   | RunCostEstimateEvent
+  | SteeringAppliedEvent
   | AwaitingApprovalEvent
   | NodeStartedEvent
   | NodeTextDeltaEvent
@@ -243,6 +244,28 @@ export interface SubteamSpawnedEvent {
   type: 'subteam_spawned';
   parent_node_id: string;
   child_graph_summary: string;
+}
+
+// ─── GraphDiff (Phase K) ─────────────────────────────────────────────────────
+
+/**
+ * Mirrors `task_graph::GraphDiff` (Rust).
+ *
+ * Produced by `#[serde(tag = "op", rename_all = "snake_case")]`.
+ */
+export type GraphDiff =
+  | { op: 'add_node'; node: TaskNode }
+  | { op: 'remove_node'; id: string }
+  | { op: 'split_node'; id: string; into: TaskNode[] }
+  | { op: 'reroute_edge'; node_id: string; old_dep: string; new_dep: string }
+  | { op: 'set_role'; id: string; role: string | null }
+  | { op: 'set_tools'; id: string; tool_allowlist: string[] }
+  | { op: 'wrap_in_team'; ids: string[]; team_id: string; team_goal: string };
+
+export interface SteeringAppliedEvent {
+  type: 'steering_applied';
+  diff: GraphDiff;
+  applied_at_wave: number;
 }
 
 // ─── HITL / approval types ───────────────────────────────────────────────────

--- a/tests/ts/components/SteeringPanel.test.tsx
+++ b/tests/ts/components/SteeringPanel.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tests for SteeringPanel component and applyDiff pure helper.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SteeringPanel, { applyDiff } from '../../../src/pages/Orchestrator/components/SteeringPanel';
+import type { TaskGraph, GraphDiff, TaskNode } from '../../../src/types/orchestrator';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const nodeA: TaskNode = {
+  id: 'a',
+  goal: 'goal A',
+  depends_on: [],
+  tool_allowlist: [],
+  status: 'pending',
+};
+
+const nodeB: TaskNode = {
+  id: 'b',
+  goal: 'goal B',
+  depends_on: ['a'],
+  tool_allowlist: [],
+  status: 'pending',
+};
+
+const baseGraph: TaskGraph = {
+  goal: 'test goal',
+  nodes: { a: nodeA, b: nodeB },
+  hitl_mode: 'None',
+};
+
+// ─── applyDiff: AddNode ───────────────────────────────────────────────────────
+
+describe('applyDiff — add_node', () => {
+  it('adds the node to the graph', () => {
+    const newNode: TaskNode = { id: 'c', goal: 'goal C', depends_on: ['b'], tool_allowlist: [], status: 'pending' };
+    const diff: GraphDiff = { op: 'add_node', node: newNode };
+    const result = applyDiff(baseGraph, diff);
+    expect(result.nodes['c']).toEqual(newNode);
+    expect(Object.keys(result.nodes)).toHaveLength(3);
+  });
+});
+
+// ─── applyDiff: RemoveNode ────────────────────────────────────────────────────
+
+describe('applyDiff — remove_node', () => {
+  it('removes the node and strips outgoing edges', () => {
+    const diff: GraphDiff = { op: 'remove_node', id: 'a' };
+    const result = applyDiff(baseGraph, diff);
+    expect(result.nodes['a']).toBeUndefined();
+    expect(result.nodes['b'].depends_on).not.toContain('a');
+  });
+});
+
+// ─── applyDiff: SplitNode ─────────────────────────────────────────────────────
+
+describe('applyDiff — split_node', () => {
+  it('removes original and repoints dependants', () => {
+    const a1: TaskNode = { id: 'a1', goal: 'a1', depends_on: [], tool_allowlist: [], status: 'pending' };
+    const a2: TaskNode = { id: 'a2', goal: 'a2', depends_on: [], tool_allowlist: [], status: 'pending' };
+    const diff: GraphDiff = { op: 'split_node', id: 'a', into: [a1, a2] };
+    const result = applyDiff(baseGraph, diff);
+    expect(result.nodes['a']).toBeUndefined();
+    expect(result.nodes['a1']).toBeDefined();
+    expect(result.nodes['a2']).toBeDefined();
+    expect(result.nodes['b'].depends_on).toContain('a1');
+    expect(result.nodes['b'].depends_on).toContain('a2');
+  });
+});
+
+// ─── applyDiff: RerouteEdge ───────────────────────────────────────────────────
+
+describe('applyDiff — reroute_edge', () => {
+  it('replaces old dep with new dep in the target node', () => {
+    const nodeC: TaskNode = { id: 'c', goal: 'c', depends_on: [], tool_allowlist: [], status: 'pending' };
+    const g: TaskGraph = { ...baseGraph, nodes: { ...baseGraph.nodes, c: nodeC } };
+    const diff: GraphDiff = { op: 'reroute_edge', node_id: 'b', old_dep: 'a', new_dep: 'c' };
+    const result = applyDiff(g, diff);
+    expect(result.nodes['b'].depends_on).not.toContain('a');
+    expect(result.nodes['b'].depends_on).toContain('c');
+  });
+});
+
+// ─── applyDiff: SetTools ──────────────────────────────────────────────────────
+
+describe('applyDiff — set_tools', () => {
+  it('replaces the tool allowlist', () => {
+    const diff: GraphDiff = { op: 'set_tools', id: 'a', tool_allowlist: ['search', 'calc'] };
+    const result = applyDiff(baseGraph, diff);
+    expect(result.nodes['a'].tool_allowlist).toEqual(['search', 'calc']);
+  });
+});
+
+// ─── applyDiff: WrapInTeam ────────────────────────────────────────────────────
+
+describe('applyDiff — wrap_in_team', () => {
+  it('removes wrapped nodes and adds team node', () => {
+    const diff: GraphDiff = { op: 'wrap_in_team', ids: ['a', 'b'], team_id: 'team_ab', team_goal: 'combined' };
+    const result = applyDiff(baseGraph, diff);
+    expect(result.nodes['a']).toBeUndefined();
+    expect(result.nodes['b']).toBeUndefined();
+    expect(result.nodes['team_ab']).toBeDefined();
+    expect(result.nodes['team_ab'].goal).toBe('combined');
+  });
+});
+
+// ─── SteeringPanel: renders input and submit button ──────────────────────────
+
+describe('SteeringPanel rendering', () => {
+  const onGraphChange = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('renders the instruction textarea', () => {
+    render(
+      <SteeringPanel graph={baseGraph} port={9887} onGraphChange={onGraphChange} />
+    );
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('submit button is disabled when input is empty', () => {
+    render(
+      <SteeringPanel graph={baseGraph} port={9887} onGraphChange={onGraphChange} />
+    );
+    const button = screen.getByRole('button', { name: /preview/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('shows diff preview after successful fetch', async () => {
+    const diff: GraphDiff = { op: 'add_node', node: { id: 'c', goal: 'goal C', depends_on: [], tool_allowlist: [], status: 'pending' } };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ diff }),
+    });
+
+    render(
+      <SteeringPanel graph={baseGraph} port={9887} onGraphChange={onGraphChange} />
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'add a node c' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ADD/i)).toBeInTheDocument();
+    });
+  });
+
+  it('apply diff button calls onGraphChange', async () => {
+    const diff: GraphDiff = { op: 'remove_node', id: 'b' };
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ diff }),
+    });
+
+    render(
+      <SteeringPanel graph={baseGraph} port={9887} onGraphChange={onGraphChange} />
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'remove b' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }));
+
+    await waitFor(() => screen.getByText(/REMOVE/i));
+
+    fireEvent.click(screen.getByRole('button', { name: /apply diff/i }));
+    expect(onGraphChange).toHaveBeenCalledOnce();
+    const newGraph = onGraphChange.mock.calls[0][0] as TaskGraph;
+    expect(newGraph.nodes['b']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #507

## Summary

Implements Phase K of the orchestrator roadmap: **Conversational Steering** (side-channel note injection during a live run) and **GraphDiff Preview** (LLM-driven graph mutation with visual preview before apply).

---

## Changes

### Core (`gglib-core`)
- **`task_graph.rs`** — `GraphDiff` enum (`AddNode`, `RemoveNode`, `SplitNode`, `RerouteEdge`, `SetRole`, `SetTools`, `WrapInTeam`) tagged with `#[serde(tag = "op")]`; `apply_diff` with clone-and-swap rollback; `NodeNotFound` and `DiffInvalid` error variants

### Agent (`gglib-agent`)
- **`steering.rs`** (new) — `NoteQueue` type alias (`Arc<Mutex<Vec<String>>>`), `SteeringError`, `steering_call()` async fn that calls the LLM via `get_structured` with the diff JSON schema
- **`prompts.rs`** — `STEERING_SYSTEM_PROMPT` (with `<GRAPH_JSON>` placeholder) and `graph_diff_schema()`
- **`executor.rs`** — `note_queue: Option<NoteQueue>` in `OrchestratorConfig`; wave-drain loop at depth 0 applies steering notes before each wave; `run_wave_loop` takes `&mut TaskGraph`

### Axum (`gglib-axum`)
- **`bootstrap.rs`** — `steering_note_queues` registry on `AxumContext`
- **`run.rs`** — pre-generates `run_id`, creates + registers + cleans up `NoteQueue` after `execute()` completes
- **`steer.rs`** (new) — `POST /api/orchestrator/steer` — accepts `{ graph, instruction, port, model? }`, returns `{ diff: GraphDiff }`
- **`note.rs`** (new) — `POST /api/orchestrator/runs/{run_id}/note` — appends instruction to the in-flight run's queue; `202 Accepted` or `404` if run not found
- **`routes.rs`** — both new routes wired in

### Proxy + CLI
- `orchestrator_proxy.rs` + CLI `orchestrate.rs` — `SteeringApplied` event handled (no-output for proxy, brief `eprintln!` for CLI)

### Tauri (`src-tauri`)
- `main.rs` — `steering_note_queues` added to manually constructed `AxumContext`

### Frontend (`src/`)
- **`types/orchestrator.ts`** — `GraphDiff` discriminated union (7 variants) + `SteeringAppliedEvent`
- **`OrchestratorContext.tsx`** — `pendingDiff: GraphDiff | null` in `OrchestratorSession`; `SET_PENDING_DIFF` action + reducer case
- **`useOrchestrator.ts`** — `steering_applied` SSE event → `SET_PENDING_DIFF`
- **`SteeringPanel.tsx`** (new) — instruction textarea, `POST /api/orchestrator/steer` call, diff preview with colour-coded `DiffBadge` (green = add, red = remove, amber = reroute/modify), "Apply diff" / "Discard" buttons; exports `applyDiff` pure helper
- **`HitlApprovalModal.tsx`** — plan-edit section now uses `<SteeringPanel>` instead of raw JSON textarea

---

## Tests

| Suite | Count | Status |
|---|---|---|
| `crates/gglib-core/tests/apply_diff.rs` | 9 (7 happy-path + 2 error) | ✅ |
| `tests/ts/components/SteeringPanel.test.tsx` | 10 (`applyDiff` variants + component render/interaction) | ✅ |
| All existing Rust lib/bin tests | 293 | ✅ |
| All existing frontend tests | 613 | ✅ |
| `cargo clippy --all-targets -- -D warnings` | — | ✅ clean |
| `npx tsc --noEmit` | — | ✅ clean |