### PR TITLE
fix(benchmark): reasoning content, settings-driven defaults, ctx_size override

### DIFF
--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -104,7 +104,18 @@ pub async fn run_compare(
             })
             .await;
 
-        match run_single_compare(deps, model_id, &model, &config, run_id, &tx, default_ctx, global_inf.as_ref()).await {
+        match run_single_compare(
+            deps,
+            model_id,
+            &model,
+            &config,
+            run_id,
+            &tx,
+            default_ctx,
+            global_inf.as_ref(),
+        )
+        .await
+        {
             Ok(result) => {
                 if let Err(e) = deps.bench_repo.save_compare_result(&result, run_id).await {
                     warn!("benchmark: failed to save compare result for model {model_id}: {e}");
@@ -196,7 +207,10 @@ async fn run_single_compare(
         let chunk = match chunk_result {
             Ok(c) => c,
             Err(e) => {
-                warn!("benchmark: SSE byte-stream error for model '{}': {e}", model.name);
+                warn!(
+                    "benchmark: SSE byte-stream error for model '{}': {e}",
+                    model.name
+                );
                 break;
             }
         };
@@ -330,13 +344,27 @@ fn build_compare_request_body(
         "stream": true
     });
 
-    if let Some(v) = resolved.temperature        { body["temperature"]       = serde_json::json!(v); }
-    if let Some(v) = resolved.max_tokens         { body["max_tokens"]        = serde_json::json!(v); }
-    if let Some(v) = resolved.top_p              { body["top_p"]             = serde_json::json!(v); }
-    if let Some(v) = resolved.top_k              { body["top_k"]             = serde_json::json!(v); }
-    if let Some(v) = resolved.repeat_penalty     { body["repeat_penalty"]    = serde_json::json!(v); }
-    if let Some(v) = resolved.presence_penalty   { body["presence_penalty"]  = serde_json::json!(v); }
-    if let Some(v) = resolved.min_p              { body["min_p"]             = serde_json::json!(v); }
+    if let Some(v) = resolved.temperature {
+        body["temperature"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolved.max_tokens {
+        body["max_tokens"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolved.top_p {
+        body["top_p"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolved.top_k {
+        body["top_k"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolved.repeat_penalty {
+        body["repeat_penalty"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolved.presence_penalty {
+        body["presence_penalty"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolved.min_p {
+        body["min_p"] = serde_json::json!(v);
+    }
 
     body
 }

--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -29,9 +29,11 @@ use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
+use gglib_core::domain::InferenceConfig;
 use gglib_core::domain::benchmark::{
     BenchmarkEvent, BenchmarkModelResult, BenchmarkRunType, CompareConfig, ModelCompareResult,
 };
+use gglib_core::settings::DEFAULT_CONTEXT_SIZE;
 
 use super::BenchmarkDeps;
 use super::mapper::{
@@ -45,6 +47,13 @@ pub async fn run_compare(
     tx: Sender<BenchmarkEvent>,
     cancel: CancellationToken,
 ) -> Result<()> {
+    // ── Load settings once per run (mirrors the proxy's per-request read) ──
+    let settings = deps.settings_repo.load().await.ok();
+    let default_ctx = settings
+        .as_ref()
+        .and_then(|s| s.default_context_size)
+        .unwrap_or(DEFAULT_CONTEXT_SIZE);
+    let global_inf = settings.and_then(|s| s.inference_defaults);
     let config_json = serde_json::to_string(&config).ok();
     let run_id = deps
         .bench_repo
@@ -95,7 +104,7 @@ pub async fn run_compare(
             })
             .await;
 
-        match run_single_compare(deps, model_id, &model.name, &config, run_id, &tx).await {
+        match run_single_compare(deps, model_id, &model, &config, run_id, &tx, default_ctx, global_inf.as_ref()).await {
             Ok(result) => {
                 if let Err(e) = deps.bench_repo.save_compare_result(&result, run_id).await {
                     warn!("benchmark: failed to save compare result for model {model_id}: {e}");
@@ -127,35 +136,31 @@ pub async fn run_compare(
 }
 
 /// Run the compare prompt through one model and collect results.
+///
+/// `default_ctx` and `global_inf` are resolved once per run by the caller
+/// ([`run_compare`]) to avoid redundant settings reads per model.
+#[allow(clippy::too_many_arguments)]
 async fn run_single_compare(
     deps: &BenchmarkDeps,
     model_id: i64,
-    model_name: &str,
+    model: &gglib_core::domain::Model,
     config: &CompareConfig,
     run_id: i64,
     tx: &Sender<BenchmarkEvent>,
+    default_ctx: u64,
+    global_inf: Option<&InferenceConfig>,
 ) -> Result<ModelCompareResult> {
     // Start (or keep running) the model server via SingleSwap.
+    // `config.ctx_size` is the per-run override (CLI --ctx-size / API field);
+    // `default_ctx` comes from `settings.default_context_size` (same as proxy).
     let target = deps
         .runtime
-        .ensure_model_running(model_name, None, 4096)
+        .ensure_model_running(&model.name, config.ctx_size, default_ctx)
         .await
-        .with_context(|| format!("failed to start model '{model_name}'"))?;
+        .with_context(|| format!("failed to start model '{}'", model.name))?;
 
-    // Build the chat completions request body.
-    let mut req_body = serde_json::json!({
-        "model": model_name,
-        "messages": build_messages(config),
-        "stream": true
-    });
-    if let Some(inf) = &config.inference {
-        if let Some(temp) = inf.temperature {
-            req_body["temperature"] = serde_json::json!(temp);
-        }
-        if let Some(max_tokens) = inf.max_tokens {
-            req_body["max_tokens"] = serde_json::json!(max_tokens);
-        }
-    }
+    // Build the request body with fully-resolved inference parameters.
+    let req_body = build_compare_request_body(config, model, global_inf);
 
     let response = deps
         .http_client
@@ -191,7 +196,7 @@ async fn run_single_compare(
         let chunk = match chunk_result {
             Ok(c) => c,
             Err(e) => {
-                warn!("benchmark: SSE byte-stream error for model '{model_name}': {e}");
+                warn!("benchmark: SSE byte-stream error for model '{}': {e}", model.name);
                 break;
             }
         };
@@ -253,7 +258,8 @@ async fn run_single_compare(
                                 }
                                 Err(e) => {
                                     warn!(
-                                        "benchmark: failed to parse SSE chunk for '{model_name}': {e}"
+                                        "benchmark: failed to parse SSE chunk for '{}': {e}",
+                                        model.name
                                     );
                                 }
                             }
@@ -298,4 +304,39 @@ fn build_messages(config: &CompareConfig) -> serde_json::Value {
     }
     messages.push(serde_json::json!({ "role": "user", "content": config.prompt }));
     serde_json::json!(messages)
+}
+
+/// Build the full chat-completions request body with resolved inference params.
+///
+/// Applies the 4-level inference defaults hierarchy to ALL sampling parameters:
+///   request (`config.inference`) → model defaults → global settings defaults
+///   → hardcoded fallback (`InferenceConfig::with_hardcoded_defaults`).
+///
+/// This mirrors the resolution the proxy performs for every routed request.
+fn build_compare_request_body(
+    config: &CompareConfig,
+    model: &gglib_core::domain::Model,
+    global_inf: Option<&InferenceConfig>,
+) -> serde_json::Value {
+    let resolved = config
+        .inference
+        .clone()
+        .unwrap_or_default()
+        .resolve_with_defaults(model.inference_defaults.as_ref(), global_inf);
+
+    let mut body = serde_json::json!({
+        "model": model.name,
+        "messages": build_messages(config),
+        "stream": true
+    });
+
+    if let Some(v) = resolved.temperature        { body["temperature"]       = serde_json::json!(v); }
+    if let Some(v) = resolved.max_tokens         { body["max_tokens"]        = serde_json::json!(v); }
+    if let Some(v) = resolved.top_p              { body["top_p"]             = serde_json::json!(v); }
+    if let Some(v) = resolved.top_k              { body["top_k"]             = serde_json::json!(v); }
+    if let Some(v) = resolved.repeat_penalty     { body["repeat_penalty"]    = serde_json::json!(v); }
+    if let Some(v) = resolved.presence_penalty   { body["presence_penalty"]  = serde_json::json!(v); }
+    if let Some(v) = resolved.min_p              { body["min_p"]             = serde_json::json!(v); }
+
+    body
 }

--- a/crates/gglib-app-services/src/benchmark/mapper.rs
+++ b/crates/gglib-app-services/src/benchmark/mapper.rs
@@ -375,10 +375,7 @@ mod tests {
         let val = json!({
             "choices": [{ "delta": { "content": "Hello, world!" } }]
         });
-        assert_eq!(
-            extract_text_delta(&val),
-            Some("Hello, world!".to_string())
-        );
+        assert_eq!(extract_text_delta(&val), Some("Hello, world!".to_string()));
     }
 
     /// Thinking model during reasoning phase: `content` is null, only
@@ -401,10 +398,7 @@ mod tests {
         let val = json!({
             "choices": [{ "delta": { "content": "", "reasoning_content": "thinking..." } }]
         });
-        assert_eq!(
-            extract_text_delta(&val),
-            Some("thinking...".to_string())
-        );
+        assert_eq!(extract_text_delta(&val), Some("thinking...".to_string()));
     }
 
     /// Both `content` and `reasoning_content` present and non-empty →

--- a/crates/gglib-app-services/src/benchmark/mapper.rs
+++ b/crates/gglib-app-services/src/benchmark/mapper.rs
@@ -20,15 +20,36 @@ use serde_json::Value;
 
 /// Extract the streaming text delta from one SSE chunk.
 ///
-/// Returns the content string from `choices[0].delta.content`, or `None` if
-/// that path is absent (e.g. the final chunk with `finish_reason`).
+/// Checks `choices[0].delta.content` first.  When that field is absent or an
+/// empty string — as happens during the *thinking* phase of reasoning models
+/// such as Qwen3, which stream thinking tokens in `reasoning_content` instead
+/// of `content` — this falls back to `choices[0].delta.reasoning_content`.
+///
+/// Priority: `content` (non-empty) > `reasoning_content` (non-empty) > `None`.
+///
+/// Returning `None` signals "no text in this chunk" (e.g. the final chunk
+/// that only carries `finish_reason`).
 pub fn extract_text_delta(val: &Value) -> Option<String> {
-    val.get("choices")
+    let delta = val
+        .get("choices")
         .and_then(|c| c.get(0))
-        .and_then(|c| c.get("delta"))
-        .and_then(|d| d.get("content"))
+        .and_then(|c| c.get("delta"))?;
+
+    // `content` takes priority — present and non-empty means the model is in
+    // its answer phase (or is a non-thinking model).
+    if let Some(s) = delta.get("content").and_then(|v| v.as_str())
+        && !s.is_empty()
+    {
+        return Some(s.to_owned());
+    }
+
+    // Fall back to `reasoning_content` for thinking models (Qwen3, DeepSeek-R1,
+    // etc.) that stream thinking tokens here while `content` is null/"".
+    delta
+        .get("reasoning_content")
         .and_then(|v| v.as_str())
-        .map(String::from)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
 }
 
 /// Extract `finish_reason` from `choices[0].finish_reason`.
@@ -344,6 +365,70 @@ mod tests {
         let reason = extract_finish_reason(&val);
         let was_truncated = reason.as_deref() == Some("length");
         assert!(!was_truncated, "finish_reason=stop → was_truncated=false");
+    }
+
+    // ── Text delta extraction tests ──────────────────────────────────────────
+
+    /// Normal (non-thinking) model: `content` field present → returned as-is.
+    #[test]
+    fn test_extract_text_delta_content_present() {
+        let val = json!({
+            "choices": [{ "delta": { "content": "Hello, world!" } }]
+        });
+        assert_eq!(
+            extract_text_delta(&val),
+            Some("Hello, world!".to_string())
+        );
+    }
+
+    /// Thinking model during reasoning phase: `content` is null, only
+    /// `reasoning_content` is present → `reasoning_content` returned.
+    #[test]
+    fn test_extract_text_delta_reasoning_content_fallback() {
+        let val = json!({
+            "choices": [{ "delta": { "content": null, "reasoning_content": "<think>step 1</think>" } }]
+        });
+        assert_eq!(
+            extract_text_delta(&val),
+            Some("<think>step 1</think>".to_string())
+        );
+    }
+
+    /// Thinking model: `content` is empty string, `reasoning_content` is
+    /// present → empty `content` is skipped; `reasoning_content` returned.
+    #[test]
+    fn test_extract_text_delta_empty_content_falls_back_to_reasoning() {
+        let val = json!({
+            "choices": [{ "delta": { "content": "", "reasoning_content": "thinking..." } }]
+        });
+        assert_eq!(
+            extract_text_delta(&val),
+            Some("thinking...".to_string())
+        );
+    }
+
+    /// Both `content` and `reasoning_content` present and non-empty →
+    /// `content` wins (answer-phase takes priority over thinking-phase).
+    #[test]
+    fn test_extract_text_delta_content_wins_over_reasoning() {
+        let val = json!({
+            "choices": [{ "delta": { "content": "answer", "reasoning_content": "thought" } }]
+        });
+        assert_eq!(
+            extract_text_delta(&val),
+            Some("answer".to_string()),
+            "content takes priority over reasoning_content"
+        );
+    }
+
+    /// Neither `content` nor `reasoning_content` present (final chunk with
+    /// only `finish_reason`) → `None`.
+    #[test]
+    fn test_extract_text_delta_neither_present_returns_none() {
+        let val = json!({
+            "choices": [{ "delta": {}, "finish_reason": "stop" }]
+        });
+        assert_eq!(extract_text_delta(&val), None);
     }
 
     // ── Perf output tests ────────────────────────────────────────────────────

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -40,7 +40,9 @@ use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
 
 use gglib_core::domain::benchmark::{BenchmarkEvent, CompareConfig, PerfConfig};
-use gglib_core::ports::{BenchmarkRepositoryPort, ModelRepository, ModelRuntimePort, SettingsRepository};
+use gglib_core::ports::{
+    BenchmarkRepositoryPort, ModelRepository, ModelRuntimePort, SettingsRepository,
+};
 
 mod compare;
 pub mod guard;

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -40,7 +40,7 @@ use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
 
 use gglib_core::domain::benchmark::{BenchmarkEvent, CompareConfig, PerfConfig};
-use gglib_core::ports::{BenchmarkRepositoryPort, ModelRepository, ModelRuntimePort};
+use gglib_core::ports::{BenchmarkRepositoryPort, ModelRepository, ModelRuntimePort, SettingsRepository};
 
 mod compare;
 pub mod guard;
@@ -77,6 +77,10 @@ pub struct BenchmarkDeps {
     pub bench_repo: Arc<dyn BenchmarkRepositoryPort>,
     /// HTTP client with a ≥ 10-minute timeout for compare-mode SSE streaming.
     pub http_client: reqwest::Client,
+    /// Settings repository used to read `default_context_size` and global
+    /// `inference_defaults` at the start of each compare run — mirrors the
+    /// same per-request settings read the proxy performs.
+    pub settings_repo: Arc<dyn SettingsRepository>,
 }
 
 impl BenchmarkDeps {

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -301,6 +301,7 @@ pub async fn bootstrap(config: ServerConfig) -> Result<AxumContext> {
         runtime: Arc::clone(&runtime),
         bench_repo: bench_repo.clone(),
         http_client: benchmark_http_client,
+        settings_repo: repos.settings.clone(),
     }));
 
     let proxy = Arc::new(ProxyOps::new(ProxyDeps {

--- a/crates/gglib-axum/src/handlers/benchmark/compare.rs
+++ b/crates/gglib-axum/src/handlers/benchmark/compare.rs
@@ -38,7 +38,8 @@ use crate::state::AppState;
 ///   "model_ids": [1, 2],
 ///   "prompt": "Explain gradient descent in one paragraph.",
 ///   "system_prompt": null,
-///   "inference": null
+///   "inference": null,
+///   "ctx_size": null
 /// }
 /// ```
 ///

--- a/crates/gglib-cli/src/bootstrap.rs
+++ b/crates/gglib-cli/src/bootstrap.rs
@@ -14,7 +14,7 @@ use gglib_app_services::CouncilApprovalRegistry;
 use gglib_bootstrap::{BootstrapConfig, BuiltCore, CoreBootstrap};
 use gglib_core::ports::{
     AppEventEmitter, DownloadManagerPort, GgufParserPort, ModelRegistrarPort, ModelRepository,
-    NoopEmitter, ProcessRunner, Repos,
+    NoopEmitter, ProcessRunner, Repos, SettingsRepository,
 };
 use gglib_core::services::AppCore;
 use gglib_db::{SqliteBenchmarkRepository, SqliteCouncilRepository};
@@ -84,6 +84,8 @@ pub struct CliContext {
     pub council_repo: Arc<SqliteCouncilRepository>,
     /// Benchmark run repository for compare and perf results.
     pub bench_repo: Arc<SqliteBenchmarkRepository>,
+    /// Settings repository for user preferences and inference defaults.
+    pub settings_repo: Arc<dyn SettingsRepository>,
     /// Orchestrator approval registry for HITL gates.
     pub approval_registry: Arc<CouncilApprovalRegistry>,
     /// Terminal progress emitter used by the interactive download monitor.
@@ -155,6 +157,7 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
         http_client: reqwest::Client::new(),
         council_repo,
         bench_repo,
+        settings_repo: repos.settings,
         approval_registry,
         download_emitter,
     })
@@ -191,6 +194,7 @@ pub fn bootstrap_with(
         http_client: reqwest::Client::new(),
         council_repo: Arc::new(SqliteCouncilRepository::new_in_memory_blocking()),
         bench_repo: Arc::new(SqliteBenchmarkRepository::new_in_memory_blocking()),
+        settings_repo: repos.settings.clone(),
         approval_registry: Arc::new(CouncilApprovalRegistry::new()),
         download_emitter: Arc::new(CliDownloadEventEmitter::new()),
     }

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -172,6 +172,7 @@ fn build_ops(ctx: &CliContext) -> Result<BenchmarkOps> {
         runtime,
         bench_repo: ctx.bench_repo.clone(),
         http_client,
+        settings_repo: ctx.settings_repo.clone(),
     }))
 }
 
@@ -215,14 +216,12 @@ async fn cmd_compare(
     } else {
         None
     };
-    // Note: ctx_size is not yet wired into CompareConfig; reserved for Phase 4.
-    let _ = ctx_size;
-
     let config = CompareConfig {
         model_ids,
         prompt,
         system_prompt,
         inference,
+        ctx_size,
     };
 
     style::print_info_banner("Benchmark Compare", "\u{1f4ca}");

--- a/crates/gglib-core/src/domain/benchmark.rs
+++ b/crates/gglib-core/src/domain/benchmark.rs
@@ -182,8 +182,14 @@ pub struct CompareConfig {
     pub prompt: String,
     /// Optional system prompt.
     pub system_prompt: Option<String>,
-    /// Per-request inference overrides (temperature, context size, etc.).
+    /// Per-request inference overrides (`temperature`, `max_tokens`, etc.).
     pub inference: Option<InferenceConfig>,
+    /// Override the llama-server context window size for this run.
+    ///
+    /// When `None` the benchmark service falls back to the app-wide
+    /// `default_context_size` setting (same fallback the proxy uses).
+    #[serde(default)]
+    pub ctx_size: Option<u64>,
 }
 
 /// Configuration for a performance (`llama-bench`) run.

--- a/crates/gglib-tauri/src/bootstrap.rs
+++ b/crates/gglib-tauri/src/bootstrap.rs
@@ -206,6 +206,7 @@ pub async fn bootstrap(config: TauriConfig, app_handle: AppHandle) -> Result<Tau
         runtime: Arc::clone(&runtime),
         bench_repo: bench_repo.clone(),
         http_client: benchmark_http,
+        settings_repo: repos.settings.clone(),
     }));
 
     // 5. Build 7 domain ops.
@@ -350,6 +351,7 @@ pub fn bootstrap_with(
         runtime: Arc::clone(&runtime),
         bench_repo: bench_repo_w.clone(),
         http_client: BenchmarkDeps::build_http_client().expect("benchmark http client"),
+        settings_repo: repos.settings.clone(),
     }));
     let proxy_ops = Arc::new(ProxyOps::new(ProxyDeps {
         supervisor: proxy_supervisor.clone(),
@@ -462,6 +464,7 @@ pub async fn bootstrap_early(config: TauriConfig) -> Result<TauriContext> {
         runtime: Arc::clone(&runtime),
         bench_repo: bench_repo_e.clone(),
         http_client: benchmark_e_http,
+        settings_repo: repos.settings.clone(),
     }));
 
     // 4. Build 7 domain ops (no AppHandle → NoopServerEvents).

--- a/src/pages/BenchmarkPage.tsx
+++ b/src/pages/BenchmarkPage.tsx
@@ -109,6 +109,7 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
   );
   const [prompt, setPrompt] = useState('Tell me a short story about a robot.');
   const [systemPrompt, setSystemPrompt] = useState('');
+  const [ctxSize, setCtxSize] = useState('');
   const [ppTokens, setPpTokens] = useState('512');
   const [tgTokens, setTgTokens] = useState('128');
   const [repetitions, setRepetitions] = useState('3');
@@ -261,6 +262,7 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
           model_ids: selectedModelIds,
           prompt,
           system_prompt: systemPrompt.trim() || null,
+          ctx_size: parseInt(ctxSize, 10) || null,
         };
         await startCompareRun(config, handleEvent, abort.signal);
       } else {
@@ -281,7 +283,7 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
         }));
       }
     }
-  }, [mode, selectedModelIds, models, prompt, systemPrompt, ppTokens, tgTokens, repetitions, handleEvent]);
+  }, [mode, selectedModelIds, models, prompt, systemPrompt, ctxSize, ppTokens, tgTokens, repetitions, handleEvent]);
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort();
@@ -479,6 +481,20 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
                   rows={2}
                   disabled={isRunning}
                   placeholder="Optional system prompt…"
+                />
+              </div>
+              <div className="flex flex-col gap-xs">
+                <label className="text-xs font-semibold text-text-secondary uppercase tracking-wide">
+                  Context Size (optional)
+                </label>
+                <Input
+                  type="number"
+                  value={ctxSize}
+                  onChange={e => setCtxSize(e.target.value)}
+                  disabled={isRunning}
+                  min={512}
+                  size="sm"
+                  placeholder="Default from settings"
                 />
               </div>
             </>

--- a/src/types/benchmark.ts
+++ b/src/types/benchmark.ts
@@ -82,6 +82,7 @@ export interface CompareConfig {
   prompt: string;
   system_prompt?: string | null;
   inference?: Record<string, unknown> | null;
+  ctx_size?: number | null;
 }
 
 export interface PerfConfig {


### PR DESCRIPTION
## Summary

Fixes two root causes of blank/incomplete output in benchmark compare mode, and adds settings-driven context size matching the proxy pattern.

### Changes

**Phase 1 — reasoning_content support** (commit `c8cec8e0`)
- `extract_text_delta` now falls back to `reasoning_content` when `content` is absent/empty
- Fixes blank compare output for Qwen3 and other thinking models that stream reasoning tokens separately

**Phase 2+3+4 — Settings-driven defaults** (commit `99987d1a`)
- `CompareConfig` gains `ctx_size: Option<u64>` for per-run override
- `BenchmarkDeps` gains `settings_repo: Arc<dyn SettingsRepository>`
- `compare.rs` reads settings once per run, mirroring the proxy per-request pattern
- `ensure_model_running` now uses `config.ctx_size` then `settings.default_context_size` then `4096` (was always `4096`)
- New `build_compare_request_body` helper resolves the full 4-level `InferenceConfig` hierarchy (request to model defaults to global settings to hardcoded fallback) and applies all 7 sampling fields (was only `temperature` + `max_tokens`)
- Wire `settings_repo` into all `BenchmarkDeps` construction sites (axum, tauri x3, cli)

**Phase 5+6 — CLI flag + API** (commit `f767e560`)
- `--ctx-size` flag was already in `benchmark_commands.rs`; now wired through to `CompareConfig`
- Axum handler doc example updated with `ctx_size` field

**Phase 7 — Frontend** (commit `5800e8aa`)
- `CompareConfig` TypeScript type gains `ctx_size?: number | null`
- `BenchmarkPage`: numeric Context Size input after System Prompt (placeholder "Default from settings")

## Testing

- `cargo clippy --workspace --exclude gglib-app --all-targets --all-features -- -D warnings` — clean
- `cargo test -p gglib-app-services -p gglib-core` — all pass (including 5 new reasoning_content tests from commit 1)
- `npm run build` — clean
