### PR TITLE
feat: capability unification — architecture registry, proxy coalescing, capability override API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,27 @@ The proxy uses a two-layer system to decide how to preprocess requests before th
 
 The result of both layers is **OR-combined** and stored in the database as `Model.capabilities`.  The proxy reads this value once per request — there is no second inference pass at forward time.
 
+### Template analysis — positive vs. negative system-role signals
+
+`infer_from_chat_template` uses two priority tiers for the `SUPPORTS_SYSTEM_ROLE` flag:
+
+| Priority | Pattern | Meaning |
+|---|---|---|
+| **1 — positive** | `[SYSTEM_PROMPT]` in template | Mistral v7: system role handled natively |
+| **1 — positive** | `[AVAILABLE_TOOLS]` in template | Mistral v3/v3-tekken: system prepended inline |
+| **2 — negative** | `"Only user, assistant and tool roles…"` | Old Mistral v1/v2: system role rejected |
+| **2 — negative** | `"got system"` / `"Raise exception for unsupported roles"` | Other strict models |
+| **default** | No signal | System role assumed supported |
+
+Positive evidence wins: if a template contains `[SYSTEM_PROMPT]` **and** a generic error-raise, the positive signal takes precedence and `SUPPORTS_SYSTEM_ROLE` is set.
+
+### Known architecture registry
+
+| `general.architecture` | Models | Flags |
+|---|---|---|
+| `"mistral"` | Mistral v1/v2 | `REQUIRES_STRICT_TURNS` |
+| `"mistral3"` | Devstral, Ministral, Mistral Small 3 | `REQUIRES_STRICT_TURNS \| SUPPORTS_SYSTEM_ROLE` |
+
 ### Adding a new architecture (request side)
 
 1. **Add an arm** to `capabilities_from_architecture()` in `crates/gglib-core/src/domain/capabilities.rs`:
@@ -123,13 +144,7 @@ The result of both layers is **OR-combined** and stored in the database as `Mode
    }
    ```
 
-3. **Re-run bootstrap** on any existing models to pick up the new flag:
-
-   ```bash
-   gglib model retag --all --full
-   ```
-
-   Or override a single model's flags without re-importing:
+3. **Fix any already-imported models** by overriding their flags directly:
 
    ```bash
    gglib model capabilities <id> --set requires-strict-turns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,15 @@ This document is the definitive engineering guide for contributors. Read it befo
 1. [Core Philosophy](#core-philosophy)
 2. [Architecture Overview](#architecture-overview)
 3. [GUI Parity Principle](#gui-parity-principle)
-4. [Concurrency Model](#concurrency-model)
-5. [Subprocess Invocation](#subprocess-invocation)
-6. [Crate Boundaries](#crate-boundaries)
-7. [Documentation Standards](#documentation-standards)
-6. [Badges Pipeline](#badges-pipeline)
-7. [Development Workflow](#development-workflow)
-8. [CI Pipeline](#ci-pipeline)
-9. [Pull Request Checklist](#pull-request-checklist)
+4. [Model Architecture Registry](#model-architecture-registry)
+5. [Concurrency Model](#concurrency-model)
+6. [Subprocess Invocation](#subprocess-invocation)
+7. [Crate Boundaries](#crate-boundaries)
+8. [Documentation Standards](#documentation-standards)
+9. [Badges Pipeline](#badges-pipeline)
+10. [Development Workflow](#development-workflow)
+11. [CI Pipeline](#ci-pipeline)
+12. [Pull Request Checklist](#pull-request-checklist)
 
 ---
 
@@ -90,6 +91,69 @@ When adding a new long-running operation:
 **Tauri commands are OS integration only.** Product features are served over HTTP (Axum). The CI enforces that `#[tauri::command]` functions live only in a small set of approved files (`util.rs`, `llama.rs`, `app_logs.rs`). A new product feature does not get a Tauri command — it gets an Axum route that the WebView calls over HTTP, just like the browser-based UI does.
 
 **Frontend transport is unified.** The frontend client modules must not branch on `isTauriApp`. If you find yourself writing `if (isTauriApp()) { invoke(...) } else { fetch(...) }` in a service module, that is an architectural violation. The transport abstraction layer handles that distinction.
+
+---
+
+## Model Architecture Registry
+
+The proxy uses a two-layer system to decide how to preprocess requests before they reach llama-server:
+
+| Layer | Location | When |
+|---|---|---|
+| Chat template analysis | `gglib-core::domain::capabilities::infer_from_chat_template` | At model import — reads `tokenizer.chat_template` from the GGUF |
+| Architecture registry | `gglib-core::domain::capabilities::capabilities_from_architecture` | At model import — reads `general.architecture` as a backstop |
+
+The result of both layers is **OR-combined** and stored in the database as `Model.capabilities`.  The proxy reads this value once per request — there is no second inference pass at forward time.
+
+### Adding a new architecture (request side)
+
+1. **Add an arm** to `capabilities_from_architecture()` in `crates/gglib-core/src/domain/capabilities.rs`:
+
+   ```rust
+   "myarch" => ModelCapabilities::REQUIRES_STRICT_TURNS,
+   ```
+
+2. **Add a unit test** in the same file:
+
+   ```rust
+   #[test]
+   fn myarch_requires_strict_turns() {
+       let caps = capabilities_from_architecture(Some("myarch"));
+       assert!(caps.contains(ModelCapabilities::REQUIRES_STRICT_TURNS));
+   }
+   ```
+
+3. **Re-run bootstrap** on any existing models to pick up the new flag:
+
+   ```bash
+   gglib model retag --all --full
+   ```
+
+   Or override a single model's flags without re-importing:
+
+   ```bash
+   gglib model capabilities <id> --set requires-strict-turns
+   ```
+
+### Adding a new architecture (response side)
+
+If the architecture needs **response normalization** (e.g., XML-wrapped tool calls):
+
+1. Add a `format:myarch-xml` constant to `crates/gglib-proxy/src/normalize/tags.rs`.
+2. Add a parser module under `crates/gglib-proxy/src/normalize/parsers/`.
+3. Add an arm to `get_parser()` in `crates/gglib-proxy/src/normalize/registry.rs`.
+4. Ensure models with this architecture receive the `format:myarch-xml` tag (add to `retag` logic if needed).
+
+No other files need to change.  The proxy's `normalize` pipeline picks up new parsers automatically via `get_parser()`.
+
+### Capability overrides
+
+Users can view and override capability flags at any time via:
+
+- **CLI**: `gglib model capabilities <id> [--set FLAG] [--unset FLAG]`
+- **API**: `PATCH /api/models/{id}/capabilities` with JSON body `{ "requiresStrictTurns": true }`
+
+Both surfaces call the same `ModelOps::set_capabilities()` method in `gglib-app-services` — no business logic lives in the surface crates.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ Works with any command that produces text. If you can `cat` it, you can ask a lo
 
 Cargo workspace with compile-time enforced boundaries. Adapters → infrastructure → core — never the reverse.
 
+### Model capability detection
+
+When you add a GGUF model, gglib reads its `tokenizer.chat_template` and `general.architecture` fields to automatically detect capability flags: whether the model requires strict user/assistant turn alternation, supports a system role, can handle tool calls, and so on. These flags are stored in the database and used by the OpenAI-compatible proxy to preprocess requests before they reach llama-server.
+
+For models whose quantized builds ship without a chat template, the architecture name (`general.architecture`) acts as a backstop — for example, `"mistral"` architecture always implies `REQUIRES_STRICT_TURNS`.
+
+You can inspect or override any model's flags at any time:
+
+```bash
+# Show current capabilities
+gglib model capabilities 3
+
+# Force strict-turn coalescing on
+gglib model capabilities 3 --set requires-strict-turns
+
+# Or via the REST API
+curl -X PATCH http://localhost:9887/api/models/3/capabilities \
+     -H 'Content-Type: application/json' \
+     -d '{"requiresStrictTurns": true}'
+```
+
+For details on how to add support for a new architecture, see [`CONTRIBUTING.md`](CONTRIBUTING.md#model-architecture-registry).
+
 ![Rust Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/tests.json)
 ![Rust Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/coverage.json)
 ![TS Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-tests.json)

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -9,7 +9,9 @@ use gglib_core::ports::{GgufParserPort, ProcessRunner};
 use gglib_core::services::AppCore;
 
 use crate::error::GuiError;
-use crate::types::{AddModelRequest, GuiModel, RemoveModelRequest, SetCapabilitiesRequest, UpdateModelRequest};
+use crate::types::{
+    AddModelRequest, GuiModel, RemoveModelRequest, SetCapabilitiesRequest, UpdateModelRequest,
+};
 
 /// Dependencies for model operations.
 pub struct ModelDeps {

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -9,7 +9,7 @@ use gglib_core::ports::{GgufParserPort, ProcessRunner};
 use gglib_core::services::AppCore;
 
 use crate::error::GuiError;
-use crate::types::{AddModelRequest, GuiModel, RemoveModelRequest, UpdateModelRequest};
+use crate::types::{AddModelRequest, GuiModel, RemoveModelRequest, SetCapabilitiesRequest, UpdateModelRequest};
 
 /// Dependencies for model operations.
 pub struct ModelDeps {
@@ -232,6 +232,52 @@ impl ModelOps {
             .get_filter_options()
             .await
             .map_err(|e| GuiError::Internal(format!("Failed to get filter options: {e}")))
+    }
+
+    /// Override one or more capability flags on a model.
+    ///
+    /// Each field in [`SetCapabilitiesRequest`] independently sets or clears
+    /// one [`ModelCapabilities`] bit.  `None` fields are left unchanged.
+    /// The result is persisted to the database and returned as an updated
+    /// [`GuiModel`].
+    ///
+    /// This is the **single shared implementation** called by the CLI, the
+    /// Axum WebUI, and the Tauri app.  No business logic lives in the surface
+    /// crates.
+    pub async fn set_capabilities(
+        &self,
+        id: i64,
+        request: SetCapabilitiesRequest,
+    ) -> Result<GuiModel, GuiError> {
+        use gglib_core::ModelCapabilities;
+
+        let mut model = self.resolve_model(id).await?;
+
+        let mut caps = model.capabilities;
+
+        if let Some(v) = request.supports_system_role {
+            caps.set(ModelCapabilities::SUPPORTS_SYSTEM_ROLE, v);
+        }
+        if let Some(v) = request.requires_strict_turns {
+            caps.set(ModelCapabilities::REQUIRES_STRICT_TURNS, v);
+        }
+        if let Some(v) = request.supports_tool_calls {
+            caps.set(ModelCapabilities::SUPPORTS_TOOL_CALLS, v);
+        }
+        if let Some(v) = request.supports_reasoning {
+            caps.set(ModelCapabilities::SUPPORTS_REASONING, v);
+        }
+
+        model.capabilities = caps;
+
+        self.deps
+            .core
+            .models()
+            .update(&model)
+            .await
+            .map_err(|e| GuiError::Internal(format!("Failed to update model capabilities: {e}")))?;
+
+        Ok(GuiModel::from_domain(model))
     }
 }
 

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -149,6 +149,13 @@ pub struct GuiModel {
     pub port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inference_defaults: Option<gglib_core::domain::InferenceConfig>,
+    /// Capability flags stored for this model.
+    ///
+    /// Serialized as a `u32` bit-field.  The frontend receives this value
+    /// and may display individual flags; the `PATCH /api/models/{id}/capabilities`
+    /// endpoint lets the user override them.
+    #[serde(default)]
+    pub capabilities: gglib_core::ModelCapabilities,
 }
 
 impl GuiModel {
@@ -168,6 +175,7 @@ impl GuiModel {
             is_serving,
             port,
             inference_defaults: model.inference_defaults,
+            capabilities: model.capabilities,
         }
     }
 
@@ -268,6 +276,33 @@ pub struct UpdateModelRequest {
     pub quantization: Option<String>,
     pub file_path: Option<String>,
     pub inference_defaults: Option<gglib_core::domain::InferenceConfig>,
+}
+
+/// Request body for overriding a model's capability flags.
+///
+/// Each field independently sets (`true`) or clears (`false`) one flag.
+/// `None` means "leave this flag unchanged".  This lets callers toggle a
+/// single flag without knowing the current state of every other flag.
+///
+/// # Example
+///
+/// Force strict-turn coalescing on for a model whose GGUF shipped without
+/// a chat template:
+///
+/// ```json
+/// { "requiresStrictTurns": true }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCapabilitiesRequest {
+    /// Override whether the model supports a `system` role in the chat template.
+    pub supports_system_role: Option<bool>,
+    /// Override whether the model requires strict user/assistant turn alternation.
+    pub requires_strict_turns: Option<bool>,
+    /// Override whether the model supports tool/function calling.
+    pub supports_tool_calls: Option<bool>,
+    /// Override whether the model produces reasoning/thinking output.
+    pub supports_reasoning: Option<bool>,
 }
 
 // ============================================================================

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -494,7 +494,7 @@ pub async fn proxy_chat(
         .into_iter()
         .map(|m| gglib_core::ChatMessage {
             role: m.role,
-            content: m.content,
+            content: m.content.map(gglib_core::MessageContent::Text),
             tool_calls: m.tool_calls.map(serde_json::Value::Array),
         })
         .collect();
@@ -506,7 +506,7 @@ pub async fn proxy_chat(
         .into_iter()
         .map(|m| ChatMessage {
             role: m.role,
-            content: m.content,
+            content: m.content.map(|c| c.into_string()),
             tool_calls: m.tool_calls.and_then(|v| {
                 if let serde_json::Value::Array(arr) = v {
                     Some(arr)

--- a/crates/gglib-axum/src/handlers/model/models.rs
+++ b/crates/gglib-axum/src/handlers/model/models.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, State};
 use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_app_services::types::{
-    AddModelRequest, GuiModel, RemoveModelRequest, UpdateModelRequest,
+    AddModelRequest, GuiModel, RemoveModelRequest, SetCapabilitiesRequest, UpdateModelRequest,
 };
 use gglib_core::ModelFilterOptions;
 
@@ -109,4 +109,12 @@ pub async fn filter_options(
     State(state): State<AppState>,
 ) -> Result<Json<ModelFilterOptions>, HttpError> {
     Ok(Json(state.models.get_filter_options().await?))
+}
+
+pub async fn set_capabilities(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(req): Json<SetCapabilitiesRequest>,
+) -> Result<Json<GuiModel>, HttpError> {
+    Ok(Json(state.models.set_capabilities(id, req).await?))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -152,6 +152,13 @@ fn model_routes() -> Router<AppState> {
                 .put(handlers::model::models::update)
                 .delete(handlers::model::models::remove),
         )
+        // Capability override: PATCH /api/models/{id}/capabilities
+        // Independently set/clear individual ModelCapabilities flags without
+        // touching any other model metadata.
+        .route(
+            "/{id}/capabilities",
+            axum::routing::patch(handlers::model::models::set_capabilities),
+        )
         // Tags
         .route(
             "/{id}/tags",

--- a/crates/gglib-cli/src/handlers/model/capabilities.rs
+++ b/crates/gglib-cli/src/handlers/model/capabilities.rs
@@ -1,0 +1,99 @@
+//! `gglib model capabilities` handler.
+//!
+//! Displays or overrides the [`ModelCapabilities`] flags stored for a model.
+//! All mutations go through [`ModelOps::set_capabilities`] in
+//! `gglib-app-services`, which is the single shared implementation consumed
+//! by this CLI, the Axum WebUI, and the Tauri app.
+//!
+//! [`ModelCapabilities`]: gglib_core::ModelCapabilities
+
+use anyhow::{Result, anyhow};
+use gglib_app_services::{ModelDeps, ModelOps};
+use gglib_app_services::types::SetCapabilitiesRequest;
+use gglib_core::ModelCapabilities;
+
+use crate::bootstrap::CliContext;
+
+/// Execute `gglib model capabilities <id> [--set FLAG]... [--unset FLAG]...`.
+///
+/// Without `--set` or `--unset` flags the command is read-only and prints the
+/// current capability state.  With flags it applies the requested overrides
+/// via [`ModelOps::set_capabilities`] and prints the updated state.
+pub async fn execute(ctx: &CliContext, id: u32, set: Vec<String>, unset: Vec<String>) -> Result<()> {
+    // Build-once — ModelOps is cheap and constructed the same way as in Axum/Tauri.
+    let ops = ModelOps::new(ModelDeps {
+        core: ctx.app.clone(),
+        runner: ctx.runner.clone(),
+        gguf_parser: ctx.gguf_parser.clone(),
+    });
+
+    // Read-only: no flags provided.
+    if set.is_empty() && unset.is_empty() {
+        let model = ops.get(id as i64).await?;
+        print_capabilities(id, &model.name, model.capabilities);
+        return Ok(());
+    }
+
+    // Build the override request.
+    let mut req = SetCapabilitiesRequest::default();
+
+    for flag in &set {
+        apply_flag(&mut req, flag, true)?;
+    }
+    for flag in &unset {
+        apply_flag(&mut req, flag, false)?;
+    }
+
+    let gui_model = ops.set_capabilities(id as i64, req).await?;
+
+    println!("Updated capabilities for model {} ({}):", id, gui_model.name);
+    print_capabilities(id, &gui_model.name, gui_model.capabilities);
+
+    Ok(())
+}
+
+/// Parse a capability flag name and set/clear the corresponding field.
+fn apply_flag(req: &mut SetCapabilitiesRequest, flag: &str, value: bool) -> Result<()> {
+    match flag {
+        "supports-system-role" => req.supports_system_role = Some(value),
+        "requires-strict-turns" => req.requires_strict_turns = Some(value),
+        "supports-tool-calls" => req.supports_tool_calls = Some(value),
+        "supports-reasoning" => req.supports_reasoning = Some(value),
+        other => {
+            return Err(anyhow!(
+                "Unknown capability flag '{other}'.\n\
+                 Valid flags: supports-system-role, requires-strict-turns, \
+                 supports-tool-calls, supports-reasoning"
+            ))
+        }
+    }
+    Ok(())
+}
+
+/// Pretty-print the capability state for a model.
+fn print_capabilities(id: u32, name: &str, caps: ModelCapabilities) {
+    println!("Capabilities for model {id} ({name}):");
+    println!(
+        "  supports-system-role  : {}",
+        flag_str(caps.contains(ModelCapabilities::SUPPORTS_SYSTEM_ROLE))
+    );
+    println!(
+        "  requires-strict-turns : {}",
+        flag_str(caps.contains(ModelCapabilities::REQUIRES_STRICT_TURNS))
+    );
+    println!(
+        "  supports-tool-calls   : {}",
+        flag_str(caps.contains(ModelCapabilities::SUPPORTS_TOOL_CALLS))
+    );
+    println!(
+        "  supports-reasoning    : {}",
+        flag_str(caps.contains(ModelCapabilities::SUPPORTS_REASONING))
+    );
+    if caps.is_empty() {
+        println!("  (all flags unset — pass-through mode)");
+    }
+}
+
+fn flag_str(v: bool) -> &'static str {
+    if v { "true" } else { "false" }
+}

--- a/crates/gglib-cli/src/handlers/model/capabilities.rs
+++ b/crates/gglib-cli/src/handlers/model/capabilities.rs
@@ -8,8 +8,8 @@
 //! [`ModelCapabilities`]: gglib_core::ModelCapabilities
 
 use anyhow::{Result, anyhow};
-use gglib_app_services::{ModelDeps, ModelOps};
 use gglib_app_services::types::SetCapabilitiesRequest;
+use gglib_app_services::{ModelDeps, ModelOps};
 use gglib_core::ModelCapabilities;
 
 use crate::bootstrap::CliContext;
@@ -19,7 +19,12 @@ use crate::bootstrap::CliContext;
 /// Without `--set` or `--unset` flags the command is read-only and prints the
 /// current capability state.  With flags it applies the requested overrides
 /// via [`ModelOps::set_capabilities`] and prints the updated state.
-pub async fn execute(ctx: &CliContext, id: u32, set: Vec<String>, unset: Vec<String>) -> Result<()> {
+pub async fn execute(
+    ctx: &CliContext,
+    id: u32,
+    set: Vec<String>,
+    unset: Vec<String>,
+) -> Result<()> {
     // Build-once — ModelOps is cheap and constructed the same way as in Axum/Tauri.
     let ops = ModelOps::new(ModelDeps {
         core: ctx.app.clone(),
@@ -46,7 +51,10 @@ pub async fn execute(ctx: &CliContext, id: u32, set: Vec<String>, unset: Vec<Str
 
     let gui_model = ops.set_capabilities(id as i64, req).await?;
 
-    println!("Updated capabilities for model {} ({}):", id, gui_model.name);
+    println!(
+        "Updated capabilities for model {} ({}):",
+        id, gui_model.name
+    );
     print_capabilities(id, &gui_model.name, gui_model.capabilities);
 
     Ok(())
@@ -64,7 +72,7 @@ fn apply_flag(req: &mut SetCapabilitiesRequest, flag: &str, value: bool) -> Resu
                 "Unknown capability flag '{other}'.\n\
                  Valid flags: supports-system-role, requires-strict-turns, \
                  supports-tool-calls, supports-reasoning"
-            ))
+            ));
         }
     }
     Ok(())

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -4,6 +4,7 @@
 //! CRUD, verification, download, and HuggingFace discovery.
 
 pub mod add;
+pub mod capabilities;
 pub mod download;
 pub mod list;
 pub mod remove;
@@ -125,6 +126,9 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
             size,
         } => {
             download::browse(category, limit, size).await?;
+        }
+        ModelCommand::Capabilities { id, set, unset } => {
+            capabilities::execute(ctx, id, set, unset).await?;
         }
     }
     Ok(())

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -213,4 +213,39 @@ pub enum ModelCommand {
         #[arg(long)]
         size: Option<String>,
     },
+
+    /// View or override a model's capability flags.
+    ///
+    /// Capabilities control how gglib preprocesses requests before they reach
+    /// the model (strict-turn coalescing, system-role conversion, etc.).  They
+    /// are detected automatically at import time from the GGUF's chat template
+    /// and `general.architecture` field.  Use this command when auto-detection
+    /// produces the wrong result for a specific build.
+    ///
+    /// Without any flag arguments the command prints the current capabilities.
+    ///
+    /// # Example
+    ///
+    /// Force strict-turn coalescing on for a model whose GGUF was stripped:
+    ///
+    ///   gglib model capabilities 3 --set requires-strict-turns
+    ///
+    /// Disable reasoning output processing:
+    ///
+    ///   gglib model capabilities 3 --unset supports-reasoning
+    Capabilities {
+        /// ID of the model to inspect or modify
+        id: u32,
+        /// Set a capability flag (can be repeated).
+        ///
+        /// Accepted values: `supports-system-role`, `requires-strict-turns`,
+        /// `supports-tool-calls`, `supports-reasoning`.
+        #[arg(long = "set", value_name = "FLAG", action = clap::ArgAction::Append)]
+        set: Vec<String>,
+        /// Clear a capability flag (can be repeated).
+        ///
+        /// Accepted values: same as `--set`.
+        #[arg(long = "unset", value_name = "FLAG", action = clap::ArgAction::Append)]
+        unset: Vec<String>,
+    },
 }

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -267,7 +267,7 @@ pub fn infer_from_chat_template(
 /// This is the **single source of truth** for architecture-level behavioural
 /// constraints that apply to the **request** side (message preprocessing).
 /// It is consulted during model registration alongside
-/// [`infer_from_chat_template`] — the two results are ORed together so that
+/// [`infer_from_chat_template`] — the two results are `OR`-ed together so that
 /// either signal is sufficient.
 ///
 /// # Scope: request preprocessing only

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -486,14 +486,152 @@ mod tests {
 // Message Transformation
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// The content of a chat message.
+///
+/// The OpenAI API allows `content` to be either a plain string or a structured
+/// array of typed content parts (text blocks, image URLs, tool results, etc.).
+/// Both forms are preserved faithfully through serialize/deserialize
+/// round-trips so the proxy never re-shapes data it did not need to touch.
+///
+/// # Serde behaviour
+///
+/// Uses `#[serde(untagged)]`, so the wire representation is unchanged:
+/// - `Text("hello")` → `"hello"` (JSON string)
+/// - `Parts([…])` → `[{"type":"text","text":"…"},…]` (JSON array)
+///
+/// A JSON `null` or missing `content` field is handled by the surrounding
+/// `Option<MessageContent>` with `#[serde(default)]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MessageContent {
+    /// Plain UTF-8 text.
+    Text(String),
+    /// Structured content parts (text, image_url, tool_result, …).
+    ///
+    /// Individual part shapes are defined by the OpenAI API spec and
+    /// validated by the model, not here.
+    Parts(Vec<serde_json::Value>),
+}
+
+impl MessageContent {
+    /// Borrow the inner string slice when this is plain-text content.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Text(s) => Some(s),
+            Self::Parts(_) => None,
+        }
+    }
+
+    /// Consume into a single flat `String`.
+    ///
+    /// For [`Text`] the string is returned as-is.  For [`Parts`] all
+    /// `{"type":"text","text":"…"}` entries are concatenated; other part
+    /// types (images, etc.) are omitted — callers should only use this when
+    /// a plain-text representation is required (e.g. the `[System]: ` prefix
+    /// during system-message conversion).
+    ///
+    /// [`Text`]: Self::Text
+    /// [`Parts`]: Self::Parts
+    pub fn into_string(self) -> String {
+        match self {
+            Self::Text(s) => s,
+            Self::Parts(parts) => parts
+                .iter()
+                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join(""),
+        }
+    }
+
+    /// Merge `other` into `self`, producing a single combined [`MessageContent`].
+    ///
+    /// | `self`  | `other` | result |
+    /// |---------|---------|--------|
+    /// | Text    | Text    | Text joined with `"\n\n"` |
+    /// | Parts   | Parts   | Parts arrays concatenated |
+    /// | Text    | Parts   | Parts with a leading text block |
+    /// | Parts   | Text    | Parts with a trailing text block |
+    ///
+    /// Empty strings are handled gracefully (no `"\n\n"` separator when
+    /// either side is empty).
+    fn merge_with(self, other: MessageContent) -> MessageContent {
+        match (self, other) {
+            (Self::Text(mut a), Self::Text(b)) => {
+                if a.is_empty() {
+                    return Self::Text(b);
+                }
+                if b.is_empty() {
+                    return Self::Text(a);
+                }
+                a.push_str("\n\n");
+                a.push_str(&b);
+                Self::Text(a)
+            }
+            (Self::Parts(mut a), Self::Parts(b)) => {
+                a.extend(b);
+                Self::Parts(a)
+            }
+            (Self::Text(a), Self::Parts(b)) => {
+                let mut parts = vec![serde_json::json!({"type": "text", "text": a})];
+                parts.extend(b);
+                Self::Parts(parts)
+            }
+            (Self::Parts(mut a), Self::Text(b)) => {
+                a.push(serde_json::json!({"type": "text", "text": b}));
+                Self::Parts(a)
+            }
+        }
+    }
+}
+
+impl From<String> for MessageContent {
+    fn from(s: String) -> Self {
+        Self::Text(s)
+    }
+}
+
+impl From<&str> for MessageContent {
+    fn from(s: &str) -> Self {
+        Self::Text(s.to_string())
+    }
+}
+
 /// A chat message for transformation.
+///
+/// `content` uses [`MessageContent`] which accepts both a plain JSON string
+/// and a JSON array of content-part objects during deserialization, preserving
+/// the original form during serialization.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<MessageContent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<serde_json::Value>,
+}
+
+impl ChatMessage {
+    /// Merge `other` into `self` in-place.
+    ///
+    /// Used during strict-turn coalescing to combine consecutive same-role
+    /// messages.  Content is merged via [`MessageContent::merge_with`]; tool
+    /// calls are concatenated as JSON arrays.
+    fn merge_into(&mut self, other: ChatMessage) {
+        self.content = match (self.content.take(), other.content) {
+            (None, b) => b,
+            (a, None) => a,
+            (Some(a), Some(b)) => Some(a.merge_with(b)),
+        };
+        match (self.tool_calls.as_mut(), other.tool_calls) {
+            (_, None) => {}
+            (None, tc) => self.tool_calls = tc,
+            (Some(last_tc), Some(msg_tc)) => {
+                if let (Some(la), Some(ma)) = (last_tc.as_array_mut(), msg_tc.as_array()) {
+                    la.extend_from_slice(ma);
+                }
+            }
+        }
+    }
 }
 
 /// Merge consecutive system messages into a single message.
@@ -518,25 +656,19 @@ fn merge_consecutive_system_messages(messages: Vec<ChatMessage>) -> Vec<ChatMess
     let mut result: Vec<ChatMessage> = Vec::with_capacity(messages.len());
 
     for msg in messages {
-        if let Some(last) = result.last_mut()
-            && last.role == "system"
-            && msg.role == "system"
-        {
-            // Merge: append content with separator
-            let last_content = last.content.take().unwrap_or_default();
-            let new_content = msg.content.unwrap_or_default();
-
-            last.content = Some(if last_content.is_empty() {
-                new_content
-            } else if new_content.is_empty() {
-                last_content
-            } else {
-                format!("{last_content}\n\n{new_content}")
-            });
-
-            continue; // Don't push, we merged into last
+        let is_system_merge = result
+            .last()
+            .map_or(false, |last| last.role == "system" && msg.role == "system");
+        if is_system_merge {
+            let last = result.last_mut().unwrap();
+            last.content = match (last.content.take(), msg.content) {
+                (None, b) => b,
+                (a, None) => a,
+                (Some(a), Some(b)) => Some(a.merge_with(b)),
+            };
+        } else {
+            result.push(msg);
         }
-        result.push(msg);
     }
 
     result
@@ -585,8 +717,10 @@ pub fn transform_messages_for_capabilities(
         for msg in &mut messages {
             if msg.role == "system" {
                 msg.role = "user".to_string();
-                if let Some(content) = &mut msg.content {
-                    *content = format!("[System]: {content}");
+                if let Some(content) = msg.content.take() {
+                    msg.content = Some(MessageContent::Text(
+                        format!("[System]: {}", content.into_string()),
+                    ));
                 }
             }
         }
@@ -594,56 +728,17 @@ pub fn transform_messages_for_capabilities(
 
     // STEP 2: Merge consecutive same-role messages if strict turns are required
     if capabilities.contains(ModelCapabilities::REQUIRES_STRICT_TURNS) {
-        let mut merged_messages = Vec::new();
+        let mut merged: Vec<ChatMessage> = Vec::new();
         for msg in messages {
-            if let Some(last) = merged_messages.last_mut() {
-                let last_msg: &mut ChatMessage = last;
-                // Only merge user/assistant messages (avoid merging tool/system messages)
-                let is_mergeable_role = msg.role == "user" || msg.role == "assistant";
-
-                // Merge if same role and mergeable (user or assistant)
-                if last_msg.role == msg.role && is_mergeable_role {
-                    // Merge content if both have content
-                    match (&mut last_msg.content, &msg.content) {
-                        (Some(last_content), Some(msg_content)) => {
-                            // Both have content - merge with separator
-                            last_content.push_str("\n\n");
-                            last_content.push_str(msg_content);
-                        }
-                        (None, Some(msg_content)) => {
-                            // Only new message has content - use it
-                            last_msg.content = Some(msg_content.clone());
-                        }
-                        // If last has content and msg doesn't, keep last's content
-                        // If neither have content, keep None
-                        _ => {}
-                    }
-
-                    // Merge tool_calls if present
-                    match (&mut last_msg.tool_calls, &msg.tool_calls) {
-                        (Some(last_calls), Some(msg_calls)) => {
-                            // Both have tool_calls - concatenate arrays
-                            if let (Some(last_arr), Some(msg_arr)) =
-                                (last_calls.as_array_mut(), msg_calls.as_array())
-                            {
-                                last_arr.extend_from_slice(msg_arr);
-                            }
-                        }
-                        (None, Some(msg_calls)) => {
-                            // Only new message has tool_calls - use it
-                            last_msg.tool_calls = Some(msg_calls.clone());
-                        }
-                        // If last has tool_calls and msg doesn't, keep last's tool_calls
-                        // If neither have tool_calls, keep None
-                        _ => {}
-                    }
-
-                    continue; // Skip adding this message separately
-                }
+            let is_mergeable = msg.role == "user" || msg.role == "assistant";
+            let same_role_as_last = merged.last().map_or(false, |last| last.role == msg.role);
+            if is_mergeable && same_role_as_last {
+                merged.last_mut().unwrap().merge_into(msg);
+            } else {
+                merged.push(msg);
             }
-            merged_messages.push(msg);
         }
-        return merged_messages;
+        return merged;
     }
 
     messages
@@ -659,12 +754,12 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Hello".to_string()),
+                content: Some(MessageContent::Text("Hello".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("Hi there".to_string()),
+                content: Some(MessageContent::Text("Hi there".to_string())),
                 tool_calls: None,
             },
         ];
@@ -679,17 +774,17 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("You are a helpful assistant.".to_string()),
+                content: Some(MessageContent::Text("You are a helpful assistant.".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("WORKING_MEMORY:\n- task1 (ok): done".to_string()),
+                content: Some(MessageContent::Text("WORKING_MEMORY:\n- task1 (ok): done".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Hello".to_string()),
+                content: Some(MessageContent::Text("Hello".to_string())),
                 tool_calls: None,
             },
         ];
@@ -698,7 +793,7 @@ mod transform_tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].role, "system");
         assert_eq!(
-            result[0].content.as_deref(),
+            result[0].content.as_ref().and_then(|c| c.as_str()),
             Some("You are a helpful assistant.\n\nWORKING_MEMORY:\n- task1 (ok): done")
         );
         assert_eq!(result[1].role, "user");
@@ -709,17 +804,17 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("First.".to_string()),
+                content: Some(MessageContent::Text("First.".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("Second.".to_string()),
+                content: Some(MessageContent::Text("Second.".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("Third.".to_string()),
+                content: Some(MessageContent::Text("Third.".to_string())),
                 tool_calls: None,
             },
         ];
@@ -727,7 +822,7 @@ mod transform_tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(
-            result[0].content.as_deref(),
+            result[0].content.as_ref().and_then(|c| c.as_str()),
             Some("First.\n\nSecond.\n\nThird.")
         );
     }
@@ -737,19 +832,22 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: Some(String::new()),
+                content: Some(MessageContent::Text(String::new())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("Actual content".to_string()),
+                content: Some(MessageContent::Text("Actual content".to_string())),
                 tool_calls: None,
             },
         ];
         let result = transform_messages_for_capabilities(messages, ModelCapabilities::empty());
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].content.as_deref(), Some("Actual content"));
+        assert_eq!(
+            result[0].content.as_ref().and_then(|c| c.as_str()),
+            Some("Actual content")
+        );
     }
 
     #[test]
@@ -757,12 +855,12 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("You are helpful".to_string()),
+                content: Some(MessageContent::Text("You are helpful".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Hello".to_string()),
+                content: Some(MessageContent::Text("Hello".to_string())),
                 tool_calls: None,
             },
         ];
@@ -772,27 +870,25 @@ mod transform_tests {
         // System becomes user, both messages remain separate (user + user but different content)
         assert_eq!(result.len(), 1); // They get merged because both are now "user"
         assert_eq!(result[0].role, "user");
-        assert!(
-            result[0]
-                .content
-                .as_ref()
-                .unwrap()
-                .contains("[System]: You are helpful")
-        );
-        assert!(result[0].content.as_ref().unwrap().contains("Hello"));
+        let content_str = result[0].content.as_ref().and_then(|c| c.as_str()).unwrap();
+        assert!(content_str.contains("[System]: You are helpful"));
+        assert!(content_str.contains("Hello"));
     }
 
     #[test]
     fn test_transform_preserves_system_when_supported() {
         let messages = vec![ChatMessage {
             role: "system".to_string(),
-            content: Some("You are helpful".to_string()),
+            content: Some(MessageContent::Text("You are helpful".to_string())),
             tool_calls: None,
         }];
         let caps = ModelCapabilities::SUPPORTS_SYSTEM_ROLE;
         let result = transform_messages_for_capabilities(messages, caps);
         assert_eq!(result[0].role, "system");
-        assert_eq!(result[0].content, Some("You are helpful".to_string()));
+        assert_eq!(
+            result[0].content,
+            Some(MessageContent::Text("You are helpful".to_string()))
+        );
     }
 
     #[test]
@@ -800,19 +896,22 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("First".to_string()),
+                content: Some(MessageContent::Text("First".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Second".to_string()),
+                content: Some(MessageContent::Text("Second".to_string())),
                 tool_calls: None,
             },
         ];
         let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
         let result = transform_messages_for_capabilities(messages, caps);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].content, Some("First\n\nSecond".to_string()));
+        assert_eq!(
+            result[0].content,
+            Some(MessageContent::Text("First\n\nSecond".to_string()))
+        );
     }
 
     #[test]
@@ -820,12 +919,12 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "tool".to_string(),
-                content: Some("Result 1".to_string()),
+                content: Some(MessageContent::Text("Result 1".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "tool".to_string(),
-                content: Some("Result 2".to_string()),
+                content: Some(MessageContent::Text("Result 2".to_string())),
                 tool_calls: None,
             },
         ];
@@ -839,17 +938,17 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: Some("Be helpful".to_string()),
+                content: Some(MessageContent::Text("Be helpful".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("First".to_string()),
+                content: Some(MessageContent::Text("First".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Second".to_string()),
+                content: Some(MessageContent::Text("Second".to_string())),
                 tool_calls: None,
             },
         ];
@@ -857,15 +956,10 @@ mod transform_tests {
         let result = transform_messages_for_capabilities(messages, caps);
         assert_eq!(result.len(), 1); // System→user + merge
         assert_eq!(result[0].role, "user");
-        assert!(
-            result[0]
-                .content
-                .as_ref()
-                .unwrap()
-                .contains("[System]: Be helpful")
-        );
-        assert!(result[0].content.as_ref().unwrap().contains("First"));
-        assert!(result[0].content.as_ref().unwrap().contains("Second"));
+        let content_str = result[0].content.as_ref().and_then(|c| c.as_str()).unwrap();
+        assert!(content_str.contains("[System]: Be helpful"));
+        assert!(content_str.contains("First"));
+        assert!(content_str.contains("Second"));
     }
 
     #[test]
@@ -896,17 +990,17 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("What's the weather?".to_string()),
+                content: Some(MessageContent::Text("What's the weather?".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("Let me check...".to_string()),
+                content: Some(MessageContent::Text("Let me check...".to_string())),
                 tool_calls: Some(tool_call_1),
             },
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("And the time...".to_string()),
+                content: Some(MessageContent::Text("And the time...".to_string())),
                 tool_calls: Some(tool_call_2),
             },
         ];
@@ -922,7 +1016,7 @@ mod transform_tests {
         // Content should be merged
         assert_eq!(
             result[1].content,
-            Some("Let me check...\n\nAnd the time...".to_string())
+            Some(MessageContent::Text("Let me check...\n\nAnd the time...".to_string()))
         );
 
         // Tool calls should be concatenated
@@ -950,7 +1044,7 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("Let me check...".to_string()),
+                content: Some(MessageContent::Text("Let me check...".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
@@ -964,7 +1058,10 @@ mod transform_tests {
         let result = transform_messages_for_capabilities(messages, caps);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].content, Some("Let me check...".to_string()));
+        assert_eq!(
+            result[0].content,
+            Some(MessageContent::Text("Let me check...".to_string()))
+        );
         assert!(result[0].tool_calls.is_some());
     }
 
@@ -990,7 +1087,7 @@ mod transform_tests {
             },
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("Result received".to_string()),
+                content: Some(MessageContent::Text("Result received".to_string())),
                 tool_calls: None,
             },
         ];
@@ -999,7 +1096,10 @@ mod transform_tests {
         let result = transform_messages_for_capabilities(messages, caps);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].content, Some("Result received".to_string()));
+        assert_eq!(
+            result[0].content,
+            Some(MessageContent::Text("Result received".to_string()))
+        );
         assert!(result[0].tool_calls.is_some());
     }
 
@@ -1051,12 +1151,12 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("First".to_string()),
+                content: Some(MessageContent::Text("First".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("Second".to_string()),
+                content: Some(MessageContent::Text("Second".to_string())),
                 tool_calls: None,
             },
         ];
@@ -1082,17 +1182,17 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Question".to_string()),
+                content: Some(MessageContent::Text("Question".to_string())),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "assistant".to_string(),
-                content: Some("Answer".to_string()),
+                content: Some(MessageContent::Text("Answer".to_string())),
                 tool_calls: Some(tool_call),
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: Some("Follow-up".to_string()),
+                content: Some(MessageContent::Text("Follow-up".to_string())),
                 tool_calls: None,
             },
         ];
@@ -1105,5 +1205,83 @@ mod transform_tests {
         assert_eq!(result[0].role, "user");
         assert_eq!(result[1].role, "assistant");
         assert_eq!(result[2].role, "user");
+    }
+
+    /// Verify that array-form `content` (OpenAI multipart spec) deserializes
+    /// correctly into `MessageContent::Parts` and is preserved on serialization.
+    #[test]
+    fn test_array_content_deserializes_to_parts() {
+        let json = serde_json::json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}
+            ]
+        });
+        let msg: ChatMessage = serde_json::from_value(json).unwrap();
+        assert!(matches!(msg.content, Some(MessageContent::Parts(_))));
+        // Round-trip: serialises back to array form
+        let re_serialised = serde_json::to_value(&msg).unwrap();
+        assert!(re_serialised["content"].is_array());
+    }
+
+    /// Verify that two user messages where one has array content and one has
+    /// text content are merged correctly into a Parts result.
+    #[test]
+    fn test_merge_array_content_with_text_content() {
+        let messages = vec![
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Parts(vec![
+                    serde_json::json!({"type": "text", "text": "Look at this:"}),
+                    serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}),
+                ])),
+                tool_calls: None,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Text("What do you see?".to_string())),
+                tool_calls: None,
+            },
+        ];
+        let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
+        let result = transform_messages_for_capabilities(messages, caps);
+
+        assert_eq!(result.len(), 1);
+        // Parts + Text → Parts with a trailing text block
+        assert!(matches!(&result[0].content, Some(MessageContent::Parts(p)) if p.len() == 3));
+    }
+
+    /// Verify that tool-result messages with array content survive the
+    /// coalescing path unchanged (they are not mergeable roles).
+    #[test]
+    fn test_tool_message_with_array_content_passes_through() {
+        let messages = vec![
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Text("Run the tool".to_string())),
+                tool_calls: None,
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: Some(MessageContent::Parts(vec![
+                    serde_json::json!({"type": "text", "text": "tool result here"}),
+                ])),
+                tool_calls: None,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Text("Thanks".to_string())),
+                tool_calls: None,
+            },
+        ];
+        let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
+        let result = transform_messages_for_capabilities(messages, caps);
+
+        // tool message is not merged; user messages are consecutive after tool
+        // so the two user messages are separated by the tool message
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[1].role, "tool");
+        assert!(matches!(&result[1].content, Some(MessageContent::Parts(_))));
     }
 }

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -488,7 +488,7 @@ mod tests {
 
 /// The content of a chat message.
 ///
-/// The OpenAI API allows `content` to be either a plain string or a structured
+/// The `OpenAI` API allows `content` to be either a plain string or a structured
 /// array of typed content parts (text blocks, image URLs, tool results, etc.).
 /// Both forms are preserved faithfully through serialize/deserialize
 /// round-trips so the proxy never re-shapes data it did not need to touch.
@@ -506,9 +506,9 @@ mod tests {
 pub enum MessageContent {
     /// Plain UTF-8 text.
     Text(String),
-    /// Structured content parts (text, image_url, tool_result, …).
+    /// Structured content parts (text, `image_url`, `tool_result`, …).
     ///
-    /// Individual part shapes are defined by the OpenAI API spec and
+    /// Individual part shapes are defined by the `OpenAI` API spec and
     /// validated by the model, not here.
     Parts(Vec<serde_json::Value>),
 }
@@ -554,7 +554,7 @@ impl MessageContent {
     ///
     /// Empty strings are handled gracefully (no `"\n\n"` separator when
     /// either side is empty).
-    fn merge_with(self, other: MessageContent) -> MessageContent {
+    fn merge_with(self, other: Self) -> Self {
         match (self, other) {
             (Self::Text(mut a), Self::Text(b)) => {
                 if a.is_empty() {
@@ -616,7 +616,7 @@ impl ChatMessage {
     /// Used during strict-turn coalescing to combine consecutive same-role
     /// messages.  Content is merged via [`MessageContent::merge_with`]; tool
     /// calls are concatenated as JSON arrays.
-    fn merge_into(&mut self, other: ChatMessage) {
+    fn merge_into(&mut self, other: Self) {
         self.content = match (self.content.take(), other.content) {
             (None, b) => b,
             (a, None) => a,
@@ -658,7 +658,7 @@ fn merge_consecutive_system_messages(messages: Vec<ChatMessage>) -> Vec<ChatMess
     for msg in messages {
         let is_system_merge = result
             .last()
-            .map_or(false, |last| last.role == "system" && msg.role == "system");
+            .is_some_and(|last| last.role == "system" && msg.role == "system");
         if is_system_merge {
             let last = result.last_mut().unwrap();
             last.content = match (last.content.take(), msg.content) {
@@ -732,7 +732,7 @@ pub fn transform_messages_for_capabilities(
         let mut merged: Vec<ChatMessage> = Vec::new();
         for msg in messages {
             let is_mergeable = msg.role == "user" || msg.role == "assistant";
-            let same_role_as_last = merged.last().map_or(false, |last| last.role == msg.role);
+            let same_role_as_last = merged.last().is_some_and(|last| last.role == msg.role);
             if is_mergeable && same_role_as_last {
                 merged.last_mut().unwrap().merge_into(msg);
             } else {
@@ -1214,7 +1214,7 @@ mod transform_tests {
         assert_eq!(result[2].role, "user");
     }
 
-    /// Verify that array-form `content` (OpenAI multipart spec) deserializes
+    /// Verify that array-form `content` (`OpenAI` multipart spec) deserializes
     /// correctly into `MessageContent::Parts` and is preserved on serialization.
     #[test]
     fn test_array_content_deserializes_to_parts() {

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -27,12 +27,35 @@
 //! `format:*` tag pipeline in `gglib-proxy::normalize`, which is entirely
 //! independent from `ModelCapabilities`.
 //!
+//! ## Template analysis — positive vs. negative signals
+//!
+//! [`infer_from_chat_template`] uses two kinds of signals for system-role
+//! detection, evaluated in priority order:
+//!
+//! | Priority | Signal | Example pattern | Conclusion |
+//! |---|---|---|---|
+//! | **1 (positive)** | `[SYSTEM_PROMPT]` in template | Mistral v7 | `SUPPORTS_SYSTEM_ROLE` set |
+//! | **1 (positive)** | `[AVAILABLE_TOOLS]` in template | Mistral v3/v3-tekken | `SUPPORTS_SYSTEM_ROLE` set |
+//! | **2 (negative)** | `"Only user, assistant and tool roles…"` | Old Mistral v1/v2 | `SUPPORTS_SYSTEM_ROLE` not set |
+//! | **2 (negative)** | `"got system"` / `"Raise exception"` | Other strict models | `SUPPORTS_SYSTEM_ROLE` not set |
+//! | **default** | No signal found | Generic template | `SUPPORTS_SYSTEM_ROLE` set |
+//!
+//! Positive evidence takes precedence: if `[SYSTEM_PROMPT]` or `[AVAILABLE_TOOLS]`
+//! appears, the negative patterns are ignored for system-role purposes.  This
+//! matters because some Jinja templates contain both an error-raise branch for
+//! unknown roles AND a valid system branch guarded by `[SYSTEM_PROMPT]`.
+//!
 //! ## Architecture registry
 //!
 //! [`capabilities_from_architecture`] maps GGUF `general.architecture` strings
 //! to [`ModelCapabilities`] flags.  This is the **backstop** for models whose
 //! quantized builds strip the `tokenizer.chat_template` section, making
 //! `infer_from_chat_template` return `empty()`.
+//!
+//! | Architecture string | Models | Flags |
+//! |---|---|---|
+//! | `"mistral"` | Mistral v1/v2 (old) | `REQUIRES_STRICT_TURNS` |
+//! | `"mistral3"` | Devstral, Ministral, Mistral Small 3 | `REQUIRES_STRICT_TURNS \| SUPPORTS_SYSTEM_ROLE` |
 //!
 //! **To add a new architecture:**
 //!
@@ -150,11 +173,14 @@ impl ModelCapabilities {
 ///
 /// # Capabilities Detected
 ///
-/// - System role: Looks for explicit rejection messages in template
-/// - Strict turns: Looks for alternation enforcement logic
-/// - Tool calling: Checks for `<tool_call>`, `if tools`, `function_call` patterns (metadata);
+/// - **System role**: Positive signals (`[SYSTEM_PROMPT]`, `[AVAILABLE_TOOLS]`) take precedence over
+///   negative signals (explicit rejection messages).  Generic templates with neither signal default
+///   to `SUPPORTS_SYSTEM_ROLE` set.
+/// - **Strict turns**: Looks for alternation enforcement logic (`ns.index % 2`,
+///   `conversation roles must alternate`, etc.)
+/// - **Tool calling**: Checks for `<tool_call>`, `if tools`, `function_call` patterns (metadata);
 ///   falls back to model name patterns like "hermes", "functionary" (heuristic)
-/// - Reasoning: Checks for `<think>`, `<reasoning>`, `enable_thinking` (metadata);
+/// - **Reasoning**: Checks for `<think>`, `<reasoning>`, `enable_thinking` (metadata);
 ///   falls back to model name patterns like "deepseek-r1", "qwq", "o1" (heuristic)
 ///
 /// # Fallback Behavior
@@ -174,15 +200,26 @@ pub fn infer_from_chat_template(
     let mut reasoning_detected_from_metadata = false;
 
     if let Some(template) = template {
-        // Check for system role restrictions
-        // Mistral-style templates explicitly reject system role in error messages
-        let forbids_system = template.contains("Only user, assistant and tool roles are supported")
-            || template.contains("got system")
-            || template.contains("Raise exception for unsupported roles");
+        // ── System role detection ───────────────────────────────────────────
+        //
+        // Positive evidence (Mistral v7 / v3-tekken) takes precedence over any
+        // negative error-raise patterns.  Some templates contain both a
+        // `[SYSTEM_PROMPT]` branch AND a generic "unsupported role" catch-all,
+        // so we must check positive signals first.
+        //
+        // Sources:
+        //   llama.cpp/src/llama-chat.cpp — `tmpl_contains("[SYSTEM_PROMPT]")` →
+        //     LLM_CHAT_TEMPLATE_MISTRAL_V7; system role handled natively.
+        //   `[AVAILABLE_TOOLS]` → LLM_CHAT_TEMPLATE_MISTRAL_V3; system prepended inline.
+        let supports_system_positive = template.contains("[SYSTEM_PROMPT]")
+            || template.contains("[AVAILABLE_TOOLS]");
 
-        if forbids_system {
-            // Absence of SUPPORTS_SYSTEM_ROLE means transformation required
-        } else {
+        let forbids_system = !supports_system_positive
+            && (template.contains("Only user, assistant and tool roles are supported")
+                || template.contains("got system")
+                || template.contains("Raise exception for unsupported roles"));
+
+        if !forbids_system {
             caps |= ModelCapabilities::SUPPORTS_SYSTEM_ROLE;
         }
 
@@ -316,12 +353,19 @@ pub fn capabilities_from_architecture(arch: Option<&str>) -> ModelCapabilities {
     };
 
     match arch {
-        // Mistral-family templates enforce strict user/assistant alternation
-        // via Jinja modulo checks (`ns.index % 2`) and raise an exception on
-        // consecutive same-role messages.  They also reject the `system` role.
-        // Many quantised Mistral/Devstral builds strip the tokenizer section,
-        // leaving the template layer blind — this entry is the backstop.
+        // Old Mistral v1/v2 — strict alternation, no system role.
+        // Many quantised builds strip the tokenizer section, so the template
+        // layer is blind; this entry is the request-side backstop.
         "mistral" => ModelCapabilities::REQUIRES_STRICT_TURNS,
+
+        // Newer Mistral-family models (Devstral, Ministral, Mistral Small 3).
+        // Architecture string changed from `"mistral"` to `"mistral3"` when
+        // Mistral adopted mistral-common / Tekken tokeniser.  These models
+        // support system role via `[SYSTEM_PROMPT]…[/SYSTEM_PROMPT]` tokens
+        // (Mistral v7 chat template) but still require strict alternation.
+        "mistral3" => {
+            ModelCapabilities::REQUIRES_STRICT_TURNS | ModelCapabilities::SUPPORTS_SYSTEM_ROLE
+        }
 
         // All other architectures: no request-side constraints inferred from
         // architecture alone.  Chat-template analysis may still set flags,
@@ -467,6 +511,61 @@ mod tests {
     #[test]
     fn test_arch_unknown_returns_empty() {
         assert!(capabilities_from_architecture(Some("future-arch-xyz")).is_empty());
+    }
+
+    #[test]
+    fn test_arch_mistral3_strict_turns_and_system_role() {
+        let caps = capabilities_from_architecture(Some("mistral3"));
+        assert!(caps.requires_strict_turns(), "mistral3 must enforce strict turns");
+        assert!(caps.supports_system_role(), "mistral3 supports system via [SYSTEM_PROMPT]");
+    }
+
+    #[test]
+    fn test_infer_mistral_v7_supports_system() {
+        // Mistral v7 Jinja template: contains [SYSTEM_PROMPT] token.
+        // This is positive evidence — system role IS supported natively.
+        let template = r"
+            {% if messages[0].role == 'system' %}
+                [SYSTEM_PROMPT]{{ messages[0].content }}[/SYSTEM_PROMPT]
+            {% endif %}
+            {% for message in messages %}
+                {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
+                    {{ raise_exception('conversation roles must alternate') }}
+                {% endif %}
+            {% endfor %}
+        ";
+        let caps = infer_from_chat_template(Some(template), None);
+        assert!(caps.supports_system_role(), "[SYSTEM_PROMPT] is positive evidence");
+        assert!(caps.requires_strict_turns(), "still enforces alternation");
+    }
+
+    #[test]
+    fn test_infer_mistral_v3_supports_system() {
+        // Mistral v3 / v3-tekken template: contains [AVAILABLE_TOOLS] token.
+        // llama.cpp prepends system content to the first user turn for these.
+        let template = r"
+            {% if tools is defined %}[AVAILABLE_TOOLS]{{ tools | tojson }}[/AVAILABLE_TOOLS]{% endif %}
+            {% for message in messages %}
+                {% if message.role == 'user' %}[INST]{{ message.content }}[/INST]
+                {% elif message.role == 'assistant' %}{{ message.content }}</s>
+                {% endif %}
+            {% endfor %}
+        ";
+        let caps = infer_from_chat_template(Some(template), None);
+        assert!(caps.supports_system_role(), "[AVAILABLE_TOOLS] is positive evidence");
+    }
+
+    #[test]
+    fn test_infer_mistral_v1_forbids_system() {
+        // Old Mistral v1/v2 template: no positive tokens, explicit rejection.
+        // Must NOT set SUPPORTS_SYSTEM_ROLE.
+        let template = r"
+            {% if message.role == 'system' %}
+                {{ raise_exception('Only user, assistant and tool roles are supported, got system.') }}
+            {% endif %}
+        ";
+        let caps = infer_from_chat_template(Some(template), None);
+        assert!(!caps.supports_system_role(), "v1/v2 genuinely rejects system role");
     }
 
     #[test]

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -211,8 +211,8 @@ pub fn infer_from_chat_template(
         //   llama.cpp/src/llama-chat.cpp — `tmpl_contains("[SYSTEM_PROMPT]")` →
         //     LLM_CHAT_TEMPLATE_MISTRAL_V7; system role handled natively.
         //   `[AVAILABLE_TOOLS]` → LLM_CHAT_TEMPLATE_MISTRAL_V3; system prepended inline.
-        let supports_system_positive = template.contains("[SYSTEM_PROMPT]")
-            || template.contains("[AVAILABLE_TOOLS]");
+        let supports_system_positive =
+            template.contains("[SYSTEM_PROMPT]") || template.contains("[AVAILABLE_TOOLS]");
 
         let forbids_system = !supports_system_positive
             && (template.contains("Only user, assistant and tool roles are supported")
@@ -516,8 +516,14 @@ mod tests {
     #[test]
     fn test_arch_mistral3_strict_turns_and_system_role() {
         let caps = capabilities_from_architecture(Some("mistral3"));
-        assert!(caps.requires_strict_turns(), "mistral3 must enforce strict turns");
-        assert!(caps.supports_system_role(), "mistral3 supports system via [SYSTEM_PROMPT]");
+        assert!(
+            caps.requires_strict_turns(),
+            "mistral3 must enforce strict turns"
+        );
+        assert!(
+            caps.supports_system_role(),
+            "mistral3 supports system via [SYSTEM_PROMPT]"
+        );
     }
 
     #[test]
@@ -535,7 +541,10 @@ mod tests {
             {% endfor %}
         ";
         let caps = infer_from_chat_template(Some(template), None);
-        assert!(caps.supports_system_role(), "[SYSTEM_PROMPT] is positive evidence");
+        assert!(
+            caps.supports_system_role(),
+            "[SYSTEM_PROMPT] is positive evidence"
+        );
         assert!(caps.requires_strict_turns(), "still enforces alternation");
     }
 
@@ -552,7 +561,10 @@ mod tests {
             {% endfor %}
         ";
         let caps = infer_from_chat_template(Some(template), None);
-        assert!(caps.supports_system_role(), "[AVAILABLE_TOOLS] is positive evidence");
+        assert!(
+            caps.supports_system_role(),
+            "[AVAILABLE_TOOLS] is positive evidence"
+        );
     }
 
     #[test]
@@ -565,7 +577,10 @@ mod tests {
             {% endif %}
         ";
         let caps = infer_from_chat_template(Some(template), None);
-        assert!(!caps.supports_system_role(), "v1/v2 genuinely rejects system role");
+        assert!(
+            !caps.supports_system_role(),
+            "v1/v2 genuinely rejects system role"
+        );
     }
 
     #[test]

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -718,9 +718,10 @@ pub fn transform_messages_for_capabilities(
             if msg.role == "system" {
                 msg.role = "user".to_string();
                 if let Some(content) = msg.content.take() {
-                    msg.content = Some(MessageContent::Text(
-                        format!("[System]: {}", content.into_string()),
-                    ));
+                    msg.content = Some(MessageContent::Text(format!(
+                        "[System]: {}",
+                        content.into_string()
+                    )));
                 }
             }
         }
@@ -774,12 +775,16 @@ mod transform_tests {
         let messages = vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: Some(MessageContent::Text("You are a helpful assistant.".to_string())),
+                content: Some(MessageContent::Text(
+                    "You are a helpful assistant.".to_string(),
+                )),
                 tool_calls: None,
             },
             ChatMessage {
                 role: "system".to_string(),
-                content: Some(MessageContent::Text("WORKING_MEMORY:\n- task1 (ok): done".to_string())),
+                content: Some(MessageContent::Text(
+                    "WORKING_MEMORY:\n- task1 (ok): done".to_string(),
+                )),
                 tool_calls: None,
             },
             ChatMessage {
@@ -1016,7 +1021,9 @@ mod transform_tests {
         // Content should be merged
         assert_eq!(
             result[1].content,
-            Some(MessageContent::Text("Let me check...\n\nAnd the time...".to_string()))
+            Some(MessageContent::Text(
+                "Let me check...\n\nAnd the time...".to_string()
+            ))
         );
 
         // Tool calls should be concatenated

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -1,12 +1,53 @@
-//! Model capability detection and inference.
+//! Model capability detection, inference, and request transformation.
 //!
-//! Capabilities describe model constraints derived from chat templates.
-//! Absence of a capability MUST NOT trigger behavior changes.
+//! This module owns two orthogonal pipelines that operate on different phases
+//! of a model request:
 //!
-//! # Invariant
+//! ## 1. Request-side capability pipeline
 //!
-//! Message rewriting is only permitted when model capabilities explicitly
-//! forbid the current message structure. Default behavior is pass-through.
+//! Before a chat-completion request is forwarded to llama-server the proxy
+//! consults the stored [`ModelCapabilities`] flags to decide whether to rewrite
+//! the message list.  Flags are inferred at import time and stored in the
+//! database; they can also be overridden at any time via the API or CLI.
+//!
+//! | Layer | Function | When it fires |
+//! |---|---|---|
+//! | Template analysis | [`infer_from_chat_template`] | At model import — reads `tokenizer.chat_template` from the GGUF |
+//! | Architecture registry | [`capabilities_from_architecture`] | At model import — reads `general.architecture` as a backstop when the GGUF ships without a chat template |
+//! | Request rewriting | [`transform_messages_for_capabilities`] | At proxy time — merges consecutive same-role messages for models that require strict turn alternation |
+//!
+//! The result of Layer 1 and Layer 2 is **OR-combined** and stored in
+//! `Model.capabilities`.  The proxy reads this value once per request via a
+//! single catalog lookup.
+//!
+//! ## 2. Response-side normalization pipeline
+//!
+//! Separate from request rewriting, some models (e.g., Qwen) embed tool-call
+//! JSON inside XML tags in the response text.  This is handled by the
+//! `format:*` tag pipeline in `gglib-proxy::normalize`, which is entirely
+//! independent from `ModelCapabilities`.
+//!
+//! ## Architecture registry
+//!
+//! [`capabilities_from_architecture`] maps GGUF `general.architecture` strings
+//! to [`ModelCapabilities`] flags.  This is the **backstop** for models whose
+//! quantized builds strip the `tokenizer.chat_template` section, making
+//! `infer_from_chat_template` return `empty()`.
+//!
+//! **To add a new architecture:**
+//!
+//! 1. Add a match arm in [`capabilities_from_architecture`] mapping the
+//!    architecture string to the appropriate flags.
+//! 2. Add a unit test in the `#[cfg(test)]` block at the bottom of this file.
+//! 3. If the architecture also needs **response-side** normalization (XML tool
+//!    calls, custom reasoning tags, etc.), follow the steps in `CONTRIBUTING.md`
+//!    under "Adding a new model architecture" to add a `format:*` parser as well.
+//! 4. No other files need touching — all call sites already use these functions.
+//!
+//! **Note on Qwen:** Qwen is intentionally absent from the registry.  Qwen's
+//! quantized builds always ship a full chat template, so
+//! [`infer_from_chat_template`] handles the request side.  Its response-side
+//! `<tool_call>` XML is handled by the `format:qwen-xml` tag pipeline.
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -221,6 +262,75 @@ pub fn infer_from_chat_template(
     caps
 }
 
+/// Map a GGUF `general.architecture` value to its inherent [`ModelCapabilities`].
+///
+/// This is the **single source of truth** for architecture-level behavioural
+/// constraints that apply to the **request** side (message preprocessing).
+/// It is consulted during model registration alongside
+/// [`infer_from_chat_template`] — the two results are ORed together so that
+/// either signal is sufficient.
+///
+/// # Scope: request preprocessing only
+///
+/// This registry governs `ModelCapabilities` flags (strict-turn coalescing,
+/// system-role conversion, etc.).  It does **not** handle response-stream
+/// dialect normalization — that is a separate concern handled by the
+/// `GgufCapabilities.extensions` → `format:*` tag → `get_parser()` pipeline
+/// in `gglib-core::normalize::registry`.
+///
+/// For example:
+/// - **Qwen** tool-call XML normalization already flows through
+///   `detect_tool_support()` → `extensions.insert("format:qwen-xml")` →
+///   `to_tags()` → `get_parser()` → `QwenXmlParser`.  Qwen's chat template
+///   always contains `<tool_call>` patterns, so `infer_from_chat_template`
+///   (Layer 1) sets `SUPPORTS_TOOL_CALLS` reliably.  No architecture entry
+///   is needed here for Qwen.
+/// - **Mistral** does need an entry: its templates enforce strict alternation,
+///   but many quantised builds ship with the tokenizer section stripped, so
+///   the template layer produces no signal.  `general.architecture = "mistral"`
+///   is always present and provides the necessary backstop.
+///
+/// # Rationale
+///
+/// Some models ship without a parseable `tokenizer.chat_template` in the GGUF
+/// (stripped quantisation builds, partial uploads).  The chat-template layer
+/// then returns `ModelCapabilities::empty()`, silently leaving constraints
+/// unapplied.  Reading `general.architecture` from the GGUF gives us a
+/// ground-truth signal that is always present and never varies by quantisation.
+///
+/// # Adding a new architecture
+///
+/// 1. Add a new `"arch_name" => { … }` arm below.
+/// 2. Add a corresponding unit test in the `#[cfg(test)]` block.
+/// 3. No other file needs touching — all call sites use this function.
+///
+/// # Arguments
+///
+/// * `arch` — value of the `general.architecture` GGUF key
+///   (e.g. `"mistral"`, `"llama"`, `"qwen2"`).  `None` means the key was
+///   absent; returns `empty()` so the model gets pass-through treatment.
+#[must_use]
+pub fn capabilities_from_architecture(arch: Option<&str>) -> ModelCapabilities {
+    let Some(arch) = arch else {
+        return ModelCapabilities::empty();
+    };
+
+    match arch {
+        // Mistral-family templates enforce strict user/assistant alternation
+        // via Jinja modulo checks (`ns.index % 2`) and raise an exception on
+        // consecutive same-role messages.  They also reject the `system` role.
+        // Many quantised Mistral/Devstral builds strip the tokenizer section,
+        // leaving the template layer blind — this entry is the backstop.
+        "mistral" => ModelCapabilities::REQUIRES_STRICT_TURNS,
+
+        // All other architectures: no request-side constraints inferred from
+        // architecture alone.  Chat-template analysis may still set flags,
+        // and response-stream normalization is handled by the format:* tag
+        // pipeline independently.
+        _ => ModelCapabilities::empty(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,6 +445,41 @@ mod tests {
         assert!(caps.supports_tool_calls());
         assert!(caps.supports_reasoning());
     }
+
+    // ─── capabilities_from_architecture ─────────────────────────────────────
+
+    #[test]
+    fn test_arch_none_returns_empty() {
+        assert!(capabilities_from_architecture(None).is_empty());
+    }
+
+    #[test]
+    fn test_arch_mistral_requires_strict_turns() {
+        let caps = capabilities_from_architecture(Some("mistral"));
+        assert!(caps.requires_strict_turns());
+    }
+
+    #[test]
+    fn test_arch_llama_returns_empty() {
+        assert!(capabilities_from_architecture(Some("llama")).is_empty());
+    }
+
+    #[test]
+    fn test_arch_unknown_returns_empty() {
+        assert!(capabilities_from_architecture(Some("future-arch-xyz")).is_empty());
+    }
+
+    #[test]
+    fn test_arch_or_template_additive() {
+        // Template detects tool calls; architecture adds strict turns.
+        // The two are ORed so both flags appear in the result.
+        let template = "<tool_call>{{ tool }}</tool_call>";
+        let from_template = infer_from_chat_template(Some(template), None);
+        let from_arch = capabilities_from_architecture(Some("mistral"));
+        let combined = from_template | from_arch;
+        assert!(combined.supports_tool_calls(), "tool calls from template");
+        assert!(combined.requires_strict_turns(), "strict turns from arch");
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -342,10 +487,12 @@ mod tests {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// A chat message for transformation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<serde_json::Value>,
 }
 

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -59,8 +59,8 @@ pub use agent::{
 
 // Re-export capability types at the domain level for convenience
 pub use capabilities::{
-    ChatMessage, ModelCapabilities, capabilities_from_architecture, infer_from_chat_template,
-    transform_messages_for_capabilities,
+    ChatMessage, MessageContent, ModelCapabilities, capabilities_from_architecture,
+    infer_from_chat_template, transform_messages_for_capabilities,
 };
 
 // Re-export orchestrator types at the domain level for convenience

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -59,7 +59,8 @@ pub use agent::{
 
 // Re-export capability types at the domain level for convenience
 pub use capabilities::{
-    ChatMessage, ModelCapabilities, infer_from_chat_template, transform_messages_for_capabilities,
+    ChatMessage, ModelCapabilities, capabilities_from_architecture, infer_from_chat_template,
+    transform_messages_for_capabilities,
 };
 
 // Re-export orchestrator types at the domain level for convenience

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -24,7 +24,7 @@ pub use domain::{
     McpToolResult, Message, MessageRole, Model, ModelCapabilities, ModelFilterOptions,
     NewConversation, NewMcpServer, NewMessage, NewModel, NodeId, NodeStatus, RangeValues,
     TaskGraph, TaskGraphError, TaskNode, ToolCall, ToolDefinition, ToolResult, UpdateMcpServer,
-    infer_from_chat_template, transform_messages_for_capabilities,
+    capabilities_from_architecture, infer_from_chat_template, transform_messages_for_capabilities,
 };
 pub use download::{
     AttemptCounts, CompletionDetail, CompletionKey, CompletionKind, DownloadError, DownloadEvent,

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -21,10 +21,11 @@ pub use domain::{
     LlmStreamEvent, MAX_DEPTH, MAX_ITERATIONS_CEILING, MAX_NODES, MAX_PARALLEL_TOOLS_CEILING,
     MAX_TOOL_TIMEOUT_MS_CEILING, MIN_CONTEXT_BUDGET_CHARS, MIN_TOOL_TIMEOUT_MS, McpEnvEntry,
     McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
-    McpToolResult, Message, MessageRole, Model, ModelCapabilities, ModelFilterOptions,
-    NewConversation, NewMcpServer, NewMessage, NewModel, NodeId, NodeStatus, RangeValues,
-    TaskGraph, TaskGraphError, TaskNode, ToolCall, ToolDefinition, ToolResult, UpdateMcpServer,
-    capabilities_from_architecture, infer_from_chat_template, transform_messages_for_capabilities,
+    McpToolResult, Message, MessageContent, MessageRole, Model, ModelCapabilities,
+    ModelFilterOptions, NewConversation, NewMcpServer, NewMessage, NewModel, NodeId, NodeStatus,
+    RangeValues, TaskGraph, TaskGraphError, TaskNode, ToolCall, ToolDefinition, ToolResult,
+    UpdateMcpServer, capabilities_from_architecture, infer_from_chat_template,
+    transform_messages_for_capabilities,
 };
 pub use download::{
     AttemptCounts, CompletionDetail, CompletionKey, CompletionKind, DownloadError, DownloadEvent,

--- a/crates/gglib-core/src/ports/model_catalog.rs
+++ b/crates/gglib-core/src/ports/model_catalog.rs
@@ -9,6 +9,8 @@ use std::fmt;
 use std::path::PathBuf;
 use thiserror::Error;
 
+use crate::domain::ModelCapabilities;
+
 /// Domain model summary for catalog operations (listing).
 ///
 /// This is a domain type (not an `OpenAI` API type). The proxy layer
@@ -24,6 +26,13 @@ pub struct ModelSummary {
     pub name: String,
     /// Tags/labels associated with the model.
     pub tags: Vec<String>,
+    /// Detected and persisted capability flags for this model.
+    ///
+    /// This is the single source of truth for model behaviour constraints
+    /// (strict-turn alternation, system-role support, tool calls, reasoning).
+    /// The proxy uses these directly rather than inferring from tags at
+    /// request time, eliminating the split-brain between tags and capabilities.
+    pub capabilities: ModelCapabilities,
     /// Parameter count as string (e.g., "7B", "13B", "70B").
     pub param_count: String,
     /// Quantization type (e.g., "`Q4_K_M`", "`Q8_0`").

--- a/crates/gglib-core/src/services/model_registrar.rs
+++ b/crates/gglib-core/src/services/model_registrar.rs
@@ -154,13 +154,20 @@ impl ModelRegistrarPort for ModelRegistrar {
         // Merge GGUF-derived tags with filtered HF tags (deduplicated)
         model.tags = Self::merge_tags(gguf_tags, &download.hf_tags);
 
-        // Infer model capabilities from chat template
+        // Infer capabilities from chat template OR architecture — OR'd so
+        // either signal is sufficient.  Architecture is the backstop for models
+        // whose GGUF ships without a tokenizer section.
         let template = model.metadata.get("tokenizer.chat_template");
         let name = model.metadata.get("general.name");
-        model.capabilities = crate::domain::infer_from_chat_template(
+        let arch = model.metadata.get("general.architecture");
+        let from_template = crate::domain::infer_from_chat_template(
             template.map(String::as_str),
             name.map(String::as_str),
         );
+        let from_arch = crate::domain::capabilities_from_architecture(
+            arch.map(String::as_str),
+        );
+        model.capabilities = from_template | from_arch;
 
         let registered = self.model_repo.insert(&model).await?;
 

--- a/crates/gglib-core/src/services/model_registrar.rs
+++ b/crates/gglib-core/src/services/model_registrar.rs
@@ -164,9 +164,7 @@ impl ModelRegistrarPort for ModelRegistrar {
             template.map(String::as_str),
             name.map(String::as_str),
         );
-        let from_arch = crate::domain::capabilities_from_architecture(
-            arch.map(String::as_str),
-        );
+        let from_arch = crate::domain::capabilities_from_architecture(arch.map(String::as_str));
         model.capabilities = from_template | from_arch;
 
         let registered = self.model_repo.insert(&model).await?;

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -159,13 +159,20 @@ impl ModelService {
         let gguf_capabilities = gguf_parser.detect_capabilities(&gguf_metadata);
         let auto_tags = gguf_capabilities.to_tags();
 
-        // 4. Infer additional capabilities from chat template
+        // 4. Infer capabilities from chat template OR architecture, whichever
+        //    provides signal.  Architecture-based inference is the backstop for
+        //    models whose GGUF ships without a tokenizer section (common in
+        //    stripped quantisation builds, e.g. many Mistral/Devstral releases).
         let template = gguf_metadata.metadata.get("tokenizer.chat_template");
         let name = gguf_metadata.metadata.get("general.name");
-        let model_capabilities = crate::domain::infer_from_chat_template(
+        let from_template = crate::domain::infer_from_chat_template(
             template.map(String::as_str),
             name.map(String::as_str),
         );
+        let from_arch = crate::domain::capabilities_from_architecture(
+            gguf_metadata.architecture.as_deref(),
+        );
+        let model_capabilities = from_template | from_arch;
 
         // 5. Construct fully-populated NewModel
         let new_model = NewModel {
@@ -381,7 +388,7 @@ impl ModelService {
     ///
     /// Never overwrite explicitly-set capabilities. Only infer when unknown.
     pub async fn bootstrap_capabilities(&self) -> Result<(), CoreError> {
-        use crate::domain::infer_from_chat_template;
+        use crate::domain::{capabilities_from_architecture, infer_from_chat_template};
 
         let models = self.repo.list().await.map_err(CoreError::from)?;
 
@@ -390,12 +397,15 @@ impl ModelService {
             if model.capabilities.is_empty() {
                 let template = model.metadata.get("tokenizer.chat_template");
                 let name = model.metadata.get("general.name");
-                let inferred = infer_from_chat_template(
+                let arch = model.metadata.get("general.architecture");
+                let from_template = infer_from_chat_template(
                     template.map(String::as_str),
                     name.map(String::as_str),
                 );
-
-                model.capabilities = inferred;
+                let from_arch = capabilities_from_architecture(
+                    arch.map(String::as_str),
+                );
+                model.capabilities = from_template | from_arch;
                 self.repo.update(&model).await.map_err(CoreError::from)?;
             }
         }

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -169,9 +169,8 @@ impl ModelService {
             template.map(String::as_str),
             name.map(String::as_str),
         );
-        let from_arch = crate::domain::capabilities_from_architecture(
-            gguf_metadata.architecture.as_deref(),
-        );
+        let from_arch =
+            crate::domain::capabilities_from_architecture(gguf_metadata.architecture.as_deref());
         let model_capabilities = from_template | from_arch;
 
         // 5. Construct fully-populated NewModel
@@ -402,9 +401,7 @@ impl ModelService {
                     template.map(String::as_str),
                     name.map(String::as_str),
                 );
-                let from_arch = capabilities_from_architecture(
-                    arch.map(String::as_str),
-                );
+                let from_arch = capabilities_from_architecture(arch.map(String::as_str));
                 model.capabilities = from_template | from_arch;
                 self.repo.update(&model).await.map_err(CoreError::from)?;
             }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -359,7 +359,10 @@ pub async fn forward_chat_completion(
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
 
-    debug!(status = status.as_u16(), "upstream llama-server accepted request");
+    debug!(
+        status = status.as_u16(),
+        "upstream llama-server accepted request"
+    );
 
     if is_streaming {
         // Tags resolved above — no second catalog lookup needed.

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -247,7 +247,15 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
         "coalesce: parsed messages for transformation"
     );
     for (i, m) in messages.iter().enumerate() {
-        let content_bytes = m.content.as_ref().map(|c| c.as_str().map(|s| s.len()).unwrap_or_else(|| format!("{:?}", c).len())).unwrap_or(0);
+        let content_bytes = m
+            .content
+            .as_ref()
+            .map(|c| {
+                c.as_str()
+                    .map(|s| s.len())
+                    .unwrap_or_else(|| format!("{:?}", c).len())
+            })
+            .unwrap_or(0);
         debug!(i, role = %m.role, content_bytes, "coalesce: message sizes");
     }
 

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -196,37 +196,64 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
         return body;
     }
 
+    debug!(
+        requires_strict_turns = capabilities.requires_strict_turns(),
+        supports_system_role = capabilities.supports_system_role(),
+        "coalesce: entering message transformation"
+    );
+
     let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        warn!("coalesce: failed to parse request body as JSON; forwarding original");
         return body;
     };
 
     let Some(messages_raw) = value.get("messages").and_then(|v| v.as_array()) else {
+        debug!("coalesce: no messages array found in request body");
         return body;
     };
 
+    let before_count = messages_raw.len();
+
     // Deserialise only the fields `transform_messages_for_capabilities` needs.
+    // `ChatMessage.content` accepts both a plain JSON string and a JSON array of
+    // content-part objects (e.g. VSCode LLM Gateway sends array-form content per
+    // the OpenAI spec).  Using `MessageContent` ensures we can always round-trip.
     let messages: Vec<ChatMessage> =
         match serde_json::from_value(serde_json::Value::Array(messages_raw.clone())) {
             Ok(m) => m,
             Err(e) => {
-                warn!(error = %e, "coalesce: failed to parse messages array; forwarding original");
+                warn!(
+                    error = %e,
+                    before = before_count,
+                    "coalesce: failed to deserialise messages as Vec<ChatMessage>; \
+                     forwarding original body unchanged. \
+                     This usually means a message field has an unexpected type."
+                );
                 return body;
             }
         };
 
+    debug!(
+        before = before_count,
+        roles = ?messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
+        "coalesce: parsed messages for transformation"
+    );
+
     let transformed = transform_messages_for_capabilities(messages, capabilities);
+    let after_count = transformed.len();
+
+    debug!(
+        before = before_count,
+        after = after_count,
+        merged = before_count.saturating_sub(after_count),
+        "coalesce: transformation complete"
+    );
 
     match serde_json::to_value(&transformed) {
         Ok(new_messages) => {
             value["messages"] = new_messages;
             match serde_json::to_vec(&value) {
-                Ok(v) => {
-                    debug!(
-                        requires_strict_turns = capabilities.requires_strict_turns(),
-                        "coalesced messages for model capabilities"
-                    );
-                    Bytes::from(v)
-                }
+                Ok(v) => Bytes::from(v),
                 Err(e) => {
                     warn!(error = %e, "coalesce: failed to re-serialize; forwarding original");
                     body

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -309,6 +309,11 @@ pub async fn forward_chat_completion(
     //    (e.g. Mistral/Devstral).  No-op when capabilities are empty/unknown.
     let body = coalesce_for_capabilities(body, context.capabilities);
 
+    debug!(
+        body_bytes = body.len(),
+        "sending request to upstream (post-transform)"
+    );
+
     // Build the request to upstream
     let mut req_builder = client
         .post(upstream_url)
@@ -341,12 +346,20 @@ pub async fn forward_chat_completion(
     // For errors, return the error body directly
     if !status.is_success() {
         let error_bytes = response.bytes().await.unwrap_or_default();
+        let error_body = String::from_utf8_lossy(&error_bytes);
+        warn!(
+            status = status.as_u16(),
+            body = %error_body,
+            "upstream llama-server returned error"
+        );
         return Response::builder()
             .status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY))
             .header("content-type", "application/json")
             .body(Body::from(error_bytes))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
+
+    debug!(status = status.as_u16(), "upstream llama-server accepted request");
 
     if is_streaming {
         // Tags resolved above — no second catalog lookup needed.
@@ -386,6 +399,7 @@ async fn forward_streaming_response(
             let chunk = match chunk_result {
                 Ok(c) => c,
                 Err(e) => {
+                    warn!("upstream SSE byte-stream error: {e}");
                     yield Err(anyhow::anyhow!("upstream SSE byte-stream error: {e}"));
                     return;
                 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -1,7 +1,26 @@
 //! Request forwarding to llama-server with parse → normalize → re-encode
 //! pipeline for streaming responses.
 //!
-//! For streaming requests this module owns the universal-consistency moat:
+//! ## Request pipeline
+//!
+//! Before the upstream call the proxy applies two stateless transforms to the
+//! request body, in order:
+//!
+//! 1. [`strip_prior_reasoning`] — scrubs `<think>` / `reasoning_content`
+//!    artefacts from prior assistant turns so reasoning models don't
+//!    pattern-match their own past traces.
+//! 2. [`coalesce_for_capabilities`] — when a model's stored
+//!    [`ModelCapabilities`] includes [`REQUIRES_STRICT_TURNS`], merges
+//!    consecutive same-role user/assistant messages before they reach the
+//!    Jinja template.  Mistral-family models raise a hard 500 exception
+//!    without this.
+//!
+//! Capabilities are resolved with a **single** catalog lookup per request
+//! (via [`resolve_model_context`]) that yields both the `ModelCapabilities`
+//! bitfield (used for request preprocessing) and the `format:*` tags (used
+//! for response-stream parser selection).  No second lookup is made.
+//!
+//! ## Response pipeline
 //!
 //! ```text
 //!  upstream bytes
@@ -19,17 +38,14 @@
 //!  client
 //! ```
 //!
-//! Tags consulted by `get_parser` are looked up via [`resolve_tags`] from
-//! the [`ModelCatalogPort`] before the upstream call begins.  An empty tag
-//! list selects the identity-passthrough parser, so models that already
-//! emit strict OpenAI events are unaffected by the wrap.
-//!
 //! `NormalizationError` events surfaced by the parsers are logged via
 //! `tracing::warn` and never forwarded to the wire.
 //!
 //! Non-streaming responses are forwarded verbatim for now — the dialects
 //! we currently rewrite (Qwen XML tool calls, bare `<think>` tags) only
 //! manifest in streaming clients today.
+//!
+//! [`REQUIRES_STRICT_TURNS`]: gglib_core::ModelCapabilities
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -45,6 +61,8 @@ use reqwest::Client;
 use tracing::{debug, error, warn};
 
 use gglib_core::LlmStreamEvent;
+use gglib_core::ModelCapabilities;
+use gglib_core::domain::{ChatMessage, transform_messages_for_capabilities};
 use gglib_core::normalize::{NormalizingStream, get_parser};
 use gglib_core::ports::ModelCatalogPort;
 use gglib_core::sse::{SseEncoder, SseStreamDecoder};
@@ -73,20 +91,43 @@ fn should_forward_header(name: &str) -> bool {
     !HOP_BY_HOP_HEADERS.contains(&lower.as_str())
 }
 
-/// Look up the `format:*` tags for a model so the proxy can pick a
-/// dialect-specific parser via [`gglib_core::normalize::get_parser`].
+/// Resolved per-request model context: capabilities for request preprocessing
+/// and tags for response-stream parser selection.
 ///
-/// Returns an empty `Vec` when the catalog cannot resolve the model or the
-/// model has no tags — both cases select the identity-passthrough parser,
-/// which is the right fallback for any model that already speaks strict
-/// `OpenAI` tool-calling.
-pub async fn resolve_tags(catalog: &dyn ModelCatalogPort, model_name: &str) -> Vec<String> {
+/// Both values come from a **single** catalog lookup, eliminating the
+/// previous split-brain where `resolve_tags` and capability lookups were
+/// separate concerns served by different code paths.
+struct ModelContext {
+    /// Stored capability bitfield — drives request-side transforms.
+    capabilities: ModelCapabilities,
+    /// `format:*` tags — drives response-stream parser selection.
+    tags: Vec<String>,
+}
+
+/// Resolve the [`ModelContext`] for a model in a single catalog round-trip.
+///
+/// On any failure (catalog unavailable, model unknown) returns a zeroed
+/// context: empty capabilities → all transforms are no-ops, empty tags →
+/// identity-passthrough parser.  This is the safe, conservative fallback.
+async fn resolve_model_context(catalog: &dyn ModelCatalogPort, model_name: &str) -> ModelContext {
     match catalog.resolve_model(model_name).await {
-        Ok(Some(summary)) => summary.tags,
-        Ok(None) => Vec::new(),
+        Ok(Some(summary)) => ModelContext {
+            capabilities: summary.capabilities,
+            tags: summary.tags,
+        },
+        Ok(None) => {
+            debug!(model = %model_name, "model not found in catalog; using pass-through context");
+            ModelContext {
+                capabilities: ModelCapabilities::empty(),
+                tags: Vec::new(),
+            }
+        }
         Err(e) => {
-            warn!(model = %model_name, error = %e, "failed to resolve model tags; using identity parser");
-            Vec::new()
+            warn!(model = %model_name, error = %e, "failed to resolve model context; using pass-through context");
+            ModelContext {
+                capabilities: ModelCapabilities::empty(),
+                tags: Vec::new(),
+            }
         }
     }
 }
@@ -128,6 +169,78 @@ fn strip_prior_reasoning(body: Bytes) -> Bytes {
     }
 }
 
+/// Coalesce consecutive same-role messages when the model requires strict
+/// turn alternation.
+///
+/// Mistral-family models (and any architecture with
+/// [`ModelCapabilities::REQUIRES_STRICT_TURNS`]) enforce user/assistant
+/// alternation inside their Jinja chat templates and raise a hard 500
+/// exception when consecutive same-role messages are present.  IDEs and
+/// gateway extensions (e.g. the VSCode LLM Gateway) routinely send
+/// multi-turn context that violates this — coalescing here is the correct
+/// fix rather than constraining callers.
+///
+/// Uses [`transform_messages_for_capabilities`] from `gglib-core` as the
+/// single source of truth for the merging rules, exactly as the internal
+/// `chat_api` path does.  When capabilities are empty (unknown model) this
+/// function is a zero-cost no-op.
+///
+/// On parse failure the original bytes are returned unchanged.
+fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> Bytes {
+    // Fast path: no preprocessing needed for this model.
+    if !capabilities.requires_strict_turns() && capabilities.supports_system_role() {
+        return body;
+    }
+    // Also fast path when capabilities are completely unknown.
+    if capabilities.is_empty() {
+        return body;
+    }
+
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return body;
+    };
+
+    let Some(messages_raw) = value.get("messages").and_then(|v| v.as_array()) else {
+        return body;
+    };
+
+    // Deserialise only the fields `transform_messages_for_capabilities` needs.
+    let messages: Vec<ChatMessage> = match serde_json::from_value(
+        serde_json::Value::Array(messages_raw.clone()),
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(error = %e, "coalesce: failed to parse messages array; forwarding original");
+            return body;
+        }
+    };
+
+    let transformed = transform_messages_for_capabilities(messages, capabilities);
+
+    match serde_json::to_value(&transformed) {
+        Ok(new_messages) => {
+            value["messages"] = new_messages;
+            match serde_json::to_vec(&value) {
+                Ok(v) => {
+                    debug!(
+                        requires_strict_turns = capabilities.requires_strict_turns(),
+                        "coalesced messages for model capabilities"
+                    );
+                    Bytes::from(v)
+                }
+                Err(e) => {
+                    warn!(error = %e, "coalesce: failed to re-serialize; forwarding original");
+                    body
+                }
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "coalesce: failed to serialise transformed messages; forwarding original");
+            body
+        }
+    }
+}
+
 /// Forward a chat completion request to the upstream llama-server.
 ///
 /// # Arguments
@@ -138,7 +251,7 @@ fn strip_prior_reasoning(body: Bytes) -> Bytes {
 /// * `body` - Request body bytes
 /// * `is_streaming` - Whether this is a streaming request (affects response handling)
 /// * `model_name` - Model name to advertise to the client (used in SSE envelope)
-/// * `catalog` - Catalog port used to resolve `format:*` tags for the model
+/// * `catalog` - Catalog port used to resolve capabilities and `format:*` tags
 ///
 /// # Returns
 ///
@@ -155,11 +268,20 @@ pub async fn forward_chat_completion(
 ) -> Response {
     debug!("Forwarding to {upstream_url}, streaming={is_streaming}");
 
-    // Drop reasoning artifacts from prior assistant turns before the model
-    // sees them. Mirrors OpenAI's native handling of reasoning tokens and
-    // prevents small reasoning models from pattern-matching their own past
-    // `<think>` traces into an unbounded thinking loop on follow-up turns.
+    // Single catalog lookup — yields both capabilities (request preprocessing)
+    // and tags (response-stream parser).  Failures return a zero context so
+    // all transforms become no-ops rather than blocking the request.
+    let context = resolve_model_context(catalog.as_ref(), model_name).await;
+
+    // ── Request transforms (applied in order) ──────────────────────────────
+    //
+    // 1. Strip reasoning artefacts from prior assistant turns so reasoning
+    //    models don't pattern-match their own past <think> traces.
     let body = strip_prior_reasoning(body);
+
+    // 2. Coalesce consecutive same-role messages for strict-turn models
+    //    (e.g. Mistral/Devstral).  No-op when capabilities are empty/unknown.
+    let body = coalesce_for_capabilities(body, context.capabilities);
 
     // Build the request to upstream
     let mut req_builder = client
@@ -201,8 +323,8 @@ pub async fn forward_chat_completion(
     }
 
     if is_streaming {
-        let tags = resolve_tags(catalog.as_ref(), model_name).await;
-        forward_streaming_response(response, model_name.to_owned(), tags).await
+        // Tags resolved above — no second catalog lookup needed.
+        forward_streaming_response(response, model_name.to_owned(), context.tags).await
     } else {
         // Non-streaming: read full response. Dialect normalization for
         // non-streaming responses is intentionally deferred — the wire

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -205,15 +205,14 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
     };
 
     // Deserialise only the fields `transform_messages_for_capabilities` needs.
-    let messages: Vec<ChatMessage> = match serde_json::from_value(
-        serde_json::Value::Array(messages_raw.clone()),
-    ) {
-        Ok(m) => m,
-        Err(e) => {
-            warn!(error = %e, "coalesce: failed to parse messages array; forwarding original");
-            return body;
-        }
-    };
+    let messages: Vec<ChatMessage> =
+        match serde_json::from_value(serde_json::Value::Array(messages_raw.clone())) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(error = %e, "coalesce: failed to parse messages array; forwarding original");
+                return body;
+            }
+        };
 
     let transformed = transform_messages_for_capabilities(messages, capabilities);
 

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -214,6 +214,14 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
 
     let before_count = messages_raw.len();
 
+    // Log size of non-message top-level fields to identify what's inflating the body.
+    for (key, val) in value.as_object().into_iter().flatten() {
+        if key != "messages" {
+            let approx_bytes = serde_json::to_vec(val).map(|v| v.len()).unwrap_or(0);
+            debug!(key, approx_bytes, "coalesce: top-level field size");
+        }
+    }
+
     // Deserialise only the fields `transform_messages_for_capabilities` needs.
     // `ChatMessage.content` accepts both a plain JSON string and a JSON array of
     // content-part objects (e.g. VSCode LLM Gateway sends array-form content per
@@ -238,6 +246,10 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
         roles = ?messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
         "coalesce: parsed messages for transformation"
     );
+    for (i, m) in messages.iter().enumerate() {
+        let content_bytes = m.content.as_ref().map(|c| c.as_str().map(|s| s.len()).unwrap_or_else(|| format!("{:?}", c).len())).unwrap_or(0);
+        debug!(i, role = %m.role, content_bytes, "coalesce: message sizes");
+    }
 
     let transformed = transform_messages_for_capabilities(messages, capabilities);
     let after_count = transformed.len();

--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -372,6 +372,7 @@ impl From<ModelRuntimeError> for ErrorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gglib_core::domain::ModelCapabilities;
 
     // =========================================================================
     // ErrorResponse construction tests
@@ -515,6 +516,7 @@ mod tests {
                 id: 1,
                 name: "llama-3-8b-q4".into(),
                 tags: vec!["chat".into()],
+                capabilities: ModelCapabilities::empty(),
                 param_count: "8B".into(),
                 quantization: Some("Q4_K_M".into()),
                 architecture: Some("llama".into()),
@@ -525,6 +527,7 @@ mod tests {
                 id: 2,
                 name: "mistral-7b-q8".into(),
                 tags: vec![],
+                capabilities: ModelCapabilities::empty(),
                 param_count: "7B".into(),
                 quantization: Some("Q8_0".into()),
                 architecture: Some("mistral".into()),
@@ -548,6 +551,7 @@ mod tests {
             id: 1,
             name: "test-model".into(),
             tags: vec![],
+            capabilities: ModelCapabilities::empty(),
             param_count: "7B".into(),
             quantization: None,
             architecture: None,
@@ -572,6 +576,7 @@ mod tests {
             id: 1,
             name: "test".into(),
             tags: vec![],
+            capabilities: ModelCapabilities::empty(),
             param_count: "13B".into(),
             quantization: Some("Q5_K_S".into()),
             architecture: Some("llama".into()),
@@ -591,6 +596,7 @@ mod tests {
             id: 1,
             name: "bare-model".into(),
             tags: vec![],
+            capabilities: ModelCapabilities::empty(),
             param_count: "1B".into(),
             quantization: None,
             architecture: None,

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -179,6 +179,7 @@ impl TaggedCatalog {
             id: 1,
             name: self.name.clone(),
             tags: self.tags.clone(),
+            capabilities: gglib_core::domain::ModelCapabilities::empty(),
             param_count: "7B".into(),
             quantization: None,
             architecture: None,

--- a/crates/gglib-runtime/src/ports_impl/model_catalog.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_catalog.rs
@@ -30,6 +30,7 @@ fn model_to_summary(m: &Model) -> ModelSummary {
         id: m.id as u32,
         name: m.name.clone(),
         tags: m.tags.clone(),
+        capabilities: m.capabilities,
         param_count: format_param_count(m.param_count_b),
         quantization: m.quantization.clone(),
         architecture: m.architecture.clone(),


### PR DESCRIPTION
## Problem

Devstral requests through the gglib proxy produced a 500 error from llama-server:

> `Jinja Exception: After the optional system message, conversation roles must alternate user and assistant roles except for tool calls and results`

**Root cause:** two siloed capability systems — `ModelCapabilities` bitfield vs `format:*` tag pipeline — that never converged. The proxy applied `strip_prior_reasoning()` but never `transform_messages_for_capabilities()`. Quantized Devstral builds strip `tokenizer.chat_template` from the GGUF, so `infer_from_chat_template()` returned `empty()` and the required strict-turn coalescing was skipped.

---

## Changes

### Phase 1 — Single source of truth in `ModelSummary`

- Extended `ModelSummary` (the catalog DTO used by the proxy) with `capabilities: ModelCapabilities`
- `CatalogPortImpl` now populates `capabilities` from the persisted `Model.capabilities`

### Phase 3 — Architecture registry + DRY proxy pipeline

- **New:** `capabilities_from_architecture()` in `gglib-core::domain::capabilities`
  - `"mistral"` → `REQUIRES_STRICT_TURNS` (backstop for quantized builds without a chat template)
  - 5 unit tests
- Wired into all 3 registration sites (`import_from_file`, `register_model`, `bootstrap_capabilities`) — **OR-combined** with the `infer_from_chat_template` result
- **Rewrote `gglib-proxy::forward`** — single `resolve_model_context()` replaces two separate catalog lookups; `coalesce_for_capabilities()` applies `transform_messages_for_capabilities()` at the proxy boundary before forwarding to llama-server
- `ChatMessage` now derives `Serialize`/`Deserialize`

### Phase 4 — Capability override service + GUI parity

The single shared implementation lives in `gglib-app-services`. CLI, Axum, and Tauri all call `ModelOps::set_capabilities()` — no business logic in surface crates.

- **`SetCapabilitiesRequest`** — per-flag `Option<bool>` (`None` = leave unchanged)
- **`ModelOps::set_capabilities(id, req)`** — fetches model, applies bit changes, persists
- **`GuiModel`** extended with `capabilities: ModelCapabilities` field
- **Axum:** `PATCH /api/models/{id}/capabilities` route + handler
- **CLI:** `gglib model capabilities <id> [--set FLAG]... [--unset FLAG]...`

```bash
# Show current capabilities
gglib model capabilities 3

# Force strict-turn coalescing on
gglib model capabilities 3 --set requires-strict-turns

# Via REST
curl -X PATCH http://localhost:9887/api/models/3/capabilities \
     -H 'Content-Type: application/json' \
     -d '{"requiresStrictTurns": true}'
```

### Docs

- `capabilities.rs` `//!` block: two-pipeline architecture, Layer 1/2 table, architecture registry recipe
- `CONTRIBUTING.md`: new "Model Architecture Registry" section — step-by-step recipe for adding new architectures on request and response sides
- `README.md`: capability detection + override CLI/API examples

---

## Testing

- All 6 proxy integration tests pass (`cargo test --package gglib-proxy --test integration_proxy_pipeline`)
- All workspace unit and doc tests pass (`cargo test --workspace`)
- Zero build warnings