### PR TITLE
feat: add Rust coverage task and llvm-tools component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,7 @@ tarpaulin-report.html
 .env
 boundary-status.json
 .vscode/settings.json
+lcov.info
+coverage/html
 
 logs/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -779,6 +779,60 @@
 				"focus": true,
 				"clear": true
 			}
+		},
+		{
+			"label": "🔬 Rust Coverage (lcov)",
+			"type": "shell",
+			"command": "$HOME/.cargo/bin/cargo llvm-cov --workspace --exclude gglib-tauri --exclude gglib-app --lcov --output-path lcov.info",
+			"options": {
+				"env": {
+					"MACOSX_DEPLOYMENT_TARGET": "14.0"
+				}
+			},
+			"group": "test",
+			"problemMatcher": ["$rustc"],
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": false,
+				"clear": true
+			}
+		},
+		{
+			"label": "🔬 Rust Coverage (table)",
+			"type": "shell",
+			"command": "$HOME/.cargo/bin/cargo llvm-cov --workspace --exclude gglib-tauri --exclude gglib-app",
+			"options": {
+				"env": {
+					"MACOSX_DEPLOYMENT_TARGET": "14.0"
+				}
+			},
+			"group": "test",
+			"problemMatcher": ["$rustc"],
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": true,
+				"clear": true
+			}
+		},
+		{
+			"label": "🔬 Rust Coverage (html)",
+			"type": "shell",
+			"command": "$HOME/.cargo/bin/cargo llvm-cov --workspace --exclude gglib-tauri --exclude gglib-app --html --output-dir coverage && open coverage/html/index.html",
+			"options": {
+				"env": {
+					"MACOSX_DEPLOYMENT_TARGET": "14.0"
+				}
+			},
+			"group": "test",
+			"problemMatcher": ["$rustc"],
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared",
+				"focus": false,
+				"clear": true
+			}
 		}
 	],
 	"inputs": [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.91.0"
 profile = "minimal"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
## Summary

Adds a VS Code task to generate Rust line coverage via `cargo-llvm-cov`.

## Changes

- **`.vscode/tasks.json`** — new `🔬 Rust Coverage (lcov)` task under the `test` group. Uses `$HOME/.cargo/bin/cargo` (absolute path to the rustup shim) to avoid PATH ordering issues where Homebrew Rust could take precedence over the rustup-managed toolchain in VS Code's non-interactive login shell.
- **`rust-toolchain.toml`** — adds `llvm-tools` to the `components` array so `rustup` installs the LLVM binaries automatically on any machine that checks out the repo.
- **`.gitignore`** — ignores the generated `lcov.info` output file.

## Usage

1. Run **Task: 🔬 Rust Coverage (lcov)** (Cmd+Shift+P → Run Task)
2. `lcov.info` is written to the workspace root
3. Open any Rust source file — install [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) and click Watch in the status bar to see per-line green/red coverage decorations