### PR TITLE
fix(download): fix download speed/ETA accuracy (sliding window estimator + XetPoller scan targets)

### DIFF
--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -11,8 +11,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
+use std::time::Instant;
 
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
+
+use crate::progress::{SlidingWindowRate, format_eta};
 
 use gglib_core::download::DownloadEvent;
 use gglib_core::events::AppEvent;
@@ -31,7 +34,7 @@ use gglib_core::ports::{AppEventEmitter, DownloadEventEmitterPort};
 // The unified template renders fine even when the bar's length is unknown
 // (the bar widget appears empty until `set_length` is called with a real
 // total) and avoids the mid-stream style switch entirely.
-const BAR_TEMPLATE: &str = "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {bytes_per_sec} eta {eta}";
+const BAR_TEMPLATE: &str = "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {prefix}";
 const TICK_INTERVAL: Duration = Duration::from_millis(120);
 
 // ─── CliDownloadEventEmitter ─────────────────────────────────────────────────
@@ -47,7 +50,7 @@ const TICK_INTERVAL: Duration = Duration::from_millis(120);
 /// can suspend rendering while collecting user input without tearing the display.
 pub struct CliDownloadEventEmitter {
     multi_progress: Arc<MultiProgress>,
-    bars: Mutex<HashMap<String, ProgressBar>>,
+    bars: Mutex<HashMap<String, (ProgressBar, SlidingWindowRate)>>,
 }
 
 impl CliDownloadEventEmitter {
@@ -81,7 +84,7 @@ impl CliDownloadEventEmitter {
     /// first and [`Self::resume_animation`] when done.
     pub fn pause_animation(&self) {
         if let Ok(bars) = self.bars.lock() {
-            for bar in bars.values() {
+            for (bar, _) in bars.values() {
                 bar.disable_steady_tick();
             }
         }
@@ -92,7 +95,7 @@ impl CliDownloadEventEmitter {
     /// Pairs with [`Self::pause_animation`].
     pub fn resume_animation(&self) {
         if let Ok(bars) = self.bars.lock() {
-            for bar in bars.values() {
+            for (bar, _) in bars.values() {
                 bar.enable_steady_tick(TICK_INTERVAL);
             }
         }
@@ -136,7 +139,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                 bar.set_message(label);
 
                 if let Ok(mut bars) = self.bars.lock() {
-                    bars.insert(id, bar);
+                    bars.insert(id, (bar, SlidingWindowRate::new()));
                 }
             }
 
@@ -148,14 +151,23 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                 eta_seconds: _,
                 percentage: _,
             } => {
-                if let Ok(bars) = self.bars.lock() {
-                    if let Some(bar) = bars.get(&id) {
+                if let Ok(mut bars) = self.bars.lock() {
+                    if let Some((bar, rate)) = bars.get_mut(&id) {
                         // First time we see a real total, set length. No
                         // set_style — the unified template is already in
                         // place from DownloadStarted.
                         if total > 0 && bar.length().unwrap_or(0) == 0 {
                             bar.set_length(total);
                         }
+                        rate.record(Instant::now(), downloaded);
+                        let speed = rate.speed_bps();
+                        #[allow(clippy::cast_precision_loss)]
+                        let eta_secs = if speed > 0.0 && downloaded < total {
+                            (total.saturating_sub(downloaded)) as f64 / speed
+                        } else {
+                            f64::INFINITY
+                        };
+                        bar.set_prefix(format!("{}/s  eta {}", HumanBytes(speed as u64), format_eta(eta_secs)));
                         bar.set_position(downloaded);
                         bar.set_message(format!("{id} {}", HumanBytes(downloaded)));
                     }
@@ -170,14 +182,23 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                 aggregate_total,
                 ..
             } => {
-                if let Ok(bars) = self.bars.lock() {
-                    if let Some(bar) = bars.get(&id) {
+                if let Ok(mut bars) = self.bars.lock() {
+                    if let Some((bar, rate)) = bars.get_mut(&id) {
                         // Update length on first real total or whenever the
                         // total changes (e.g. final shard size resolved).
                         // No set_style — unified template stays in place.
                         if aggregate_total > 0 && bar.length().unwrap_or(0) != aggregate_total {
                             bar.set_length(aggregate_total);
                         }
+                        rate.record(Instant::now(), aggregate_downloaded);
+                        let speed = rate.speed_bps();
+                        #[allow(clippy::cast_precision_loss)]
+                        let eta_secs = if speed > 0.0 && aggregate_downloaded < aggregate_total {
+                            (aggregate_total.saturating_sub(aggregate_downloaded)) as f64 / speed
+                        } else {
+                            f64::INFINITY
+                        };
+                        bar.set_prefix(format!("{}/s  eta {}", HumanBytes(speed as u64), format_eta(eta_secs)));
                         bar.set_position(aggregate_downloaded);
                         bar.set_message(format!(
                             "{id} [shard {}/{total_shards}] {}",
@@ -190,7 +211,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
 
             DownloadEvent::DownloadCompleted { id, .. } => {
                 if let Ok(mut bars) = self.bars.lock() {
-                    if let Some(bar) = bars.remove(&id) {
+                    if let Some((bar, _)) = bars.remove(&id) {
                         bar.finish_with_message(format!("✓ {id}"));
                     }
                 }
@@ -198,7 +219,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
 
             DownloadEvent::DownloadFailed { id, error } => {
                 if let Ok(mut bars) = self.bars.lock() {
-                    if let Some(bar) = bars.remove(&id) {
+                    if let Some((bar, _)) = bars.remove(&id) {
                         bar.abandon_with_message(format!("✗ {id}: {error}"));
                     }
                 }
@@ -206,7 +227,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
 
             DownloadEvent::DownloadCancelled { id } => {
                 if let Ok(mut bars) = self.bars.lock() {
-                    if let Some(bar) = bars.remove(&id) {
+                    if let Some((bar, _)) = bars.remove(&id) {
                         bar.abandon_with_message(format!("✗ {id}: cancelled"));
                     }
                 }
@@ -218,7 +239,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                 // work is still happening between "100% downloaded" and
                 // the final completion event.
                 if let Ok(bars) = self.bars.lock() {
-                    if let Some(bar) = bars.get(&id) {
+                    if let Some((bar, _)) = bars.get(&id) {
                         bar.set_message(format!("{id} — {}…", status.label()));
                     }
                 }

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -34,7 +34,8 @@ use gglib_core::ports::{AppEventEmitter, DownloadEventEmitterPort};
 // The unified template renders fine even when the bar's length is unknown
 // (the bar widget appears empty until `set_length` is called with a real
 // total) and avoids the mid-stream style switch entirely.
-const BAR_TEMPLATE: &str = "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {prefix}";
+const BAR_TEMPLATE: &str =
+    "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes} @ {prefix}";
 const TICK_INTERVAL: Duration = Duration::from_millis(120);
 
 // ─── CliDownloadEventEmitter ─────────────────────────────────────────────────
@@ -167,7 +168,11 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                         } else {
                             f64::INFINITY
                         };
-                        bar.set_prefix(format!("{}/s  eta {}", HumanBytes(speed as u64), format_eta(eta_secs)));
+                        bar.set_prefix(format!(
+                            "{}/s  eta {}",
+                            HumanBytes(speed as u64),
+                            format_eta(eta_secs)
+                        ));
                         bar.set_position(downloaded);
                         bar.set_message(format!("{id} {}", HumanBytes(downloaded)));
                     }
@@ -198,7 +203,11 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                         } else {
                             f64::INFINITY
                         };
-                        bar.set_prefix(format!("{}/s  eta {}", HumanBytes(speed as u64), format_eta(eta_secs)));
+                        bar.set_prefix(format!(
+                            "{}/s  eta {}",
+                            HumanBytes(speed as u64),
+                            format_eta(eta_secs)
+                        ));
                         bar.set_position(aggregate_downloaded);
                         bar.set_message(format!(
                             "{id} [shard {}/{total_shards}] {}",

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -110,6 +110,7 @@ impl Default for CliDownloadEventEmitter {
 }
 
 impl DownloadEventEmitterPort for CliDownloadEventEmitter {
+    #[allow(clippy::too_many_lines)]
     fn emit(&self, event: DownloadEvent) {
         match event {
             DownloadEvent::DownloadStarted {
@@ -168,6 +169,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                         } else {
                             f64::INFINITY
                         };
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                         bar.set_prefix(format!(
                             "{}/s  eta {}",
                             HumanBytes(speed as u64),
@@ -203,6 +205,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                         } else {
                             f64::INFINITY
                         };
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                         bar.set_prefix(format!(
                             "{}/s  eta {}",
                             HumanBytes(speed as u64),

--- a/crates/gglib-download/src/cli_exec/exec/progress.rs
+++ b/crates/gglib-download/src/cli_exec/exec/progress.rs
@@ -1,12 +1,15 @@
 //! CLI progress rendering for downloads.
 //!
 //! Pure sync, presentation-only module — no knowledge of Python or protocol.
-//! Provides terminal and non-terminal progress display with EWA speed calculation.
+//! Provides terminal and non-terminal progress display with 8-second sliding
+//! window speed+ETA estimation via `SlidingWindowRate`.
 
 use std::io::{self, IsTerminal, Write};
 use std::time::{Duration, Instant};
 
 use indicatif::{HumanBytes, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
+
+use crate::progress::{SlidingWindowRate, format_eta};
 
 // ============================================================================
 // Constants
@@ -15,9 +18,6 @@ use indicatif::{HumanBytes, ProgressBar, ProgressDrawTarget, ProgressState, Prog
 const KIB: u64 = 1024;
 const MIB: u64 = KIB * 1024;
 const GIB: u64 = MIB * 1024;
-
-/// Smoothing factor for exponentially weighted average speed calculation.
-const EWA_SMOOTHING: f64 = 0.02;
 
 // ============================================================================
 // CLI Progress Printer
@@ -78,6 +78,7 @@ struct FancyProgress {
     bar: ProgressBar,
     saw_length: bool,
     last_label: Option<String>,
+    rate: SlidingWindowRate,
 }
 
 impl FancyProgress {
@@ -90,6 +91,7 @@ impl FancyProgress {
             bar,
             saw_length: false,
             last_label: None,
+            rate: SlidingWindowRate::new(),
         }
     }
 
@@ -121,6 +123,15 @@ impl FancyProgress {
         }
 
         self.bar.set_position(downloaded.min(total));
+        self.rate.record(Instant::now(), downloaded);
+        let speed = self.rate.speed_bps();
+        #[allow(clippy::cast_precision_loss)]
+        let eta_secs = if speed > 0.0 && downloaded < total {
+            (total.saturating_sub(downloaded)) as f64 / speed
+        } else {
+            f64::INFINITY
+        };
+        self.bar.set_prefix(format!("{}/s  eta {}", HumanBytes(speed as u64), format_eta(eta_secs)));
     }
 
     fn finish(&self) {
@@ -133,7 +144,7 @@ impl FancyProgress {
 
     fn bar_style() -> ProgressStyle {
         ProgressStyle::with_template(
-            "⚡ {msg} {bar:28.cyan/blue} {human_bytes:>9} / {human_total:>9} ({percent:>5.1}%) @ {binary_bytes_per_sec}/s ETA {eta}"
+            "⚡ {msg} {bar:28.cyan/blue} {human_bytes:>9} / {human_total:>9} ({percent:>5.1}%) @ {prefix}"
         )
         .unwrap()
         .with_key("human_bytes", |state: &ProgressState, w: &mut dyn std::fmt::Write| {
@@ -166,21 +177,18 @@ impl FancyProgress {
 
 struct PlainProgress {
     last_emit: Instant,
-    last_bytes: u64,
     last_line_len: usize,
     printed: bool,
-    /// Exponentially weighted average speed in bytes/sec
-    ewa_speed: f64,
+    rate: SlidingWindowRate,
 }
 
 impl PlainProgress {
     fn new() -> Self {
         Self {
             last_emit: Instant::now(),
-            last_bytes: 0,
             last_line_len: 0,
             printed: false,
-            ewa_speed: 0.0,
+            rate: SlidingWindowRate::new(),
         }
     }
 
@@ -194,28 +202,13 @@ impl PlainProgress {
             return;
         }
 
-        // Calculate instantaneous speed for this interval
-        let elapsed_secs = elapsed_since_last.as_secs_f64();
-        let bytes_delta = downloaded.saturating_sub(self.last_bytes);
-        #[allow(clippy::cast_precision_loss)]
-        let instant_speed = if elapsed_secs > 0.0 {
-            bytes_delta as f64 / elapsed_secs
-        } else {
-            0.0
-        };
-
-        // Update EWA speed
-        if self.printed {
-            self.ewa_speed =
-                EWA_SMOOTHING.mul_add(instant_speed, (1.0 - EWA_SMOOTHING) * self.ewa_speed);
-        } else {
-            self.ewa_speed = instant_speed;
-        }
+        // Update speed via sliding window
+        self.rate.record(now, downloaded);
+        let speed = self.rate.speed_bps();
 
         self.last_emit = now;
-        self.last_bytes = downloaded;
 
-        let speed_mib = self.ewa_speed / (1024.0 * 1024.0);
+        let speed_mib = speed / (1024.0 * 1024.0);
 
         let (down_div, down_unit) = pick_display_unit(downloaded);
         let (total_div, total_unit) = pick_display_unit(total);
@@ -243,9 +236,16 @@ impl PlainProgress {
             if downloaded == 0 {
                 let _ = write!(line, ": Preparing... ({total_str} {total_unit})");
             } else {
+                #[allow(clippy::cast_precision_loss)]
+                let eta_secs = if speed > 0.0 && downloaded < total {
+                    (total.saturating_sub(downloaded)) as f64 / speed
+                } else {
+                    f64::INFINITY
+                };
+                let eta_str = format_eta(eta_secs);
                 let _ = write!(
                     line,
-                    ": {downloaded_str} {down_unit} / {total_str} {total_unit} ({percent:5.1}%) @ {speed_mib:5.1} MiB/s"
+                    ": {downloaded_str} {down_unit} / {total_str} {total_unit} ({percent:5.1}%) @ {speed_mib:5.1} MiB/s  eta {eta_str}"
                 );
             }
         } else {

--- a/crates/gglib-download/src/cli_exec/exec/progress.rs
+++ b/crates/gglib-download/src/cli_exec/exec/progress.rs
@@ -131,7 +131,11 @@ impl FancyProgress {
         } else {
             f64::INFINITY
         };
-        self.bar.set_prefix(format!("{}/s  eta {}", HumanBytes(speed as u64), format_eta(eta_secs)));
+        self.bar.set_prefix(format!(
+            "{}/s  eta {}",
+            HumanBytes(speed as u64),
+            format_eta(eta_secs)
+        ));
     }
 
     fn finish(&self) {

--- a/crates/gglib-download/src/cli_exec/exec/progress.rs
+++ b/crates/gglib-download/src/cli_exec/exec/progress.rs
@@ -131,6 +131,7 @@ impl FancyProgress {
         } else {
             f64::INFINITY
         };
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         self.bar.set_prefix(format!(
             "{}/s  eta {}",
             HumanBytes(speed as u64),

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -194,16 +194,27 @@ async fn run_download_process(
         buf
     });
 
-    // Scoped poller targets: per-file final paths (covers already-renamed
-    // shards) plus the .cache subdir (covers in-flight .incomplete temp files
-    // written by huggingface_hub during hf-xet transfers). Avoids counting
-    // unrelated files that happen to share the same destination directory.
-    let poller_targets: Vec<_> = request
-        .files
-        .iter()
-        .map(|f| request.destination.join(f))
-        .chain(std::iter::once(request.destination.join(".cache")))
-        .collect();
+    // XetPoller scan targets:
+    //
+    // 1. `dest/.cache` — huggingface_hub stages `.incomplete` files here
+    //    (`<dest>/.cache/huggingface/download/<file>.incomplete`) while a
+    //    transfer is in flight; this is the primary target for the local
+    //    download path.
+    //
+    // 2. Global HF hub blob dir for this repo — when `hf_xet` uses the
+    //    system-wide blob store (`~/.cache/huggingface/hub/…/blobs/`)
+    //    instead of the local dest, the `.incomplete` blob grows there.
+    //    Without this target the poller sees 0 bytes until the rename
+    //    completes and the file appears at its final path.
+    //
+    // Note: The final per-file destination paths are intentionally *not*
+    // included.  Files reach those paths via an atomic rename from the temp
+    // location, which makes the full file size appear in a single 250 ms
+    // tick and produces a bogus speed spike. Omitting them avoids that
+    // problem; the poller simply goes quiet once the rename fires, which
+    // is fine because the download is finished by then.
+    let mut poller_targets = vec![request.destination.join(".cache")];
+    poller_targets.push(hf_hub_blob_dir(request.repo_id));
 
     // Always spawn the xet stat-fallback poller — it stays dormant while real
     // tqdm events flow, then emits synthetic progress from on-disk byte counts
@@ -353,4 +364,39 @@ fn finish_progress(printer: Option<&Arc<Mutex<CliProgressPrinter>>>) {
             g.finish();
         }
     }
+}
+
+/// Resolve the `huggingface_hub` blob directory for a repository.
+///
+/// When `hf_xet` is active, `huggingface_hub` may download blobs to the
+/// system-wide hub cache (`~/.cache/huggingface/hub/models--owner--repo/blobs/`)
+/// instead of the local destination's `.cache` sub-directory. Adding this
+/// path to the [`XetPoller`] targets ensures we can track the growing
+/// `.incomplete` blob regardless of which cache location is used.
+///
+/// Checks the same environment variables as the Python `huggingface_hub`
+/// library, in priority order:
+/// 1. `HF_HUB_CACHE`
+/// 2. `HUGGINGFACE_HUB_CACHE`
+/// 3. `HF_HOME/hub`
+/// 4. `$HOME/.cache/huggingface/hub` (default)
+fn hf_hub_blob_dir(repo_id: &str) -> std::path::PathBuf {
+    use std::path::PathBuf;
+
+    let hub_cache = std::env::var("HF_HUB_CACHE")
+        .map(PathBuf::from)
+        .or_else(|_| std::env::var("HUGGINGFACE_HUB_CACHE").map(PathBuf::from))
+        .or_else(|_| std::env::var("HF_HOME").map(|h| PathBuf::from(h).join("hub")))
+        .unwrap_or_else(|_| {
+            // Default: $HOME/.cache/huggingface/hub
+            let home = std::env::var("HOME").unwrap_or_else(|_| String::from("/nonexistent"));
+            PathBuf::from(home)
+                .join(".cache")
+                .join("huggingface")
+                .join("hub")
+        });
+
+    // Convert "owner/repo" to "models--owner--repo" (HF hub cache dir format)
+    let dir_name = format!("models--{}", repo_id.replace('/', "--"));
+    hub_cache.join(dir_name).join("blobs")
 }

--- a/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
+++ b/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
@@ -78,6 +78,7 @@ impl XetPoller {
         let handle = tokio::spawn(async move {
             let mut tick = tokio::time::interval(POLL_INTERVAL);
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut baseline_bytes: Option<u64> = None;
             // The first tick fires immediately — skip it so we don't race the
             // child process to its first byte on disk.
             tick.tick().await;
@@ -89,7 +90,13 @@ impl XetPoller {
                     continue;
                 }
 
-                let downloaded = sum_sizes(&targets).await;
+                let downloaded_raw = sum_sizes(&targets).await;
+                let baseline = baseline_bytes.get_or_insert(downloaded_raw);
+                let mut downloaded = downloaded_raw.saturating_sub(*baseline);
+                if total > 0 {
+                    downloaded = downloaded.min(total);
+                }
+
                 if downloaded == 0 {
                     // Nothing on disk yet — wait for the next tick.
                     continue;
@@ -154,7 +161,8 @@ async fn is_stale(last_real: &Arc<Mutex<Instant>>) -> bool {
 /// Each target may be either a file or a directory:
 /// * **File** — its length is added directly. Missing files contribute zero
 ///   (they may simply not have been created yet).
-/// * **Directory** — every regular file beneath it is summed recursively.
+/// * **Directory** — every in-flight temp file (`*.incomplete`) beneath it is
+///   summed recursively.
 ///   This is required for the hf-xet path because `huggingface_hub` writes
 ///   bytes to `<dest>/.cache/huggingface/download/<filename>.incomplete`
 ///   while the transfer is in flight and only renames to `<dest>/<filename>`
@@ -175,7 +183,7 @@ async fn sum_sizes(targets: &[PathBuf]) -> u64 {
     total
 }
 
-/// Recursively sum the sizes of every regular file under `dir`.
+/// Recursively sum the sizes of in-flight `*.incomplete` files under `dir`.
 ///
 /// Symlinks are followed for size accounting only when the entry's metadata
 /// reports `is_file()` (i.e. the symlink points at a regular file). Errors
@@ -193,7 +201,13 @@ async fn sum_dir_size(dir: &Path) -> u64 {
                 continue;
             };
             if metadata.is_file() {
-                total = total.saturating_add(metadata.len());
+                if entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.ends_with(".incomplete"))
+                {
+                    total = total.saturating_add(metadata.len());
+                }
             } else if metadata.is_dir() {
                 stack.push(entry.path());
             }
@@ -344,8 +358,86 @@ mod tests {
 
         let entries = log.lock().unwrap().clone();
         assert!(
-            entries.iter().any(|(d, t)| *d == 6144 && *t == 8192),
-            "expected synthetic event with downloaded=6144 total=8192, got {entries:?}"
+            entries.iter().any(|(d, t)| *d == 2048 && *t == 8192),
+            "expected baseline-relative event with downloaded=2048 total=8192, got {entries:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ignores_non_incomplete_files_in_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join(".cache/huggingface/download");
+        tokio::fs::create_dir_all(&cache).await.unwrap();
+
+        // Final files and metadata should not count toward synthetic progress.
+        tokio::fs::write(cache.join("model.gguf"), vec![0u8; 8192])
+            .await
+            .unwrap();
+        tokio::fs::write(cache.join("model.gguf.metadata"), b"meta")
+            .await
+            .unwrap();
+
+        // Only `.incomplete` bytes should be observed.
+        let temp_file = cache.join("model.gguf.incomplete");
+        tokio::fs::write(&temp_file, vec![0u8; 2048]).await.unwrap();
+
+        let (cb, log) = recording_callback();
+        let poller = XetPoller::spawn(vec![dir.path().to_path_buf()], Some(8192), cb);
+
+        tokio::time::sleep(STALE_AFTER + Duration::from_millis(50)).await;
+
+        let mut f = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&temp_file)
+            .await
+            .unwrap();
+        f.write_all(&[0u8; 512]).await.unwrap();
+        f.flush().await.unwrap();
+        drop(f);
+
+        tokio::time::sleep(POLL_INTERVAL * 3).await;
+        poller.shutdown();
+
+        let entries = log.lock().unwrap().clone();
+        assert!(
+            entries.iter().any(|(d, _)| *d == 512),
+            "expected only .incomplete growth bytes to be counted, got {entries:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn subtracts_startup_baseline_for_directory_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join(".cache/huggingface/download");
+        tokio::fs::create_dir_all(&cache).await.unwrap();
+        let temp_file = cache.join("model.gguf.incomplete");
+
+        // Simulate stale pre-existing temp bytes from earlier work.
+        tokio::fs::write(&temp_file, vec![0u8; 4096]).await.unwrap();
+
+        let (cb, log) = recording_callback();
+        let poller = XetPoller::spawn(vec![dir.path().to_path_buf()], Some(8192), cb);
+
+        tokio::time::sleep(STALE_AFTER + Duration::from_millis(50)).await;
+
+        // New progress should be reported relative to baseline (1024),
+        // not absolute directory size (5120).
+        let mut f = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&temp_file)
+            .await
+            .unwrap();
+        f.write_all(&[0u8; 1024]).await.unwrap();
+        f.flush().await.unwrap();
+        drop(f);
+
+        tokio::time::sleep(POLL_INTERVAL * 3).await;
+        poller.shutdown();
+
+        let entries = log.lock().unwrap().clone();
+        assert!(
+            entries.iter().any(|(d, t)| *d == 1024 && *t == 8192),
+            "expected baseline-relative synthetic event (1024/8192), got {entries:?}"
         );
     }
 }

--- a/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
+++ b/crates/gglib-download/src/cli_exec/exec/xet_poller.rs
@@ -94,7 +94,17 @@ impl XetPoller {
                     // Nothing on disk yet — wait for the next tick.
                     continue;
                 }
-                if downloaded == last_bytes.load(Ordering::Relaxed) {
+
+                let last = last_bytes.load(Ordering::Relaxed);
+                if downloaded <= last {
+                    if downloaded < last {
+                        // Bytes decreased (e.g. an `.incomplete` file was renamed
+                        // out of the scan tree as part of a transfer completing).
+                        // Reset the high-water mark so the next genuine increase
+                        // triggers a callback and the rate estimator can continue
+                        // tracking without a spurious backwards jump.
+                        last_bytes.store(0, Ordering::Relaxed);
+                    }
                     continue;
                 }
 

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -44,6 +44,7 @@ use gglib_core::ports::{
     ResolvedFile,
 };
 
+use crate::progress::SlidingWindowRate;
 use crate::quant_selector::QuantizationSelector;
 use crate::queue::{DownloadQueue, QueuedItem};
 use crate::resolver::HfQuantizationResolver;
@@ -52,9 +53,6 @@ use shard_group_tracker::{GroupMetadata, ShardGroupTracker};
 
 pub use paths::DownloadDestination;
 pub use worker::{CompletedJob, DownloadJob, ProgressUpdate, WorkerDeps};
-
-/// EWA smoothing factor for speed calculation (2% of instant speed, 98% of previous).
-const EWA_SMOOTHING: f64 = 0.02;
 
 /// Lease ID for tracking active downloads.
 ///
@@ -954,10 +952,7 @@ impl DownloadManagerImpl {
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             let mut last_emitted = ProgressUpdate::default();
-            let mut last_bytes = 0u64;
-            let mut last_time = Instant::now();
-            let mut ewa_speed = 0.0f64;
-            let mut first_update = true;
+            let mut rate = SlidingWindowRate::new();
 
             loop {
                 tokio::select! {
@@ -974,15 +969,19 @@ impl DownloadManagerImpl {
                             let final_progress = rx.borrow().clone();
                             if final_progress.seq > last_emitted.seq {
                                 let now = Instant::now();
-                                let (speed, eta) = calculate_speed_eta(
-                                    final_progress.downloaded,
-                                    final_progress.total,
-                                    last_bytes,
-                                    last_time,
-                                    now,
-                                    ewa_speed,
-                                    first_update,
-                                );
+                                rate.record(now, final_progress.downloaded);
+                                let speed = rate.speed_bps();
+                                #[allow(clippy::cast_precision_loss)]
+                                let eta = if speed > 0.0
+                                    && final_progress.downloaded < final_progress.total
+                                {
+                                    let remaining = final_progress
+                                        .total
+                                        .saturating_sub(final_progress.downloaded);
+                                    remaining as f64 / speed
+                                } else {
+                                    0.0
+                                };
                                 emit_progress(
                                     &event_emitter,
                                     &id_str,
@@ -1001,33 +1000,13 @@ impl DownloadManagerImpl {
                         let current = rx.borrow().clone();
                         if current.seq > last_emitted.seq {
                             let now = Instant::now();
-                            let elapsed = now.duration_since(last_time).as_secs_f64();
+                            rate.record(now, current.downloaded);
+                            let speed = rate.speed_bps();
 
-                            if elapsed > 0.0 {
-                                let bytes_delta = current.downloaded.saturating_sub(last_bytes);
-                                #[allow(clippy::cast_precision_loss)]
-                                let instant_speed = bytes_delta as f64 / elapsed;
-
-                                // Update EWA speed
-                                if first_update {
-                                    ewa_speed = instant_speed;
-                                    first_update = false;
-                                } else {
-                                    ewa_speed = EWA_SMOOTHING.mul_add(
-                                        instant_speed,
-                                        (1.0 - EWA_SMOOTHING) * ewa_speed
-                                    );
-                                }
-
-                                last_bytes = current.downloaded;
-                                last_time = now;
-                            }
-
-                            // Calculate ETA
                             #[allow(clippy::cast_precision_loss)]
-                            let eta = if ewa_speed > 0.0 && current.downloaded < current.total {
+                            let eta = if speed > 0.0 && current.downloaded < current.total {
                                 let remaining = current.total.saturating_sub(current.downloaded);
-                                remaining as f64 / ewa_speed
+                                remaining as f64 / speed
                             } else {
                                 0.0
                             };
@@ -1037,7 +1016,7 @@ impl DownloadManagerImpl {
                                 &id_str,
                                 shard_info.as_ref(),
                                 &current,
-                                ewa_speed,
+                                speed,
                                 eta,
                             );
                             last_emitted = current;
@@ -1269,43 +1248,6 @@ impl DownloadManagerImpl {
                 CompletionKind::Cancelled => (d, f, c + 1),
             })
     }
-}
-
-/// Helper to calculate speed and ETA from progress deltas.
-fn calculate_speed_eta(
-    downloaded: u64,
-    total: u64,
-    last_bytes: u64,
-    last_time: std::time::Instant,
-    now: std::time::Instant,
-    ewa_speed: f64,
-    first_update: bool,
-) -> (f64, f64) {
-    let elapsed = now.duration_since(last_time).as_secs_f64();
-
-    if elapsed <= 0.0 {
-        return (ewa_speed, 0.0);
-    }
-
-    let bytes_delta = downloaded.saturating_sub(last_bytes);
-    #[allow(clippy::cast_precision_loss)]
-    let instant_speed = bytes_delta as f64 / elapsed;
-
-    let speed = if first_update {
-        instant_speed
-    } else {
-        EWA_SMOOTHING.mul_add(instant_speed, (1.0 - EWA_SMOOTHING) * ewa_speed)
-    };
-
-    #[allow(clippy::cast_precision_loss)]
-    let eta = if speed > 0.0 && downloaded < total {
-        let remaining = total.saturating_sub(downloaded);
-        remaining as f64 / speed
-    } else {
-        0.0
-    };
-
-    (speed, eta)
 }
 
 /// Emit a progress event.

--- a/crates/gglib-download/src/progress/README.md
+++ b/crates/gglib-download/src/progress/README.md
@@ -2,19 +2,24 @@
 
 <!-- module-docs:start -->
 
-Progress tracking and throttling.
+Progress tracking, throttling, and speed estimation.
 
-This module handles progress aggregation and rate-limiting for download progress events to prevent UI flooding.
+This module handles progress aggregation, rate-limiting, and accurate speed/ETA
+calculation for download progress events.
 
 ## Components
 
 | Component | Description |
 |-----------|-------------|
 | `ProgressThrottle` | Rate-limits progress events (e.g., max 10/sec) |
+| `SlidingWindowRate` | 8-second sliding window speed estimator (bytes/sec) |
+| `format_eta` | Formats an ETA in seconds as `M:SS` or `H:MM:SS` |
 
 ## Design
 
 Downloads may report progress thousands of times per second. This module aggregates updates and emits throttled events suitable for UI consumption.
+
+`SlidingWindowRate` replaces the previous α=0.02 exponentially-weighted-average approach. It retains timestamped byte-count samples over an 8-second window and reports `(Δbytes / Δtime)` across that window, which closely matches what system monitors show.
 
 <!-- module-docs:end -->
 
@@ -24,6 +29,7 @@ Downloads may report progress thousands of times per second. This module aggrega
 <!-- module-table:start -->
 | Module | LOC | Complexity | Coverage |
 |--------|-----|------------|----------|
+| [`rate.rs`](rate.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-progress-rate-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-progress-rate-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-progress-rate-coverage.json) |
 | [`throttle.rs`](throttle.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-progress-throttle-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-progress-throttle-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-progress-throttle-coverage.json) |
 <!-- module-table:end -->
 

--- a/crates/gglib-download/src/progress/mod.rs
+++ b/crates/gglib-download/src/progress/mod.rs
@@ -1,8 +1,11 @@
-//! Progress tracking and throttling.
+//! Progress tracking, throttling, and speed estimation.
 //!
-//! This module handles progress aggregation and rate-limiting for download
-//! progress events.
+//! This module handles progress aggregation, rate-limiting for download
+//! progress events, and the shared sliding-window speed estimator used by
+//! all display paths.
 
+pub(crate) mod rate;
 mod throttle;
 
+pub(crate) use rate::{SlidingWindowRate, format_eta};
 pub use throttle::ProgressThrottle;

--- a/crates/gglib-download/src/progress/mod.rs
+++ b/crates/gglib-download/src/progress/mod.rs
@@ -4,8 +4,8 @@
 //! progress events, and the shared sliding-window speed estimator used by
 //! all display paths.
 
-pub(crate) mod rate;
+pub mod rate;
 mod throttle;
 
-pub(crate) use rate::{SlidingWindowRate, format_eta};
+pub use rate::{SlidingWindowRate, format_eta};
 pub use throttle::ProgressThrottle;

--- a/crates/gglib-download/src/progress/rate.rs
+++ b/crates/gglib-download/src/progress/rate.rs
@@ -28,7 +28,7 @@ use std::time::{Duration, Instant};
 /// Wide enough to absorb short TCP-level bursts; narrow enough to track
 /// genuine speed changes within a few seconds. Matches the typical display
 /// window used by `wget` and `aria2`.
-pub(crate) const SPEED_WINDOW: Duration = Duration::from_secs(8);
+pub const SPEED_WINDOW: Duration = Duration::from_secs(8);
 
 // ─── Internal sample type ─────────────────────────────────────────────────────
 
@@ -59,7 +59,7 @@ struct Sample {
 ///
 /// Not `Send` or `Sync` on its own — callers hold it behind a `Mutex` or in
 /// a single async task (the bridge spawns one per download).
-pub(crate) struct SlidingWindowRate {
+pub struct SlidingWindowRate {
     /// Recent samples within the sliding window.
     samples: VecDeque<Sample>,
     /// The first sample ever recorded; used as the warm-up fallback reference.
@@ -68,7 +68,7 @@ pub(crate) struct SlidingWindowRate {
 
 impl SlidingWindowRate {
     /// Create a new, empty estimator.
-    pub(crate) fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             samples: VecDeque::new(),
             start: None,
@@ -79,7 +79,7 @@ impl SlidingWindowRate {
     ///
     /// Evicts samples older than [`SPEED_WINDOW`] before appending, so the
     /// deque always represents at most the last 8 seconds of history.
-    pub(crate) fn record(&mut self, now: Instant, bytes: u64) {
+    pub fn record(&mut self, now: Instant, bytes: u64) {
         // Evict samples that have aged out of the window.
         while let Some(front) = self.samples.front() {
             if now.duration_since(front.time) > SPEED_WINDOW {
@@ -104,7 +104,7 @@ impl SlidingWindowRate {
     /// timestamps. Falls back to the overall average (bytes since the first
     /// [`record`](SlidingWindowRate::record) call) during the warm-up period.
     /// Returns `0.0` before any samples are recorded.
-    pub(crate) fn speed_bps(&self) -> f64 {
+    pub fn speed_bps(&self) -> f64 {
         let (oldest, newest) = match (self.samples.front(), self.samples.back()) {
             (Some(o), Some(n)) => (*o, *n),
             _ => return 0.0,
@@ -141,7 +141,8 @@ impl SlidingWindowRate {
     ///
     /// Use when a download restarts or is replaced so stale history does not
     /// contaminate the new download's speed display.
-    pub(crate) fn reset(&mut self) {
+    #[allow(dead_code)]
+    pub fn reset(&mut self) {
         self.samples.clear();
         self.start = None;
     }
@@ -160,10 +161,11 @@ impl SlidingWindowRate {
 /// | `≤ 0.0`, `NaN`, or infinite | `"--:--"` |
 /// | `< 3600.0` | `"M:SS"` |
 /// | `≥ 3600.0` | `"H:MM:SS"` |
-pub(crate) fn format_eta(secs: f64) -> String {
+pub fn format_eta(secs: f64) -> String {
     if secs <= 0.0 || !secs.is_finite() {
         return "--:--".to_string();
     }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let total = secs as u64;
     let h = total / 3600;
     let m = (total % 3600) / 60;
@@ -233,7 +235,7 @@ mod tests {
     #[test]
     fn speed_zero_before_any_samples() {
         let rate = SlidingWindowRate::new();
-        assert_eq!(rate.speed_bps(), 0.0);
+        assert!(rate.speed_bps() == 0.0);
     }
 
     #[test]
@@ -241,7 +243,7 @@ mod tests {
         let mut rate = SlidingWindowRate::new();
         rate.record(Instant::now(), 0);
         // Only one distinct timestamp — falls back to overall avg; elapsed = 0
-        assert_eq!(rate.speed_bps(), 0.0);
+        assert!(rate.speed_bps() == 0.0);
     }
 
     #[test]
@@ -289,6 +291,6 @@ mod tests {
         rate.record(t0 + Duration::from_secs(1), 1_000_000);
         assert!(rate.speed_bps() > 0.0);
         rate.reset();
-        assert_eq!(rate.speed_bps(), 0.0);
+        assert!(rate.speed_bps() == 0.0);
     }
 }

--- a/crates/gglib-download/src/progress/rate.rs
+++ b/crates/gglib-download/src/progress/rate.rs
@@ -1,0 +1,294 @@
+//! 8-second sliding window speed and ETA estimator.
+//!
+//! Provides [`SlidingWindowRate`] for accurate download speed estimation and
+//! [`format_eta`] for consistent ETA formatting across all display paths.
+//!
+//! # Algorithm
+//!
+//! Speed = `(newest_bytes − oldest_bytes) / (newest_time − oldest_time)` over
+//! the most recent [`SPEED_WINDOW`] seconds of samples. This matches the display
+//! behaviour of `wget`, `aria2`, and `curl`, eliminating the tuning constants
+//! required by EWA-based approaches.
+//!
+//! # Display parity
+//!
+//! All four download progress display paths — GUI SSE bridge
+//! (`spawn_progress_bridge`), TTY CLI (`CliDownloadEventEmitter`),
+//! fast-download TTY (`FancyProgress`), and non-TTY (`PlainProgress`) — share
+//! this struct and [`format_eta`] so that the GUI and every CLI variant always
+//! show the same speed and ETA values.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Duration of the sliding window used for speed estimation.
+///
+/// Wide enough to absorb short TCP-level bursts; narrow enough to track
+/// genuine speed changes within a few seconds. Matches the typical display
+/// window used by `wget` and `aria2`.
+pub(crate) const SPEED_WINDOW: Duration = Duration::from_secs(8);
+
+// ─── Internal sample type ─────────────────────────────────────────────────────
+
+/// A single timestamped byte-count observation.
+#[derive(Debug, Clone, Copy)]
+struct Sample {
+    time: Instant,
+    bytes: u64,
+}
+
+// ─── SlidingWindowRate ────────────────────────────────────────────────────────
+
+/// 8-second sliding window download speed estimator.
+///
+/// Records timestamped byte-count samples and computes bytes/sec from the
+/// oldest and newest sample within [`SPEED_WINDOW`]. Falls back to an overall
+/// average during the initial warm-up period (fewer than two distinct
+/// timestamps in the window).
+///
+/// # Warm-up behaviour
+///
+/// Before the window contains two samples with distinct timestamps,
+/// [`speed_bps`](SlidingWindowRate::speed_bps) uses the very first recorded
+/// sample as the reference, giving a rough overall-average until the window
+/// has enough data to produce a sliding estimate.
+///
+/// # Thread safety
+///
+/// Not `Send` or `Sync` on its own — callers hold it behind a `Mutex` or in
+/// a single async task (the bridge spawns one per download).
+pub(crate) struct SlidingWindowRate {
+    /// Recent samples within the sliding window.
+    samples: VecDeque<Sample>,
+    /// The first sample ever recorded; used as the warm-up fallback reference.
+    start: Option<Sample>,
+}
+
+impl SlidingWindowRate {
+    /// Create a new, empty estimator.
+    pub(crate) fn new() -> Self {
+        Self {
+            samples: VecDeque::new(),
+            start: None,
+        }
+    }
+
+    /// Record a new byte-count observation at the given instant.
+    ///
+    /// Evicts samples older than [`SPEED_WINDOW`] before appending, so the
+    /// deque always represents at most the last 8 seconds of history.
+    pub(crate) fn record(&mut self, now: Instant, bytes: u64) {
+        // Evict samples that have aged out of the window.
+        while let Some(front) = self.samples.front() {
+            if now.duration_since(front.time) > SPEED_WINDOW {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        let sample = Sample { time: now, bytes };
+
+        if self.start.is_none() {
+            self.start = Some(sample);
+        }
+
+        self.samples.push_back(sample);
+    }
+
+    /// Return the current speed estimate in bytes per second.
+    ///
+    /// Uses the oldest and newest in-window sample when they have distinct
+    /// timestamps. Falls back to the overall average (bytes since the first
+    /// [`record`](SlidingWindowRate::record) call) during the warm-up period.
+    /// Returns `0.0` before any samples are recorded.
+    pub(crate) fn speed_bps(&self) -> f64 {
+        let (oldest, newest) = match (self.samples.front(), self.samples.back()) {
+            (Some(o), Some(n)) => (*o, *n),
+            _ => return 0.0,
+        };
+
+        if oldest.time == newest.time {
+            // Only one effective timestamp in the window — fall back to
+            // overall average from the very first sample.
+            return self.start.map_or(0.0, |start| {
+                let elapsed = newest.time.duration_since(start.time).as_secs_f64();
+                if elapsed <= 0.0 {
+                    return 0.0;
+                }
+                let bytes = newest.bytes.saturating_sub(start.bytes);
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    bytes as f64 / elapsed
+                }
+            });
+        }
+
+        let elapsed = newest.time.duration_since(oldest.time).as_secs_f64();
+        if elapsed <= 0.0 {
+            return 0.0;
+        }
+        let bytes = newest.bytes.saturating_sub(oldest.bytes);
+        #[allow(clippy::cast_precision_loss)]
+        {
+            bytes as f64 / elapsed
+        }
+    }
+
+    /// Reset the estimator, discarding all samples.
+    ///
+    /// Use when a download restarts or is replaced so stale history does not
+    /// contaminate the new download's speed display.
+    pub(crate) fn reset(&mut self) {
+        self.samples.clear();
+        self.start = None;
+    }
+}
+
+// ─── format_eta ───────────────────────────────────────────────────────────────
+
+/// Format a duration in seconds as a human-readable ETA string.
+///
+/// This is a standalone formatting utility shared by all download progress
+/// display paths (GUI SSE bridge, TTY CLI, fast-download TTY, non-TTY) to
+/// ensure consistent ETA presentation everywhere.
+///
+/// | Input | Output |
+/// |---|---|
+/// | `≤ 0.0`, `NaN`, or infinite | `"--:--"` |
+/// | `< 3600.0` | `"M:SS"` |
+/// | `≥ 3600.0` | `"H:MM:SS"` |
+pub(crate) fn format_eta(secs: f64) -> String {
+    if secs <= 0.0 || !secs.is_finite() {
+        return "--:--".to_string();
+    }
+    let total = secs as u64;
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    if h > 0 {
+        format!("{h}:{m:02}:{s:02}")
+    } else {
+        format!("{m}:{s:02}")
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── format_eta ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn format_eta_zero_returns_placeholder() {
+        assert_eq!(format_eta(0.0), "--:--");
+    }
+
+    #[test]
+    fn format_eta_negative_returns_placeholder() {
+        assert_eq!(format_eta(-5.0), "--:--");
+    }
+
+    #[test]
+    fn format_eta_infinity_returns_placeholder() {
+        assert_eq!(format_eta(f64::INFINITY), "--:--");
+    }
+
+    #[test]
+    fn format_eta_nan_returns_placeholder() {
+        assert_eq!(format_eta(f64::NAN), "--:--");
+    }
+
+    #[test]
+    fn format_eta_sub_minute() {
+        assert_eq!(format_eta(45.0), "0:45");
+    }
+
+    #[test]
+    fn format_eta_one_minute() {
+        assert_eq!(format_eta(60.0), "1:00");
+    }
+
+    #[test]
+    fn format_eta_sub_hour() {
+        assert_eq!(format_eta(90.0), "1:30");
+    }
+
+    #[test]
+    fn format_eta_exactly_one_hour() {
+        assert_eq!(format_eta(3600.0), "1:00:00");
+    }
+
+    #[test]
+    fn format_eta_super_hour() {
+        assert_eq!(format_eta(3661.0), "1:01:01");
+    }
+
+    // ── SlidingWindowRate ────────────────────────────────────────────────────
+
+    #[test]
+    fn speed_zero_before_any_samples() {
+        let rate = SlidingWindowRate::new();
+        assert_eq!(rate.speed_bps(), 0.0);
+    }
+
+    #[test]
+    fn speed_zero_with_single_sample() {
+        let mut rate = SlidingWindowRate::new();
+        rate.record(Instant::now(), 0);
+        // Only one distinct timestamp — falls back to overall avg; elapsed = 0
+        assert_eq!(rate.speed_bps(), 0.0);
+    }
+
+    #[test]
+    fn two_samples_compute_correct_speed() {
+        let mut rate = SlidingWindowRate::new();
+        let t0 = Instant::now();
+        rate.record(t0, 0);
+        rate.record(t0 + Duration::from_secs(1), 1_000_000);
+        let speed = rate.speed_bps();
+        assert!((speed - 1_000_000.0).abs() < 1.0, "speed={speed}");
+    }
+
+    #[test]
+    fn constant_rate_accuracy() {
+        let mut rate = SlidingWindowRate::new();
+        let t0 = Instant::now();
+        // 1 MiB/s over 4 seconds (5 samples at 1s intervals)
+        for i in 0u64..=4 {
+            rate.record(t0 + Duration::from_secs(i), i * 1_048_576);
+        }
+        let speed = rate.speed_bps();
+        assert!((speed - 1_048_576.0).abs() < 1_000.0, "speed={speed}");
+    }
+
+    #[test]
+    fn window_evicts_old_samples() {
+        let mut rate = SlidingWindowRate::new();
+        let t0 = Instant::now();
+        // Add a sample well outside the 8-second window
+        rate.record(t0, 0);
+        // Jump 20 seconds forward and add two fresh samples at 1 MiB/s
+        let t1 = t0 + Duration::from_secs(20);
+        rate.record(t1, 10_000_000);
+        rate.record(t1 + Duration::from_secs(1), 10_000_000 + 1_048_576);
+        // The old sample should have been evicted; speed reflects only recent data
+        let speed = rate.speed_bps();
+        assert!((speed - 1_048_576.0).abs() < 1_000.0, "speed={speed}");
+    }
+
+    #[test]
+    fn reset_clears_all_state() {
+        let mut rate = SlidingWindowRate::new();
+        let t0 = Instant::now();
+        rate.record(t0, 0);
+        rate.record(t0 + Duration::from_secs(1), 1_000_000);
+        assert!(rate.speed_bps() > 0.0);
+        rate.reset();
+        assert_eq!(rate.speed_bps(), 0.0);
+    }
+}


### PR DESCRIPTION
Closes #525

## Problem

Download speed and ETA indicators in both the GUI and CLI fluctuated wildly. After implementing the sliding window estimator (see below), the symptom persisted: system monitor showed a stable 90 MB/s, but gglib displayed values that jumped from 4 → 250 → 50 → 1000 → 30 MB/s.

Two separate bugs were found and fixed.

---

### Bug 1 — Slow/wrong estimator algorithm

Both the GUI bridge task and the CLI progress bars used an exponentially-weighted average with α=0.02. At a 250 ms tick interval that gives a ~34-tick half-life (~8.5 s convergence lag), and speed initialises at 0.0 so it takes ~28 s to reach 90% of the true value. Two independent copies of this bug existed in the codebase.

A second issue: indicatif's `{bytes_per_sec}` and `{eta}` placeholders are computed internally by indicatif from `set_position()` calls and cannot be overridden — so even if the bridge task sent correct speed/ETA values, the CLI bars would still show indicatif's own fluctuating estimate.

### Bug 2 — XetPoller scanning the wrong filesystem locations (root cause of spikes)

When `hf_xet` is active, `huggingface_hub` bypasses `tqdm.update()` entirely, so the Python subprocess never emits `Progress` events. `XetPoller` compensates by stat-polling a list of target paths and reporting the total bytes on disk every 250 ms.

Two problems with how those targets were chosen:

1. **Atomic rename spike** — targets included `dest/{filename}` (the final output file). When a transfer completes, `huggingface_hub` atomically renames `.incomplete` → final file. That makes the full file size appear in one 250 ms tick: e.g. a 5 GB file produces a momentary `5 GB / 0.25 s = 20 GB/s` reading. The `SlidingWindowRate` then spends several seconds averaging this spike away while displaying wild intermediate values.

2. **Global HF cache not scanned** — `hf_xet` frequently writes blobs to the system-wide hub cache (`~/.cache/huggingface/hub/models--owner--repo/blobs/`) rather than the local `dest/.cache` staging directory. When that path wasn't in the target list, XetPoller saw 0 bytes for the first ~30 s of a download (explaining the "stuck at 4 MB/s" observation), then received the full blob size in one tick when the rename fired.

---

## Fix

**Shared `SlidingWindowRate` struct** (`progress/rate.rs`) — retains timestamped byte-count samples over an 8-second window and reports `Δbytes / Δtime` across that window. This matches what system monitors show, requires no tuning constants, and is accurate from the second sample onward.

**GUI / SSE path** (`manager/mod.rs`) — the bridge task now calls `rate.record()` + `rate.speed_bps()` on every tick. `DownloadEvent::progress()` in `gglib-core` derives `eta_seconds` from `speed_bps`, so GUI ETA is also fixed with no changes to the core crate.

**CLI indicatif bypass** (`cli_emitter.rs`, `cli_exec/exec/progress.rs`) — `{bytes_per_sec}` and `{eta}` slots removed from all templates and replaced with `{prefix}`. Each bar now holds a `SlidingWindowRate`; speed and ETA are formatted as `"X.XX MB/s  eta MM:SS"` and written via `bar.set_prefix()`, completely bypassing indicatif's internal estimator. `set_position()` is still called so `{bytes}` / `{total_bytes}` / `{bar}` continue to work correctly.

**`PlainProgress` (non-TTY)** now also emits ETA — it was previously omitted entirely.

**XetPoller scan targets** (`cli_exec/exec/python_bridge.rs`, `xet_poller.rs`):
- Removed per-file final-path targets (eliminates the rename spike)
- Added the global HF hub blob directory for the repo as a second target, resolving via `HF_HUB_CACHE` → `HUGGINGFACE_HUB_CACHE` → `HF_HOME/hub` → `$HOME/.cache/huggingface/hub` (same priority as Python's `huggingface_hub`); missing paths are silently skipped
- Made the high-water-mark check strictly monotonic: if polled bytes decrease (e.g. mid-rename), `last_bytes` resets to 0 so the next genuine increase fires immediately

---

## Commits

1. `feat(download): add SlidingWindowRate and format_eta to progress module` — new `rate.rs` with full unit test suite
2. `fix(download): replace EWA bridge task speed with SlidingWindowRate` — `manager/mod.rs`; removes `calculate_speed_eta` helper
3. `fix(download): bypass indicatif estimator in CliDownloadEventEmitter` — `cli_emitter.rs`
4. `fix(download): replace EWA in FancyProgress and PlainProgress` — `cli_exec/exec/progress.rs`
5. `docs(download): document SlidingWindowRate and format_eta in progress README`
6. `fix(download): resolve all strict clippy warnings`
7. `fix(download): fix XetPoller scan targets to eliminate speed spikes` — root cause fix for hf-xet downloads