### PR TITLE
refactor: canonical ServerConfig builder for full launch-surface parity

### DIFF
--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -15,11 +15,11 @@ use tracing::{debug, warn};
 use gglib_core::domain::Model;
 use gglib_core::events::{AppEvent, ServerSummary};
 use gglib_core::ports::{
-    AppEventEmitter, ProcessHandle, ProcessRunner, ServerConfig, ServerHealthStatus,
+    AppEventEmitter, ProcessHandle, ProcessRunner, ServerHealthStatus,
     ToolSupportDetectorPort,
 };
 use gglib_core::services::AppCore;
-use gglib_runtime::llama::args::{resolve_mtp_args, resolve_reasoning_format};
+use gglib_runtime::server_config::{ServerConfigOptions, build_server_config};
 
 use crate::error::GuiError;
 use crate::types::{ServerInfo, StartServerRequest, StartServerResponse, ToolSupportResponse};
@@ -168,6 +168,9 @@ impl ServerOps {
 
     /// Build a [`ServerConfig`] from a model and GUI request.
     ///
+    /// Delegates to [`build_server_config`] so that this path generates
+    /// identical llama-server arguments to every other launch surface.
+    ///
     /// Context size precedence: explicit request field → global settings
     /// default → llama-server built-in default.
     fn build_config(
@@ -175,66 +178,23 @@ impl ServerOps {
         request: &StartServerRequest,
         base_port: u16,
         default_context_size: Option<u64>,
-    ) -> ServerConfig {
-        let mut config = ServerConfig::new(
+    ) -> gglib_core::ports::ServerConfig {
+        build_server_config(
             model.id,
             model.name.clone(),
             model.file_path.clone(),
             base_port,
-        );
-
-        if let Some(ctx) = request.context_length.or(default_context_size) {
-            config = config.with_context_size(ctx);
-        }
-
-        if let Some(port) = request.port {
-            config = config.with_port(port);
-        }
-
-        if let Some(true) = request.jinja {
-            config = config.with_jinja();
-        }
-
-        if let Some(ref format) = request.reasoning_format
-            && format != "none"
-        {
-            config = config.with_reasoning_format(format.clone());
-        } else if request.reasoning_format.is_none() {
-            // Auto-detect reasoning format from model tags when frontend doesn't specify
-            let reasoning = resolve_reasoning_format(None, &model.tags);
-            if let Some(format) = reasoning.format {
-                debug!(
-                    format = %format,
-                    source = ?reasoning.source,
-                    "Auto-detected reasoning format from model tags"
-                );
-                config = config.with_reasoning_format(format);
-            }
-        }
-
-        if let Some(ref params) = request.inference_params {
-            config = config.with_inference_config(params.clone());
-        }
-
-        // Resolve MTP speculative decoding (auto-enabled by "mtp" tag, overrideable)
-        let mtp = resolve_mtp_args(
-            request.mtp_draft_n_max,
-            request.mtp_draft_p_min,
             &model.tags,
-        );
-        if mtp.enabled {
-            debug!(
-                n_max = mtp.draft_n_max,
-                p_min = mtp.draft_p_min,
-                source = ?mtp.source,
-                "Enabling MTP speculative decoding"
-            );
-            config = config
-                .with_spec_draft_n_max(mtp.draft_n_max)
-                .with_spec_draft_p_min(mtp.draft_p_min);
-        }
-
-        config
+            ServerConfigOptions {
+                context_size: request.context_length.or(default_context_size),
+                port: request.port,
+                jinja: request.jinja,
+                reasoning_format: request.reasoning_format.clone(),
+                mtp_draft_n_max: request.mtp_draft_n_max,
+                mtp_draft_p_min: request.mtp_draft_p_min,
+                inference_params: request.inference_params.clone(),
+            },
+        )
     }
 
     /// Start serving a model.

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -15,8 +15,7 @@ use tracing::{debug, warn};
 use gglib_core::domain::Model;
 use gglib_core::events::{AppEvent, ServerSummary};
 use gglib_core::ports::{
-    AppEventEmitter, ProcessHandle, ProcessRunner, ServerHealthStatus,
-    ToolSupportDetectorPort,
+    AppEventEmitter, ProcessHandle, ProcessRunner, ServerHealthStatus, ToolSupportDetectorPort,
 };
 use gglib_core::services::AppCore;
 use gglib_runtime::server_config::{ServerConfigOptions, build_server_config};

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -371,6 +371,17 @@ pub enum Commands {
     ///
     /// Serves /v1 chat completions and /mcp (MCP Streamable HTTP) from a single port.
     /// Configure OpenWebUI with the /v1 base URL and connect MCP tools via /mcp.
+    ///
+    /// When a request arrives for a model that is not yet running, the proxy
+    /// auto-starts a llama-server and automatically enables the appropriate
+    /// flags based on the model's capability tags:
+    ///
+    /// - `"mtp"` tag  → MTP speculative decoding (--spec-type draft-mtp)
+    /// - `"reasoning"` tag → reasoning format extraction (--reasoning-format)
+    /// - `"agent"` tag → Jinja template support (--jinja)
+    ///
+    /// This is identical to the behaviour when starting a model from the GUI or
+    /// CLI — all surfaces go through the same canonical config builder.
     #[command(display_order = 22)]
     Proxy {
         /// Host to bind to

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use gglib_core::domain::InferenceConfig;
 use gglib_core::ports::AgentLoopPort;
-use gglib_core::{ProcessHandle, ServerConfig};
+use gglib_core::ProcessHandle;
 use gglib_runtime::compose_agent_loop_with_sampling;
-use gglib_runtime::llama::args::{resolve_jinja_flag, resolve_reasoning_format};
 use gglib_runtime::llama::{ContextInput, resolve_context_size};
+use gglib_runtime::server_config::{ServerConfigOptions, build_server_config};
 
 use crate::bootstrap::CliContext;
 use crate::handlers::inference::chat::ChatArgs;
@@ -169,28 +169,17 @@ async fn resolve_port(
         settings_default: settings.default_context_size,
     })?;
 
-    let mut server_config = ServerConfig::new(
+    let server_config = build_server_config(
         model.id,
         model.name.clone(),
         model.file_path.clone(),
         ctx.base_port,
+        &model.tags,
+        ServerConfigOptions {
+            context_size: context_resolution.value.map(u64::from),
+            ..Default::default()
+        },
     );
-    if let Some(ctx_size) = context_resolution.value {
-        server_config = server_config.with_context_size(u64::from(ctx_size));
-    }
-
-    // Auto-detect jinja and reasoning format from model tags
-    let jinja = resolve_jinja_flag(None, &model.tags);
-    if jinja.enabled {
-        tracing::debug!(source = ?jinja.source, "auto-enabling --jinja");
-        server_config = server_config.with_jinja();
-    }
-
-    let reasoning = resolve_reasoning_format(None, &model.tags);
-    if let Some(format) = reasoning.format {
-        tracing::debug!(source = ?reasoning.source, format = %format, "auto-enabling --reasoning-format");
-        server_config = server_config.with_reasoning_format(format);
-    }
 
     if !banner.quiet {
         style::print_info_banner("Info", "\u{2139}\u{fe0f}");

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -10,9 +10,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
+use gglib_core::ProcessHandle;
 use gglib_core::domain::InferenceConfig;
 use gglib_core::ports::AgentLoopPort;
-use gglib_core::ProcessHandle;
 use gglib_runtime::compose_agent_loop_with_sampling;
 use gglib_runtime::llama::{ContextInput, resolve_context_size};
 use gglib_runtime::server_config::{ServerConfigOptions, build_server_config};

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -153,6 +153,24 @@ Pass `num_ctx` at the request root to override default context size:
 }
 ```
 
+### Model Capability Auto-Detection
+
+When the proxy auto-starts a llama-server for an incoming request, it reads the
+model's capability tags and automatically enables the appropriate llama-server
+flags — no extra configuration required:
+
+| Tag | Effect |
+|-----|--------|
+| `"mtp"` | Enables MTP speculative decoding (`--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75`) |
+| `"reasoning"` | Enables reasoning format extraction (`--reasoning-format deepseek` or equivalent) |
+| `"agent"` | Enables Jinja template support (`--jinja`) |
+
+Tags are detected automatically at model import time from GGUF metadata and
+stored in the model catalog. This parity is architecturally enforced: the proxy,
+GUI, and CLI all route through `build_server_config` in `gglib-runtime`, so any
+model that works correctly when started from the GUI or CLI will behave
+identically when auto-started by the proxy.
+
 ## Usage
 
 This crate is used by `gglib-runtime`'s `ProxySupervisor`. The supervisor binds a `TcpListener` and passes it to `gglib_proxy::serve()` along with port trait implementations:

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -109,6 +109,50 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **Health Monitoring** — Polls server health endpoints for readiness
 - **GPU Detection** — Detects available GPUs and VRAM for context sizing
 - **Reasoning Model Support** — Streaming of thinking/reasoning phases
+- **MTP Speculative Decoding** — Auto-enabled for models with the `"mtp"` tag via the canonical `build_server_config` builder
+
+## ServerConfig Builder
+
+All launch surfaces (proxy auto-start, GUI/HTTP start-server, CLI agent chat)
+must use `build_server_config` to construct a `ServerConfig`. This is the
+canonical entry point that calls all capability resolvers in one place and
+guarantees identical llama-server arguments across every surface.
+
+```rust,ignore
+use gglib_runtime::{build_server_config, ServerConfigOptions};
+
+// Fully tag-driven — capabilities auto-detected from model metadata:
+let config = build_server_config(
+    model_id,
+    model_name,
+    model_path,
+    base_port,
+    &model.tags,
+    ServerConfigOptions::default(),
+);
+
+// With caller overrides (e.g. explicit context size from a GUI request):
+let config = build_server_config(
+    model_id,
+    model_name,
+    model_path,
+    base_port,
+    &model.tags,
+    ServerConfigOptions {
+        context_size: Some(8192),
+        mtp_draft_n_max: Some(0), // explicitly disable MTP
+        ..Default::default()
+    },
+);
+```
+
+### Capability detection precedence
+
+| Feature | Explicit override wins over… | Tag-based default |
+|---------|------------------------------|-------------------|
+| Jinja templates | `opts.jinja = Some(true/false)` | `"agent"` tag → enabled |
+| Reasoning format | `opts.reasoning_format = Some(…)` | model tags |
+| MTP speculative decoding | `opts.mtp_draft_n_max = Some(0)` (off) or `Some(n)` (on) | `"mtp"` tag → `n=2, p_min=0.75` |
 
 ## Usage
 

--- a/crates/gglib-runtime/src/lib.rs
+++ b/crates/gglib-runtime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod process;
 mod process_core;
 pub mod proxy;
 mod runner;
+pub mod server_config;
 pub mod system;
 
 // Re-export the main ProcessRunner implementation
@@ -49,3 +50,6 @@ pub use system::DefaultSystemProbe;
 
 // Re-export orchestrator runner adapter for proxy injection
 pub use council_runner::CouncilRunnerAdapter;
+
+// Re-export canonical ServerConfig builder for all launch surfaces
+pub use server_config::{ServerConfigOptions, build_server_config};

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -17,6 +17,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+use crate::server_config::{ServerConfigOptions, build_server_config};
+
 /// Currently running model state for SingleSwap strategy.
 #[derive(Debug, Clone)]
 pub struct CurrentModelState {
@@ -269,14 +271,17 @@ impl ProcessManager {
             "Starting model"
         );
 
-        let config = ServerConfig::new(
+        let config = build_server_config(
             launch_spec.id as i64,
             launch_spec.name.clone(),
             model_path.to_path_buf(),
             0, // base_port unused — GuiProcessCore resolves port internally
-        )
-        .with_context_size(effective_ctx)
-        .with_jinja(); // Enable jinja by default for proxy
+            &launch_spec.tags,
+            ServerConfigOptions {
+                context_size: Some(effective_ctx),
+                ..Default::default()
+            },
+        );
 
         let port = {
             let mut core = self.core.write().await;

--- a/crates/gglib-runtime/src/server_config.rs
+++ b/crates/gglib-runtime/src/server_config.rs
@@ -1,0 +1,181 @@
+//! Canonical [`ServerConfig`] builder for all llama-server launch surfaces.
+//!
+//! ## Why this module exists
+//!
+//! Multiple surfaces in gglib can trigger a llama-server launch:
+//! - The **GUI/HTTP** start-server endpoint (`gglib-app-services`)
+//! - The **CLI** agent-chat / question commands (`gglib-cli`)
+//! - The **proxy** auto-start path (`gglib-runtime` `ProcessManager`)
+//!
+//! Without a shared builder, each surface independently assembled a
+//! [`ServerConfig`], leading to capability drift — features such as MTP
+//! speculative decoding, reasoning-format detection, and Jinja templates
+//! were applied inconsistently depending on which surface triggered the
+//! start.
+//!
+//! [`build_server_config`] is the **single source of truth** for translating
+//! a model's tags and optional caller overrides into a fully-resolved
+//! [`ServerConfig`].  All surfaces must go through this function; adding a
+//! new capability resolver here automatically propagates parity to every
+//! launch path.
+//!
+//! ## Capability detection precedence
+//!
+//! | Feature | Explicit override wins over… | Tag-based default |
+//! |---------|------------------------------|-------------------|
+//! | Jinja templates | `opts.jinja = Some(…)` | `"agent"` tag → enabled |
+//! | Reasoning format | `opts.reasoning_format = Some(…)` | model tags |
+//! | MTP speculative decoding | `opts.mtp_draft_n_max = Some(0)` (off) or `Some(n)` (on) | `"mtp"` tag → enabled |
+
+use std::path::PathBuf;
+
+use gglib_core::domain::InferenceConfig;
+use gglib_core::ports::ServerConfig;
+use tracing::debug;
+
+use crate::llama::args::{resolve_jinja_flag, resolve_mtp_args, resolve_reasoning_format};
+
+// =============================================================================
+// Options
+// =============================================================================
+
+/// Caller-supplied overrides for [`build_server_config`].
+///
+/// All fields default to `None`, which means "auto-detect from model tags".
+/// Explicit values always take precedence over tag detection.
+#[derive(Debug, Clone, Default)]
+pub struct ServerConfigOptions {
+    /// Override the context window size forwarded to llama-server.
+    /// `None` lets llama-server use its built-in default.
+    pub context_size: Option<u64>,
+
+    /// Bind llama-server to a specific port instead of letting the allocator
+    /// choose.
+    pub port: Option<u16>,
+
+    /// Override Jinja template support.
+    /// - `None` → auto-detect: enabled when the model has the `"agent"` tag.
+    /// - `Some(true)` → force enable regardless of tags.
+    /// - `Some(false)` → force disable regardless of tags.
+    pub jinja: Option<bool>,
+
+    /// Override the reasoning format passed to llama-server.
+    /// - `None` → auto-detect from model tags (e.g. `"reasoning"` tag).
+    /// - `Some("none")` → explicitly suppress reasoning extraction even if the
+    ///   model has a reasoning tag.
+    /// - `Some("deepseek")` / `Some("deepseek-legacy")` → force a specific
+    ///   format.
+    pub reasoning_format: Option<String>,
+
+    /// Override the MTP draft token count.
+    /// - `None` → auto-detect: enabled with default `n=2` when the model has
+    ///   the `"mtp"` tag.
+    /// - `Some(0)` → explicitly disable MTP even if the model has the `"mtp"`
+    ///   tag.
+    /// - `Some(n)` → enable MTP with `n` draft tokens.
+    pub mtp_draft_n_max: Option<u32>,
+
+    /// Override the MTP acceptance probability threshold.
+    /// Only meaningful when MTP is enabled. `None` uses the default (`0.75`).
+    pub mtp_draft_p_min: Option<f32>,
+
+    /// Inference parameter overrides (temperature, top-p, etc.) forwarded
+    /// directly to llama-server.
+    pub inference_params: Option<InferenceConfig>,
+}
+
+// =============================================================================
+// Builder
+// =============================================================================
+
+/// Build a [`ServerConfig`] from model identity, model tags, and caller options.
+///
+/// This is the **canonical entry point** for constructing a [`ServerConfig`] and
+/// **must** be used by all launch surfaces to guarantee that the same model
+/// always receives the same llama-server arguments regardless of which surface
+/// triggered the start.
+///
+/// # Arguments
+///
+/// * `model_id` — Unique numeric model identifier (database row id).
+/// * `model_name` — Human-readable model name forwarded to the process manager.
+/// * `model_path` — Absolute path to the GGUF model file.
+/// * `base_port` — Base port for llama-server port allocation.  Pass `0` when
+///   the underlying [`GuiProcessCore`] allocates the port itself.
+/// * `tags` — Model capability tags (e.g. `["mtp", "agent", "reasoning"]`).
+///   Used for all tag-based auto-detection when the corresponding option field
+///   is `None`.
+/// * `opts` — Caller-supplied overrides.  Use
+///   `ServerConfigOptions::default()` for fully automatic tag-based
+///   configuration.
+pub fn build_server_config(
+    model_id: i64,
+    model_name: String,
+    model_path: PathBuf,
+    base_port: u16,
+    tags: &[String],
+    opts: ServerConfigOptions,
+) -> ServerConfig {
+    let mut config = ServerConfig::new(model_id, model_name, model_path, base_port);
+
+    if let Some(ctx) = opts.context_size {
+        config = config.with_context_size(ctx);
+    }
+
+    if let Some(port) = opts.port {
+        config = config.with_port(port);
+    }
+
+    // --- Jinja templates -------------------------------------------------------
+    let jinja = resolve_jinja_flag(opts.jinja, tags);
+    if jinja.enabled {
+        debug!(source = ?jinja.source, "enabling --jinja for model");
+        config = config.with_jinja();
+    }
+
+    // --- Reasoning format ------------------------------------------------------
+    match opts.reasoning_format.as_deref() {
+        Some("none") => {
+            // Caller explicitly suppressed reasoning — don't set the flag.
+            debug!("reasoning format explicitly suppressed by caller");
+        }
+        Some(format) => {
+            // Caller provided an explicit format string — use it directly.
+            debug!(format, "using explicit reasoning format");
+            config = config.with_reasoning_format(format.to_owned());
+        }
+        None => {
+            // Auto-detect from model tags.
+            let reasoning = resolve_reasoning_format(None, tags);
+            if let Some(format) = reasoning.format {
+                debug!(
+                    format = %format,
+                    source = ?reasoning.source,
+                    "auto-detected reasoning format from model tags"
+                );
+                config = config.with_reasoning_format(format);
+            }
+        }
+    }
+
+    // --- Inference parameters --------------------------------------------------
+    if let Some(params) = opts.inference_params {
+        config = config.with_inference_config(params);
+    }
+
+    // --- MTP speculative decoding ----------------------------------------------
+    let mtp = resolve_mtp_args(opts.mtp_draft_n_max, opts.mtp_draft_p_min, tags);
+    if mtp.enabled {
+        debug!(
+            n_max = mtp.draft_n_max,
+            p_min = mtp.draft_p_min,
+            source = ?mtp.source,
+            "enabling MTP speculative decoding"
+        );
+        config = config
+            .with_spec_draft_n_max(mtp.draft_n_max)
+            .with_spec_draft_p_min(mtp.draft_p_min);
+    }
+
+    config
+}


### PR DESCRIPTION
## Summary

Introduces a single canonical `build_server_config` function in `gglib-runtime` that all llama-server launch surfaces must use. This fixes three capability parity gaps and makes it architecturally impossible for future capability additions to diverge across surfaces.

---

## Problem

Three separate call sites were manually assembling a `ServerConfig`, each with different gaps:

| Launch surface | File | Jinja | Reasoning | MTP |
|---|---|:---:|:---:|:---:|
| GUI/HTTP start-server | `gglib-app-services/src/servers.rs` | ✅ | ✅ | ✅ |
| CLI agent-chat/question | `gglib-cli/src/handlers/agent_chat/config.rs` | ✅ | ✅ | ❌ |
| Proxy auto-start | `gglib-runtime/src/process/manager.rs` | ❌ hardcoded ON | ❌ | ❌ |

A client app sending a request to `gglib proxy` with an MTP model would cause the proxy to auto-start llama-server **without** `--spec-type draft-mtp`, silently falling back to single-token generation.

---

## Solution

### Phase 1 — Shared builder (`gglib-runtime/src/server_config.rs`)

**`ServerConfigOptions`** — a `Default`-deriving struct with one optional field per capability. `None` = auto-detect from model tags.

**`build_server_config(id, name, path, base_port, tags, opts)`** — calls all resolvers in one place:
- `resolve_jinja_flag(opts.jinja, tags)` — `"agent"` tag
- `resolve_reasoning_format(opts.reasoning_format, tags)` — `"reasoning"` tag
- `resolve_mtp_args(opts.mtp_draft_n_max, opts.mtp_draft_p_min, tags)` — `"mtp"` tag

Re-exported from `lib.rs` as `gglib_runtime::{build_server_config, ServerConfigOptions}`.

### Phase 1 — Three call-site migrations

| File | Before | After |
|---|---|---|
| `manager.rs` | `ServerConfig::new().with_context_size().with_jinja()` | `build_server_config(..., ServerConfigOptions { context_size: Some(ctx), ..Default::default() })` |
| `servers.rs` | 50-line manual build chain with inline resolver calls | thin `ServerConfigOptions` mapping into `build_server_config` |
| `agent_chat/config.rs` | manual jinja + reasoning detection, no MTP | `build_server_config(..., ServerConfigOptions { context_size, ..Default::default() })` |

### Phase 2 — Documentation

- **`gglib-proxy/README.md`** — new "Model Capability Auto-Detection" section with capability→flag table
- **`gglib-runtime/README.md`** — MTP feature bullet + new "ServerConfig Builder" section with usage examples and precedence table
- **`gglib-cli/src/commands.rs`** (Proxy doc comment) — documents tag-aware auto-start in `--help` and `cargo doc`

---

## Breaking change

The proxy auto-start path previously hardcoded `--jinja` on every model. It is now tag-driven: `--jinja` is only passed for models with the `"agent"` tag, matching GUI and CLI behaviour. Any non-agent model served via the proxy that relied on the hardcoded Jinja flag will need the `"agent"` tag added.

---

## Commits

1. `feat(runtime): add canonical ServerConfig builder with full capability parity`
2. `refactor: migrate all launch surfaces to shared build_server_config`
3. `docs: update proxy/runtime READMEs and CLI help for tag-aware auto-config`
