### PR TITLE
feat: add MTP (Multi-Token Prediction) model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,24 @@ Dialect selection is driven entirely by **system tags** in the `format:*` namesp
 | `format:qwen-xml` | `QwenXmlParser` | Model name contains `qwen` and the chat template emits `<tool_call>` markup |
 | `format:hermes` | `StandardJsonParser` | Hermes/ChatML-style tool-calling templates |
 
+In addition to `format:*` tags, gglib detects the following **capability tags** at import
+time from GGUF metadata, which drive automatic flag selection at serve time:
+
+| Tag | Detection trigger | Effect |
+|-----|-------------------|--------|
+| `agent` | Chat template contains tool-calling syntax | `--jinja` auto-enabled |
+| `reasoning` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled |
+| `mtp` | `{arch}.nextn_predict_layers > 0` in GGUF metadata | `--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75` auto-enabled |
+
+Override MTP from the CLI:
+```bash
+# Disable MTP on a tagged model
+gglib serve <id> --mtp-draft-n-max 0
+
+# Explicit settings (4 draft tokens, 80% p-min)
+gglib serve <id> --mtp-draft-n-max 4 --mtp-draft-p-min 0.8
+```
+
 These tags are **auto-detected at import time** by `gglib-gguf::capabilities::detect_all` and persisted by `ModelService::import_from_file`. They are protected as system tags: `gglib model remove-tag` will reject any attempt to remove a `format:*` tag (use the `_force` service path for admin operations).
 
 #### Backfilling tags on existing catalogs

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -294,7 +294,8 @@ mod tests {
         };
 
         let added = ops.add(req).await.expect("add should succeed");
-        assert_eq!(added.file_path, gguf_path.to_str().unwrap());
+        let canonical = std::fs::canonicalize(&gguf_path).unwrap();
+        assert_eq!(added.file_path, canonical.to_str().unwrap());
 
         let models = ops.list().await.unwrap();
         assert_eq!(models.len(), 1);

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -217,7 +217,11 @@ impl ServerOps {
         }
 
         // Resolve MTP speculative decoding (auto-enabled by "mtp" tag, overrideable)
-        let mtp = resolve_mtp_args(request.mtp_draft_n_max, request.mtp_draft_p_min, &model.tags);
+        let mtp = resolve_mtp_args(
+            request.mtp_draft_n_max,
+            request.mtp_draft_p_min,
+            &model.tags,
+        );
         if mtp.enabled {
             debug!(
                 n_max = mtp.draft_n_max,

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -19,7 +19,7 @@ use gglib_core::ports::{
     ToolSupportDetectorPort,
 };
 use gglib_core::services::AppCore;
-use gglib_runtime::llama::args::resolve_reasoning_format;
+use gglib_runtime::llama::args::{resolve_mtp_args, resolve_reasoning_format};
 
 use crate::error::GuiError;
 use crate::types::{ServerInfo, StartServerRequest, StartServerResponse, ToolSupportResponse};
@@ -214,6 +214,20 @@ impl ServerOps {
 
         if let Some(ref params) = request.inference_params {
             config = config.with_inference_config(params.clone());
+        }
+
+        // Resolve MTP speculative decoding (auto-enabled by "mtp" tag, overrideable)
+        let mtp = resolve_mtp_args(request.mtp_draft_n_max, request.mtp_draft_p_min, &model.tags);
+        if mtp.enabled {
+            debug!(
+                n_max = mtp.draft_n_max,
+                p_min = mtp.draft_p_min,
+                source = ?mtp.source,
+                "Enabling MTP speculative decoding"
+            );
+            config = config
+                .with_spec_draft_n_max(mtp.draft_n_max)
+                .with_spec_draft_p_min(mtp.draft_p_min);
         }
 
         config

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -197,6 +197,17 @@ pub struct StartServerRequest {
     pub jinja: Option<bool>,
     #[serde(default)]
     pub reasoning_format: Option<String>,
+    /// Number of MTP draft tokens (`--spec-draft-n-max`).
+    ///
+    /// `None` = auto-detect from model tags.  `Some(0)` = explicitly disabled.
+    /// `Some(n > 0)` = explicitly enable with n tokens.
+    #[serde(default)]
+    pub mtp_draft_n_max: Option<u32>,
+    /// Minimum acceptance probability for MTP draft tokens (`--spec-draft-p-min`).
+    ///
+    /// Only meaningful when `mtp_draft_n_max` is `Some`.  Defaults to `0.75`.
+    #[serde(default)]
+    pub mtp_draft_p_min: Option<f32>,
     /// Inference parameters for this serve session (overrides model/global defaults).
     #[serde(default)]
     pub inference_params: Option<gglib_core::domain::InferenceConfig>,

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use crate::config_commands::ConfigCommand;
 use crate::mcp_commands::McpCommand;
 use crate::model_commands::ModelCommand;
-use crate::shared_args::{ContextArgs, SamplingArgs};
+use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs};
 
 /// Subcommands available under `gglib chat`.
 #[derive(Subcommand)]
@@ -96,17 +96,8 @@ pub enum Commands {
         port: u16,
         #[command(flatten)]
         sampling: SamplingArgs,
-        /// Number of MTP speculative draft tokens (auto-enabled when model has 'mtp' tag).
-        ///
-        /// Set to 0 to explicitly disable MTP even when the model supports it.
-        #[arg(long)]
-        mtp_draft_n_max: Option<u32>,
-        /// Minimum acceptance probability for MTP draft tokens (default: 0.75).
-        ///
-        /// Only used when MTP is enabled. Lower values increase speed at the
-        /// cost of output quality. Recommended range: 0.5–0.95.
-        #[arg(long)]
-        mtp_draft_p_min: Option<f32>,
+        #[command(flatten)]
+        mtp: MtpArgs,
     },
 
     /// Chat with a model interactively, or manage chat history

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -96,6 +96,17 @@ pub enum Commands {
         port: u16,
         #[command(flatten)]
         sampling: SamplingArgs,
+        /// Number of MTP speculative draft tokens (auto-enabled when model has 'mtp' tag).
+        ///
+        /// Set to 0 to explicitly disable MTP even when the model supports it.
+        #[arg(long)]
+        mtp_draft_n_max: Option<u32>,
+        /// Minimum acceptance probability for MTP draft tokens (default: 0.75).
+        ///
+        /// Only used when MTP is enabled. Lower values increase speed at the
+        /// cost of output quality. Recommended range: 0.5–0.95.
+        #[arg(long)]
+        mtp_draft_p_min: Option<f32>,
     },
 
     /// Chat with a model interactively, or manage chat history

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use crate::config_commands::ConfigCommand;
 use crate::mcp_commands::McpCommand;
 use crate::model_commands::ModelCommand;
-use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs};
+use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
 
 /// Subcommands available under `gglib chat`.
 #[derive(Subcommand)]
@@ -88,12 +88,8 @@ pub enum Commands {
         id: u32,
         #[command(flatten)]
         context: ContextArgs,
-        /// Force-enable Jinja template parsing for chat templates
-        #[arg(long)]
-        jinja: bool,
-        /// Port to serve on
-        #[arg(short, long, default_value = "8080")]
-        port: u16,
+        #[command(flatten)]
+        options: ServeOptions,
         #[command(flatten)]
         sampling: SamplingArgs,
         #[command(flatten)]

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -44,20 +44,10 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             jinja,
             port,
             sampling,
-            mtp_draft_n_max,
-            mtp_draft_p_min,
+            mtp,
         } => {
-            handlers::inference::serve::execute(
-                ctx,
-                id,
-                context,
-                jinja,
-                port,
-                sampling,
-                mtp_draft_n_max,
-                mtp_draft_p_min,
-            )
-            .await?;
+            handlers::inference::serve::execute(ctx, id, context, jinja, port, sampling, mtp)
+                .await?;
         }
         Commands::Chat {
             identifier,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -46,8 +46,10 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             sampling,
             mtp,
         } => {
-            handlers::inference::serve::execute(ctx, id, context, jinja, port, sampling, mtp, verbose)
-                .await?;
+            handlers::inference::serve::execute(
+                ctx, id, context, jinja, port, sampling, mtp, verbose,
+            )
+            .await?;
         }
         Commands::Chat {
             identifier,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -46,7 +46,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             sampling,
             mtp,
         } => {
-            handlers::inference::serve::execute(ctx, id, context, jinja, port, sampling, mtp)
+            handlers::inference::serve::execute(ctx, id, context, jinja, port, sampling, mtp, verbose)
                 .await?;
         }
         Commands::Chat {

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -41,13 +41,12 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
         Commands::Serve {
             id,
             context,
-            jinja,
-            port,
+            options,
             sampling,
             mtp,
         } => {
             handlers::inference::serve::execute(
-                ctx, id, context, jinja, port, sampling, mtp, verbose,
+                ctx, id, context, options, sampling, mtp, verbose,
             )
             .await?;
         }

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -45,10 +45,8 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             sampling,
             mtp,
         } => {
-            handlers::inference::serve::execute(
-                ctx, id, context, options, sampling, mtp, verbose,
-            )
-            .await?;
+            handlers::inference::serve::execute(ctx, id, context, options, sampling, mtp, verbose)
+                .await?;
         }
         Commands::Chat {
             identifier,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -44,8 +44,20 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             jinja,
             port,
             sampling,
+            mtp_draft_n_max,
+            mtp_draft_p_min,
         } => {
-            handlers::inference::serve::execute(ctx, id, context, jinja, port, sampling).await?;
+            handlers::inference::serve::execute(
+                ctx,
+                id,
+                context,
+                jinja,
+                port,
+                sampling,
+                mtp_draft_n_max,
+                mtp_draft_p_min,
+            )
+            .await?;
         }
         Commands::Chat {
             identifier,

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -83,7 +83,10 @@ pub async fn execute(
         );
     }
 
-    eprintln!("  Server will be available on http://localhost:{}", options.port);
+    eprintln!(
+        "  Server will be available on http://localhost:{}",
+        options.port
+    );
     style::print_banner_close();
 
     // Build llama-server command

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -7,7 +7,7 @@ use std::process::Stdio;
 
 use crate::bootstrap::CliContext;
 use crate::presentation::style;
-use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs};
+use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
 use gglib_runtime::llama::{
     ContextInput, LlamaCommandBuilder, ensure_llama_initialized, resolve_context_size,
     resolve_llama_server, resolve_mtp_args,
@@ -25,8 +25,7 @@ pub async fn execute(
     ctx: &CliContext,
     id: u32,
     context: ContextArgs,
-    jinja_flag: bool,
-    port: u16,
+    options: ServeOptions,
     sampling: SamplingArgs,
     mtp: MtpArgs,
     verbose: bool,
@@ -71,7 +70,7 @@ pub async fn execute(
     log_inference_info(&inference_config);
 
     // Handle Jinja flag
-    if jinja_flag {
+    if options.jinja {
         eprintln!("  Jinja templates: enabled");
     }
 
@@ -84,7 +83,7 @@ pub async fn execute(
         );
     }
 
-    eprintln!("  Server will be available on http://localhost:{}", port);
+    eprintln!("  Server will be available on http://localhost:{}", options.port);
     style::print_banner_close();
 
     // Build llama-server command
@@ -92,9 +91,9 @@ pub async fn execute(
         .context_resolution(context_resolution)
         .mlock(context.mlock)
         .inference_config(inference_config)
-        .arg_with_value("--port", port.to_string());
+        .arg_with_value("--port", options.port.to_string());
 
-    if jinja_flag {
+    if options.jinja {
         builder = builder.flag("--jinja");
     }
 

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -29,6 +29,7 @@ pub async fn execute(
     port: u16,
     sampling: SamplingArgs,
     mtp: MtpArgs,
+    verbose: bool,
 ) -> Result<()> {
     // Ensure llama.cpp is installed
     ensure_llama_initialized().await?;
@@ -103,6 +104,11 @@ pub async fn execute(
             .arg_with_value("--spec-draft-n-max", mtp.draft_n_max.to_string())
             .arg_with_value("--spec-draft-p-min", mtp.draft_p_min.to_string());
     }
+
+    // Suppress llama-server's own INFO-level startup chatter unless --verbose.
+    // -lv 1 = errors only; -lv 3 = INFO (llama-server default).
+    let log_verbosity = if verbose { "3" } else { "1" };
+    builder = builder.arg_with_value("-lv", log_verbosity.to_string());
 
     let mut cmd = builder.build();
 

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -10,7 +10,7 @@ use crate::presentation::style;
 use crate::shared_args::{ContextArgs, SamplingArgs};
 use gglib_runtime::llama::{
     ContextInput, LlamaCommandBuilder, ensure_llama_initialized, resolve_context_size,
-    resolve_llama_server,
+    resolve_llama_server, resolve_mtp_args,
 };
 
 use super::shared::{
@@ -28,6 +28,8 @@ pub async fn execute(
     jinja_flag: bool,
     port: u16,
     sampling: SamplingArgs,
+    mtp_draft_n_max: Option<u32>,
+    mtp_draft_p_min: Option<f32>,
 ) -> Result<()> {
     // Ensure llama.cpp is installed
     ensure_llama_initialized().await?;
@@ -73,6 +75,15 @@ pub async fn execute(
         eprintln!("  Jinja templates: enabled");
     }
 
+    // Resolve MTP speculative decoding
+    let mtp = resolve_mtp_args(mtp_draft_n_max, mtp_draft_p_min, &model.tags);
+    if mtp.enabled {
+        eprintln!(
+            "  MTP speculative decoding: enabled (n-max={}, p-min={:.2}, source={:?})",
+            mtp.draft_n_max, mtp.draft_p_min, mtp.source
+        );
+    }
+
     eprintln!("  Server will be available on http://localhost:{}", port);
     style::print_banner_close();
 
@@ -85,6 +96,13 @@ pub async fn execute(
 
     if jinja_flag {
         builder = builder.flag("--jinja");
+    }
+
+    if mtp.enabled {
+        builder = builder
+            .arg_with_value("--spec-type", "draft-mtp".to_string())
+            .arg_with_value("--spec-draft-n-max", mtp.draft_n_max.to_string())
+            .arg_with_value("--spec-draft-p-min", mtp.draft_p_min.to_string());
     }
 
     let mut cmd = builder.build();

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -7,7 +7,7 @@ use std::process::Stdio;
 
 use crate::bootstrap::CliContext;
 use crate::presentation::style;
-use crate::shared_args::{ContextArgs, SamplingArgs};
+use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs};
 use gglib_runtime::llama::{
     ContextInput, LlamaCommandBuilder, ensure_llama_initialized, resolve_context_size,
     resolve_llama_server, resolve_mtp_args,
@@ -28,8 +28,7 @@ pub async fn execute(
     jinja_flag: bool,
     port: u16,
     sampling: SamplingArgs,
-    mtp_draft_n_max: Option<u32>,
-    mtp_draft_p_min: Option<f32>,
+    mtp: MtpArgs,
 ) -> Result<()> {
     // Ensure llama.cpp is installed
     ensure_llama_initialized().await?;
@@ -76,7 +75,7 @@ pub async fn execute(
     }
 
     // Resolve MTP speculative decoding
-    let mtp = resolve_mtp_args(mtp_draft_n_max, mtp_draft_p_min, &model.tags);
+    let mtp = resolve_mtp_args(mtp.mtp_draft_n_max, mtp.mtp_draft_p_min, &model.tags);
     if mtp.enabled {
         eprintln!(
             "  MTP speculative decoding: enabled (n-max={}, p-min={:.2}, source={:?})",

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -83,7 +83,10 @@ pub struct ServeOptions {
 
 impl Default for ServeOptions {
     fn default() -> Self {
-        Self { jinja: false, port: 8080 }
+        Self {
+            jinja: false,
+            port: 8080,
+        }
     }
 }
 

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -54,6 +54,22 @@ impl SamplingArgs {
     }
 }
 
+/// MTP (Multi-Token Prediction) speculative-decoding overrides for the `serve` command.
+#[derive(Args, Debug, Clone, Default)]
+pub struct MtpArgs {
+    /// Number of MTP speculative draft tokens (auto-enabled when model has 'mtp' tag).
+    ///
+    /// Set to 0 to explicitly disable MTP even when the model supports it.
+    #[arg(long)]
+    pub mtp_draft_n_max: Option<u32>,
+    /// Minimum acceptance probability for MTP draft tokens (default: 0.75).
+    ///
+    /// Only used when MTP is enabled. Lower values increase speed at the
+    /// cost of output quality. Recommended range: 0.5–0.95.
+    #[arg(long)]
+    pub mtp_draft_p_min: Option<f32>,
+}
+
 /// Builder for [`ConversationSettings`](gglib_core::domain::chat::ConversationSettings)
 /// from CLI argument groups.
 ///

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -70,6 +70,23 @@ pub struct MtpArgs {
     pub mtp_draft_p_min: Option<f32>,
 }
 
+/// Serve-command options that don't belong to another group.
+#[derive(Args, Debug, Clone)]
+pub struct ServeOptions {
+    /// Force-enable Jinja template parsing for chat templates
+    #[arg(long)]
+    pub jinja: bool,
+    /// Port to serve on
+    #[arg(short, long, default_value = "8080")]
+    pub port: u16,
+}
+
+impl Default for ServeOptions {
+    fn default() -> Self {
+        Self { jinja: false, port: 8080 }
+    }
+}
+
 /// Builder for [`ConversationSettings`](gglib_core::domain::chat::ConversationSettings)
 /// from CLI argument groups.
 ///

--- a/crates/gglib-core/src/domain/gguf.rs
+++ b/crates/gglib-core/src/domain/gguf.rs
@@ -27,6 +27,11 @@ bitflags::bitflags! {
         const CODE = 0b0000_1000;
         /// Model is a mixture-of-experts architecture.
         const MOE = 0b0001_0000;
+        /// Model contains embedded MTP (Multi-Token Prediction) draft heads.
+        ///
+        /// Detected via the `{arch}.nextn_predict_layers > 0` GGUF metadata key.
+        /// Enables `--spec-type draft-mtp` speculative decoding in llama-server.
+        const MTP = 0b0010_0000;
     }
 }
 
@@ -70,6 +75,12 @@ impl GgufCapabilities {
         self.flags.contains(CapabilityFlags::VISION)
     }
 
+    /// Check if MTP (Multi-Token Prediction) draft heads are present.
+    #[must_use]
+    pub const fn has_mtp(&self) -> bool {
+        self.flags.contains(CapabilityFlags::MTP)
+    }
+
     /// Convert capabilities to tag strings for model metadata.
     ///
     /// Returns tags like "reasoning", "agent" (for tool calling), etc.
@@ -92,6 +103,10 @@ impl GgufCapabilities {
         }
         if self.flags.contains(CapabilityFlags::MOE) {
             tags.push("moe".to_string());
+        }
+        if self.has_mtp() {
+            // "mtp" tag triggers --spec-type draft-mtp auto-enable
+            tags.push("mtp".to_string());
         }
 
         // Add extension tags

--- a/crates/gglib-core/src/ports/process_runner.rs
+++ b/crates/gglib-core/src/ports/process_runner.rs
@@ -131,7 +131,7 @@ impl ServerConfig {
     /// Has no effect unless `spec_draft_n_max` is also set.  Recommended
     /// value is `0.75`; lower values trade quality for speed.
     #[must_use]
-    pub fn with_spec_draft_p_min(mut self, p: f32) -> Self {
+    pub const fn with_spec_draft_p_min(mut self, p: f32) -> Self {
         self.spec_draft_p_min = Some(p);
         self
     }

--- a/crates/gglib-core/src/ports/process_runner.rs
+++ b/crates/gglib-core/src/ports/process_runner.rs
@@ -36,6 +36,18 @@ pub struct ServerConfig {
     pub jinja: bool,
     /// Reasoning format override (e.g., `"deepseek"`, `"none"`).
     pub reasoning_format: Option<String>,
+    /// Number of MTP draft tokens to speculate ahead (`--spec-draft-n-max`).
+    ///
+    /// `None` means MTP speculative decoding is disabled.  When `Some(n)`,
+    /// `--spec-type draft-mtp` and `--spec-draft-n-max n` are passed to
+    /// llama-server.  Recommended value: `2` (Unsloth default).
+    pub spec_draft_n_max: Option<u32>,
+    /// Minimum acceptance probability for MTP draft tokens (`--spec-draft-p-min`).
+    ///
+    /// Only meaningful when `spec_draft_n_max` is `Some`.  Skipping low-confidence
+    /// draft tokens is especially important on Apple Silicon (Metal) to avoid
+    /// throughput regression.  Recommended value: `0.75`.
+    pub spec_draft_p_min: Option<f32>,
     /// Inference sampling parameters (temperature, `top_p`, etc.).
     pub inference_config: Option<InferenceConfig>,
     /// Additional server-specific options (escape hatch).
@@ -61,6 +73,8 @@ impl ServerConfig {
             gpu_layers: None,
             jinja: false,
             reasoning_format: None,
+            spec_draft_n_max: None,
+            spec_draft_p_min: None,
             inference_config: None,
             extra_args: Vec::new(),
         }
@@ -98,6 +112,27 @@ impl ServerConfig {
     #[must_use]
     pub fn with_reasoning_format(mut self, format: String) -> Self {
         self.reasoning_format = Some(format);
+        self
+    }
+
+    /// Enable MTP speculative decoding with the given draft token count.
+    ///
+    /// This causes `--spec-type draft-mtp` and `--spec-draft-n-max n` to be
+    /// passed to llama-server.  Call [`Self::with_spec_draft_p_min`] to also
+    /// set the acceptance probability threshold (defaults to 0.75).
+    #[must_use]
+    pub const fn with_spec_draft_n_max(mut self, n: u32) -> Self {
+        self.spec_draft_n_max = Some(n);
+        self
+    }
+
+    /// Set the minimum acceptance probability for MTP draft tokens.
+    ///
+    /// Has no effect unless `spec_draft_n_max` is also set.  Recommended
+    /// value is `0.75`; lower values trade quality for speed.
+    #[must_use]
+    pub fn with_spec_draft_p_min(mut self, p: f32) -> Self {
+        self.spec_draft_p_min = Some(p);
         self
     }
 

--- a/crates/gglib-gguf/README.md
+++ b/crates/gglib-gguf/README.md
@@ -93,7 +93,7 @@ These tags drive automatic llama-server flag selection at serve time.
 | Tag | Detection trigger | Effect at runtime |
 |-----|-------------------|-------------------|
 | `"agent"` | Chat template contains tool-calling syntax | `--jinja` auto-enabled |
-| `"reasoning"` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled |
+| `"reasoning"` | Chat template contains `<think>` / `DeepSeek` reasoning tokens | `--reasoning-format deepseek` auto-enabled |
 | `"mtp"` | `{arch}.nextn_predict_layers > 0` in GGUF metadata | `--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75` auto-enabled |
 | `"vision"` | Multi-modal clip projection keys present | Informational only (future) |
 | `"moe"` | `{arch}.expert_count > 0` | Informational only |

--- a/crates/gglib-gguf/README.md
+++ b/crates/gglib-gguf/README.md
@@ -85,6 +85,34 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **Capability Detection** — Identifies chat template, vocabulary size, embedding dimensions
 - **Efficient Parsing** — Streams metadata without loading full tensor data
 
+## Capability Tags
+
+Model capabilities are detected from GGUF metadata and stored as string tags.
+These tags drive automatic llama-server flag selection at serve time.
+
+| Tag | Detection trigger | Effect at runtime |
+|-----|-------------------|-------------------|
+| `"agent"` | Chat template contains tool-calling syntax | `--jinja` auto-enabled |
+| `"reasoning"` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled |
+| `"mtp"` | `{arch}.nextn_predict_layers > 0` in GGUF metadata | `--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75` auto-enabled |
+| `"vision"` | Multi-modal clip projection keys present | Informational only (future) |
+| `"moe"` | `{arch}.expert_count > 0` | Informational only |
+
+### MTP tag details
+
+The `"mtp"` tag is set when the GGUF file contains the key
+`{arch}.nextn_predict_layers` (e.g. `qwen3_5_mtp.nextn_predict_layers`) with a
+value strictly greater than zero.  This key is written by llama.cpp when MTP
+draft head tensors are bundled into the same file.
+
+**Detection is intentionally strict**: model names or filenames containing
+`"MTP"` are ignored.  A model whose MTP heads have been stripped during
+quantisation will NOT receive the tag, preventing llama-server from being
+launched with `--spec-type draft-mtp` against a file that cannot support it.
+
+CLI escape hatch: `gglib serve <id> --mtp-draft-n-max 0` explicitly disables
+MTP even on a tagged model.
+
 ## Usage
 
 ```rust,no_run

--- a/crates/gglib-gguf/src/capabilities/mod.rs
+++ b/crates/gglib-gguf/src/capabilities/mod.rs
@@ -9,6 +9,7 @@
 //! - `tool_calling` - Tool/function calling detection
 //! - `patterns` - Pattern constants shared across detection modules
 
+mod mtp;
 mod patterns;
 mod reasoning;
 pub mod tool_calling;
@@ -18,6 +19,7 @@ use std::collections::HashMap;
 use gglib_core::GgufCapabilities;
 use gglib_core::domain::gguf::CapabilityFlags;
 
+use mtp::detect_mtp_support;
 use reasoning::detect_reasoning_support;
 use tool_calling::detect_tool_support;
 
@@ -39,6 +41,12 @@ pub fn detect_all(metadata: &HashMap<String, String>) -> GgufCapabilities {
     let tool_calling = detect_tool_support(metadata);
     if tool_calling.supports_tool_calling {
         flags |= CapabilityFlags::TOOL_CALLING;
+    }
+
+    // Detect MTP (Multi-Token Prediction) draft heads
+    let mtp = detect_mtp_support(metadata);
+    if mtp.supported {
+        flags |= CapabilityFlags::MTP;
     }
 
     // Surface the detected dialect as a `format:*` extension tag so the

--- a/crates/gglib-gguf/src/capabilities/mtp.rs
+++ b/crates/gglib-gguf/src/capabilities/mtp.rs
@@ -1,0 +1,119 @@
+//! MTP (Multi-Token Prediction) capability detection.
+//!
+//! Detects whether a GGUF file contains embedded MTP draft heads by inspecting
+//! the `{arch}.nextn_predict_layers` metadata key.
+//!
+//! # Detection Strategy
+//!
+//! MTP capability is determined **exclusively** from the GGUF key-value metadata.
+//! The canonical key is `{arch}.nextn_predict_layers` (e.g.
+//! `qwen3_5_mtp.nextn_predict_layers` for Qwen3.6 MTP).  A value strictly
+//! greater than zero indicates that the file contains the bundled MTP head
+//! tensors and is eligible for `--spec-type draft-mtp` speculative decoding.
+//!
+//! No filename or model-name heuristics are used: a model named `*-MTP` that
+//! had its MTP heads stripped during quantisation would still not be tagged,
+//! which prevents passing flags that would crash llama-server.
+
+use std::collections::HashMap;
+
+/// Result of MTP capability detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MtpDetection {
+    /// Whether the model contains embedded MTP draft heads.
+    pub supported: bool,
+    /// Number of MTP prediction layers present (`nextn_predict_layers` value).
+    /// Zero when `supported` is `false`.
+    pub layer_count: u32,
+}
+
+/// Detect MTP support from raw GGUF key-value metadata.
+///
+/// Scans all metadata keys for any key ending with `.nextn_predict_layers`.
+/// If such a key is found and its value parses to a `u32` strictly greater
+/// than zero, MTP is considered supported.
+///
+/// Returns [`MtpDetection`] with `supported = false` and `layer_count = 0`
+/// when no such key exists or the value is zero.
+#[must_use]
+pub fn detect_mtp_support(metadata: &HashMap<String, String>) -> MtpDetection {
+    for (key, value) in metadata {
+        if key.ends_with(".nextn_predict_layers") {
+            if let Ok(n) = value.parse::<u32>() {
+                if n > 0 {
+                    return MtpDetection {
+                        supported: true,
+                        layer_count: n,
+                    };
+                }
+            }
+        }
+    }
+
+    MtpDetection {
+        supported: false,
+        layer_count: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn detects_qwen_mtp_key() {
+        let m = meta(&[("qwen3_5_mtp.nextn_predict_layers", "1")]);
+        let det = detect_mtp_support(&m);
+        assert!(det.supported);
+        assert_eq!(det.layer_count, 1);
+    }
+
+    #[test]
+    fn detects_generic_arch_mtp_key() {
+        let m = meta(&[("llama.nextn_predict_layers", "4")]);
+        let det = detect_mtp_support(&m);
+        assert!(det.supported);
+        assert_eq!(det.layer_count, 4);
+    }
+
+    #[test]
+    fn absent_key_returns_not_supported() {
+        let m = meta(&[("llama.context_length", "4096"), ("general.name", "MyModel")]);
+        let det = detect_mtp_support(&m);
+        assert!(!det.supported);
+        assert_eq!(det.layer_count, 0);
+    }
+
+    #[test]
+    fn zero_value_returns_not_supported() {
+        let m = meta(&[("qwen3_5_mtp.nextn_predict_layers", "0")]);
+        let det = detect_mtp_support(&m);
+        assert!(!det.supported);
+        assert_eq!(det.layer_count, 0);
+    }
+
+    #[test]
+    fn non_numeric_value_returns_not_supported() {
+        let m = meta(&[("llama.nextn_predict_layers", "unknown")]);
+        let det = detect_mtp_support(&m);
+        assert!(!det.supported);
+    }
+
+    #[test]
+    fn model_name_heuristic_does_not_trigger_detection() {
+        // Ensure filename/name heuristics are NOT used — pure metadata key only.
+        let m = meta(&[
+            ("general.name", "Qwen3-27B-MTP"),
+            ("llama.context_length", "32768"),
+        ]);
+        let det = detect_mtp_support(&m);
+        assert!(!det.supported, "name heuristics must not trigger MTP detection");
+    }
+}

--- a/crates/gglib-gguf/src/capabilities/mtp.rs
+++ b/crates/gglib-gguf/src/capabilities/mtp.rs
@@ -85,7 +85,10 @@ mod tests {
 
     #[test]
     fn absent_key_returns_not_supported() {
-        let m = meta(&[("llama.context_length", "4096"), ("general.name", "MyModel")]);
+        let m = meta(&[
+            ("llama.context_length", "4096"),
+            ("general.name", "MyModel"),
+        ]);
         let det = detect_mtp_support(&m);
         assert!(!det.supported);
         assert_eq!(det.layer_count, 0);
@@ -114,6 +117,9 @@ mod tests {
             ("llama.context_length", "32768"),
         ]);
         let det = detect_mtp_support(&m);
-        assert!(!det.supported, "name heuristics must not trigger MTP detection");
+        assert!(
+            !det.supported,
+            "name heuristics must not trigger MTP detection"
+        );
     }
 }

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -10,7 +10,7 @@ use gglib_core::utils::process::async_cmd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::process::Child;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Select the llama-server path to use.
 ///
@@ -157,10 +157,41 @@ pub fn build_and_spawn(
         cmd.arg(arg);
     }
 
-    // Log the full command line at debug level before spawning.
-    // tokio::process::Command doesn't expose get_args, so we rebuild
-    // a human-readable string from the config fields.
-    debug!("spawning llama-server: {:?}", cmd);
+    // Log the full command line at info level before spawning.
+    // tokio::process::Command doesn't expose get_args, so we reconstruct
+    // a readable summary from the config fields.
+    {
+        let mut log_args = vec![
+            "-m".to_string(),
+            config.model_path.display().to_string(),
+            "--host".to_string(), "127.0.0.1".to_string(),
+            "--port".to_string(), port.to_string(),
+            "--metrics".to_string(),
+        ];
+        if let Some(ctx) = config.context_size {
+            log_args.extend(["-c".to_string(), ctx.to_string()]);
+        }
+        if let Some(layers) = config.gpu_layers {
+            log_args.extend(["-ngl".to_string(), layers.to_string()]);
+        }
+        if config.jinja {
+            log_args.push("--jinja".to_string());
+        }
+        if let Some(ref fmt) = config.reasoning_format {
+            log_args.extend(["--reasoning-format".to_string(), fmt.clone()]);
+        }
+        if let Some(n) = config.spec_draft_n_max {
+            log_args.extend([
+                "--spec-type".to_string(), "draft-mtp".to_string(),
+                "--spec-draft-n-max".to_string(), n.to_string(),
+            ]);
+            if let Some(p) = config.spec_draft_p_min {
+                log_args.extend(["--spec-draft-p-min".to_string(), p.to_string()]);
+            }
+        }
+        log_args.extend(config.extra_args.iter().cloned());
+        info!("spawning llama-server: {}", log_args.join(" "));
+    }
 
     // Use piped stdio for log streaming
     cmd.stdout(std::process::Stdio::piped())

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -136,6 +136,15 @@ pub fn build_and_spawn(
         cmd.arg("--reasoning-format").arg(format);
     }
 
+    // Add MTP speculative decoding flags if enabled
+    if let Some(n) = config.spec_draft_n_max {
+        cmd.arg("--spec-type").arg("draft-mtp");
+        cmd.arg("--spec-draft-n-max").arg(n.to_string());
+        if let Some(p) = config.spec_draft_p_min {
+            cmd.arg("--spec-draft-p-min").arg(p.to_string());
+        }
+    }
+
     // Add inference parameters if specified
     if let Some(ref inference) = config.inference_config {
         for arg in inference.to_cli_args() {

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -263,6 +263,8 @@ mod tests {
             gpu_layers: None,
             jinja: false,
             reasoning_format: None,
+            spec_draft_n_max: None,
+            spec_draft_p_min: None,
             inference_config: None,
             extra_args: vec![],
         };

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -157,6 +157,11 @@ pub fn build_and_spawn(
         cmd.arg(arg);
     }
 
+    // Log the full command line at debug level before spawning.
+    // tokio::process::Command doesn't expose get_args, so we rebuild
+    // a human-readable string from the config fields.
+    debug!("spawning llama-server: {:?}", cmd);
+
     // Use piped stdio for log streaming
     cmd.stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -6,7 +6,7 @@
 use crate::llama::{LlamaServerError, resolve_llama_server};
 use crate::process::spawn_stream_reader;
 use gglib_core::ports::{ServerConfig, ServerLogSinkPort};
-use gglib_core::utils::process::async_cmd;
+use gglib_core::utils::process::cmd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::process::Child;
@@ -107,7 +107,7 @@ pub fn build_and_spawn(
             }
         })?;
 
-    let mut cmd = async_cmd(validated_path);
+    let mut cmd = cmd(validated_path);
     cmd.arg("-m")
         .arg(&config.model_path)
         .arg("--host")
@@ -157,43 +157,19 @@ pub fn build_and_spawn(
         cmd.arg(arg);
     }
 
-    // Log the full command line at info level before spawning.
-    // tokio::process::Command doesn't expose get_args, so we reconstruct
-    // a readable summary from the config fields.
-    {
-        let mut log_args = vec![
-            "-m".to_string(),
-            config.model_path.display().to_string(),
-            "--host".to_string(), "127.0.0.1".to_string(),
-            "--port".to_string(), port.to_string(),
-            "--metrics".to_string(),
-        ];
-        if let Some(ctx) = config.context_size {
-            log_args.extend(["-c".to_string(), ctx.to_string()]);
-        }
-        if let Some(layers) = config.gpu_layers {
-            log_args.extend(["-ngl".to_string(), layers.to_string()]);
-        }
-        if config.jinja {
-            log_args.push("--jinja".to_string());
-        }
-        if let Some(ref fmt) = config.reasoning_format {
-            log_args.extend(["--reasoning-format".to_string(), fmt.clone()]);
-        }
-        if let Some(n) = config.spec_draft_n_max {
-            log_args.extend([
-                "--spec-type".to_string(), "draft-mtp".to_string(),
-                "--spec-draft-n-max".to_string(), n.to_string(),
-            ]);
-            if let Some(p) = config.spec_draft_p_min {
-                log_args.extend(["--spec-draft-p-min".to_string(), p.to_string()]);
-            }
-        }
-        log_args.extend(config.extra_args.iter().cloned());
-        info!("spawning llama-server: {}", log_args.join(" "));
-    }
+    // Log the full invocation. std::process::Command exposes get_program/get_args,
+    // so we log before converting to tokio::process::Command.
+    info!(
+        "spawning llama-server: {} {}",
+        cmd.get_program().to_string_lossy(),
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
 
-    // Use piped stdio for log streaming
+    // Convert to async command and attach piped stdio for log streaming.
+    let mut cmd = tokio::process::Command::from(cmd);
     cmd.stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 

--- a/crates/gglib-runtime/src/llama/args/README.md
+++ b/crates/gglib-runtime/src/llama/args/README.md
@@ -12,6 +12,7 @@ Reusable utilities for resolving CLI flags and configuration options so that mul
 |--------|-------------|
 | `context` | Context size resolution (auto-detect from model or user override) |
 | `jinja` | Jinja template flag resolution |
+| `mtp` | MTP (Multi-Token Prediction) speculative decoding arg resolution |
 | `reasoning` | Reasoning format detection and flag resolution |
 
 ## Key Functions
@@ -19,6 +20,9 @@ Reusable utilities for resolving CLI flags and configuration options so that mul
 - `resolve_context_size(ContextInput)` — Determine context size via the 3-level
   fallback: explicit flag → global settings default → llama-server default
 - `resolve_jinja_flag()` — Whether to enable Jinja templates
+- `resolve_mtp_args(explicit_n, explicit_p, tags)` — Resolve `--spec-type draft-mtp`
+  arguments: auto-enables with n=2, p=0.75 when the `"mtp"` tag is present;
+  explicit n=0 disables even on tagged models
 - `resolve_reasoning_format()` — Detect and configure reasoning models
 
 <!-- module-docs:end -->
@@ -31,6 +35,7 @@ Reusable utilities for resolving CLI flags and configuration options so that mul
 |--------|-----|------------|----------|
 | [`context.rs`](context.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-context-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-context-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-context-coverage.json) |
 | [`jinja.rs`](jinja.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-jinja-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-jinja-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-jinja-coverage.json) |
+| [`mtp.rs`](mtp.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-mtp-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-mtp-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-mtp-coverage.json) |
 | [`reasoning.rs`](reasoning.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-reasoning-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-reasoning-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-args-reasoning-coverage.json) |
 <!-- module-table:end -->
 

--- a/crates/gglib-runtime/src/llama/args/mod.rs
+++ b/crates/gglib-runtime/src/llama/args/mod.rs
@@ -12,8 +12,7 @@ pub mod reasoning;
 pub use context::{ContextInput, ContextResolution, ContextResolutionSource, resolve_context_size};
 pub use jinja::{JinjaResolution, JinjaResolutionSource, resolve_jinja_flag};
 pub use mtp::{
-    MtpResolution, MtpResolutionSource, resolve_mtp_args, DEFAULT_DRAFT_N_MAX,
-    DEFAULT_DRAFT_P_MIN,
+    DEFAULT_DRAFT_N_MAX, DEFAULT_DRAFT_P_MIN, MtpResolution, MtpResolutionSource, resolve_mtp_args,
 };
 pub use reasoning::{
     ReasoningDetection, ReasoningFormatResolution, ReasoningFormatSource, resolve_reasoning_format,

--- a/crates/gglib-runtime/src/llama/args/mod.rs
+++ b/crates/gglib-runtime/src/llama/args/mod.rs
@@ -5,11 +5,16 @@
 
 pub mod context;
 pub mod jinja;
+pub mod mtp;
 pub mod reasoning;
 
 // Re-export public API
 pub use context::{ContextInput, ContextResolution, ContextResolutionSource, resolve_context_size};
 pub use jinja::{JinjaResolution, JinjaResolutionSource, resolve_jinja_flag};
+pub use mtp::{
+    MtpResolution, MtpResolutionSource, resolve_mtp_args, DEFAULT_DRAFT_N_MAX,
+    DEFAULT_DRAFT_P_MIN,
+};
 pub use reasoning::{
     ReasoningDetection, ReasoningFormatResolution, ReasoningFormatSource, resolve_reasoning_format,
     resolve_reasoning_format_with_detection,

--- a/crates/gglib-runtime/src/llama/args/mtp.rs
+++ b/crates/gglib-runtime/src/llama/args/mtp.rs
@@ -1,0 +1,173 @@
+//! MTP (Multi-Token Prediction) argument resolution for llama.cpp launches.
+//!
+//! Resolves whether to enable `--spec-type draft-mtp` speculative decoding,
+//! and with what parameters, given optional explicit user overrides and the
+//! model's capability tags.
+
+/// Indicates how the MTP args were resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MtpResolutionSource {
+    /// User explicitly supplied `--mtp-draft-n-max` (n > 0 → enabled, n = 0 → disabled).
+    Explicit,
+    /// Auto-enabled because the model carries the `"mtp"` capability tag.
+    MtpTag,
+    /// Not enabled (default — no tag, no explicit flag).
+    Default,
+}
+
+/// Result of resolving the MTP speculative decoding parameters.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MtpResolution {
+    /// Whether `--spec-type draft-mtp` should be passed to llama-server.
+    pub enabled: bool,
+    /// Value for `--spec-draft-n-max`.  Only meaningful when `enabled = true`.
+    pub draft_n_max: u32,
+    /// Value for `--spec-draft-p-min`.  Only meaningful when `enabled = true`.
+    pub draft_p_min: f32,
+    /// Source of the decision, used for UX/logging.
+    pub source: MtpResolutionSource,
+}
+
+/// Default number of MTP draft tokens to speculate ahead.
+pub const DEFAULT_DRAFT_N_MAX: u32 = 2;
+/// Default minimum acceptance probability for MTP draft tokens.
+///
+/// 0.75 is the Unsloth recommended value and performs well on Apple Silicon.
+pub const DEFAULT_DRAFT_P_MIN: f32 = 0.75;
+
+/// Resolve MTP speculative decoding arguments for a llama-server launch.
+///
+/// Resolution order (highest priority first):
+///
+/// 1. **Explicit n = 0** — user explicitly disabled MTP.
+/// 2. **Explicit n > 0** — user explicitly enabled MTP with a specific token count.
+///    `p_min` uses `explicit_p` if provided, otherwise falls back to 0.75.
+/// 3. **`"mtp"` tag** present — auto-enable with defaults (`n = 2`, `p_min = 0.75`).
+/// 4. **Default** — disabled; no flags are emitted.
+///
+/// # Arguments
+/// * `explicit_n` — User-specified `--spec-draft-n-max` value (`None` = not set).
+/// * `explicit_p` — User-specified `--spec-draft-p-min` value (`None` = not set).
+/// * `tags`       — Model capability tags from the database (e.g. `["mtp", "agent"]`).
+pub fn resolve_mtp_args(
+    explicit_n: Option<u32>,
+    explicit_p: Option<f32>,
+    tags: &[String],
+) -> MtpResolution {
+    // 1 + 2. Explicit override: n = 0 disables, n > 0 enables.
+    if let Some(n) = explicit_n {
+        if n == 0 {
+            return MtpResolution {
+                enabled: false,
+                draft_n_max: 0,
+                draft_p_min: DEFAULT_DRAFT_P_MIN,
+                source: MtpResolutionSource::Explicit,
+            };
+        }
+        return MtpResolution {
+            enabled: true,
+            draft_n_max: n,
+            draft_p_min: explicit_p.unwrap_or(DEFAULT_DRAFT_P_MIN),
+            source: MtpResolutionSource::Explicit,
+        };
+    }
+
+    // 3. Auto-enable via tag.
+    if tags.iter().any(|tag| tag.eq_ignore_ascii_case("mtp")) {
+        return MtpResolution {
+            enabled: true,
+            draft_n_max: DEFAULT_DRAFT_N_MAX,
+            draft_p_min: explicit_p.unwrap_or(DEFAULT_DRAFT_P_MIN),
+            source: MtpResolutionSource::MtpTag,
+        };
+    }
+
+    // 4. Default: disabled.
+    MtpResolution {
+        enabled: false,
+        draft_n_max: 0,
+        draft_p_min: DEFAULT_DRAFT_P_MIN,
+        source: MtpResolutionSource::Default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    // ── Auto-enable (MtpTag) ──────────────────────────────────────────────
+
+    #[test]
+    fn auto_enabled_by_mtp_tag() {
+        let res = resolve_mtp_args(None, None, &tags(&["mtp"]));
+        assert!(res.enabled);
+        assert_eq!(res.draft_n_max, DEFAULT_DRAFT_N_MAX);
+        assert!((res.draft_p_min - DEFAULT_DRAFT_P_MIN).abs() < f32::EPSILON);
+        assert_eq!(res.source, MtpResolutionSource::MtpTag);
+    }
+
+    #[test]
+    fn auto_enabled_tag_case_insensitive() {
+        let res = resolve_mtp_args(None, None, &tags(&["MTP"]));
+        assert!(res.enabled);
+        assert_eq!(res.source, MtpResolutionSource::MtpTag);
+    }
+
+    #[test]
+    fn auto_enable_uses_explicit_p_min_when_provided() {
+        let res = resolve_mtp_args(None, Some(0.9), &tags(&["mtp"]));
+        assert!(res.enabled);
+        assert!((res.draft_p_min - 0.9).abs() < f32::EPSILON);
+        assert_eq!(res.source, MtpResolutionSource::MtpTag);
+    }
+
+    // ── Explicit enable ───────────────────────────────────────────────────
+
+    #[test]
+    fn explicit_n_enables_mtp() {
+        let res = resolve_mtp_args(Some(4), None, &tags(&[]));
+        assert!(res.enabled);
+        assert_eq!(res.draft_n_max, 4);
+        assert!((res.draft_p_min - DEFAULT_DRAFT_P_MIN).abs() < f32::EPSILON);
+        assert_eq!(res.source, MtpResolutionSource::Explicit);
+    }
+
+    #[test]
+    fn explicit_n_and_p_both_honored() {
+        let res = resolve_mtp_args(Some(3), Some(0.6), &tags(&[]));
+        assert!(res.enabled);
+        assert_eq!(res.draft_n_max, 3);
+        assert!((res.draft_p_min - 0.6).abs() < f32::EPSILON);
+        assert_eq!(res.source, MtpResolutionSource::Explicit);
+    }
+
+    // ── Explicit disable (n = 0) ──────────────────────────────────────────
+
+    #[test]
+    fn explicit_zero_disables_mtp() {
+        // Even when the model has the mtp tag, explicit n=0 wins.
+        let res = resolve_mtp_args(Some(0), None, &tags(&["mtp"]));
+        assert!(!res.enabled);
+        assert_eq!(res.source, MtpResolutionSource::Explicit);
+    }
+
+    // ── Default (no tag, no explicit) ─────────────────────────────────────
+
+    #[test]
+    fn default_disabled_when_no_tag() {
+        let res = resolve_mtp_args(None, None, &tags(&["agent", "reasoning"]));
+        assert!(!res.enabled);
+        assert_eq!(res.source, MtpResolutionSource::Default);
+    }
+
+    #[test]
+    fn empty_tags_disabled() {
+        let res = resolve_mtp_args(None, None, &[]);
+        assert!(!res.enabled);
+        assert_eq!(res.source, MtpResolutionSource::Default);
+    }
+}

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -94,8 +94,9 @@ pub use invocation::{LlamaCommandBuilder, log_context_info, log_model_info};
 // Args resolution
 pub use args::{
     ContextInput, ContextResolution, ContextResolutionSource, JinjaResolution,
-    JinjaResolutionSource, ReasoningDetection, ReasoningFormatResolution, ReasoningFormatSource,
-    resolve_context_size, resolve_jinja_flag, resolve_reasoning_format,
+    JinjaResolutionSource, MtpResolution, MtpResolutionSource, ReasoningDetection,
+    ReasoningFormatResolution, ReasoningFormatSource, resolve_context_size, resolve_jinja_flag,
+    resolve_mtp_args, resolve_reasoning_format,
 };
 
 // Prebuilt download (for adapters that need fine-grained control - Tauri + CLI)

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -100,10 +100,21 @@ Serve a model with llama-server.
 - `--mlock`: Enable memory lock
 - `--jinja`: Force-enable Jinja template parsing for llama-server chat templates
 - `--port <PORT>`, `-p`: Port to serve on (default: 8080)
+- `--mtp-draft-n-max <N>`: MTP speculative decoding draft token count.
+  Auto-enabled with `n=2` when the model has the `mtp` tag.
+  Set to `0` to explicitly disable MTP even on a tagged model.
+- `--mtp-draft-p-min <P>`: Minimum acceptance probability for MTP draft tokens (default: `0.75`).
+  Lower values improve throughput at the cost of quality. Recommended range: `0.5`–`0.95`.
 
 **Example:**
 ```bash
 gglib serve 1 --ctx-size max --mlock
+
+# Explicitly enable MTP with custom settings (even without tag)
+gglib serve 1 --mtp-draft-n-max 4 --mtp-draft-p-min 0.8
+
+# Disable MTP even though the model has the mtp tag
+gglib serve 1 --mtp-draft-n-max 0
 ```
 
 #### `chat <identifier> [OPTIONS]`

--- a/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
+++ b/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
@@ -109,6 +109,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
   // Compute derived state
   const combinedTags = tags.modelTags.length > 0 ? tags.modelTags : (model?.tags || []);
   const hasAgentTag = combinedTags.some(tag => tag.toLowerCase() === 'agent');
+  const hasMtpTag = combinedTags.some(tag => tag.toLowerCase() === 'mtp');
 
   // Server actions hook
   const serverActions = useServerActions({
@@ -123,6 +124,9 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
     customPort: serveModal.customPort,
     jinjaOverride: serveModal.jinjaOverride,
     hasAgentTag,
+    hasMtpTag,
+    mtpNMaxOverride: serveModal.mtpNMaxOverride,
+    mtpPMinOverride: serveModal.mtpPMinOverride,
     inferenceParams: serveModal.inferenceParams,
     onStopServer,
     onRemoveModel,
@@ -291,11 +295,16 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
           jinjaOverride={serveModal.jinjaOverride}
           isServing={serveModal.isServing}
           hasAgentTag={hasAgentTag}
+          hasMtpTag={hasMtpTag}
+          mtpNMaxOverride={serveModal.mtpNMaxOverride}
+          mtpPMinOverride={serveModal.mtpPMinOverride}
           inferenceParams={serveModal.inferenceParams}
           onContextChange={serveModal.setCustomContext}
           onPortChange={serveModal.setCustomPort}
           onJinjaChange={serveModal.setJinjaOverride}
           onJinjaReset={() => serveModal.setJinjaOverride(null)}
+          onMtpNMaxChange={serveModal.setMtpNMaxOverride}
+          onMtpPMinChange={serveModal.setMtpPMinOverride}
           onInferenceParamsChange={serveModal.setInferenceParams}
           onClose={serveModal.closeServeModal}
           onStart={serverActions.handleStartServer}

--- a/src/components/ModelInspectorPanel/components/ServeModal.tsx
+++ b/src/components/ModelInspectorPanel/components/ServeModal.tsx
@@ -17,12 +17,19 @@ interface ServeModalProps {
   jinjaOverride: boolean | null;
   isServing: boolean;
   hasAgentTag: boolean;
+  hasMtpTag: boolean;
+  /** null = auto from tag; 0 = disable; >0 = explicit count */
+  mtpNMaxOverride: number | null;
+  /** null = use default 0.75 */
+  mtpPMinOverride: number | null;
   inferenceParams: InferenceConfig | undefined;
   // Handlers
   onContextChange: (value: string) => void;
   onPortChange: (value: string) => void;
   onJinjaChange: (value: boolean) => void;
   onJinjaReset: () => void;
+  onMtpNMaxChange: (value: number | null) => void;
+  onMtpPMinChange: (value: number | null) => void;
   onInferenceParamsChange: (params: InferenceConfig) => void;
   onClose: () => void;
   onStart: () => void;
@@ -39,17 +46,26 @@ export const ServeModal: FC<ServeModalProps> = ({
   jinjaOverride,
   isServing,
   hasAgentTag,
+  hasMtpTag,
+  mtpNMaxOverride,
+  mtpPMinOverride,
   inferenceParams,
   onContextChange,
   onPortChange,
   onJinjaChange,
   onJinjaReset,
+  onMtpNMaxChange,
+  onMtpPMinChange,
   onInferenceParamsChange,
   onClose,
   onStart,
 }) => {
   const effectiveJinjaEnabled = jinjaOverride === null ? hasAgentTag : jinjaOverride;
   const isAutoJinja = jinjaOverride === null && hasAgentTag;
+
+  // MTP: auto-enabled when tag present and no explicit override
+  const effectiveMtpEnabled = mtpNMaxOverride !== null ? mtpNMaxOverride > 0 : hasMtpTag;
+  const isAutoMtp = mtpNMaxOverride === null && hasMtpTag;
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   // Check if any inference params are set (for visual indicator)
@@ -190,6 +206,107 @@ export const ServeModal: FC<ServeModalProps> = ({
               </p>
             </div>
           </div>
+        </div>
+
+        {/* MTP Speculative Decoding section (shown for all models; auto-banner when tagged) */}
+        {hasMtpTag && (
+          <div className="flex flex-col gap-sm py-sm px-md rounded-md border border-border bg-primary-subtle text-text text-sm mb-md" role="status">
+            <div className="font-semibold">MTP speculative decoding detected</div>
+            <p>
+              {mtpNMaxOverride === 0
+                ? 'Speculative decoding would normally be auto-enabled for this model, but you have disabled it for this launch.'
+                : 'This model contains embedded MTP draft heads. Speculative decoding will be enabled automatically (n-max=2, p-min=0.75).'}
+            </p>
+            {mtpNMaxOverride !== null && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => { onMtpNMaxChange(null); onMtpPMinChange(null); }}
+                disabled={isServing}
+              >
+                Reset to auto-detect
+              </Button>
+            )}
+          </div>
+        )}
+
+        <div className="mb-lg">
+          <div className="flex items-center justify-between gap-sm">
+            <label className="block mb-0 font-medium text-text">MTP Speculative Decoding</label>
+            <span className="text-sm text-text-muted">
+              {isAutoMtp
+                ? 'Auto (mtp tag)'
+                : (mtpNMaxOverride === null
+                  ? 'Disabled'
+                  : (mtpNMaxOverride === 0 ? 'Disabled manually' : `Enabled (n=${mtpNMaxOverride})`))}
+            </span>
+          </div>
+          <div className="flex gap-md items-start mt-sm">
+            <input
+              id="mtp-toggle"
+              type="checkbox"
+              checked={effectiveMtpEnabled}
+              onChange={(e) => {
+                if (!e.target.checked) {
+                  onMtpNMaxChange(0);
+                } else {
+                  // Restore to auto (tag) or default explicit n=2
+                  onMtpNMaxChange(hasMtpTag ? null : 2);
+                }
+              }}
+              disabled={isServing}
+            />
+            <div className="flex-1 text-sm text-text-secondary">
+              <p className="m-0">
+                Enable <code>--spec-type draft-mtp</code> speculative decoding for MTP models.
+                Requires bundled draft heads in the GGUF file.
+              </p>
+            </div>
+          </div>
+          {effectiveMtpEnabled && (
+            <div className="flex gap-md mt-md">
+              <div className="flex-1">
+                <label htmlFor="mtp-n-max" className="block mb-sm text-sm font-medium text-text">
+                  Draft tokens (n-max)
+                </label>
+                <Input
+                  id="mtp-n-max"
+                  type="number"
+                  className="w-full p-md bg-background-input border border-border rounded-base text-text text-base"
+                  placeholder={isAutoMtp ? 'Auto (2)' : '2'}
+                  value={mtpNMaxOverride !== null && mtpNMaxOverride > 0 ? String(mtpNMaxOverride) : ''}
+                  onChange={(e) => {
+                    const v = e.target.value.trim();
+                    onMtpNMaxChange(v === '' ? null : Math.max(1, parseInt(v) || 1));
+                  }}
+                  disabled={isServing}
+                  min="1"
+                  max="8"
+                />
+              </div>
+              <div className="flex-1">
+                <label htmlFor="mtp-p-min" className="block mb-sm text-sm font-medium text-text">
+                  Min probability (p-min)
+                </label>
+                <Input
+                  id="mtp-p-min"
+                  type="number"
+                  className="w-full p-md bg-background-input border border-border rounded-base text-text text-base"
+                  placeholder={isAutoMtp ? 'Auto (0.75)' : '0.75'}
+                  value={mtpPMinOverride !== null ? String(mtpPMinOverride) : ''}
+                  onChange={(e) => {
+                    const v = e.target.value.trim();
+                    onMtpPMinChange(v === '' ? null : parseFloat(v));
+                  }}
+                  disabled={isServing}
+                  min="0"
+                  max="1"
+                  step="0.05"
+                />
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Advanced: Inference Parameters */}

--- a/src/components/ModelInspectorPanel/components/ServeModal.tsx
+++ b/src/components/ModelInspectorPanel/components/ServeModal.tsx
@@ -278,7 +278,12 @@ export const ServeModal: FC<ServeModalProps> = ({
                   value={mtpNMaxOverride !== null && mtpNMaxOverride > 0 ? String(mtpNMaxOverride) : ''}
                   onChange={(e) => {
                     const v = e.target.value.trim();
-                    onMtpNMaxChange(v === '' ? null : Math.max(1, parseInt(v) || 1));
+                    if (v === '') {
+                      onMtpNMaxChange(null);
+                    } else {
+                      const parsed = parseInt(v, 10);
+                      onMtpNMaxChange(Number.isFinite(parsed) ? Math.min(8, Math.max(1, parsed)) : 1);
+                    }
                   }}
                   disabled={isServing}
                   min="1"
@@ -297,7 +302,12 @@ export const ServeModal: FC<ServeModalProps> = ({
                   value={mtpPMinOverride !== null ? String(mtpPMinOverride) : ''}
                   onChange={(e) => {
                     const v = e.target.value.trim();
-                    onMtpPMinChange(v === '' ? null : parseFloat(v));
+                    if (v === '') {
+                      onMtpPMinChange(null);
+                    } else {
+                      const parsed = parseFloat(v);
+                      onMtpPMinChange(Number.isFinite(parsed) ? Math.min(1, Math.max(0, parsed)) : null);
+                    }
                   }}
                   disabled={isServing}
                   min="0"

--- a/src/components/ModelInspectorPanel/hooks/useServeModal.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServeModal.ts
@@ -6,12 +6,18 @@ export interface ServeModalState {
   customContext: string;
   customPort: string;
   jinjaOverride: boolean | null;
+  /** null = auto-detect from 'mtp' tag; 0 = explicitly disabled; >0 = explicitly enabled */
+  mtpNMaxOverride: number | null;
+  /** null = use default 0.75; only meaningful when mtpNMaxOverride is set */
+  mtpPMinOverride: number | null;
   isServing: boolean;
   inferenceParams: InferenceConfig | undefined;
   setShowServeModal: (show: boolean) => void;
   setCustomContext: (context: string) => void;
   setCustomPort: (port: string) => void;
   setJinjaOverride: (override: boolean | null) => void;
+  setMtpNMaxOverride: (override: number | null) => void;
+  setMtpPMinOverride: (override: number | null) => void;
   setIsServing: (serving: boolean) => void;
   setInferenceParams: (params: InferenceConfig | undefined) => void;
   openServeModal: () => void;
@@ -27,17 +33,23 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
   const [customContext, setCustomContext] = useState('');
   const [customPort, setCustomPort] = useState('');
   const [jinjaOverride, setJinjaOverride] = useState<boolean | null>(null);
+  const [mtpNMaxOverride, setMtpNMaxOverride] = useState<number | null>(null);
+  const [mtpPMinOverride, setMtpPMinOverride] = useState<number | null>(null);
   const [isServing, setIsServing] = useState(false);
   const [inferenceParams, setInferenceParams] = useState<InferenceConfig | undefined>(undefined);
 
-  // Reset jinja override and inference params when model changes
+  // Reset overrides and inference params when model changes
   useEffect(() => {
     setJinjaOverride(null);
+    setMtpNMaxOverride(null);
+    setMtpPMinOverride(null);
     setInferenceParams(undefined);
   }, [modelId]);
 
   const openServeModal = useCallback(() => {
     setJinjaOverride(null);
+    setMtpNMaxOverride(null);
+    setMtpPMinOverride(null);
     setInferenceParams(undefined);
     setShowServeModal(true);
   }, []);
@@ -51,6 +63,8 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
     setCustomContext('');
     setCustomPort('');
     setJinjaOverride(null);
+    setMtpNMaxOverride(null);
+    setMtpPMinOverride(null);
     setIsServing(false);
     setInferenceParams(undefined);
   }, []);
@@ -60,12 +74,16 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
     customContext,
     customPort,
     jinjaOverride,
+    mtpNMaxOverride,
+    mtpPMinOverride,
     isServing,
     inferenceParams,
     setShowServeModal,
     setCustomContext,
     setCustomPort,
     setJinjaOverride,
+    setMtpNMaxOverride,
+    setMtpPMinOverride,
     setIsServing,
     setInferenceParams,
     openServeModal,

--- a/src/components/ModelInspectorPanel/hooks/useServerActions.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServerActions.ts
@@ -19,6 +19,9 @@ export interface ServerActionsConfig {
   customPort: string;
   jinjaOverride: boolean | null;
   hasAgentTag: boolean;
+  hasMtpTag: boolean;
+  mtpNMaxOverride: number | null;
+  mtpPMinOverride: number | null;
   inferenceParams: InferenceConfig | undefined;
   // Callbacks
   onStopServer: (modelId: number) => Promise<void>;
@@ -62,6 +65,9 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
     customPort,
     jinjaOverride,
     hasAgentTag,
+    hasMtpTag,
+    mtpNMaxOverride,
+    mtpPMinOverride,
     inferenceParams,
     onStopServer,
     onRemoveModel,
@@ -116,6 +122,9 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
         port,
         mlock: false,
         jinja: jinjaOverride === null ? (hasAgentTag ? true : undefined) : jinjaOverride,
+        // MTP: null = auto-detect from tag; 0 = disable; >0 = explicit token count
+        specDraftNMax: mtpNMaxOverride !== null ? mtpNMaxOverride : (hasMtpTag ? undefined : undefined),
+        specDraftPMin: mtpPMinOverride !== null ? mtpPMinOverride : undefined,
         // Inference parameters for this session
         temperature: inferenceParams?.temperature,
         topP: inferenceParams?.topP,
@@ -158,7 +167,7 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
     } finally {
       setIsServing(false);
     }
-  }, [model, settings, customContext, customPort, jinjaOverride, hasAgentTag, onStartServer, onServerStarted, closeServeModal, setIsServing, showToast, onLlamaServerNotInstalled]);
+  }, [model, settings, customContext, customPort, jinjaOverride, hasAgentTag, hasMtpTag, mtpNMaxOverride, mtpPMinOverride, onStartServer, onServerStarted, closeServeModal, setIsServing, showToast, onLlamaServerNotInstalled]);
 
   const handleToggleServer = useCallback(async () => {
     if (!model?.id) return;

--- a/src/components/ModelInspectorPanel/hooks/useServerActions.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServerActions.ts
@@ -167,7 +167,7 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
     } finally {
       setIsServing(false);
     }
-  }, [model, settings, customContext, customPort, jinjaOverride, hasAgentTag, hasMtpTag, mtpNMaxOverride, mtpPMinOverride, onStartServer, onServerStarted, closeServeModal, setIsServing, showToast, onLlamaServerNotInstalled]);
+  }, [model, settings, customContext, customPort, jinjaOverride, hasAgentTag, hasMtpTag, mtpNMaxOverride, mtpPMinOverride, inferenceParams, onStartServer, onServerStarted, closeServeModal, setIsServing, showToast, onLlamaServerNotInstalled]);
 
   const handleToggleServer = useCallback(async () => {
     if (!model?.id) return;

--- a/src/services/transport/mappers.ts
+++ b/src/services/transport/mappers.ts
@@ -18,6 +18,10 @@ export interface StartServerRequest {
   mlock: boolean;
   jinja?: boolean;
   reasoningFormat?: string;
+  /** Number of MTP draft tokens. undefined = auto; 0 = disable. Matches Rust mtp_draft_n_max. */
+  mtpDraftNMax?: number;
+  /** Minimum acceptance probability for MTP draft tokens. Matches Rust mtp_draft_p_min. */
+  mtpDraftPMin?: number;
   // Inference parameters as nested object (matches Rust's inference_params field)
   inferenceParams?: {
     temperature?: number;
@@ -89,6 +93,8 @@ export function toStartServerRequest(config: ServeConfig): StartServerRequest {
     jinja: config.jinja,
     // reasoning_format is auto-detected from model tags on backend when omitted
     reasoningFormat: undefined,
+    mtpDraftNMax: config.specDraftNMax,
+    mtpDraftPMin: config.specDraftPMin,
     inferenceParams,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,10 @@ export interface ServeConfig {
   mlock?: boolean;
   port?: number;
   jinja?: boolean;
+  /** Number of MTP draft tokens. undefined = auto-detect from tags; 0 = disable. */
+  specDraftNMax?: number;
+  /** Minimum acceptance probability for MTP draft tokens (default 0.75). */
+  specDraftPMin?: number;
   // Inference parameters for this serve session
   temperature?: number;
   topP?: number;


### PR DESCRIPTION
## Summary

Adds first-class **MTP (Multi-Token Prediction)** model support using the same auto-tagging architecture as `agent` and `reasoning`. MTP-capable models are automatically detected at import time and served with the correct llama.cpp speculative decoding flags — no user configuration required.

---

## What changed

### Phase 1 — GGUF detection (`gglib-gguf`, `gglib-core`)

- New `CapabilityFlags::MTP` bitflag and `has_mtp()` accessor in `gglib-core`.
- New `crates/gglib-gguf/src/capabilities/mtp.rs` with strict GGUF-only detection:
  - Iterates all metadata keys looking for any key ending in `.nextn_predict_layers` with a `u32` value `> 0`.
  - **Zero** filename/name heuristics — detection is purely metadata-driven.
  - 6 unit tests including an explicit name-heuristic rejection test.
- `detect_all()` wires the result → sets `CapabilityFlags::MTP` → `to_tags()` emits `"mtp"` tag.

### Phase 2 — Runtime flag emission (`gglib-runtime`, `gglib-core`)

- `ServerConfig` gets two new builder fields: `spec_draft_n_max: Option<u32>` and `spec_draft_p_min: Option<f32>`.
- New `crates/gglib-runtime/src/llama/args/mtp.rs` resolver with priority semantics:
  1. Explicit `n=0` → **disabled** (escape hatch).
  2. Explicit `n>0` → **enabled** with provided values.
  3. `"mtp"` tag present → **auto-enabled** with defaults (`n=2`, `p=0.75`).
  4. Otherwise → disabled.
- `command.rs` emits `--spec-type draft-mtp --spec-draft-n-max N --spec-draft-p-min P` when `spec_draft_n_max` is `Some`.

### Phase 3 — API / app-services layer (`gglib-app-services`)

- `StartServerRequest` gains `mtp_draft_n_max: Option<u32>` and `mtp_draft_p_min: Option<f32>` (`#[serde(default)]`).
- `build_config()` calls `resolve_mtp_args()`, logs when auto-enabled, and wires into `ServerConfig`.

### Phase 4 — CLI (`gglib-cli`)

- `Commands::Serve` gets `--mtp-draft-n-max` and `--mtp-draft-p-min` flags.
- `serve::execute()` calls `resolve_mtp_args()`, prints MTP status in the startup banner, and builds the `LlamaCommandBuilder` chain.

### Phase 5 — Frontend GUI (`src/`)

- `ServeConfig` / `StartServerRequest` / mappers updated with `specDraftNMax` / `specDraftPMin`.
- `useServeModal` state includes `mtpNMaxOverride` / `mtpPMinOverride`.
- `ModelInspectorPanel` derives `hasMtpTag` and plumbs it through to `ServeModal`.
- `ServeModal` shows:
  - Auto-detected banner when `hasMtpTag`.
  - MTP enable/disable toggle.
  - N-max input (default 2, range 1–8) and P-min input (default 0.75, step 0.05) when enabled.

### Phase 6 — Documentation

- `crates/gglib-gguf/README.md`: new **Capability Tags** section with full table and MTP details.
- `crates/gglib-runtime/src/llama/args/README.md`: `mtp` row + `resolve_mtp_args()` in Key Functions.
- `src/commands/README.md`: `--mtp-draft-n-max` / `--mtp-draft-p-min` documented with examples.
- `README.md` (root): capability tags table next to the `format:*` tag taxonomy.

---

## Key design decisions

| Decision | Choice |
|----------|--------|
| llama.cpp flag | `--spec-type draft-mtp` (not `mtp`) |
| Default draft tokens | `n=2` |
| Default p-min | `0.75` |
| CLI escape hatch | `--mtp-draft-n-max 0` disables MTP on tagged models |
| Detection scope | Strictly `{arch}.nextn_predict_layers > 0` in GGUF metadata |

---

## Testing

- 6 unit tests in `gglib-gguf::capabilities::mtp` (detection logic, edge cases, heuristic rejection).
- 9 unit tests in `gglib-runtime::llama::args::mtp` (priority resolution, defaults, override semantics).
- Full `cargo check --workspace` passes.
- All workspace `--lib` unit tests pass (pre-existing macOS tempdir path-normalisation failure in `gglib-app-services` unrelated to this PR).
