### PR TITLE
refactor(cli): standardise model commands to accept name-or-id identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-agent"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-app"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-app-services"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-axum"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-bootstrap"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1981,14 +1981,14 @@ dependencies = [
 
 [[package]]
 name = "gglib-build-info"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "vergen-gix",
 ]
 
 [[package]]
 name = "gglib-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-db"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-download"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-gguf"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "gglib-core",
  "memmap2",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-hf"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "gglib-core",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-mcp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-proxy"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-runtime"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "gglib-tauri"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "gglib-app-services",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 # Shared package metadata for all workspace crates
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/mmogr/gglib"

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -124,8 +124,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `council show <id>` | Show run details + event timeline |
 | `council resume <id>` | Continue an interrupted run |
 | `council rewind <id> --wave N` | Roll back to a previous wave and re-execute |
-| `verify <id>` | Verify model integrity via SHA256 hash comparison |
-| `repair <id>` | Re-download corrupt shards for a model |
+| `verify <id\|name>` | Verify model integrity via SHA256 hash comparison |
+| `repair <id\|name>` | Re-download corrupt shards for a model |
 | `completions <shell>` | Print a shell completion script to stdout |
 
 ### Shell Completions

--- a/crates/gglib-cli/src/handlers/model/capabilities.rs
+++ b/crates/gglib-cli/src/handlers/model/capabilities.rs
@@ -13,6 +13,7 @@ use gglib_app_services::{ModelDeps, ModelOps};
 use gglib_core::ModelCapabilities;
 
 use crate::bootstrap::CliContext;
+use super::resolver;
 
 /// Execute `gglib model capabilities <id> [--set FLAG]... [--unset FLAG]...`.
 ///
@@ -21,10 +22,12 @@ use crate::bootstrap::CliContext;
 /// via [`ModelOps::set_capabilities`] and prints the updated state.
 pub async fn execute(
     ctx: &CliContext,
-    id: u32,
+    identifier: &str,
     set: Vec<String>,
     unset: Vec<String>,
 ) -> Result<()> {
+    let core_model = resolver::resolve_model_identifier(ctx, identifier).await?;
+
     // Build-once — ModelOps is cheap and constructed the same way as in Axum/Tauri.
     let ops = ModelOps::new(ModelDeps {
         core: ctx.app.clone(),
@@ -34,8 +37,8 @@ pub async fn execute(
 
     // Read-only: no flags provided.
     if set.is_empty() && unset.is_empty() {
-        let model = ops.get(id as i64).await?;
-        print_capabilities(id, &model.name, model.capabilities);
+        let model = ops.get(core_model.id).await?;
+        print_capabilities(core_model.id, &model.name, model.capabilities);
         return Ok(());
     }
 
@@ -49,13 +52,13 @@ pub async fn execute(
         apply_flag(&mut req, flag, false)?;
     }
 
-    let gui_model = ops.set_capabilities(id as i64, req).await?;
+    let gui_model = ops.set_capabilities(core_model.id, req).await?;
 
     println!(
         "Updated capabilities for model {} ({}):",
-        id, gui_model.name
+        core_model.id, gui_model.name
     );
-    print_capabilities(id, &gui_model.name, gui_model.capabilities);
+    print_capabilities(core_model.id, &gui_model.name, gui_model.capabilities);
 
     Ok(())
 }
@@ -79,7 +82,7 @@ fn apply_flag(req: &mut SetCapabilitiesRequest, flag: &str, value: bool) -> Resu
 }
 
 /// Pretty-print the capability state for a model.
-fn print_capabilities(id: u32, name: &str, caps: ModelCapabilities) {
+fn print_capabilities(id: i64, name: &str, caps: ModelCapabilities) {
     println!("Capabilities for model {id} ({name}):");
     println!(
         "  supports-system-role  : {}",

--- a/crates/gglib-cli/src/handlers/model/capabilities.rs
+++ b/crates/gglib-cli/src/handlers/model/capabilities.rs
@@ -12,8 +12,8 @@ use gglib_app_services::types::SetCapabilitiesRequest;
 use gglib_app_services::{ModelDeps, ModelOps};
 use gglib_core::ModelCapabilities;
 
-use crate::bootstrap::CliContext;
 use super::resolver;
+use crate::bootstrap::CliContext;
 
 /// Execute `gglib model capabilities <id> [--set FLAG]... [--unset FLAG]...`.
 ///

--- a/crates/gglib-cli/src/handlers/model/download/check_updates.rs
+++ b/crates/gglib-cli/src/handlers/model/download/check_updates.rs
@@ -5,11 +5,12 @@
 use anyhow::Result;
 
 use crate::bootstrap::CliContext;
+use crate::handlers::model::resolver;
 
 /// Execute the check-updates command.
 ///
 /// Checks if locally downloaded models have updates available on HuggingFace.
-pub async fn execute(ctx: &CliContext, model_id: Option<u32>, all: bool) -> Result<()> {
+pub async fn execute(ctx: &CliContext, identifier: Option<&str>, all: bool) -> Result<()> {
     if all {
         println!("Checking updates for all models...");
         let models = ctx.app.models().list().await?;
@@ -29,24 +30,18 @@ pub async fn execute(ctx: &CliContext, model_id: Option<u32>, all: bool) -> Resu
                 );
             }
         }
-    } else if let Some(id) = model_id {
-        match ctx.app.models().get_by_id(id as i64).await? {
-            Some(model) => {
-                if let Some(hf_repo) = &model.hf_repo_id {
-                    check_model_update(&model, hf_repo).await?;
-                } else {
-                    println!(
-                        "Model '{}' is not from HuggingFace, cannot check for updates.",
-                        model.name
-                    );
-                }
-            }
-            None => {
-                println!("Model with ID {} not found.", id);
-            }
+    } else if let Some(ident) = identifier {
+        let model = resolver::resolve_model_identifier(ctx, ident).await?;
+        if let Some(hf_repo) = &model.hf_repo_id {
+            check_model_update(&model, hf_repo).await?;
+        } else {
+            println!(
+                "Model '{}' is not from HuggingFace, cannot check for updates.",
+                model.name
+            );
         }
     } else {
-        println!("Please specify --model-id <ID> or --all to check for updates.");
+        println!("Please specify --identifier <id|name> or --all to check for updates.");
     }
 
     Ok(())

--- a/crates/gglib-cli/src/handlers/model/download/update_model.rs
+++ b/crates/gglib-cli/src/handlers/model/download/update_model.rs
@@ -7,21 +7,17 @@ use chrono::Utc;
 use gglib_download::cli_exec::{self, CliUpdateRequest};
 
 use crate::bootstrap::CliContext;
+use crate::handlers::model::resolver;
 use gglib_core::paths::resolve_models_dir;
 
 /// Execute the update-model command.
 ///
 /// Updates a model to the latest version from HuggingFace.
-pub async fn execute(ctx: &CliContext, model_id: u32) -> Result<()> {
+pub async fn execute(ctx: &CliContext, identifier: &str) -> Result<()> {
     let models_dir = resolve_models_dir(None)?.path;
 
     // Get model from database
-    let mut model = ctx
-        .app
-        .models()
-        .get_by_id(model_id as i64)
-        .await?
-        .ok_or_else(|| anyhow!("Model with ID {} not found", model_id))?;
+    let mut model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
     let hf_repo = model
         .hf_repo_id
@@ -35,7 +31,7 @@ pub async fn execute(ctx: &CliContext, model_id: u32) -> Result<()> {
         .ok_or_else(|| anyhow!("Model has no quantization info stored"))?
         .clone();
 
-    println!("Updating model {} (ID: {})...", model.name, model_id);
+    println!("Updating model {} (ID: {})...", model.name, model.id);
     println!("  Repository: {}", hf_repo);
     println!("  Quantization: {}", quantization);
 

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -82,7 +82,10 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
         } => {
             retag::execute(ctx, identifier, all, full).await?;
         }
-        ModelCommand::Verify { identifier, verbose } => {
+        ModelCommand::Verify {
+            identifier,
+            verbose,
+        } => {
             verification::execute_verify(ctx, &identifier, verbose).await?;
         }
         ModelCommand::Repair {
@@ -133,7 +136,11 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
         } => {
             download::browse(category, limit, size).await?;
         }
-        ModelCommand::Capabilities { identifier, set, unset } => {
+        ModelCommand::Capabilities {
+            identifier,
+            set,
+            unset,
+        } => {
             capabilities::execute(ctx, &identifier, set, unset).await?;
         }
         ModelCommand::Inspect {

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -9,6 +9,7 @@ pub mod download;
 pub mod inspect;
 pub mod list;
 pub mod remove;
+pub mod resolver;
 pub mod retag;
 pub mod update;
 pub mod verification;
@@ -31,7 +32,7 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
             remove::execute(ctx, &identifier, force).await?;
         }
         ModelCommand::Update {
-            id,
+            identifier,
             name,
             param_count,
             architecture,
@@ -52,7 +53,7 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
             force,
         } => {
             let args = update::UpdateArgs {
-                id,
+                identifier,
                 name,
                 param_count,
                 architecture,
@@ -81,15 +82,15 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
         } => {
             retag::execute(ctx, identifier, all, full).await?;
         }
-        ModelCommand::Verify { model_id, verbose } => {
-            verification::execute_verify(ctx, model_id, verbose).await?;
+        ModelCommand::Verify { identifier, verbose } => {
+            verification::execute_verify(ctx, &identifier, verbose).await?;
         }
         ModelCommand::Repair {
-            model_id,
+            identifier,
             shards,
             force,
         } => {
-            verification::execute_repair(ctx, model_id, shards, force).await?;
+            verification::execute_repair(ctx, &identifier, shards, force).await?;
         }
         ModelCommand::Download {
             model_id,
@@ -108,14 +109,14 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
             };
             download::download(ctx, args).await?;
         }
-        ModelCommand::CheckUpdates { model_id, all } => {
-            download::check_updates(ctx, model_id, all).await?;
+        ModelCommand::CheckUpdates { identifier, all } => {
+            download::check_updates(ctx, identifier.as_deref(), all).await?;
         }
         ModelCommand::Upgrade {
-            model_id,
+            identifier,
             force: _force,
         } => {
-            download::update_model(ctx, model_id).await?;
+            download::update_model(ctx, &identifier).await?;
         }
         ModelCommand::Search {
             query,
@@ -132,8 +133,8 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
         } => {
             download::browse(category, limit, size).await?;
         }
-        ModelCommand::Capabilities { id, set, unset } => {
-            capabilities::execute(ctx, id, set, unset).await?;
+        ModelCommand::Capabilities { identifier, set, unset } => {
+            capabilities::execute(ctx, &identifier, set, unset).await?;
         }
         ModelCommand::Inspect {
             identifier,

--- a/crates/gglib-cli/src/handlers/model/resolver.rs
+++ b/crates/gglib-cli/src/handlers/model/resolver.rs
@@ -18,14 +18,10 @@ use crate::bootstrap::CliContext;
 /// returns an error with a helpful message rather than `Ok(None)`, ensuring
 /// consistent non-zero exit codes across all callers.
 pub async fn resolve_model_identifier(ctx: &CliContext, identifier: &str) -> Result<Model> {
-    ctx.app
-        .models()
-        .get(identifier)
-        .await?
-        .ok_or_else(|| {
-            anyhow!(
-                "No model found matching: '{identifier}'\n\
+    ctx.app.models().get(identifier).await?.ok_or_else(|| {
+        anyhow!(
+            "No model found matching: '{identifier}'\n\
                  Use 'gglib model list' to see available models."
-            )
-        })
+        )
+    })
 }

--- a/crates/gglib-cli/src/handlers/model/resolver.rs
+++ b/crates/gglib-cli/src/handlers/model/resolver.rs
@@ -1,0 +1,31 @@
+//! Model identifier resolver.
+//!
+//! Provides a single entry-point for resolving a user-supplied identifier
+//! (either a numeric ID or a model name) to a [`Model`] record.  All model
+//! command handlers use this instead of calling `get_by_id` directly, giving
+//! every command consistent name-or-id resolution and error messaging.
+//!
+//! [`Model`]: gglib_core::domain::Model
+
+use anyhow::{Result, anyhow};
+use gglib_core::domain::Model;
+
+use crate::bootstrap::CliContext;
+
+/// Resolve a user-supplied identifier to a [`Model`].
+///
+/// Accepts either a numeric model ID or a model name.  If no model matches,
+/// returns an error with a helpful message rather than `Ok(None)`, ensuring
+/// consistent non-zero exit codes across all callers.
+pub async fn resolve_model_identifier(ctx: &CliContext, identifier: &str) -> Result<Model> {
+    ctx.app
+        .models()
+        .get(identifier)
+        .await?
+        .ok_or_else(|| {
+            anyhow!(
+                "No model found matching: '{identifier}'\n\
+                 Use 'gglib model list' to see available models."
+            )
+        })
+}

--- a/crates/gglib-cli/src/handlers/model/update.rs
+++ b/crates/gglib-cli/src/handlers/model/update.rs
@@ -13,7 +13,7 @@ use crate::bootstrap::CliContext;
 /// Arguments for the update command.
 #[derive(Debug, Clone)]
 pub struct UpdateArgs {
-    pub id: u32,
+    pub identifier: String,
     pub name: Option<String>,
     pub param_count: Option<f64>,
     pub architecture: Option<String>,
@@ -48,13 +48,13 @@ pub struct UpdateArgs {
 ///
 /// Returns `Result<()>` indicating the success or failure of the operation.
 pub async fn execute(ctx: &CliContext, args: UpdateArgs) -> Result<()> {
-    // Get the existing model by ID
+    // Get the existing model by name or ID
     let existing_model = ctx
         .app
         .models()
-        .get_by_id(args.id as i64)
+        .get(&args.identifier)
         .await?
-        .ok_or_else(|| anyhow!("Model with ID {} not found", args.id))?;
+        .ok_or_else(|| anyhow!("No model found matching: '{}'", args.identifier))?;
 
     // Verify the file still exists
     if !existing_model.file_path.exists() && !args.force {
@@ -523,7 +523,7 @@ mod tests {
     fn test_create_updated_model() {
         let existing = create_test_model();
         let args = UpdateArgs {
-            id: 1,
+            identifier: "1".to_string(),
             name: Some("Updated Name".to_string()),
             param_count: Some(13.0),
             architecture: Some("mistral".to_string()),

--- a/crates/gglib-cli/src/handlers/model/verification.rs
+++ b/crates/gglib-cli/src/handlers/model/verification.rs
@@ -7,34 +7,30 @@ use anyhow::Result;
 use std::time::Instant;
 
 use crate::bootstrap::CliContext;
+use super::resolver;
 
 /// Execute the verify command.
 ///
 /// Verifies model integrity by computing SHA256 hashes and comparing against
 /// stored OIDs from HuggingFace.
-pub async fn execute_verify(ctx: &CliContext, model_id: i64, verbose: bool) -> Result<()> {
+pub async fn execute_verify(ctx: &CliContext, identifier: &str, verbose: bool) -> Result<()> {
     // Get verification service
     let verification = ctx
         .app
         .verification()
         .ok_or_else(|| anyhow::anyhow!("Verification service not available"))?;
 
-    // Get model info for display
-    let model = ctx
-        .app
-        .models()
-        .get_by_id(model_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Model with ID {} not found", model_id))?;
+    // Resolve name-or-id to a model record.
+    let model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
-    println!("🔍 Verifying model: {}", model.name);
+    println!("\u{1f50d} Verifying model: {}", model.name);
     println!();
 
     let start = Instant::now();
 
     // Start verification
     let (mut progress_rx, handle) = verification
-        .verify_model_integrity(model_id)
+        .verify_model_integrity(model.id)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to start verification: {}", e))?;
 
@@ -139,7 +135,7 @@ pub async fn execute_verify(ctx: &CliContext, model_id: i64, verbose: bool) -> R
         println!();
         println!(
             "⚠️  Model has integrity issues. Run 'gglib model repair {}' to fix.",
-            model_id
+            model.name
         );
         std::process::exit(1);
     }
@@ -152,7 +148,7 @@ pub async fn execute_verify(ctx: &CliContext, model_id: i64, verbose: bool) -> R
 /// Repairs a corrupt model by deleting failed shards and re-downloading them.
 pub async fn execute_repair(
     ctx: &CliContext,
-    model_id: i64,
+    identifier: &str,
     shards: Option<String>,
     force: bool,
 ) -> Result<()> {
@@ -162,15 +158,10 @@ pub async fn execute_repair(
         .verification()
         .ok_or_else(|| anyhow::anyhow!("Verification service not available"))?;
 
-    // Get model info for display
-    let model = ctx
-        .app
-        .models()
-        .get_by_id(model_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Model with ID {} not found", model_id))?;
+    // Resolve name-or-id to a model record.
+    let model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
-    println!("🔧 Repairing model: {}", model.name);
+    println!("\u{1f527} Repairing model: {}", model.name);
 
     // Parse shard indices if provided
     let shard_indices = if let Some(shard_str) = shards {
@@ -209,7 +200,7 @@ pub async fn execute_repair(
 
     // Execute repair
     verification
-        .repair_model(model_id, shard_indices)
+        .repair_model(model.id, shard_indices)
         .await
         .map_err(|e| anyhow::anyhow!("Repair failed: {}", e))?;
 
@@ -218,7 +209,7 @@ pub async fn execute_repair(
     println!("Note: The model files have been queued for re-download.");
     println!(
         "      Use 'gglib model verify {}' to check status after download completes.",
-        model_id
+        model.name
     );
 
     Ok(())

--- a/crates/gglib-cli/src/handlers/model/verification.rs
+++ b/crates/gglib-cli/src/handlers/model/verification.rs
@@ -6,8 +6,8 @@
 use anyhow::Result;
 use std::time::Instant;
 
-use crate::bootstrap::CliContext;
 use super::resolver;
+use crate::bootstrap::CliContext;
 
 /// Execute the verify command.
 ///

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -32,8 +32,8 @@ pub enum ModelCommand {
 
     /// Update model metadata in the database
     Update {
-        /// ID of the model to update
-        id: u32,
+        /// Name or ID of the model to update
+        identifier: String,
         /// New name for the model
         #[arg(short, long)]
         name: Option<String>,
@@ -116,8 +116,8 @@ pub enum ModelCommand {
 
     /// Verify model integrity by computing SHA256 hashes
     Verify {
-        /// ID of the model to verify
-        model_id: i64,
+        /// Name or ID of the model to verify
+        identifier: String,
         /// Show detailed progress for each shard
         #[arg(short, long)]
         verbose: bool,
@@ -125,8 +125,8 @@ pub enum ModelCommand {
 
     /// Repair a corrupt model by re-downloading failed shards
     Repair {
-        /// ID of the model to repair
-        model_id: i64,
+        /// Name or ID of the model to repair
+        identifier: String,
         /// Specific shard indices to repair (comma-separated, e.g., "0,2,5")
         #[arg(short, long)]
         shards: Option<String>,
@@ -175,9 +175,9 @@ pub enum ModelCommand {
 
     /// Check for updates to downloaded models
     CheckUpdates {
-        /// Check specific model by ID
-        #[arg(short, long)]
-        model_id: Option<u32>,
+        /// Check a specific model by name or ID
+        #[arg(long)]
+        identifier: Option<String>,
         /// Check all models
         #[arg(long)]
         all: bool,
@@ -185,8 +185,8 @@ pub enum ModelCommand {
 
     /// Upgrade a model to the latest version
     Upgrade {
-        /// ID of the model to upgrade
-        model_id: u32,
+        /// Name or ID of the model to upgrade
+        identifier: String,
         /// Skip confirmation prompt
         #[arg(short, long)]
         force: bool,
@@ -240,8 +240,8 @@ pub enum ModelCommand {
     ///
     ///   gglib model capabilities 3 --unset supports-reasoning
     Capabilities {
-        /// ID of the model to inspect or modify
-        id: u32,
+        /// Name or ID of the model to inspect or modify
+        identifier: String,
         /// Set a capability flag (can be repeated).
         ///
         /// Accepted values: `supports-system-role`, `requires-strict-turns`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gglib-gui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Modern GUI for GGLib GGUF Model Manager",
   "author": "mmogr",
   "license": "AGPL-3.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "GGLib GUI",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "com.gglib.gui",
   "build": {
     "beforeBuildCommand": "npm run build:tauri",


### PR DESCRIPTION
Closes #544.

## Summary

Six model subcommands previously accepted only a numeric database ID. All six now accept either a numeric ID or a model name, matching the existing behaviour of `inspect` and `remove`.

| Command | Before | After |
|---|---|---|
| `capabilities` | `id: u32` | `identifier: String` |
| `verify` | `model_id: i64` | `identifier: String` |
| `repair` | `model_id: i64` | `identifier: String` |
| `update` | `id: u32` | `identifier: String` |
| `upgrade` | `model_id: u32` | `identifier: String` |
| `check-updates` | `model_id: Option<u32>` | `identifier: Option<String>` |

`check-updates` flag renamed `--model-id` → `--identifier` (intentional breaking change).

## Implementation

- **New:** `crates/gglib-cli/src/handlers/model/resolver.rs`  
  `resolve_model_identifier(ctx, identifier)` wraps `AppCore::models().get()` (two-step: numeric parse → name lookup) and returns `Err` on not-found for consistent non-zero exits. Lives alongside the other handler modules; `mod.rs` stays strictly routing.

- All six handlers call the resolver and use `model.id: i64` for downstream service calls — all `u32`/`i64` casts removed.

- `verification.rs`: cross-command hint strings now show `model.name` instead of the old numeric ID variable.

- `README.md`: `<id>` → `<id|name>` for `verify` and `repair` entries.

## Verification

```
cargo check -p gglib-cli          # zero warnings
cargo test -p gglib-cli           # 3 passed, 0 failed
cargo clippy -p gglib-cli -D warnings  # clean
cargo doc --workspace --no-deps --exclude gglib-app  # no new warnings
```