### PR TITLE
feat: add model inspect command with full-stack parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ presence_penalty=1.5  min_p=0.0  repeat_penalty=1.0
 These are baked into the database at download time and are fully user-overridable:
 
 ```bash
-# Inspect the auto-applied defaults
-gglib model list <id>
+# Inspect all stored details for a model (arch, quant, capabilities, inference defaults)
+gglib model inspect <id>
 
 # Override individual params
 gglib model update <id> --presence-penalty 0.8 --max-tokens 32768

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -3,14 +3,15 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use gglib_core::ModelFilterOptions;
+use gglib_core::{ModelCapabilities, ModelFilterOptions};
 use gglib_core::domain::Model;
 use gglib_core::ports::{GgufParserPort, ProcessRunner};
 use gglib_core::services::AppCore;
 
 use crate::error::GuiError;
 use crate::types::{
-    AddModelRequest, GuiModel, RemoveModelRequest, SetCapabilitiesRequest, UpdateModelRequest,
+    AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, SetCapabilitiesRequest,
+    UpdateModelRequest,
 };
 
 /// Dependencies for model operations.
@@ -99,10 +100,10 @@ impl ModelOps {
     /// includes raw GGUF metadata, MoE topology, and full HuggingFace
     /// provenance.  This is the shared data source for the CLI
     /// `model inspect` command and the `GET /api/models/:id/detail` route.
-    pub async fn get_detail(&self, id: i64) -> Result<crate::types::ModelDetailDto, GuiError> {
+    pub async fn get_detail(&self, id: i64) -> Result<ModelDetailDto, GuiError> {
         let model = self.resolve_model(id).await?;
         let (is_serving, port) = self.get_server_status(id).await;
-        Ok(crate::types::ModelDetailDto::from_model(model, is_serving, port))
+        Ok(ModelDetailDto::from_model(model, is_serving, port))
     }
 
     pub async fn add(&self, request: AddModelRequest) -> Result<GuiModel, GuiError> {
@@ -263,8 +264,6 @@ impl ModelOps {
         id: i64,
         request: SetCapabilitiesRequest,
     ) -> Result<GuiModel, GuiError> {
-        use gglib_core::ModelCapabilities;
-
         let mut model = self.resolve_model(id).await?;
 
         let mut caps = model.capabilities;

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -93,6 +93,18 @@ impl ModelOps {
         Ok(GuiModel::from_model(model, is_serving, port))
     }
 
+    /// Get full details for a model by ID, for the inspect view.
+    ///
+    /// Returns a [`ModelDetailDto`] — a superset of [`GuiModel`] that
+    /// includes raw GGUF metadata, MoE topology, and full HuggingFace
+    /// provenance.  This is the shared data source for the CLI
+    /// `model inspect` command and the `GET /api/models/:id/detail` route.
+    pub async fn get_detail(&self, id: i64) -> Result<crate::types::ModelDetailDto, GuiError> {
+        let model = self.resolve_model(id).await?;
+        let (is_serving, port) = self.get_server_status(id).await;
+        Ok(crate::types::ModelDetailDto::from_model(model, is_serving, port))
+    }
+
     pub async fn add(&self, request: AddModelRequest) -> Result<GuiModel, GuiError> {
         let path = PathBuf::from(&request.file_path);
 

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -3,10 +3,10 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use gglib_core::{ModelCapabilities, ModelFilterOptions};
 use gglib_core::domain::Model;
 use gglib_core::ports::{GgufParserPort, ProcessRunner};
 use gglib_core::services::AppCore;
+use gglib_core::{ModelCapabilities, ModelFilterOptions};
 
 use crate::error::GuiError;
 use crate::types::{

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -192,6 +192,133 @@ impl From<Model> for GuiModel {
 }
 
 // ============================================================================
+// Model Inspect DTO
+// ============================================================================
+
+/// Complete model details for the inspect view.
+///
+/// This is a superset of [`GuiModel`] that includes all fields from the domain
+/// [`Model`], including raw GGUF metadata, MoE topology, and full HuggingFace
+/// provenance.  It is the single shared contract consumed by:
+///
+/// - CLI: `gglib model inspect` (human-readable or `--json`)
+/// - Axum: `GET /api/models/:id/detail`
+/// - GUI frontend: model detail panel
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDetailDto {
+    // ── Core identity ─────────────────────────────────────────────────────────
+    /// Database ID of the model.
+    pub id: i64,
+    /// Human-readable name.
+    pub name: String,
+    /// Absolute path to the GGUF file on disk.
+    pub file_path: String,
+    /// Parameter count in billions.
+    pub param_count_b: f64,
+    /// Model architecture (e.g. `"llama"`, `"mistral"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    /// Quantization type (e.g. `"Q4_K_M"`, `"F16"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantization: Option<String>,
+    /// Maximum context length in tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u64>,
+    // ── MoE topology (omitted for non-MoE models) ─────────────────────────────
+    /// Total number of experts (MoE models only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expert_count: Option<u32>,
+    /// Experts activated per token (MoE models only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expert_used_count: Option<u32>,
+    /// Shared experts that are always active (MoE models only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expert_shared_count: Option<u32>,
+    // ── HuggingFace provenance ────────────────────────────────────────────────
+    /// HuggingFace repository ID (e.g. `"bartowski/Llama-3.1-8B-GGUF"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hf_repo_id: Option<String>,
+    /// Original filename on HuggingFace Hub.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hf_filename: Option<String>,
+    /// Git commit SHA from HuggingFace Hub.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hf_commit_sha: Option<String>,
+    /// When the model was downloaded from HuggingFace (`"%Y-%m-%d %H:%M:%S"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub download_date: Option<String>,
+    /// Last time an update check was performed (`"%Y-%m-%d %H:%M:%S"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_update_check: Option<String>,
+    // ── Organisation ──────────────────────────────────────────────────────────
+    /// User-defined and auto-generated tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Capability flags serialized as a `u32` bit-field.
+    #[serde(default)]
+    pub capabilities: gglib_core::ModelCapabilities,
+    // ── Inference defaults ────────────────────────────────────────────────────
+    /// Per-model inference parameter overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_defaults: Option<gglib_core::domain::InferenceConfig>,
+    // ── Timestamps ────────────────────────────────────────────────────────────
+    /// When the model was first added to the database (`"%Y-%m-%d %H:%M:%S"`).
+    pub added_at: String,
+    // ── Serving status ────────────────────────────────────────────────────────
+    /// Whether the model is currently being served.
+    #[serde(default)]
+    pub is_serving: bool,
+    /// Port the model is served on, if currently serving.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    // ── Raw GGUF key-value pairs ──────────────────────────────────────────────
+    /// All raw key-value pairs stored from the GGUF file.
+    ///
+    /// Presentation layers decide whether to surface this.  The CLI gates it
+    /// behind `--metadata`; the GUI may show it in a collapsible panel.
+    pub metadata: std::collections::HashMap<String, String>,
+}
+
+impl ModelDetailDto {
+    /// Convert a domain [`Model`] to [`ModelDetailDto`].
+    ///
+    /// `is_serving` and `port` are injected by the service layer, which has
+    /// access to the running-process list.  Pass `false` / `None` from
+    /// contexts where serving state is not relevant (e.g. the CLI).
+    pub fn from_model(model: Model, is_serving: bool, port: Option<u16>) -> Self {
+        Self {
+            id: model.id,
+            name: model.name,
+            file_path: model.file_path.to_string_lossy().to_string(),
+            param_count_b: model.param_count_b,
+            architecture: model.architecture,
+            quantization: model.quantization,
+            context_length: model.context_length,
+            expert_count: model.expert_count,
+            expert_used_count: model.expert_used_count,
+            expert_shared_count: model.expert_shared_count,
+            hf_repo_id: model.hf_repo_id,
+            hf_filename: model.hf_filename,
+            hf_commit_sha: model.hf_commit_sha,
+            download_date: model
+                .download_date
+                .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string()),
+            last_update_check: model
+                .last_update_check
+                .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string()),
+            tags: model.tags,
+            capabilities: model.capabilities,
+            inference_defaults: model.inference_defaults,
+            added_at: model.added_at.format("%Y-%m-%d %H:%M:%S").to_string(),
+            is_serving,
+            port,
+            metadata: model.metadata,
+        }
+    }
+}
+
+// ============================================================================
 // Server Types
 // ============================================================================
 

--- a/crates/gglib-axum/src/handlers/model/models.rs
+++ b/crates/gglib-axum/src/handlers/model/models.rs
@@ -6,7 +6,8 @@ use axum::extract::{Path, State};
 use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_app_services::types::{
-    AddModelRequest, GuiModel, RemoveModelRequest, SetCapabilitiesRequest, UpdateModelRequest,
+    AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, SetCapabilitiesRequest,
+    UpdateModelRequest,
 };
 use gglib_core::ModelFilterOptions;
 
@@ -117,4 +118,17 @@ pub async fn set_capabilities(
     Json(req): Json<SetCapabilitiesRequest>,
 ) -> Result<Json<GuiModel>, HttpError> {
     Ok(Json(state.models.set_capabilities(id, req).await?))
+}
+
+/// Get full details for a model by ID (inspect view).
+///
+/// Returns a [`ModelDetailDto`] containing every stored field — a superset of
+/// the [`GuiModel`] returned by `GET /api/models/{id}`.  Includes raw GGUF
+/// metadata, MoE topology, full HuggingFace provenance, capability flags,
+/// inference defaults, and timestamps.
+pub async fn detail(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<ModelDetailDto>, HttpError> {
+    Ok(Json(state.models.get_detail(id).await?))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -159,6 +159,13 @@ fn model_routes() -> Router<AppState> {
             "/{id}/capabilities",
             axum::routing::patch(handlers::model::models::set_capabilities),
         )
+        // Full inspect view: GET /api/models/{id}/detail
+        // Returns ModelDetailDto — superset of GuiModel with raw GGUF metadata,
+        // MoE topology, HuggingFace provenance, inference defaults, and timestamps.
+        .route(
+            "/{id}/detail",
+            get(handlers::model::models::detail),
+        )
         // Tags
         .route(
             "/{id}/tags",

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -162,10 +162,7 @@ fn model_routes() -> Router<AppState> {
         // Full inspect view: GET /api/models/{id}/detail
         // Returns ModelDetailDto — superset of GuiModel with raw GGUF metadata,
         // MoE topology, HuggingFace provenance, inference defaults, and timestamps.
-        .route(
-            "/{id}/detail",
-            get(handlers::model::models::detail),
-        )
+        .route("/{id}/detail", get(handlers::model::models::detail))
         // Tags
         .route(
             "/{id}/tags",

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -106,6 +106,7 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 |---------|-------------|
 | `add <path>` | Add a GGUF model to the library |
 | `list` | List all models with metadata |
+| `inspect <id\|name>` | Show full details for a model (arch, quant, capabilities, inference defaults, GGUF metadata) |
 | `remove <id>` | Remove a model from the library |
 | `serve <id>` | Start llama-server for a model |
 | `chat <id>` | Start interactive llama-cli chat |

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -5,14 +5,15 @@
 //! inference defaults, and timestamps.
 //!
 //! This handler is intentionally thin:
-//! - Model lookup via `AppCore::models().get()` (handles name **or** ID)
+//! - Flexible identifier resolution via `AppCore::models().get()` (name **or** ID)
+//! - Serving-status-aware DTO via `ModelOps::get_detail()` (same path as the Axum route)
 //! - `--json` → serialize [`ModelDetailDto`] to stdout
 //! - human mode → delegate to [`inspect_display::print_model_detail`]
 //!
 //! All terminal rendering lives in `presentation/inspect_display.rs`.
 
 use anyhow::Result;
-use gglib_app_services::types::ModelDetailDto;
+use gglib_app_services::{ModelDeps, ModelOps};
 
 use crate::bootstrap::CliContext;
 use crate::presentation::inspect_display;
@@ -24,6 +25,7 @@ pub async fn execute(
     show_metadata: bool,
     json: bool,
 ) -> Result<()> {
+    // Step 1: resolve name-or-id via the flexible core service.
     let model = match ctx.app.models().get(identifier).await? {
         Some(m) => m,
         None => {
@@ -33,7 +35,15 @@ pub async fn execute(
         }
     };
 
-    let dto = ModelDetailDto::from_model(model, false, None);
+    // Step 2: fetch the full DTO via ModelOps so serving status is included.
+    // This mirrors exactly what the Axum detail route does, ensuring CLI and
+    // REST API output are consistent for a model that is currently being served.
+    let ops = ModelOps::new(ModelDeps {
+        core: ctx.app.clone(),
+        runner: ctx.runner.clone(),
+        gguf_parser: ctx.gguf_parser.clone(),
+    });
+    let dto = ops.get_detail(model.id).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&dto)?);
@@ -43,4 +53,5 @@ pub async fn execute(
     inspect_display::print_model_detail(&dto, show_metadata);
     Ok(())
 }
+
 

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -53,5 +53,3 @@ pub async fn execute(
     inspect_display::print_model_detail(&dto, show_metadata);
     Ok(())
 }
-
-

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -1,0 +1,19 @@
+//! Inspect command handler.
+//!
+//! Displays full details for a single model — every stored field including
+//! raw GGUF metadata, MoE topology, HuggingFace provenance, capability flags,
+//! inference defaults, and timestamps.
+
+use anyhow::Result;
+
+use crate::bootstrap::CliContext;
+
+/// Execute the inspect command.
+pub async fn execute(
+    _ctx: &CliContext,
+    _identifier: &str,
+    _metadata: bool,
+    _json: bool,
+) -> Result<()> {
+    todo!("Phase 3: implement inspect handler")
+}

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -3,17 +3,44 @@
 //! Displays full details for a single model — every stored field including
 //! raw GGUF metadata, MoE topology, HuggingFace provenance, capability flags,
 //! inference defaults, and timestamps.
+//!
+//! This handler is intentionally thin:
+//! - Model lookup via `AppCore::models().get()` (handles name **or** ID)
+//! - `--json` → serialize [`ModelDetailDto`] to stdout
+//! - human mode → delegate to [`inspect_display::print_model_detail`]
+//!
+//! All terminal rendering lives in `presentation/inspect_display.rs`.
 
 use anyhow::Result;
+use gglib_app_services::types::ModelDetailDto;
 
 use crate::bootstrap::CliContext;
+use crate::presentation::inspect_display;
 
-/// Execute the inspect command.
+/// Execute `gglib model inspect <identifier> [--metadata] [--json]`.
 pub async fn execute(
-    _ctx: &CliContext,
-    _identifier: &str,
-    _metadata: bool,
-    _json: bool,
+    ctx: &CliContext,
+    identifier: &str,
+    show_metadata: bool,
+    json: bool,
 ) -> Result<()> {
-    todo!("Phase 3: implement inspect handler")
+    let model = match ctx.app.models().get(identifier).await? {
+        Some(m) => m,
+        None => {
+            eprintln!("No model found matching: '{identifier}'");
+            eprintln!("Use 'gglib model list' to see available models.");
+            return Ok(());
+        }
+    };
+
+    let dto = ModelDetailDto::from_model(model, false, None);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&dto)?);
+        return Ok(());
+    }
+
+    inspect_display::print_model_detail(&dto, show_metadata);
+    Ok(())
 }
+

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -7,7 +7,7 @@
 //! This handler is intentionally thin:
 //! - Flexible identifier resolution via `AppCore::models().get()` (name **or** ID)
 //! - Serving-status-aware DTO via `ModelOps::get_detail()` (same path as the Axum route)
-//! - `--json` → serialize [`ModelDetailDto`] to stdout
+//! - `--json` → serialize `ModelDetailDto` to stdout
 //! - human mode → delegate to [`inspect_display::print_model_detail`]
 //!
 //! All terminal rendering lives in `presentation/inspect_display.rs`.

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -6,6 +6,7 @@
 pub mod add;
 pub mod capabilities;
 pub mod download;
+pub mod inspect;
 pub mod list;
 pub mod remove;
 pub mod retag;
@@ -133,6 +134,13 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
         }
         ModelCommand::Capabilities { id, set, unset } => {
             capabilities::execute(ctx, id, set, unset).await?;
+        }
+        ModelCommand::Inspect {
+            identifier,
+            metadata,
+            json,
+        } => {
+            inspect::execute(ctx, &identifier, metadata, json).await?;
         }
     }
     Ok(())

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -254,4 +254,27 @@ pub enum ModelCommand {
         #[arg(long = "unset", value_name = "FLAG", action = clap::ArgAction::Append)]
         unset: Vec<String>,
     },
+
+    /// Display full details for a single model.
+    ///
+    /// Shows every piece of stored information: architecture, quantization,
+    /// context length, MoE topology, HuggingFace provenance, capability flags,
+    /// inference defaults, and timestamps.
+    ///
+    /// # Examples
+    ///
+    ///   gglib model inspect 3
+    ///   gglib model inspect "Llama-3-8B"
+    ///   gglib model inspect 3 --metadata   # include raw GGUF key-value pairs
+    ///   gglib model inspect 3 --json       # machine-readable JSON output
+    Inspect {
+        /// Name or ID of the model to inspect
+        identifier: String,
+        /// Include raw GGUF key-value metadata in the output
+        #[arg(long)]
+        metadata: bool,
+        /// Output as JSON instead of human-readable format
+        #[arg(long)]
+        json: bool,
+    },
 }

--- a/crates/gglib-cli/src/presentation/inspect_display.rs
+++ b/crates/gglib-cli/src/presentation/inspect_display.rs
@@ -34,10 +34,7 @@ pub fn print_model_detail(dto: &ModelDetailDto, show_metadata: bool) {
         println!("  Context Length : {ctx} tokens");
     }
     if dto.is_serving {
-        let port_str = dto
-            .port
-            .map(|p| format!(" (port {p})"))
-            .unwrap_or_default();
+        let port_str = dto.port.map(|p| format!(" (port {p})")).unwrap_or_default();
         println!("  Serving        : yes{port_str}");
     }
 

--- a/crates/gglib-cli/src/presentation/inspect_display.rs
+++ b/crates/gglib-cli/src/presentation/inspect_display.rs
@@ -1,0 +1,184 @@
+//! Terminal formatter for `gglib model inspect`.
+//!
+//! All rendering logic lives here; the handler in
+//! `handlers/model/inspect.rs` is kept thin — it only fetches the model,
+//! branches on `--json`, and delegates to [`print_model_detail`].
+
+use gglib_app_services::types::ModelDetailDto;
+use gglib_core::ModelCapabilities;
+
+use crate::presentation::{format_relative_time, print_separator};
+
+const SEP_WIDTH: usize = 60;
+
+/// Render all sections for the given [`ModelDetailDto`] to stdout.
+///
+/// The `show_metadata` flag gates the raw GGUF key-value section.  Pass
+/// `true` only when the user supplies `--metadata` — the dictionary can be
+/// several hundred lines for large models.
+pub fn print_model_detail(dto: &ModelDetailDto, show_metadata: bool) {
+    // ── Overview ──────────────────────────────────────────────────────────────
+    print_separator(SEP_WIDTH);
+    println!("  Model: {}", dto.name);
+    print_separator(SEP_WIDTH);
+    println!("  ID             : {}", dto.id);
+    println!("  File           : {}", dto.file_path);
+    println!("  Parameters     : {:.1}B", dto.param_count_b);
+    if let Some(arch) = &dto.architecture {
+        println!("  Architecture   : {arch}");
+    }
+    if let Some(quant) = &dto.quantization {
+        println!("  Quantization   : {quant}");
+    }
+    if let Some(ctx) = dto.context_length {
+        println!("  Context Length : {ctx} tokens");
+    }
+    if dto.is_serving {
+        let port_str = dto
+            .port
+            .map(|p| format!(" (port {p})"))
+            .unwrap_or_default();
+        println!("  Serving        : yes{port_str}");
+    }
+
+    // ── MoE Topology (MoE models only) ────────────────────────────────────────
+    if dto.expert_count.is_some() {
+        println!();
+        println!("  MoE Topology");
+        print_separator(SEP_WIDTH);
+        if let Some(n) = dto.expert_count {
+            println!("  Total Experts  : {n}");
+        }
+        if let Some(n) = dto.expert_used_count {
+            println!("  Used / Token   : {n}");
+        }
+        if let Some(n) = dto.expert_shared_count {
+            println!("  Shared Experts : {n}");
+        }
+    }
+
+    // ── HuggingFace Provenance ─────────────────────────────────────────────────
+    if dto.hf_repo_id.is_some() {
+        println!();
+        println!("  HuggingFace");
+        print_separator(SEP_WIDTH);
+        if let Some(repo) = &dto.hf_repo_id {
+            println!("  Repo           : {repo}");
+        }
+        if let Some(filename) = &dto.hf_filename {
+            println!("  Filename       : {filename}");
+        }
+        if let Some(sha) = &dto.hf_commit_sha {
+            // Show first 12 chars — enough to identify, not overwhelming.
+            println!("  Commit SHA     : {}", &sha[..sha.len().min(12)]);
+        }
+        if let Some(dl) = &dto.download_date {
+            println!("  Downloaded     : {dl} ({})", format_relative_time(dl));
+        }
+        if let Some(upd) = &dto.last_update_check {
+            println!("  Update Check   : {upd} ({})", format_relative_time(upd));
+        }
+    }
+
+    // ── Tags ──────────────────────────────────────────────────────────────────
+    if !dto.tags.is_empty() {
+        println!();
+        println!("  Tags");
+        print_separator(SEP_WIDTH);
+        println!("  {}", dto.tags.join(", "));
+    }
+
+    // ── Capabilities ──────────────────────────────────────────────────────────
+    println!();
+    println!("  Capabilities");
+    print_separator(SEP_WIDTH);
+    let caps = dto.capabilities;
+    println!(
+        "  supports-system-role  : {}",
+        flag_str(caps.contains(ModelCapabilities::SUPPORTS_SYSTEM_ROLE))
+    );
+    println!(
+        "  requires-strict-turns : {}",
+        flag_str(caps.contains(ModelCapabilities::REQUIRES_STRICT_TURNS))
+    );
+    println!(
+        "  supports-tool-calls   : {}",
+        flag_str(caps.contains(ModelCapabilities::SUPPORTS_TOOL_CALLS))
+    );
+    println!(
+        "  supports-reasoning    : {}",
+        flag_str(caps.contains(ModelCapabilities::SUPPORTS_REASONING))
+    );
+
+    // ── Inference Defaults ────────────────────────────────────────────────────
+    if let Some(inf) = &dto.inference_defaults {
+        let has_any = inf.temperature.is_some()
+            || inf.top_p.is_some()
+            || inf.top_k.is_some()
+            || inf.max_tokens.is_some()
+            || inf.repeat_penalty.is_some()
+            || inf.presence_penalty.is_some()
+            || inf.min_p.is_some();
+
+        if has_any {
+            println!();
+            println!("  Inference Defaults");
+            print_separator(SEP_WIDTH);
+            print_opt_f32("  temperature      ", inf.temperature);
+            print_opt_f32("  top_p            ", inf.top_p);
+            print_opt_i32("  top_k            ", inf.top_k);
+            print_opt_u32("  max_tokens       ", inf.max_tokens);
+            print_opt_f32("  repeat_penalty   ", inf.repeat_penalty);
+            print_opt_f32("  presence_penalty ", inf.presence_penalty);
+            print_opt_f32("  min_p            ", inf.min_p);
+        }
+    }
+
+    // ── Timestamps ────────────────────────────────────────────────────────────
+    println!();
+    println!("  Timestamps");
+    print_separator(SEP_WIDTH);
+    println!(
+        "  Added          : {} ({})",
+        dto.added_at,
+        format_relative_time(&dto.added_at)
+    );
+
+    // ── Raw GGUF Metadata ─────────────────────────────────────────────────────
+    if show_metadata && !dto.metadata.is_empty() {
+        println!();
+        println!("  Raw GGUF Metadata  ({} keys)", dto.metadata.len());
+        print_separator(SEP_WIDTH);
+        let mut pairs: Vec<_> = dto.metadata.iter().collect();
+        pairs.sort_by_key(|(k, _)| k.as_str());
+        for (key, value) in pairs {
+            println!("  {key} = {value}");
+        }
+    }
+
+    print_separator(SEP_WIDTH);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn flag_str(v: bool) -> &'static str {
+    if v { "yes" } else { "no" }
+}
+
+fn print_opt_f32(label: &str, value: Option<f32>) {
+    if let Some(v) = value {
+        println!("{label} : {v}");
+    }
+}
+
+fn print_opt_i32(label: &str, value: Option<i32>) {
+    if let Some(v) = value {
+        println!("{label} : {v}");
+    }
+}
+
+fn print_opt_u32(label: &str, value: Option<u32>) {
+    if let Some(v) = value {
+        println!("{label} : {v}");
+    }
+}

--- a/crates/gglib-cli/src/presentation/mod.rs
+++ b/crates/gglib-cli/src/presentation/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod dag;
 pub mod input;
+pub mod inspect_display;
 pub mod model_display;
 pub mod style;
 pub mod tables;


### PR DESCRIPTION
## Summary

Adds `gglib model inspect <id|name>` — a new command that displays every piece of stored information about a single model. Fills a gap that required users to cross-reference `model list`, `model capabilities`, and raw database queries to get a complete picture.

## What's new

| Layer | Change |
|-------|--------|
| `gglib-app-services` | New `ModelDetailDto` (superset of `GuiModel`); new `ModelOps::get_detail()` |
| CLI | `gglib model inspect <id|name> [--metadata] [--json]` |
| Axum | `GET /api/models/:id/detail` → `Json<ModelDetailDto>` |

## CLI output sections

```
------------------------------------------------------------
  Model: Llama-3-8B-Instruct
------------------------------------------------------------
  ID             : 3
  File           : /models/llama-3-8b.gguf
  Parameters     : 8.0B
  Architecture   : llama
  Quantization   : Q4_K_M
  Context Length : 131072 tokens

  HuggingFace
  ------------------------------------------------------------
  Repo           : bartowski/Meta-Llama-3-8B-Instruct-GGUF
  Filename       : Meta-Llama-3-8B-Instruct-Q4_K_M.gguf
  Downloaded     : 2025-06-10 14:22:01 (10 days ago)

  Capabilities
  ------------------------------------------------------------
  supports-system-role  : yes
  requires-strict-turns : no
  supports-tool-calls   : yes
  supports-reasoning    : no

  Timestamps
  ------------------------------------------------------------
  Added          : 2025-06-10 14:22:04 (10 days ago)
------------------------------------------------------------
```

Pass `--metadata` to append raw GGUF key-value pairs.  
Pass `--json` to get the full `ModelDetailDto` as pretty-printed JSON on stdout.

## Architecture

- `ModelDetailDto` lives in `gglib-app-services` alongside `GuiModel`, following the existing DTO convention
- CLI uses a two-step resolve: `AppCore::models().get()` for flexible name-or-id lookup, then `ModelOps::get_detail()` for serving-status-aware DTO construction — the same path the Axum route takes
- No `#[tauri::command]` needed; the Tauri frontend calls the Axum HTTP API

## Also fixed

- `README.md` referenced `gglib model list <id>` (which takes no arguments) in the inference-defaults section — corrected to `gglib model inspect <id>`

## Related tech debt (separate issue)

Several other model commands (`capabilities`, `verify`, `repair`, `update`) accept only numeric IDs while `remove`, `retag`, and `inspect` accept name-or-id strings. This inconsistency predates this PR and deserves a focused follow-up.