### PR TITLE
fix(proxy): replace total timeout with connect_timeout for SSE streaming

### DIFF
--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -87,14 +87,28 @@ pub async fn serve(
     info!("Proxy server starting on {addr}");
 
     // Create HTTP client for upstream requests.
-    // 300-second timeout guards against a hung-but-alive llama-server that
-    // stops responding mid-inference (e.g. OOM stall).  The timeout fires
-    // as a reqwest::Error::is_timeout(), which forward_chat_completion
-    // maps to ForwardError::UpstreamDead so the handler can clear stale
-    // state and return a retriable 503 instead of hanging indefinitely.
+    //
+    // We use connect_timeout (not a total-request timeout) deliberately:
+    //
+    // * A wall-clock `.timeout()` on the whole request kills long-running
+    //   SSE streams — e.g. a 36 k-token prompt at 125 t/s takes ~290 s of
+    //   prompt processing before the first generated token appears.  With a
+    //   300 s total timeout, any heavy request races against that deadline
+    //   and the proxy severs the connection mid-stream, surfacing a spurious
+    //   "upstream SSE byte-stream error" to the client.
+    //
+    // * connect_timeout only measures the TCP handshake to 127.0.0.1, which
+    //   completes in <1 ms under normal conditions.  A 10 s budget is more
+    //   than enough to detect a dead/not-yet-started port while imposing no
+    //   limit on how long an actual inference may take.
+    //
+    // Dead-server protection during streaming is handled separately: if
+    // llama-server crashes mid-stream the reqwest byte-stream returns an
+    // error, which forward_chat_completion surfaces as ForwardError::UpstreamDead
+    // and the handler clears stale state for the next request.
     let client = Client::builder()
         .pool_max_idle_per_host(10)
-        .timeout(std::time::Duration::from_secs(300))
+        .connect_timeout(std::time::Duration::from_secs(10))
         .build()?;
 
     let state = AppState {


### PR DESCRIPTION
## Root Cause

The reqwest `Client` was built with `.timeout(Duration::from_secs(300))`, which imposes a wall-clock deadline on the **entire** request — including the SSE streaming response body. For heavy prompts, this deadline fires mid-stream and severs the connection, surfacing a spurious error to the client.

### Evidence from production logs

```
02:16:16 — forward started (36,259-token prompt, ~125 t/s)
02:21:16 — exactly 300 s later, reqwest kills the byte-stream
           WARN upstream SSE byte-stream error: error decoding response body
           ERROR proxy stream error: upstream SSE byte-stream error: ...
```

With concurrent subagents the effect is amplified — all requests share the same client-level timer epoch and expire simultaneously:

```
02:24:43 — 5 subagent requests dispatched
02:29:43 — exactly 300 s later, three simultaneous WARN lines 16 ms apart
```

**llama-server was alive and healthy throughout.** It logged `cancel task` *after* receiving the connection-close, confirming it was the proxy that terminated the stream.

## Fix

Replace `.timeout(300s)` with `.connect_timeout(10s)`:

| | Before | After |
|---|---|---|
| What it limits | Entire request (connect + stream body) | TCP handshake only |
| Effect on 36k-token prompt | Kills stream at 300 s | No limit — completes normally |
| Dead-port detection | Yes (fires on hung connect) | Yes (10 s connect timeout) |

`connect_timeout` only measures the TCP handshake to `127.0.0.1`, which completes in \<1 ms under normal conditions. A 10 s budget is generous enough to detect a dead or not-yet-started port while imposing no limit on inference duration.

Dead-server protection during streaming is already handled separately: if llama-server crashes mid-stream, reqwest surfaces an EOF error which `forward.rs` maps to `ForwardError::UpstreamDead` and the handler clears stale state for the next request (see PR #564).

## Testing

- `cargo test --workspace` ✅
- `cargo clippy --package gglib-proxy --all-targets -- -D warnings` ✅