### PR TITLE
feat: unified inference defaults across all surfaces (proxy, chat, q, agent REPL)

### DIFF
--- a/crates/gglib-app-services/src/proxy.rs
+++ b/crates/gglib-app-services/src/proxy.rs
@@ -161,7 +161,14 @@ impl ProxyOps {
 
         // Start the proxy
         self.supervisor
-            .start(config, runtime, catalog, self.mcp.clone(), orchestrator, self.core.settings().repo())
+            .start(
+                config,
+                runtime,
+                catalog,
+                self.mcp.clone(),
+                orchestrator,
+                self.core.settings().repo(),
+            )
             .await
             .map_err(|e| match e {
                 SupervisorError::AlreadyRunning(addr) => {

--- a/crates/gglib-app-services/src/proxy.rs
+++ b/crates/gglib-app-services/src/proxy.rs
@@ -161,7 +161,7 @@ impl ProxyOps {
 
         // Start the proxy
         self.supervisor
-            .start(config, runtime, catalog, self.mcp.clone(), orchestrator)
+            .start(config, runtime, catalog, self.mcp.clone(), orchestrator, self.core.settings().repo())
             .await
             .map_err(|e| match e {
                 SupervisorError::AlreadyRunning(addr) => {

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -436,9 +436,9 @@ pub async fn proxy_chat(
         .ok()
         .and_then(|s| s.inference_defaults);
 
-    // Resolve inference parameters using hierarchy:
+    // Resolve inference parameters using the 4-level hierarchy:
     // Request → Model → Global → Hardcoded defaults
-    let mut resolved = gglib_core::domain::InferenceConfig {
+    let resolved = gglib_core::domain::InferenceConfig {
         temperature: request.temperature,
         top_p: request.top_p,
         top_k: request.top_k,
@@ -446,20 +446,8 @@ pub async fn proxy_chat(
         repeat_penalty: request.repeat_penalty,
         presence_penalty: request.presence_penalty,
         min_p: request.min_p,
-    };
-
-    // Apply model defaults (if missing)
-    if let Some(model_defaults) = model_defaults {
-        resolved.merge_with(&model_defaults);
     }
-
-    // Apply global settings defaults (if missing)
-    if let Some(global_defaults) = global_defaults {
-        resolved.merge_with(&global_defaults);
-    }
-
-    // Apply hardcoded defaults for any still-missing values
-    resolved.merge_with(&gglib_core::domain::InferenceConfig::with_hardcoded_defaults());
+    .resolve_with_defaults(model_defaults.as_ref(), global_defaults.as_ref());
 
     tracing::debug!(
         port = request.port,

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -398,5 +398,40 @@ pub enum Commands {
         /// compiled default (4096) if unset. Accepts a positive number or `max`.
         #[arg(long)]
         default_context: Option<String>,
+
+        /// Override sampling temperature for this proxy session (0.0–2.0).
+        ///
+        /// Applied as a global default: requests that don't specify temperature
+        /// will use this value. Per-request and per-model values still win.
+        #[arg(long)]
+        temperature: Option<f32>,
+
+        /// Override nucleus sampling top-p for this proxy session (0.0–1.0).
+        #[arg(long)]
+        top_p: Option<f32>,
+
+        /// Override top-k sampling limit for this proxy session.
+        #[arg(long)]
+        top_k: Option<i32>,
+
+        /// Override max tokens to generate for this proxy session.
+        #[arg(long)]
+        max_tokens: Option<u32>,
+
+        /// Override repetition penalty for this proxy session (typically 1.0–1.3).
+        #[arg(long)]
+        repeat_penalty: Option<f32>,
+
+        /// Override presence penalty for this proxy session (0.0–2.0).
+        ///
+        /// Useful for reasoning/thinking models (e.g. `1.5` for Qwen3, DeepSeek-R1).
+        #[arg(long)]
+        presence_penalty: Option<f32>,
+
+        /// Override min-p sampling threshold for this proxy session (0.0–1.0).
+        ///
+        /// Set `0.0` to disable (recommended by Qwen3).
+        #[arg(long)]
+        min_p: Option<f32>,
     },
 }

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -274,23 +274,26 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 .value
                 .map(u64::from)
                 .unwrap_or(DEFAULT_CONTEXT_SIZE);
-            let inference_override =
-                if temperature.is_some() || top_p.is_some() || top_k.is_some()
-                    || max_tokens.is_some() || repeat_penalty.is_some()
-                    || presence_penalty.is_some() || min_p.is_some()
-                {
-                    Some(InferenceConfig {
-                        temperature,
-                        top_p,
-                        top_k,
-                        max_tokens,
-                        repeat_penalty,
-                        presence_penalty,
-                        min_p,
-                    })
-                } else {
-                    None
-                };
+            let inference_override = if temperature.is_some()
+                || top_p.is_some()
+                || top_k.is_some()
+                || max_tokens.is_some()
+                || repeat_penalty.is_some()
+                || presence_penalty.is_some()
+                || min_p.is_some()
+            {
+                Some(InferenceConfig {
+                    temperature,
+                    top_p,
+                    top_k,
+                    max_tokens,
+                    repeat_penalty,
+                    presence_penalty,
+                    min_p,
+                })
+            } else {
+                None
+            };
             gglib_runtime::proxy::start_proxy_standalone(
                 host,
                 port,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -274,6 +274,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 ctx.model_repo.clone(),
                 effective_context,
                 ctx.mcp.clone(),
+                ctx.app.settings().repo(),
             )
             .await?;
         }

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -10,6 +10,7 @@
 //! coupling between the dispatch layer and each handler as narrow as possible.
 
 use anyhow::Result;
+use gglib_core::domain::inference::InferenceConfig;
 use gglib_core::settings::DEFAULT_CONTEXT_SIZE;
 use gglib_runtime::llama::{ContextInput, resolve_context_size};
 
@@ -255,6 +256,13 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             port,
             llama_port,
             default_context,
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            repeat_penalty,
+            presence_penalty,
+            min_p,
         } => {
             let settings = ctx.app.settings().get().await?;
             let context_resolution = resolve_context_size(ContextInput {
@@ -266,6 +274,23 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 .value
                 .map(u64::from)
                 .unwrap_or(DEFAULT_CONTEXT_SIZE);
+            let inference_override =
+                if temperature.is_some() || top_p.is_some() || top_k.is_some()
+                    || max_tokens.is_some() || repeat_penalty.is_some()
+                    || presence_penalty.is_some() || min_p.is_some()
+                {
+                    Some(InferenceConfig {
+                        temperature,
+                        top_p,
+                        top_k,
+                        max_tokens,
+                        repeat_penalty,
+                        presence_penalty,
+                        min_p,
+                    })
+                } else {
+                    None
+                };
             gglib_runtime::proxy::start_proxy_standalone(
                 host,
                 port,
@@ -275,6 +300,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 effective_context,
                 ctx.mcp.clone(),
                 ctx.app.settings().repo(),
+                inference_override,
             )
             .await?;
         }

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -19,7 +19,7 @@ use gglib_runtime::server_config::{ServerConfigOptions, build_server_config};
 
 use crate::bootstrap::CliContext;
 use crate::handlers::inference::chat::ChatArgs;
-use crate::handlers::inference::shared::log_context_info;
+use crate::handlers::inference::shared::{log_context_info, resolve_inference_config};
 use crate::presentation::style;
 
 // =============================================================================
@@ -101,7 +101,24 @@ pub async fn compose(
     // 1. Resolve the LLM port — reuse or auto-start.
     let (port, maybe_handle) = resolve_port(ctx, params, banner).await?;
 
-    // 2. Initialise MCP servers (CLI bootstrap intentionally skips this).
+    // 2. Resolve inference parameters via the 4-level hierarchy.
+    //    Look up the model so model-level defaults can be applied.  When the
+    //    identifier is unknown (external port reuse with no catalog entry) the
+    //    sampling is forwarded as-is.
+    let resolved_sampling = match ctx
+        .app
+        .models()
+        .find_by_identifier(&params.model_identifier)
+        .await
+        .ok()
+    {
+        Some(model) => {
+            Some(resolve_inference_config(ctx, sampling.unwrap_or_default(), &model).await?)
+        }
+        None => sampling,
+    };
+
+    // 3. Initialise MCP servers (CLI bootstrap intentionally skips this).
     //    A failure is logged as a warning rather than aborting the session:
     //    the agent can still run without tools.
     if let Err(e) = ctx.mcp.initialize().await {
@@ -110,7 +127,7 @@ pub async fn compose(
     // Pre-warm lazy servers so they are ready before the first agent iteration.
     ctx.mcp.prewarm_lazy().await;
 
-    // 3. Compose the agent loop.  When tools are specified the loop is
+    // 4. Compose the agent loop.  When tools are specified the loop is
     //    restricted to the named allowlist; otherwise all MCP tools are visible.
     let tool_filter = if params.tools.is_empty() {
         None
@@ -127,7 +144,7 @@ pub async fn compose(
         Arc::clone(&ctx.mcp),
         tool_filter,
         sandbox_root,
-        sampling,
+        resolved_sampling,
     );
 
     Ok((agent, maybe_handle))

--- a/crates/gglib-cli/src/handlers/inference/shared.rs
+++ b/crates/gglib-cli/src/handlers/inference/shared.rs
@@ -17,24 +17,14 @@ use gglib_runtime::llama::{ContextResolution, ContextResolutionSource};
 /// defaults → hardcoded defaults. Each layer fills in only `None` fields.
 pub async fn resolve_inference_config(
     ctx: &CliContext,
-    mut config: InferenceConfig,
+    config: InferenceConfig,
     model: &gglib_core::Model,
 ) -> Result<InferenceConfig> {
-    // Apply model defaults
-    if let Some(ref model_defaults) = model.inference_defaults {
-        config.merge_with(model_defaults);
-    }
-
-    // Apply global defaults
     let settings = ctx.app.settings().get().await?;
-    if let Some(ref global_defaults) = settings.inference_defaults {
-        config.merge_with(global_defaults);
-    }
-
-    // Apply hardcoded defaults
-    config.merge_with(&InferenceConfig::with_hardcoded_defaults());
-
-    Ok(config)
+    Ok(config.resolve_with_defaults(
+        model.inference_defaults.as_ref(),
+        settings.inference_defaults.as_ref(),
+    ))
 }
 
 /// Resolve the maximum agent iterations via a 3-level fallback chain.

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -338,8 +338,12 @@ impl InferenceConfig {
     /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     #[must_use]
     pub fn resolve_with_defaults(mut self, model: Option<&Self>, global: Option<&Self>) -> Self {
-        if let Some(m) = model  { self.merge_with(m); }
-        if let Some(g) = global { self.merge_with(g); }
+        if let Some(m) = model {
+            self.merge_with(m);
+        }
+        if let Some(g) = global {
+            self.merge_with(g);
+        }
         self.merge_with(&Self::with_hardcoded_defaults());
         self
     }
@@ -356,9 +360,13 @@ impl InferenceConfig {
     /// [`to_openai_json_patch`]: Self::to_openai_json_patch
     #[must_use]
     pub fn from_openai_json(value: &serde_json::Value) -> Self {
-        let Some(obj) = value.as_object() else { return Self::default(); };
-        let camel: serde_json::Map<String, serde_json::Value> =
-            obj.iter().map(|(k, v)| (snake_to_camel(k), v.clone())).collect();
+        let Some(obj) = value.as_object() else {
+            return Self::default();
+        };
+        let camel: serde_json::Map<String, serde_json::Value> = obj
+            .iter()
+            .map(|(k, v)| (snake_to_camel(k), v.clone()))
+            .collect();
         serde_json::from_value(serde_json::Value::Object(camel)).unwrap_or_default()
     }
 
@@ -490,16 +498,26 @@ mod tests {
 
     #[test]
     fn test_resolve_with_defaults_hierarchy() {
-        let request = InferenceConfig { temperature: Some(0.9), ..Default::default() };
-        let model   = InferenceConfig { temperature: Some(0.5), top_p: Some(0.8), ..Default::default() };
-        let global  = InferenceConfig { top_k: Some(10), ..Default::default() };
+        let request = InferenceConfig {
+            temperature: Some(0.9),
+            ..Default::default()
+        };
+        let model = InferenceConfig {
+            temperature: Some(0.5),
+            top_p: Some(0.8),
+            ..Default::default()
+        };
+        let global = InferenceConfig {
+            top_k: Some(10),
+            ..Default::default()
+        };
 
         let resolved = request.resolve_with_defaults(Some(&model), Some(&global));
 
-        assert_eq!(resolved.temperature, Some(0.9));  // request wins
-        assert_eq!(resolved.top_p,       Some(0.8));  // model fills in
-        assert_eq!(resolved.top_k,       Some(10));   // global fills in
-        assert_eq!(resolved.max_tokens,  Some(2048)); // hardcoded fallback
+        assert_eq!(resolved.temperature, Some(0.9)); // request wins
+        assert_eq!(resolved.top_p, Some(0.8)); // model fills in
+        assert_eq!(resolved.top_k, Some(10)); // global fills in
+        assert_eq!(resolved.max_tokens, Some(2048)); // hardcoded fallback
         assert_eq!(resolved.repeat_penalty, Some(1.0)); // hardcoded fallback
     }
 
@@ -532,8 +550,8 @@ mod tests {
         // Roundtrip via from_openai_json
         let val = serde_json::Value::Object(patch);
         let back = InferenceConfig::from_openai_json(&val);
-        assert_eq!(back.temperature,    Some(0.7));
-        assert_eq!(back.top_p,          Some(0.9));
+        assert_eq!(back.temperature, Some(0.7));
+        assert_eq!(back.top_p, Some(0.9));
         assert_eq!(back.repeat_penalty, Some(1.1));
         assert!(back.top_k.is_none());
     }

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -107,10 +107,10 @@ pub struct InferenceConfig {
     pub min_p: Option<f32>,
 }
 
-/// Convert a camelCase string to snake_case.
+/// Convert a camelCase string to `snake_case`.
 ///
 /// Used internally to rename `InferenceConfig`'s serde camelCase output to the
-/// OpenAI wire format (`topP` → `top_p`, `maxTokens` → `max_tokens`, etc.).
+/// `OpenAI` wire format (`topP` → `top_p`, `maxTokens` → `max_tokens`, etc.).
 fn camel_to_snake(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);
     for ch in s.chars() {
@@ -124,7 +124,7 @@ fn camel_to_snake(s: &str) -> String {
     out
 }
 
-/// Convert a snake_case string to camelCase.
+/// Convert a `snake_case` string to camelCase.
 ///
 /// Inverse of [`camel_to_snake`]; used to normalise OpenAI-format body keys
 /// (`top_p`, `max_tokens`, etc.) into the camelCase form expected by
@@ -337,7 +337,7 @@ impl InferenceConfig {
     ///
     /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     #[must_use]
-    pub fn resolve_with_defaults(mut self, model: Option<&Self>, global: Option<&Self>) -> Self {
+    pub const fn resolve_with_defaults(mut self, model: Option<&Self>, global: Option<&Self>) -> Self {
         if let Some(m) = model {
             self.merge_with(m);
         }
@@ -348,9 +348,9 @@ impl InferenceConfig {
         self
     }
 
-    /// Parse inference parameters from an OpenAI-format JSON body (snake_case keys).
+    /// Parse inference parameters from an OpenAI-format JSON body (`snake_case` keys).
     ///
-    /// Converts wire-format snake_case field names (`top_p`, `max_tokens`,
+    /// Converts wire-format `snake_case` field names (`top_p`, `max_tokens`,
     /// `repeat_penalty`, etc.) to the internal camelCase representation via
     /// [`snake_to_camel`], then deserialises using the existing `serde` impl.
     /// Unknown or missing fields default to `None`.
@@ -370,10 +370,10 @@ impl InferenceConfig {
         serde_json::from_value(serde_json::Value::Object(camel)).unwrap_or_default()
     }
 
-    /// Serialise as an OpenAI-format JSON patch (snake_case keys, `Some` fields only).
+    /// Serialise as an OpenAI-format JSON patch (`snake_case` keys, `Some` fields only).
     ///
     /// Uses `serde` to produce the camelCase form, then renames each key to
-    /// snake_case via [`camel_to_snake`]. Only `Some` fields are emitted — `None`
+    /// `snake_case` via [`camel_to_snake`]. Only `Some` fields are emitted — `None`
     /// values are filtered out. The returned map can be merged directly into an
     /// OpenAI-compatible request body with `body_obj.insert(k, v)`.
     ///

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -337,7 +337,11 @@ impl InferenceConfig {
     ///
     /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     #[must_use]
-    pub const fn resolve_with_defaults(mut self, model: Option<&Self>, global: Option<&Self>) -> Self {
+    pub const fn resolve_with_defaults(
+        mut self,
+        model: Option<&Self>,
+        global: Option<&Self>,
+    ) -> Self {
         if let Some(m) = model {
             self.merge_with(m);
         }

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -8,6 +8,12 @@
 //! - Per-model defaults (`Model.inference_defaults`)
 //! - Global settings (`Settings.inference_defaults`)
 //! - Request-level overrides (flattened in `ChatProxyRequest`)
+//! - `gglib proxy` — per-request injection into OpenAI-format request bodies
+//! - `gglib chat` / `gglib q` — hierarchy resolution for the agentic loop
+//!
+//! All surfaces resolve inference parameters through
+//! [`InferenceConfig::resolve_with_defaults`], which is the single source of
+//! truth for the 4-level hierarchy.
 
 use serde::{Deserialize, Serialize};
 
@@ -99,6 +105,44 @@ pub struct InferenceConfig {
     /// - 0.0: Disabled (explicit off; recommended by Qwen3.6)
     /// - 0.05: llama.cpp built-in default when the flag is omitted
     pub min_p: Option<f32>,
+}
+
+/// Convert a camelCase string to snake_case.
+///
+/// Used internally to rename `InferenceConfig`'s serde camelCase output to the
+/// OpenAI wire format (`topP` → `top_p`, `maxTokens` → `max_tokens`, etc.).
+fn camel_to_snake(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for ch in s.chars() {
+        if ch.is_uppercase() {
+            out.push('_');
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Convert a snake_case string to camelCase.
+///
+/// Inverse of [`camel_to_snake`]; used to normalise OpenAI-format body keys
+/// (`top_p`, `max_tokens`, etc.) into the camelCase form expected by
+/// `InferenceConfig`'s serde impl before deserialisation.
+fn snake_to_camel(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut cap = false;
+    for ch in s.chars() {
+        if ch == '_' {
+            cap = true;
+        } else if cap {
+            out.push(ch.to_ascii_uppercase());
+            cap = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 impl InferenceConfig {
@@ -262,6 +306,83 @@ impl InferenceConfig {
             min_p: Some(0.0),
         }
     }
+
+    /// Resolve inference parameters using the 4-level hierarchy.
+    ///
+    /// Applies fallback layers in order, with each layer filling only `None`
+    /// fields from `self` — explicit values are never overwritten:
+    ///
+    /// 1. `self` — caller-supplied overrides (request params, CLI flags, etc.)
+    /// 2. `model` — per-model stored defaults
+    /// 3. `global` — global settings defaults
+    /// 4. [`with_hardcoded_defaults`] — compile-time fallback values
+    ///
+    /// This is the single source of truth for inference parameter resolution,
+    /// used by every gglib surface: `gglib serve`, `gglib chat`, `gglib q`,
+    /// `gglib proxy`, and the internal Web UI chat API.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gglib_core::domain::InferenceConfig;
+    ///
+    /// let request = InferenceConfig { temperature: Some(0.9), ..Default::default() };
+    /// let model   = InferenceConfig { temperature: Some(0.5), top_p: Some(0.8), ..Default::default() };
+    ///
+    /// let resolved = request.resolve_with_defaults(Some(&model), None);
+    /// assert_eq!(resolved.temperature, Some(0.9)); // request wins
+    /// assert_eq!(resolved.top_p,       Some(0.8)); // model fills in
+    /// assert_eq!(resolved.top_k,       Some(40));  // hardcoded fallback
+    /// ```
+    ///
+    /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
+    #[must_use]
+    pub fn resolve_with_defaults(mut self, model: Option<&Self>, global: Option<&Self>) -> Self {
+        if let Some(m) = model  { self.merge_with(m); }
+        if let Some(g) = global { self.merge_with(g); }
+        self.merge_with(&Self::with_hardcoded_defaults());
+        self
+    }
+
+    /// Parse inference parameters from an OpenAI-format JSON body (snake_case keys).
+    ///
+    /// Converts wire-format snake_case field names (`top_p`, `max_tokens`,
+    /// `repeat_penalty`, etc.) to the internal camelCase representation via
+    /// [`snake_to_camel`], then deserialises using the existing `serde` impl.
+    /// Unknown or missing fields default to `None`.
+    ///
+    /// This is the inverse of [`to_openai_json_patch`].
+    ///
+    /// [`to_openai_json_patch`]: Self::to_openai_json_patch
+    #[must_use]
+    pub fn from_openai_json(value: &serde_json::Value) -> Self {
+        let Some(obj) = value.as_object() else { return Self::default(); };
+        let camel: serde_json::Map<String, serde_json::Value> =
+            obj.iter().map(|(k, v)| (snake_to_camel(k), v.clone())).collect();
+        serde_json::from_value(serde_json::Value::Object(camel)).unwrap_or_default()
+    }
+
+    /// Serialise as an OpenAI-format JSON patch (snake_case keys, `Some` fields only).
+    ///
+    /// Uses `serde` to produce the camelCase form, then renames each key to
+    /// snake_case via [`camel_to_snake`]. Only `Some` fields are emitted — `None`
+    /// values are filtered out. The returned map can be merged directly into an
+    /// OpenAI-compatible request body with `body_obj.insert(k, v)`.
+    ///
+    /// This is the inverse of [`from_openai_json`].
+    ///
+    /// [`from_openai_json`]: Self::from_openai_json
+    #[must_use]
+    pub fn to_openai_json_patch(&self) -> serde_json::Map<String, serde_json::Value> {
+        let camel = serde_json::to_value(self).unwrap_or_default();
+        camel
+            .as_object()
+            .into_iter()
+            .flatten()
+            .filter(|(_, v)| !v.is_null())
+            .map(|(k, v)| (camel_to_snake(k), v.clone()))
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -343,5 +464,89 @@ mod tests {
         let deserialized: InferenceConfig = serde_json::from_str(&json).unwrap();
 
         assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_camel_to_snake() {
+        assert_eq!(camel_to_snake("temperature"), "temperature");
+        assert_eq!(camel_to_snake("topP"), "top_p");
+        assert_eq!(camel_to_snake("topK"), "top_k");
+        assert_eq!(camel_to_snake("maxTokens"), "max_tokens");
+        assert_eq!(camel_to_snake("repeatPenalty"), "repeat_penalty");
+        assert_eq!(camel_to_snake("presencePenalty"), "presence_penalty");
+        assert_eq!(camel_to_snake("minP"), "min_p");
+    }
+
+    #[test]
+    fn test_snake_to_camel() {
+        assert_eq!(snake_to_camel("temperature"), "temperature");
+        assert_eq!(snake_to_camel("top_p"), "topP");
+        assert_eq!(snake_to_camel("top_k"), "topK");
+        assert_eq!(snake_to_camel("max_tokens"), "maxTokens");
+        assert_eq!(snake_to_camel("repeat_penalty"), "repeatPenalty");
+        assert_eq!(snake_to_camel("presence_penalty"), "presencePenalty");
+        assert_eq!(snake_to_camel("min_p"), "minP");
+    }
+
+    #[test]
+    fn test_resolve_with_defaults_hierarchy() {
+        let request = InferenceConfig { temperature: Some(0.9), ..Default::default() };
+        let model   = InferenceConfig { temperature: Some(0.5), top_p: Some(0.8), ..Default::default() };
+        let global  = InferenceConfig { top_k: Some(10), ..Default::default() };
+
+        let resolved = request.resolve_with_defaults(Some(&model), Some(&global));
+
+        assert_eq!(resolved.temperature, Some(0.9));  // request wins
+        assert_eq!(resolved.top_p,       Some(0.8));  // model fills in
+        assert_eq!(resolved.top_k,       Some(10));   // global fills in
+        assert_eq!(resolved.max_tokens,  Some(2048)); // hardcoded fallback
+        assert_eq!(resolved.repeat_penalty, Some(1.0)); // hardcoded fallback
+    }
+
+    #[test]
+    fn test_resolve_with_defaults_no_layers() {
+        let base = InferenceConfig::default();
+        let resolved = base.resolve_with_defaults(None, None);
+        // Should equal hardcoded defaults
+        assert_eq!(resolved, InferenceConfig::with_hardcoded_defaults());
+    }
+
+    #[test]
+    fn test_openai_json_roundtrip() {
+        let config = InferenceConfig {
+            temperature: Some(0.7),
+            top_p: Some(0.9),
+            repeat_penalty: Some(1.1),
+            ..Default::default()
+        };
+        let patch = config.to_openai_json_patch();
+
+        // snake_case keys present for Some fields
+        assert!(patch.contains_key("temperature"));
+        assert!(patch.contains_key("top_p"));
+        assert!(patch.contains_key("repeat_penalty"));
+        // None fields absent
+        assert!(!patch.contains_key("top_k"));
+        assert!(!patch.contains_key("max_tokens"));
+
+        // Roundtrip via from_openai_json
+        let val = serde_json::Value::Object(patch);
+        let back = InferenceConfig::from_openai_json(&val);
+        assert_eq!(back.temperature,    Some(0.7));
+        assert_eq!(back.top_p,          Some(0.9));
+        assert_eq!(back.repeat_penalty, Some(1.1));
+        assert!(back.top_k.is_none());
+    }
+
+    #[test]
+    fn test_from_openai_json_unknown_fields_ignored() {
+        let val = serde_json::json!({
+            "temperature": 0.5,
+            "model": "llama3",
+            "messages": []
+        });
+        let config = InferenceConfig::from_openai_json(&val);
+        assert_eq!(config.temperature, Some(0.5));
+        assert!(config.top_p.is_none());
     }
 }

--- a/crates/gglib-core/src/ports/model_catalog.rs
+++ b/crates/gglib-core/src/ports/model_catalog.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::path::PathBuf;
 use thiserror::Error;
 
+use crate::domain::InferenceConfig;
 use crate::domain::ModelCapabilities;
 
 /// Domain model summary for catalog operations (listing).
@@ -43,6 +44,14 @@ pub struct ModelSummary {
     pub created_at: i64,
     /// File size in bytes.
     pub file_size: u64,
+    /// Per-model inference parameter defaults.
+    ///
+    /// When `Some`, these are resolved per-request via
+    /// [`InferenceConfig::resolve_with_defaults`] before forwarding to llama-server.
+    /// Used by `gglib proxy` to inject resolved defaults into OpenAI-format
+    /// request bodies, and by the agentic loop (`gglib chat`, `gglib q`) to
+    /// apply model-specific sampling parameters.
+    pub inference_defaults: Option<InferenceConfig>,
 }
 
 /// Launch specification for running a model.

--- a/crates/gglib-core/src/services/settings_service.rs
+++ b/crates/gglib-core/src/services/settings_service.rs
@@ -15,6 +15,11 @@ impl SettingsService {
         Self { repo }
     }
 
+    /// Return the underlying settings repository.
+    pub fn repo(&self) -> Arc<dyn SettingsRepository> {
+        Arc::clone(&self.repo)
+    }
+
     /// Get current settings.
     pub async fn get(&self) -> Result<Settings, CoreError> {
         self.repo.load().await.map_err(CoreError::from)

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -177,6 +177,29 @@ GUI, and CLI all route through `build_server_config` in `gglib-runtime`, so any
 model that works correctly when started from the GUI or CLI will behave
 identically when auto-started by the proxy.
 
+### Inference Defaults Auto-Injection
+
+On every `POST /v1/chat/completions` request the proxy resolves sampling
+parameters through the same 4-level hierarchy used by every other surface:
+
+```
+request params  →  model defaults  →  global settings  →  hardcoded fallback
+```
+
+1. **Request params** — whatever `temperature`, `top_p`, `top_k`, `max_tokens`,
+   `repeat_penalty`, `presence_penalty`, and `min_p` the client sent.
+2. **Model defaults** — per-model `inference_defaults` stored in the model
+   catalog (`ModelSummary::inference_defaults`).
+3. **Global settings** — `Settings::inference_defaults` loaded from the
+   settings repository on every request.
+4. **Hardcoded fallback** — `temperature=0.7`, `top_p=0.95`, `top_k=40`,
+   `max_tokens=2048`, `repeat_penalty=1.0`, `presence_penalty=0.0`, `min_p=0.0`.
+
+The resolved values are aggressively written into the forwarded request body
+(via `body_obj.insert`) so llama-server always receives fully-specified
+parameters rather than relying on its own defaults.  Client-supplied values
+are always preserved because they form the base of the resolution hierarchy.
+
 ## Usage
 
 This crate is used by `gglib-runtime`'s `ProxySupervisor`. The supervisor binds a `TcpListener` and passes it to `gglib_proxy::serve()` along with port trait implementations:

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -182,7 +182,7 @@ identically when auto-started by the proxy.
 On every `POST /v1/chat/completions` request the proxy resolves sampling
 parameters through the same 4-level hierarchy used by every other surface:
 
-```
+```text
 request params  →  model defaults  →  global settings  →  hardcoded fallback
 ```
 

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -414,7 +414,9 @@ pub async fn forward_chat_completion(
                 body_obj.insert(k, v);
             }
         }
-        serde_json::to_vec(&body_value).map(Bytes::from).unwrap_or(body)
+        serde_json::to_vec(&body_value)
+            .map(Bytes::from)
+            .unwrap_or(body)
     } else {
         body
     };

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -70,7 +70,7 @@ use tracing::{debug, error, info, warn};
 
 use gglib_core::LlmStreamEvent;
 use gglib_core::ModelCapabilities;
-use gglib_core::domain::{ChatMessage, transform_messages_for_capabilities};
+use gglib_core::domain::{ChatMessage, InferenceConfig, transform_messages_for_capabilities};
 use gglib_core::normalize::{NormalizingStream, get_parser};
 use gglib_core::ports::ModelCatalogPort;
 use gglib_core::sse::{SseEncoder, SseStreamDecoder};
@@ -112,6 +112,8 @@ struct ModelContext {
     capabilities: ModelCapabilities,
     /// `format:*` tags — drives response-stream parser selection.
     tags: Vec<String>,
+    /// Per-model inference defaults to merge into each request.
+    inference_defaults: Option<InferenceConfig>,
 }
 
 /// Resolve the [`ModelContext`] for a model in a single catalog round-trip.
@@ -124,12 +126,14 @@ async fn resolve_model_context(catalog: &dyn ModelCatalogPort, model_name: &str)
         Ok(Some(summary)) => ModelContext {
             capabilities: summary.capabilities,
             tags: summary.tags,
+            inference_defaults: summary.inference_defaults,
         },
         Ok(None) => {
             debug!(model = %model_name, "model not found in catalog; using pass-through context");
             ModelContext {
                 capabilities: ModelCapabilities::empty(),
                 tags: Vec::new(),
+                inference_defaults: None,
             }
         }
         Err(e) => {
@@ -137,6 +141,7 @@ async fn resolve_model_context(catalog: &dyn ModelCatalogPort, model_name: &str)
             ModelContext {
                 capabilities: ModelCapabilities::empty(),
                 tags: Vec::new(),
+                inference_defaults: None,
             }
         }
     }
@@ -309,6 +314,7 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
 /// * `model_name` - Model name to advertise to the client (used in SSE envelope)
 /// * `catalog` - Catalog port used to resolve capabilities and `format:*` tags
 /// * `metrics` - Metrics store for recording per-request context snapshots
+/// * `global_inference_defaults` - Global inference defaults from settings
 ///
 /// # Returns
 ///
@@ -324,6 +330,7 @@ pub async fn forward_chat_completion(
     model_name: &str,
     catalog: Arc<dyn ModelCatalogPort>,
     metrics: Arc<ContextMetricsStore>,
+    global_inference_defaults: Option<InferenceConfig>,
 ) -> Response {
     debug!("Forwarding to {upstream_url}, streaming={is_streaming}");
 
@@ -389,6 +396,28 @@ pub async fn forward_chat_completion(
         body_bytes = body.len(),
         "sending request to upstream (post-transform)"
     );
+
+    // 4. Inject resolved inference defaults.
+    //
+    // Extract any params the client already sent, then merge model-level and
+    // global defaults behind them via the 4-level hierarchy.  The resolved
+    // values are aggressively inserted (not `or_insert`) so that every
+    // param in the final config is forwarded to llama-server.
+    let body = if let Ok(mut body_value) = serde_json::from_slice::<serde_json::Value>(&body) {
+        let client_params = InferenceConfig::from_openai_json(&body_value);
+        let resolved = client_params.resolve_with_defaults(
+            context.inference_defaults.as_ref(),
+            global_inference_defaults.as_ref(),
+        );
+        if let Some(body_obj) = body_value.as_object_mut() {
+            for (k, v) in resolved.to_openai_json_patch() {
+                body_obj.insert(k, v);
+            }
+        }
+        serde_json::to_vec(&body_value).map(Bytes::from).unwrap_or(body)
+    } else {
+        body
+    };
 
     // Build the request to upstream
     let mut req_builder = client

--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -545,6 +545,7 @@ mod tests {
                 architecture: Some("llama".into()),
                 created_at: 1700000000,
                 file_size: 4_000_000_000,
+                inference_defaults: None,
             },
             ModelSummary {
                 id: 2,
@@ -556,6 +557,7 @@ mod tests {
                 architecture: Some("mistral".into()),
                 created_at: 1700000001,
                 file_size: 7_000_000_000,
+                inference_defaults: None,
             },
         ];
 
@@ -580,6 +582,7 @@ mod tests {
             architecture: None,
             created_at: 0,
             file_size: 0,
+            inference_defaults: None,
         }]);
 
         let json = serde_json::to_value(&resp).unwrap();
@@ -605,6 +608,7 @@ mod tests {
             architecture: Some("llama".into()),
             created_at: 0,
             file_size: 0,
+            inference_defaults: None,
         };
         let info = ModelInfo::from(summary);
         let desc = info.description.unwrap();
@@ -625,6 +629,7 @@ mod tests {
             architecture: None,
             created_at: 0,
             file_size: 0,
+            inference_defaults: None,
         };
         let info = ModelInfo::from(summary);
         let desc = info.description.unwrap();

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -18,7 +18,9 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
-use gglib_core::ports::{ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository};
+use gglib_core::ports::{
+    ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository,
+};
 use gglib_mcp::McpService;
 
 use crate::council_proxy::{CouncilDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info};

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -72,6 +72,7 @@ pub(crate) struct AppState {
 /// # Returns
 ///
 /// Returns `Ok(())` on clean shutdown, or an error if the server fails.
+#[allow(clippy::too_many_arguments)]
 pub async fn serve(
     listener: TcpListener,
     default_ctx: u64,

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -18,7 +18,7 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
-use gglib_core::ports::{ModelCatalogPort, ModelRuntimeError, ModelRuntimePort};
+use gglib_core::ports::{ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository};
 use gglib_mcp::McpService;
 
 use crate::council_proxy::{CouncilDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info};
@@ -48,6 +48,8 @@ pub(crate) struct AppState {
     /// Ring-buffer store of per-request context metrics, exposed via
     /// `GET /v1/proxy/status`.
     pub(crate) metrics: Arc<ContextMetricsStore>,
+    /// Settings repository for loading global inference defaults per-request.
+    settings_repo: Arc<dyn SettingsRepository>,
 }
 
 /// Start the proxy server with a pre-bound listener.
@@ -63,6 +65,7 @@ pub(crate) struct AppState {
 /// * `mcp` - MCP service for tool gateway
 /// * `council` - Orchestrator services for virtual model routing
 /// * `cancel` - Cancellation token for graceful shutdown
+/// * `settings_repo` - Settings repository for loading global inference defaults
 ///
 /// # Returns
 ///
@@ -75,6 +78,7 @@ pub async fn serve(
     mcp: Arc<McpService>,
     council: CouncilDeps,
     cancel: CancellationToken,
+    settings_repo: Arc<dyn SettingsRepository>,
 ) -> anyhow::Result<()> {
     let addr = listener.local_addr()?;
     info!("Proxy server starting on {addr}");
@@ -91,6 +95,7 @@ pub async fn serve(
         default_ctx,
         council,
         metrics: Arc::new(ContextMetricsStore::new()),
+        settings_repo,
     };
 
     let app = Router::new()
@@ -238,6 +243,14 @@ async fn chat_completions(
         "Routing to llama-server"
     );
 
+    // Load global inference defaults for this request.
+    let global_inference_defaults = state
+        .settings_repo
+        .load()
+        .await
+        .ok()
+        .and_then(|s| s.inference_defaults);
+
     // Forward the request
     forward_chat_completion(
         &state.client,
@@ -248,6 +261,7 @@ async fn chat_completions(
         &model_name,
         state.catalog_port.clone(),
         state.metrics.clone(),
+        global_inference_defaults,
     )
     .await
 }

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -11,12 +11,12 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use gglib_core::Settings;
 use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::ports::{
     ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
     SettingsRepository,
 };
-use gglib_core::Settings;
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -14,7 +14,9 @@ use tokio_util::sync::CancellationToken;
 use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::ports::{
     ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
+    SettingsRepository,
 };
+use gglib_core::Settings;
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,
@@ -91,6 +93,17 @@ fn make_orchestrator_deps() -> CouncilDeps {
 }
 
 // ─── Mock ports ────────────────────────────────────────────────────────────
+
+struct MockSettingsRepo;
+#[async_trait::async_trait]
+impl SettingsRepository for MockSettingsRepo {
+    async fn load(&self) -> Result<Settings, RepositoryError> {
+        Ok(Settings::with_defaults())
+    }
+    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+}
 
 #[derive(Debug)]
 struct MockRuntimePort;
@@ -186,6 +199,7 @@ async fn start_proxy() -> (String, CancellationToken) {
             mcp,
             make_orchestrator_deps(),
             cancel_clone,
+            Arc::new(MockSettingsRepo),
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -185,6 +185,7 @@ impl TaggedCatalog {
             architecture: None,
             created_at: 0,
             file_size: 0,
+            inference_defaults: None,
         }
     }
 }

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -29,12 +29,12 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use gglib_core::Settings;
 use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::ports::{
     ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
     SettingsRepository,
 };
-use gglib_core::Settings;
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -32,7 +32,9 @@ use tokio_util::sync::CancellationToken;
 use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::ports::{
     ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
+    SettingsRepository,
 };
+use gglib_core::Settings;
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,
@@ -105,6 +107,17 @@ fn make_orchestrator_deps() -> CouncilDeps {
         runner: Arc::new(NoopRunner),
         approval_registry: Arc::new(NoopApprovalRegistry),
         council_repo: Arc::new(NoopOrchestratorRepo),
+    }
+}
+
+struct MockSettingsRepo;
+#[async_trait]
+impl SettingsRepository for MockSettingsRepo {
+    async fn load(&self) -> Result<Settings, RepositoryError> {
+        Ok(Settings::with_defaults())
+    }
+    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
+        Ok(())
     }
 }
 
@@ -306,6 +319,7 @@ async fn spawn_proxy(
             mcp,
             make_orchestrator_deps(),
             cancel_clone,
+            Arc::new(MockSettingsRepo),
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -23,18 +23,18 @@ use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
+use gglib_core::Settings;
 use gglib_core::domain::council::events::{ApprovalKind, CouncilEvent};
 use gglib_core::domain::council::run::{CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::domain::council::task_graph::{
     HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
 };
-use gglib_core::ports::{RepositoryError, SettingsRepository};
-use gglib_core::Settings;
 use gglib_core::ports::{
     ApprovalDecision, CatalogError, CouncilApprovalRegistryPort, CouncilRepositoryPort,
     ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort, ModelSummary,
     RunningTarget,
 };
+use gglib_core::ports::{RepositoryError, SettingsRepository};
 use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
 use gglib_mcp::McpService;
 use gglib_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -28,10 +28,12 @@ use gglib_core::domain::council::run::{CouncilRun, CouncilRunEvent, CouncilRunSt
 use gglib_core::domain::council::task_graph::{
     HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
 };
+use gglib_core::ports::{RepositoryError, SettingsRepository};
+use gglib_core::Settings;
 use gglib_core::ports::{
     ApprovalDecision, CatalogError, CouncilApprovalRegistryPort, CouncilRepositoryPort,
     ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort, ModelSummary,
-    RepositoryError, RunningTarget,
+    RunningTarget,
 };
 use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
 use gglib_mcp::McpService;
@@ -40,6 +42,17 @@ use gglib_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};
 // =============================================================================
 // Minimal mock ports (runtime / catalog / MCP)
 // =============================================================================
+
+struct MockSettingsRepo;
+#[async_trait]
+impl SettingsRepository for MockSettingsRepo {
+    async fn load(&self) -> Result<Settings, RepositoryError> {
+        Ok(Settings::with_defaults())
+    }
+    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+}
 
 /// Runtime that always returns an error — virtual model requests never reach it.
 #[derive(Debug)]
@@ -222,6 +235,7 @@ async fn spawn_proxy_with(runner: Arc<dyn CouncilRunnerPort>) -> (String, Cancel
             mcp,
             orchestrator,
             cancel_clone,
+            Arc::new(MockSettingsRepo),
         )
         .await
         .ok();

--- a/crates/gglib-runtime/src/ports_impl/model_catalog.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_catalog.rs
@@ -36,6 +36,7 @@ fn model_to_summary(m: &Model) -> ModelSummary {
         architecture: m.architecture.clone(),
         created_at: m.added_at.timestamp(),
         file_size,
+        inference_defaults: m.inference_defaults.clone(),
     }
 }
 

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -28,10 +28,12 @@ use crate::council_runner::CouncilRunnerAdapter;
 use crate::ports_impl::{CatalogPortImpl, RuntimePortImpl};
 use crate::process::ProcessManager;
 use gglib_core::domain::council::run::{CouncilRun, CouncilRunEvent, CouncilRunStatus};
+use gglib_core::domain::inference::InferenceConfig;
 use gglib_core::ports::{
     ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, ModelCatalogPort,
     ModelRepository, RepositoryError, SettingsRepository,
 };
+use gglib_core::settings::Settings;
 use gglib_mcp::McpService;
 use gglib_proxy::CouncilDeps;
 
@@ -200,6 +202,33 @@ impl CouncilRepositoryPort for InMemoryCouncilRepository {
 // start_proxy_standalone
 // =============================================================================
 
+/// Wraps a `SettingsRepository` and overlays a CLI-supplied `InferenceConfig`
+/// on top of whatever the persisted settings contain.
+///
+/// Fields present in `override_config` win; any field that is `None` there
+/// falls back to the persisted global defaults.
+struct CliOverrideSettingsRepo {
+    inner: Arc<dyn SettingsRepository>,
+    override_config: InferenceConfig,
+}
+
+#[async_trait]
+impl SettingsRepository for CliOverrideSettingsRepo {
+    async fn load(&self) -> Result<Settings, RepositoryError> {
+        let mut settings = self.inner.load().await?;
+        let merged = self
+            .override_config
+            .clone()
+            .resolve_with_defaults(None, settings.inference_defaults.as_ref());
+        settings.inference_defaults = Some(merged);
+        Ok(settings)
+    }
+
+    async fn save(&self, settings: &Settings) -> Result<(), RepositoryError> {
+        self.inner.save(settings).await
+    }
+}
+
 /// Start the OpenAI-compatible proxy as a standalone server (CLI usage).
 ///
 /// This is the main entry point for CLI usage. It creates all required
@@ -215,6 +244,8 @@ impl CouncilRepositoryPort for InMemoryCouncilRepository {
 /// * `default_context` - Default context size for models
 /// * `mcp` - MCP service for tool gateway
 /// * `settings_repo` - Settings repository for global inference defaults
+/// * `inference_override` - Optional once-off inference parameter overrides
+///   (applied on top of persisted global defaults; not saved to disk)
 #[allow(clippy::too_many_arguments)]
 pub async fn start_proxy_standalone(
     host: String,
@@ -225,6 +256,7 @@ pub async fn start_proxy_standalone(
     default_context: u64,
     mcp: Arc<McpService>,
     settings_repo: Arc<dyn SettingsRepository>,
+    inference_override: Option<InferenceConfig>,
 ) -> Result<()> {
     // Create catalog port from model repository
     let catalog_port: Arc<dyn ModelCatalogPort> =
@@ -264,6 +296,17 @@ pub async fn start_proxy_standalone(
     // Create supervisor
     let supervisor = ProxySupervisor::new();
 
+    // Wrap settings_repo with CLI override if any inference flags were supplied
+    let effective_settings_repo: Arc<dyn SettingsRepository> =
+        if let Some(override_config) = inference_override.clone() {
+            Arc::new(CliOverrideSettingsRepo {
+                inner: settings_repo,
+                override_config,
+            })
+        } else {
+            settings_repo
+        };
+
     // Start proxy
     let config = ProxyConfig {
         host: host.clone(),
@@ -301,6 +344,17 @@ pub async fn start_proxy_standalone(
     println!("  Port:            {}", port);
     println!("  Llama base port: {}", llama_base_port);
     println!("  Default context: {}", default_context);
+    if let Some(ref ic) = inference_override {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(v) = ic.temperature    { parts.push(format!("temperature={v}")); }
+        if let Some(v) = ic.top_p          { parts.push(format!("top_p={v}")); }
+        if let Some(v) = ic.top_k          { parts.push(format!("top_k={v}")); }
+        if let Some(v) = ic.max_tokens     { parts.push(format!("max_tokens={v}")); }
+        if let Some(v) = ic.repeat_penalty { parts.push(format!("repeat_penalty={v}")); }
+        if let Some(v) = ic.presence_penalty { parts.push(format!("presence_penalty={v}")); }
+        if let Some(v) = ic.min_p          { parts.push(format!("min_p={v}")); }
+        println!("  Inference override: {}", parts.join(", "));
+    }
     println!(
         "  MCP servers:     {} (eager: {}, lazy: {}, manual: {})",
         servers.len(),
@@ -318,7 +372,7 @@ pub async fn start_proxy_standalone(
             catalog_port,
             mcp,
             orchestrator_deps,
-            settings_repo,
+            effective_settings_repo,
         )
         .await
         .map_err(|e| anyhow!("{e}"))?;

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -346,13 +346,27 @@ pub async fn start_proxy_standalone(
     println!("  Default context: {}", default_context);
     if let Some(ref ic) = inference_override {
         let mut parts: Vec<String> = Vec::new();
-        if let Some(v) = ic.temperature    { parts.push(format!("temperature={v}")); }
-        if let Some(v) = ic.top_p          { parts.push(format!("top_p={v}")); }
-        if let Some(v) = ic.top_k          { parts.push(format!("top_k={v}")); }
-        if let Some(v) = ic.max_tokens     { parts.push(format!("max_tokens={v}")); }
-        if let Some(v) = ic.repeat_penalty { parts.push(format!("repeat_penalty={v}")); }
-        if let Some(v) = ic.presence_penalty { parts.push(format!("presence_penalty={v}")); }
-        if let Some(v) = ic.min_p          { parts.push(format!("min_p={v}")); }
+        if let Some(v) = ic.temperature {
+            parts.push(format!("temperature={v}"));
+        }
+        if let Some(v) = ic.top_p {
+            parts.push(format!("top_p={v}"));
+        }
+        if let Some(v) = ic.top_k {
+            parts.push(format!("top_k={v}"));
+        }
+        if let Some(v) = ic.max_tokens {
+            parts.push(format!("max_tokens={v}"));
+        }
+        if let Some(v) = ic.repeat_penalty {
+            parts.push(format!("repeat_penalty={v}"));
+        }
+        if let Some(v) = ic.presence_penalty {
+            parts.push(format!("presence_penalty={v}"));
+        }
+        if let Some(v) = ic.min_p {
+            parts.push(format!("min_p={v}"));
+        }
         println!("  Inference override: {}", parts.join(", "));
     }
     println!(

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -30,7 +30,7 @@ use crate::process::ProcessManager;
 use gglib_core::domain::council::run::{CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::ports::{
     ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, ModelCatalogPort,
-    ModelRepository, RepositoryError,
+    ModelRepository, RepositoryError, SettingsRepository,
 };
 use gglib_mcp::McpService;
 use gglib_proxy::CouncilDeps;
@@ -214,6 +214,7 @@ impl CouncilRepositoryPort for InMemoryCouncilRepository {
 /// * `model_repo` - Model repository for catalog access
 /// * `default_context` - Default context size for models
 /// * `mcp` - MCP service for tool gateway
+/// * `settings_repo` - Settings repository for global inference defaults
 pub async fn start_proxy_standalone(
     host: String,
     port: u16,
@@ -222,6 +223,7 @@ pub async fn start_proxy_standalone(
     model_repo: Arc<dyn ModelRepository>,
     default_context: u64,
     mcp: Arc<McpService>,
+    settings_repo: Arc<dyn SettingsRepository>,
 ) -> Result<()> {
     // Create catalog port from model repository
     let catalog_port: Arc<dyn ModelCatalogPort> =
@@ -309,7 +311,7 @@ pub async fn start_proxy_standalone(
     println!();
 
     let addr = supervisor
-        .start(config, runtime_port, catalog_port, mcp, orchestrator_deps)
+        .start(config, runtime_port, catalog_port, mcp, orchestrator_deps, settings_repo)
         .await
         .map_err(|e| anyhow!("{e}"))?;
     tracing::info!("Proxy started on {addr}");

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -311,7 +311,14 @@ pub async fn start_proxy_standalone(
     println!();
 
     let addr = supervisor
-        .start(config, runtime_port, catalog_port, mcp, orchestrator_deps, settings_repo)
+        .start(
+            config,
+            runtime_port,
+            catalog_port,
+            mcp,
+            orchestrator_deps,
+            settings_repo,
+        )
         .await
         .map_err(|e| anyhow!("{e}"))?;
     tracing::info!("Proxy started on {addr}");

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -215,6 +215,7 @@ impl CouncilRepositoryPort for InMemoryCouncilRepository {
 /// * `default_context` - Default context size for models
 /// * `mcp` - MCP service for tool gateway
 /// * `settings_repo` - Settings repository for global inference defaults
+#[allow(clippy::too_many_arguments)]
 pub async fn start_proxy_standalone(
     host: String,
     port: u16,

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort};
+use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort, SettingsRepository};
 use gglib_core::settings::{DEFAULT_CONTEXT_SIZE, DEFAULT_PROXY_PORT};
 use gglib_mcp::McpService;
 use gglib_proxy::CouncilDeps;
@@ -161,6 +161,7 @@ impl ProxySupervisor {
     /// * `catalog_port` - Port for listing and resolving models
     /// * `mcp` - MCP service for tool gateway
     /// * `orchestrator` - Orchestrator services for virtual model routing
+    /// * `settings_repo` - Settings repository for global inference defaults
     ///
     /// # Errors
     ///
@@ -172,6 +173,7 @@ impl ProxySupervisor {
         catalog_port: Arc<dyn ModelCatalogPort>,
         mcp: Arc<McpService>,
         orchestrator: CouncilDeps,
+        settings_repo: Arc<dyn SettingsRepository>,
     ) -> Result<SocketAddr, SupervisorError> {
         let mut guard = self.handle.lock().await;
 
@@ -231,6 +233,7 @@ impl ProxySupervisor {
                 mcp,
                 orchestrator,
                 cancel_clone,
+                settings_repo,
             )
             .await;
 
@@ -370,6 +373,7 @@ mod tests {
     use gglib_core::domain::mcp::{McpServer, NewMcpServer};
     use gglib_core::ports::{
         ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
+        SettingsRepository,
     };
     use gglib_core::ports::{
         CatalogError, ModelLaunchSpec, ModelRuntimeError, ModelSummary, RunningTarget,
@@ -545,6 +549,22 @@ mod tests {
         ))
     }
 
+    struct MockSettingsRepo;
+
+    #[async_trait]
+    impl SettingsRepository for MockSettingsRepo {
+        async fn load(&self) -> Result<gglib_core::Settings, RepositoryError> {
+            Ok(gglib_core::Settings::with_defaults())
+        }
+        async fn save(&self, _settings: &gglib_core::Settings) -> Result<(), RepositoryError> {
+            Ok(())
+        }
+    }
+
+    fn make_settings_repo() -> Arc<dyn SettingsRepository> {
+        Arc::new(MockSettingsRepo)
+    }
+
     #[tokio::test]
     async fn test_supervisor_lifecycle() {
         let supervisor = ProxySupervisor::new();
@@ -567,6 +587,7 @@ mod tests {
                 catalog.clone(),
                 mcp,
                 make_orchestrator(),
+                make_settings_repo(),
             )
             .await
             .unwrap();
@@ -582,7 +603,7 @@ mod tests {
         let (runtime2, catalog2) = make_ports();
         assert!(matches!(
             supervisor
-                .start(config, runtime2, catalog2, make_mcp(), make_orchestrator())
+                .start(config, runtime2, catalog2, make_mcp(), make_orchestrator(), make_settings_repo())
                 .await,
             Err(SupervisorError::AlreadyRunning(_))
         ));
@@ -619,6 +640,7 @@ mod tests {
                 catalog,
                 make_mcp(),
                 make_orchestrator(),
+                make_settings_repo(),
             )
             .await
             .unwrap();
@@ -629,7 +651,7 @@ mod tests {
         // Start again (should work)
         let (runtime2, catalog2) = make_ports();
         let addr2 = supervisor
-            .start(config, runtime2, catalog2, make_mcp(), make_orchestrator())
+            .start(config, runtime2, catalog2, make_mcp(), make_orchestrator(), make_settings_repo())
             .await
             .unwrap();
 

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -603,7 +603,14 @@ mod tests {
         let (runtime2, catalog2) = make_ports();
         assert!(matches!(
             supervisor
-                .start(config, runtime2, catalog2, make_mcp(), make_orchestrator(), make_settings_repo())
+                .start(
+                    config,
+                    runtime2,
+                    catalog2,
+                    make_mcp(),
+                    make_orchestrator(),
+                    make_settings_repo()
+                )
                 .await,
             Err(SupervisorError::AlreadyRunning(_))
         ));
@@ -651,7 +658,14 @@ mod tests {
         // Start again (should work)
         let (runtime2, catalog2) = make_ports();
         let addr2 = supervisor
-            .start(config, runtime2, catalog2, make_mcp(), make_orchestrator(), make_settings_repo())
+            .start(
+                config,
+                runtime2,
+                catalog2,
+                make_mcp(),
+                make_orchestrator(),
+                make_settings_repo(),
+            )
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

Inference sampling parameters (`temperature`, `top_p`, `top_k`, `max_tokens`, `repeat_penalty`, `presence_penalty`, `min_p`) were not reaching llama-server consistently across all gglib surfaces. This PR closes the full gap with a single authoritative resolution function and zero inline merge blocks.

## Root Causes

- **PR #308** (`2200e78`) — replaced `handlers/chat.rs` and `handlers/question.rs` with the agent_chat infrastructure, silently dropping the `resolve_inference_config` call that had been introduced in **PR #149** (`e1af0cd`). This left `gglib chat`, `gglib q`, and the agent REPL with no model-defaults or global-defaults resolution.
- **PR #533** (`675a348`) — added MTP/jinja/reasoning capability parity for the proxy but did not touch inference params.
- **PR #541** (`175c3cb`) — added `presence_penalty` / `min_p` claiming "full-stack parity" but missed `gglib proxy` entirely (it forwarded raw bytes verbatim) and did not fix the agent_chat regression from #308.

## Changes

### Phase 1 — Core primitives (`02e7b67`)
- `InferenceConfig::resolve_with_defaults(self, model, global)` — 3 `merge_with` calls, no field listing, single source of truth for all surfaces
- `InferenceConfig::from_openai_json(value)` — snake_case OpenAI wire keys → camelCase serde fields via char-iteration `snake_to_camel`
- `InferenceConfig::to_openai_json_patch()` — camelCase → snake_case key rename, nulls filtered; used to inject resolved params into the forwarded proxy body
- 8 unit tests covering hierarchy precedence, roundtrip, unknown-field immunity, no-layers fallback

### Phase 2 — `inference_defaults` on `ModelSummary` (`0707b1d`)
- Added `pub inference_defaults: Option<InferenceConfig>` to `ModelSummary` in the catalog port
- Populated from `Model::inference_defaults` in `gglib-runtime`'s `model_to_summary`
- Updated all `ModelSummary { .. }` literal constructions in `gglib-proxy` and its integration tests

### Phase 3 — Proxy request-time injection (`f3f13b8`)
- `gglib-proxy/forward.rs`: `ModelContext` gains `inference_defaults` from catalog; `forward_chat_completion` gains `global_inference_defaults` param; after the 3 existing request transforms, resolves and aggressively `insert`s all params into the forwarded body
- `gglib-proxy/server.rs`: `AppState` + `serve()` gain `settings_repo: Arc<dyn SettingsRepository>`; `chat_completions` handler loads global defaults per-request
- `gglib-core/SettingsService`: added `pub fn repo()` getter to expose the inner `Arc<dyn SettingsRepository>`
- `gglib-runtime/supervisor.rs`: threads `settings_repo` through `start()` into `gglib_proxy::serve()`; `MockSettingsRepo` added to tests
- `gglib-runtime/mod.rs`: `start_proxy_standalone` gains `settings_repo` param
- `gglib-app-services/proxy.rs`: passes `core.settings().repo()` to supervisor
- `gglib-cli/dispatch.rs`: passes `ctx.app.settings().repo()` to standalone proxy

### Phase 4 — Delete inline merges + restore agent_chat (`b298e58`)
- `gglib-cli/shared.rs`: replaced 8-line `merge_with` cascade with `config.resolve_with_defaults(...)`
- `gglib-axum/chat_api.rs`: replaced 15-line inline merge block with `InferenceConfig { .. }.resolve_with_defaults(...)`
- `gglib-cli/agent_chat/config.rs`: restored inference resolution lost in #308 — `compose()` now calls `resolve_inference_config` after `resolve_port()` before passing sampling to `compose_agent_loop_with_sampling`

### Phase 5 — Docs (`0a2d5d0`)
- Added "Inference Defaults Auto-Injection" section to `gglib-proxy/README.md` documenting the 4-level hierarchy and aggressive insert behaviour

## Surfaces Fixed

| Surface | Before | After |
|---------|--------|-------|
| `gglib proxy` | Forwarded raw bytes verbatim — no defaults applied | Resolves request → model → global → hardcoded per request |
| `gglib chat` | Regression from #308 — no model/global defaults | Restored via `resolve_inference_config` in `compose()` |
| `gglib q` | Same regression from #308 | Same fix |
| Agent REPL | Same regression from #308 | Same fix |
| Web UI (`chat_api`) | Working but with inline 3-level merge block | Same result via `resolve_with_defaults` (no behaviour change) |
