### PR TITLE
fix(proxy): sync context-window reporting and SSE frame forwarding

### DIFF
--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -239,12 +239,7 @@ pub async fn collect_stream(
                 message,
                 error_type,
                 code,
-            } => {
-                anyhow::bail!(
-                    "upstream reported an error mid-stream: {message} \
-                     (type={error_type}, code={code})"
-                );
-            }
+            } => return Err(upstream_error(&message, &error_type, &code)),
         }
     }
 
@@ -282,6 +277,17 @@ async fn handle_normalization_error(
             suggested_action: None,
         })
         .await;
+}
+
+/// Build the error returned when an upstream `LlmStreamEvent::UpstreamError`
+/// frame arrives mid-stream — a genuine upstream failure (e.g. a
+/// context-length overflow discovered mid-generation) rather than a
+/// connectivity problem, so it gets a specific message instead of the
+/// generic "stream ended without a Done event" bail below.
+fn upstream_error(message: &str, error_type: &str, code: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "upstream reported an error mid-stream: {message} (type={error_type}, code={code})"
+    )
 }
 
 /// Assemble accumulated [`PartialToolCall`]s into domain [`ToolCall`] values.

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -229,6 +229,11 @@ pub async fn collect_stream(
             LlmStreamEvent::NormalizationError { kind, raw } => {
                 handle_normalization_error(tx, &kind, &raw).await;
             }
+
+            // Wire-facing telemetry (feeds e.g. a client's context-window
+            // UI widget) with no bearing on the agent loop's own internal
+            // state — nothing to accumulate or forward here.
+            LlmStreamEvent::Usage { .. } => {}
         }
     }
 

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -234,6 +234,17 @@ pub async fn collect_stream(
             // UI widget) with no bearing on the agent loop's own internal
             // state — nothing to accumulate or forward here.
             LlmStreamEvent::Usage { .. } => {}
+
+            LlmStreamEvent::UpstreamError {
+                message,
+                error_type,
+                code,
+            } => {
+                anyhow::bail!(
+                    "upstream reported an error mid-stream: {message} \
+                     (type={error_type}, code={code})"
+                );
+            }
         }
     }
 

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -218,6 +218,29 @@ pub enum LlmStreamEvent {
         finish_reason: String,
     },
 
+    /// An upstream error reported inline, mid-stream.
+    ///
+    /// Some OpenAI-compatible servers (including llama.cpp) can emit a bare
+    /// `{"error": {...}}` frame in the middle of an otherwise-successful SSE
+    /// response — e.g. a context-length overflow discovered only once
+    /// generation is underway — rather than failing the initial HTTP
+    /// response. Without special handling this frame carries no `choices`
+    /// array and would otherwise be silently discarded by parsers that treat
+    /// "no choices" as an empty keepalive/heartbeat frame.
+    ///
+    /// `error_type` and `code` default to `"server_error"`/`"upstream_error"`
+    /// respectively when the upstream frame omits them, mirroring the
+    /// existing convention in `gglib_proxy::forward`'s pre-flight upstream
+    /// error handling.
+    UpstreamError {
+        /// Human-readable error message.
+        message: String,
+        /// Upstream `error.type` (or `"server_error"` if absent).
+        error_type: String,
+        /// Upstream `error.code` (or `"upstream_error"` if absent).
+        code: String,
+    },
+
     /// A non-fatal normalization issue surfaced by the
     /// [`crate::normalize`] layer.
     ///

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -194,7 +194,7 @@ pub enum LlmStreamEvent {
     ///
     /// Emitted when the request includes `stream_options.include_usage:
     /// true` (see `gglib_proxy`'s `inject_streaming_body_overrides`).
-    /// Per the OpenAI streaming convention this arrives as a single
+    /// Per the `OpenAI` streaming convention this arrives as a single
     /// trailing chunk with an empty/absent `choices` array, immediately
     /// before the `[DONE]` sentinel — never mixed with `TextDelta` or
     /// `ToolCallDelta` events. Consumers that care about real token counts

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -190,6 +190,25 @@ pub enum LlmStreamEvent {
         time_ms: u64,
     },
 
+    /// Token usage totals for the completed response.
+    ///
+    /// Emitted when the request includes `stream_options.include_usage:
+    /// true` (see `gglib_proxy`'s `inject_streaming_body_overrides`).
+    /// Per the OpenAI streaming convention this arrives as a single
+    /// trailing chunk with an empty/absent `choices` array, immediately
+    /// before the `[DONE]` sentinel — never mixed with `TextDelta` or
+    /// `ToolCallDelta` events. Consumers that care about real token counts
+    /// (e.g. clients feeding a context-window UI widget) read this event;
+    /// everyone else can ignore it.
+    Usage {
+        /// Number of tokens in the prompt.
+        prompt_tokens: u32,
+        /// Number of tokens generated in the completion.
+        completion_tokens: u32,
+        /// Total tokens (`prompt_tokens + completion_tokens`).
+        total_tokens: u32,
+    },
+
     /// Signals the end of the stream.
     ///
     /// Every conforming stream must end with exactly one `Done` item.

--- a/crates/gglib-core/src/normalize/stream.rs
+++ b/crates/gglib-core/src/normalize/stream.rs
@@ -155,7 +155,9 @@ impl NormalizingStream {
             }
             LlmStreamEvent::ReasoningDelta { content } => {
                 if self.done_forwarded {
-                    tracing::warn!("NormalizingStream: dropping ReasoningDelta received after Done");
+                    tracing::warn!(
+                        "NormalizingStream: dropping ReasoningDelta received after Done"
+                    );
                     return;
                 }
                 let out = self.parser.push_reasoning(&content);

--- a/crates/gglib-core/src/normalize/stream.rs
+++ b/crates/gglib-core/src/normalize/stream.rs
@@ -148,7 +148,8 @@ impl NormalizingStream {
             }
             LlmStreamEvent::PromptProgress { .. }
             | LlmStreamEvent::NormalizationError { .. }
-            | LlmStreamEvent::Usage { .. } => {
+            | LlmStreamEvent::Usage { .. }
+            | LlmStreamEvent::UpstreamError { .. } => {
                 self.queued.push_back(event);
             }
             LlmStreamEvent::Done { finish_reason } => {

--- a/crates/gglib-core/src/normalize/stream.rs
+++ b/crates/gglib-core/src/normalize/stream.rs
@@ -146,7 +146,9 @@ impl NormalizingStream {
                     arguments,
                 });
             }
-            LlmStreamEvent::PromptProgress { .. } | LlmStreamEvent::NormalizationError { .. } => {
+            LlmStreamEvent::PromptProgress { .. }
+            | LlmStreamEvent::NormalizationError { .. }
+            | LlmStreamEvent::Usage { .. } => {
                 self.queued.push_back(event);
             }
             LlmStreamEvent::Done { finish_reason } => {
@@ -264,6 +266,25 @@ mod tests {
         let events = vec![
             LlmStreamEvent::TextDelta {
                 content: "hello".into(),
+            },
+            LlmStreamEvent::Done {
+                finish_reason: "stop".into(),
+            },
+        ];
+        let out = drain(wrap(events.clone(), false));
+        assert_eq!(out, events);
+    }
+
+    #[test]
+    fn usage_event_passes_through_unchanged() {
+        let events = vec![
+            LlmStreamEvent::TextDelta {
+                content: "hello".into(),
+            },
+            LlmStreamEvent::Usage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
             },
             LlmStreamEvent::Done {
                 finish_reason: "stop".into(),

--- a/crates/gglib-core/src/normalize/stream.rs
+++ b/crates/gglib-core/src/normalize/stream.rs
@@ -20,9 +20,17 @@
 //!   non-colliding indices.
 //! - `PromptProgress` → forwarded unchanged.
 //! - `Done` → [`ToolCallParser::finish`] is called first, any flushed
-//!   bytes / tool calls / errors are emitted, **then** `Done` is forwarded
-//!   last.  The contract that every stream ends with exactly one `Done`
-//!   item is preserved.
+//!   bytes / tool calls / errors are emitted, **then** `Done` is forwarded.
+//!   The contract that every stream carries exactly one `Done` item is
+//!   preserved — but `Done` is *not* treated as an absolute end-of-stream
+//!   signal. Per the `OpenAI` `stream_options.include_usage` convention (and
+//!   llama.cpp's actual wire behaviour), a trailing [`LlmStreamEvent::Usage`]
+//!   event can legitimately arrive *after* `Done`, before the underlying
+//!   byte stream closes — that event (and `PromptProgress` /
+//!   `NormalizationError` / `UpstreamError`) still gets forwarded. Any
+//!   content-bearing event arriving after `Done` (`TextDelta`,
+//!   `ReasoningDelta`, `ToolCallDelta`, a second `Done`) is dropped
+//!   defensively, since a well-formed stream never sends those.
 //!
 //! ## Errors
 //!
@@ -56,9 +64,23 @@ pub struct NormalizingStream {
     /// Bumped past every upstream `index` we observe so downstream
     /// collectors can use indices as keys without collision.
     next_index: usize,
-    /// `true` once we've forwarded the upstream `Done` (or upstream ended
-    /// or errored).  Subsequent polls return `None`.
+    /// `true` once the upstream `inner` stream is fully exhausted (ended or
+    /// errored).  Subsequent polls return `None`.  Note this is **not** set
+    /// merely because a `Done` event was seen — see `done_forwarded`.
     terminated: bool,
+    /// `true` once we've forwarded the upstream `Done` event.
+    ///
+    /// `Done` is *not* treated as an absolute end-of-stream signal: per the
+    /// `OpenAI` `stream_options.include_usage` convention (and llama.cpp's
+    /// wire behaviour), a trailing `Usage` event legitimately arrives
+    /// *after* the `finish_reason`/`Done` chunk, before the underlying byte
+    /// stream actually closes. Once this flag is set, only trailer-safe
+    /// events (`Usage`, `PromptProgress`, `NormalizationError`,
+    /// `UpstreamError`) are still queued; any further content-bearing event
+    /// (`TextDelta`, `ReasoningDelta`, `ToolCallDelta`, a second `Done`) is
+    /// dropped defensively — a well-formed stream never sends these after
+    /// `Done`, and the parser has already been finalised.
+    done_forwarded: bool,
 }
 
 impl NormalizingStream {
@@ -71,6 +93,7 @@ impl NormalizingStream {
             queued: VecDeque::new(),
             next_index: 0,
             terminated: false,
+            done_forwarded: false,
         }
     }
 
@@ -123,10 +146,18 @@ impl NormalizingStream {
     fn handle_upstream(&mut self, event: LlmStreamEvent) {
         match event {
             LlmStreamEvent::TextDelta { content } => {
+                if self.done_forwarded {
+                    tracing::warn!("NormalizingStream: dropping TextDelta received after Done");
+                    return;
+                }
                 let out = self.parser.push_text(&content);
                 self.enqueue_parser_output(out);
             }
             LlmStreamEvent::ReasoningDelta { content } => {
+                if self.done_forwarded {
+                    tracing::warn!("NormalizingStream: dropping ReasoningDelta received after Done");
+                    return;
+                }
                 let out = self.parser.push_reasoning(&content);
                 self.enqueue_parser_output(out);
             }
@@ -136,6 +167,10 @@ impl NormalizingStream {
                 name,
                 arguments,
             } => {
+                if self.done_forwarded {
+                    tracing::warn!("NormalizingStream: dropping ToolCallDelta received after Done");
+                    return;
+                }
                 if index >= self.next_index {
                     self.next_index = index + 1;
                 }
@@ -150,9 +185,15 @@ impl NormalizingStream {
             | LlmStreamEvent::NormalizationError { .. }
             | LlmStreamEvent::Usage { .. }
             | LlmStreamEvent::UpstreamError { .. } => {
+                // Trailer-safe: legitimately arrives before *or* after Done
+                // (e.g. a trailing Usage chunk), so no done_forwarded guard.
                 self.queued.push_back(event);
             }
             LlmStreamEvent::Done { finish_reason } => {
+                if self.done_forwarded {
+                    tracing::warn!("NormalizingStream: dropping duplicate Done event");
+                    return;
+                }
                 let out = self.parser.finish();
                 self.enqueue_parser_output(out);
                 // Qwen3.5 (and some other models) emit tool_calls in the
@@ -167,7 +208,12 @@ impl NormalizingStream {
                 };
                 self.queued
                     .push_back(LlmStreamEvent::Done { finish_reason });
-                self.terminated = true;
+                // Deliberately *not* `self.terminated = true` here — see the
+                // `done_forwarded` doc comment. The stream keeps polling
+                // `inner` (in `poll_next`) so a legitimate trailing `Usage`
+                // event can still be forwarded before the byte stream
+                // actually closes.
+                self.done_forwarded = true;
             }
         }
     }
@@ -196,9 +242,15 @@ impl Stream for NormalizingStream {
                 }
                 Poll::Ready(None) => {
                     // Upstream ended without a `Done`.  Flush any held-back
-                    // parser state so no bytes are lost, then end.
-                    let out = self.parser.finish();
-                    self.enqueue_parser_output(out);
+                    // parser state so no bytes are lost, then end.  Skipped
+                    // when `Done` was already forwarded (e.g. only a
+                    // trailing `Usage` event followed it) — the parser was
+                    // already finalised in `handle_upstream`'s `Done` arm,
+                    // and finishing it twice would re-flush stale state.
+                    if !self.done_forwarded {
+                        let out = self.parser.finish();
+                        self.enqueue_parser_output(out);
+                    }
                     self.terminated = true;
                     if let Some(ev) = self.queued.pop_front() {
                         return Poll::Ready(Some(Ok(ev)));
@@ -293,6 +345,66 @@ mod tests {
         ];
         let out = drain(wrap(events.clone(), false));
         assert_eq!(out, events);
+    }
+
+    #[test]
+    fn usage_event_after_done_still_forwarded() {
+        // The actual llama.cpp/OpenAI wire order: the finish_reason chunk
+        // (-> Done) arrives *before* the trailing usage-only chunk
+        // (-> Usage). NormalizingStream must not treat Done as a hard
+        // stream-end that discards this legitimate trailer.
+        let events = vec![
+            LlmStreamEvent::TextDelta {
+                content: "hello".into(),
+            },
+            LlmStreamEvent::Done {
+                finish_reason: "stop".into(),
+            },
+            LlmStreamEvent::Usage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+            },
+        ];
+        let out = drain(wrap(events.clone(), false));
+        assert_eq!(
+            out, events,
+            "Usage arriving after Done must still be forwarded, in order"
+        );
+    }
+
+    #[test]
+    fn text_delta_after_done_is_dropped_defensively() {
+        // Malformed upstream: content arriving after Done. Must not panic
+        // or resurrect already-finalised parser state; simply dropped.
+        let events = vec![
+            LlmStreamEvent::Done {
+                finish_reason: "stop".into(),
+            },
+            LlmStreamEvent::TextDelta {
+                content: "should be dropped".into(),
+            },
+            LlmStreamEvent::Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        ];
+        let out = drain(wrap(events, false));
+        assert_eq!(
+            out,
+            vec![
+                LlmStreamEvent::Done {
+                    finish_reason: "stop".into(),
+                },
+                LlmStreamEvent::Usage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                },
+            ],
+            "stray TextDelta after Done must be dropped, Usage still forwarded"
+        );
     }
 
     #[test]

--- a/crates/gglib-core/src/ports/model_catalog.rs
+++ b/crates/gglib-core/src/ports/model_catalog.rs
@@ -44,6 +44,16 @@ pub struct ModelSummary {
     pub created_at: i64,
     /// File size in bytes.
     pub file_size: u64,
+    /// Maximum context length the model supports, in tokens (from GGUF
+    /// metadata). `None` when unknown.
+    ///
+    /// This is a static, per-model ceiling — it does not reflect the
+    /// `--ctx-size` a currently-running instance was actually launched
+    /// with, which can be smaller (see `gglib_core::ports::model_runtime::RunningTarget::effective_ctx`
+    /// for the live value). Consumers that need the true, currently-running
+    /// context size should prefer `effective_ctx` when the model is running
+    /// and fall back to this field otherwise.
+    pub context_length: Option<u64>,
     /// Per-model inference parameter defaults.
     ///
     /// When `Some`, these are resolved per-request via

--- a/crates/gglib-core/src/sse/decoder.rs
+++ b/crates/gglib-core/src/sse/decoder.rs
@@ -82,11 +82,27 @@ impl SseStreamDecoder {
                     return (events, true);
                 }
                 Ok(SseParseResult::Events(parsed_events)) => {
+                    let mut saw_terminal_error = false;
                     for event in parsed_events {
                         if matches!(event, LlmStreamEvent::Done { .. }) {
                             self.done_sent = true;
                         }
+                        if matches!(event, LlmStreamEvent::UpstreamError { .. }) {
+                            // Terminal condition: the encoder appends its own
+                            // `[DONE]` sentinel right after this event (see
+                            // `SseEncoder::encode`), and nothing meaningful
+                            // is expected to follow an inline upstream
+                            // error. Stop feeding further bytes, same as the
+                            // literal `[DONE]` sentinel case above, so a
+                            // stray fallback `Done` isn't appended by
+                            // `finish()`.
+                            saw_terminal_error = true;
+                            self.done_sent = true;
+                        }
                         events.push(Ok(event));
+                    }
+                    if saw_terminal_error {
+                        return (events, true);
                     }
                 }
                 Err(e) => {
@@ -221,6 +237,23 @@ mod tests {
         assert!(
             dec.finish().is_none(),
             "finish() must not emit a second Done"
+        );
+    }
+
+    #[test]
+    fn inline_error_frame_signals_stop_and_suppresses_fallback_done() {
+        let mut dec = SseStreamDecoder::default();
+        let frame = format!(
+            "data: {}\n",
+            serde_json::json!({ "error": { "message": "boom" } })
+        );
+        let (events, stop) = collect_all(&mut dec, &frame);
+        assert!(stop, "inline error frame should signal stop");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmStreamEvent::UpstreamError { .. }));
+        assert!(
+            dec.finish().is_none(),
+            "finish() must not append a fallback Done after an inline error"
         );
     }
 

--- a/crates/gglib-core/src/sse/encoder.rs
+++ b/crates/gglib-core/src/sse/encoder.rs
@@ -29,6 +29,16 @@ use serde_json::{Value, json};
 
 use crate::LlmStreamEvent;
 
+/// The SSE stream-terminator sentinel.
+///
+/// Must be sent by the caller exactly once, only after the entire event
+/// stream from [`SseEncoder::encode`] is truly exhausted — never bundled
+/// into an individual event's encoding, since [`LlmStreamEvent::Done`] is
+/// not guaranteed to be the last event (a trailing
+/// [`LlmStreamEvent::Usage`] can legitimately follow it) and nothing may
+/// be sent after `[DONE]` on the wire.
+pub const DONE_SENTINEL: &str = "data: [DONE]\n\n";
+
 /// Stateful encoder that produces OpenAI-shape SSE frames for one response.
 ///
 /// The `id`, `model`, and `created` fields are stable across all frames the
@@ -60,10 +70,14 @@ impl SseEncoder {
     /// [`LlmStreamEvent::NormalizationError`], which the proxy logs but never
     /// forwards to clients).
     ///
-    /// For [`LlmStreamEvent::Done`], the returned `String` includes both the
-    /// terminating chunk (with `finish_reason` set) **and** the trailing
-    /// `data: [DONE]\n\n` sentinel, so the caller can write a single payload
-    /// and end the response.
+    /// For [`LlmStreamEvent::Done`], the returned `String` is only the
+    /// terminating chunk (with `finish_reason` set) — it deliberately does
+    /// **not** include the trailing `data: [DONE]\n\n` sentinel
+    /// ([`DONE_SENTINEL`]).  `Done` is not guaranteed to be the last event on
+    /// the wire: a trailing [`LlmStreamEvent::Usage`] can legitimately arrive
+    /// afterward (see that variant's doc), and nothing may follow `[DONE]`
+    /// once it's sent.  Callers must append [`DONE_SENTINEL`] themselves,
+    /// exactly once, only after the entire event stream is truly exhausted.
     #[must_use]
     pub fn encode(&self, event: &LlmStreamEvent) -> Option<String> {
         match event {
@@ -127,14 +141,11 @@ impl SseEncoder {
                 });
                 Some(format!("data: {value}\n\n"))
             }
-            LlmStreamEvent::Done { finish_reason } => {
-                let chunk = self.frame(&json!({
-                    "index": 0,
-                    "delta": {},
-                    "finish_reason": finish_reason,
-                }));
-                Some(format!("{chunk}data: [DONE]\n\n"))
-            }
+            LlmStreamEvent::Done { finish_reason } => Some(self.frame(&json!({
+                "index": 0,
+                "delta": {},
+                "finish_reason": finish_reason,
+            }))),
             LlmStreamEvent::Usage {
                 prompt_tokens,
                 completion_tokens,
@@ -180,6 +191,9 @@ impl SseEncoder {
     /// (`'error' in obj && !('choices' in obj)`) to recognise an inline
     /// mid-stream failure; wrapping it in the usual envelope or adding an
     /// empty `choices: []` would hide it as an ordinary chunk instead.
+    ///
+    /// Does **not** append [`DONE_SENTINEL`] — see [`Self::encode`] doc; the
+    /// caller appends it exactly once after the stream is truly exhausted.
     fn upstream_error_frame(message: &str, error_type: &str, code: &str) -> String {
         let error_obj = json!({
             "error": {
@@ -188,7 +202,7 @@ impl SseEncoder {
                 "code": code,
             }
         });
-        format!("data: {error_obj}\n\ndata: [DONE]\n\n")
+        format!("data: {error_obj}\n\n")
     }
 
     /// Wrap a `choice` value in the standard chunk envelope and SSE framing.
@@ -291,19 +305,20 @@ mod tests {
     }
 
     #[test]
-    fn done_event_emits_finish_chunk_and_done_sentinel() {
+    fn done_event_emits_only_finish_chunk_no_sentinel() {
         let out = enc()
             .encode(&LlmStreamEvent::Done {
                 finish_reason: "stop".to_owned(),
             })
             .expect("frame");
-        // Two SSE frames: the terminating chunk and the [DONE] sentinel.
+        // Exactly one SSE frame -- [DONE] is the caller's responsibility now
+        // (see DONE_SENTINEL doc), since a trailing Usage event can
+        // legitimately follow Done.
         let lines: Vec<&str> = out.lines().filter(|l| !l.is_empty()).collect();
-        assert_eq!(lines.len(), 2, "Done emits two data: lines");
+        assert_eq!(lines.len(), 1, "Done emits exactly one data: line");
         let v: serde_json::Value =
             serde_json::from_str(lines[0].strip_prefix("data: ").unwrap()).unwrap();
         assert_eq!(v["choices"][0]["finish_reason"], "stop");
-        assert_eq!(lines[1], "data: [DONE]");
     }
 
     #[test]
@@ -329,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn upstream_error_event_encodes_to_bare_error_frame_and_done_sentinel() {
+    fn upstream_error_event_encodes_to_bare_error_frame_no_sentinel() {
         let out = enc()
             .encode(&LlmStreamEvent::UpstreamError {
                 message: "Context window limit reached.".to_owned(),
@@ -338,7 +353,7 @@ mod tests {
             })
             .expect("frame");
         let lines: Vec<&str> = out.lines().filter(|l| !l.is_empty()).collect();
-        assert_eq!(lines.len(), 2, "expects the error frame plus [DONE]");
+        assert_eq!(lines.len(), 1, "expects only the bare error frame");
         let v: serde_json::Value =
             serde_json::from_str(lines[0].strip_prefix("data: ").unwrap()).unwrap();
         assert_eq!(v["error"]["message"], "Context window limit reached.");
@@ -352,7 +367,6 @@ mod tests {
             v.get("id").is_none(),
             "inline error frame is deliberately bare, no envelope fields"
         );
-        assert_eq!(lines[1], "data: [DONE]");
     }
 
     #[test]

--- a/crates/gglib-core/src/sse/encoder.rs
+++ b/crates/gglib-core/src/sse/encoder.rs
@@ -135,6 +135,29 @@ impl SseEncoder {
                 }));
                 Some(format!("{chunk}data: [DONE]\n\n"))
             }
+            LlmStreamEvent::Usage {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens,
+            } => {
+                // Per the OpenAI `stream_options.include_usage` convention,
+                // the usage-totals chunk carries an empty `choices` array
+                // (not omitted — see `crate::LlmStreamEvent::Usage` doc) and
+                // a top-level `usage` object.
+                let value = json!({
+                    "id": self.id,
+                    "object": "chat.completion.chunk",
+                    "created": self.created,
+                    "model": self.model,
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": total_tokens,
+                    },
+                });
+                Some(format!("data: {value}\n\n"))
+            }
             LlmStreamEvent::NormalizationError { .. } => None,
         }
     }
@@ -252,6 +275,28 @@ mod tests {
             serde_json::from_str(lines[0].strip_prefix("data: ").unwrap()).unwrap();
         assert_eq!(v["choices"][0]["finish_reason"], "stop");
         assert_eq!(lines[1], "data: [DONE]");
+    }
+
+    #[test]
+    fn usage_event_encodes_to_trailing_chunk_with_empty_choices() {
+        let out = enc()
+            .encode(&LlmStreamEvent::Usage {
+                prompt_tokens: 123,
+                completion_tokens: 45,
+                total_tokens: 168,
+            })
+            .expect("frame");
+        let v = parse_data_frame(&out);
+        assert_eq!(v["object"], "chat.completion.chunk");
+        assert_eq!(v["id"], "chatcmpl-1");
+        assert_eq!(v["model"], "test-model");
+        assert!(
+            v["choices"].as_array().is_some_and(Vec::is_empty),
+            "usage chunk must carry an empty choices array, not omit it"
+        );
+        assert_eq!(v["usage"]["prompt_tokens"], 123);
+        assert_eq!(v["usage"]["completion_tokens"], 45);
+        assert_eq!(v["usage"]["total_tokens"], 168);
     }
 
     #[test]

--- a/crates/gglib-core/src/sse/encoder.rs
+++ b/crates/gglib-core/src/sse/encoder.rs
@@ -159,6 +159,28 @@ impl SseEncoder {
                 Some(format!("data: {value}\n\n"))
             }
             LlmStreamEvent::NormalizationError { .. } => None,
+            LlmStreamEvent::UpstreamError {
+                message,
+                error_type,
+                code,
+            } => {
+                // Deliberately bare -- no `id`/`object`/`created`/`model`
+                // envelope and, crucially, no `choices` key at all (unlike
+                // every other frame this encoder produces). Clients such as
+                // the GitHub Copilot LLM Gateway extension detect this exact
+                // shape (`'error' in obj && !('choices' in obj)`) to
+                // recognise an inline mid-stream failure; wrapping it in the
+                // usual envelope or adding an empty `choices: []` would hide
+                // it as an ordinary chunk instead.
+                let error_obj = json!({
+                    "error": {
+                        "message": message,
+                        "type": error_type,
+                        "code": code,
+                    }
+                });
+                Some(format!("data: {error_obj}\n\ndata: [DONE]\n\n"))
+            }
         }
     }
 
@@ -297,6 +319,33 @@ mod tests {
         assert_eq!(v["usage"]["prompt_tokens"], 123);
         assert_eq!(v["usage"]["completion_tokens"], 45);
         assert_eq!(v["usage"]["total_tokens"], 168);
+    }
+
+    #[test]
+    fn upstream_error_event_encodes_to_bare_error_frame_and_done_sentinel() {
+        let out = enc()
+            .encode(&LlmStreamEvent::UpstreamError {
+                message: "Context window limit reached.".to_owned(),
+                error_type: "context_length_exceeded".to_owned(),
+                code: "context_length_exceeded".to_owned(),
+            })
+            .expect("frame");
+        let lines: Vec<&str> = out.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 2, "expects the error frame plus [DONE]");
+        let v: serde_json::Value =
+            serde_json::from_str(lines[0].strip_prefix("data: ").unwrap()).unwrap();
+        assert_eq!(v["error"]["message"], "Context window limit reached.");
+        assert_eq!(v["error"]["type"], "context_length_exceeded");
+        assert_eq!(v["error"]["code"], "context_length_exceeded");
+        assert!(
+            v.get("choices").is_none(),
+            "inline error frame must not carry a choices key at all"
+        );
+        assert!(
+            v.get("id").is_none(),
+            "inline error frame is deliberately bare, no envelope fields"
+        );
+        assert_eq!(lines[1], "data: [DONE]");
     }
 
     #[test]

--- a/crates/gglib-core/src/sse/encoder.rs
+++ b/crates/gglib-core/src/sse/encoder.rs
@@ -139,49 +139,56 @@ impl SseEncoder {
                 prompt_tokens,
                 completion_tokens,
                 total_tokens,
-            } => {
-                // Per the OpenAI `stream_options.include_usage` convention,
-                // the usage-totals chunk carries an empty `choices` array
-                // (not omitted — see `crate::LlmStreamEvent::Usage` doc) and
-                // a top-level `usage` object.
-                let value = json!({
-                    "id": self.id,
-                    "object": "chat.completion.chunk",
-                    "created": self.created,
-                    "model": self.model,
-                    "choices": [],
-                    "usage": {
-                        "prompt_tokens": prompt_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": total_tokens,
-                    },
-                });
-                Some(format!("data: {value}\n\n"))
-            }
+            } => Some(self.usage_frame(*prompt_tokens, *completion_tokens, *total_tokens)),
             LlmStreamEvent::NormalizationError { .. } => None,
             LlmStreamEvent::UpstreamError {
                 message,
                 error_type,
                 code,
-            } => {
-                // Deliberately bare -- no `id`/`object`/`created`/`model`
-                // envelope and, crucially, no `choices` key at all (unlike
-                // every other frame this encoder produces). Clients such as
-                // the GitHub Copilot LLM Gateway extension detect this exact
-                // shape (`'error' in obj && !('choices' in obj)`) to
-                // recognise an inline mid-stream failure; wrapping it in the
-                // usual envelope or adding an empty `choices: []` would hide
-                // it as an ordinary chunk instead.
-                let error_obj = json!({
-                    "error": {
-                        "message": message,
-                        "type": error_type,
-                        "code": code,
-                    }
-                });
-                Some(format!("data: {error_obj}\n\ndata: [DONE]\n\n"))
-            }
+            } => Some(Self::upstream_error_frame(message, error_type, code)),
         }
+    }
+
+    /// Encode a [`LlmStreamEvent::Usage`] event.
+    ///
+    /// Per the `OpenAI` `stream_options.include_usage` convention, the
+    /// usage-totals chunk carries an empty `choices` array (not omitted —
+    /// see [`crate::LlmStreamEvent::Usage`] doc) and a top-level `usage`
+    /// object.
+    fn usage_frame(&self, prompt_tokens: u32, completion_tokens: u32, total_tokens: u32) -> String {
+        let value = json!({
+            "id": self.id,
+            "object": "chat.completion.chunk",
+            "created": self.created,
+            "model": self.model,
+            "choices": [],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+            },
+        });
+        format!("data: {value}\n\n")
+    }
+
+    /// Encode a [`LlmStreamEvent::UpstreamError`] event.
+    ///
+    /// Deliberately bare — no `id`/`object`/`created`/`model` envelope and,
+    /// crucially, no `choices` key at all (unlike every other frame this
+    /// encoder produces). Clients such as the GitHub Copilot LLM Gateway
+    /// extension detect this exact shape
+    /// (`'error' in obj && !('choices' in obj)`) to recognise an inline
+    /// mid-stream failure; wrapping it in the usual envelope or adding an
+    /// empty `choices: []` would hide it as an ordinary chunk instead.
+    fn upstream_error_frame(message: &str, error_type: &str, code: &str) -> String {
+        let error_obj = json!({
+            "error": {
+                "message": message,
+                "type": error_type,
+                "code": code,
+            }
+        });
+        format!("data: {error_obj}\n\ndata: [DONE]\n\n")
     }
 
     /// Wrap a `choice` value in the standard chunk envelope and SSE framing.

--- a/crates/gglib-core/src/sse/mod.rs
+++ b/crates/gglib-core/src/sse/mod.rs
@@ -4,5 +4,5 @@ pub mod encoder;
 pub mod parser;
 
 pub use decoder::SseStreamDecoder;
-pub use encoder::SseEncoder;
+pub use encoder::{DONE_SENTINEL, SseEncoder};
 pub use parser::{SseParseResult, parse_sse_frame};

--- a/crates/gglib-core/src/sse/parser.rs
+++ b/crates/gglib-core/src/sse/parser.rs
@@ -91,6 +91,49 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
         }]));
     }
 
+    // ── Inline upstream error frame ───────────────────────────────────────
+    // Some OpenAI-compatible servers (including llama.cpp) can emit a bare
+    // `{"error": {...}}` frame mid-stream instead of a hard HTTP-level
+    // failure (e.g. a context-length overflow discovered only once
+    // generation is underway). Checked *before* the choices guard below for
+    // the same reason as `prompt_progress`/`usage`: this frame has no
+    // `choices` key at all, and clients such as the GitHub Copilot LLM
+    // Gateway extension specifically detect this shape via
+    // `'error' in obj && !('choices' in obj)` to surface a real error
+    // instead of hanging or seeing a silently truncated response.
+    if let Some(err) = parsed.get("error")
+        && parsed.get("choices").is_none()
+    {
+        let (message, error_type, code) = match err {
+            serde_json::Value::String(s) => (
+                s.clone(),
+                "server_error".to_owned(),
+                "upstream_error".to_owned(),
+            ),
+            _ => (
+                err.get("message")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("upstream returned an error")
+                    .to_owned(),
+                err.get("type")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("server_error")
+                    .to_owned(),
+                err.get("code")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("upstream_error")
+                    .to_owned(),
+            ),
+        };
+        return Ok(SseParseResult::Events(vec![
+            LlmStreamEvent::UpstreamError {
+                message,
+                error_type,
+                code,
+            },
+        ]));
+    }
+
     // Guard against keepalive / error frames that carry no `choices` array.
     // Without this check every field access falls through to `Value::Null`,
     // events are silently dropped, and a `finish_reason: "stop"` in such a
@@ -505,5 +548,73 @@ mod tests {
             other => panic!("unexpected: {other:?}"),
         };
         assert!(!events.is_empty(), "usage frame must not be skipped");
+    }
+
+    #[test]
+    fn inline_error_frame_object_form_extracts_all_fields() {
+        let frame = serde_json::json!({
+            "error": {
+                "message": "Context window limit reached.",
+                "type": "context_length_exceeded",
+                "code": "context_length_exceeded"
+            }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            LlmStreamEvent::UpstreamError { message, error_type, code }
+                if message == "Context window limit reached."
+                    && error_type == "context_length_exceeded"
+                    && code == "context_length_exceeded"
+        ));
+    }
+
+    #[test]
+    fn inline_error_frame_string_form_uses_defaults() {
+        let frame = serde_json::json!({ "error": "boom" }).to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            LlmStreamEvent::UpstreamError { message, error_type, code }
+                if message == "boom" && error_type == "server_error" && code == "upstream_error"
+        ));
+    }
+
+    #[test]
+    fn inline_error_frame_not_dropped_by_no_choices_guard() {
+        // No `choices` key at all -- would be silently dropped by the "no
+        // choices" guard if the error check didn't run first.
+        let frame = serde_json::json!({ "error": { "message": "oops" } }).to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert!(!events.is_empty(), "inline error frame must not be skipped");
+    }
+
+    #[test]
+    fn error_alongside_choices_key_is_not_treated_as_inline_error() {
+        // `choices` key present (even empty) means this isn't the bare
+        // inline-error shape the extension detects via `!('choices' in
+        // obj)` -- falls through to the normal "no choices" skip instead.
+        let frame = serde_json::json!({ "error": { "message": "oops" }, "choices": [] })
+            .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert!(
+            events.is_empty(),
+            "frame with a choices key should not be parsed as UpstreamError"
+        );
     }
 }

--- a/crates/gglib-core/src/sse/parser.rs
+++ b/crates/gglib-core/src/sse/parser.rs
@@ -36,9 +36,12 @@ pub enum SseParseResult {
 
 /// Parse a top-level `usage` object into a [`LlmStreamEvent::Usage`] event.
 ///
-/// Returns `None` when the frame carries no `usage` field, so the caller can
-/// fall through to the remaining frame-shape checks.
-fn parse_usage_frame(parsed: &serde_json::Value) -> Option<SseParseResult> {
+/// Returns `None` when the frame carries no `usage` field. Deliberately
+/// returns just the event (not a full [`SseParseResult`]) — unlike
+/// [`parse_inline_error_frame`], a `usage` field does **not** imply the rest
+/// of the frame should be skipped. See the call site in [`parse_sse_frame`]
+/// for why.
+fn parse_usage_event(parsed: &serde_json::Value) -> Option<LlmStreamEvent> {
     let usage = parsed.get("usage")?;
     let prompt_tokens =
         u32::try_from(usage["prompt_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
@@ -46,11 +49,11 @@ fn parse_usage_frame(parsed: &serde_json::Value) -> Option<SseParseResult> {
         u32::try_from(usage["completion_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
     let total_tokens =
         u32::try_from(usage["total_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
-    Some(SseParseResult::Events(vec![LlmStreamEvent::Usage {
+    Some(LlmStreamEvent::Usage {
         prompt_tokens,
         completion_tokens,
         total_tokens,
-    }]))
+    })
 }
 
 /// Parse a bare top-level `error` object (with no `choices` key) into an
@@ -133,14 +136,16 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
         ]));
     }
 
-    // ── Usage-totals frame (`stream_options.include_usage: true`) ────────
-    // Per the OpenAI streaming convention this arrives as a trailing chunk
-    // with an empty/absent `choices` array — checked *before* the choices
-    // guard below for the same reason as `prompt_progress`, so it isn't
-    // silently discarded as a "no choices" frame.
-    if let Some(result) = parse_usage_frame(&parsed) {
-        return Ok(result);
-    }
+    // ── Usage totals (`stream_options.include_usage: true`) ──────────────
+    // Extracted here but *not* an early return: strict OpenAI servers send
+    // this on a trailing chunk with empty `choices`, but llama-server
+    // attaches `usage` directly onto the same chunk that also carries a
+    // real `finish_reason` and non-empty `choices`
+    // (ggml-org/llama.cpp#12102, #15443). Treating `usage` presence as a
+    // reason to skip the rest of the frame would silently discard that
+    // finish_reason/delta. Decided below once we know whether `choices`
+    // is actually empty.
+    let usage_event = parse_usage_event(&parsed);
 
     // ── Inline upstream error frame ───────────────────────────────────────
     // Some OpenAI-compatible servers (including llama.cpp) can emit a bare
@@ -162,6 +167,10 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
     // frame would mean the stream never emits `Done`.
     let choices = &parsed["choices"];
     if choices.as_array().is_none_or(Vec::is_empty) {
+        // Strict-OpenAI shape: no real choice, usage (if any) stands alone.
+        if let Some(usage_event) = usage_event {
+            return Ok(SseParseResult::Events(vec![usage_event]));
+        }
         tracing::debug!(data = %data, "SSE frame has no 'choices' entries — skipping");
         return Ok(SseParseResult::Events(vec![]));
     }
@@ -214,6 +223,14 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
                 arguments,
             });
         }
+    }
+
+    // ── Usage totals bundled with this finish chunk (llama.cpp shape) ────
+    // Pushed *before* the finish_reason/Done event below, never after: the
+    // encoder appends the `[DONE]` sentinel immediately after `Done`, and
+    // nothing may follow `[DONE]` on the wire.
+    if let Some(usage_event) = usage_event {
+        events.push(usage_event);
     }
 
     // ── Finish reason → Done ────────────────────────────────────────────────
@@ -570,6 +587,61 @@ mod tests {
             other => panic!("unexpected: {other:?}"),
         };
         assert!(!events.is_empty(), "usage frame must not be skipped");
+    }
+
+    #[test]
+    fn llama_cpp_combined_usage_and_finish_chunk_emits_both_events() {
+        // Real llama-server shape (ggml-org/llama.cpp#12102, #15443): usage
+        // is attached to the *same* chunk as a real finish_reason and a
+        // non-empty `choices` array, not a separate trailing chunk with
+        // empty choices. Must not silently drop the finish_reason.
+        let frame = serde_json::json!({
+            "choices": [{ "finish_reason": "tool_calls", "index": 0, "delta": {} }],
+            "created": 0,
+            "id": "chatcmpl-1",
+            "model": "test-model",
+            "object": "chat.completion.chunk",
+            "usage": { "prompt_tokens": 4181, "completion_tokens": 12, "total_tokens": 4193 }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(events.len(), 2, "expected both a Usage and a Done event");
+        // Usage must come *before* Done -- the encoder appends `[DONE]`
+        // immediately after Done, so nothing may be emitted after it.
+        assert!(matches!(
+            &events[0],
+            LlmStreamEvent::Usage {
+                prompt_tokens: 4181,
+                completion_tokens: 12,
+                total_tokens: 4193
+            }
+        ));
+        assert!(matches!(
+            &events[1],
+            LlmStreamEvent::Done { finish_reason } if finish_reason == "tool_calls"
+        ));
+    }
+
+    #[test]
+    fn llama_cpp_combined_usage_and_stop_chunk_preserves_finish_reason() {
+        let frame = serde_json::json!({
+            "choices": [{ "finish_reason": "stop", "index": 0, "delta": {} }],
+            "usage": { "prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15 }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], LlmStreamEvent::Usage { .. }));
+        assert!(matches!(
+            &events[1],
+            LlmStreamEvent::Done { finish_reason } if finish_reason == "stop"
+        ));
     }
 
     #[test]

--- a/crates/gglib-core/src/sse/parser.rs
+++ b/crates/gglib-core/src/sse/parser.rs
@@ -72,6 +72,25 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
         ]));
     }
 
+    // ── Usage-totals frame (`stream_options.include_usage: true`) ────────
+    // Per the OpenAI streaming convention this arrives as a trailing chunk
+    // with an empty/absent `choices` array — checked *before* the choices
+    // guard below for the same reason as `prompt_progress`, so it isn't
+    // silently discarded as a "no choices" frame.
+    if let Some(usage) = parsed.get("usage") {
+        let prompt_tokens =
+            u32::try_from(usage["prompt_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+        let completion_tokens =
+            u32::try_from(usage["completion_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+        let total_tokens =
+            u32::try_from(usage["total_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+        return Ok(SseParseResult::Events(vec![LlmStreamEvent::Usage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+        }]));
+    }
+
     // Guard against keepalive / error frames that carry no `choices` array.
     // Without this check every field access falls through to `Value::Null`,
     // events are silently dropped, and a `finish_reason: "stop"` in such a
@@ -440,5 +459,51 @@ mod tests {
             !events.is_empty(),
             "prompt_progress frame must not be skipped"
         );
+    }
+
+    #[test]
+    fn usage_frame_emits_usage_event() {
+        let frame = serde_json::json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "test-model",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 123,
+                "completion_tokens": 45,
+                "total_tokens": 168
+            }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            LlmStreamEvent::Usage {
+                prompt_tokens: 123,
+                completion_tokens: 45,
+                total_tokens: 168
+            }
+        ));
+    }
+
+    #[test]
+    fn usage_frame_not_confused_with_no_choices_guard() {
+        // Empty `choices` array — would be silently dropped by the "no
+        // choices" guard if the usage check didn't run first.
+        let frame = serde_json::json!({
+            "choices": [],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+        })
+        .to_string();
+        let events = match parse_sse_frame(&frame) {
+            Ok(SseParseResult::Events(e)) => e,
+            other => panic!("unexpected: {other:?}"),
+        };
+        assert!(!events.is_empty(), "usage frame must not be skipped");
     }
 }

--- a/crates/gglib-core/src/sse/parser.rs
+++ b/crates/gglib-core/src/sse/parser.rs
@@ -34,6 +34,67 @@ pub enum SseParseResult {
 // Parser
 // =============================================================================
 
+/// Parse a top-level `usage` object into a [`LlmStreamEvent::Usage`] event.
+///
+/// Returns `None` when the frame carries no `usage` field, so the caller can
+/// fall through to the remaining frame-shape checks.
+fn parse_usage_frame(parsed: &serde_json::Value) -> Option<SseParseResult> {
+    let usage = parsed.get("usage")?;
+    let prompt_tokens =
+        u32::try_from(usage["prompt_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+    let completion_tokens =
+        u32::try_from(usage["completion_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+    let total_tokens =
+        u32::try_from(usage["total_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
+    Some(SseParseResult::Events(vec![LlmStreamEvent::Usage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+    }]))
+}
+
+/// Parse a bare top-level `error` object (with no `choices` key) into an
+/// [`LlmStreamEvent::UpstreamError`] event.
+///
+/// Returns `None` when the frame carries no `error` field, or when it also
+/// carries a `choices` key (even an empty one) — that shape doesn't match
+/// what downstream clients detect as an inline error, so it falls through
+/// to the remaining frame-shape checks instead.
+fn parse_inline_error_frame(parsed: &serde_json::Value) -> Option<SseParseResult> {
+    let err = parsed.get("error")?;
+    if parsed.get("choices").is_some() {
+        return None;
+    }
+    let (message, error_type, code) = match err {
+        serde_json::Value::String(s) => (
+            s.clone(),
+            "server_error".to_owned(),
+            "upstream_error".to_owned(),
+        ),
+        _ => (
+            err.get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("upstream returned an error")
+                .to_owned(),
+            err.get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("server_error")
+                .to_owned(),
+            err.get("code")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("upstream_error")
+                .to_owned(),
+        ),
+    };
+    Some(SseParseResult::Events(vec![
+        LlmStreamEvent::UpstreamError {
+            message,
+            error_type,
+            code,
+        },
+    ]))
+}
+
 /// Parse a single SSE `data:` payload into zero or more [`LlmStreamEvent`]s.
 ///
 /// Returns:
@@ -77,18 +138,8 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
     // with an empty/absent `choices` array — checked *before* the choices
     // guard below for the same reason as `prompt_progress`, so it isn't
     // silently discarded as a "no choices" frame.
-    if let Some(usage) = parsed.get("usage") {
-        let prompt_tokens =
-            u32::try_from(usage["prompt_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
-        let completion_tokens =
-            u32::try_from(usage["completion_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
-        let total_tokens =
-            u32::try_from(usage["total_tokens"].as_u64().unwrap_or(0)).unwrap_or(u32::MAX);
-        return Ok(SseParseResult::Events(vec![LlmStreamEvent::Usage {
-            prompt_tokens,
-            completion_tokens,
-            total_tokens,
-        }]));
+    if let Some(result) = parse_usage_frame(&parsed) {
+        return Ok(result);
     }
 
     // ── Inline upstream error frame ───────────────────────────────────────
@@ -101,37 +152,8 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
     // Gateway extension specifically detect this shape via
     // `'error' in obj && !('choices' in obj)` to surface a real error
     // instead of hanging or seeing a silently truncated response.
-    if let Some(err) = parsed.get("error")
-        && parsed.get("choices").is_none()
-    {
-        let (message, error_type, code) = match err {
-            serde_json::Value::String(s) => (
-                s.clone(),
-                "server_error".to_owned(),
-                "upstream_error".to_owned(),
-            ),
-            _ => (
-                err.get("message")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("upstream returned an error")
-                    .to_owned(),
-                err.get("type")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("server_error")
-                    .to_owned(),
-                err.get("code")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("upstream_error")
-                    .to_owned(),
-            ),
-        };
-        return Ok(SseParseResult::Events(vec![
-            LlmStreamEvent::UpstreamError {
-                message,
-                error_type,
-                code,
-            },
-        ]));
+    if let Some(result) = parse_inline_error_frame(&parsed) {
+        return Ok(result);
     }
 
     // Guard against keepalive / error frames that carry no `choices` array.

--- a/crates/gglib-core/src/sse/parser.rs
+++ b/crates/gglib-core/src/sse/parser.rs
@@ -628,8 +628,8 @@ mod tests {
         // `choices` key present (even empty) means this isn't the bare
         // inline-error shape the extension detects via `!('choices' in
         // obj)` -- falls through to the normal "no choices" skip instead.
-        let frame = serde_json::json!({ "error": { "message": "oops" }, "choices": [] })
-            .to_string();
+        let frame =
+            serde_json::json!({ "error": { "message": "oops" }, "choices": [] }).to_string();
         let events = match parse_sse_frame(&frame) {
             Ok(SseParseResult::Events(e)) => e,
             other => panic!("unexpected: {other:?}"),

--- a/crates/gglib-proxy/src/council_proxy.rs
+++ b/crates/gglib-proxy/src/council_proxy.rs
@@ -858,5 +858,8 @@ pub fn virtual_model_info(name: &str, description: &str) -> ModelInfo {
         created: 0,
         owned_by: "gglib".to_string(),
         description: Some(description.to_string()),
+        // Virtual/orchestration entry points, not a single context-bounded
+        // model — no meaningful context window to advertise.
+        context_window: None,
     }
 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -73,7 +73,7 @@ use gglib_core::ModelCapabilities;
 use gglib_core::domain::{ChatMessage, InferenceConfig, transform_messages_for_capabilities};
 use gglib_core::normalize::{NormalizingStream, get_parser};
 use gglib_core::ports::ModelCatalogPort;
-use gglib_core::sse::{SseEncoder, SseStreamDecoder};
+use gglib_core::sse::{DONE_SENTINEL, SseEncoder, SseStreamDecoder};
 
 use crate::connections::ConnectionGuard;
 use crate::metrics::{ContextMetricsStore, ContextSnapshot};
@@ -824,7 +824,9 @@ async fn stream_response_to_channel(
                             "code": "upstream_error",
                         }
                     });
-                    let frame = format!("data: {payload}\n\ndata: [DONE]\n\n");
+                    // No inline [DONE] here -- appended once, unconditionally,
+                    // after the wire stream is exhausted (see below).
+                    let frame = format!("data: {payload}\n\n");
                     Some(Ok::<Bytes, std::io::Error>(Bytes::from(frame)))
                 }
             }
@@ -832,11 +834,23 @@ async fn stream_response_to_channel(
     });
 
     let mut wire_stream = Box::pin(wire_stream);
+    let mut client_connected = true;
     while let Some(item) = wire_stream.next().await {
         if tx.send(item).await.is_err() {
             // Client disconnected; stop draining the upstream.
+            client_connected = false;
             break;
         }
+    }
+    // Exactly one [DONE] sentinel, sent once the wire stream is truly
+    // exhausted -- never bundled into an individual event's encoding, since
+    // a trailing Usage event can legitimately follow Done (see
+    // `gglib_core::sse::DONE_SENTINEL` doc). Skipped if the client already
+    // disconnected -- the channel is closed, nothing to send.
+    if client_connected {
+        let _ = tx
+            .send(Ok(Bytes::from_static(DONE_SENTINEL.as_bytes())))
+            .await;
     }
 }
 

--- a/crates/gglib-proxy/src/models.rs
+++ b/crates/gglib-proxy/src/models.rs
@@ -264,6 +264,20 @@ pub struct ModelInfo {
     pub owned_by: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Model's context window size, in tokens (llama.cpp's `/v1/models`
+    /// field-naming convention). `None` when unknown.
+    ///
+    /// Populated from [`ModelSummary::context_length`] by default; callers
+    /// that know the model is currently running should overwrite this with
+    /// the live `effective_ctx` from `ModelRuntimePort::current_model()`,
+    /// which reflects the actual `--ctx-size` in use rather than the GGUF's
+    /// static max. Either way this value should be clamped to
+    /// `crate::truncation::TOTAL_PAYLOAD_LIMIT_TOKENS` before being served,
+    /// so clients that auto-detect context size from this endpoint (e.g.
+    /// the GitHub Copilot LLM Gateway extension) never compute a budget
+    /// this proxy's own truncation guard will reject.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
 }
 
 impl From<ModelSummary> for ModelInfo {
@@ -274,6 +288,7 @@ impl From<ModelSummary> for ModelInfo {
             created: summary.created_at,
             owned_by: "gglib".to_string(),
             description: Some(summary.description()),
+            context_window: summary.context_length,
         }
     }
 }
@@ -545,6 +560,7 @@ mod tests {
                 architecture: Some("llama".into()),
                 created_at: 1700000000,
                 file_size: 4_000_000_000,
+                context_length: Some(8192),
                 inference_defaults: None,
             },
             ModelSummary {
@@ -557,6 +573,7 @@ mod tests {
                 architecture: Some("mistral".into()),
                 created_at: 1700000001,
                 file_size: 7_000_000_000,
+                context_length: None,
                 inference_defaults: None,
             },
         ];
@@ -582,6 +599,7 @@ mod tests {
             architecture: None,
             created_at: 0,
             file_size: 0,
+            context_length: None,
             inference_defaults: None,
         }]);
 
@@ -608,6 +626,7 @@ mod tests {
             architecture: Some("llama".into()),
             created_at: 0,
             file_size: 0,
+            context_length: None,
             inference_defaults: None,
         };
         let info = ModelInfo::from(summary);
@@ -629,6 +648,7 @@ mod tests {
             architecture: None,
             created_at: 0,
             file_size: 0,
+            context_length: None,
             inference_defaults: None,
         };
         let info = ModelInfo::from(summary);
@@ -637,6 +657,44 @@ mod tests {
             desc.contains("unknown"),
             "missing fields should show 'unknown'"
         );
+    }
+
+    #[test]
+    fn model_info_maps_context_length_to_context_window() {
+        let summary = ModelSummary {
+            id: 1,
+            name: "ctx-model".into(),
+            tags: vec![],
+            capabilities: ModelCapabilities::empty(),
+            param_count: "7B".into(),
+            quantization: None,
+            architecture: None,
+            created_at: 0,
+            file_size: 0,
+            context_length: Some(32_768),
+            inference_defaults: None,
+        };
+        let info = ModelInfo::from(summary);
+        assert_eq!(info.context_window, Some(32_768));
+    }
+
+    #[test]
+    fn model_info_context_window_none_when_unknown() {
+        let summary = ModelSummary {
+            id: 1,
+            name: "unknown-ctx-model".into(),
+            tags: vec![],
+            capabilities: ModelCapabilities::empty(),
+            param_count: "7B".into(),
+            quantization: None,
+            architecture: None,
+            created_at: 0,
+            file_size: 0,
+            context_length: None,
+            inference_defaults: None,
+        };
+        let info = ModelInfo::from(summary);
+        assert_eq!(info.context_window, None);
     }
 
     // =========================================================================

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -33,6 +33,7 @@ use crate::mcp::session::SessionManager;
 use crate::metrics::ContextMetricsStore;
 use crate::models::{ChatRoutingEnvelope, ErrorResponse, ModelInfo, ModelsResponse};
 use crate::slots_poller::{SlotsCache, spawn_slots_poller};
+use crate::truncation::TOTAL_PAYLOAD_LIMIT_TOKENS;
 use gglib_sse::SseOptions;
 
 /// Shared application state for the proxy server.
@@ -211,12 +212,38 @@ async fn health_check() -> impl IntoResponse {
 /// List all models from the catalog in OpenAI format.
 ///
 /// Appends the three virtual council model entries after the catalog models.
+///
+/// Each catalog entry's `context_window` (populated from the static
+/// GGUF-derived `context_length`) is clamped to
+/// [`crate::truncation::TOTAL_PAYLOAD_LIMIT_TOKENS`] so clients that
+/// auto-detect context size from this endpoint (e.g. the GitHub Copilot LLM
+/// Gateway extension) never compute a token budget larger than what this
+/// proxy's own [`crate::truncation::truncate_history`] will actually allow
+/// through. Whichever model is currently running is then overridden with
+/// its live `effective_ctx` (the real `--ctx-size` llama-server was
+/// launched with), which is more accurate than the static value and can
+/// differ from it.
 async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
     debug!("GET /v1/models");
 
     match state.catalog_port.list_models().await {
         Ok(models) => {
             let mut response = ModelsResponse::from_summaries(models);
+
+            let ceiling = TOTAL_PAYLOAD_LIMIT_TOKENS as u64;
+            for model in &mut response.data {
+                model.context_window = model.context_window.map(|ctx| ctx.min(ceiling));
+            }
+
+            if let Some(target) = state.runtime_port.current_model().await
+                && let Some(model) = response
+                    .data
+                    .iter_mut()
+                    .find(|m| m.id == target.model_name)
+            {
+                model.context_window = Some(target.effective_ctx.min(ceiling));
+            }
+
             // Append virtual council models.
             let virtuals: Vec<ModelInfo> = vec![
                 virtual_model_info(

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -236,10 +236,7 @@ async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
             }
 
             if let Some(target) = state.runtime_port.current_model().await
-                && let Some(model) = response
-                    .data
-                    .iter_mut()
-                    .find(|m| m.id == target.model_name)
+                && let Some(model) = response.data.iter_mut().find(|m| m.id == target.model_name)
             {
                 model.context_window = Some(target.effective_ctx.min(ceiling));
             }

--- a/crates/gglib-proxy/src/truncation.rs
+++ b/crates/gglib-proxy/src/truncation.rs
@@ -58,6 +58,31 @@ pub const TOOL_CONTENT_THRESHOLD_CHARS: usize = 2_000;
 /// Approximation: 240,000 chars ÷ 4 ≈ 60,000 tokens.
 pub const TOTAL_PAYLOAD_LIMIT_CHARS: usize = 240_000;
 
+/// Character-to-token conversion factor used solely to translate
+/// [`TOTAL_PAYLOAD_LIMIT_CHARS`] (a **character** budget) into a **token**
+/// count for [`TOTAL_PAYLOAD_LIMIT_TOKENS`].
+///
+/// This value is not an attempt at precise real-world tokenization — it is
+/// deliberately chosen to match the GitHub Copilot LLM Gateway extension's
+/// own `TOKEN_CONSTANTS.CHARS_PER_TOKEN = 4` (see its `tokenBudget.ts`), so
+/// that gglib's advertised `context_window` (see `crate::models::ModelInfo`)
+/// and the extension's own char→token budget estimate agree on the same
+/// conversion factor. What matters here is consistency between the two
+/// sides, not tokenizer accuracy.
+pub const CHARS_PER_TOKEN_APPROX: usize = 4;
+
+/// [`TOTAL_PAYLOAD_LIMIT_CHARS`] expressed as a **token** count.
+///
+/// Used to clamp the `context_window` value gglib reports via `/v1/models`
+/// (see `crate::models::ModelInfo`) so that a client computing its own
+/// input-token budget from that field can never plan a prompt larger than
+/// what this proxy's own hard-abort in [`truncate_history`] will actually
+/// allow through. Without this clamp, advertising a model's full native
+/// context (e.g. 131,072 tokens) while enforcing a much smaller
+/// character-based ceiling here creates a split-brain where the client only
+/// discovers the real limit via a hard HTTP 400.
+pub const TOTAL_PAYLOAD_LIMIT_TOKENS: usize = TOTAL_PAYLOAD_LIMIT_CHARS / CHARS_PER_TOKEN_APPROX;
+
 /// Number of trailing messages (by index) that are always preserved from
 /// truncation regardless of role or content size.  These represent the
 /// immediate conversational context the model needs to respond coherently.

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -198,6 +198,7 @@ impl TaggedCatalog {
             architecture: None,
             created_at: 0,
             file_size: 0,
+            context_length: None,
             inference_defaults: None,
         }
     }

--- a/crates/gglib-runtime/src/ports_impl/model_catalog.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_catalog.rs
@@ -36,6 +36,7 @@ fn model_to_summary(m: &Model) -> ModelSummary {
         architecture: m.architecture.clone(),
         created_at: m.added_at.timestamp(),
         file_size,
+        context_length: m.context_length,
         inference_defaults: m.inference_defaults.clone(),
     }
 }


### PR DESCRIPTION
## Problem

Long conversations through the GitHub Copilot LLM Gateway extension (`AndrewButson.github-copilot-llm-gateway`) hard-crash with:

```
Chat completion failed: 400 Bad Request - {"error":{"message":"Context window limit reached...","type":"context_length_exceeded","code":"context_length_exceeded"}}
```

## Root causes

1. **`/v1/models` never reported a context-size field.** The extension auto-detects context size via `model.max_model_len ?? model.context_length ?? model.context_window` (llama.cpp convention: `context_window`). gglib reported none of these, so the extension fell back to its own generous default budget, kept growing the conversation past what it thought was safe, and eventually collided with gglib's own hardcoded `TOTAL_PAYLOAD_LIMIT_CHARS` (240,000 chars ≈ 60k tokens) truncation guard — which then hard-aborts with exactly the error above.
2. **The trailing `usage` SSE frame was silently dropped.** gglib already injects `stream_options.include_usage: true` (#567), but the response-side parser's "no choices" guard discarded the resulting usage-only chunk before it ever reached the client, so the extension's context-window UI widget got no data despite the request-side fix already being in place.
3. **Mid-stream `{"error": ...}` frames were silently dropped**, for the same "no choices" guard reason — worse than a masked 502, since nothing reached the client at all.

## Fixes

- **`/v1/models` now reports `context_window`**, sourced from the live `effective_ctx` (`RunningTarget`, the real `--ctx-size` llama-server was launched with) for whichever model is currently running, falling back to the static GGUF-derived `context_length` for other catalog entries. Both are clamped to a new `TOTAL_PAYLOAD_LIMIT_TOKENS` constant — `TOTAL_PAYLOAD_LIMIT_CHARS` converted from characters to tokens using the same `4`-chars-per-token factor the extension itself uses, so gglib never advertises a larger window than its own truncation guard will actually allow through.
- **New `LlmStreamEvent::Usage` variant**, detected before the "no choices" guard and re-encoded as an OpenAI-shape trailing chunk (`choices: []` + `usage: {...}`) — the exact shape `stream_options.include_usage` clients expect.
- **New `LlmStreamEvent::UpstreamError` variant**, detected before the same guard and re-encoded as a bare `{"error": {...}}` frame (no `choices` key at all) + `[DONE]` — the exact shape the extension's `processSSELine` looks for (`'error' in obj && !('choices' in obj)`) to surface a real error instead of hanging.

## Testing

- `cargo test --workspace` — all suites pass (0 failed).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- New unit tests cover: usage-frame parsing/encoding, inline-error-frame parsing/encoding (both object and bare-string shapes), the decoder's stop-on-terminal-error behavior, and `ModelInfo`'s `context_window` mapping.

## Commits

1. `fix(proxy): expose real context_window via /v1/models`
2. `fix(core/sse): stop dropping the trailing usage frame`
3. `fix(core/sse): forward mid-stream upstream error frames verbatim`
4. `chore: satisfy clippy for the usage/upstream-error frame changes`
