### PR TITLE
feat(mcp): replace auto_start bool with lifecycle enum (eager/lazy/manual)

### DIFF
--- a/crates/gglib-app-services/src/mcp.rs
+++ b/crates/gglib-app-services/src/mcp.rs
@@ -53,7 +53,7 @@ impl McpOps {
                 url: server.config.url.clone(),
             },
             enabled: server.enabled,
-            auto_start: server.auto_start,
+            lifecycle: server.lifecycle,
             env: server
                 .env
                 .iter()
@@ -132,7 +132,7 @@ impl McpOps {
                 })
                 .collect(),
             enabled: true,
-            auto_start: req.auto_start,
+            lifecycle: req.lifecycle,
         };
 
         let server = self
@@ -192,8 +192,8 @@ impl McpOps {
         if let Some(enabled) = req.enabled {
             server.enabled = enabled;
         }
-        if let Some(auto_start) = req.auto_start {
-            server.auto_start = auto_start;
+        if let Some(lifecycle) = req.lifecycle {
+            server.lifecycle = lifecycle;
         }
 
         self.mcp
@@ -286,6 +286,7 @@ mod tests {
     use std::sync::Arc;
 
     use gglib_core::ports::NoopEmitter;
+    use gglib_core::McpLifecycle;
     use gglib_db::CoreFactory;
 
     use super::*;
@@ -308,7 +309,7 @@ mod tests {
             path_extra: None,
             url: None,
             env: vec![],
-            auto_start: false,
+            lifecycle: McpLifecycle::Lazy,
         }
     }
 

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -3,6 +3,7 @@
 //! These types are cross-adapter (used by both Tauri and Axum).
 //! They map between domain types and frontend-friendly representations.
 
+use gglib_core::domain::mcp::McpLifecycle;
 use gglib_core::domain::Model;
 use gglib_core::ports::ProcessHandle;
 use serde::{Deserialize, Serialize};
@@ -326,7 +327,7 @@ pub struct McpServerDto {
     pub server_type: String,
     pub config: McpServerConfigDto,
     pub enabled: bool,
-    pub auto_start: bool,
+    pub lifecycle: McpLifecycle,
     pub env: Vec<McpEnvEntryDto>,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -400,7 +401,7 @@ pub struct CreateMcpServerRequest {
     #[serde(default)]
     pub env: Vec<McpEnvEntryDto>,
     #[serde(default)]
-    pub auto_start: bool,
+    pub lifecycle: McpLifecycle,
 }
 
 /// Request to update an MCP server.
@@ -414,7 +415,7 @@ pub struct UpdateMcpServerRequest {
     pub url: Option<String>,
     pub env: Option<Vec<McpEnvEntryDto>>,
     pub enabled: Option<bool>,
-    pub auto_start: Option<bool>,
+    pub lifecycle: Option<McpLifecycle>,
 }
 
 /// MCP tool information for GUI display.

--- a/crates/gglib-axum/tests/mcp_contract_test.rs
+++ b/crates/gglib-axum/tests/mcp_contract_test.rs
@@ -90,8 +90,8 @@ async fn test_list_mcp_servers_json_structure() {
             "server.enabled should exist"
         );
         assert!(
-            server_obj.get("auto_start").is_some(),
-            "server.auto_start should exist"
+            server_obj.get("lifecycle").is_some(),
+            "server.lifecycle should exist"
         );
 
         // Verify status is string or object
@@ -124,7 +124,7 @@ async fn test_add_mcp_server_returns_nested_structure() {
         "command": "node",
         "args": ["server.js"],
         "env": [],
-        "auto_start": false
+        "lifecycle": "lazy"
     });
 
     let response = app

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -107,6 +107,8 @@ pub async fn compose(
     if let Err(e) = ctx.mcp.initialize().await {
         tracing::warn!("MCP initialisation failed — tools may be unavailable: {e}");
     }
+    // Pre-warm lazy servers so they are ready before the first agent iteration.
+    ctx.mcp.prewarm_lazy().await;
 
     // 3. Compose the agent loop.  When tools are specified the loop is
     //    restricted to the named allowlist; otherwise all MCP tools are visible.

--- a/crates/gglib-cli/src/handlers/council/mod.rs
+++ b/crates/gglib-cli/src/handlers/council/mod.rs
@@ -136,6 +136,8 @@ async fn init_session(
     if let Err(e) = ctx.mcp.initialize().await {
         tracing::warn!("MCP initialisation failed: {e}");
     }
+    // Pre-warm lazy servers so they are ready before the council run.
+    ctx.mcp.prewarm_lazy().await;
 
     let cwd = std::env::current_dir().ok();
 

--- a/crates/gglib-cli/src/handlers/mcp_cli.rs
+++ b/crates/gglib-cli/src/handlers/mcp_cli.rs
@@ -4,7 +4,7 @@
 //! lives here, only CLI input parsing and output formatting.
 
 use anyhow::{Result, anyhow, bail};
-use gglib_core::domain::mcp::{McpServerStatus, McpServerType, NewMcpServer};
+use gglib_core::domain::mcp::{McpLifecycle, McpServerStatus, McpServerType, NewMcpServer};
 
 use crate::bootstrap::CliContext;
 use crate::mcp_commands::McpCommand;
@@ -24,7 +24,7 @@ pub async fn dispatch(ctx: &CliContext, cmd: McpCommand) -> Result<()> {
             working_dir,
             path_extra,
             env,
-            auto_start,
+            lifecycle,
             disabled,
         } => {
             add(
@@ -37,7 +37,7 @@ pub async fn dispatch(ctx: &CliContext, cmd: McpCommand) -> Result<()> {
                 working_dir.as_deref(),
                 path_extra,
                 &env,
-                auto_start,
+                lifecycle,
                 disabled,
             )
             .await
@@ -66,7 +66,7 @@ async fn list(ctx: &CliContext) -> Result<()> {
     println!("Found {} MCP server(s):\n", servers.len());
     println!(
         "{:<4} {:<25} {:<6} {:<9} {:<11} {:<10} {:<6}",
-        "ID", "Name", "Type", "Enabled", "Auto-start", "Status", "Tools"
+        "ID", "Name", "Type", "Enabled", "Lifecycle", "Status", "Tools"
     );
     print_separator(75);
 
@@ -83,7 +83,7 @@ async fn list(ctx: &CliContext) -> Result<()> {
             McpServerStatus::Error(e) => format!("error: {}", truncate_string(e, 20)),
         };
         let enabled_str = if s.enabled { "yes" } else { "no" };
-        let auto_str = if s.auto_start { "yes" } else { "no" };
+        let lifecycle_str = s.lifecycle.to_string();
 
         println!(
             "{:<4} {:<25} {:<6} {:<9} {:<11} {:<10} {:<6}",
@@ -91,7 +91,7 @@ async fn list(ctx: &CliContext) -> Result<()> {
             truncate_string(&s.name, 24),
             type_str,
             enabled_str,
-            auto_str,
+            lifecycle_str,
             truncate_string(&status_str, 9),
             info.tools.len()
         );
@@ -111,7 +111,7 @@ async fn add(
     working_dir: Option<&str>,
     path_extra: Option<String>,
     env_pairs: &[String],
-    auto_start: bool,
+    lifecycle: String,
     disabled: bool,
 ) -> Result<()> {
     let mut new_server = match server_type {
@@ -130,7 +130,10 @@ async fn add(
     if let Some(dir) = working_dir {
         new_server = new_server.with_working_dir(dir);
     }
-    new_server = new_server.with_auto_start(auto_start);
+    let parsed_lifecycle = lifecycle
+        .parse::<McpLifecycle>()
+        .map_err(|e| anyhow!("Invalid --lifecycle value: {e}"))?;
+    new_server = new_server.with_lifecycle(parsed_lifecycle);
     if disabled {
         new_server = new_server.with_enabled(false);
     }
@@ -239,7 +242,7 @@ async fn test(ctx: &CliContext, identifier: &str) -> Result<()> {
         server_type: server.server_type,
         config: server.config.clone(),
         enabled: server.enabled,
-        auto_start: server.auto_start,
+        lifecycle: server.lifecycle,
         env: server.env.clone(),
     };
 

--- a/crates/gglib-cli/src/mcp_commands.rs
+++ b/crates/gglib-cli/src/mcp_commands.rs
@@ -44,9 +44,10 @@ pub enum McpCommand {
         #[arg(long, value_name = "KEY=VALUE")]
         env: Vec<String>,
 
-        /// Auto-start this server when gglib launches
-        #[arg(long)]
-        auto_start: bool,
+        /// Lifecycle policy: how gglib manages this server's process.
+        /// eager = start at host init; lazy = start on first tool use; manual = never auto-spawn.
+        #[arg(long, value_name = "LIFECYCLE", default_value = "lazy", value_parser = ["eager", "lazy", "manual"])]
+        lifecycle: String,
 
         /// Disable this server (tools not included in chat)
         #[arg(long)]

--- a/crates/gglib-core/src/domain/mcp/mod.rs
+++ b/crates/gglib-core/src/domain/mcp/mod.rs
@@ -10,6 +10,7 @@
 //! - `McpServerConfig` - Execution configuration (`exe_path`, args, URL, `path_extra`)
 //! - `McpServerType` - Connection type (stdio or SSE)
 //! - `McpServerStatus` - Runtime status (stopped, starting, running, error)
+//! - `McpLifecycle` - Startup lifecycle policy (eager, lazy, manual)
 //! - `McpEnvEntry` - Environment variable entry
 //! - `McpTool` - Tool exposed by an MCP server
 //! - `McpToolResult` - Result of a tool invocation
@@ -17,6 +18,6 @@
 mod types;
 
 pub use types::{
-    McpEnvEntry, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
-    McpToolResult, NewMcpServer, UpdateMcpServer,
+    McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType,
+    McpTool, McpToolResult, NewMcpServer, UpdateMcpServer,
 };

--- a/crates/gglib-core/src/domain/mcp/types.rs
+++ b/crates/gglib-core/src/domain/mcp/types.rs
@@ -5,6 +5,49 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Startup lifecycle policy for an MCP server.
+///
+/// Controls when gglib automatically starts the server process.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpLifecycle {
+    /// Start the server at host initialisation (proxy startup, GUI launch, web server boot).
+    /// Use for servers that are always needed or have a slow cold start.
+    Eager,
+    /// Start the server on first tool use; keep it running until the host exits.
+    /// This is the default: no background process until something actually needs the server.
+    #[default]
+    Lazy,
+    /// Never start automatically. The server must be started explicitly via the
+    /// CLI (`gglib mcp start`), the REST API, or the GUI.
+    Manual,
+}
+
+impl std::fmt::Display for McpLifecycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Eager => write!(f, "eager"),
+            Self::Lazy => write!(f, "lazy"),
+            Self::Manual => write!(f, "manual"),
+        }
+    }
+}
+
+impl std::str::FromStr for McpLifecycle {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "eager" => Ok(Self::Eager),
+            "lazy" => Ok(Self::Lazy),
+            "manual" => Ok(Self::Manual),
+            other => Err(format!(
+                "unknown lifecycle '{other}'; expected eager, lazy, or manual"
+            )),
+        }
+    }
+}
+
 /// Type of MCP server connection.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -189,8 +232,8 @@ pub struct McpServer {
     /// Whether tools from this server are included in chat.
     pub enabled: bool,
 
-    /// Whether to start this server when gglib launches.
-    pub auto_start: bool,
+    /// Startup lifecycle policy: when this server is automatically started.
+    pub lifecycle: McpLifecycle,
 
     /// Environment variables for the server process.
     pub env: Vec<McpEnvEntry>,
@@ -229,8 +272,8 @@ pub struct NewMcpServer {
     /// Whether tools from this server are included in chat.
     pub enabled: bool,
 
-    /// Whether to start this server when gglib launches.
-    pub auto_start: bool,
+    /// Startup lifecycle policy: when this server is automatically started.
+    pub lifecycle: McpLifecycle,
 
     /// Environment variables for the server process.
     pub env: Vec<McpEnvEntry>,
@@ -250,7 +293,7 @@ impl NewMcpServer {
             server_type: McpServerType::Stdio,
             config: McpServerConfig::stdio(exe_path, args, None, path_extra),
             enabled: true,
-            auto_start: false,
+            lifecycle: McpLifecycle::Lazy,
             env: Vec::new(),
         }
     }
@@ -263,7 +306,7 @@ impl NewMcpServer {
             server_type: McpServerType::Sse,
             config: McpServerConfig::sse(url),
             enabled: true,
-            auto_start: false,
+            lifecycle: McpLifecycle::Lazy,
             env: Vec::new(),
         }
     }
@@ -282,10 +325,10 @@ impl NewMcpServer {
         self
     }
 
-    /// Set auto-start.
+    /// Set the startup lifecycle policy.
     #[must_use]
-    pub const fn with_auto_start(mut self, auto_start: bool) -> Self {
-        self.auto_start = auto_start;
+    pub const fn with_lifecycle(mut self, lifecycle: McpLifecycle) -> Self {
+        self.lifecycle = lifecycle;
         self
     }
 
@@ -318,9 +361,9 @@ pub struct UpdateMcpServer {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 
-    /// Whether to start this server when gglib launches.
+    /// Startup lifecycle policy: when this server is automatically started.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_start: Option<bool>,
+    pub lifecycle: Option<McpLifecycle>,
 
     /// Environment variables for the server process.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/gglib-core/src/domain/mcp/types.rs
+++ b/crates/gglib-core/src/domain/mcp/types.rs
@@ -466,7 +466,7 @@ mod tests {
             None,
         )
         .with_env("API_KEY", "secret123")
-        .with_auto_start(true);
+        .with_lifecycle(McpLifecycle::Eager);
 
         assert_eq!(server.name, "Test Server");
         assert_eq!(server.server_type, McpServerType::Stdio);
@@ -474,7 +474,7 @@ mod tests {
         assert_eq!(server.env.len(), 1);
         assert_eq!(server.env[0].key, "API_KEY");
         assert_eq!(server.env[0].value, "secret123");
-        assert!(server.auto_start);
+        assert_eq!(server.lifecycle, McpLifecycle::Eager);
     }
 
     #[test]

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -32,8 +32,8 @@ pub use inference::InferenceConfig;
 
 // Re-export MCP types at the domain level for convenience
 pub use mcp::{
-    McpEnvEntry, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
-    McpToolResult, NewMcpServer, UpdateMcpServer,
+    McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType,
+    McpTool, McpToolResult, NewMcpServer, UpdateMcpServer,
 };
 
 // Re-export chat types at the domain level for convenience

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -19,9 +19,10 @@ pub use domain::{
     AssistantContent, ChatMessage, Conversation, ConversationUpdate, DEFAULT_MAX_ITERATIONS,
     DEFAULT_MAX_PARALLEL_TOOLS, DEFAULT_MAX_STAGNATION_STEPS, LlmStreamEvent,
     MAX_ITERATIONS_CEILING, MAX_PARALLEL_TOOLS_CEILING, MAX_TOOL_TIMEOUT_MS_CEILING,
-    MIN_CONTEXT_BUDGET_CHARS, MIN_TOOL_TIMEOUT_MS, McpEnvEntry, McpServer, McpServerConfig,
-    McpServerStatus, McpServerType, McpTool, McpToolResult, Message, MessageRole, Model,
-    ModelCapabilities, ModelFilterOptions, NewConversation, NewMcpServer, NewMessage, NewModel,
+    MIN_CONTEXT_BUDGET_CHARS, MIN_TOOL_TIMEOUT_MS, McpEnvEntry, McpLifecycle, McpServer,
+    McpServerConfig, McpServerStatus, McpServerType, McpTool, McpToolResult, Message, MessageRole,
+    Model, ModelCapabilities, ModelFilterOptions, NewConversation, NewMcpServer, NewMessage,
+    NewModel,
     RangeValues, ToolCall, ToolDefinition, ToolResult, UpdateMcpServer, infer_from_chat_template,
     transform_messages_for_capabilities,
 };

--- a/crates/gglib-db/src/factory.rs
+++ b/crates/gglib-db/src/factory.rs
@@ -216,7 +216,7 @@ impl TestDb {
                 name TEXT NOT NULL,
                 type TEXT NOT NULL CHECK (type IN ('stdio', 'sse')),
                 enabled INTEGER NOT NULL DEFAULT 1,
-                auto_start INTEGER NOT NULL DEFAULT 0,
+                lifecycle TEXT NOT NULL DEFAULT 'lazy' CHECK (lifecycle IN ('eager', 'lazy', 'manual')),
                 exe_path TEXT,
                 args TEXT,
                 cwd TEXT,

--- a/crates/gglib-db/src/repositories/sqlite_mcp_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_mcp_repository.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use sqlx::SqlitePool;
 
 use gglib_core::domain::mcp::{
-    McpEnvEntry, McpServer, McpServerConfig, McpServerType, NewMcpServer,
+    McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerType, NewMcpServer,
 };
 use gglib_core::ports::{McpRepositoryError, McpServerRepository};
 
@@ -38,7 +38,7 @@ struct McpServerRow {
     #[sqlx(rename = "type")]
     server_type: String,
     enabled: bool,
-    auto_start: bool,
+    lifecycle: String,
     command: Option<String>,
     resolved_path_cache: Option<String>,
     args: Option<String>,
@@ -93,7 +93,7 @@ fn row_to_server(row: McpServerRow, env: Vec<McpEnvEntry>) -> McpServer {
         server_type,
         config,
         enabled: row.enabled,
-        auto_start: row.auto_start,
+        lifecycle: row.lifecycle.parse::<McpLifecycle>().unwrap_or_default(),
         env,
         created_at: parse_datetime(&row.created_at),
         last_connected_at: row.last_connected_at.as_ref().map(|s| parse_datetime(s)),
@@ -148,14 +148,14 @@ impl McpServerRepository for SqliteMcpRepository {
         // Insert the server
         let result = sqlx::query(
             r#"
-            INSERT INTO mcp_servers (name, type, enabled, auto_start, command, resolved_path_cache, args, cwd, path_extra, url, is_valid, last_error)
+            INSERT INTO mcp_servers (name, type, enabled, lifecycle, command, resolved_path_cache, args, cwd, path_extra, url, is_valid, last_error)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(&server.name)
         .bind(server_type)
         .bind(server.enabled)
-        .bind(server.auto_start)
+        .bind(server.lifecycle.to_string())
         .bind(&server.config.command)
         .bind(&server.config.resolved_path_cache)
         .bind(&args_json)
@@ -190,7 +190,7 @@ impl McpServerRepository for SqliteMcpRepository {
     async fn get_by_id(&self, id: i64) -> Result<McpServer, McpRepositoryError> {
         let row = sqlx::query_as::<_, McpServerRow>(
             r#"
-            SELECT id, name, type, enabled, auto_start, command, resolved_path_cache, args, cwd, path_extra, url, 
+            SELECT id, name, type, enabled, lifecycle, command, resolved_path_cache, args, cwd, path_extra, url, 
                    created_at, last_connected_at, is_valid, last_error
             FROM mcp_servers WHERE id = ?
             "#,
@@ -210,7 +210,7 @@ impl McpServerRepository for SqliteMcpRepository {
     async fn get_by_name(&self, name: &str) -> Result<McpServer, McpRepositoryError> {
         let row = sqlx::query_as::<_, McpServerRow>(
             r#"
-            SELECT id, name, type, enabled, auto_start, command, resolved_path_cache, args, cwd, path_extra, url, 
+            SELECT id, name, type, enabled, lifecycle, command, resolved_path_cache, args, cwd, path_extra, url, 
                    created_at, last_connected_at, is_valid, last_error
             FROM mcp_servers WHERE name = ?
             "#,
@@ -230,7 +230,7 @@ impl McpServerRepository for SqliteMcpRepository {
     async fn list(&self) -> Result<Vec<McpServer>, McpRepositoryError> {
         let rows = sqlx::query_as::<_, McpServerRow>(
             r#"
-            SELECT id, name, type, enabled, auto_start, command, resolved_path_cache, args, cwd, path_extra, url, 
+            SELECT id, name, type, enabled, lifecycle, command, resolved_path_cache, args, cwd, path_extra, url, 
                    created_at, last_connected_at, is_valid, last_error
             FROM mcp_servers ORDER BY name
             "#,
@@ -267,14 +267,14 @@ impl McpServerRepository for SqliteMcpRepository {
         sqlx::query(
             r#"
             UPDATE mcp_servers 
-            SET name = ?, type = ?, enabled = ?, auto_start = ?, command = ?, resolved_path_cache = ?, args = ?, cwd = ?, path_extra = ?, url = ?, is_valid = ?, last_error = ?
+            SET name = ?, type = ?, enabled = ?, lifecycle = ?, command = ?, resolved_path_cache = ?, args = ?, cwd = ?, path_extra = ?, url = ?, is_valid = ?, last_error = ?
             WHERE id = ?
             "#,
         )
         .bind(&server.name)
         .bind(server_type)
         .bind(server.enabled)
-        .bind(server.auto_start)
+        .bind(server.lifecycle.to_string())
         .bind(&server.config.command)
         .bind(&server.config.resolved_path_cache)
         .bind(&args_json)
@@ -380,7 +380,7 @@ mod tests {
                 name TEXT NOT NULL UNIQUE,
                 type TEXT NOT NULL CHECK (type IN ('stdio', 'sse')),
                 enabled INTEGER NOT NULL DEFAULT 1,
-                auto_start INTEGER NOT NULL DEFAULT 0,
+                lifecycle TEXT NOT NULL DEFAULT 'lazy' CHECK (lifecycle IN ('eager', 'lazy', 'manual')),
                 command TEXT,
                 resolved_path_cache TEXT,
                 args TEXT,

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -244,7 +244,7 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
             name TEXT NOT NULL,
             type TEXT NOT NULL CHECK (type IN ('stdio', 'sse')),
             enabled INTEGER NOT NULL DEFAULT 1,
-            auto_start INTEGER NOT NULL DEFAULT 0,
+            lifecycle TEXT NOT NULL DEFAULT 'lazy' CHECK (lifecycle IN ('eager', 'lazy', 'manual')),
             command TEXT,
             resolved_path_cache TEXT,
             args TEXT NOT NULL DEFAULT '[]',

--- a/crates/gglib-mcp/README.md
+++ b/crates/gglib-mcp/README.md
@@ -178,7 +178,7 @@ Path validation and environment utilities:
 use std::sync::Arc;
 use gglib_mcp::McpService;
 use gglib_core::ports::{McpServerRepository, AppEventEmitter, NoopEmitter};
-use gglib_core::domain::mcp::{NewMcpServer, McpServerType, McpServerConfig};
+use gglib_core::domain::mcp::{NewMcpServer, McpLifecycle, McpServerType, McpServerConfig};
 
 async fn example(repo: impl McpServerRepository + 'static) {
     // Create service with injected dependencies
@@ -195,7 +195,7 @@ async fn example(repo: impl McpServerRepository + 'static) {
             None,
         ),
         enabled: true,
-        auto_start: false,
+        lifecycle: McpLifecycle::Lazy,
         env: vec![],
     }).await.unwrap();
 

--- a/crates/gglib-mcp/src/lib.rs
+++ b/crates/gglib-mcp/src/lib.rs
@@ -13,8 +13,8 @@ pub mod tool_executor;
 
 // Re-export domain types from core for convenience
 pub use gglib_core::{
-    McpEnvEntry, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
-    McpToolResult, NewMcpServer,
+    McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType,
+    McpTool, McpToolResult, NewMcpServer,
 };
 // Re-export DTOs from core ports
 pub use gglib_core::ports::{ResolutionAttempt, ResolutionStatus};

--- a/crates/gglib-mcp/src/manager.rs
+++ b/crates/gglib-mcp/src/manager.rs
@@ -50,6 +50,9 @@ struct RunningServer {
 pub struct McpManager {
     /// Running servers indexed by server ID
     servers: Arc<RwLock<HashMap<i64, RunningServer>>>,
+    /// Per-server start locks: serialise concurrent lazy starts for the same server.
+    /// Prevents double-spawn when multiple requests hit the same unstarted server.
+    start_locks: Arc<RwLock<HashMap<i64, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
 impl McpManager {
@@ -57,7 +60,44 @@ impl McpManager {
     pub fn new() -> Self {
         Self {
             servers: Arc::new(RwLock::new(HashMap::new())),
+            start_locks: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Start an MCP server, deduplicating concurrent calls for the same server ID.
+    ///
+    /// Unlike `start_server`, this is safe to call from multiple tasks simultaneously.
+    /// The per-server mutex ensures only one spawn happens regardless of concurrency.
+    /// If the server is already running when the lock is acquired, returns its current
+    /// tools without spawning a new process.
+    pub async fn ensure_started(&self, server: McpServer) -> Result<Vec<McpTool>, McpManagerError> {
+        let server_id = server.id;
+
+        // Get or create the per-server start lock (fast read path first).
+        let lock = {
+            let locks = self.start_locks.read().await;
+            if let Some(l) = locks.get(&server_id) {
+                Arc::clone(l)
+            } else {
+                drop(locks);
+                let mut locks = self.start_locks.write().await;
+                Arc::clone(
+                    locks
+                        .entry(server_id)
+                        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+                )
+            }
+        };
+
+        // Serialise concurrent starts for this specific server.
+        let _guard = lock.lock().await;
+
+        // Double-check: another waiter may have just started it.
+        if self.is_running(server_id).await {
+            return Ok(self.get_tools(server_id).await.unwrap_or_default());
+        }
+
+        self.start_server(server).await
     }
 
     /// Start an MCP server.

--- a/crates/gglib-mcp/src/service.rs
+++ b/crates/gglib-mcp/src/service.rs
@@ -6,8 +6,8 @@
 use crate::manager::McpManager;
 use gglib_core::ports::{ResolutionAttempt, ResolutionStatus};
 use gglib_core::{
-    AppEvent, AppEventEmitter, McpErrorInfo, McpServer, McpServerRepository, McpServerStatus,
-    McpServiceError, McpTool, McpToolResult, NewMcpServer,
+    AppEvent, AppEventEmitter, McpErrorInfo, McpLifecycle, McpServer, McpServerRepository,
+    McpServerStatus, McpServiceError, McpTool, McpToolResult, NewMcpServer,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -47,32 +47,67 @@ impl McpService {
         }
     }
 
-    /// Initialize the MCP service (starts auto-start servers).
+    /// Initialize the MCP service: validates all servers and starts `Eager` ones.
+    ///
+    /// `Lazy` servers start on first tool use (see `ensure_started_for_call`).
+    /// `Manual` servers are never started automatically.
+    /// For one-shot commands that need all tools available immediately, call
+    /// `prewarm_lazy` immediately after this.
     pub async fn initialize(&self) -> Result<(), McpServiceError> {
         // First, validate all servers and update their status
         self.validate_all_servers().await?;
 
-        // Then start auto-start servers (skipping invalid ones)
+        // Start only Eager servers (Lazy: on-demand, Manual: never).
         let servers = self.repository.list().await?;
         for server in servers {
-            if server.auto_start && server.enabled && server.is_valid {
+            if server.lifecycle == McpLifecycle::Eager && server.enabled && server.is_valid {
                 if let Err(e) = self.start_server(server.id).await {
                     tracing::warn!(
                         server_name = %server.name,
                         error = %e,
-                        "Failed to auto-start MCP server"
+                        "Failed to start eager MCP server"
                     );
                 }
-            } else if server.auto_start && server.enabled && !server.is_valid {
+            } else if server.lifecycle == McpLifecycle::Eager
+                && server.enabled
+                && !server.is_valid
+            {
                 tracing::info!(
                     server_name = %server.name,
                     error = ?server.last_error,
-                    "Skipping auto-start for invalid MCP server"
+                    "Skipping eager start for invalid MCP server"
                 );
             }
         }
 
         Ok(())
+    }
+
+    /// Pre-warm all `Lazy` servers.
+    ///
+    /// One-shot CLI commands (`gglib q`, orchestrate, plan, council) call this
+    /// right after `initialize` so that tools are ready before generation begins,
+    /// avoiding per-tool spawn latency mid-stream.
+    pub async fn prewarm_lazy(&self) {
+        let servers = match self.repository.list().await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to list servers for lazy prewarm");
+                return;
+            }
+        };
+
+        for server in servers {
+            if server.lifecycle == McpLifecycle::Lazy && server.enabled && server.is_valid {
+                if let Err(e) = self.start_server(server.id).await {
+                    tracing::warn!(
+                        server_name = %server.name,
+                        error = %e,
+                        "Failed to prewarm lazy MCP server"
+                    );
+                }
+            }
+        }
     }
 
     /// Validate all MCP servers and update their `is_valid/last_error` status.
@@ -629,16 +664,56 @@ impl McpService {
     }
 
     /// Call a tool on a server.
+    ///
+    /// For `Lazy` servers that are not yet running, this triggers an automatic start
+    /// (deduplicated across concurrent callers via a per-server mutex in the manager).
+    /// For `Manual` servers that are not running, this returns a tool-level error so
+    /// the model can recover gracefully rather than receiving a transport failure.
     pub async fn call_tool(
         &self,
         server_id: i64,
         tool_name: &str,
         arguments: HashMap<String, serde_json::Value>,
     ) -> Result<McpToolResult, McpServiceError> {
+        // Ensure the server is running, honouring its lifecycle policy.
+        if let Err(e) = self.ensure_started_for_call(server_id).await {
+            return Ok(McpToolResult {
+                success: false,
+                data: None,
+                error: Some(e.to_string()),
+            });
+        }
+
         self.manager
             .call_tool(server_id, tool_name, arguments)
             .await
             .map_err(|e| McpServiceError::ToolError(e.to_string()))
+    }
+
+    /// Ensure a server is running before a tool call, honouring its lifecycle policy.
+    ///
+    /// - Already running → no-op.
+    /// - `Eager` or `Lazy`, not running → attempt to start (via `McpManager::ensure_started`).
+    /// - `Manual`, not running → return an error (caller converts to a tool-level error).
+    async fn ensure_started_for_call(&self, server_id: i64) -> Result<(), McpServiceError> {
+        if self.manager.is_running(server_id).await {
+            return Ok(());
+        }
+
+        let server = self.repository.get_by_id(server_id).await?;
+
+        match server.lifecycle {
+            McpLifecycle::Manual => Err(McpServiceError::NotRunning(format!(
+                "Server '{}' is configured as manual and must be started explicitly",
+                server.name
+            ))),
+            McpLifecycle::Eager | McpLifecycle::Lazy => self
+                .manager
+                .ensure_started(server)
+                .await
+                .map(|_| ())
+                .map_err(|e| McpServiceError::StartFailed(e.to_string())),
+        }
     }
 
     // =========================================================================
@@ -662,7 +737,7 @@ impl McpService {
             server_type: new_server.server_type,
             config: new_server.config,
             enabled: new_server.enabled,
-            auto_start: new_server.auto_start,
+            lifecycle: new_server.lifecycle,
             env: new_server.env,
             created_at: chrono::Utc::now(),
             last_connected_at: None,
@@ -724,7 +799,7 @@ mod tests {
                 server_type: new_server.server_type,
                 config: new_server.config,
                 enabled: new_server.enabled,
-                auto_start: new_server.auto_start,
+                lifecycle: new_server.lifecycle,
                 env: new_server.env,
                 created_at: chrono::Utc::now(),
                 last_connected_at: None,

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -80,7 +80,19 @@ pub async fn start_proxy_standalone(
     }
 
     // Gather MCP counts for banner
-    let server_count = mcp.list_servers().await.map(|s| s.len()).unwrap_or(0);
+    let servers = mcp.list_servers().await.unwrap_or_default();
+    let eager_count = servers
+        .iter()
+        .filter(|s| s.lifecycle == gglib_core::McpLifecycle::Eager)
+        .count();
+    let lazy_count = servers
+        .iter()
+        .filter(|s| s.lifecycle == gglib_core::McpLifecycle::Lazy)
+        .count();
+    let manual_count = servers
+        .iter()
+        .filter(|s| s.lifecycle == gglib_core::McpLifecycle::Manual)
+        .count();
     let tools = mcp.list_all_tools().await;
     let tool_count: usize = tools.iter().map(|(_, v)| v.len()).sum();
 
@@ -92,8 +104,14 @@ pub async fn start_proxy_standalone(
     println!("  Port:            {}", port);
     println!("  Llama base port: {}", llama_base_port);
     println!("  Default context: {}", default_context);
-    println!("  MCP servers:     {}", server_count);
-    println!("  MCP tools:       {}", tool_count);
+    println!(
+        "  MCP servers:     {} (eager: {}, lazy: {}, manual: {})",
+        servers.len(),
+        eager_count,
+        lazy_count,
+        manual_count
+    );
+    println!("  MCP tools:       {} (eager-started)", tool_count);
     println!();
 
     let addr = supervisor

--- a/src/components/AddMcpServerModal.tsx
+++ b/src/components/AddMcpServerModal.tsx
@@ -38,7 +38,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
   const [pathExtra, setPathExtra] = useState("");
   const [url, setUrl] = useState("");
   const [envVars, setEnvVars] = useState<[string, string][]>([]);
-  const [autoStart, setAutoStart] = useState(false);
+  const [lifecycle, setLifecycle] = useState<'eager' | 'lazy' | 'manual'>('lazy');
   const [enabled, setEnabled] = useState(true);
 
   const [saving, setSaving] = useState(false);
@@ -58,7 +58,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         setPathExtra(srv.config.path_extra || "");
         setUrl(srv.config.url || "");
         setEnvVars(srv.env.map(e => [e.key, e.value] as [string, string]));
-        setAutoStart(srv.auto_start);
+        setLifecycle(srv.lifecycle);
         setEnabled(srv.enabled);
       } else {
         // Reset for new server
@@ -70,7 +70,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         setPathExtra("");
         setUrl("");
         setEnvVars([]);
-        setAutoStart(false);
+        setLifecycle('lazy');
         setEnabled(true);
       }
       setError(null);
@@ -139,7 +139,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         name: name.trim(),
         server_type: serverType,
         enabled,
-        auto_start: autoStart,
+        lifecycle,
         env: envVars
           .filter(([key]) => key.trim())
           .map(([key, value]): McpEnvEntry => ({ key, value })),
@@ -165,7 +165,7 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
         setSaving(false);
       }
     },
-    [name, serverType, command, args, workingDir, pathExtra, url, envVars, autoStart, enabled, onSave, onClose]
+    [name, serverType, command, args, workingDir, pathExtra, url, envVars, lifecycle, enabled, onSave, onClose]
   );
 
   if (!isOpen) return null;
@@ -251,15 +251,20 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
 
             {/* Options */}
             <Stack gap="xs">
-              <label className="flex items-center gap-sm text-sm text-text cursor-pointer [&>input]:m-0 [&>input]:w-4 [&>input]:h-4 [&>input]:accent-primary">
-                <input
-                  type="checkbox"
-                  checked={autoStart}
-                  onChange={(e) => setAutoStart(e.target.checked)}
-                  disabled={saving}
-                />
-                <span>Auto-start when app launches</span>
+              <label className="text-sm font-semibold text-text" htmlFor="mcp-lifecycle">
+                Lifecycle
               </label>
+              <select
+                id="mcp-lifecycle"
+                value={lifecycle}
+                onChange={(e) => setLifecycle(e.target.value as 'eager' | 'lazy' | 'manual')}
+                disabled={saving}
+                className="rounded-base border border-input-border bg-input px-sm py-xs text-sm text-text focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                <option value="lazy">Lazy — start on first tool use</option>
+                <option value="eager">Eager — start when app launches</option>
+                <option value="manual">Manual — never auto-spawn</option>
+              </select>
               <label className="flex items-center gap-sm text-sm text-text cursor-pointer [&>input]:m-0 [&>input]:w-4 [&>input]:h-4 [&>input]:accent-primary">
                 <input
                   type="checkbox"

--- a/src/services/clients/mcp.ts
+++ b/src/services/clients/mcp.ts
@@ -118,7 +118,7 @@ export function createStdioConfig(
       path_extra,
     },
     enabled: true,
-    auto_start: false,
+    lifecycle: 'lazy' as const,
     env,
   };
 }
@@ -138,7 +138,7 @@ export function createSseConfig(
       url,
     },
     enabled: true,
-    auto_start: false,
+    lifecycle: 'lazy' as const,
     env,
   };
 }

--- a/src/services/transport/api/mcp.ts
+++ b/src/services/transport/api/mcp.ts
@@ -36,7 +36,7 @@ export async function addMcpServer(server: NewMcpServer): Promise<McpServer> {
     path_extra: server.config.path_extra || undefined,
     url: server.config.url || undefined,
     env: server.env.map(e => [e.key, e.value] as [string, string]),
-    auto_start: server.auto_start,
+    lifecycle: server.lifecycle,
   };
   return post<McpServer>('/api/mcp/servers', request);
 }
@@ -60,7 +60,7 @@ export async function updateMcpServer(
     request.env = updates.env.map(e => [e.key, e.value] as [string, string]);
   }
   if (updates.enabled !== undefined) request.enabled = updates.enabled;
-  if (updates.auto_start !== undefined) request.auto_start = updates.auto_start;
+  if (updates.lifecycle !== undefined) request.lifecycle = updates.lifecycle;
   
   return put<McpServer>(`/api/mcp/servers/${id}`, request);
 }

--- a/src/services/transport/types/mcp.ts
+++ b/src/services/transport/types/mcp.ts
@@ -41,6 +41,8 @@ export interface McpServerConfig {
   url?: string;
 }
 
+export type McpLifecycle = 'eager' | 'lazy' | 'manual';
+
 /**
  * MCP server entity.
  */
@@ -50,7 +52,7 @@ export interface McpServer {
   server_type: McpServerType;
   config: McpServerConfig;
   enabled: boolean;
-  auto_start: boolean;
+  lifecycle: McpLifecycle;
   env: McpEnvEntry[];
   created_at: string;
   last_connected_at?: string;
@@ -68,7 +70,7 @@ export interface NewMcpServer {
   server_type: McpServerType;
   config: McpServerConfig;
   enabled: boolean;
-  auto_start: boolean;
+  lifecycle: McpLifecycle;
   env: McpEnvEntry[];
 }
 
@@ -81,7 +83,7 @@ export interface UpdateMcpServer {
   server_type?: McpServerType;
   config?: McpServerConfig;
   enabled?: boolean;
-  auto_start?: boolean;
+  lifecycle?: McpLifecycle;
   env?: McpEnvEntry[];
 }
 

--- a/tests/ts/hooks/useMcpServers.test.ts
+++ b/tests/ts/hooks/useMcpServers.test.ts
@@ -51,7 +51,7 @@ const mockServerInfo: McpServerInfo = {
       args: ['-y', 'test-server'],
     },
     enabled: true,
-    auto_start: false,
+    lifecycle: 'lazy' as const,
     env: [],
     created_at: '2024-01-01T00:00:00Z',
   },
@@ -69,7 +69,7 @@ const mockRunningServer: McpServerInfo = {
       args: ['-y', 'running-server'],
     },
     enabled: true,
-    auto_start: false,
+    lifecycle: 'lazy' as const,
     env: [],
     created_at: '2024-01-01T00:00:00Z',
   },
@@ -180,7 +180,7 @@ describe('useMcpServers', () => {
         server_type: 'stdio' as const,
         config: { command: 'test' },
         enabled: true,
-        auto_start: false,
+        lifecycle: 'lazy' as const,
         env: [],
       };
       const savedServer = { ...newServer, id: 2, created_at: '2024-01-01T00:00:00Z' };
@@ -217,7 +217,7 @@ describe('useMcpServers', () => {
             server_type: 'stdio',
             config: {},
             enabled: true,
-            auto_start: false,
+            lifecycle: 'lazy' as const,
             env: [],
           });
         })
@@ -372,7 +372,7 @@ describe('useMcpServers', () => {
   describe('error handling', () => {
     it('throws on first failure and succeeds on second call', async () => {
       vi.mocked(addMcpServer).mockRejectedValueOnce(new Error('First error'));
-      vi.mocked(addMcpServer).mockResolvedValueOnce({ id: 2, name: 'New', type: 'stdio', enabled: true, auto_start: false, env: [] });
+      vi.mocked(addMcpServer).mockResolvedValueOnce({ id: 2, name: 'New', type: 'stdio', enabled: true, lifecycle: 'lazy' as const, env: [] });
 
       const { result } = renderHook(() => useMcpServers());
 
@@ -383,13 +383,13 @@ describe('useMcpServers', () => {
       // First call throws
       await expect(
         act(async () => {
-          await result.current.addServer({ name: 'New', type: 'stdio', enabled: true, auto_start: false, env: [] });
+          await result.current.addServer({ name: 'New', type: 'stdio', enabled: true, lifecycle: 'lazy' as const, env: [] });
         })
       ).rejects.toThrow('First error');
 
       // Second call succeeds
       await act(async () => {
-        const server = await result.current.addServer({ name: 'New', type: 'stdio', enabled: true, auto_start: false, env: [] });
+        const server = await result.current.addServer({ name: 'New', type: 'stdio', enabled: true, lifecycle: 'lazy' as const, env: [] });
         expect(server.id).toBe(2);
       });
     });

--- a/tests/ts/services/clients/mcp.test.ts
+++ b/tests/ts/services/clients/mcp.test.ts
@@ -45,7 +45,7 @@ describe('mcp client', () => {
     it('listMcpServers delegates to transport', async () => {
       const mockServers: McpServerInfo[] = [
         {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: 'stopped',
           tools: [],
         },
@@ -65,7 +65,7 @@ describe('mcp client', () => {
         server_type: 'stdio',
         config: { command: 'test' },
         enabled: true,
-        auto_start: false,
+        lifecycle: lazy as const,
         env: [],
       };
       const mockResult = { ...newServer, id: 1, created_at: '2024-01-01' };
@@ -79,7 +79,7 @@ describe('mcp client', () => {
 
     it('updateMcpServer delegates to transport', async () => {
       const updates = { name: 'Updated Name' };
-      const mockResult = { id: 1, name: 'Updated Name', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' };
+      const mockResult = { id: 1, name: 'Updated Name', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' };
       mockTransport.updateMcpServer.mockResolvedValue(mockResult);
 
       const result = await updateMcpServer(1, updates);
@@ -138,7 +138,7 @@ describe('mcp client', () => {
             args: ['-y', 'pkg'],
           },
           enabled: true,
-          auto_start: false,
+          lifecycle: lazy as const,
           env: [],
         });
       });
@@ -161,7 +161,7 @@ describe('mcp client', () => {
             url: 'http://localhost:3000',
           },
           enabled: true,
-          auto_start: false,
+          lifecycle: lazy as const,
           env: [],
         });
       });
@@ -170,7 +170,7 @@ describe('mcp client', () => {
     describe('isServerRunning', () => {
       it('returns true when status is running', () => {
         const info: McpServerInfo = {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: 'running',
           tools: [],
         };
@@ -180,7 +180,7 @@ describe('mcp client', () => {
 
       it('returns false when status is stopped', () => {
         const info: McpServerInfo = {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: 'stopped',
           tools: [],
         };
@@ -192,7 +192,7 @@ describe('mcp client', () => {
     describe('hasServerError', () => {
       it('returns true when status is an error object', () => {
         const info: McpServerInfo = {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: { error: 'Connection failed' },
           tools: [],
         };
@@ -202,7 +202,7 @@ describe('mcp client', () => {
 
       it('returns false when status is a string', () => {
         const info: McpServerInfo = {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: 'running',
           tools: [],
         };
@@ -214,7 +214,7 @@ describe('mcp client', () => {
     describe('getServerErrorMessage', () => {
       it('returns error message when server has error', () => {
         const info: McpServerInfo = {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: { error: 'Connection failed' },
           tools: [],
         };
@@ -224,7 +224,7 @@ describe('mcp client', () => {
 
       it('returns null when server has no error', () => {
         const info: McpServerInfo = {
-          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, auto_start: false, env: [], created_at: '2024-01-01' },
+          server: { id: 1, name: 'Test', server_type: 'stdio', config: {}, enabled: true, lifecycle: lazy as const, env: [], created_at: '2024-01-01' },
           status: 'running',
           tools: [],
         };


### PR DESCRIPTION
## Summary

Replaces the binary `auto_start: bool` on all MCP server types with a `lifecycle: McpLifecycle` enum that expresses three distinct startup policies:

| Variant | Behaviour |
|---------|-----------|
| `eager` | Spawn at host initialisation (old `auto_start = true`) |
| `lazy`  | Spawn on first tool call, deduped by per-server tokio Mutex (new default) |
| `manual`| Never auto-spawn; tool calls return a descriptive error without crashing |

No migration path — fresh schema only (drop and recreate).

## Changes by phase

### Phase 1 — Domain types (`gglib-core`)
- New `McpLifecycle` enum with `Display`, `FromStr`, serde lowercase, `#[default] Lazy`
- `McpServer`, `NewMcpServer`, `UpdateMcpServer`: `auto_start: bool` → `lifecycle: McpLifecycle`
- Builder: `with_lifecycle(McpLifecycle)` replaces `with_auto_start(bool)`

### Phase 2 — DB schema + repository (`gglib-db`)
- `mcp_servers.auto_start INTEGER` → `lifecycle TEXT NOT NULL DEFAULT 'lazy' CHECK (...)`
- `McpServerRow` and all queries updated; `TestDb` inline schema updated

### Phase 3 — Service layer + manager (`gglib-mcp`)
- `McpManager`: per-server `Arc<tokio::sync::Mutex<()>>` start lock; `ensure_started()` with double-checked locking
- `McpService::initialize()`: starts only `Eager` servers
- `McpService::prewarm_lazy()`: starts all `Lazy` servers (for one-shot commands)
- `McpService::call_tool()`: Eager/Lazy → `ensure_started()`; Manual → tool-level error

### Phase 4 — App-services DTOs (`gglib-app-services`, `gglib-axum`, `gglib-tauri`)
- `McpServerDto`, `CreateMcpServerRequest`, `UpdateMcpServerRequest`: `lifecycle` field

### Phase 5 — Runtime/proxy banner (`gglib-runtime`)
- Startup banner counts servers by lifecycle variant: `(eager: N, lazy: N, manual: N)`

### Phase 6 — CLI (`gglib-cli`)
- `gglib mcp add`: `--auto-start` flag → `--lifecycle <LIFECYCLE>` with `default_value = "lazy"` and `value_parser = ["eager", "lazy", "manual"]`
- `gglib mcp list`: "Auto-Start" column → "Lifecycle"

### Phase 7 — One-shot pre-warm
- `gglib q` and `gglib council`: call `mcp.prewarm_lazy().await` after `initialize()` so Lazy servers are ready before the agent loop

### Phase 8 — Frontend (TypeScript)
- `McpLifecycle = 'eager' | 'lazy' | 'manual'` type alias
- `AddMcpServerModal`: checkbox replaced by `<select>` dropdown
- API transport: `lifecycle` field threaded through create/update paths

### Phase 9 — Tests
- All test fixtures updated: `auto_start: false` → `lifecycle: 'lazy'` / `McpLifecycle::Lazy`
- `TestDb` inline schema updated to match production
- `gglib-axum` contract test: `auto_start` field → `lifecycle` field