### PR TITLE
feat(proxy): inject stream_options usage + preserve upstream error type/code

### DIFF
--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -465,6 +465,36 @@ pub(crate) async fn forward_chat_completion(
         //    to assign a slot.  Once headers arrive the task streams the real
         //    response through the normalization pipeline via the same channel.
 
+        // Inject `stream_options: { include_usage: true }` so llama.cpp emits
+        // a final usage SSE chunk with real token counts.  The LLM Gateway
+        // extension (v1.1.0) reads `e.usage` in `dispatchParsedChunk` and
+        // reports it to VS Code via `LanguageModelDataPart("usage")`, which
+        // feeds the context window indicator and enables automatic proactive
+        // compaction before the context limit is ever reached.
+        //
+        // Safety: if the body is not a JSON object the original bytes are
+        // forwarded unchanged.  No panic paths — every operation returns an
+        // Option or Result and is handled explicitly.
+        let body = match serde_json::from_slice::<serde_json::Value>(&body) {
+            Ok(mut value) => {
+                if let Some(obj) = value.as_object_mut() {
+                    let stream_opts = obj
+                        .entry("stream_options")
+                        .or_insert_with(|| serde_json::json!({}));
+                    if let serde_json::Value::Object(opts) = stream_opts {
+                        // Force-insert: we always need usage data, even if
+                        // the client sent include_usage: false.
+                        opts.insert(
+                            "include_usage".to_owned(),
+                            serde_json::Value::Bool(true),
+                        );
+                    }
+                }
+                serde_json::to_vec(&value).map(Bytes::from).unwrap_or(body)
+            }
+            Err(_) => body, // not JSON — forward as-is
+        };
+
         // Phase 1 — TCP probe (1 s timeout).
         let probe_addr = host_port_from_url(upstream_url);
         let probe_result = tokio::time::timeout(
@@ -524,19 +554,52 @@ pub(crate) async fn forward_chat_completion(
                 Ok(resp) => {
                     let status = resp.status();
                     let error_bytes = resp.bytes().await.unwrap_or_default();
-                    let body_str = String::from_utf8_lossy(&error_bytes);
                     warn!(
                         status = status.as_u16(),
-                        body = %body_str,
+                        bytes = error_bytes.len(),
                         "upstream returned error during slot-queue wait"
                     );
-                    let payload = serde_json::json!({
-                        "error": {
-                            "message": format!("upstream returned {}: {}", status, body_str),
-                            "type": "server_error",
-                            "code": "upstream_error",
+                    // Preserve the upstream error's `type` and `code` so the
+                    // LLM Gateway extension (and VS Code) can identify errors
+                    // like `context_length_exceeded` rather than seeing an
+                    // opaque `server_error` wrapper.  Falls back to the
+                    // generic envelope only when the body is not valid JSON.
+                    // No panic paths: every operation is Option/Result-safe.
+                    let payload = match serde_json::from_slice::<serde_json::Value>(&error_bytes)
+                    {
+                        Ok(upstream) => {
+                            let msg = upstream
+                                .pointer("/error/message")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("upstream returned an error");
+                            let typ = upstream
+                                .pointer("/error/type")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("server_error");
+                            let code = upstream
+                                .pointer("/error/code")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("upstream_error");
+                            serde_json::json!({
+                                "error": { "message": msg, "type": typ, "code": code }
+                            })
                         }
-                    });
+                        Err(_) => {
+                            // Non-JSON body — fall back to a generic wrapper
+                            // that includes the raw bytes as context.
+                            let body_str = String::from_utf8_lossy(&error_bytes);
+                            serde_json::json!({
+                                "error": {
+                                    "message": format!(
+                                        "upstream returned {}: {}",
+                                        status, body_str
+                                    ),
+                                    "type": "server_error",
+                                    "code": "upstream_error",
+                                }
+                            })
+                        }
+                    };
                     let frame = format!("data: {payload}\n\ndata: [DONE]\n\n");
                     let _ = tx.send(Ok(Bytes::from(frame))).await;
                 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -484,10 +484,7 @@ pub(crate) async fn forward_chat_completion(
                     if let serde_json::Value::Object(opts) = stream_opts {
                         // Force-insert: we always need usage data, even if
                         // the client sent include_usage: false.
-                        opts.insert(
-                            "include_usage".to_owned(),
-                            serde_json::Value::Bool(true),
-                        );
+                        opts.insert("include_usage".to_owned(), serde_json::Value::Bool(true));
                     }
                 }
                 serde_json::to_vec(&value).map(Bytes::from).unwrap_or(body)
@@ -565,8 +562,7 @@ pub(crate) async fn forward_chat_completion(
                     // opaque `server_error` wrapper.  Falls back to the
                     // generic envelope only when the body is not valid JSON.
                     // No panic paths: every operation is Option/Result-safe.
-                    let payload = match serde_json::from_slice::<serde_json::Value>(&error_bytes)
-                    {
+                    let payload = match serde_json::from_slice::<serde_json::Value>(&error_bytes) {
                         Ok(upstream) => {
                             let msg = upstream
                                 .pointer("/error/message")


### PR DESCRIPTION
## Problem

VS Code's automatic context compaction never fires for local models via the LLM Gateway extension, so long conversations eventually hit the hard `context_length_exceeded` 400 error from llama.cpp with no graceful recovery.

Two root causes:

**1. VS Code context window indicator always shows 0%**
The LLM Gateway extension (v1.1.0) already has the full usage-reporting pipeline: `dispatchParsedChunk` reads `e.usage` from any SSE chunk and calls `reportUsage`, which emits `LanguageModelDataPart("usage")` to VS Code. VS Code 1.120+ reads this and updates the context window gauge. The missing piece was that llama.cpp only emits a final usage chunk when explicitly asked — and gglib was never injecting `stream_options: {include_usage: true}`.

**2. Streaming errors lose their identity**
After PR #566 (keepalive), all streaming errors are returned as SSE data frames. The previous implementation wrapped every upstream error as `type:"server_error" / code:"upstream_error"`, so a `context_length_exceeded` 400 from llama.cpp became unrecognizable to the extension and VS Code.

## Changes — `crates/gglib-proxy/src/forward.rs`

### stream_options injection (proactive compaction)

At the top of the `if is_streaming` branch, after inference-defaults merging but before the TCP probe, the body is mutated in-place:

```rust
let body = match serde_json::from_slice::<serde_json::Value>(&body) {
    Ok(mut value) => {
        if let Some(obj) = value.as_object_mut() {
            let stream_opts = obj.entry("stream_options")
                .or_insert_with(|| serde_json::json!({}));
            if let serde_json::Value::Object(opts) = stream_opts {
                opts.insert("include_usage".to_owned(), serde_json::Value::Bool(true));
            }
        }
        serde_json::to_vec(&value).map(Bytes::from).unwrap_or(body)
    }
    Err(_) => body,
};
```

- Uses the `entry` API: an existing `stream_options` object is preserved, only `include_usage` is force-inserted
- Non-JSON body is forwarded unchanged
- Zero `.unwrap()` / `.expect()` calls

### Upstream error type/code preservation (reactive path)

The `Ok(resp)` non-2xx arm in `tokio::spawn` now tries to parse the upstream body and forward its `error.message` / `error.type` / `error.code` verbatim:

```rust
let payload = match serde_json::from_slice::<serde_json::Value>(&error_bytes) {
    Ok(upstream) => serde_json::json!({
        "error": {
            "message": upstream.pointer("/error/message").and_then(Value::as_str).unwrap_or("..."),
            "type":    upstream.pointer("/error/type").and_then(Value::as_str).unwrap_or("server_error"),
            "code":    upstream.pointer("/error/code").and_then(Value::as_str).unwrap_or("upstream_error"),
        }
    }),
    Err(_) => serde_json::json!({ "error": { "message": "upstream returned N: ...", ... } }),
};
```

- All lookups use `.pointer()` + `.and_then()` + `.unwrap_or()` — zero panic paths
- Falls back to previous generic wrapper for non-JSON bodies

## End-to-end flow after this PR

```
llama.cpp final chunk: {"usage":{"prompt_tokens":45231,...}}
  → gglib proxy (stream_response_to_channel, unchanged)
  → LLM Gateway extension dispatchParsedChunk reads e.usage
  → reportUsage: e.report(new LanguageModelDataPart(encoded, "usage"))
  → VS Code 1.120+ context window gauge shows real %
  → Copilot Chat auto-compacts before hitting the hard limit
```

## Testing
- `cargo test --workspace --exclude gglib-tauri --exclude gglib-app` — all passing
- `cargo clippy --package gglib-proxy --all-targets -- -D warnings` — clean