### PR TITLE
fix: use pre-built release binary in setup to avoid double cargo build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ build-tauri:
 # bare-CPU machines.
 setup: check-deps build-gui build-tauri install
 	@echo "Configuring models directory (press Enter to accept the default)"
-	@$(CARGO) run -p gglib-cli -- config models-dir prompt
+	@./target/release/gglib config models-dir prompt
 	@echo "✓ Core setup complete!"
 	@$(MAKE) llama-install-auto
 


### PR DESCRIPTION
## Problem

`make setup` was invoking `$(CARGO) run -p gglib-cli -- config models-dir prompt` without `--release`, triggering a full debug-profile compile (~41s) immediately after `build-tauri` had already produced `./target/release/gglib`.

Closes #522

## Fix

Switch to invoking the already-built binary directly:

```makefile
# Before
@$(CARGO) run -p gglib-cli -- config models-dir prompt

# After
@./target/release/gglib config models-dir prompt
```

This matches the pattern already used by `llama-install`, `llama-update`, and `llama-status`.

## History

`setup` has used `$(CARGO) run` since the first commit. The only prior change (`61e7554`) switched bare `cargo run` → `$(CARGO) run` to source the Rust env but didn't address the redundant build. The sibling targets were correctly updated in `5c5bba8` but `setup` was missed.