### PR TITLE
fix(proxy): Catch-Clear-503 — recover from stale model state after llama-server crash

### DIFF
--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -331,7 +331,7 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
 /// The response from llama-server, with the streaming SSE body re-emitted
 /// through the universal normalization pipeline when `is_streaming` is true.
 #[allow(clippy::too_many_arguments)]
-pub async fn forward_chat_completion(
+pub(crate) async fn forward_chat_completion(
     client: &Client,
     upstream_url: &str,
     headers: &HeaderMap,

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -79,6 +79,16 @@ use crate::metrics::{ContextMetricsStore, ContextSnapshot};
 use crate::models::ErrorResponse;
 use crate::truncation::truncate_history;
 
+/// Signals that the upstream llama-server was unreachable (connection refused
+/// or timed out).  Returned by [`forward_chat_completion`] so the caller can
+/// invalidate stale model state and surface a retriable 503 to the client
+/// instead of a terminal 502.
+#[derive(Debug)]
+pub(crate) enum ForwardError {
+    /// The upstream llama-server could not be reached (ECONNREFUSED or timeout).
+    UpstreamDead,
+}
+
 /// Headers that should NOT be forwarded (hop-by-hop headers).
 const HOP_BY_HOP_HEADERS: &[&str] = &[
     "connection",
@@ -331,7 +341,7 @@ pub async fn forward_chat_completion(
     catalog: Arc<dyn ModelCatalogPort>,
     metrics: Arc<ContextMetricsStore>,
     global_inference_defaults: Option<InferenceConfig>,
-) -> Response {
+) -> Result<Response, ForwardError> {
     debug!("Forwarding to {upstream_url}, streaming={is_streaming}");
 
     // Single catalog lookup — yields both capabilities (request preprocessing)
@@ -388,7 +398,7 @@ pub async fn forward_chat_completion(
                     .unwrap_or_default()
                     .as_secs(),
             });
-            return *response;
+            return Ok(*response);
         }
     };
 
@@ -438,13 +448,20 @@ pub async fn forward_chat_completion(
     // Send the request
     let response = match req_builder.body(body).send().await {
         Ok(resp) => resp,
+        Err(e) if e.is_connect() || e.is_timeout() => {
+            // Connection refused or timed out — the llama-server process is dead
+            // or hung.  Signal the caller so it can clear stale state and return
+            // a retriable 503 rather than a terminal 502.
+            error!("Upstream llama-server unreachable (connect/timeout): {e}");
+            return Err(ForwardError::UpstreamDead);
+        }
         Err(e) => {
-            error!("Failed to connect to llama-server: {e}");
-            return (
+            error!("Failed to send request to llama-server: {e}");
+            return Ok((
                 StatusCode::BAD_GATEWAY,
                 axum::Json(ErrorResponse::upstream_error(&e.to_string())),
             )
-                .into_response();
+                .into_response());
         }
     };
 
@@ -459,11 +476,11 @@ pub async fn forward_chat_completion(
             body = %error_body,
             "upstream llama-server returned error"
         );
-        return Response::builder()
+        return Ok(Response::builder()
             .status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY))
             .header("content-type", "application/json")
             .body(Body::from(error_bytes))
-            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()));
     }
 
     debug!(
@@ -473,13 +490,13 @@ pub async fn forward_chat_completion(
 
     if is_streaming {
         // Tags resolved above — no second catalog lookup needed.
-        forward_streaming_response(response, model_name.to_owned(), context.tags).await
+        Ok(forward_streaming_response(response, model_name.to_owned(), context.tags).await)
     } else {
         // Non-streaming: read full response. Dialect normalization for
         // non-streaming responses is intentionally deferred — the wire
         // formats we currently rewrite (Qwen XML tool calls, bare <think>
         // tags) only manifest in streaming clients today.
-        forward_non_streaming_response(response).await
+        Ok(forward_non_streaming_response(response).await)
     }
 }
 

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -298,8 +298,7 @@ async fn chat_completions(
 
             // Bounded polling: give up after 130 s (120 s health-check window
             // plus 10 s of margin).
-            let deadline = std::time::Instant::now()
-                + std::time::Duration::from_secs(130);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(130);
 
             let new_target = loop {
                 match state
@@ -314,21 +313,15 @@ async fn chat_completions(
                         // fatal 503 to the client.
                         if std::time::Instant::now() >= deadline {
                             warn!("Timed out waiting for model restart after upstream failure");
-                            return handle_runtime_error(
-                                ModelRuntimeError::ModelLoading,
-                            );
+                            return handle_runtime_error(ModelRuntimeError::ModelLoading);
                         }
-                        tokio::time::sleep(
-                            std::time::Duration::from_secs(2),
-                        )
-                        .await;
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                     }
                     Err(e) => return handle_runtime_error(e),
                 }
             };
 
-            let retry_url =
-                format!("{}/v1/chat/completions", new_target.base_url);
+            let retry_url = format!("{}/v1/chat/completions", new_target.base_url);
             let retry_defaults = state
                 .settings_repo
                 .load()

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -262,6 +262,10 @@ async fn chat_completions(
         .ok()
         .and_then(|s| s.inference_defaults);
 
+    // Clone body before forwarding — Bytes is reference-counted so this is
+    // O(1).  Needed to retry with the original payload if the upstream dies.
+    let body_for_retry = body.clone();
+
     // Forward the request
     match forward_chat_completion(
         &state.client,
@@ -278,24 +282,88 @@ async fn chat_completions(
     {
         Ok(resp) => resp,
         Err(ForwardError::UpstreamDead) => {
-            // The llama-server process crashed or timed out after
-            // ensure_model_running() already returned a stale port.
-            // Clear the stale CurrentModelState so the next request
-            // triggers a clean restart via ensure_model_running().
+            // llama-server was dead after ensure_model_running() returned a
+            // stale port.  Strategy:
+            //   1. Clear stale state via stop_current().
+            //   2. Poll ensure_model_running() until it returns Ok (one
+            //      request drives the restart; concurrent requests wait here
+            //      rather than surfacing a 503 to the client, because the VS
+            //      Code LLM Gateway treats 503 as a terminal error).
+            //   3. Retry the forward once with the cloned body.
             warn!(
                 upstream = %upstream_url,
-                "upstream dead after ensure_model_running — clearing stale state for restart"
+                "upstream dead — clearing stale state and restarting model for transparent retry"
             );
             let _ = state.runtime_port.stop_current().await;
-            let mut response = (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(ErrorResponse::model_loading()),
+
+            // Bounded polling: give up after 130 s (120 s health-check window
+            // plus 10 s of margin).
+            let deadline = std::time::Instant::now()
+                + std::time::Duration::from_secs(130);
+
+            let new_target = loop {
+                match state
+                    .runtime_port
+                    .ensure_model_running(&model_name, num_ctx, state.default_ctx)
+                    .await
+                {
+                    Ok(t) => break t,
+                    Err(ModelRuntimeError::ModelLoading) => {
+                        // Another request is already driving the restart.
+                        // Sleep briefly then re-poll rather than returning a
+                        // fatal 503 to the client.
+                        if std::time::Instant::now() >= deadline {
+                            warn!("Timed out waiting for model restart after upstream failure");
+                            return handle_runtime_error(
+                                ModelRuntimeError::ModelLoading,
+                            );
+                        }
+                        tokio::time::sleep(
+                            std::time::Duration::from_secs(2),
+                        )
+                        .await;
+                    }
+                    Err(e) => return handle_runtime_error(e),
+                }
+            };
+
+            let retry_url =
+                format!("{}/v1/chat/completions", new_target.base_url);
+            let retry_defaults = state
+                .settings_repo
+                .load()
+                .await
+                .ok()
+                .and_then(|s| s.inference_defaults);
+
+            match forward_chat_completion(
+                &state.client,
+                &retry_url,
+                &headers,
+                body_for_retry,
+                is_streaming,
+                &model_name,
+                state.catalog_port.clone(),
+                state.metrics.clone(),
+                retry_defaults,
             )
-                .into_response();
-            if let Ok(value) = "5".parse() {
-                response.headers_mut().insert("retry-after", value);
+            .await
+            {
+                Ok(resp) => resp,
+                Err(_) => {
+                    // Server failed immediately after a fresh restart —
+                    // genuinely pathological; give up.
+                    let mut resp = (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(ErrorResponse::model_loading()),
+                    )
+                        .into_response();
+                    if let Ok(value) = "5".parse() {
+                        resp.headers_mut().insert("retry-after", value);
+                    }
+                    resp
+                }
             }
-            response
         }
     }
 }

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -86,8 +86,16 @@ pub async fn serve(
     let addr = listener.local_addr()?;
     info!("Proxy server starting on {addr}");
 
-    // Create HTTP client for upstream requests
-    let client = Client::builder().pool_max_idle_per_host(10).build()?;
+    // Create HTTP client for upstream requests.
+    // 300-second timeout guards against a hung-but-alive llama-server that
+    // stops responding mid-inference (e.g. OOM stall).  The timeout fires
+    // as a reqwest::Error::is_timeout(), which forward_chat_completion
+    // maps to ForwardError::UpstreamDead so the handler can clear stale
+    // state and return a retriable 503 instead of hanging indefinitely.
+    let client = Client::builder()
+        .pool_max_idle_per_host(10)
+        .timeout(std::time::Duration::from_secs(300))
+        .build()?;
 
     let state = AppState {
         client,

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use reqwest::Client;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use gglib_core::ports::{
     ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository,
@@ -24,7 +24,7 @@ use gglib_core::ports::{
 use gglib_mcp::McpService;
 
 use crate::council_proxy::{CouncilDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info};
-use crate::forward::forward_chat_completion;
+use crate::forward::{ForwardError, forward_chat_completion};
 use crate::mcp::handlers::{delete_mcp, get_mcp, post_mcp};
 use crate::mcp::session::SessionManager;
 use crate::metrics::ContextMetricsStore;
@@ -255,7 +255,7 @@ async fn chat_completions(
         .and_then(|s| s.inference_defaults);
 
     // Forward the request
-    forward_chat_completion(
+    match forward_chat_completion(
         &state.client,
         &upstream_url,
         &headers,
@@ -267,6 +267,29 @@ async fn chat_completions(
         global_inference_defaults,
     )
     .await
+    {
+        Ok(resp) => resp,
+        Err(ForwardError::UpstreamDead) => {
+            // The llama-server process crashed or timed out after
+            // ensure_model_running() already returned a stale port.
+            // Clear the stale CurrentModelState so the next request
+            // triggers a clean restart via ensure_model_running().
+            warn!(
+                upstream = %upstream_url,
+                "upstream dead after ensure_model_running — clearing stale state for restart"
+            );
+            let _ = state.runtime_port.stop_current().await;
+            let mut response = (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse::model_loading()),
+            )
+                .into_response();
+            if let Ok(value) = "5".parse() {
+                response.headers_mut().insert("retry-after", value);
+            }
+            response
+        }
+    }
 }
 
 /// Convert ModelRuntimeError to HTTP response with appropriate status code.


### PR DESCRIPTION
## Problem

When `gglib` is used as a local LLM backend for VS Code Copilot (via the LLM Gateway extension), intermittent `502 Bad Gateway` errors occur with the message:

```
Failed to connect to model server: error sending request for url (http://127.0.0.1:5500/v1/chat/completions)
```

### Root Cause

`ProcessManager::ensure_model_running()` has a "same model + same context" fast path (step 3) that returns the cached port from `CurrentModelState` **without any liveness check**. If `llama.cpp` crashes or is OOM-killed after a successful startup, `CurrentModelState` is never invalidated. Every subsequent request hits the fast path, forwards to the dead port, receives `ECONNREFUSED`, and the proxy returns `502`.

The existing `ServerHealthMonitor` detects the crash, but its results are never wired back to clear `CurrentModelState`.

## Solution: Catch-Clear-503

A reactive pattern with **zero overhead on the hot path** — no pre-flight health I/O on every request.

```
Client → POST /v1/chat/completions
              ↓
   ensure_model_running() → Ok(stale port)   ← fast path, no change
              ↓
   forward_chat_completion() → Err(UpstreamDead)  ← NEW: is_connect() detected
              ↓
   stop_current()   ← clears stale CurrentModelState
              ↓
   503 Service Unavailable + Retry-After: 5   ← client retries → clean restart
```

On retry, `ensure_model_running()` sees an empty `CurrentModelState`, enters the full startup path, spawns a fresh `llama-server`, waits for its health check, and the request succeeds.

## Changes

### Commit 1 — `crates/gglib-proxy/src/forward.rs`

- Add `pub(crate) enum ForwardError { UpstreamDead }`
- Change `forward_chat_completion` return type from `-> Response` to `-> Result<Response, ForwardError>`
- Split the `.send().await` error arm: `e.is_connect() || e.is_timeout()` → `Err(ForwardError::UpstreamDead)`; all other transport errors remain `Ok(502)` unchanged
- All other return sites mechanically wrapped in `Ok(...)`

### Commit 2 — `crates/gglib-proxy/src/server.rs`

- `chat_completions` handler now matches on `forward_chat_completion`'s result
- `Ok(resp)` → return it (hot path, no change)
- `Err(ForwardError::UpstreamDead)` → calls `stop_current()` (fire-and-forget) to clear stale state, then returns `503 Service Unavailable` with `Retry-After: 5` — the same contract already used by the model-loading path that VS Code clients handle correctly

### Commit 3 — `crates/gglib-proxy/src/server.rs`

- Add `.timeout(Duration::from_secs(300))` to the upstream `reqwest::Client` builder
- Prevents a hung-but-alive `llama-server` (OOM stall, stuck inference) from blocking the proxy indefinitely — the timeout fires as `is_timeout()`, completing the `UpstreamDead` recovery path for both failure modes

## Properties

| Property | Value |
|---|---|
| Hot-path overhead | Zero — no health I/O on every request |
| New trait methods | None — reuses existing `stop_current()` |
| New files | None |
| State-clearing correctness | `stop_current()` calls `guard.take()` before `kill()`, so state is cleared even if the process is already dead (ESRCH) |
| Non-2xx passthroughs | Unchanged — llama.cpp 503 (slot exhaustion) still propagates as `Ok(503)` |

## Testing

All existing tests pass (`cargo test --workspace`).

Manual verification: kill `llama-server` while the proxy is running → next Copilot request receives `503 + Retry-After: 5` instead of `502` → model restarts on the next request → subsequent requests succeed.