### PR TITLE
Fix Unsloth 'UD-' dynamic quant collisions with plain quants

### DIFF
--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -373,6 +373,10 @@ gglib model search "llama 3 GGUF"
 
 # Download from HuggingFace
 gglib model download TheBloke/Llama-2-7B-GGUF --quant Q4_K_M
+
+# Download an Unsloth Dynamic ("UD-") quant -- distinct from the plain quant
+# of the same suffix, e.g. "UD-Q6_K" vs "Q6_K"
+gglib model download unsloth/Qwen3-Coder-Next-GGUF --quant UD-Q6_K
 ```
 
 ## Design Decisions

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -250,7 +250,8 @@ pub enum ModelCommand {
     Download {
         /// HuggingFace model repository (e.g., "bartowski/Qwen2.5-7B-Instruct-GGUF")
         model_id: String,
-        /// Specific quantization to download (e.g., "Q4_K_M", "F16")
+        /// Specific quantization to download (e.g., "Q4_K_M", "F16", or an
+        /// Unsloth Dynamic quant like "UD-Q4_K_M")
         #[arg(short, long)]
         quantization: Option<String>,
         /// List available quantizations for the model

--- a/crates/gglib-core/src/download/README.md
+++ b/crates/gglib-core/src/download/README.md
@@ -9,7 +9,10 @@ system. No I/O, networking, or runtime dependencies allowed.
 
 # Structure
 
-- `types` - Core identifiers and data structures (`DownloadId`, `Quantization`, `ShardInfo`)
+- `types` - Core identifiers and data structures (`DownloadId`, `Quantization`, `ShardInfo`).
+  `Quantization` models Unsloth Dynamic ("UD-") quants (e.g. `UD-Q6_K`) as distinct
+  values from their plain counterparts (`Q6_K`), since `HuggingFace` repos frequently
+  publish both with the same bit-depth suffix.
 - `events` - Download events and status types (`DownloadEvent`, `DownloadStatus`)
 - `errors` - Error types for download operations
 - `queue` - Queue snapshot DTOs (`QueueSnapshot`, `QueuedDownload`, `FailedDownload`)

--- a/crates/gglib-core/src/download/types.rs
+++ b/crates/gglib-core/src/download/types.rs
@@ -598,6 +598,86 @@ mod tests {
     }
 
     #[test]
+    fn test_quantization_distinguishes_ud_dynamic_from_plain() {
+        // Real-world collision: unsloth/Qwen3-Coder-Next-GGUF publishes both
+        // Q6_K/ and UD-Q6_K/ directories with the same bit-depth suffix.
+        assert_eq!(
+            Quantization::from_filename("Qwen3-Coder-Next-Q6_K.gguf"),
+            Quantization::Q6K
+        );
+        assert_eq!(
+            Quantization::from_filename("Qwen3-Coder-Next-UD-Q6_K.gguf"),
+            Quantization::UdQ6K
+        );
+        assert_ne!(Quantization::Q6K, Quantization::UdQ6K);
+    }
+
+    #[test]
+    fn test_quantization_longest_match_wins_over_table_order() {
+        // "UD-Q6_K_XL" contains the shorter "Q6_K" pattern as a boundary-valid
+        // substring too, but the longer, more specific "Q6_K_XL" pattern (which
+        // is listed *after* plain "UD-" handling would apply) must still win.
+        assert_eq!(
+            Quantization::from_filename("Qwen3-Coder-Next-UD-Q6_K_XL.gguf"),
+            Quantization::Q6KXl
+        );
+        assert_eq!(
+            Quantization::from_filename("Qwen3-Coder-Next-UD-Q4_K_XL.gguf"),
+            Quantization::Q4KXl
+        );
+    }
+
+    #[test]
+    fn test_quantization_boundary_avoids_model_name_collisions() {
+        // "Q6King" is not a delimited "Q6_K" token, so it must not match.
+        assert_eq!(
+            Quantization::from_filename("Deepseek-Q6King-7B.gguf"),
+            Quantization::Unknown
+        );
+    }
+
+    #[test]
+    fn test_quantization_ud_only_variants_previously_unknown() {
+        // These previously had no pattern at all and silently mapped to Unknown.
+        assert_eq!(
+            Quantization::from_filename("Qwen3-Coder-Next-UD-IQ1_S.gguf"),
+            Quantization::UdIq1S
+        );
+        assert_eq!(
+            Quantization::from_filename("Qwen3-Coder-Next-UD-TQ1_0.gguf"),
+            Quantization::UdTq1_0
+        );
+    }
+
+    #[test]
+    fn test_quantization_ud_variant_as_str_round_trip() {
+        for (base, ud) in [
+            (Quantization::Q3KM, Quantization::UdQ3KM),
+            (Quantization::Q3KS, Quantization::UdQ3KS),
+            (Quantization::Q4KM, Quantization::UdQ4KM),
+            (Quantization::Q4KS, Quantization::UdQ4KS),
+            (Quantization::Q5KM, Quantization::UdQ5KM),
+            (Quantization::Q5KS, Quantization::UdQ5KS),
+            (Quantization::Q6K, Quantization::UdQ6K),
+        ] {
+            assert_eq!(ud.as_str(), format!("UD-{}", base.as_str()));
+            assert_eq!(ud.as_str().parse::<Quantization>().unwrap(), ud);
+            assert_eq!(base.as_str().parse::<Quantization>().unwrap(), base);
+        }
+    }
+
+    #[test]
+    fn test_quantization_from_str_ud_prefix() {
+        assert_eq!("UD-Q6_K".parse::<Quantization>().unwrap(), Quantization::UdQ6K);
+        assert_eq!(
+            "ud-q6_k".parse::<Quantization>().unwrap(),
+            Quantization::UdQ6K
+        );
+        assert_eq!("Q6_K".parse::<Quantization>().unwrap(), Quantization::Q6K);
+        assert!("UD-NOT_A_QUANT".parse::<Quantization>().is_err());
+    }
+
+    #[test]
     fn test_shard_info_display() {
         let shard = ShardInfo::new(1, 5, "model-00002-of-00005.gguf");
         assert_eq!(shard.display(), "Part 2/5");

--- a/crates/gglib-core/src/download/types.rs
+++ b/crates/gglib-core/src/download/types.rs
@@ -96,34 +96,76 @@ impl FromStr for DownloadId {
 ///
 /// This enum provides type-safe handling of quantization types commonly used
 /// in GGUF model naming conventions.
+///
+/// # Unsloth Dynamic ("UD-") quants
+///
+/// Unsloth publishes many repos with both a plain quant (e.g. `Q6_K`) and a
+/// "UD-" prefixed *Unsloth Dynamic* quant (e.g. `UD-Q6_K`) that otherwise shares
+/// the exact same bit-depth suffix. These are modeled as distinct variants
+/// (`Q6K` vs `UdQ6K`) so they are never conflated: without this distinction, a
+/// naive filename match would treat `Q6_K/model.gguf` and `UD-Q6_K/model.gguf`
+/// as the same quantization, which previously caused both to be downloaded
+/// together as if they were shards of one request. See [`from_filename`] for
+/// how the "UD-" modifier is detected.
+///
+/// [`from_filename`]: Self::from_filename
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum Quantization {
     // 1-bit quantizations
     Iq1S,
     Iq1M,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq1S`].
+    UdIq1S,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq1M`].
+    UdIq1M,
+    // Ternary quantizations
+    Tq1_0,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Tq1_0`].
+    UdTq1_0,
     // 2-bit quantizations
     Iq2Xxs,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq2Xxs`].
+    UdIq2Xxs,
     Iq2Xs,
     Iq2S,
     Iq2M,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq2M`].
+    UdIq2M,
     Q2KXl,
     Q2KL,
     Q2K,
     // 3-bit quantizations
     Iq3Xxs,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq3Xxs`].
+    UdIq3Xxs,
     Iq3Xs,
+    Iq3S,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq3S`].
+    UdIq3S,
     Iq3M,
     Q3KXl,
     Q3KL,
     Q3KM,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q3KM`].
+    UdQ3KM,
     Q3KS,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q3KS`].
+    UdQ3KS,
     // 4-bit quantizations
     Iq4Xs,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq4Xs`].
+    UdIq4Xs,
     Iq4Nl,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Iq4Nl`].
+    UdIq4Nl,
     Q4KXl,
     Q4KL,
     Q4KM,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q4KM`].
+    UdQ4KM,
     Q4KS,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q4KS`].
+    UdQ4KS,
     Q4_1,
     Q4_0,
     Mxfp4,
@@ -132,7 +174,11 @@ pub enum Quantization {
     Q5KXl,
     Q5KL,
     Q5KM,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q5KM`].
+    UdQ5KM,
     Q5KS,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q5KS`].
+    UdQ5KS,
     Q5_0,
     Q5_1,
     Q5,
@@ -140,6 +186,8 @@ pub enum Quantization {
     Q6KXl,
     Q6KL,
     Q6K,
+    /// Unsloth Dynamic ("UD-") variant of [`Self::Q6K`].
+    UdQ6K,
     Q6,
     // 8-bit quantizations
     Q8KXl,
@@ -156,11 +204,22 @@ pub enum Quantization {
     Unknown,
 }
 
-/// Pattern table for quantization extraction, ordered by specificity.
+/// Pattern table for quantization extraction, ordered by family for readability.
+///
+/// Ordering is *not* load-bearing for correctness: [`Quantization::from_filename`]
+/// checks every pattern and picks the longest boundary-valid match, so a more
+/// specific pattern (e.g. `"Q6_K_XL"`) always wins over a shorter one it contains
+/// (e.g. `"Q6_K"`) regardless of table order.
+///
+/// This table intentionally has no `"UD-"` prefixed entries — that modifier is
+/// detected orthogonally in `from_filename` via [`UD_VARIANT_MAP`] instead of
+/// duplicating every family's pattern string.
 const QUANT_PATTERNS: &[(&str, Quantization)] = &[
     // 1-bit
     ("IQ1_S", Quantization::Iq1S),
     ("IQ1_M", Quantization::Iq1M),
+    // Ternary
+    ("TQ1_0", Quantization::Tq1_0),
     // 2-bit (most specific first)
     ("IQ2_XXS", Quantization::Iq2Xxs),
     ("IQ2_XS", Quantization::Iq2Xs),
@@ -172,6 +231,7 @@ const QUANT_PATTERNS: &[(&str, Quantization)] = &[
     // 3-bit
     ("IQ3_XXS", Quantization::Iq3Xxs),
     ("IQ3_XS", Quantization::Iq3Xs),
+    ("IQ3_S", Quantization::Iq3S),
     ("IQ3_M", Quantization::Iq3M),
     ("Q3_K_XL", Quantization::Q3KXl),
     ("Q3_K_L", Quantization::Q3KL),
@@ -215,6 +275,85 @@ const QUANT_PATTERNS: &[(&str, Quantization)] = &[
     ("IMATRIX", Quantization::Imatrix),
 ];
 
+/// Maps a base quantization to its Unsloth Dynamic ("UD-") counterpart, for the
+/// families where Unsloth publishes both a plain and a "UD-" prefixed variant
+/// with an otherwise identical suffix (e.g. `Q6_K` vs `UD-Q6_K`).
+///
+/// Kept as a small lookup table rather than duplicating full pattern strings
+/// like `"UD-Q6_K"` in [`QUANT_PATTERNS`], so the "UD-" modifier only needs to be
+/// detected once, generically, in [`Quantization::from_filename`].
+const UD_VARIANT_MAP: &[(Quantization, Quantization)] = &[
+    (Quantization::Iq1S, Quantization::UdIq1S),
+    (Quantization::Iq1M, Quantization::UdIq1M),
+    (Quantization::Tq1_0, Quantization::UdTq1_0),
+    (Quantization::Iq2Xxs, Quantization::UdIq2Xxs),
+    (Quantization::Iq2M, Quantization::UdIq2M),
+    (Quantization::Iq3Xxs, Quantization::UdIq3Xxs),
+    (Quantization::Iq3S, Quantization::UdIq3S),
+    (Quantization::Q3KM, Quantization::UdQ3KM),
+    (Quantization::Q3KS, Quantization::UdQ3KS),
+    (Quantization::Iq4Xs, Quantization::UdIq4Xs),
+    (Quantization::Iq4Nl, Quantization::UdIq4Nl),
+    (Quantization::Q4KM, Quantization::UdQ4KM),
+    (Quantization::Q4KS, Quantization::UdQ4KS),
+    (Quantization::Q5KM, Quantization::UdQ5KM),
+    (Quantization::Q5KS, Quantization::UdQ5KS),
+    (Quantization::Q6K, Quantization::UdQ6K),
+];
+
+/// Returns the byte offset of the first ASCII case-insensitive occurrence of
+/// `pattern` in `haystack` that is flanked by non-alphanumeric characters (or
+/// the start/end of the string).
+///
+/// This boundary requirement avoids false positives against unrelated
+/// alphanumeric substrings inside a model name (e.g. a hypothetical segment
+/// like `"Q6King"` no longer falsely matches the `"Q6_K"` pattern). Operates
+/// directly on byte slices with no heap allocation and no regex, since this
+/// runs on every file encountered while scanning a repository's file listing.
+fn find_boundary_match(haystack: &[u8], pattern: &[u8]) -> Option<usize> {
+    let plen = pattern.len();
+    if plen == 0 || plen > haystack.len() {
+        return None;
+    }
+
+    haystack.windows(plen).enumerate().find_map(|(start, window)| {
+        if !window.eq_ignore_ascii_case(pattern) {
+            return None;
+        }
+        let before_ok = start == 0 || !haystack[start - 1].is_ascii_alphanumeric();
+        let after = start + plen;
+        let after_ok = after == haystack.len() || !haystack[after].is_ascii_alphanumeric();
+        (before_ok && after_ok).then_some(start)
+    })
+}
+
+/// Returns true if the standalone token immediately preceding `match_start`
+/// (delimited on both sides) is `"UD"` (ASCII case-insensitive) — e.g. detects
+/// the `UD-` in `"...UD-Q6_K.gguf"` when `match_start` is the offset of `Q6_K`.
+fn has_ud_prefix(haystack: &[u8], match_start: usize) -> bool {
+    // Need room for at least "UD" plus one delimiter byte before the match.
+    let Some(token_start) = match_start.checked_sub(3) else {
+        return false;
+    };
+    let delimiter = haystack[match_start - 1];
+    if delimiter.is_ascii_alphanumeric() {
+        return false;
+    }
+    if !haystack[token_start..match_start - 1].eq_ignore_ascii_case(b"UD") {
+        return false;
+    }
+    token_start == 0 || !haystack[token_start - 1].is_ascii_alphanumeric()
+}
+
+/// Looks up the Unsloth Dynamic ("UD-") counterpart of a base quantization, if
+/// one is defined in [`UD_VARIANT_MAP`].
+fn ud_variant_of(base: Quantization) -> Option<Quantization> {
+    UD_VARIANT_MAP
+        .iter()
+        .find(|(candidate, _)| *candidate == base)
+        .map(|(_, dynamic)| *dynamic)
+}
+
 impl Quantization {
     /// Returns true if this quantization type is unknown.
     #[must_use]
@@ -223,13 +362,42 @@ impl Quantization {
     }
 
     /// Extract quantization type from a filename.
+    ///
+    /// Matching is boundary-aware and allocation-free: a pattern only counts as
+    /// a match when it is flanked by non-alphanumeric characters (or the
+    /// start/end of the string), which avoids false positives against
+    /// unrelated alphanumeric substrings in a model name. When multiple
+    /// patterns match, the *longest* one wins, so correctness does not depend
+    /// on [`QUANT_PATTERNS`] ordering.
+    ///
+    /// Unsloth's "UD-" ("Unsloth Dynamic") naming convention is detected as an
+    /// orthogonal, delimited token immediately preceding the matched base
+    /// pattern (see [`UD_VARIANT_MAP`]), rather than by duplicating full
+    /// pattern strings like `"UD-Q6_K"` — this keeps e.g. `Q6_K` and `UD-Q6_K`
+    /// as distinct values even though they share the same underlying
+    /// bit-depth pattern.
     #[must_use]
     pub fn from_filename(filename: &str) -> Self {
-        let upper = filename.to_uppercase();
-        QUANT_PATTERNS
-            .iter()
-            .find(|(pattern, _)| upper.contains(pattern))
-            .map_or(Self::Unknown, |(_, q)| *q)
+        let bytes = filename.as_bytes();
+        let mut best: Option<(usize, Self)> = None;
+
+        for (pattern, quant) in QUANT_PATTERNS {
+            let Some(pos) = find_boundary_match(bytes, pattern.as_bytes()) else {
+                continue;
+            };
+            let len = pattern.len();
+            if best.is_some_and(|(best_len, _)| best_len >= len) {
+                continue;
+            }
+            let resolved = if has_ud_prefix(bytes, pos) {
+                ud_variant_of(*quant).unwrap_or(*quant)
+            } else {
+                *quant
+            };
+            best = Some((len, resolved));
+        }
+
+        best.map_or(Self::Unknown, |(_, q)| q)
     }
 
     /// Get the canonical string representation.
@@ -238,26 +406,41 @@ impl Quantization {
         match self {
             Self::Iq1S => "IQ1_S",
             Self::Iq1M => "IQ1_M",
+            Self::UdIq1S => "UD-IQ1_S",
+            Self::UdIq1M => "UD-IQ1_M",
+            Self::Tq1_0 => "TQ1_0",
+            Self::UdTq1_0 => "UD-TQ1_0",
             Self::Iq2Xxs => "IQ2_XXS",
+            Self::UdIq2Xxs => "UD-IQ2_XXS",
             Self::Iq2Xs => "IQ2_XS",
             Self::Iq2S => "IQ2_S",
             Self::Iq2M => "IQ2_M",
+            Self::UdIq2M => "UD-IQ2_M",
             Self::Q2KXl => "Q2_K_XL",
             Self::Q2KL => "Q2_K_L",
             Self::Q2K => "Q2_K",
             Self::Iq3Xxs => "IQ3_XXS",
+            Self::UdIq3Xxs => "UD-IQ3_XXS",
             Self::Iq3Xs => "IQ3_XS",
+            Self::Iq3S => "IQ3_S",
+            Self::UdIq3S => "UD-IQ3_S",
             Self::Iq3M => "IQ3_M",
             Self::Q3KXl => "Q3_K_XL",
             Self::Q3KL => "Q3_K_L",
             Self::Q3KM => "Q3_K_M",
+            Self::UdQ3KM => "UD-Q3_K_M",
             Self::Q3KS => "Q3_K_S",
+            Self::UdQ3KS => "UD-Q3_K_S",
             Self::Iq4Xs => "IQ4_XS",
+            Self::UdIq4Xs => "UD-IQ4_XS",
             Self::Iq4Nl => "IQ4_NL",
+            Self::UdIq4Nl => "UD-IQ4_NL",
             Self::Q4KXl => "Q4_K_XL",
             Self::Q4KL => "Q4_K_L",
             Self::Q4KM => "Q4_K_M",
+            Self::UdQ4KM => "UD-Q4_K_M",
             Self::Q4KS => "Q4_K_S",
+            Self::UdQ4KS => "UD-Q4_K_S",
             Self::Q4_1 => "Q4_1",
             Self::Q4_0 => "Q4_0",
             Self::Mxfp4 => "MXFP4",
@@ -265,13 +448,16 @@ impl Quantization {
             Self::Q5KXl => "Q5_K_XL",
             Self::Q5KL => "Q5_K_L",
             Self::Q5KM => "Q5_K_M",
+            Self::UdQ5KM => "UD-Q5_K_M",
             Self::Q5KS => "Q5_K_S",
+            Self::UdQ5KS => "UD-Q5_K_S",
             Self::Q5_0 => "Q5_0",
             Self::Q5_1 => "Q5_1",
             Self::Q5 => "Q5",
             Self::Q6KXl => "Q6_K_XL",
             Self::Q6KL => "Q6_K_L",
             Self::Q6K => "Q6_K",
+            Self::UdQ6K => "UD-Q6_K",
             Self::Q6 => "Q6",
             Self::Q8KXl => "Q8_K_XL",
             Self::Q8_0 => "Q8_0",
@@ -296,10 +482,22 @@ impl FromStr for Quantization {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let upper = s.to_uppercase();
+
+        if let Some((_, q)) = QUANT_PATTERNS.iter().find(|(pattern, _)| *pattern == upper) {
+            return Ok(*q);
+        }
+
+        // Fall back to stripping a "UD-" (Unsloth Dynamic) modifier prefix and
+        // mapping the remaining base pattern to its distinct dynamic variant.
+        let rest = upper
+            .strip_prefix("UD-")
+            .or_else(|| upper.strip_prefix("UD_"))
+            .ok_or(())?;
+
         QUANT_PATTERNS
             .iter()
-            .find(|(pattern, _)| *pattern == upper)
-            .map(|(_, q)| *q)
+            .find(|(pattern, _)| *pattern == rest)
+            .and_then(|(_, base)| ud_variant_of(*base))
             .ok_or(())
     }
 }

--- a/crates/gglib-core/src/download/types.rs
+++ b/crates/gglib-core/src/download/types.rs
@@ -316,15 +316,18 @@ fn find_boundary_match(haystack: &[u8], pattern: &[u8]) -> Option<usize> {
         return None;
     }
 
-    haystack.windows(plen).enumerate().find_map(|(start, window)| {
-        if !window.eq_ignore_ascii_case(pattern) {
-            return None;
-        }
-        let before_ok = start == 0 || !haystack[start - 1].is_ascii_alphanumeric();
-        let after = start + plen;
-        let after_ok = after == haystack.len() || !haystack[after].is_ascii_alphanumeric();
-        (before_ok && after_ok).then_some(start)
-    })
+    haystack
+        .windows(plen)
+        .enumerate()
+        .find_map(|(start, window)| {
+            if !window.eq_ignore_ascii_case(pattern) {
+                return None;
+            }
+            let before_ok = start == 0 || !haystack[start - 1].is_ascii_alphanumeric();
+            let after = start + plen;
+            let after_ok = after == haystack.len() || !haystack[after].is_ascii_alphanumeric();
+            (before_ok && after_ok).then_some(start)
+        })
 }
 
 /// Returns true if the standalone token immediately preceding `match_start`
@@ -668,7 +671,10 @@ mod tests {
 
     #[test]
     fn test_quantization_from_str_ud_prefix() {
-        assert_eq!("UD-Q6_K".parse::<Quantization>().unwrap(), Quantization::UdQ6K);
+        assert_eq!(
+            "UD-Q6_K".parse::<Quantization>().unwrap(),
+            Quantization::UdQ6K
+        );
         assert_eq!(
             "ud-q6_k".parse::<Quantization>().unwrap(),
             Quantization::UdQ6K

--- a/crates/gglib-download/README.md
+++ b/crates/gglib-download/README.md
@@ -122,6 +122,10 @@ let id = manager.queue_download(request).await?;
 // - Single quant available → auto-picks it
 // - Multiple quants → uses default preference (Q5_K_M, Q4_K_M, etc.)
 // - Explicit quant → validates it exists
+//
+// Note: Unsloth Dynamic ("UD-") quants (e.g. "UD-Q6_K") are always distinct,
+// separately selectable entries from their plain counterparts ("Q6_K") -- they
+// are never picked by the default preference list, so request them explicitly.
 let (position, shard_count) = Arc::clone(&manager)
     .queue_smart("user/model".to_string(), Some("Q8_0".to_string()))
     .await?;

--- a/crates/gglib-hf/README.md
+++ b/crates/gglib-hf/README.md
@@ -82,7 +82,9 @@ async fn example() {
 ## Features
 
 - **Model Search**: Search `HuggingFace` Hub for GGUF models with pagination and sorting
-- **Quantization Listing**: List available quantization variants (`Q4_K_M`, `Q5_K_S`, etc.)
+- **Quantization Listing**: List available quantization variants (`Q4_K_M`, `Q5_K_S`, etc.),
+  including Unsloth Dynamic ("UD-") quants (`UD-Q4_K_M`, `UD-Q6_K`, etc.) as separate,
+  independently selectable entries from their plain counterparts
 - **File Resolution**: Find specific GGUF files for download, including sharded models
 - **Commit SHA Lookup**: Get latest commit SHA for version tracking
 - **Authenticated Access**: Optional `HuggingFace` token for gated models

--- a/crates/gglib-hf/src/client/repo_files.rs
+++ b/crates/gglib-hf/src/client/repo_files.rs
@@ -210,6 +210,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_find_quantization_files_excludes_unsloth_ud_variant() {
+        // Regression: a request for the plain "Q6_K" quantization must not
+        // also return the unrelated Unsloth Dynamic "UD-Q6_K" file, even
+        // though both share the same "Q6_K" bit-depth suffix.
+        let backend = FakeBackend::new().with_response(
+            "tree/main",
+            CannedResponse {
+                json: json!([
+                    {"path": "model-Q6_K.gguf", "type": "file", "size": 6_000_000_000_u64},
+                    {"path": "model-UD-Q6_K.gguf", "type": "file", "size": 6_500_000_000_u64},
+                ]),
+                has_more: false,
+            },
+        );
+
+        let client = HfClient::with_backend(test_config(), backend);
+        let repo = HfRepoRef::new("unsloth", "Qwen3-Coder-Next-GGUF");
+
+        let plain = client
+            .find_quantization_files(&repo, "Q6_K")
+            .await
+            .unwrap();
+        assert_eq!(plain.len(), 1);
+        assert_eq!(plain[0].path, "model-Q6_K.gguf");
+
+        let dynamic = client
+            .find_quantization_files(&repo, "UD-Q6_K")
+            .await
+            .unwrap();
+        assert_eq!(dynamic.len(), 1);
+        assert_eq!(dynamic[0].path, "model-UD-Q6_K.gguf");
+    }
+
+    #[tokio::test]
     async fn test_get_commit_sha() {
         let backend = FakeBackend::new().with_response(
             "Llama-2-7B-GGUF",

--- a/crates/gglib-hf/src/client/repo_files.rs
+++ b/crates/gglib-hf/src/client/repo_files.rs
@@ -228,10 +228,7 @@ mod tests {
         let client = HfClient::with_backend(test_config(), backend);
         let repo = HfRepoRef::new("unsloth", "Qwen3-Coder-Next-GGUF");
 
-        let plain = client
-            .find_quantization_files(&repo, "Q6_K")
-            .await
-            .unwrap();
+        let plain = client.find_quantization_files(&repo, "Q6_K").await.unwrap();
         assert_eq!(plain.len(), 1);
         assert_eq!(plain[0].path, "model-Q6_K.gguf");
 

--- a/crates/gglib-hf/src/parsing.rs
+++ b/crates/gglib-hf/src/parsing.rs
@@ -267,7 +267,11 @@ mod tests {
 
         let quantizations = aggregate_quantizations(&files);
 
-        assert_eq!(quantizations.len(), 2, "plain and UD- quants must not merge");
+        assert_eq!(
+            quantizations.len(),
+            2,
+            "plain and UD- quants must not merge"
+        );
         let plain = quantizations
             .iter()
             .find(|q| q.name == "Q6_K")

--- a/crates/gglib-hf/src/parsing.rs
+++ b/crates/gglib-hf/src/parsing.rs
@@ -243,7 +243,61 @@ pub fn filter_files_by_quantization(files: &[HfFileEntry], quantization: &str) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::HfEntryType;
     use serde_json::json;
+
+    fn gguf_file(path: &str, size: u64) -> HfFileEntry {
+        HfFileEntry {
+            path: path.to_string(),
+            entry_type: HfEntryType::File,
+            size,
+            oid: None,
+        }
+    }
+
+    #[test]
+    fn test_aggregate_quantizations_distinguishes_ud_dynamic_quants() {
+        // Regression for the real unsloth/Qwen3-Coder-Next-GGUF collision: a
+        // plain Q6_K/ directory and a UD-Q6_K/ (Unsloth Dynamic) directory
+        // previously collapsed into a single merged HfQuantization group.
+        let files = vec![
+            gguf_file("Q6_K/model-Q6_K.gguf", 6_000_000_000),
+            gguf_file("UD-Q6_K/model-UD-Q6_K.gguf", 6_500_000_000),
+        ];
+
+        let quantizations = aggregate_quantizations(&files);
+
+        assert_eq!(quantizations.len(), 2, "plain and UD- quants must not merge");
+        let plain = quantizations
+            .iter()
+            .find(|q| q.name == "Q6_K")
+            .expect("plain Q6_K group present");
+        let dynamic = quantizations
+            .iter()
+            .find(|q| q.name == "UD-Q6_K")
+            .expect("UD-Q6_K group present");
+
+        assert_eq!(plain.shard_count, 1);
+        assert_eq!(plain.total_size, 6_000_000_000);
+        assert_eq!(dynamic.shard_count, 1);
+        assert_eq!(dynamic.total_size, 6_500_000_000);
+    }
+
+    #[test]
+    fn test_filter_files_by_quantization_excludes_ud_variant() {
+        let files = vec![
+            gguf_file("Q6_K/model-Q6_K.gguf", 6_000_000_000),
+            gguf_file("UD-Q6_K/model-UD-Q6_K.gguf", 6_500_000_000),
+        ];
+
+        let plain = filter_files_by_quantization(&files, "Q6_K");
+        assert_eq!(plain.len(), 1);
+        assert_eq!(plain[0].path, "Q6_K/model-Q6_K.gguf");
+
+        let dynamic = filter_files_by_quantization(&files, "UD-Q6_K");
+        assert_eq!(dynamic.len(), 1);
+        assert_eq!(dynamic[0].path, "UD-Q6_K/model-UD-Q6_K.gguf");
+    }
 
     #[test]
     fn test_parse_model_summary_with_all_fields() {


### PR DESCRIPTION
Fixes #572

## Summary

Unsloth GGUF repos (e.g. `unsloth/Qwen3-Coder-Next-GGUF`) publish both plain quants
(`Q6_K/`) and "UD-" prefixed *Unsloth Dynamic* quants (`UD-Q6_K/`) that share the same
bit-depth suffix. `Quantization::from_filename()` previously matched only the bare
pattern via naive, order-dependent substring `.contains()`, so files from both
directories resolved to the identical `Quantization::Q6K` value. Because the whole
download pipeline keys off `Quantization` equality, requesting `-q Q6_K` silently
downloaded the unrelated `UD-Q6_K` file(s) too (confirmed against the live HF repo
tree, and matches a user-reported bug where an `unsloth/Qwen3-Coder-Next-GGUF`
download produced two files for one requested quant).

## Changes

- **Boundary-aware, longest-match parsing** (`crates/gglib-core/src/download/types.rs`):
  `from_filename` now only counts a pattern match if it's flanked by non-alphanumeric
  delimiters (or string start/end), and picks the *longest* valid match across the
  whole table rather than the first one found in table order — correctness no longer
  depends on `QUANT_PATTERNS` ordering, and accidental collisions with model-name
  substrings (e.g. a hypothetical `"Q6King"`) are avoided.
- **"UD-" detection is orthogonal, not duplicated per family**: the modifier is
  detected as a standalone delimited token immediately preceding the matched base
  quant, then mapped through a small `UD_VARIANT_MAP` lookup table to a dedicated
  enum variant (e.g. `UdQ6K` → `"UD-Q6_K"`) — instead of duplicating full pattern
  strings like `"UD-Q6_K"` per family.
- Adds 16 new `Quantization` variants (7 fix real collisions: Q3/Q4/Q5_K_M/S, Q6_K;
  9 are previously-invisible UD-only quants that silently mapped to `Unknown`:
  UD-IQ1_S/M, UD-IQ2_XXS/M, UD-IQ3_S/XXS, UD-IQ4_NL/XS, UD-TQ1_0), plus the 2 missing
  bare patterns they attach to (`IQ3_S`, `TQ1_0`).
- **Performance**: no heap allocations or regex in the hot `from_filename` path —
  operates directly on byte slices with `eq_ignore_ascii_case` and static lookup
  tables, since this runs on every file encountered while scanning a repo.
- Regression tests reproducing the exact collision at both the `gglib-core` parsing
  layer and the `gglib-hf` aggregation/filtering layer.
- Docs updated: crate READMEs (`gglib-core/download`, `gglib-hf`, `gglib-download`)
  and CLI `--quant` help text / README example now document `UD-` quant support.

## Out of scope (by design, see issue for full rationale)

- No DB schema changes — `quantization` column is already free-form `TEXT`.
- No frontend/Axum/Tauri changes — quantization already crosses that boundary as a
  plain `String`, and the frontend fetches quant lists dynamically with no hardcoded
  enum, so `UD-` variants are automatically exposed everywhere once this lands.
- `DEFAULT_QUANT_PREFERENCE` unchanged — auto-selection still prefers plain quants;
  `UD-` quants must be requested explicitly.
- Not generalizing to arbitrary future disambiguating prefixes beyond `UD-`.

## Verification

- `cargo test --workspace --exclude gglib-tauri --exclude gglib-app` — all green
  (0 failures).
- `cargo clippy --workspace --exclude gglib-tauri --exclude gglib-app --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `./scripts/check_boundaries.sh` (includes `check_readmes.sh --strict`) — all pass.
