### PR TITLE
feat: MCP progressive disclosure — replace full-schema tool list with 3 meta-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,54 @@ Auto-generated from source and updated with every release.
 ![HuggingFace](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Hub-yellow?style=flat-square)
 ![Llama.cpp](https://img.shields.io/badge/Llama.cpp-Inference-lightgrey?style=flat-square)
 
+## LLM Optimization / Progressive Disclosure
+
+When gglib is connected to an external MCP client (VS Code Copilot, OpenWebUI,
+etc.), the proxy exposes a **Progressive Disclosure** interface instead of
+dumping every tool schema up-front. This reduces context-window consumption by
+90 %+ and eliminates timeout failures caused by 100 k-token schema payloads.
+
+### How it works
+
+`tools/list` always returns exactly **three meta-tools** regardless of how many
+internal MCP servers are running:
+
+| Meta-tool         | Purpose                                                        |
+|-------------------|----------------------------------------------------------------|
+| `search_tools`    | Keyword search over tool IDs and descriptions (≤ 30 results)  |
+| `get_tool_schema` | Lazily fetch the full JSON input schema for one specific tool  |
+| `invoke_tool`     | Execute a tool by its qualified ID with the given arguments    |
+
+### Typical client flow
+
+```
+1. tools/list         → receives 3 meta-tool specs (~300 tokens)
+2. search_tools       → discovers relevant tool IDs by keyword
+3. get_tool_schema    → fetches only the schema it actually needs
+4. invoke_tool        → executes with known arguments
+```
+
+### Qualified tool IDs
+
+Internal tools are addressed with a double-underscore namespaced format:
+`"<server_name>__<tool_name>"` (e.g. `"filesystem__read_file"`). This ID is
+returned by `search_tools` and accepted by both `get_tool_schema` and
+`invoke_tool`.
+
+### Hard break — no legacy passthrough
+
+Direct calls to raw tool names via `tools/call` return `METHOD_NOT_FOUND`.
+All tool invocations must go through `invoke_tool`. There is no compatibility
+shim for the pre-disclosure interface.
+
+### Implementation
+
+| Location | Role |
+|---|---|
+| [`gglib-core/src/domain/mcp/tool_index.rs`](crates/gglib-core/src/domain/mcp/tool_index.rs) | `ToolIndex` + `ToolSummary` pure-data types; `SEARCH_RESULTS_CAP = 30` |
+| [`gglib-proxy/src/mcp/meta_tools.rs`](crates/gglib-proxy/src/mcp/meta_tools.rs) | Index construction from `McpService`; 3 static `McpToolSpec` definitions |
+| [`gglib-proxy/src/mcp/handlers.rs`](crates/gglib-proxy/src/mcp/handlers.rs) | `handle_meta_tools_list` + `handle_meta_tools_call` dispatch |
+
 ## License
 
 GGLib is open source under the [GNU Affero General Public License v3.0](LICENSE) (AGPL-3.0).

--- a/crates/gglib-core/src/domain/mcp/mod.rs
+++ b/crates/gglib-core/src/domain/mcp/mod.rs
@@ -14,9 +14,12 @@
 //! - `McpEnvEntry` - Environment variable entry
 //! - `McpTool` - Tool exposed by an MCP server
 //! - `McpToolResult` - Result of a tool invocation
+//! - `ToolIndex` / `ToolSummary` - Progressive-disclosure tool registry index
 
+mod tool_index;
 mod types;
 
+pub use tool_index::{SEARCH_RESULTS_CAP, ToolIndex, ToolSummary};
 pub use types::{
     McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
     McpToolResult, NewMcpServer, UpdateMcpServer,

--- a/crates/gglib-core/src/domain/mcp/tool_index.rs
+++ b/crates/gglib-core/src/domain/mcp/tool_index.rs
@@ -1,0 +1,296 @@
+//! In-memory index for progressive tool disclosure.
+//!
+//! # Problem
+//!
+//! Dumping the full JSON schema of every MCP tool to an external client (e.g.
+//! VS Code Copilot) on every `tools/list` call costs 100 k+ tokens at 100+
+//! tools and causes context-window timeouts.  The Progressive Disclosure
+//! pattern fixes this by exposing three meta-tools instead of the full
+//! registry:
+//!
+//! | Meta-tool         | Purpose                                        |
+//! |-------------------|------------------------------------------------|
+//! | `search_tools`    | Keyword search; returns lightweight summaries  |
+//! | `get_tool_schema` | Lazily fetches one tool's full JSON schema     |
+//! | `invoke_tool`     | Forwards execution to the upstream MCP server  |
+//!
+//! # Design
+//!
+//! `ToolIndex` is a pure-data, allocation-once structure built from the
+//! complete `McpTool` list that the `McpService` already holds in memory.
+//! It lives in `gglib-core` so that every frontend (CLI, Axum, Tauri) can
+//! share the same type without depending on `gglib-mcp`.
+//!
+//! The index intentionally does **not** cache itself inside `AppState`.
+//! Rebuilding from the in-memory `McpService` on each `search_tools` or
+//! `get_tool_schema` call is microseconds and automatically reflects MCP
+//! server start / stop events.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::McpTool;
+
+/// Maximum number of [`ToolSummary`] entries returned by a single
+/// [`ToolIndex::search`] call.
+///
+/// This cap exists to prevent "blank conditioning" — a failure mode observed
+/// when an LLM receives more candidate tools than it can effectively
+/// discriminate between.  Searches that match more than this number of tools
+/// should be refined with a more specific query.
+pub const SEARCH_RESULTS_CAP: usize = 30;
+
+// ─── ToolSummary ─────────────────────────────────────────────────────────────
+
+/// A lightweight, schema-free description of a single MCP tool.
+///
+/// Returned by [`ToolIndex::search`] so that an external client can discover
+/// what tools exist without receiving every tool's full JSON input schema.
+/// Once the client has identified the specific tool it needs, it calls
+/// `get_tool_schema` with the [`tool_id`](ToolSummary::tool_id) to retrieve
+/// the full schema lazily.
+///
+/// # Naming convention
+///
+/// `tool_id` uses the double-underscore qualified format
+/// `"<server_name>__<tool_name>"` so that the ID is both human-readable and
+/// usable as the `tool_id` argument to `get_tool_schema` and `invoke_tool`
+/// without any further look-up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolSummary {
+    /// Qualified tool identifier: `"<server_name>__<tool_name>"`.
+    ///
+    /// Pass this string directly to `get_tool_schema` or `invoke_tool`.
+    pub tool_id: String,
+
+    /// One-line human-readable description, or an empty string if the
+    /// upstream MCP server did not provide one.
+    pub description: String,
+}
+
+// ─── ToolIndex ───────────────────────────────────────────────────────────────
+
+/// An in-memory index over all tools from all running MCP servers.
+///
+/// Build one via [`ToolIndex::from_tools`], then use [`search`] and
+/// [`get_schema`] to serve progressive-disclosure meta-tool calls without
+/// exposing the full registry to external clients.
+///
+/// [`search`]: ToolIndex::search
+/// [`get_schema`]: ToolIndex::get_schema
+#[derive(Debug, Default)]
+pub struct ToolIndex {
+    /// Keyed by `"<server_name>__<tool_name>"`.
+    by_id: HashMap<String, McpTool>,
+}
+
+impl ToolIndex {
+    /// Build a `ToolIndex` from an iterator of `(qualified_id, tool)` pairs.
+    ///
+    /// The caller is responsible for constructing `qualified_id` in the format
+    /// `"<server_name>__<tool_name>"`.  See [`build_tool_index`] in
+    /// `gglib-proxy` for the canonical construction path.
+    ///
+    /// Duplicate IDs are silently overwritten by the last occurrence (mirrors
+    /// the behaviour of the MCP server registry, which does not permit two
+    /// servers with the same name to be active simultaneously).
+    pub fn from_tools(iter: impl IntoIterator<Item = (String, McpTool)>) -> Self {
+        Self {
+            by_id: iter.into_iter().collect(),
+        }
+    }
+
+    /// Search the index by keyword and return at most [`SEARCH_RESULTS_CAP`]
+    /// lightweight [`ToolSummary`] entries.
+    ///
+    /// # Matching
+    ///
+    /// Both the `tool_id` and the tool's `description` field are searched
+    /// using case-insensitive substring matching.  A tool is included if the
+    /// lowercased `query` appears anywhere in either field.
+    ///
+    /// An **empty `query`** returns the first `SEARCH_RESULTS_CAP` tools in
+    /// an unspecified (but deterministic within a single process run) order —
+    /// useful for an LLM that wants a broad overview before deciding what to
+    /// fetch.
+    ///
+    /// # Hard cap
+    ///
+    /// At most [`SEARCH_RESULTS_CAP`] results are returned regardless of how
+    /// many tools match.  This is intentional: searches that return too many
+    /// results should be narrowed with a more specific keyword.
+    pub fn search(&self, query: &str) -> Vec<ToolSummary> {
+        let q = query.to_lowercase();
+        self.by_id
+            .iter()
+            .filter(|(id, tool)| {
+                if q.is_empty() {
+                    return true;
+                }
+                let desc = tool.description.as_deref().unwrap_or("").to_lowercase();
+                id.to_lowercase().contains(&q) || desc.contains(&q)
+            })
+            .take(SEARCH_RESULTS_CAP)
+            .map(|(id, tool)| ToolSummary {
+                tool_id: id.clone(),
+                description: tool.description.clone().unwrap_or_default(),
+            })
+            .collect()
+    }
+
+    /// Retrieve the full JSON input schema for a single tool by its qualified
+    /// `tool_id`.
+    ///
+    /// Returns `None` when no tool with that ID exists in the index, or when
+    /// the tool exists but its upstream server did not expose a schema.
+    ///
+    /// # Token cost
+    ///
+    /// Calling this for a single tool is the central efficiency gain of the
+    /// Progressive Disclosure pattern — the client pays only for the one
+    /// schema it actually needs, not for all schemas in the registry.
+    pub fn get_schema(&self, tool_id: &str) -> Option<&serde_json::Value> {
+        self.by_id
+            .get(tool_id)
+            .and_then(|t| t.input_schema.as_ref())
+    }
+
+    /// Returns `true` if the index contains a tool with the given `tool_id`.
+    ///
+    /// Used by `invoke_tool` to validate the ID before attempting resolution
+    /// against the live MCP service.
+    pub fn contains(&self, tool_id: &str) -> bool {
+        self.by_id.contains_key(tool_id)
+    }
+
+    /// Total number of tools in the index across all MCP servers.
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Returns `true` if no tools are currently indexed (no MCP servers
+    /// running or all servers have zero tools).
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn make_tool(description: Option<&str>, schema: Option<serde_json::Value>) -> McpTool {
+        let mut t = McpTool::new("dummy");
+        if let Some(d) = description {
+            t = t.with_description(d);
+        }
+        if let Some(s) = schema {
+            t = t.with_input_schema(s);
+        }
+        t
+    }
+
+    fn sample_index() -> ToolIndex {
+        ToolIndex::from_tools([
+            (
+                "files__read_file".to_string(),
+                make_tool(
+                    Some("Read the contents of a file"),
+                    Some(json!({"type": "object", "properties": {"path": {"type": "string"}}})),
+                ),
+            ),
+            (
+                "files__write_file".to_string(),
+                make_tool(Some("Write text to a file"), None),
+            ),
+            (
+                "search__web_search".to_string(),
+                make_tool(Some("Search the web"), Some(json!({}))),
+            ),
+            ("no_desc__tool".to_string(), make_tool(None, None)),
+        ])
+    }
+
+    #[test]
+    fn search_by_keyword_in_id() {
+        let idx = sample_index();
+        let results = idx.search("web");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].tool_id, "search__web_search");
+    }
+
+    #[test]
+    fn search_by_keyword_in_description() {
+        let idx = sample_index();
+        let results = idx.search("contents");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].tool_id, "files__read_file");
+    }
+
+    #[test]
+    fn search_case_insensitive() {
+        let idx = sample_index();
+        let results = idx.search("FILE");
+        // matches "files__read_file", "files__write_file" (id), and "Read the contents of a FILE" (desc)
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.tool_id == "files__read_file"));
+    }
+
+    #[test]
+    fn empty_query_returns_all_up_to_cap() {
+        let idx = sample_index();
+        let results = idx.search("");
+        assert_eq!(results.len(), 4);
+    }
+
+    #[test]
+    fn search_respects_cap() {
+        // Build an index with SEARCH_RESULTS_CAP + 5 tools.
+        let tools: Vec<(String, McpTool)> = (0..SEARCH_RESULTS_CAP + 5)
+            .map(|i| (format!("srv__tool_{i}"), make_tool(Some("match"), None)))
+            .collect();
+        let idx = ToolIndex::from_tools(tools);
+        let results = idx.search("match");
+        assert_eq!(results.len(), SEARCH_RESULTS_CAP);
+    }
+
+    #[test]
+    fn get_schema_returns_schema() {
+        let idx = sample_index();
+        let schema = idx.get_schema("files__read_file");
+        assert!(schema.is_some());
+    }
+
+    #[test]
+    fn get_schema_missing_tool_returns_none() {
+        let idx = sample_index();
+        assert!(idx.get_schema("nonexistent__tool").is_none());
+    }
+
+    #[test]
+    fn get_schema_tool_without_schema_returns_none() {
+        let idx = sample_index();
+        assert!(idx.get_schema("files__write_file").is_none());
+    }
+
+    #[test]
+    fn contains_and_len() {
+        let idx = sample_index();
+        assert!(idx.contains("files__read_file"));
+        assert!(!idx.contains("nothing__here"));
+        assert_eq!(idx.len(), 4);
+        assert!(!idx.is_empty());
+    }
+
+    #[test]
+    fn empty_index_is_empty() {
+        let idx = ToolIndex::default();
+        assert!(idx.is_empty());
+        assert_eq!(idx.len(), 0);
+        assert!(idx.search("anything").is_empty());
+        assert!(idx.get_schema("anything").is_none());
+    }
+}

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -34,7 +34,7 @@ pub use inference::InferenceConfig;
 // Re-export MCP types at the domain level for convenience
 pub use mcp::{
     McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
-    McpToolResult, NewMcpServer, UpdateMcpServer,
+    McpToolResult, NewMcpServer, SEARCH_RESULTS_CAP, ToolIndex, ToolSummary, UpdateMcpServer,
 };
 
 // Re-export chat types at the domain level for convenience

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -23,6 +23,7 @@ pub use domain::{
     McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
     McpToolResult, Message, MessageContent, MessageRole, Model, ModelCapabilities,
     ModelFilterOptions, NewConversation, NewMcpServer, NewMessage, NewModel, NodeId, NodeStatus,
+    SEARCH_RESULTS_CAP, ToolIndex, ToolSummary,
     RangeValues, TaskGraph, TaskGraphError, TaskNode, ToolCall, ToolDefinition, ToolResult,
     UpdateMcpServer, capabilities_from_architecture, infer_from_chat_template,
     transform_messages_for_capabilities,

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -23,10 +23,9 @@ pub use domain::{
     McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
     McpToolResult, Message, MessageContent, MessageRole, Model, ModelCapabilities,
     ModelFilterOptions, NewConversation, NewMcpServer, NewMessage, NewModel, NodeId, NodeStatus,
-    SEARCH_RESULTS_CAP, ToolIndex, ToolSummary,
-    RangeValues, TaskGraph, TaskGraphError, TaskNode, ToolCall, ToolDefinition, ToolResult,
-    UpdateMcpServer, capabilities_from_architecture, infer_from_chat_template,
-    transform_messages_for_capabilities,
+    RangeValues, SEARCH_RESULTS_CAP, TaskGraph, TaskGraphError, TaskNode, ToolCall, ToolDefinition,
+    ToolIndex, ToolResult, ToolSummary, UpdateMcpServer, capabilities_from_architecture,
+    infer_from_chat_template, transform_messages_for_capabilities,
 };
 pub use download::{
     AttemptCounts, CompletionDetail, CompletionKey, CompletionKind, DownloadError, DownloadEvent,

--- a/crates/gglib-proxy/src/mcp/handlers.rs
+++ b/crates/gglib-proxy/src/mcp/handlers.rs
@@ -2,15 +2,22 @@
 //!
 //! Implements the single-endpoint design from MCP spec 2025-03-26:
 //!
-//! | Method   | Path   | Behaviour                                      |
+//! | Method   | Path   | Behaviour                                       |
 //! |----------|--------|-------------------------------------------------|
 //! | `POST`   | `/mcp` | JSON-RPC dispatch (initialize, tools/*, ping)   |
 //! | `GET`    | `/mcp` | 405 Method Not Allowed (no server-push yet)     |
 //! | `DELETE` | `/mcp` | Session termination via `Mcp-Session-Id` header |
 //!
-//! `tools/call` returns `text/event-stream` (SSE). All other methods
-//! return `application/json`. Both are valid per spec — clients MUST
-//! support either content type.
+//! # Progressive Disclosure
+//!
+//! `tools/list` no longer exposes raw tool schemas. Instead it returns
+//! exactly **three meta-tools** (`search_tools`, `get_tool_schema`,
+//! `invoke_tool`). External clients discover capabilities incrementally
+//! rather than receiving every schema up-front, reducing context-window
+//! consumption by 90%+. See [`super::meta_tools`] for details.
+//!
+//! `tools/call` results are returned as `text/event-stream` (SSE).
+//! All other methods return `application/json`. Both are valid per spec.
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -80,8 +87,8 @@ pub(crate) async fn post_mcp(
     match request.method.as_str() {
         "initialize" => handle_initialize(&state.sessions, id).await,
         "ping" => handle_ping(id),
-        "tools/list" => handle_tools_list(&state.mcp, id).await,
-        "tools/call" => handle_tools_call(&state.mcp, id, request.params).await,
+        "tools/list" => handle_meta_tools_list(&state.mcp, id).await,
+        "tools/call" => handle_meta_tools_call(&state.mcp, id, request.params).await,
         _ => json_rpc_error_response(
             StatusCode::OK,
             id,
@@ -156,54 +163,31 @@ fn handle_ping(id: Value) -> Response {
     Json(JsonRpcResponse::success(id, serde_json::json!({}))).into_response()
 }
 
-/// Handle `tools/list` — enumerate all tools from all running MCP servers.
-async fn handle_tools_list(mcp: &gglib_mcp::McpService, id: Value) -> Response {
-    let (tools, server_names) = build_tool_list(mcp).await;
-
-    // Build McpToolSpec list with qualified names
-    let specs: Vec<McpToolSpec> = tools
-        .into_iter()
-        .map(|(server_id, tool)| {
-            let server_name = server_names
-                .get(&server_id)
-                .map(String::as_str)
-                .unwrap_or("unknown");
-            McpToolSpec {
-                name: format!("{server_name}__{}", tool.name),
-                description: tool.description,
-                input_schema: tool.input_schema,
-                title: tool.title,
-            }
-        })
-        .collect();
-
+/// Handle `tools/list` — return the three progressive-disclosure meta-tools.
+///
+/// External clients (VS Code Copilot, OpenWebUI, etc.) receive exactly three
+/// stable tool specs rather than the full registry. This keeps the baseline
+/// context cost constant regardless of how many MCP servers are running.
+async fn handle_meta_tools_list(mcp: &gglib_mcp::McpService, id: Value) -> Response {
+    let index = super::meta_tools::build_tool_index(mcp).await;
+    let specs = super::meta_tools::meta_tools_list(&index);
     let result = ToolsListResult { tools: specs };
-    Json(JsonRpcResponse::success(
-        id,
-        serde_json::to_value(result).unwrap(),
-    ))
-    .into_response()
+    Json(JsonRpcResponse::success(id, serde_json::to_value(result).unwrap())).into_response()
 }
 
-/// Handle `tools/call` — resolve the qualified name, invoke the tool,
-/// and return the result as an SSE stream.
-async fn handle_tools_call(
+/// Handle `tools/call` — dispatch to one of the three meta-tools.
+///
+/// Routing is strict: only `search_tools`, `get_tool_schema`, and
+/// `invoke_tool` are accepted. Any other name — including direct calls to
+/// raw `"server__tool"` identifiers — returns `METHOD_NOT_FOUND`. There is
+/// no legacy passthrough.
+async fn handle_meta_tools_call(
     mcp: &gglib_mcp::McpService,
     id: Value,
     params: Option<Value>,
 ) -> Response {
-    // Parse params
-    let call_params: ToolsCallParams = match params {
-        Some(v) => match serde_json::from_value(v) {
-            Ok(p) => p,
-            Err(e) => {
-                return json_rpc_error_response(
-                    StatusCode::OK,
-                    id,
-                    JsonRpcError::new(INVALID_PARAMS, format!("Invalid params: {e}")),
-                );
-            }
-        },
+    let params_val = match params {
+        Some(v) => v,
         None => {
             return json_rpc_error_response(
                 StatusCode::OK,
@@ -213,80 +197,131 @@ async fn handle_tools_call(
         }
     };
 
-    // Resolve qualified name → (server_id, bare_name)
-    let (server_id, bare_name) = match resolve_tool_name(mcp, &call_params.name).await {
-        Some(pair) => pair,
+    let name = match params_val.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n.to_string(),
         None => {
             return json_rpc_error_response(
                 StatusCode::OK,
                 id,
-                JsonRpcError::new(
-                    INVALID_PARAMS,
-                    format!("Unknown tool: {}", call_params.name),
+                JsonRpcError::new(INVALID_PARAMS, "Missing 'name' field"),
+            );
+        }
+    };
+
+    // Shorthand: the "arguments" object sent by the MCP client for this call.
+    let meta_args = params_val
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(serde_json::Map::new()));
+
+    match name.as_str() {
+        // ── search_tools ──────────────────────────────────────────────────
+        "search_tools" => {
+            let query = meta_args
+                .get("query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let index = super::meta_tools::build_tool_index(mcp).await;
+            let summaries = index.search(query);
+            let text = serde_json::to_string(&summaries).unwrap_or_default();
+            sse_tool_result(id, text, false)
+        }
+
+        // ── get_tool_schema ───────────────────────────────────────────────
+        "get_tool_schema" => {
+            let tool_id = match meta_args.get("tool_id").and_then(|v| v.as_str()) {
+                Some(t) => t.to_string(),
+                None => {
+                    return json_rpc_error_response(
+                        StatusCode::OK,
+                        id,
+                        JsonRpcError::new(INVALID_PARAMS, "Missing 'tool_id' argument"),
+                    );
+                }
+            };
+            let index = super::meta_tools::build_tool_index(mcp).await;
+            match index.get_schema(&tool_id) {
+                Some(schema) => {
+                    let text = serde_json::to_string(schema).unwrap_or_default();
+                    sse_tool_result(id, text, false)
+                }
+                None => json_rpc_error_response(
+                    StatusCode::OK,
+                    id,
+                    JsonRpcError::new(
+                        INVALID_PARAMS,
+                        format!("Unknown tool: '{tool_id}'. Use search_tools to discover available tool IDs."),
+                    ),
                 ),
-            );
+            }
         }
-    };
 
-    // Convert arguments from Value to HashMap<String, Value>
-    let arguments: HashMap<String, Value> = match call_params.arguments {
-        Some(Value::Object(map)) => map.into_iter().collect(),
-        Some(_) => {
-            return json_rpc_error_response(
-                StatusCode::OK,
-                id,
-                JsonRpcError::new(INVALID_PARAMS, "arguments must be an object"),
-            );
-        }
-        None => HashMap::new(),
-    };
-
-    // Invoke the tool
-    let result = mcp.call_tool(server_id, &bare_name, arguments).await;
-
-    // Build JSON-RPC response
-    let rpc_response = match result {
-        Ok(tool_result) => {
-            let text = if let Some(data) = tool_result.data {
-                serde_json::to_string_pretty(&data).unwrap_or_default()
-            } else {
-                String::new()
+        // ── invoke_tool ───────────────────────────────────────────────────
+        "invoke_tool" => {
+            let tool_id = match meta_args.get("tool_id").and_then(|v| v.as_str()) {
+                Some(t) => t.to_string(),
+                None => {
+                    return json_rpc_error_response(
+                        StatusCode::OK,
+                        id,
+                        JsonRpcError::new(INVALID_PARAMS, "Missing 'tool_id' argument"),
+                    );
+                }
             };
-            let call_result = CallToolResult {
-                content: vec![ToolContent {
-                    content_type: "text".to_string(),
-                    text,
-                }],
-                is_error: if tool_result.success {
-                    None
-                } else {
-                    Some(true)
-                },
-            };
-            JsonRpcResponse::success(id, serde_json::to_value(call_result).unwrap())
-        }
-        Err(e) => {
-            error!("MCP tools/call error: {e}");
-            let call_result = CallToolResult {
-                content: vec![ToolContent {
-                    content_type: "text".to_string(),
-                    text: e.to_string(),
-                }],
-                is_error: Some(true),
-            };
-            JsonRpcResponse::success(id, serde_json::to_value(call_result).unwrap())
-        }
-    };
 
-    // Return as SSE stream (spec: server may return text/event-stream)
-    let payload = serde_json::to_string(&rpc_response).unwrap();
-    let event_stream = stream::once(async move {
-        Ok::<_, Infallible>(Event::default().event("message").data(payload))
-    });
+            let (server_id, bare_name) =
+                match super::meta_tools::resolve_tool_name(mcp, &tool_id).await {
+                    Some(pair) => pair,
+                    None => {
+                        return json_rpc_error_response(
+                            StatusCode::OK,
+                            id,
+                            JsonRpcError::new(
+                                INVALID_PARAMS,
+                                format!("Unknown tool: '{tool_id}'. Use search_tools to discover available tool IDs."),
+                            ),
+                        );
+                    }
+                };
 
-    Sse::new(event_stream)
-        .keep_alive(KeepAlive::default())
-        .into_response()
+            let tool_args: HashMap<String, Value> =
+                match meta_args.get("arguments").cloned() {
+                    Some(Value::Object(map)) => map.into_iter().collect(),
+                    Some(_) => {
+                        return json_rpc_error_response(
+                            StatusCode::OK,
+                            id,
+                            JsonRpcError::new(INVALID_PARAMS, "'arguments' must be a JSON object"),
+                        );
+                    }
+                    None => HashMap::new(),
+                };
+
+            match mcp.call_tool(server_id, &bare_name, tool_args).await {
+                Ok(tool_result) => {
+                    let text = tool_result
+                        .data
+                        .map(|d| serde_json::to_string_pretty(&d).unwrap_or_default())
+                        .unwrap_or_default();
+                    sse_tool_result(id, text, !tool_result.success)
+                }
+                Err(e) => {
+                    error!("MCP invoke_tool error for '{tool_id}': {e}");
+                    sse_tool_result(id, e.to_string(), true)
+                }
+            }
+        }
+
+        // ── Hard break — no legacy passthrough ────────────────────────────
+        _ => json_rpc_error_response(
+            StatusCode::OK,
+            id,
+            JsonRpcError::new(
+                METHOD_NOT_FOUND,
+                format!("Unknown tool: '{name}'. Use search_tools to discover available tools."),
+            ),
+        ),
+    }
 }
 
 // ─── Notification handling ─────────────────────────────────────────────────
@@ -360,30 +395,28 @@ async fn require_session(
     }
 }
 
-/// Build a flattened tool list and server-id-to-name mapping.
-async fn build_tool_list(
-    mcp: &gglib_mcp::McpService,
-) -> (Vec<(i64, gglib_core::McpTool)>, HashMap<i64, String>) {
-    let servers = mcp.list_servers().await.unwrap_or_default();
-    let server_names: HashMap<i64, String> =
-        servers.iter().map(|s| (s.id, s.name.clone())).collect();
-
-    let all_tools = mcp.list_all_tools().await;
-    let flat: Vec<(i64, gglib_core::McpTool)> = all_tools
-        .into_iter()
-        .flat_map(|(sid, tools)| tools.into_iter().map(move |t| (sid, t)))
-        .collect();
-
-    (flat, server_names)
-}
-
-/// Resolve a qualified tool name ("server__tool") to (server_id, bare_name).
-async fn resolve_tool_name(mcp: &gglib_mcp::McpService, qualified: &str) -> Option<(i64, String)> {
-    let (server_names, bare_name) = qualified.split_once("__")?;
-
-    let server = mcp.get_server_by_name(server_names).await.ok()?;
-
-    Some((server.id, bare_name.to_string()))
+/// Wrap `text` in a standard MCP `CallToolResult` and return it as a
+/// single-event SSE stream.
+///
+/// `is_error` maps to `CallToolResult::is_error`; pass `true` when the
+/// upstream tool reported a failure so that the MCP client can distinguish
+/// application-level errors from successful (but empty) results.
+fn sse_tool_result(id: Value, text: String, is_error: bool) -> Response {
+    let call_result = CallToolResult {
+        content: vec![ToolContent {
+            content_type: "text".to_string(),
+            text,
+        }],
+        is_error: if is_error { Some(true) } else { None },
+    };
+    let rpc_response = JsonRpcResponse::success(id, serde_json::to_value(call_result).unwrap());
+    let payload = serde_json::to_string(&rpc_response).unwrap();
+    let event_stream = stream::once(async move {
+        Ok::<_, Infallible>(Event::default().event("message").data(payload))
+    });
+    Sse::new(event_stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 /// Build a JSON-RPC error as an HTTP response.

--- a/crates/gglib-proxy/src/mcp/handlers.rs
+++ b/crates/gglib-proxy/src/mcp/handlers.rs
@@ -172,7 +172,11 @@ async fn handle_meta_tools_list(mcp: &gglib_mcp::McpService, id: Value) -> Respo
     let index = super::meta_tools::build_tool_index(mcp).await;
     let specs = super::meta_tools::meta_tools_list(&index);
     let result = ToolsListResult { tools: specs };
-    Json(JsonRpcResponse::success(id, serde_json::to_value(result).unwrap())).into_response()
+    Json(JsonRpcResponse::success(
+        id,
+        serde_json::to_value(result).unwrap(),
+    ))
+    .into_response()
 }
 
 /// Handle `tools/call` — dispatch to one of the three meta-tools.
@@ -250,7 +254,9 @@ async fn handle_meta_tools_call(
                     id,
                     JsonRpcError::new(
                         INVALID_PARAMS,
-                        format!("Unknown tool: '{tool_id}'. Use search_tools to discover available tool IDs."),
+                        format!(
+                            "Unknown tool: '{tool_id}'. Use search_tools to discover available tool IDs."
+                        ),
                     ),
                 ),
             }
@@ -269,33 +275,35 @@ async fn handle_meta_tools_call(
                 }
             };
 
-            let (server_id, bare_name) =
-                match super::meta_tools::resolve_tool_name(mcp, &tool_id).await {
-                    Some(pair) => pair,
-                    None => {
-                        return json_rpc_error_response(
-                            StatusCode::OK,
-                            id,
-                            JsonRpcError::new(
-                                INVALID_PARAMS,
-                                format!("Unknown tool: '{tool_id}'. Use search_tools to discover available tool IDs."),
+            let (server_id, bare_name) = match super::meta_tools::resolve_tool_name(mcp, &tool_id)
+                .await
+            {
+                Some(pair) => pair,
+                None => {
+                    return json_rpc_error_response(
+                        StatusCode::OK,
+                        id,
+                        JsonRpcError::new(
+                            INVALID_PARAMS,
+                            format!(
+                                "Unknown tool: '{tool_id}'. Use search_tools to discover available tool IDs."
                             ),
-                        );
-                    }
-                };
+                        ),
+                    );
+                }
+            };
 
-            let tool_args: HashMap<String, Value> =
-                match meta_args.get("arguments").cloned() {
-                    Some(Value::Object(map)) => map.into_iter().collect(),
-                    Some(_) => {
-                        return json_rpc_error_response(
-                            StatusCode::OK,
-                            id,
-                            JsonRpcError::new(INVALID_PARAMS, "'arguments' must be a JSON object"),
-                        );
-                    }
-                    None => HashMap::new(),
-                };
+            let tool_args: HashMap<String, Value> = match meta_args.get("arguments").cloned() {
+                Some(Value::Object(map)) => map.into_iter().collect(),
+                Some(_) => {
+                    return json_rpc_error_response(
+                        StatusCode::OK,
+                        id,
+                        JsonRpcError::new(INVALID_PARAMS, "'arguments' must be a JSON object"),
+                    );
+                }
+                None => HashMap::new(),
+            };
 
             match mcp.call_tool(server_id, &bare_name, tool_args).await {
                 Ok(tool_result) => {

--- a/crates/gglib-proxy/src/mcp/meta_tools.rs
+++ b/crates/gglib-proxy/src/mcp/meta_tools.rs
@@ -60,10 +60,7 @@ pub(super) async fn build_tool_index(mcp: &McpService) -> ToolIndex {
 ///
 /// Returns `None` when the ID is malformed (missing `__`), the server name
 /// is not found, or the server is not currently running.
-pub(super) async fn resolve_tool_name(
-    mcp: &McpService,
-    qualified: &str,
-) -> Option<(i64, String)> {
+pub(super) async fn resolve_tool_name(mcp: &McpService, qualified: &str) -> Option<(i64, String)> {
     let (server_name, bare_name) = qualified.split_once("__")?;
     let server = mcp.get_server_by_name(server_name).await.ok()?;
     Some((server.id, bare_name.to_string()))
@@ -158,9 +155,7 @@ pub(super) fn meta_tools_list(_index: &ToolIndex) -> Vec<McpToolSpec> {
 /// remaining internal callers.  It performs two `McpService` calls which read
 /// from in-memory state and are not expected to fail; failures produce empty
 /// collections rather than propagating an error.
-async fn build_flat_tool_list(
-    mcp: &McpService,
-) -> (Vec<(i64, McpTool)>, HashMap<i64, String>) {
+async fn build_flat_tool_list(mcp: &McpService) -> (Vec<(i64, McpTool)>, HashMap<i64, String>) {
     let servers = mcp.list_servers().await.unwrap_or_default();
     let server_names: HashMap<i64, String> =
         servers.iter().map(|s| (s.id, s.name.clone())).collect();

--- a/crates/gglib-proxy/src/mcp/meta_tools.rs
+++ b/crates/gglib-proxy/src/mcp/meta_tools.rs
@@ -1,0 +1,175 @@
+//! Progressive-disclosure adapter between the internal `McpService` registry
+//! and the three meta-tools exposed to external MCP clients.
+//!
+//! # Why three meta-tools?
+//!
+//! Dumping every tool's full JSON input schema on every `tools/list` response
+//! costs tens of thousands of tokens when many MCP servers are running.
+//! Instead the proxy exposes exactly three stable entry points:
+//!
+//! | Tool              | Token cost    | Purpose                                  |
+//! |-------------------|---------------|------------------------------------------|
+//! | `search_tools`    | Minimal       | Keyword search; returns IDs + one-liners |
+//! | `get_tool_schema` | One schema    | Lazily fetch a single tool's full schema |
+//! | `invoke_tool`     | Zero overhead | Execute by qualified ID + arguments      |
+//!
+//! The external client pays only for the schemas it actually needs.
+//!
+//! # Relationship to `gglib-mcp`
+//!
+//! This module is a **read-only adapter**.  It calls `McpService::list_servers`,
+//! `McpService::list_all_tools`, and `McpService::get_server_by_name` to build
+//! and query a [`ToolIndex`].  The execution path (`invoke_tool`) delegates
+//! directly to `McpService::call_tool` — the internal MCP engine is untouched.
+
+use std::collections::HashMap;
+
+use gglib_core::{McpTool, ToolIndex};
+use gglib_mcp::McpService;
+use serde_json::json;
+
+use super::types::McpToolSpec;
+
+// ─── Index construction ───────────────────────────────────────────────────
+
+/// Build a [`ToolIndex`] from all tools currently registered across all
+/// running MCP servers.
+///
+/// The `tool_id` for each entry uses the double-underscore qualified format
+/// `"<server_name>__<tool_name>"` so it can be passed directly to
+/// `get_tool_schema` or `invoke_tool` without any further transformation.
+///
+/// This function re-queries `McpService` on every call — no stale cache.
+/// `list_all_tools()` reads from an in-memory map inside `McpManager` and is
+/// microseconds in practice.
+pub(super) async fn build_tool_index(mcp: &McpService) -> ToolIndex {
+    let (flat, server_names) = build_flat_tool_list(mcp).await;
+    let entries = flat.into_iter().map(|(server_id, tool)| {
+        let server_name = server_names
+            .get(&server_id)
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        let qualified_id = format!("{server_name}__{}", tool.name);
+        (qualified_id, tool)
+    });
+    ToolIndex::from_tools(entries)
+}
+
+/// Resolve a `"server_name__tool_name"` qualified ID to the numeric
+/// `(server_id, bare_tool_name)` pair required by `McpService::call_tool`.
+///
+/// Returns `None` when the ID is malformed (missing `__`), the server name
+/// is not found, or the server is not currently running.
+pub(super) async fn resolve_tool_name(
+    mcp: &McpService,
+    qualified: &str,
+) -> Option<(i64, String)> {
+    let (server_name, bare_name) = qualified.split_once("__")?;
+    let server = mcp.get_server_by_name(server_name).await.ok()?;
+    Some((server.id, bare_name.to_string()))
+}
+
+// ─── Meta-tool spec construction ──────────────────────────────────────────
+
+/// Build the three [`McpToolSpec`] entries that are sent to external clients
+/// on every `tools/list` response.
+///
+/// These specs are intentionally **static** — their descriptions never contain
+/// dynamic content such as a capability index.  The LLM must call
+/// `search_tools` to discover what is available.
+///
+/// The input schemas are minimal JSON Schema objects that unambiguously
+/// describe each tool's parameters without token waste.
+pub(super) fn meta_tools_list(_index: &ToolIndex) -> Vec<McpToolSpec> {
+    vec![
+        McpToolSpec {
+            name: "search_tools".to_string(),
+            description: Some(
+                "Search the internal registry for available tools by keyword. \
+                 Returns a list of matching tool IDs and short descriptions. \
+                 Pass an empty string to browse all available tools (up to 30 results). \
+                 Use the returned tool_id with get_tool_schema or invoke_tool."
+                    .to_string(),
+            ),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Keyword to search for in tool names and descriptions. Pass an empty string to list all available tools."
+                    }
+                },
+                "required": ["query"]
+            })),
+            title: None,
+        },
+        McpToolSpec {
+            name: "get_tool_schema".to_string(),
+            description: Some(
+                "Fetch the full JSON input schema for a specific tool by its qualified ID. \
+                 Call search_tools first to discover available tool IDs."
+                    .to_string(),
+            ),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "tool_id": {
+                        "type": "string",
+                        "description": "The qualified tool ID in the format \"server_name__tool_name\", as returned by search_tools."
+                    }
+                },
+                "required": ["tool_id"]
+            })),
+            title: None,
+        },
+        McpToolSpec {
+            name: "invoke_tool".to_string(),
+            description: Some(
+                "Invoke a specific MCP tool by its qualified ID with the given arguments. \
+                 Call get_tool_schema first to discover the required argument fields."
+                    .to_string(),
+            ),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "tool_id": {
+                        "type": "string",
+                        "description": "The qualified tool ID in the format \"server_name__tool_name\", as returned by search_tools."
+                    },
+                    "arguments": {
+                        "type": "object",
+                        "description": "Arguments to pass to the tool. Use get_tool_schema to discover the required fields.",
+                        "additionalProperties": true
+                    }
+                },
+                "required": ["tool_id", "arguments"]
+            })),
+            title: None,
+        },
+    ]
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────
+
+/// Flatten all tools from all running MCP servers into a `(server_id, McpTool)`
+/// list alongside a `server_id → name` map.
+///
+/// This is a shared primitive used by both [`build_tool_index`] and any
+/// remaining internal callers.  It performs two `McpService` calls which read
+/// from in-memory state and are not expected to fail; failures produce empty
+/// collections rather than propagating an error.
+async fn build_flat_tool_list(
+    mcp: &McpService,
+) -> (Vec<(i64, McpTool)>, HashMap<i64, String>) {
+    let servers = mcp.list_servers().await.unwrap_or_default();
+    let server_names: HashMap<i64, String> =
+        servers.iter().map(|s| (s.id, s.name.clone())).collect();
+
+    let all_tools = mcp.list_all_tools().await;
+    let flat: Vec<(i64, McpTool)> = all_tools
+        .into_iter()
+        .flat_map(|(sid, tools)| tools.into_iter().map(move |t| (sid, t)))
+        .collect();
+
+    (flat, server_names)
+}

--- a/crates/gglib-proxy/src/mcp/mod.rs
+++ b/crates/gglib-proxy/src/mcp/mod.rs
@@ -7,12 +7,14 @@
 //!
 //! # Module layout
 //!
-//! | Module     | Responsibility                                    |
-//! |------------|---------------------------------------------------|
-//! | `types`    | JSON-RPC 2.0 and MCP wire types (serde structs)   |
-//! | `session`  | `Mcp-Session-Id` tracking and validation          |
-//! | `handlers` | Axum route handlers for POST/GET/DELETE `/mcp`    |
+//! | Module       | Responsibility                                      |
+//! |--------------|-----------------------------------------------------|
+//! | `types`      | JSON-RPC 2.0 and MCP wire types (serde structs)     |
+//! | `session`    | `Mcp-Session-Id` tracking and validation            |
+//! | `meta_tools` | Progressive-disclosure index + 3 meta-tool specs    |
+//! | `handlers`   | Axum route handlers for POST/GET/DELETE `/mcp`      |
 
 pub mod handlers;
+pub(crate) mod meta_tools;
 pub mod session;
 pub mod types;

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -365,9 +365,17 @@ async fn full_happy_path_initialize_list_delete() {
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body["jsonrpc"], "2.0");
     assert_eq!(body["id"], 2);
-    // Empty repo → empty tools list
+    // Progressive disclosure: always exactly 3 meta-tools regardless of how
+    // many MCP servers are running.
     let tools = body["result"]["tools"].as_array().unwrap();
-    assert!(tools.is_empty());
+    assert_eq!(tools.len(), 3);
+    let tool_names: Vec<&str> = tools
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(tool_names.contains(&"search_tools"));
+    assert!(tool_names.contains(&"get_tool_schema"));
+    assert!(tool_names.contains(&"invoke_tool"));
 
     // ── Step 4: ping ──
     let resp = post_mcp(

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -369,10 +369,7 @@ async fn full_happy_path_initialize_list_delete() {
     // many MCP servers are running.
     let tools = body["result"]["tools"].as_array().unwrap();
     assert_eq!(tools.len(), 3);
-    let tool_names: Vec<&str> = tools
-        .iter()
-        .map(|t| t["name"].as_str().unwrap())
-        .collect();
+    let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert!(tool_names.contains(&"search_tools"));
     assert!(tool_names.contains(&"get_tool_schema"));
     assert!(tool_names.contains(&"invoke_tool"));


### PR DESCRIPTION
## Summary

Fixes severe context-window bloat (100 k+ tokens) when VS Code Copilot connects to the gglib MCP gateway. The proxy was dumping the full JSON input schema of every registered MCP tool on every `tools/list` call. At 100+ tools this caused constant timeouts.

## Solution: Progressive Disclosure / Wrapper Meta-Tool Pattern

`tools/list` now returns exactly **3 stable meta-tools** instead of the full registry. External clients discover capabilities incrementally:

| Meta-tool | Purpose |
|---|---|
| `search_tools` | Keyword search over tool IDs + descriptions (≤ 30 results) |
| `get_tool_schema` | Lazily fetch one tool's full JSON schema |
| `invoke_tool` | Execute by qualified ID + arguments |

Baseline token cost drops from ~30,000+ tokens to ~300 tokens per connection (~90% reduction).

## Changes

### Phase 1 — `gglib-core` (new pure-data types, zero new deps)
- **New** `crates/gglib-core/src/domain/mcp/tool_index.rs`
  - `ToolIndex` — in-memory index over all `McpTool` entries
  - `ToolSummary` — lightweight `{tool_id, description}` search result
  - `SEARCH_RESULTS_CAP = 30` — hard cap preventing LLM blank-conditioning
  - 10 unit tests

### Phase 2 — `gglib-proxy` meta-tools module
- **New** `crates/gglib-proxy/src/mcp/meta_tools.rs`
  - `build_tool_index()` — builds `ToolIndex` from live `McpService` (no cache)
  - `resolve_tool_name()` — maps `"server__tool"` → `(server_id, bare_name)`
  - `meta_tools_list()` — returns the 3 static `McpToolSpec` definitions

### Phase 3 — `gglib-proxy` handlers rewrite
- **Deleted**: `handle_tools_list`, `handle_tools_call`, `build_tool_list`, `resolve_tool_name` from `handlers.rs`
- **Added**: `handle_meta_tools_list`, `handle_meta_tools_call`, `sse_tool_result`
- **Hard break**: unknown tool names return `METHOD_NOT_FOUND` — no legacy passthrough
- Updated integration test to assert exactly 3 meta-tools on `tools/list`

### Documentation
- Appended "LLM Optimization / Progressive Disclosure" section to `README.md`

## Architecture constraints honoured
- No backward compatibility: legacy `tools/call` with raw names is broken by design
- `gglib-mcp` execution engine untouched — `invoke_tool` delegates to `McpService::call_tool` verbatim
- `ToolIndex`/`ToolSummary` in `gglib-core` — available to CLI, Axum, and Tauri without `gglib-mcp` dependency
- All descriptions are static — no capability index embedded in tool descriptions

## Test results
80/80 tests pass, zero warnings, full workspace `cargo check` clean.