### PR TITLE
test(queue): improve test coverage for download queue system

### DIFF
--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -436,4 +436,23 @@ mod tests {
         assert_eq!(download.downloaded_bytes, 1500);
         assert!((download.speed_bps - 100.0).abs() < 0.01);
     }
+
+    /// Test `update_progress` with zero total bytes (division-by-zero guard).
+    #[test]
+    fn test_update_progress_zero_total_bytes() {
+        let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
+
+        // Call update_progress with total = 0
+        download.update_progress(500, 0, 100.0);
+
+        // Progress percent is 0.0 (the `if total > 0` guard prevents division by zero)
+        assert_eq!(download.progress_percent, 0.0, "Progress should be 0.0 when total is 0");
+
+        // ETA is None because `total > downloaded` is false when total is 0
+        assert!(download.eta_seconds.is_none(), "ETA should be None when total is 0");
+
+        // Downloaded bytes and speed are still updated
+        assert_eq!(download.downloaded_bytes, 500);
+        assert!((download.speed_bps - 100.0).abs() < 0.01);
+    }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -354,6 +354,19 @@ mod tests {
 
         download.speed_bps = 500.0;
         assert_eq!(download.speed_display(), "500 B/s");
+
+        // Edge cases: exact boundaries and just-below thresholds
+        download.speed_bps = 1_000.0;
+        assert_eq!(download.speed_display(), "1.0 KB/s");
+
+        download.speed_bps = 999.0;
+        assert_eq!(download.speed_display(), "999 B/s");
+
+        download.speed_bps = 1_000_000.0;
+        assert_eq!(download.speed_display(), "1.0 MB/s");
+
+        download.speed_bps = 1_000_000_000.0;
+        assert_eq!(download.speed_display(), "1.0 GB/s");
     }
 
     #[test]
@@ -361,6 +374,11 @@ mod tests {
         assert_eq!(format_duration(30), "30s");
         assert_eq!(format_duration(90), "1m 30s");
         assert_eq!(format_duration(3661), "1h 1m");
+
+        // Edge cases: exact hour boundaries and zero
+        assert_eq!(format_duration(0), "0s");
+        assert_eq!(format_duration(3600), "1h 0m");
+        assert_eq!(format_duration(7200), "2h 0m");
     }
 
     #[test]

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -374,4 +374,45 @@ mod tests {
         assert_eq!(parsed.id, "id");
         assert_eq!(parsed.quantization, Some(Quantization::Q4KM));
     }
+
+    /// Comprehensive test: verify `is_active()` and `is_complete()` for all 7 `DownloadStatus` variants.
+    #[test]
+    fn test_status_classification_all_variants() {
+        let base = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
+
+        // Queued: not active, not complete
+        let queued = base.clone().with_status(DownloadStatus::Queued);
+        assert!(!queued.is_active(), "Queued should not be active");
+        assert!(!queued.is_complete(), "Queued should not be complete");
+
+        // Downloading: active, not complete
+        let downloading = base.clone().with_status(DownloadStatus::Downloading);
+        assert!(downloading.is_active(), "Downloading should be active");
+        assert!(!downloading.is_complete(), "Downloading should not be complete");
+
+        // Finalizing: not active, not complete
+        let finalizing = base.clone().with_status(DownloadStatus::Finalizing);
+        assert!(!finalizing.is_active(), "Finalizing should not be active");
+        assert!(!finalizing.is_complete(), "Finalizing should not be complete");
+
+        // Registering: not active, not complete
+        let registering = base.clone().with_status(DownloadStatus::Registering);
+        assert!(!registering.is_active(), "Registering should not be active");
+        assert!(!registering.is_complete(), "Registering should not be complete");
+
+        // Completed: not active, complete
+        let completed = base.clone().with_status(DownloadStatus::Completed);
+        assert!(!completed.is_active(), "Completed should not be active");
+        assert!(completed.is_complete(), "Completed should be complete");
+
+        // Failed: not active, complete
+        let failed = base.clone().with_status(DownloadStatus::Failed);
+        assert!(!failed.is_active(), "Failed should not be active");
+        assert!(failed.is_complete(), "Failed should be complete");
+
+        // Cancelled: not active, complete
+        let cancelled = base.clone().with_status(DownloadStatus::Cancelled);
+        assert!(!cancelled.is_active(), "Cancelled should not be active");
+        assert!(cancelled.is_complete(), "Cancelled should be complete");
+    }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -438,13 +438,13 @@ mod tests {
         assert!(failed.is_complete(), "Failed should be complete");
 
         // Cancelled: not active, complete
-        let cancelled = base.clone().with_status(DownloadStatus::Cancelled);
+        let cancelled = base.with_status(DownloadStatus::Cancelled);
         assert!(!cancelled.is_active(), "Cancelled should not be active");
         assert!(cancelled.is_complete(), "Cancelled should be complete");
     }
 
     /// Test `update_progress` when downloaded bytes exceed total bytes.
-    /// This documents the current behavior: progress_percent can exceed 100%, and eta_seconds becomes None.
+    /// This documents the current behavior: `progress_percent` can exceed 100%, and `eta_seconds` becomes None.
     #[test]
     fn test_update_progress_downloaded_exceeds_total() {
         let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
@@ -475,6 +475,7 @@ mod tests {
 
     /// Test `update_progress` with zero total bytes (division-by-zero guard).
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_update_progress_zero_total_bytes() {
         let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
 
@@ -500,6 +501,7 @@ mod tests {
 
     /// Test `update_progress` with zero speed (division-by-zero guard for ETA).
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_update_progress_zero_speed() {
         let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
 
@@ -522,6 +524,7 @@ mod tests {
 
     /// Test `update_progress` when download is complete (downloaded == total).
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_update_progress_complete_download() {
         let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
 
@@ -572,8 +575,7 @@ mod tests {
         let eta = download.eta_seconds.unwrap();
         assert!(
             (eta - 50_000.0).abs() < 1.0,
-            "ETA should be ~50,000 seconds, got {}",
-            eta
+            "ETA should be ~50,000 seconds, got {eta}"
         );
 
         // Verify downloaded_bytes and speed were updated

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -474,4 +474,23 @@ mod tests {
         assert_eq!(download.downloaded_bytes, 500);
         assert_eq!(download.speed_bps, 0.0);
     }
+
+    /// Test `update_progress` when download is complete (downloaded == total).
+    #[test]
+    fn test_update_progress_complete_download() {
+        let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
+
+        // Call update_progress with downloaded equal to total
+        download.update_progress(1000, 1000, 100.0);
+
+        // Progress percent should be 100%
+        assert_eq!(download.progress_percent, 100.0, "Progress should be 100.0%");
+
+        // ETA is None because `total > downloaded` guard is false when equal
+        assert!(download.eta_seconds.is_none(), "ETA should be None when download is complete");
+
+        // Downloaded bytes and speed are updated normally
+        assert_eq!(download.downloaded_bytes, 1000);
+        assert!((download.speed_bps - 100.0).abs() < 0.01);
+    }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -493,4 +493,40 @@ mod tests {
         assert_eq!(download.downloaded_bytes, 1000);
         assert!((download.speed_bps - 100.0).abs() < 0.01);
     }
+
+    /// Test `update_progress` with large u64 values — verifies no overflow/panic and results are in the right ballpark despite f64 precision loss.
+    #[test]
+    fn test_update_progress_large_u64_values() {
+        let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
+
+        // 50 TB downloaded out of 100 TB total, at 1 GB/s
+        let downloaded: u64 = 50_000_000_000_000;
+        let total: u64 = 100_000_000_000_000;
+        let speed_bps: f64 = 1_000_000_000.0; // 1 GB/s
+
+        download.update_progress(downloaded, total, speed_bps);
+
+        // Progress should be approximately 50% (within tolerance for f64 precision loss)
+        assert!(
+            (download.progress_percent - 50.0).abs() < 0.1,
+            "Progress should be ~50%, got {}",
+            download.progress_percent
+        );
+
+        // ETA: remaining bytes / speed = 50 TB / 1 GB/s = 50_000 seconds
+        assert!(
+            download.eta_seconds.is_some(),
+            "ETA should be Some for large values"
+        );
+        let eta = download.eta_seconds.unwrap();
+        assert!(
+            (eta - 50_000.0).abs() < 1.0,
+            "ETA should be ~50,000 seconds, got {}",
+            eta
+        );
+
+        // Verify downloaded_bytes and speed were updated
+        assert_eq!(download.downloaded_bytes, downloaded);
+        assert!((download.speed_bps - speed_bps).abs() < 0.01);
+    }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -529,4 +529,51 @@ mod tests {
         assert_eq!(download.downloaded_bytes, downloaded);
         assert!((download.speed_bps - speed_bps).abs() < 0.01);
     }
+
+    /// Test `FailedDownload` builder pattern — defaults and chained setters.
+    #[test]
+    fn test_failed_download_builders() {
+        // Create with new() and verify defaults
+        let failed = FailedDownload::new("id", "Display", "network error", 1_234_567_890);
+
+        assert_eq!(failed.id, "id");
+        assert_eq!(failed.display_name, "Display");
+        assert_eq!(failed.error, "network error");
+        assert_eq!(failed.failed_at, 1_234_567_890);
+        // Defaults
+        assert!(!failed.recoverable, "recoverable should default to false");
+        assert_eq!(failed.downloaded_bytes, 0, "downloaded_bytes should default to 0");
+
+        // Chain builders and verify values are set
+        let failed2 = FailedDownload::new("id2", "Display2", "timeout", 0)
+            .with_recoverable(true)
+            .with_downloaded_bytes(500_000);
+
+        assert!(failed2.recoverable, "recoverable should be true after with_recoverable(true)");
+        assert_eq!(failed2.downloaded_bytes, 500_000, "downloaded_bytes should be 500_000");
+    }
+
+    /// Test `QueueSnapshot::default()` produces the same state as `QueueSnapshot::new(0)`.
+    #[test]
+    fn test_queue_snapshot_default() {
+        let default_snapshot = QueueSnapshot::default();
+        let zero_snapshot = QueueSnapshot::new(0);
+
+        // max_size should be 0 for both
+        assert_eq!(default_snapshot.max_size, 0);
+        assert_eq!(zero_snapshot.max_size, 0);
+        assert_eq!(default_snapshot.max_size, zero_snapshot.max_size);
+
+        // items should be empty
+        assert!(default_snapshot.items.is_empty());
+        assert_eq!(default_snapshot.items.len(), zero_snapshot.items.len());
+
+        // counts should be zero
+        assert_eq!(default_snapshot.active_count, 0);
+        assert_eq!(default_snapshot.pending_count, 0);
+
+        // recent_failures should be empty
+        assert!(default_snapshot.recent_failures.is_empty());
+        assert_eq!(default_snapshot.recent_failures.len(), zero_snapshot.recent_failures.len());
+    }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -455,4 +455,23 @@ mod tests {
         assert_eq!(download.downloaded_bytes, 500);
         assert!((download.speed_bps - 100.0).abs() < 0.01);
     }
+
+    /// Test `update_progress` with zero speed (division-by-zero guard for ETA).
+    #[test]
+    fn test_update_progress_zero_speed() {
+        let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
+
+        // Call update_progress with speed = 0.0
+        download.update_progress(500, 1000, 0.0);
+
+        // Progress percent is still calculated correctly (50%)
+        assert_eq!(download.progress_percent, 50.0, "Progress should be 50.0%");
+
+        // ETA is None because `speed_bps > 0.0` guard prevents division by zero / infinity
+        assert!(download.eta_seconds.is_none(), "ETA should be None when speed is 0");
+
+        // Downloaded bytes are updated, speed is 0
+        assert_eq!(download.downloaded_bytes, 500);
+        assert_eq!(download.speed_bps, 0.0);
+    }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -406,17 +406,26 @@ mod tests {
         // Downloading: active, not complete
         let downloading = base.clone().with_status(DownloadStatus::Downloading);
         assert!(downloading.is_active(), "Downloading should be active");
-        assert!(!downloading.is_complete(), "Downloading should not be complete");
+        assert!(
+            !downloading.is_complete(),
+            "Downloading should not be complete"
+        );
 
         // Finalizing: not active, not complete
         let finalizing = base.clone().with_status(DownloadStatus::Finalizing);
         assert!(!finalizing.is_active(), "Finalizing should not be active");
-        assert!(!finalizing.is_complete(), "Finalizing should not be complete");
+        assert!(
+            !finalizing.is_complete(),
+            "Finalizing should not be complete"
+        );
 
         // Registering: not active, not complete
         let registering = base.clone().with_status(DownloadStatus::Registering);
         assert!(!registering.is_active(), "Registering should not be active");
-        assert!(!registering.is_complete(), "Registering should not be complete");
+        assert!(
+            !registering.is_complete(),
+            "Registering should not be complete"
+        );
 
         // Completed: not active, complete
         let completed = base.clone().with_status(DownloadStatus::Completed);
@@ -444,11 +453,20 @@ mod tests {
         download.update_progress(1500, 1000, 100.0);
 
         // Progress percent exceeds 100% (no clamping)
-        assert!(download.progress_percent > 100.0, "Progress should exceed 100% when downloaded > total");
-        assert!((download.progress_percent - 150.0).abs() < 0.01, "Progress should be 150.0%");
+        assert!(
+            download.progress_percent > 100.0,
+            "Progress should exceed 100% when downloaded > total"
+        );
+        assert!(
+            (download.progress_percent - 150.0).abs() < 0.01,
+            "Progress should be 150.0%"
+        );
 
         // ETA is None because total > downloaded condition is false
-        assert!(download.eta_seconds.is_none(), "ETA should be None when downloaded >= total");
+        assert!(
+            download.eta_seconds.is_none(),
+            "ETA should be None when downloaded >= total"
+        );
 
         // Speed and bytes are still updated
         assert_eq!(download.downloaded_bytes, 1500);
@@ -464,10 +482,16 @@ mod tests {
         download.update_progress(500, 0, 100.0);
 
         // Progress percent is 0.0 (the `if total > 0` guard prevents division by zero)
-        assert_eq!(download.progress_percent, 0.0, "Progress should be 0.0 when total is 0");
+        assert_eq!(
+            download.progress_percent, 0.0,
+            "Progress should be 0.0 when total is 0"
+        );
 
         // ETA is None because `total > downloaded` is false when total is 0
-        assert!(download.eta_seconds.is_none(), "ETA should be None when total is 0");
+        assert!(
+            download.eta_seconds.is_none(),
+            "ETA should be None when total is 0"
+        );
 
         // Downloaded bytes and speed are still updated
         assert_eq!(download.downloaded_bytes, 500);
@@ -486,7 +510,10 @@ mod tests {
         assert_eq!(download.progress_percent, 50.0, "Progress should be 50.0%");
 
         // ETA is None because `speed_bps > 0.0` guard prevents division by zero / infinity
-        assert!(download.eta_seconds.is_none(), "ETA should be None when speed is 0");
+        assert!(
+            download.eta_seconds.is_none(),
+            "ETA should be None when speed is 0"
+        );
 
         // Downloaded bytes are updated, speed is 0
         assert_eq!(download.downloaded_bytes, 500);
@@ -502,10 +529,16 @@ mod tests {
         download.update_progress(1000, 1000, 100.0);
 
         // Progress percent should be 100%
-        assert_eq!(download.progress_percent, 100.0, "Progress should be 100.0%");
+        assert_eq!(
+            download.progress_percent, 100.0,
+            "Progress should be 100.0%"
+        );
 
         // ETA is None because `total > downloaded` guard is false when equal
-        assert!(download.eta_seconds.is_none(), "ETA should be None when download is complete");
+        assert!(
+            download.eta_seconds.is_none(),
+            "ETA should be None when download is complete"
+        );
 
         // Downloaded bytes and speed are updated normally
         assert_eq!(download.downloaded_bytes, 1000);
@@ -560,15 +593,24 @@ mod tests {
         assert_eq!(failed.failed_at, 1_234_567_890);
         // Defaults
         assert!(!failed.recoverable, "recoverable should default to false");
-        assert_eq!(failed.downloaded_bytes, 0, "downloaded_bytes should default to 0");
+        assert_eq!(
+            failed.downloaded_bytes, 0,
+            "downloaded_bytes should default to 0"
+        );
 
         // Chain builders and verify values are set
         let failed2 = FailedDownload::new("id2", "Display2", "timeout", 0)
             .with_recoverable(true)
             .with_downloaded_bytes(500_000);
 
-        assert!(failed2.recoverable, "recoverable should be true after with_recoverable(true)");
-        assert_eq!(failed2.downloaded_bytes, 500_000, "downloaded_bytes should be 500_000");
+        assert!(
+            failed2.recoverable,
+            "recoverable should be true after with_recoverable(true)"
+        );
+        assert_eq!(
+            failed2.downloaded_bytes, 500_000,
+            "downloaded_bytes should be 500_000"
+        );
     }
 
     /// Test `QueueSnapshot::default()` produces the same state as `QueueSnapshot::new(0)`.
@@ -592,6 +634,9 @@ mod tests {
 
         // recent_failures should be empty
         assert!(default_snapshot.recent_failures.is_empty());
-        assert_eq!(default_snapshot.recent_failures.len(), zero_snapshot.recent_failures.len());
+        assert_eq!(
+            default_snapshot.recent_failures.len(),
+            zero_snapshot.recent_failures.len()
+        );
     }
 }

--- a/crates/gglib-core/src/download/queue.rs
+++ b/crates/gglib-core/src/download/queue.rs
@@ -415,4 +415,25 @@ mod tests {
         assert!(!cancelled.is_active(), "Cancelled should not be active");
         assert!(cancelled.is_complete(), "Cancelled should be complete");
     }
+
+    /// Test `update_progress` when downloaded bytes exceed total bytes.
+    /// This documents the current behavior: progress_percent can exceed 100%, and eta_seconds becomes None.
+    #[test]
+    fn test_update_progress_downloaded_exceeds_total() {
+        let mut download = QueuedDownload::new("test-id", "test-model", "test-display", 1, 0);
+
+        // Call update_progress with downloaded > total
+        download.update_progress(1500, 1000, 100.0);
+
+        // Progress percent exceeds 100% (no clamping)
+        assert!(download.progress_percent > 100.0, "Progress should exceed 100% when downloaded > total");
+        assert!((download.progress_percent - 150.0).abs() < 0.01, "Progress should be 150.0%");
+
+        // ETA is None because total > downloaded condition is false
+        assert!(download.eta_seconds.is_none(), "ETA should be None when downloaded >= total");
+
+        // Speed and bytes are still updated
+        assert_eq!(download.downloaded_bytes, 1500);
+        assert!((download.speed_bps - 100.0).abs() < 0.01);
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -892,4 +892,47 @@ mod tests {
         // Queue is now empty - dequeue returns None
         assert!(queue.dequeue().is_none());
     }
+
+    /// Test that positions shift down after dequeue.
+    #[test]
+    fn test_position_tracking_on_enqueue_dequeue() {
+        let mut queue = DownloadQueue::new(3);
+
+        // Enqueue 3 items: "a", "b", "c"
+        let id_a = test_id("a", None);
+        let id_b = test_id("b", None);
+        let id_c = test_id("c", None);
+
+        queue
+            .queue(id_a.clone(), test_completion_key(&id_a), false)
+            .unwrap();
+        queue
+            .queue(id_b.clone(), test_completion_key(&id_b), false)
+            .unwrap();
+        queue
+            .queue(id_c.clone(), test_completion_key(&id_c), false)
+            .unwrap();
+
+        // Snapshot: positions should be 1, 2, 3
+        let snapshot = queue.snapshot(None);
+        assert_eq!(snapshot.items.len(), 3);
+        assert_eq!(snapshot.items[0].position, 1);
+        assert_eq!(snapshot.items[0].id, "a");
+        assert_eq!(snapshot.items[1].position, 2);
+        assert_eq!(snapshot.items[1].id, "b");
+        assert_eq!(snapshot.items[2].position, 3);
+        assert_eq!(snapshot.items[2].id, "c");
+
+        // Dequeue "a"
+        let dequeued = queue.dequeue().unwrap();
+        assert_eq!(dequeued.id.model_id(), "a");
+
+        // Snapshot again: positions should have shifted down
+        let snapshot = queue.snapshot(None);
+        assert_eq!(snapshot.items.len(), 2);
+        assert_eq!(snapshot.items[0].position, 1);
+        assert_eq!(snapshot.items[0].id, "b");
+        assert_eq!(snapshot.items[1].position, 2);
+        assert_eq!(snapshot.items[1].id, "c");
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -935,4 +935,41 @@ mod tests {
         assert_eq!(snapshot.items[1].position, 2);
         assert_eq!(snapshot.items[1].id, "c");
     }
+
+    /// Test that snapshot() produces correct DTOs with active/pending counts.
+    #[test]
+    fn test_snapshot_produces_correct_dtos() {
+        let mut queue = DownloadQueue::new(5);
+
+        // Enqueue 2 items: "model-x" and "model-y"
+        let id_x = test_id("model-x", None);
+        let id_y = test_id("model-y", None);
+
+        queue
+            .queue(id_x.clone(), test_completion_key(&id_x), false)
+            .unwrap();
+        queue
+            .queue(id_y.clone(), test_completion_key(&id_y), false)
+            .unwrap();
+
+        // Snapshot with nothing active: 0 active, 2 pending
+        let snapshot = queue.snapshot(None);
+        assert_eq!(snapshot.items.len(), 2);
+        assert_eq!(snapshot.active_count, 0);
+        assert_eq!(snapshot.pending_count, 2);
+        assert_eq!(snapshot.items[0].position, 1);
+        assert_eq!(snapshot.items[0].id, "model-x");
+        assert_eq!(snapshot.items[1].position, 2);
+        assert_eq!(snapshot.items[1].id, "model-y");
+
+        // Dequeue "model-x" and mark it as downloading
+        let current = queue.dequeue().unwrap();
+        assert_eq!(current.id.model_id(), "model-x");
+        let current_dto = current.to_dto(1, DownloadStatus::Downloading);
+
+        // Snapshot with active item: 1 active, 1 pending
+        let snapshot = queue.snapshot(Some(current_dto));
+        assert_eq!(snapshot.active_count, 1);
+        assert_eq!(snapshot.pending_count, 1);
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -1040,4 +1040,13 @@ mod tests {
         let snapshot = queue.snapshot(None);
         assert_eq!(snapshot.recent_failures.len(), 0);
     }
+
+    /// Test that dequeue on an empty queue returns None gracefully.
+    #[test]
+    fn test_dequeue_from_empty_queue_returns_none() {
+        let mut queue = DownloadQueue::new(3);
+
+        // Dequeue immediately — should return None, not panic or deadlock
+        assert!(queue.dequeue().is_none());
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -1049,4 +1049,45 @@ mod tests {
         // Dequeue immediately — should return None, not panic or deadlock
         assert!(queue.dequeue().is_none());
     }
+
+    /// Test that concurrent snapshot() reads complete without deadlock.
+    /// Because DownloadQueue is wrapped in a tokio::sync::RwLock, multiple
+    /// readers can hold shared references simultaneously — all snapshots
+    /// should complete quickly and return consistent queued-item counts.
+    #[tokio::test]
+    async fn test_concurrent_snapshot_reads() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let mut queue = DownloadQueue::new(10);
+
+        // Enqueue 2 items so the queue is non-empty
+        let id_a = test_id("concurrent-a", None);
+        let id_b = test_id("concurrent-b", None);
+        queue
+            .queue(id_a.clone(), test_completion_key(&id_a), false)
+            .unwrap();
+        queue
+            .queue(id_b.clone(), test_completion_key(&id_b), false)
+            .unwrap();
+
+        let queue = Arc::new(RwLock::new(queue));
+
+        // Launch 3 concurrent tasks, each reading a snapshot
+        let (s1, s2, s3) = tokio::join!(
+            async { queue.read().await.snapshot(None) },
+            async { queue.read().await.snapshot(None) },
+            async { queue.read().await.snapshot(None) },
+        );
+
+        // All three snapshots should succeed and agree on queued items count
+        assert_eq!(s1.items.len(), 2);
+        assert_eq!(s2.items.len(), 2);
+        assert_eq!(s3.items.len(), 2);
+
+        // Each snapshot should have the same pending count
+        assert_eq!(s1.pending_count, 2);
+        assert_eq!(s2.pending_count, 2);
+        assert_eq!(s3.pending_count, 2);
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -1143,4 +1143,121 @@ mod tests {
         assert_eq!(final_snapshot.items.len(), 2);
         assert_eq!(final_snapshot.pending_count, 2);
     }
+
+    /// Test that concurrent enqueue writes are serialized safely by RwLock.
+    /// Multiple tasks enqueue simultaneously; none should be lost.
+    #[tokio::test]
+    async fn test_concurrent_enqueue_writes() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let queue = Arc::new(RwLock::new(DownloadQueue::new(10)));
+
+        // Spawn 8 concurrent tasks, each enqueuing a unique item
+        let h0 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-0", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h1 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-1", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h2 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-2", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h3 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-3", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h4 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-4", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h5 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-5", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h6 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-6", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+        let h7 = {
+            let q = Arc::clone(&queue);
+            tokio::spawn(async move {
+                let id = test_id("concurrent-7", None);
+                let key = test_completion_key(&id);
+                let mut guard = q.write().await;
+                guard.queue(id.clone(), key, true).unwrap();
+                id
+            })
+        };
+
+        // Wait for all tasks to complete using tokio::join!
+        let (r0, r1, r2, r3, r4, r5, r6, r7) = tokio::join!(h0, h1, h2, h3, h4, h5, h6, h7);
+        // All tasks should have completed successfully
+        r0.unwrap();
+        r1.unwrap();
+        r2.unwrap();
+        r3.unwrap();
+        r4.unwrap();
+        r5.unwrap();
+        r6.unwrap();
+        r7.unwrap();
+
+        // Dequeue all items and verify none were lost
+        let mut dequeued = Vec::new();
+        loop {
+            let item = queue.write().await.dequeue();
+            match item {
+                Some(q_item) => dequeued.push(q_item.id),
+                None => break,
+            }
+        }
+
+        // Exactly 8 items should have been dequeued
+        assert_eq!(dequeued.len(), 8);
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -858,4 +858,38 @@ mod tests {
         let result = queue.queue(id_c.clone(), test_completion_key(&id_c), false);
         assert!(matches!(result, Err(DownloadError::QueueFull { .. })));
     }
+
+    /// Test that enqueue → dequeue follows strict FIFO ordering with capacity 3.
+    #[test]
+    fn test_enqueue_dequeue_fifo_ordering() {
+        let mut queue = DownloadQueue::new(3);
+
+        // Enqueue 3 items with distinct IDs
+        let id_a = test_id("model-a", None);
+        let id_b = test_id("model-b", None);
+        let id_c = test_id("model-c", None);
+
+        queue
+            .queue(id_a.clone(), test_completion_key(&id_a), false)
+            .unwrap();
+        queue
+            .queue(id_b.clone(), test_completion_key(&id_b), false)
+            .unwrap();
+        queue
+            .queue(id_c.clone(), test_completion_key(&id_c), false)
+            .unwrap();
+
+        // Dequeue in FIFO order
+        let first = queue.dequeue().unwrap();
+        assert_eq!(first.id.model_id(), "model-a");
+
+        let second = queue.dequeue().unwrap();
+        assert_eq!(second.id.model_id(), "model-b");
+
+        let third = queue.dequeue().unwrap();
+        assert_eq!(third.id.model_id(), "model-c");
+
+        // Queue is now empty - dequeue returns None
+        assert!(queue.dequeue().is_none());
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -936,7 +936,7 @@ mod tests {
         assert_eq!(snapshot.items[1].id, "c");
     }
 
-    /// Test that snapshot() produces correct DTOs with active/pending counts.
+    /// Test that `snapshot()` produces correct DTOs with active/pending counts.
     #[test]
     fn test_snapshot_produces_correct_dtos() {
         let mut queue = DownloadQueue::new(5);
@@ -973,7 +973,7 @@ mod tests {
         assert_eq!(snapshot.pending_count, 1);
     }
 
-    /// Test that mark_failed() moves an item to the failed list correctly.
+    /// Test that `mark_failed()` moves an item to the failed list correctly.
     #[test]
     fn test_remove_item_moves_to_failed() {
         let mut queue = DownloadQueue::new(3);
@@ -1008,7 +1008,7 @@ mod tests {
         assert_eq!(snapshot.recent_failures[0].error, error_msg);
     }
 
-    /// Test that clear_failed() drains the failed list.
+    /// Test that `clear_failed()` drains the failed list.
     #[test]
     fn test_clear_failed_drains_list() {
         let mut queue = DownloadQueue::new(5);
@@ -1054,8 +1054,8 @@ mod tests {
         assert!(queue.dequeue().is_none());
     }
 
-    /// Test that concurrent snapshot() reads complete without deadlock.
-    /// Because DownloadQueue is wrapped in a tokio::sync::RwLock, multiple
+    /// Test that concurrent `snapshot()` reads complete without deadlock.
+    /// Because `DownloadQueue` is wrapped in a `tokio::sync::RwLock`, multiple
     /// readers can hold shared references simultaneously — all snapshots
     /// should complete quickly and return consistent queued-item counts.
     #[tokio::test]
@@ -1148,8 +1148,9 @@ mod tests {
         assert_eq!(final_snapshot.pending_count, 2);
     }
 
-    /// Test that concurrent enqueue writes are serialized safely by RwLock.
+    /// Test that concurrent enqueue writes are serialized safely by `RwLock`.
     /// Multiple tasks enqueue simultaneously; none should be lost.
+    #[allow(clippy::too_many_lines)]
     #[tokio::test]
     async fn test_concurrent_enqueue_writes() {
         use std::sync::Arc;

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -1017,8 +1017,12 @@ mod tests {
         let id_a = test_id("a", None);
         let id_b = test_id("b", None);
 
-        queue.queue(id_a.clone(), test_completion_key(&id_a), false).unwrap();
-        queue.queue(id_b.clone(), test_completion_key(&id_b), false).unwrap();
+        queue
+            .queue(id_a.clone(), test_completion_key(&id_a), false)
+            .unwrap();
+        queue
+            .queue(id_b.clone(), test_completion_key(&id_b), false)
+            .unwrap();
 
         // Dequeue both, then mark each as failed with different errors
         let item_a = queue.dequeue().unwrap();

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -1090,4 +1090,57 @@ mod tests {
         assert_eq!(s2.pending_count, 2);
         assert_eq!(s3.pending_count, 2);
     }
+
+    /// Test that enqueue can proceed while a snapshot reader is active.
+    /// The writer (enqueue) waits for the reader to release the lock, then proceeds.
+    #[tokio::test]
+    async fn test_enqueue_while_snapshot_reading() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let mut queue = DownloadQueue::new(10);
+
+        // Enqueue 1 initial item
+        let id_a = test_id("reader-item", None);
+        queue
+            .queue(id_a.clone(), test_completion_key(&id_a), false)
+            .unwrap();
+
+        let queue = Arc::new(RwLock::new(queue));
+
+        // Spawn a "reader" task that holds the read lock for 50ms
+        let reader_queue = Arc::clone(&queue);
+        let reader = tokio::spawn(async move {
+            let guard = reader_queue.read().await;
+            let snapshot = guard.snapshot(None);
+            drop(guard); // Release read lock before sleeping
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            snapshot
+        });
+
+        // Spawn an "enqueuer" task that adds a new item while reader is active
+        let enqueuer_queue = Arc::clone(&queue);
+        let id_b = test_id("writer-item", None);
+        let enqueuer = tokio::spawn(async move {
+            let mut guard = enqueuer_queue.write().await;
+            let key = test_completion_key(&id_b);
+            guard.queue(id_b.clone(), key, false).unwrap();
+            id_b
+        });
+
+        // Wait for both tasks to complete
+        let reader_snapshot = reader.await.unwrap();
+        let enqueued_id = enqueuer.await.unwrap();
+
+        // Reader saw 1 item (before enqueue)
+        assert_eq!(reader_snapshot.items.len(), 1);
+
+        // Enqueuer completed successfully
+        assert_eq!(enqueued_id.model_id(), "writer-item");
+
+        // Final snapshot should show 2 items
+        let final_snapshot = queue.read().await.snapshot(None);
+        assert_eq!(final_snapshot.items.len(), 2);
+        assert_eq!(final_snapshot.pending_count, 2);
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -1007,4 +1007,37 @@ mod tests {
         assert_eq!(snapshot.recent_failures[0].id, "model-a");
         assert_eq!(snapshot.recent_failures[0].error, error_msg);
     }
+
+    /// Test that clear_failed() drains the failed list.
+    #[test]
+    fn test_clear_failed_drains_list() {
+        let mut queue = DownloadQueue::new(5);
+
+        // Enqueue 2 items: "a" and "b"
+        let id_a = test_id("a", None);
+        let id_b = test_id("b", None);
+
+        queue.queue(id_a.clone(), test_completion_key(&id_a), false).unwrap();
+        queue.queue(id_b.clone(), test_completion_key(&id_b), false).unwrap();
+
+        // Dequeue both, then mark each as failed with different errors
+        let item_a = queue.dequeue().unwrap();
+        let item_b = queue.dequeue().unwrap();
+
+        queue.mark_failed(item_a, "error for a");
+        queue.mark_failed(item_b, "error for b");
+
+        // Verify 2 failed items
+        assert_eq!(queue.failed_len(), 2);
+        let snapshot = queue.snapshot(None);
+        assert_eq!(snapshot.recent_failures.len(), 2);
+
+        // Clear the failed list
+        queue.clear_failed();
+
+        // Verify list is drained
+        assert_eq!(queue.failed_len(), 0);
+        let snapshot = queue.snapshot(None);
+        assert_eq!(snapshot.recent_failures.len(), 0);
+    }
 }

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -972,4 +972,39 @@ mod tests {
         assert_eq!(snapshot.active_count, 1);
         assert_eq!(snapshot.pending_count, 1);
     }
+
+    /// Test that mark_failed() moves an item to the failed list correctly.
+    #[test]
+    fn test_remove_item_moves_to_failed() {
+        let mut queue = DownloadQueue::new(3);
+
+        // Enqueue 2 items: "model-a" and "model-b"
+        let id_a = test_id("model-a", None);
+        let id_b = test_id("model-b", None);
+
+        queue
+            .queue(id_a.clone(), test_completion_key(&id_a), false)
+            .unwrap();
+        queue
+            .queue(id_b.clone(), test_completion_key(&id_b), false)
+            .unwrap();
+
+        // Dequeue "model-a" then mark it as failed
+        let item = queue.dequeue().unwrap();
+        assert_eq!(item.id.model_id(), "model-a");
+
+        let error_msg = "connection timeout";
+        queue.mark_failed(item, error_msg);
+
+        // Snapshot: only "model-b" remains in pending, failed item in recent_failures
+        let snapshot = queue.snapshot(None);
+        assert_eq!(snapshot.items.len(), 1);
+        assert_eq!(snapshot.items[0].id, "model-b");
+        assert_eq!(snapshot.pending_count, 1);
+
+        // Verify the failed item appears in recent_failures
+        assert_eq!(snapshot.recent_failures.len(), 1);
+        assert_eq!(snapshot.recent_failures[0].id, "model-a");
+        assert_eq!(snapshot.recent_failures[0].error, error_msg);
+    }
 }

--- a/crates/gglib-download/src/queue/types.rs
+++ b/crates/gglib-download/src/queue/types.rs
@@ -175,4 +175,58 @@ mod tests {
 
         assert_eq!(failed.error, "Network timeout");
     }
+
+    #[test]
+    fn test_failed_item_from_queued_item() {
+        let id = DownloadId::new("author/model-name", Some("Q8_0"));
+        let key = test_completion_key(&id);
+        let item = QueuedItem::new(id.clone(), key);
+        let error_msg = "Connection refused";
+        let failed = FailedItem::new(item, error_msg);
+
+        // Error message is captured
+        assert_eq!(failed.error, error_msg);
+
+        // Original queued item is preserved
+        assert_eq!(failed.item.id, id);
+
+        // DTO conversion propagates model info and error
+        let dto = failed.to_dto();
+        assert_eq!(dto.id, "author/model-name:Q8_0");
+        assert_eq!(dto.error, error_msg);
+        assert_eq!(dto.failed_at, 0);
+    }
+
+    #[test]
+    fn test_queued_item_to_dto_with_all_statuses() {
+        let id = DownloadId::new("model/test", Some("Q4_K_M"));
+        let key = test_completion_key(&id);
+        let item = QueuedItem::new(id.clone(), key);
+
+        let statuses = vec![
+            DownloadStatus::Queued,
+            DownloadStatus::Downloading,
+            DownloadStatus::Finalizing,
+            DownloadStatus::Registering,
+            DownloadStatus::Completed,
+            DownloadStatus::Failed,
+            DownloadStatus::Cancelled,
+        ];
+
+        for status in statuses {
+            let dto = item.to_dto(1, status);
+
+            // Status should match what was passed
+            assert_eq!(dto.status, status, "Status mismatch for {:?}", status);
+
+            // Position should be preserved
+            assert_eq!(dto.position, 1);
+
+            // ID fields should be populated
+            assert_eq!(dto.id, "model/test:Q4_K_M");
+
+            // Model ID should match
+            assert_eq!(dto.model_id.as_str(), "model/test");
+        }
+    }
 }

--- a/crates/gglib-download/src/queue/types.rs
+++ b/crates/gglib-download/src/queue/types.rs
@@ -201,7 +201,7 @@ mod tests {
     fn test_queued_item_to_dto_with_all_statuses() {
         let id = DownloadId::new("model/test", Some("Q4_K_M"));
         let key = test_completion_key(&id);
-        let item = QueuedItem::new(id.clone(), key);
+        let item = QueuedItem::new(id, key);
 
         let statuses = vec![
             DownloadStatus::Queued,
@@ -217,7 +217,7 @@ mod tests {
             let dto = item.to_dto(1, status);
 
             // Status should match what was passed
-            assert_eq!(dto.status, status, "Status mismatch for {:?}", status);
+            assert_eq!(dto.status, status, "Status mismatch for {status:?}");
 
             // Position should be preserved
             assert_eq!(dto.position, 1);


### PR DESCRIPTION
## Summary

Improved test coverage across the download queue system — both DTOs (`gglib-core`) and queue manager (`gglib-download`). Added **19 new tests** covering edge cases, state transitions, queue dynamics, and concurrency.

## Tests Added

### `gglib-core` — Queue DTOs (8 tests)
- Status classification for all 7 `DownloadStatus` variants
- `update_progress` edge cases: downloaded exceeds total, zero total bytes, zero speed, complete download, large u64 values
- `FailedDownload` builders and `QueueSnapshot::Default`
- Formatting boundaries: speed display, duration formatting

### `gglib-download` — Queue Manager (11 tests)
- **Queue dynamics**: FIFO ordering, position tracking, snapshot DTOs, mark_failed → recent_failures, clear_failed drain, empty queue dequeue
- **State transitions**: `QueuedItem::to_dto()` with all statuses, `FailedItem` creation from queued item
- **Concurrency** (3 tests):
  - Concurrent snapshot reads complete without deadlock (RwLock shared readers)
  - Enqueue proceeds after snapshot read lock releases (reader-writer ordering)
  - Concurrent enqueue writes capture all items safely (no lost enqueues)

## Branch
`improve-queue-test-coverage`