### PR TITLE
fix(agent): dual-threshold observation loop guard — resolves false positives on ReAct browser cycles (#528)

### DIFF
--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -415,7 +415,12 @@ impl Guards {
         }
         if !tool_calls.is_empty() {
             if let Some(max_steps) = config.max_repeated_batch_steps {
-                if let Err(e) = self.loop_detector.check(tool_calls, max_steps) {
+                if let Err(e) = self.loop_detector.check(
+                    tool_calls,
+                    max_steps,
+                    &config.observation_tools,
+                    config.max_observation_steps,
+                ) {
                     emit_error_event(tx, &e.to_string()).await;
                     return Err(e);
                 }

--- a/crates/gglib-agent/src/loop_detection/mod.rs
+++ b/crates/gglib-agent/src/loop_detection/mod.rs
@@ -15,7 +15,7 @@
 //! Observation-only tools (e.g. browser snapshots, page screenshots) take no
 //! meaningful arguments, so every call hashes to the same signature regardless
 //! of the page content returned.  With a strict threshold this causes false
-//! positives on legitimate ReAct *observe → act → observe* cycles.
+//! positives on legitimate `ReAct` *observe → act → observe* cycles.
 //!
 //! The detector therefore applies **two thresholds**:
 //!
@@ -166,7 +166,7 @@ fn batch_signature(calls: &[ToolCall]) -> String {
 /// An empty `calls` slice returns `true` (vacuous truth), but the caller
 /// ([`LoopDetector::check`]) is never invoked with an empty batch — the
 /// agent loop skips loop detection when there are no tool calls.
-pub(crate) fn is_observation_batch(calls: &[ToolCall], patterns: &[String]) -> bool {
+pub fn is_observation_batch(calls: &[ToolCall], patterns: &[String]) -> bool {
     if patterns.is_empty() {
         return false;
     }

--- a/crates/gglib-agent/src/loop_detection/mod.rs
+++ b/crates/gglib-agent/src/loop_detection/mod.rs
@@ -7,10 +7,35 @@
 //! 2. Sort the individual signatures and join them with `"|"` to form a
 //!    **batch signature** that is independent of tool-call ordering.
 //! 3. A [`LoopDetector`] counts how many times each batch signature has been
-//!    seen.  When the count exceeds `max_repeated_batch_steps` the loop is
-//!    considered stuck and [`AgentError::LoopDetected`] is returned.
+//!    seen.  The threshold applied depends on whether the batch is classified
+//!    as "observation-only" (see below).
 //!
-//! ## Hash algorithm
+//! # Dual-threshold detection
+//!
+//! Observation-only tools (e.g. browser snapshots, page screenshots) take no
+//! meaningful arguments, so every call hashes to the same signature regardless
+//! of the page content returned.  With a strict threshold this causes false
+//! positives on legitimate ReAct *observe → act → observe* cycles.
+//!
+//! The detector therefore applies **two thresholds**:
+//!
+//! | Batch type | Threshold used |
+//! |------------|---------------|
+//! | Every call matches an observation pattern | `max_observation_steps` |
+//! | At least one call does **not** match | `max_repeated_batch_steps` |
+//!
+//! A batch is observation-only when [`is_observation_batch`] returns `true`:
+//! every call's lowercased name satisfies
+//! `name.ends_with(pattern) || name.contains(pattern)` for at least one
+//! pattern in the configured list.  Substring/suffix matching is used
+//! intentionally so that namespaced MCP tool names such as
+//! `playwright_mcp_browser_snapshot` are matched by the short pattern
+//! `"snapshot"` without requiring users to enumerate every vendor variant.
+//!
+//! **Mixed batches** (≥ 1 non-observation call) always fall back to the
+//! stricter `max_repeated_batch_steps` — the conservative choice.
+//!
+//! # Hash algorithm
 //!
 //! FNV-1a 64-bit with:
 //! - Offset basis: `14_695_981_039_346_656_037`
@@ -125,6 +150,35 @@ fn batch_signature(calls: &[ToolCall]) -> String {
 }
 
 // =============================================================================
+// Observation-batch classifier
+// =============================================================================
+
+/// Return `true` if **every** call in `calls` is an observation-only tool.
+///
+/// A tool call is classified as observation-only when its lowercased name
+/// satisfies `name.ends_with(pattern) || name.contains(pattern)` for at
+/// least one pattern in `patterns`.  Matching is case-insensitive (both
+/// sides are lowercased before comparison).
+///
+/// An empty `patterns` list means no tools are ever classified as
+/// observation-only, so the function always returns `false`.
+///
+/// An empty `calls` slice returns `true` (vacuous truth), but the caller
+/// ([`LoopDetector::check`]) is never invoked with an empty batch — the
+/// agent loop skips loop detection when there are no tool calls.
+pub(crate) fn is_observation_batch(calls: &[ToolCall], patterns: &[String]) -> bool {
+    if patterns.is_empty() {
+        return false;
+    }
+    calls.iter().all(|call| {
+        let name = call.name.to_lowercase();
+        patterns
+            .iter()
+            .any(|pat| name.ends_with(pat.as_str()) || name.contains(pat.as_str()))
+    })
+}
+
+// =============================================================================
 // LoopDetector
 // =============================================================================
 
@@ -140,23 +194,35 @@ pub struct LoopDetector {
 impl LoopDetector {
     /// Record the current batch of tool calls and error if a loop is detected.
     ///
-    /// A loop is declared when the same batch signature has been seen more
-    /// than `max_strikes` times.  The count is incremented **before** the
-    /// comparison so that `max_strikes = 2` allows two identical batches
-    /// before erroring on the third.
+    /// Selects the effective threshold based on batch classification:
     ///
-    /// `max_strikes = 0` rejects the very first occurrence (zero tolerance).
-    /// `max_strikes = 1` rejects on the second occurrence (one repeat allowed).
+    /// - If every call in `calls` matches an observation pattern in
+    ///   `observation_tools` (via [`is_observation_batch`]), `max_observation_steps`
+    ///   is used as the threshold (falling back to `max_strikes` when `None`).
+    /// - Otherwise, `max_strikes` (`max_repeated_batch_steps`) is used.
+    ///
+    /// The count is incremented **before** the comparison so that
+    /// `effective_max = 2` allows two identical batches before erroring on
+    /// the third.
+    ///
+    /// `effective_max = 0` rejects the very first occurrence (zero tolerance).
     pub(crate) fn check(
         &mut self,
         calls: &[ToolCall],
         max_strikes: usize,
+        observation_tools: &[String],
+        max_observation_steps: Option<usize>,
     ) -> Result<(), AgentError> {
+        let effective_max = if is_observation_batch(calls, observation_tools) {
+            max_observation_steps.unwrap_or(max_strikes)
+        } else {
+            max_strikes
+        };
         let sig = batch_signature(calls);
         let entry = self.hits.entry(sig.clone()).or_insert(0);
         *entry += 1;
         let count = *entry;
-        if count > max_strikes {
+        if count > effective_max {
             return Err(AgentError::LoopDetected { signature: sig });
         }
         Ok(())

--- a/crates/gglib-agent/src/loop_detection/tests.rs
+++ b/crates/gglib-agent/src/loop_detection/tests.rs
@@ -287,7 +287,7 @@ fn obs_batch(name: &str) -> Vec<ToolCall> {
 }
 
 fn patterns(list: &[&str]) -> Vec<String> {
-    list.iter().map(|s| s.to_string()).collect()
+    list.iter().map(|s| (*s).to_string()).collect()
 }
 
 #[test]

--- a/crates/gglib-agent/src/loop_detection/tests.rs
+++ b/crates/gglib-agent/src/loop_detection/tests.rs
@@ -117,8 +117,8 @@ fn loop_not_detected_within_limit() {
         arguments: json!({}),
     }];
     // max_strikes = 2: first two calls must succeed
-    assert!(det.check(&calls, 2).is_ok());
-    assert!(det.check(&calls, 2).is_ok());
+    assert!(det.check(&calls, 2, &[], None).is_ok());
+    assert!(det.check(&calls, 2, &[], None).is_ok());
 }
 
 #[test]
@@ -129,9 +129,9 @@ fn loop_detected_on_third_identical_batch_with_max_strikes_2() {
         name: "t".into(),
         arguments: json!({}),
     }];
-    assert!(det.check(&calls, 2).is_ok());
-    assert!(det.check(&calls, 2).is_ok());
-    let err = det.check(&calls, 2).unwrap_err();
+    assert!(det.check(&calls, 2, &[], None).is_ok());
+    assert!(det.check(&calls, 2, &[], None).is_ok());
+    let err = det.check(&calls, 2, &[], None).unwrap_err();
     assert!(matches!(err, AgentError::LoopDetected { .. }));
 }
 
@@ -153,22 +153,22 @@ fn different_batches_do_not_trigger_loop() {
     // max_strikes = 10: each may appear 10 times
     for _ in 0..10 {
         assert!(
-            det.check(&a, 10).is_ok(),
+            det.check(&a, 10, &[], None).is_ok(),
             "batch a should not trigger within limit"
         );
         assert!(
-            det.check(&b, 10).is_ok(),
+            det.check(&b, 10, &[], None).is_ok(),
             "batch b should not trigger within limit"
         );
     }
     // 11th appearance of `a` should fire (count 11 > 10)
     assert!(
-        det.check(&a, 10).is_err(),
+        det.check(&a, 10, &[], None).is_err(),
         "batch a should trigger on 11th occurrence"
     );
     // `b` is still at count 10 — one more must fire
     assert!(
-        det.check(&b, 10).is_err(),
+        det.check(&b, 10, &[], None).is_err(),
         "batch b should trigger on 11th occurrence"
     );
 }
@@ -183,7 +183,7 @@ fn loop_error_signature_matches_batch_sig() {
     let expected_sig = batch_signature(&calls);
     // max_strikes = 0 → first occurrence triggers immediately.
     let mut det = LoopDetector::default();
-    let err = det.check(&calls, 0).unwrap_err();
+    let err = det.check(&calls, 0, &[], None).unwrap_err();
     if let AgentError::LoopDetected { signature } = err {
         assert_eq!(signature, expected_sig);
     }
@@ -201,7 +201,7 @@ fn same_name_different_args_do_not_trigger_loop() {
             arguments: json!({ "q": i }),
         }];
         assert!(
-            det.check(&calls, 2).is_ok(),
+            det.check(&calls, 2, &[], None).is_ok(),
             "distinct arguments should not trigger loop detection (i={i})"
         );
     }
@@ -218,7 +218,7 @@ fn max_strikes_zero_triggers_on_first_occurrence() {
         arguments: json!({}),
     }];
     let err = det
-        .check(&calls, 0)
+        .check(&calls, 0, &[], None)
         .expect_err("max_strikes=0 must reject the first occurrence");
     assert!(
         matches!(err, AgentError::LoopDetected { .. }),
@@ -272,5 +272,130 @@ fn stable_repr_below_max_depth_produces_full_output() {
     assert!(
         !repr.contains("\"...\""),
         "stable_repr at depth=MAX_REPR_DEPTH-1 must not sentinel; got: {repr}",
+    );
+}
+
+// ---- is_observation_batch ---------------------------------------------------
+
+/// Build a single-call batch with the given tool name (no args).
+fn obs_batch(name: &str) -> Vec<ToolCall> {
+    vec![ToolCall {
+        id: "c1".into(),
+        name: name.into(),
+        arguments: serde_json::json!({}),
+    }]
+}
+
+fn patterns(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn is_observation_batch_ends_with_match() {
+    // `playwright_mcp_browser_snapshot` ends_with `snapshot` → true.
+    let calls = obs_batch("playwright_mcp_browser_snapshot");
+    assert!(
+        is_observation_batch(&calls, &patterns(&["snapshot"])),
+        "ends_with match should return true"
+    );
+}
+
+#[test]
+fn is_observation_batch_contains_match() {
+    // `take_screenshot_full` contains `screenshot` → true.
+    let calls = obs_batch("take_screenshot_full");
+    assert!(
+        is_observation_batch(&calls, &patterns(&["screenshot"])),
+        "contains match should return true"
+    );
+}
+
+#[test]
+fn is_observation_batch_case_insensitive() {
+    // `BROWSER_SNAPSHOT` uppercased must still match pattern `snapshot`.
+    let calls = obs_batch("BROWSER_SNAPSHOT");
+    assert!(
+        is_observation_batch(&calls, &patterns(&["snapshot"])),
+        "matching should be case-insensitive"
+    );
+}
+
+#[test]
+fn is_observation_batch_mixed_returns_false() {
+    // A batch containing both an observation tool and a non-observation tool
+    // must return false — the whole batch falls back to the standard threshold.
+    let calls = vec![
+        ToolCall {
+            id: "c1".into(),
+            name: "browser_snapshot".into(),
+            arguments: serde_json::json!({}),
+        },
+        ToolCall {
+            id: "c2".into(),
+            name: "do_thing".into(),
+            arguments: serde_json::json!({}),
+        },
+    ];
+    assert!(
+        !is_observation_batch(&calls, &patterns(&["snapshot"])),
+        "mixed batch (snapshot + do_thing) should return false"
+    );
+}
+
+#[test]
+fn is_observation_batch_empty_patterns_always_false() {
+    // An empty pattern list means no tools are ever classified as
+    // observation-only — the standard threshold always applies.
+    let calls = obs_batch("browser_snapshot");
+    assert!(
+        !is_observation_batch(&calls, &[]),
+        "empty pattern list should always return false"
+    );
+}
+
+#[test]
+fn loop_detector_observation_batch_uses_higher_threshold() {
+    // With max_strikes=2 and max_observation_steps=5, an observation-only
+    // batch must be allowed up to 5 repetitions without triggering.
+    let mut det = LoopDetector::default();
+    let calls = obs_batch("playwright_mcp_browser_snapshot");
+    let obs_patterns = patterns(&["snapshot"]);
+    for _ in 0..5 {
+        assert!(
+            det.check(&calls, 2, &obs_patterns, Some(5)).is_ok(),
+            "observation batch must not trigger within max_observation_steps"
+        );
+    }
+    // 6th occurrence (count = 6 > 5) must fire.
+    assert!(
+        det.check(&calls, 2, &obs_patterns, Some(5)).is_err(),
+        "observation batch must trigger on 6th occurrence"
+    );
+}
+
+#[test]
+fn loop_detector_mixed_batch_uses_standard_threshold() {
+    // A mixed batch (snapshot + do_thing) must use max_strikes=2, not the
+    // higher observation threshold, even though snapshot is in the list.
+    let mut det = LoopDetector::default();
+    let mixed = vec![
+        ToolCall {
+            id: "c1".into(),
+            name: "browser_snapshot".into(),
+            arguments: serde_json::json!({}),
+        },
+        ToolCall {
+            id: "c2".into(),
+            name: "do_thing".into(),
+            arguments: serde_json::json!({}),
+        },
+    ];
+    let obs_patterns = patterns(&["snapshot"]);
+    assert!(det.check(&mixed, 2, &obs_patterns, Some(10)).is_ok());
+    assert!(det.check(&mixed, 2, &obs_patterns, Some(10)).is_ok());
+    // 3rd occurrence (count = 3 > 2) must fire — standard threshold applies.
+    assert!(
+        det.check(&mixed, 2, &obs_patterns, Some(10)).is_err(),
+        "mixed batch must use standard threshold (max_strikes=2)"
     );
 }

--- a/crates/gglib-agent/tests/council_plan_eval.rs
+++ b/crates/gglib-agent/tests/council_plan_eval.rs
@@ -224,5 +224,5 @@ async fn eval_canonical_acceptance_prompt() {
         r.error
     );
     assert!(r.coherent, "canonical prompt produced an incoherent graph");
-    assert!(r.node_count >= 2, "expected ≥2 nodes, got {}", r.node_count,);
+    assert!(r.node_count >= 2, "expected ≥2 nodes, got {}", r.node_count);
 }

--- a/crates/gglib-agent/tests/integration_guards.rs
+++ b/crates/gglib-agent/tests/integration_guards.rs
@@ -533,8 +533,8 @@ async fn test_observation_tool_fires_at_higher_threshold() {
 #[tokio::test]
 async fn test_mixed_batch_uses_standard_threshold() {
     // Each LLM response emits two tool calls: one observation, one action.
-    let llm = Arc::new(MockLlmPort::new().push_many((0..10).map(|i| {
-        MockLlmResponse {
+    let llm = Arc::new(
+        MockLlmPort::new().push_many((0..10).map(|i| MockLlmResponse {
             reasoning: None,
             content: None,
             tool_calls: vec![
@@ -550,8 +550,8 @@ async fn test_mixed_batch_uses_standard_threshold() {
                 },
             ],
             finish_reason: "tool_calls".into(),
-        }
-    })));
+        })),
+    );
 
     let executor = MockToolExecutorPort::new()
         .with_tool(

--- a/crates/gglib-agent/tests/integration_guards.rs
+++ b/crates/gglib-agent/tests/integration_guards.rs
@@ -8,11 +8,14 @@
 //!
 //! | Test | Guard exercised |
 //! |------|----------------|
-//! | [`test_max_iterations_reached`]         | [`AgentConfig::max_iterations`] limit |
-//! | [`test_loop_detection`]                 | Repeated tool-call batch → [`AgentError::LoopDetected`] |
-//! | [`test_stagnation_detected_integration`] | Repeated text response → [`AgentError::StagnationDetected`] |
-//! | [`test_stagnation_fires_before_finalize`] | Stagnation catches repeated final answer |
-//! | [`test_too_many_tool_calls_integration`] | Oversized tool-call batch → soft-recovery via synthetic tool error + [`AgentEvent::SystemWarning`] |
+//! | [`test_max_iterations_reached`]                  | [`AgentConfig::max_iterations`] limit |
+//! | [`test_loop_detection`]                          | Repeated tool-call batch → [`AgentError::LoopDetected`] |
+//! | [`test_stagnation_detected_integration`]         | Repeated text response → [`AgentError::StagnationDetected`] |
+//! | [`test_stagnation_fires_before_finalize`]        | Stagnation catches repeated final answer |
+//! | [`test_too_many_tool_calls_integration`]         | Oversized tool-call batch → soft-recovery via synthetic tool error + [`AgentEvent::SystemWarning`] |
+//! | [`test_observation_tool_uses_higher_threshold`]  | Observation-only batch stays safe up to `max_observation_steps` |
+//! | [`test_observation_tool_fires_at_higher_threshold`] | Observation batch fires after `max_observation_steps` |
+//! | [`test_mixed_batch_uses_standard_threshold`]     | Mixed batch (obs + action) uses `max_repeated_batch_steps` |
 
 mod common;
 
@@ -404,5 +407,195 @@ async fn test_stagnation_fires_before_finalize() {
     assert!(
         !has_final_answer(&events),
         "FinalAnswer must not be emitted when stagnation aborts a text-only iteration"
+    );
+}
+
+// =============================================================================
+// Dual-threshold observation guard
+// =============================================================================
+
+/// **Observation threshold — safe under limit**: an observation-only batch
+/// (every call's name matches an observation pattern) must be allowed to
+/// repeat up to `max_observation_steps` times without firing.
+///
+/// Uses `max_repeated_batch_steps=2` (the production default) with
+/// `max_observation_steps=10`.  The batch repeats 10 times — each must
+/// succeed.  The 11th repetition is handled by the next test.
+#[tokio::test]
+async fn test_observation_tool_uses_higher_threshold() {
+    // 12 identical observation-only calls — we'll check the first 10 pass.
+    let llm = Arc::new(MockLlmPort::new().push_many((0..12).map(|i| {
+        MockLlmResponse::tool_call(
+            format!("obs{i}"),
+            "playwright_mcp_browser_snapshot",
+            json!({}),
+        )
+    })));
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("playwright_mcp_browser_snapshot"),
+        MockToolBehavior::Immediate {
+            content: "page html...".into(),
+        },
+    );
+
+    let agent = AgentLoop::build(llm, Arc::new(executor), None);
+    let (tx, rx) = mpsc::channel(256);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "browse".into(),
+            }],
+            common::for_test(|c| {
+                c.max_iterations = 10;
+                c.max_repeated_batch_steps = Some(2);
+                c.max_observation_steps = Some(10);
+                c.observation_tools = vec!["snapshot".into()];
+                c.max_stagnation_steps = None;
+            }),
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // With max_observation_steps=10 the loop hits max_iterations (10) before
+    // the observation guard fires — it must NOT return LoopDetected.
+    assert!(
+        !matches!(result, Err(AgentError::LoopDetected { .. })),
+        "observation-only batch must not trigger LoopDetected within max_observation_steps; \
+         got: {result:?}"
+    );
+    assert!(
+        !has_final_answer(&events),
+        "no FinalAnswer expected — loop hit max_iterations"
+    );
+}
+
+/// **Observation threshold — fires at limit**: the same observation-only batch
+/// must eventually fire `LoopDetected` once the count exceeds
+/// `max_observation_steps`.
+///
+/// Uses `max_observation_steps=5` and repeats the batch 6 times.
+#[tokio::test]
+async fn test_observation_tool_fires_at_higher_threshold() {
+    let llm = Arc::new(MockLlmPort::new().push_many((0..10).map(|i| {
+        MockLlmResponse::tool_call(
+            format!("obs{i}"),
+            "playwright_mcp_browser_snapshot",
+            json!({}),
+        )
+    })));
+
+    let executor = MockToolExecutorPort::new().with_tool(
+        ToolDefinition::new("playwright_mcp_browser_snapshot"),
+        MockToolBehavior::Immediate {
+            content: "page html...".into(),
+        },
+    );
+
+    let agent = AgentLoop::build(llm, Arc::new(executor), None);
+    let (tx, rx) = mpsc::channel(256);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "browse".into(),
+            }],
+            common::for_test(|c| {
+                c.max_iterations = 20;
+                c.max_repeated_batch_steps = Some(2);
+                c.max_observation_steps = Some(5);
+                c.observation_tools = vec!["snapshot".into()];
+                c.max_stagnation_steps = None;
+            }),
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // max_observation_steps=5 → fires on 6th occurrence (count 6 > 5).
+    assert!(
+        matches!(result, Err(AgentError::LoopDetected { .. })),
+        "observation batch must fire LoopDetected after max_observation_steps; got: {result:?}"
+    );
+    assert!(
+        has_error_event(&events),
+        "AgentEvent::Error must be emitted before stream closes"
+    );
+}
+
+/// **Mixed batch — standard threshold applies**: a batch containing both an
+/// observation tool and a non-observation tool must use `max_repeated_batch_steps`
+/// (not the elevated observation threshold), and fire on the 3rd repetition.
+#[tokio::test]
+async fn test_mixed_batch_uses_standard_threshold() {
+    // Each LLM response emits two tool calls: one observation, one action.
+    let llm = Arc::new(MockLlmPort::new().push_many((0..10).map(|i| {
+        MockLlmResponse {
+            reasoning: None,
+            content: None,
+            tool_calls: vec![
+                ToolCall {
+                    id: format!("snap{i}"),
+                    name: "browser_snapshot".into(),
+                    arguments: json!({}),
+                },
+                ToolCall {
+                    id: format!("act{i}"),
+                    name: "do_thing".into(),
+                    arguments: json!({}),
+                },
+            ],
+            finish_reason: "tool_calls".into(),
+        }
+    })));
+
+    let executor = MockToolExecutorPort::new()
+        .with_tool(
+            ToolDefinition::new("browser_snapshot"),
+            MockToolBehavior::Immediate {
+                content: "page".into(),
+            },
+        )
+        .with_tool(
+            ToolDefinition::new("do_thing"),
+            MockToolBehavior::Immediate {
+                content: "done".into(),
+            },
+        );
+
+    let agent = AgentLoop::build(llm, Arc::new(executor), None);
+    let (tx, rx) = mpsc::channel(256);
+
+    let result = agent
+        .run(
+            vec![AgentMessage::User {
+                content: "go".into(),
+            }],
+            common::for_test(|c| {
+                c.max_iterations = 20;
+                c.max_repeated_batch_steps = Some(2);
+                c.max_observation_steps = Some(10); // elevated — must NOT apply
+                c.observation_tools = vec!["snapshot".into()];
+                c.max_stagnation_steps = None;
+            }),
+            tx,
+        )
+        .await;
+
+    let events = collect_events(rx).await;
+
+    // Mixed batch → standard threshold (max_repeated_batch_steps=2) applies.
+    // Fires on 3rd occurrence (count 3 > 2), not on the 11th.
+    assert!(
+        matches!(result, Err(AgentError::LoopDetected { .. })),
+        "mixed batch must fire LoopDetected at standard threshold; got: {result:?}"
+    );
+    assert!(
+        has_error_event(&events),
+        "AgentEvent::Error must be emitted before stream closes"
     );
 }

--- a/crates/gglib-axum/src/handlers/agent/dto.rs
+++ b/crates/gglib-axum/src/handlers/agent/dto.rs
@@ -14,6 +14,14 @@ use gglib_core::domain::agent::{AgentConfig, AgentMessage};
 ///
 /// All numeric fields are clamped server-side to the ceiling constants defined
 /// in [`gglib_core::domain::agent::config`] to prevent resource exhaustion.
+///
+/// # Observation-tool fields
+///
+/// `observation_tools` and `max_observation_steps` are intentionally exposed
+/// to callers because gglib is a BYO-MCP platform: users may connect arbitrary
+/// MCP servers whose tool names are unknown at compile time.  Callers that want
+/// to classify a custom tool as observation-only (and therefore subject to the
+/// higher repetition threshold) should pass its name fragment here.
 #[derive(Debug, Deserialize, Default)]
 #[serde(default)]
 pub struct AgentRequestConfig {
@@ -28,6 +36,25 @@ pub struct AgentRequestConfig {
     /// Per-tool execution timeout in milliseconds.
     /// Clamped to [`MAX_TOOL_TIMEOUT_MS_CEILING`] server-side.
     pub tool_timeout_ms: Option<u64>,
+
+    /// Substring/suffix patterns that classify a tool as observation-only.
+    ///
+    /// When **every** call in a batch matches a pattern, the higher
+    /// `max_observation_steps` threshold is applied instead of the standard
+    /// loop-detection threshold.  Matching is case-insensitive and uses
+    /// `ends_with` OR `contains` semantics.
+    ///
+    /// `Some([])` disables observation classification entirely.
+    /// `None` (field absent) keeps the built-in defaults
+    /// (`["snapshot", "screenshot", "read_page"]`).
+    pub observation_tools: Option<Vec<String>>,
+
+    /// Maximum repetitions of an observation-only batch before loop detection
+    /// fires.
+    ///
+    /// Clamped to `MAX_OBSERVATION_STEPS_CEILING` (100) server-side.
+    /// `None` (field absent) keeps the built-in default of `10`.
+    pub max_observation_steps: Option<usize>,
 }
 
 impl From<AgentRequestConfig> for AgentConfig {
@@ -36,8 +63,8 @@ impl From<AgentRequestConfig> for AgentConfig {
             req.max_iterations,
             req.max_parallel_tools,
             req.tool_timeout_ms,
-            None, // observation_tools — wired in Phase 4
-            None, // max_observation_steps — wired in Phase 4
+            req.observation_tools,
+            req.max_observation_steps,
         )
         .expect("clamped AgentConfig must pass validation")
     }

--- a/crates/gglib-axum/src/handlers/agent/dto.rs
+++ b/crates/gglib-axum/src/handlers/agent/dto.rs
@@ -36,6 +36,8 @@ impl From<AgentRequestConfig> for AgentConfig {
             req.max_iterations,
             req.max_parallel_tools,
             req.tool_timeout_ms,
+            None, // observation_tools — wired in Phase 4
+            None, // max_observation_steps — wired in Phase 4
         )
         .expect("clamped AgentConfig must pass validation")
     }

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -214,6 +214,17 @@ pub enum Commands {
         /// Resume a previous conversation by ID (use `gglib chat history` to find IDs)
         #[arg(long = "continue", alias = "c")]
         continue_id: Option<i64>,
+        /// Observation-only tool name patterns for the dual-threshold loop guard.
+        /// A tool whose name ends with or contains any pattern is classified as
+        /// observation-only and subject to the higher --max-observation-steps limit.
+        /// Omit to use the built-in defaults (snapshot, screenshot, read_page).
+        /// Pass an empty string to disable observation classification entirely.
+        #[arg(long = "observation-tool", value_delimiter = ',')]
+        observation_tools: Vec<String>,
+        /// Maximum times an observation-only batch may repeat before loop detection
+        /// fires. Clamped to 100. Defaults to 10.
+        #[arg(long = "max-observation-steps")]
+        max_observation_steps: Option<usize>,
         /// Subcommand (e.g. `history`)
         #[command(subcommand)]
         command: Option<ChatCommand>,
@@ -263,6 +274,16 @@ pub enum Commands {
         /// Maximum number of tools executed in parallel per iteration
         #[arg(long = "max-parallel")]
         max_parallel: Option<usize>,
+        /// Observation-only tool name patterns for the dual-threshold loop guard.
+        /// A tool whose name ends with or contains any pattern is classified as
+        /// observation-only and subject to the higher --max-observation-steps limit.
+        /// Omit to use the built-in defaults (snapshot, screenshot, read_page).
+        #[arg(long = "observation-tool", value_delimiter = ',')]
+        observation_tools: Vec<String>,
+        /// Maximum times an observation-only batch may repeat before loop detection
+        /// fires. Clamped to 100. Defaults to 10.
+        #[arg(long = "max-observation-steps")]
+        max_observation_steps: Option<usize>,
     },
 
     /// Decompose a goal into a validated task graph (planning only, no execution)

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -61,6 +61,8 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             max_parallel,
             model,
             continue_id,
+            observation_tools,
+            max_observation_steps,
             command,
         } => {
             // Subcommand takes priority (e.g. `gglib chat history`)
@@ -85,6 +87,8 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                     verbose, // global flag forwarded here
                     model,
                     continue_id,
+                    observation_tools,
+                    max_observation_steps,
                 };
                 handlers::inference::chat::execute(ctx, args).await?;
             }
@@ -104,6 +108,8 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             tools,
             tool_timeout_ms,
             max_parallel,
+            observation_tools,
+            max_observation_steps,
         } => {
             // When --no-tools is set, override tools to an empty allowlist
             // so the agent loop exposes zero tools to the model.
@@ -123,6 +129,8 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 effective_tools,
                 tool_timeout_ms,
                 max_parallel,
+                observation_tools,
+                max_observation_steps,
                 verbose,
                 quiet,
                 sampling,

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -89,10 +89,11 @@ pub async fn run_repl_with_prior(
         ),
         args.max_parallel,
         args.tool_timeout_ms,
-        None, // observation_tools — wired in Phase 5
-        None, // max_observation_steps — wired in Phase 5
+        // Some(vec) replaces defaults; empty vec passes None to preserve defaults.
+        Some(args.observation_tools.clone()).filter(|v| !v.is_empty()),
+        args.max_observation_steps,
     )
-    .map_err(|e| anyhow::anyhow!("invalid agent config: {e}"))?;
+    .map_err(|e| anyhow::anyhow!("invalid agent config: {e}"))?;;
 
     let messages = if prior_messages.is_empty() {
         // Fresh session: optionally prepend system prompt.

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -89,6 +89,8 @@ pub async fn run_repl_with_prior(
         ),
         args.max_parallel,
         args.tool_timeout_ms,
+        None, // observation_tools — wired in Phase 5
+        None, // max_observation_steps — wired in Phase 5
     )
     .map_err(|e| anyhow::anyhow!("invalid agent config: {e}"))?;
 

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -93,7 +93,7 @@ pub async fn run_repl_with_prior(
         Some(args.observation_tools.clone()).filter(|v| !v.is_empty()),
         args.max_observation_steps,
     )
-    .map_err(|e| anyhow::anyhow!("invalid agent config: {e}"))?;;
+    .map_err(|e| anyhow::anyhow!("invalid agent config: {e}"))?;
 
     let messages = if prior_messages.is_empty() {
         // Fresh session: optionally prepend system prompt.

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -42,6 +42,8 @@ pub async fn execute(
     tools: Vec<String>,
     tool_timeout_ms: Option<u64>,
     max_parallel: Option<usize>,
+    observation_tools: Vec<String>,
+    max_observation_steps: Option<usize>,
     verbose: bool,
     quiet: bool,
     sampling: SamplingArgs,
@@ -115,8 +117,9 @@ pub async fn execute(
             Some(resolved_max_iterations),
             max_parallel,
             tool_timeout_ms,
-            None, // observation_tools — wired in Phase 5
-            None, // max_observation_steps — wired in Phase 5
+            // Some(vec) replaces defaults; empty vec passes None to preserve defaults.
+            Some(observation_tools).filter(|v| !v.is_empty()),
+            max_observation_steps,
         )
             .map_err(|e| anyhow!("invalid agent config: {e}"))?;
 

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -112,16 +112,15 @@ pub async fn execute(
 
     let resolved_max_iterations = resolve_max_iterations(max_iterations, &settings);
 
-    let config =
-        AgentConfig::from_user_params(
-            Some(resolved_max_iterations),
-            max_parallel,
-            tool_timeout_ms,
-            // Some(vec) replaces defaults; empty vec passes None to preserve defaults.
-            Some(observation_tools).filter(|v| !v.is_empty()),
-            max_observation_steps,
-        )
-            .map_err(|e| anyhow!("invalid agent config: {e}"))?;
+    let config = AgentConfig::from_user_params(
+        Some(resolved_max_iterations),
+        max_parallel,
+        tool_timeout_ms,
+        // Some(vec) replaces defaults; empty vec passes None to preserve defaults.
+        Some(observation_tools).filter(|v| !v.is_empty()),
+        max_observation_steps,
+    )
+    .map_err(|e| anyhow!("invalid agent config: {e}"))?;
 
     // Build messages
     let mut messages = vec![AgentMessage::System {

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -111,7 +111,13 @@ pub async fn execute(
     let resolved_max_iterations = resolve_max_iterations(max_iterations, &settings);
 
     let config =
-        AgentConfig::from_user_params(Some(resolved_max_iterations), max_parallel, tool_timeout_ms)
+        AgentConfig::from_user_params(
+            Some(resolved_max_iterations),
+            max_parallel,
+            tool_timeout_ms,
+            None, // observation_tools — wired in Phase 5
+            None, // max_observation_steps — wired in Phase 5
+        )
             .map_err(|e| anyhow!("invalid agent config: {e}"))?;
 
     // Build messages

--- a/crates/gglib-cli/src/handlers/inference/chat.rs
+++ b/crates/gglib-cli/src/handlers/inference/chat.rs
@@ -27,6 +27,11 @@ pub struct ChatArgs {
     pub model: Option<String>,
     /// Resume a previous conversation by ID.
     pub continue_id: Option<i64>,
+    /// Observation-tool name patterns for the dual-threshold loop guard.
+    /// An empty vec means "use defaults" (see `AgentConfig::observation_tools`).
+    pub observation_tools: Vec<String>,
+    /// Elevated repetition limit for observation-only tool batches.
+    pub max_observation_steps: Option<usize>,
 }
 
 /// Execute the chat command — always routes to the agentic REPL.

--- a/crates/gglib-core/src/domain/agent/config.rs
+++ b/crates/gglib-core/src/domain/agent/config.rs
@@ -193,7 +193,6 @@ pub struct AgentConfig {
     // observation tool, preventing false-positive loop aborts during ReAct
     // observation cycles while still eventually catching a genuinely confused
     // agent.
-
     /// Substring/suffix patterns used to classify tools as "observation-only".
     ///
     /// A tool call whose **lowercased** name satisfies
@@ -257,11 +256,7 @@ impl Default for AgentConfig {
             max_stagnation_steps: Some(DEFAULT_MAX_STAGNATION_STEPS),
             prune_keep_tool_messages: 10,
             prune_keep_tail_messages: 12,
-            observation_tools: vec![
-                "snapshot".into(),
-                "screenshot".into(),
-                "read_page".into(),
-            ],
+            observation_tools: vec!["snapshot".into(), "screenshot".into(), "read_page".into()],
             max_observation_steps: Some(DEFAULT_MAX_OBSERVATION_STEPS),
         }
     }
@@ -509,8 +504,7 @@ mod tests {
     #[test]
     fn from_user_params_clamps_extremes() {
         // Zero iterations → clamped to 1.
-        let cfg =
-            AgentConfig::from_user_params(Some(0), Some(0), Some(0), None, None).unwrap();
+        let cfg = AgentConfig::from_user_params(Some(0), Some(0), Some(0), None, None).unwrap();
         assert_eq!(cfg.max_iterations, 1);
         assert_eq!(cfg.max_parallel_tools, 1);
         assert_eq!(cfg.tool_timeout_ms, MIN_TOOL_TIMEOUT_MS);
@@ -554,15 +548,13 @@ mod tests {
     #[test]
     fn from_user_params_empty_observation_tools_disables_classification() {
         // Some([]) disables observation classification — no tools ever match.
-        let cfg =
-            AgentConfig::from_user_params(None, None, None, Some(vec![]), None).unwrap();
+        let cfg = AgentConfig::from_user_params(None, None, None, Some(vec![]), None).unwrap();
         assert!(cfg.observation_tools.is_empty());
     }
 
     #[test]
     fn from_user_params_observation_steps_clamped_to_ceiling() {
-        let cfg =
-            AgentConfig::from_user_params(None, None, None, None, Some(usize::MAX)).unwrap();
+        let cfg = AgentConfig::from_user_params(None, None, None, None, Some(usize::MAX)).unwrap();
         assert_eq!(
             cfg.max_observation_steps,
             Some(MAX_OBSERVATION_STEPS_CEILING),

--- a/crates/gglib-core/src/domain/agent/config.rs
+++ b/crates/gglib-core/src/domain/agent/config.rs
@@ -71,6 +71,25 @@ pub const DEFAULT_MAX_PARALLEL_TOOLS: usize = 25;
 /// than this many times, preventing infinite stagnant output.
 pub const DEFAULT_MAX_STAGNATION_STEPS: usize = 5;
 
+/// Hard ceiling on [`AgentConfig::max_observation_steps`] accepted from
+/// external callers.
+///
+/// Prevents an API or CLI caller from setting `max_observation_steps` to an
+/// arbitrarily large value, which would silently neutralise the observation
+/// guard and allow a confused agent to call observation tools indefinitely.
+/// 100 observation-only iterations is far more than any legitimate browsing
+/// task requires.
+pub const MAX_OBSERVATION_STEPS_CEILING: usize = 100;
+
+/// Default value for [`AgentConfig::max_observation_steps`].
+///
+/// An observation-only batch (every call matches a pattern in
+/// [`AgentConfig::observation_tools`]) may repeat up to this many times
+/// before loop detection fires.  10 is generous for multi-page browsing
+/// tasks while still catching a genuinely confused agent within a
+/// reasonable token budget.
+pub const DEFAULT_MAX_OBSERVATION_STEPS: usize = 10;
+
 /// Configuration that governs a single agentic loop run.
 ///
 /// All fields have sensible defaults via [`Default`] that match the historical
@@ -160,6 +179,71 @@ pub struct AgentConfig {
     /// Same rationale as [`Self::prune_keep_tool_messages`].
     #[serde(skip)]
     pub prune_keep_tail_messages: usize,
+
+    // -------------------------------------------------------------------------
+    // Dual-threshold observation guard
+    // -------------------------------------------------------------------------
+    //
+    // Standard loop detection (max_repeated_batch_steps) hashes tool names and
+    // arguments to detect stuck cycles.  Observation-only tools (e.g. browser
+    // snapshots, screenshots) legitimately repeat with identical signatures
+    // because they take no meaningful arguments, yet return completely different
+    // page content on each call.  These two fields allow a separate, higher
+    // threshold to be applied when every tool in a batch is classified as an
+    // observation tool, preventing false-positive loop aborts during ReAct
+    // observation cycles while still eventually catching a genuinely confused
+    // agent.
+
+    /// Substring/suffix patterns used to classify tools as "observation-only".
+    ///
+    /// A tool call whose **lowercased** name satisfies
+    /// `name.ends_with(pattern) || name.contains(pattern)` for any pattern in
+    /// this list is classified as an observation tool.  When **every** call in
+    /// a batch matches, [`Self::max_observation_steps`] is applied as the loop
+    /// detection threshold instead of [`Self::max_repeated_batch_steps`].
+    ///
+    /// **Matching semantics** — substring/suffix rather than exact string — are
+    /// intentional: MCP servers routinely prepend namespace prefixes to tool
+    /// names (e.g. `playwright_mcp_browser_snapshot`), so exact matching would
+    /// require users to enumerate every vendor variant.  The pattern `"snapshot"`
+    /// matches all of: `snapshot`, `browser_snapshot`,
+    /// `playwright_mcp_browser_snapshot`.
+    ///
+    /// **BYO-MCP:** users connecting custom MCP servers should extend or replace
+    /// this list via [`AgentConfig::from_user_params`] to include their own
+    /// observation-only tool name fragments (e.g. `"get_dom"`, `"fetch_page"`).
+    ///
+    /// An empty list means no tools are ever classified as observation-only;
+    /// the standard [`Self::max_repeated_batch_steps`] threshold applies to all
+    /// batches.
+    ///
+    /// Default: `["snapshot", "screenshot", "read_page"]`.
+    pub observation_tools: Vec<String>,
+
+    /// Maximum number of times an observation-only batch may repeat before
+    /// loop detection fires.
+    ///
+    /// Applied **instead of** [`Self::max_repeated_batch_steps`] when every
+    /// tool call in the current batch matches a pattern in
+    /// [`Self::observation_tools`].  A higher value (default: 10) gives the
+    /// agent room to perform legitimate multi-page observation cycles (e.g.
+    /// browsing through search results) while still eventually aborting a
+    /// genuinely confused agent before it exhausts the token budget.
+    ///
+    /// **Mixed batches** (at least one non-observation tool alongside an
+    /// observation tool) always fall back to [`Self::max_repeated_batch_steps`]
+    /// — the conservative choice, since the non-observation call may be making
+    /// meaningful side-effectful progress.
+    ///
+    /// Clamped to [`MAX_OBSERVATION_STEPS_CEILING`] when supplied via
+    /// [`AgentConfig::from_user_params`] to prevent API callers from providing
+    /// a value large enough to neutralise the guard.
+    ///
+    /// Set to `None` to disable the elevated threshold entirely; observation
+    /// batches then use [`Self::max_repeated_batch_steps`] like any other batch.
+    ///
+    /// Default: `Some(10)`.
+    pub max_observation_steps: Option<usize>,
 }
 
 impl Default for AgentConfig {
@@ -173,6 +257,12 @@ impl Default for AgentConfig {
             max_stagnation_steps: Some(DEFAULT_MAX_STAGNATION_STEPS),
             prune_keep_tool_messages: 10,
             prune_keep_tail_messages: 12,
+            observation_tools: vec![
+                "snapshot".into(),
+                "screenshot".into(),
+                "read_page".into(),
+            ],
+            max_observation_steps: Some(DEFAULT_MAX_OBSERVATION_STEPS),
         }
     }
 }
@@ -213,12 +303,24 @@ pub enum AgentConfigError {
 impl AgentConfig {
     /// Build an `AgentConfig` from user-supplied overrides.
     ///
-    /// Each `Some` value is clamped to the safe `[floor, ceiling]` range
-    /// before assignment; `None` fields retain their [`Default`] values.
+    /// Each `Some` numeric value is clamped to the safe `[floor, ceiling]`
+    /// range before assignment; `None` fields retain their [`Default`] values.
     /// The result is validated before returning.
     ///
-    /// This is the **single entry-point** for both HTTP and CLI callers,
+    /// This is the **single entry-point** for HTTP, Tauri, and CLI callers,
     /// eliminating duplicated clamping logic at every call site.
+    ///
+    /// # Observation-tool parameters
+    ///
+    /// - `observation_tools: Some(vec)` — **replaces** the default pattern list
+    ///   entirely.  Pass the complete list you want, including any defaults you
+    ///   wish to preserve.  `Some(vec![])` disables observation classification
+    ///   (standard threshold applies to all batches).  `None` keeps the
+    ///   built-in defaults (`["snapshot", "screenshot", "read_page"]`).
+    ///
+    /// - `max_observation_steps: Some(n)` — clamped to
+    ///   `[1, MAX_OBSERVATION_STEPS_CEILING]`.  `None` keeps the built-in
+    ///   default of `Some(10)`.
     ///
     /// # Errors
     ///
@@ -228,6 +330,8 @@ impl AgentConfig {
         max_iterations: Option<usize>,
         max_parallel_tools: Option<usize>,
         tool_timeout_ms: Option<u64>,
+        observation_tools: Option<Vec<String>>,
+        max_observation_steps: Option<usize>,
     ) -> Result<Self, AgentConfigError> {
         let mut cfg = Self::default();
         if let Some(n) = max_iterations {
@@ -238,6 +342,12 @@ impl AgentConfig {
         }
         if let Some(ms) = tool_timeout_ms {
             cfg.tool_timeout_ms = ms.clamp(MIN_TOOL_TIMEOUT_MS, MAX_TOOL_TIMEOUT_MS_CEILING);
+        }
+        if let Some(tools) = observation_tools {
+            cfg.observation_tools = tools;
+        }
+        if let Some(n) = max_observation_steps {
+            cfg.max_observation_steps = Some(n.clamp(1, MAX_OBSERVATION_STEPS_CEILING));
         }
         cfg.validated()
     }
@@ -251,7 +361,7 @@ impl AgentConfig {
     /// # Errors
     ///
     /// Returns `Err(AgentConfigError)` if any field violates its invariant.
-    pub const fn validated(self) -> Result<Self, AgentConfigError> {
+    pub fn validated(self) -> Result<Self, AgentConfigError> {
         if self.max_iterations < 1 {
             return Err(AgentConfigError::MaxIterationsZero(self.max_iterations));
         }
@@ -291,6 +401,16 @@ mod tests {
         );
         assert_eq!(cfg.prune_keep_tool_messages, 10);
         assert_eq!(cfg.prune_keep_tail_messages, 12);
+        assert_eq!(
+            cfg.observation_tools,
+            vec!["snapshot", "screenshot", "read_page"],
+            "default observation patterns must cover common Playwright/Puppeteer MCP tool names"
+        );
+        assert_eq!(
+            cfg.max_observation_steps,
+            Some(DEFAULT_MAX_OBSERVATION_STEPS),
+            "must match DEFAULT_MAX_OBSERVATION_STEPS"
+        );
     }
 
     #[test]
@@ -379,7 +499,8 @@ mod tests {
     #[test]
     fn from_user_params_clamps_and_validates() {
         // All values within range → accepted as-is.
-        let cfg = AgentConfig::from_user_params(Some(10), Some(3), Some(5_000)).unwrap();
+        let cfg =
+            AgentConfig::from_user_params(Some(10), Some(3), Some(5_000), None, None).unwrap();
         assert_eq!(cfg.max_iterations, 10);
         assert_eq!(cfg.max_parallel_tools, 3);
         assert_eq!(cfg.tool_timeout_ms, 5_000);
@@ -388,7 +509,8 @@ mod tests {
     #[test]
     fn from_user_params_clamps_extremes() {
         // Zero iterations → clamped to 1.
-        let cfg = AgentConfig::from_user_params(Some(0), Some(0), Some(0)).unwrap();
+        let cfg =
+            AgentConfig::from_user_params(Some(0), Some(0), Some(0), None, None).unwrap();
         assert_eq!(cfg.max_iterations, 1);
         assert_eq!(cfg.max_parallel_tools, 1);
         assert_eq!(cfg.tool_timeout_ms, MIN_TOOL_TIMEOUT_MS);
@@ -396,8 +518,14 @@ mod tests {
 
     #[test]
     fn from_user_params_clamps_above_ceiling() {
-        let cfg = AgentConfig::from_user_params(Some(usize::MAX), Some(usize::MAX), Some(u64::MAX))
-            .unwrap();
+        let cfg = AgentConfig::from_user_params(
+            Some(usize::MAX),
+            Some(usize::MAX),
+            Some(u64::MAX),
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(cfg.max_iterations, MAX_ITERATIONS_CEILING);
         assert_eq!(cfg.max_parallel_tools, MAX_PARALLEL_TOOLS_CEILING);
         assert_eq!(cfg.tool_timeout_ms, MAX_TOOL_TIMEOUT_MS_CEILING);
@@ -405,10 +533,52 @@ mod tests {
 
     #[test]
     fn from_user_params_none_keeps_defaults() {
-        let cfg = AgentConfig::from_user_params(None, None, None).unwrap();
+        let cfg = AgentConfig::from_user_params(None, None, None, None, None).unwrap();
         let def = AgentConfig::default();
         assert_eq!(cfg.max_iterations, def.max_iterations);
         assert_eq!(cfg.max_parallel_tools, def.max_parallel_tools);
         assert_eq!(cfg.tool_timeout_ms, def.tool_timeout_ms);
+        assert_eq!(cfg.observation_tools, def.observation_tools);
+        assert_eq!(cfg.max_observation_steps, def.max_observation_steps);
+    }
+
+    #[test]
+    fn from_user_params_observation_tools_replaces_defaults() {
+        // A non-None observation_tools list replaces the built-in defaults.
+        let custom = vec!["get_dom".into(), "fetch_page".into()];
+        let cfg =
+            AgentConfig::from_user_params(None, None, None, Some(custom.clone()), None).unwrap();
+        assert_eq!(cfg.observation_tools, custom);
+    }
+
+    #[test]
+    fn from_user_params_empty_observation_tools_disables_classification() {
+        // Some([]) disables observation classification — no tools ever match.
+        let cfg =
+            AgentConfig::from_user_params(None, None, None, Some(vec![]), None).unwrap();
+        assert!(cfg.observation_tools.is_empty());
+    }
+
+    #[test]
+    fn from_user_params_observation_steps_clamped_to_ceiling() {
+        let cfg =
+            AgentConfig::from_user_params(None, None, None, None, Some(usize::MAX)).unwrap();
+        assert_eq!(
+            cfg.max_observation_steps,
+            Some(MAX_OBSERVATION_STEPS_CEILING),
+        );
+    }
+
+    #[test]
+    fn from_user_params_observation_steps_clamped_to_floor() {
+        // Zero would mean fire on the very first occurrence — clamp to 1.
+        let cfg = AgentConfig::from_user_params(None, None, None, None, Some(0)).unwrap();
+        assert_eq!(cfg.max_observation_steps, Some(1));
+    }
+
+    #[test]
+    fn from_user_params_observation_steps_within_range_unchanged() {
+        let cfg = AgentConfig::from_user_params(None, None, None, None, Some(15)).unwrap();
+        assert_eq!(cfg.max_observation_steps, Some(15));
     }
 }

--- a/crates/gglib-core/src/sse/decoder.rs
+++ b/crates/gglib-core/src/sse/decoder.rs
@@ -58,10 +58,7 @@ impl SseStreamDecoder {
         self.buf.push_str(text);
         let mut events = Vec::new();
 
-        loop {
-            let Some(newline_pos) = self.buf.find('\n') else {
-                break;
-            };
+        while let Some(newline_pos) = self.buf.find('\n') {
             let line = self.buf[..newline_pos].trim_end_matches('\r').to_owned();
             self.buf.drain(..=newline_pos);
 

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -1170,7 +1170,7 @@ impl DownloadManagerImpl {
 
         let completed_at_ms = Self::get_current_timestamp_ms();
         let mut items = Self::build_completion_details(run.completions);
-        items.sort_by(|a, b| b.last_completed_at_ms.cmp(&a.last_completed_at_ms));
+        items.sort_by_key(|b| std::cmp::Reverse(b.last_completed_at_ms));
 
         let (total_attempts_downloaded, total_attempts_failed, total_attempts_cancelled) =
             Self::calculate_total_attempts(&items);

--- a/crates/gglib-download/src/manager/shard_group_tracker.rs
+++ b/crates/gglib-download/src/manager/shard_group_tracker.rs
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(tracker.active_count(), 1);
 
         // GC with large TTL - should not remove
-        let removed = tracker.gc_expired(Duration::from_secs(3600));
+        let removed = tracker.gc_expired(Duration::from_hours(1));
         assert_eq!(removed, 0);
         assert_eq!(tracker.active_count(), 1);
 

--- a/crates/gglib-hf/src/config.rs
+++ b/crates/gglib-hf/src/config.rs
@@ -132,13 +132,13 @@ mod tests {
         let config = HfClientConfig::new()
             .with_base_url("https://custom.api/")
             .with_user_agent("test-agent")
-            .with_timeout(Duration::from_secs(60))
+            .with_timeout(Duration::from_mins(1))
             .with_token("secret")
             .with_max_retries(5);
 
         assert_eq!(config.base_url, "https://custom.api/");
         assert_eq!(config.user_agent, "test-agent");
-        assert_eq!(config.timeout, Duration::from_secs(60));
+        assert_eq!(config.timeout, Duration::from_mins(1));
         assert_eq!(config.token, Some("secret".to_string()));
         assert_eq!(config.max_retries, 5);
     }


### PR DESCRIPTION
## Summary

Fixes the false-positive `LoopDetected` abort that fired when an agent performed legitimate ReAct *observe → act → observe* cycles using observation-only tools (browser snapshots, screenshots, etc.) that take no meaningful arguments and therefore always hash to the same batch signature.

Closes #528.

---

## Problem

The `LoopDetector` computes a batch signature from tool names + argument hashes. Tools like `browser_snapshot` take zero arguments, so every call produces the same signature regardless of the completely different page content returned. With `max_repeated_batch_steps = 2` (the default), the guard aborted on the **third** consecutive snapshot call:

```
tool-call loop detected (repeated signature: 2:browser_snapshot:08f44b07b5901a25)
```

This was especially acute in **BYO-MCP** setups where users connect Playwright, Puppeteer, or other browser automation servers with namespaced tool names like `playwright_mcp_browser_snapshot`.

---

## Solution — Dual-Threshold Detection

Rather than a blanket exemption, we introduce a separate, higher threshold for **observation-only batches**. A batch is observation-only iff every call's lowercased name satisfies `ends_with(pattern) || contains(pattern)` for at least one pattern in a configurable list. Mixed batches (≥1 non-observation call) always fall back to the strict standard threshold.

### New `AgentConfig` fields

| Field | Default | Description |
|-------|---------|-------------|
| `observation_tools: Vec<String>` | `["snapshot", "screenshot", "read_page"]` | Substring/suffix patterns; case-insensitive matching handles namespaced MCP names |
| `max_observation_steps: Option<usize>` | `Some(10)` | Elevated threshold for observation-only batches; clamped to `MAX_OBSERVATION_STEPS_CEILING = 100` |

### User-configurable (BYO-MCP)

Both fields are fully exposed through all entry points:

| Layer | How |
|-------|-----|
| Axum HTTP API | `AgentRequestConfig` JSON fields `observation_tools` / `max_observation_steps` |
| CLI `gglib chat` | `--observation-tool <pattern>` / `--max-observation-steps <n>` |
| CLI `gglib q` | Same flags |
| `AgentConfig::from_user_params()` | Two new params (single entry-point for all callers) |

`Some(vec)` replaces the default list entirely; `None` or omitted keeps built-in defaults.

---

## Commits

| Commit | Scope |
|--------|-------|
| `50a4a69` feat(core): add dual-threshold observation loop config | `gglib-core` — fields, constants, `Default`, `from_user_params()`, drop `const` from `validated()`, docstrings, 6 new tests |
| `9b3fb07` feat(agent): implement dual-threshold loop detection logic | `gglib-agent` — `is_observation_batch()`, updated `LoopDetector::check()`, wired through `Guards::check()`, 7 new unit tests |
| `c79d35b` feat(api/cli): expose observation loop config to users | `gglib-axum` DTO + `From` impl, `gglib-cli` `ChatArgs`, `commands.rs`, `dispatch.rs`, `repl.rs`, `agent_question.rs` |
| `056bd9a` test(agent): add integration tests for dual-threshold loop guard | 3 end-to-end `integration_guards` tests |

---

## Test Coverage

### New unit tests (`gglib-core`)
- `defaults_match_frontend_constants` — asserts new default values
- `from_user_params_observation_tools_replaces_defaults`
- `from_user_params_empty_observation_tools_disables_classification`
- `from_user_params_observation_steps_clamped_to_ceiling`
- `from_user_params_observation_steps_clamped_to_floor`
- `from_user_params_observation_steps_within_range_unchanged`

### New unit tests (`gglib-agent` — `loop_detection/tests.rs`)
- `is_observation_batch_ends_with_match`
- `is_observation_batch_contains_match`
- `is_observation_batch_case_insensitive`
- `is_observation_batch_mixed_returns_false`
- `is_observation_batch_empty_patterns_always_false`
- `loop_detector_observation_batch_uses_higher_threshold`
- `loop_detector_mixed_batch_uses_standard_threshold`

### New integration tests (`gglib-agent` — `integration_guards.rs`)
- `test_observation_tool_uses_higher_threshold` — 10 identical `playwright_mcp_browser_snapshot` calls with `max_repeated_batch_steps=2`, `max_observation_steps=10` → no `LoopDetected`
- `test_observation_tool_fires_at_higher_threshold` — same config with `max_observation_steps=5` → fires `LoopDetected` on 6th repetition
- `test_mixed_batch_uses_standard_threshold` — `[browser_snapshot, do_thing]` batch repeated with `max_repeated_batch_steps=2` → fires at 3rd repetition (not exempt)

### Totals
- All **298** `gglib-core` tests green
- All **89** `gglib-agent` unit tests green  
- All **8** `integration_guards` tests green (5 existing + 3 new)
- Full `cargo test --workspace` exit 0

---

## Collateral change: `validated()` loses `const`

`AgentConfig::validated()` was `const fn`. Adding `Vec<String>` to the struct is incompatible with `const fn` on Rust 1.91 (non-trivial destructor). The qualifier is removed; no caller uses it at compile time — purely a mechanical qualifier drop with zero semantic effect.