### PR TITLE
fix: pin esbuild >=0.28.1 to resolve GHSA-g7r4-m6w7-qqqr

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "typescript-eslint": "^8.18.1",
     "vite": "^7.3.0",
     "vitest": "^4.0.16"
+  },
+  "overrides": {
+    "esbuild": ">=0.28.1 <0.29"
   }
 }


### PR DESCRIPTION
## Summary

`vite@7.x` depends on `esbuild@0.27.7`, which falls in the affected range for [GHSA-g7r4-m6w7-qqqr](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr) (arbitrary file read on Windows dev server, patched in `esbuild@0.28.1`).

`npm audit fix` cannot resolve it automatically because esbuild is a transitive dependency and vite 7.x is effectively in maintenance (v8 dropped esbuild in favour of rolldown).

## Change

Added an `overrides` entry to `package.json`:

```json
"overrides": {
  "esbuild": ">=0.28.1 <0.29"
}
```

The range cap (`<0.29`) prevents silent adoption of a future breaking-change release while still allowing patch updates within 0.28.x.

## Verification

```
npm ls esbuild   → esbuild@0.28.1
npm audit        → found 0 vulnerabilities
```

## Notes

- The vulnerability is **Windows-only** (path traversal via `\` in dev server requests) — no macOS exposure.
- Override can be removed once we upgrade to vite 8 (which uses rolldown and has no esbuild dependency).