### PR TITLE
ci: bump all GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -353,7 +353,7 @@ jobs:
           ls -la badges/
 
       - name: Deploy to badges branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./badges
@@ -706,7 +706,7 @@ jobs:
           ls -la badges/
 
       - name: Deploy to badges branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./badges
@@ -1049,7 +1049,7 @@ jobs:
           ls -la badges/
 
       - name: Deploy to badges branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./badges

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout badges branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: badges
           fetch-depth: 1
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout badges branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: badges
           fetch-depth: 1
@@ -729,7 +729,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch (for source analysis)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Need full history for tag checks
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           # Using GitHub App token to ensure PR triggers CI workflows
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -177,7 +177,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -244,7 +244,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           cargo metadata --locked --format-version 1 --manifest-path src-tauri/Cargo.toml > /dev/null
 
       - name: Cache Cargo registry and target directory
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -233,7 +233,7 @@ jobs:
           components: clippy
 
       - name: Cache Cargo registry and target directory
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -281,7 +281,7 @@ jobs:
           toolchain: 1.91.0
 
       - name: Cache Cargo registry and target directory
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -33,7 +33,7 @@ jobs:
     needs: [fmt]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check crate boundaries
         run: ./scripts/check_boundaries.sh
@@ -51,7 +51,7 @@ jobs:
     needs: [fmt]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check Tauri command placement
         run: ./scripts/check-tauri-commands.sh
@@ -79,7 +79,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -174,7 +174,7 @@ jobs:
     needs: [clippy]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -214,7 +214,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -273,7 +273,7 @@ jobs:
             os: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./scripts/check_boundaries.sh
 
       - name: Upload boundary results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: boundary-results
@@ -146,7 +146,7 @@ jobs:
         run: cargo test --doc --verbose
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results
@@ -188,7 +188,7 @@ jobs:
         run: npm run test:run -- --reporter=json --reporter=default --outputFile=ts-test-results.json 2>&1 | tee ts-test-output.txt
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ts-test-results

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Cache Cargo registry and target directory
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -122,7 +122,7 @@ jobs:
             --html
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Update deployment status
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
             pkg-config
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Always checkout main branch for docs, even when triggered by release tag
           ref: main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './target/doc'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       is-prerelease: ${{ steps.version-check.outputs.is-prerelease }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +96,7 @@ jobs:
           echo "This is a test run. Skipping actual release creation."
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -132,7 +132,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Always checkout main branch for docs, even when triggered by release tag
           ref: main
@@ -299,7 +299,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -428,7 +428,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Update deployment status
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,14 +157,14 @@ jobs:
           cache-on-failure: true
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: ubuntu-${{ runner.arch }}-node-${{ hashFiles('package.json') }}
 
       - name: Cache Web UI
         id: webui-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: web_ui
           key: ubuntu-${{ runner.arch }}-webui-${{ hashFiles('src/**/*.{ts,tsx}', 'index.html', 'vite.config.ts', 'package.json') }}
@@ -328,14 +328,14 @@ jobs:
           cache-on-failure: true
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: ${{ matrix.target }}-node-${{ hashFiles('package.json') }}
 
       - name: Cache Web UI
         id: webui-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: web_ui
           key: ${{ matrix.target }}-webui-${{ hashFiles('src/**/*.{ts,tsx}', 'index.html', 'vite.config.ts', 'package.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.webui-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -342,7 +342,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.webui-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -445,7 +445,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './target/doc'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,15 +111,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ needs.check-version.outputs.new-version }}
           name: Release v${{ needs.check-version.outputs.new-version }}
           draft: false
           prerelease: ${{ needs.check-version.outputs.is-prerelease == 'true' }}
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-docs:
     name: Deploy Documentation
@@ -377,21 +376,19 @@ jobs:
 
       - name: Upload binary to release (Unix)
         if: matrix.os != 'windows-2022' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ needs.check-version.outputs.new-version }}
           files: gglib-${{ needs.check-version.outputs.new-version }}-${{ matrix.target }}.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload binary to release (Windows)
         if: matrix.os == 'windows-2022' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ needs.check-version.outputs.new-version }}
           files: gglib-${{ needs.check-version.outputs.new-version }}-${{ matrix.target }}.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-gui:
     name: Build GUI ${{ matrix.target }}
@@ -616,18 +613,16 @@ jobs:
 
       - name: Upload GUI binary to release (Unix)
         if: (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')) && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ needs.check-version.outputs.new-version }}
           files: gglib-gui-${{ needs.check-version.outputs.new-version }}-${{ matrix.target }}.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload GUI binary to release (Windows)
         if: matrix.os == 'windows-2022' && needs.check-version.outputs.is-test-version != 'true' && inputs.test_run != true
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ needs.check-version.outputs.new-version }}
           files: gglib-gui-${{ needs.check-version.outputs.new-version }}-${{ matrix.target }}.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Eliminates the remaining 37 Node 20 deprecation warnings by upgrading all action binaries to versions compiled for Node 24.

## Changes

| Action | From | To |
|--------|------|----|
| `actions/cache` | `@v3` | `@v6` |
| `actions/checkout` | `@v4` | `@v7` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/upload-pages-artifact` | `@v3` | `@v5` |
| `actions/deploy-pages` | `@v4` | `@v5` |
| `softprops/action-gh-release` | `@v1` | `@v3` |
| `peter-evans/create-pull-request` | `@v6` | `@v8` |
| `peaceiris/actions-gh-pages` | `@v3` | `@v4` |

## Breaking changes handled

- **`softprops/action-gh-release@v3`**: Migrated auth from `env: GITHUB_TOKEN` to `with: token:` (required by v2+). All 5 usages in `release.yml` updated.
- **`actions/setup-node@v6`**: v5+ auto-caches based on `packageManager` field in `package.json`. This repo has no `packageManager` field, so no `package-manager-cache: false` guard is needed.
- **`actions/checkout@v7`**: Security change blocks fork PRs for `pull_request_target`/`workflow_run` triggers. All our workflows use `pull_request` — safe, no changes needed.

## Not changed

`dtolnay/rust-toolchain@master`, `Swatinem/rust-cache@v2`, `jlumbroso/free-disk-space@main`, `taiki-e/install-action@cargo-llvm-cov`, `actions/github-script@v7`, `actions/create-github-app-token@v1`, `actions/configure-pages@v5` (composite action, already current).