### PR TITLE
fix(proxy): robust long-conversation streaming — visible failures + upstream health recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ gglib serve <id> --mtp-draft-n-max 0
 gglib serve <id> --mtp-draft-n-max 4 --mtp-draft-p-min 0.8
 ```
 
+Disable MTP globally on **every** launch path (including proxy auto-start,
+where no per-model flag is reachable) with an environment variable — useful
+for A/B testing speculative decoding as a suspect for long-context issues:
+```bash
+# Truthy values: 1, true, yes, on (case-insensitive)
+GGLIB_DISABLE_MTP=1 gglib proxy
+```
+
 These tags are **auto-detected at import time** by `gglib-gguf::capabilities::detect_all` and persisted by `ModelService::import_from_file`. They are protected as system tags: `gglib model remove-tag` will reject any attempt to remove a `format:*` tag (use the `_force` service path for admin operations).
 
 #### Inference parameter defaults

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -124,7 +124,9 @@ This crate provides an OpenAI-compatible HTTP server that:
 | [`server.rs`](src/server.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-server-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-server-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-server-coverage.json) |
 | [`slots_poller.rs`](src/slots_poller.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-slots_poller-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-slots_poller-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-slots_poller-coverage.json) |
 | [`slots.rs`](src/slots.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-slots-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-slots-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-slots-coverage.json) |
+| [`token_calibration.rs`](src/token_calibration.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-token_calibration-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-token_calibration-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-token_calibration-coverage.json) |
 | [`truncation.rs`](src/truncation.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-truncation-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-truncation-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-truncation-coverage.json) |
+| [`upstream_health.rs`](src/upstream_health.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-upstream_health-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-upstream_health-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-upstream_health-coverage.json) |
 | [`mcp/`](src/mcp/) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-mcp-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-mcp-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-mcp-coverage.json) |
 <!-- module-table:end -->
 
@@ -135,6 +137,8 @@ This crate provides an OpenAI-compatible HTTP server that:
 - **`models.rs`** — `/v1/models` endpoint, OpenAI-compatible error response factories
 - **`forward.rs`** — HTTP forwarding to llama-server with three-step request transform pipeline
 - **`truncation.rs`** — Stateless history truncation pass (Step 3 of the request pipeline)
+- **`token_calibration.rs`** — Per-model chars-per-token estimator (EWMA over real `usage.prompt_tokens`) that sizes the truncation budget
+- **`upstream_health.rs`** — Consecutive-failure watchdog that recycles a degraded (empty-response / first-byte-timeout) llama-server; feeds `DashboardSnapshot.upstream_health`
 - **`metrics.rs`** — `ContextMetricsStore` ring buffer feeding `DashboardSnapshot.recent_requests`
 - **`connections.rs`** — `ActiveConnectionsRegistry` + RAII `ConnectionGuard`; tracks every in-flight `/v1/chat/completions` request (direct and council/virtual-model) through `Queued` → `ProcessingPrompt` → `Generating`, feeding `DashboardSnapshot.active_connections`
 - **`slots.rs`** — Fetch + defensive parsing of llama.cpp's native `GET /slots` endpoint into `SlotSnapshot`
@@ -322,22 +326,32 @@ truncation pass **before** forwarding to llama-server:
 
 | Constant | Value | Meaning |
 |----------|-------|---------|
-| `TOOL_CONTENT_THRESHOLD_CHARS` | **2,000** chars | Per-message content length that triggers replacement |
-| `TOTAL_PAYLOAD_LIMIT_CHARS` | **240,000** chars | Total request body budget (≈ 60,000 tokens) |
-| `PROTECTED_TAIL_COUNT` | **4** messages | Most-recent messages always preserved |
+| `TOOL_CONTENT_THRESHOLD_CHARS` | **2,000** chars | Minimum per-message content length eligible for replacement |
+| `TOTAL_PAYLOAD_LIMIT_CHARS` | **240,000** chars | Floor for the request body budget (≈ 60,000 tokens) |
+| `PROTECTED_TAIL_COUNT` | **8** messages | Most-recent messages always preserved |
+
+The budget itself is dynamic: `effective_ctx × chars_per_token`, floored at
+`TOTAL_PAYLOAD_LIMIT_CHARS`. The `chars_per_token` factor is a per-model value
+calibrated from real `usage.prompt_tokens` counts (see
+[`token_calibration.rs`](src/token_calibration.rs)), falling back to the static
+default of 4 until a model has been observed.
 
 **Algorithm:**
 
-1. Any unprotected `role: "tool"` or `role: "assistant"` message whose
-   `content` string exceeds 2,000 characters has its content replaced with:
+1. **Budget gate** — while the whole payload fits within budget it is
+   forwarded **unchanged**; no history is elided while there is room.
+2. **Oldest-first trim** — only when over budget, unprotected `role: "tool"` /
+   `role: "assistant"` messages whose `content` string exceeds 2,000
+   characters are replaced **from oldest to newest**, stopping as soon as the
+   payload drops back under budget, with:
 
    > `[Raw tool output truncated by proxy to maintain context window. Rely on your previous observations.]`
 
-2. `role: "system"` messages and the last 4 messages are never modified.
-3. Array-form content (multi-part messages) and `tool_calls` fields are
+3. `role: "system"` messages and the last 8 messages are never modified.
+4. Array-form content (multi-part messages) and `tool_calls` fields are
    never touched.
-4. If the total payload still exceeds 240,000 characters after step 1, the
-   request is **rejected** with HTTP 400:
+5. If the payload still exceeds the budget after every eligible message is
+   trimmed, the request is **rejected** with HTTP 400:
    ```json
    {
      "error": {

--- a/crates/gglib-proxy/src/connections.rs
+++ b/crates/gglib-proxy/src/connections.rs
@@ -235,6 +235,26 @@ impl ActiveConnectionsRegistry {
         self.len() == 0
     }
 
+    /// `true` if any connection *other than* `exclude` is actively occupying
+    /// the upstream — i.e. past the `Queued` phase (prompt processing or
+    /// generating).
+    ///
+    /// Used to distinguish a slow-because-busy upstream (another request holds
+    /// the single llama-server slot) from a genuinely wedged one, so the
+    /// streaming keepalive path does not treat a legitimate queue wait as a
+    /// degradation strike.
+    #[must_use]
+    pub fn others_busy(&self, exclude: Uuid) -> bool {
+        let guard = self.connections.lock().unwrap_or_else(|e| e.into_inner());
+        guard.iter().any(|(id, conn)| {
+            *id != exclude
+                && matches!(
+                    conn.phase,
+                    ConnectionPhase::ProcessingPrompt | ConnectionPhase::Generating
+                )
+        })
+    }
+
     /// Remove `id` from the registry. Only called from [`ConnectionGuard`]'s
     /// `Drop` impl.
     fn remove(&self, id: Uuid) {
@@ -274,6 +294,17 @@ impl ConnectionGuard {
     /// Mark this connection as generating (post-prefill).
     pub fn mark_generating(&self) {
         self.registry.mark_generating(self.id);
+    }
+
+    /// `true` if any *other* in-flight connection is actively occupying the
+    /// upstream slot (prompt processing or generating).
+    ///
+    /// A `true` result means "the upstream is busy serving someone else",
+    /// which the streaming keepalive path treats as a legitimate queue wait
+    /// rather than a degradation.
+    #[must_use]
+    pub fn others_active(&self) -> bool {
+        self.registry.others_busy(self.id)
     }
 }
 
@@ -342,6 +373,31 @@ mod tests {
 
         let snapshots = registry.snapshot();
         assert_eq!(snapshots[0].phase, ConnectionPhase::Generating);
+    }
+
+    #[test]
+    fn others_active_ignores_self_and_queued_peers() {
+        let registry = Arc::new(ActiveConnectionsRegistry::new());
+        let a = registry.register("m", true, None);
+        let b = registry.register("m", true, None);
+
+        // Both are in Queued phase → neither counts as busy for the other.
+        assert!(!a.others_active());
+        assert!(!b.others_active());
+
+        // b starts processing its prompt → now a sees a busy peer, but b
+        // (looking at itself + queued a) does not.
+        b.update_progress(10, 100, 0, 5);
+        assert!(a.others_active());
+        assert!(!b.others_active());
+
+        // A generating peer also counts as busy.
+        b.mark_generating();
+        assert!(a.others_active());
+
+        // Once b drops, a is alone again.
+        drop(b);
+        assert!(!a.others_active());
     }
 
     #[test]

--- a/crates/gglib-proxy/src/dashboard.rs
+++ b/crates/gglib-proxy/src/dashboard.rs
@@ -40,6 +40,7 @@ use crate::connections::{ActiveConnectionSnapshot, ActiveConnectionsRegistry};
 use crate::metrics::{ContextMetricsStore, ContextSnapshot};
 use crate::slots::{SlotSnapshot, SlotsPollResult};
 use crate::slots_poller::SlotsCache;
+use crate::upstream_health::{UpstreamHealth, UpstreamHealthSnapshot};
 
 /// Number of recent request snapshots included in each [`DashboardSnapshot`].
 const RECENT_REQUEST_LIMIT: usize = 20;
@@ -83,6 +84,9 @@ pub struct DashboardSnapshot {
     /// Total requests handled since the proxy started, including any
     /// evicted from `recent_requests`'s ring buffer.
     pub total_requests: u64,
+    /// Upstream-degradation watchdog counters (empty responses, first-byte
+    /// timeouts, proactive recycles) since the proxy started.
+    pub upstream_health: UpstreamHealthSnapshot,
 }
 
 impl DashboardSnapshot {
@@ -94,6 +98,7 @@ impl DashboardSnapshot {
         connections: &ActiveConnectionsRegistry,
         slots: &SlotsCache,
         metrics: &ContextMetricsStore,
+        upstream_health: &UpstreamHealth,
     ) -> Self {
         let (slots_available, slots_vec, slots_status) = match slots.get() {
             SlotsPollResult::Available(snapshots) => (true, snapshots, None),
@@ -112,6 +117,7 @@ impl DashboardSnapshot {
             slots_status,
             recent_requests: metrics.recent(RECENT_REQUEST_LIMIT),
             total_requests: metrics.total_requests(),
+            upstream_health: upstream_health.snapshot(),
         }
     }
 }
@@ -130,6 +136,7 @@ pub struct DashboardState {
     pub connections: Arc<ActiveConnectionsRegistry>,
     pub slots: Arc<SlotsCache>,
     pub metrics: Arc<ContextMetricsStore>,
+    pub upstream_health: Arc<UpstreamHealth>,
     pub broadcaster: Arc<Broadcaster<DashboardSnapshot>>,
 }
 
@@ -141,11 +148,13 @@ impl DashboardState {
         connections: Arc<ActiveConnectionsRegistry>,
         slots: Arc<SlotsCache>,
         metrics: Arc<ContextMetricsStore>,
+        upstream_health: Arc<UpstreamHealth>,
     ) -> Self {
         Self {
             connections,
             slots,
             metrics,
+            upstream_health,
             broadcaster: Arc::new(Broadcaster::new(BROADCAST_CAPACITY)),
         }
     }
@@ -154,7 +163,12 @@ impl DashboardState {
     /// stores.
     #[must_use]
     pub fn snapshot(&self) -> DashboardSnapshot {
-        DashboardSnapshot::build(&self.connections, &self.slots, &self.metrics)
+        DashboardSnapshot::build(
+            &self.connections,
+            &self.slots,
+            &self.metrics,
+            &self.upstream_health,
+        )
     }
 }
 
@@ -202,6 +216,7 @@ mod tests {
             Arc::new(ActiveConnectionsRegistry::new()),
             Arc::new(SlotsCache::new()),
             Arc::new(ContextMetricsStore::new()),
+            Arc::new(UpstreamHealth::new()),
         ))
     }
 
@@ -210,8 +225,9 @@ mod tests {
         let connections = ActiveConnectionsRegistry::new();
         let slots = SlotsCache::new();
         let metrics = ContextMetricsStore::new();
+        let upstream_health = UpstreamHealth::new();
 
-        let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics);
+        let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics, &upstream_health);
 
         assert!(snapshot.active_connections.is_empty());
         assert!(!snapshot.slots_available);
@@ -236,7 +252,8 @@ mod tests {
             recorded_at_secs: 0,
         });
 
-        let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics);
+        let upstream_health = UpstreamHealth::new();
+        let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics, &upstream_health);
 
         assert_eq!(snapshot.active_connections.len(), 1);
         assert_eq!(snapshot.active_connections[0].model_name, "qwen-3b");
@@ -250,8 +267,9 @@ mod tests {
         let slots = SlotsCache::new();
         slots.set(SlotsPollResult::Available(vec![]));
         let metrics = ContextMetricsStore::new();
+        let upstream_health = UpstreamHealth::new();
 
-        let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics);
+        let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics, &upstream_health);
 
         assert!(snapshot.slots_available);
         assert!(snapshot.slots_status.is_none());
@@ -273,7 +291,8 @@ mod tests {
             let slots = SlotsCache::new();
             slots.set(result);
             let metrics = ContextMetricsStore::new();
-            let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics);
+            let upstream_health = UpstreamHealth::new();
+            let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics, &upstream_health);
 
             serde_json::to_string(&snapshot).expect("DashboardSnapshot must always serialize");
         }

--- a/crates/gglib-proxy/src/dashboard.rs
+++ b/crates/gglib-proxy/src/dashboard.rs
@@ -292,7 +292,8 @@ mod tests {
             slots.set(result);
             let metrics = ContextMetricsStore::new();
             let upstream_health = UpstreamHealth::new();
-            let snapshot = DashboardSnapshot::build(&connections, &slots, &metrics, &upstream_health);
+            let snapshot =
+                DashboardSnapshot::build(&connections, &slots, &metrics, &upstream_health);
 
             serde_json::to_string(&snapshot).expect("DashboardSnapshot must always serialize");
         }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -79,6 +79,7 @@ use crate::connections::ConnectionGuard;
 use crate::metrics::{ContextMetricsStore, ContextSnapshot};
 use crate::models::ErrorResponse;
 use crate::truncation::truncate_history;
+use crate::upstream_health::UpstreamHealth;
 
 /// Signals that the upstream llama-server was unreachable (connection refused
 /// or timed out).  Returned by [`forward_chat_completion`] so the caller can
@@ -426,6 +427,10 @@ fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> By
 ///   exactly as long as that task); held for the duration of this function
 ///   for the non-streaming path. Dropping it (by any path — completion,
 ///   early return, or panic) unregisters the connection from the dashboard.
+/// * `upstream_health` - Consecutive-failure watchdog. The streaming task
+///   records each terminal outcome (empty stream or first-byte timeout is a
+///   strike; any visible output resets it) so the handler can recycle a
+///   degraded-but-`/health`-green upstream before the next request.
 ///
 /// # Returns
 ///
@@ -444,6 +449,7 @@ pub(crate) async fn forward_chat_completion(
     metrics: Arc<ContextMetricsStore>,
     global_inference_defaults: Option<InferenceConfig>,
     connection: ConnectionGuard,
+    upstream_health: Arc<UpstreamHealth>,
 ) -> Result<Response, ForwardError> {
     debug!("Forwarding to {upstream_url}, streaming={is_streaming}");
 
@@ -638,6 +644,7 @@ pub(crate) async fn forward_chat_completion(
                             deadline_secs = FIRST_BYTE_DEADLINE_SECS,
                             "slot-queue wait exceeded first-byte deadline; treating upstream as degraded"
                         );
+                        upstream_health.record_timeout();
                         let visible = visible_content_frame(
                             &model_name_owned,
                             &format!(
@@ -672,7 +679,12 @@ pub(crate) async fn forward_chat_completion(
                         status = resp.status().as_u16(),
                         "upstream accepted streaming request after slot-queue wait"
                     );
-                    stream_response_to_channel(resp, model_name_owned, tags, tx, &connection).await;
+                    let outcome =
+                        stream_response_to_channel(resp, model_name_owned, tags, tx, &connection)
+                            .await;
+                    // Feed the terminal outcome to the watchdog: an empty
+                    // response is a strike, visible output resets the streak.
+                    upstream_health.record_stream_outcome(outcome.saw_output);
                 }
                 Ok(resp) => {
                     let status = resp.status();

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -15,13 +15,15 @@
 //!    Jinja template.  Mistral-family models raise a hard 500 exception
 //!    without this.
 //! 3. [`truncate_history`] — defends against client-side context compaction
-//!    failures.  Any unprotected `role: "tool"` or `role: "assistant"` message
-//!    whose string `content` exceeds **2,000 characters** is replaced with a
-//!    short placeholder.  If the total payload still exceeds **240,000
-//!    characters** (≈ 60,000 tokens) after this pass, the request is rejected
-//!    with HTTP 400 / `context_length_exceeded` rather than forwarding a
-//!    prompt that would cause the model to fail.  The last four messages and
-//!    all `role: "system"` messages are always preserved.
+//!    failures.  While the request fits within the model's live context
+//!    budget it is forwarded **unchanged**; only when the payload exceeds the
+//!    budget are the **oldest** unprotected `role: "tool"` / `role:
+//!    "assistant"` messages whose string `content` exceeds **2,000
+//!    characters** replaced with a short placeholder — just enough of them,
+//!    oldest-first, to drop back under budget.  If the payload still exceeds
+//!    the budget after every eligible message is trimmed, the request is
+//!    rejected with HTTP 400 / `context_length_exceeded`.  The last eight
+//!    messages and all `role: "system"` messages are always preserved.
 //!
 //! Capabilities are resolved with a **single** catalog lookup per request
 //! (via [`resolve_model_context`]) that yields both the `ModelCapabilities`

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -90,6 +90,21 @@ pub(crate) enum ForwardError {
     UpstreamDead,
 }
 
+/// Outcome of draining one upstream streaming response through the
+/// normalization pipeline, returned by [`stream_response_to_channel`].
+///
+/// Used by the caller to distinguish a healthy response from a degenerate one
+/// (no output at all) for upstream-health bookkeeping.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct StreamOutcome {
+    /// `true` if at least one visible frame (content, reasoning, tool call,
+    /// recovered normalization text, or an error frame) was emitted to the
+    /// client. `false` means the model produced a completely empty response.
+    pub saw_output: bool,
+    /// The `finish_reason` from the terminating `Done` event, if one arrived.
+    pub finish_reason: Option<String>,
+}
+
 /// Headers that should NOT be forwarded (hop-by-hop headers).
 const HOP_BY_HOP_HEADERS: &[&str] = &[
     "connection",
@@ -123,6 +138,19 @@ fn should_forward_header(name: &str) -> bool {
 /// always sees *something* and can tell the model attempted a tool call the
 /// proxy could not parse.
 const NORMALIZATION_NOTICE_PREFIX: &str = "\n\n⚠️ [proxy: unparsed tool-call output] ";
+
+/// Diagnostic text synthesized and sent to the client when an upstream
+/// streaming response completes without emitting a single visible frame.
+///
+/// Without this, a degenerate generation (the model producing zero tokens —
+/// e.g. a wedged or context-overflowed llama-server) reaches the client as a
+/// silent empty stream that the LLM Gateway reports as "the model returned an
+/// empty response" with no cause. Emitting a visible notice turns that silent
+/// failure into a diagnosable one.
+const EMPTY_STREAM_NOTICE: &str =
+    "⚠️ [proxy] The model produced no output for this request. The upstream \
+     server may be overloaded or degraded — retry, and if it persists restart \
+     the model.";
 
 /// Force-insert the streaming-only overrides every forwarded chat-completion
 /// request needs, regardless of what the client sent.
@@ -775,7 +803,7 @@ async fn stream_response_to_channel(
     tags: Vec<String>,
     tx: tokio::sync::mpsc::Sender<Result<Bytes, std::io::Error>>,
     connection: &ConnectionGuard,
-) {
+) -> StreamOutcome {
     let id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
     let created = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -815,6 +843,7 @@ async fn stream_response_to_channel(
     let normalized = NormalizingStream::new(Box::pin(event_stream), parser);
     let mut normalized = Box::pin(normalized);
 
+    let mut outcome = StreamOutcome::default();
     let mut client_connected = true;
     while let Some(event) = normalized.next().await {
         let frame: Option<Bytes> = match event {
@@ -833,10 +862,24 @@ async fn stream_response_to_channel(
                     // rather than dropping it silently (which manifested as an
                     // empty response when the whole turn was one bad tool call).
                     warn!(?kind, raw = %raw, "proxy: surfacing normalization issue as visible content");
+                    outcome.saw_output = true;
                     let recovered = LlmStreamEvent::TextDelta {
                         content: format!("{NORMALIZATION_NOTICE_PREFIX}{raw}"),
                     };
                     encoder.encode(&recovered).map(Bytes::from)
+                }
+                LlmStreamEvent::TextDelta { .. }
+                | LlmStreamEvent::ReasoningDelta { .. }
+                | LlmStreamEvent::ToolCallDelta { .. }
+                | LlmStreamEvent::UpstreamError { .. } => {
+                    connection.mark_generating();
+                    outcome.saw_output = true;
+                    encoder.encode(&ev).map(Bytes::from)
+                }
+                LlmStreamEvent::Done { finish_reason } => {
+                    connection.mark_generating();
+                    outcome.finish_reason = Some(finish_reason.clone());
+                    encoder.encode(&ev).map(Bytes::from)
                 }
                 _ => {
                     connection.mark_generating();
@@ -845,6 +888,7 @@ async fn stream_response_to_channel(
             },
             Err(e) => {
                 error!("proxy stream error: {e}");
+                outcome.saw_output = true;
                 let payload = serde_json::json!({
                     "error": {
                         "message": e.to_string(),
@@ -866,6 +910,22 @@ async fn stream_response_to_channel(
             break;
         }
     }
+
+    // Empty-stream detector: if the upstream completed without emitting a
+    // single visible frame, synthesize a diagnostic so the client never sees
+    // an unexplained empty response. Skipped when the client already
+    // disconnected (nothing to send) or when output was surfaced.
+    if client_connected && !outcome.saw_output {
+        let reason = outcome.finish_reason.as_deref().unwrap_or("none");
+        warn!(
+            finish_reason = %reason,
+            "proxy: upstream stream produced no visible output; emitting diagnostic"
+        );
+        let notice = format!("{EMPTY_STREAM_NOTICE} (finish_reason: {reason})");
+        if let Some(s) = encoder.encode(&LlmStreamEvent::TextDelta { content: notice }) {
+            let _ = tx.send(Ok(Bytes::from(s))).await;
+        }
+    }
     // Exactly one [DONE] sentinel, sent once the wire stream is truly
     // exhausted -- never bundled into an individual event's encoding, since
     // a trailing Usage event can legitimately follow Done (see
@@ -876,6 +936,8 @@ async fn stream_response_to_channel(
             .send(Ok(Bytes::from_static(DONE_SENTINEL.as_bytes())))
             .await;
     }
+
+    outcome
 }
 
 /// Forward a non-streaming JSON response from llama-server.

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -154,8 +154,7 @@ const NORMALIZATION_NOTICE_PREFIX: &str = "\n\n⚠️ [proxy: unparsed tool-call
 /// silent empty stream that the LLM Gateway reports as "the model returned an
 /// empty response" with no cause. Emitting a visible notice turns that silent
 /// failure into a diagnosable one.
-const EMPTY_STREAM_NOTICE: &str =
-    "⚠️ [proxy] The model produced no output for this request. The upstream \
+const EMPTY_STREAM_NOTICE: &str = "⚠️ [proxy] The model produced no output for this request. The upstream \
      server may be overloaded or degraded — retry, and if it persists restart \
      the model.";
 
@@ -645,9 +644,8 @@ pub(crate) async fn forward_chat_completion(
             // Overall first-byte deadline: bounds pathological slot-queue
             // waits so a wedged upstream cannot hang the client indefinitely
             // on keepalive comments.
-            let deadline = tokio::time::sleep(std::time::Duration::from_secs(
-                FIRST_BYTE_DEADLINE_SECS,
-            ));
+            let deadline =
+                tokio::time::sleep(std::time::Duration::from_secs(FIRST_BYTE_DEADLINE_SECS));
             tokio::pin!(deadline);
 
             let upstream_response = loop {

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -152,6 +152,17 @@ const EMPTY_STREAM_NOTICE: &str =
      server may be overloaded or degraded — retry, and if it persists restart \
      the model.";
 
+/// Maximum time (seconds) the proxy waits for llama-server to return response
+/// headers — i.e. assign a slot and begin the response — during the streaming
+/// keepalive wait, before treating the upstream as wedged.
+///
+/// Large-context prefills on constrained hardware are legitimately slow (a
+/// 60k-token prompt can take minutes), so this is generous. Its purpose is to
+/// bound *pathological* waits — a degraded or deadlocked llama-server that
+/// would otherwise keep the client hanging on keepalive comments indefinitely
+/// — not to cap normal prefill latency.
+const FIRST_BYTE_DEADLINE_SECS: u64 = 300;
+
 /// Force-insert the streaming-only overrides every forwarded chat-completion
 /// request needs, regardless of what the client sent.
 ///
@@ -610,10 +621,42 @@ pub(crate) async fn forward_chat_completion(
             let send_future = req_builder.body(body).send();
             tokio::pin!(send_future);
 
+            // Overall first-byte deadline: bounds pathological slot-queue
+            // waits so a wedged upstream cannot hang the client indefinitely
+            // on keepalive comments.
+            let deadline = tokio::time::sleep(std::time::Duration::from_secs(
+                FIRST_BYTE_DEADLINE_SECS,
+            ));
+            tokio::pin!(deadline);
+
             let upstream_response = loop {
                 tokio::select! {
                     biased;
                     result = &mut send_future => break result,
+                    () = &mut deadline => {
+                        warn!(
+                            deadline_secs = FIRST_BYTE_DEADLINE_SECS,
+                            "slot-queue wait exceeded first-byte deadline; treating upstream as degraded"
+                        );
+                        let visible = visible_content_frame(
+                            &model_name_owned,
+                            &format!(
+                                "⚠️ [proxy] upstream model server did not begin responding within {FIRST_BYTE_DEADLINE_SECS}s — it may be overloaded or wedged. Retry; if it persists the model will be recycled."
+                            ),
+                        );
+                        let payload = serde_json::json!({
+                            "error": {
+                                "message": format!(
+                                    "upstream did not respond within {FIRST_BYTE_DEADLINE_SECS}s"
+                                ),
+                                "type": "server_error",
+                                "code": "upstream_timeout",
+                            }
+                        });
+                        let frame = format!("{visible}data: {payload}\n\ndata: [DONE]\n\n");
+                        let _ = tx.send(Ok(Bytes::from(frame))).await;
+                        return;
+                    }
                     _ = keepalive_interval.tick() => {
                         debug!("slot-queue wait: sending SSE keepalive to client");
                         if tx.send(Ok(Bytes::from_static(b":\n\n"))).await.is_err() {

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -167,6 +167,12 @@ const EMPTY_STREAM_NOTICE: &str = "⚠️ [proxy] The model produced no output f
 /// bound *pathological* waits — a degraded or deadlocked llama-server that
 /// would otherwise keep the client hanging on keepalive comments indefinitely
 /// — not to cap normal prefill latency.
+///
+/// This is a *per-cycle* bound, not an absolute cap: with `--parallel 1` a
+/// second request legitimately queues behind an in-flight one, so when the
+/// deadline fires and another connection is still active the wait is extended
+/// for another cycle rather than failed (see the keepalive loop). Only an
+/// expiry with no other active request counts as degradation.
 const FIRST_BYTE_DEADLINE_SECS: u64 = 300;
 
 /// Force-insert the streaming-only overrides every forwarded chat-completion
@@ -653,9 +659,26 @@ pub(crate) async fn forward_chat_completion(
                     biased;
                     result = &mut send_future => break result,
                     () = &mut deadline => {
+                        // The single-slot upstream may legitimately be busy
+                        // serving another (possibly minutes-long) request, in
+                        // which case this request is correctly queued, not
+                        // wedged. Only treat a deadline expiry as degradation
+                        // when NO other connection is actively occupying the
+                        // slot; otherwise extend the deadline and keep waiting.
+                        if connection.others_active() {
+                            warn!(
+                                deadline_secs = FIRST_BYTE_DEADLINE_SECS,
+                                "slot-queue wait exceeded deadline but another request is active; extending (upstream busy, not wedged)"
+                            );
+                            deadline.as_mut().reset(
+                                tokio::time::Instant::now()
+                                    + std::time::Duration::from_secs(FIRST_BYTE_DEADLINE_SECS),
+                            );
+                            continue;
+                        }
                         warn!(
                             deadline_secs = FIRST_BYTE_DEADLINE_SECS,
-                            "slot-queue wait exceeded first-byte deadline; treating upstream as degraded"
+                            "slot-queue wait exceeded first-byte deadline with no other active request; treating upstream as degraded"
                         );
                         upstream_health.record_timeout();
                         let visible = visible_content_frame(

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -680,6 +680,15 @@ pub(crate) async fn forward_chat_completion(
                         }
                     };
                     let frame = format!("data: {payload}\n\ndata: [DONE]\n\n");
+                    let human = payload
+                        .pointer("/error/message")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("upstream returned an error");
+                    let visible = visible_content_frame(
+                        &model_name_owned,
+                        &format!("⚠️ [proxy] upstream model server error ({status}): {human}"),
+                    );
+                    let frame = format!("{visible}{frame}");
                     let _ = tx.send(Ok(Bytes::from(frame))).await;
                 }
                 Err(e) => {
@@ -692,6 +701,11 @@ pub(crate) async fn forward_chat_completion(
                         }
                     });
                     let frame = format!("data: {payload}\n\ndata: [DONE]\n\n");
+                    let visible = visible_content_frame(
+                        &model_name_owned,
+                        &format!("⚠️ [proxy] upstream llama-server unavailable: {e}"),
+                    );
+                    let frame = format!("{visible}{frame}");
                     let _ = tx.send(Ok(Bytes::from(frame))).await;
                 }
             }
@@ -784,6 +798,35 @@ fn host_port_from_url(url: &str) -> String {
             );
             "127.0.0.1:0".to_owned()
         })
+}
+
+/// Build a single SSE `chat.completion.chunk` frame carrying visible assistant
+/// `content`.
+///
+/// Used to surface proxy/upstream failures as text the human can actually read
+/// in the chat pane. Some clients (notably the VS Code LLM Gateway) do not
+/// render bare inline `{"error": {...}}` frames inside an already-committed
+/// 200 stream, so an error delivered only as a structured error frame looks
+/// like an empty response. Pairing every such error with a visible content
+/// frame guarantees the cause is shown.
+fn visible_content_frame(model: &str, content: &str) -> String {
+    let created = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
+    let value = serde_json::json!({
+        "id": id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": { "content": content },
+            "finish_reason": serde_json::Value::Null,
+        }],
+    });
+    format!("data: {value}\n\n")
 }
 
 /// Feed a streaming response through the normalization pipeline and send each

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -112,6 +112,18 @@ fn should_forward_header(name: &str) -> bool {
     !HOP_BY_HOP_HEADERS.contains(&lower.as_str())
 }
 
+/// Prefix prepended to malformed / unclosed tool-call markup when it is
+/// surfaced to the client as visible assistant text instead of being silently
+/// dropped.
+///
+/// The old behaviour logged a `warn!` and discarded the offending bytes, so a
+/// turn whose entire output was an unparseable `<tool_call>` reached the client
+/// as a zero-content stream — indistinguishable from "the model returned an
+/// empty response". Surfacing the raw body (visually flagged) means the human
+/// always sees *something* and can tell the model attempted a tool call the
+/// proxy could not parse.
+const NORMALIZATION_NOTICE_PREFIX: &str = "\n\n⚠️ [proxy: unparsed tool-call output] ";
+
 /// Force-insert the streaming-only overrides every forwarded chat-completion
 /// request needs, regardless of what the client sent.
 ///
@@ -801,52 +813,54 @@ async fn stream_response_to_channel(
 
     let parser = get_parser(&tags);
     let normalized = NormalizingStream::new(Box::pin(event_stream), parser);
+    let mut normalized = Box::pin(normalized);
 
-    let wire_stream = normalized.filter_map(move |event| {
-        let encoder = encoder.clone();
-        async move {
-            match event {
-                Ok(ev) => {
-                    match &ev {
-                        LlmStreamEvent::PromptProgress {
-                            processed,
-                            total,
-                            cached,
-                            time_ms,
-                        } => {
-                            connection.update_progress(*processed, *total, *cached, *time_ms);
-                        }
-                        LlmStreamEvent::NormalizationError { kind, raw } => {
-                            warn!(?kind, raw = %raw, "proxy: suppressing normalization issue from wire");
-                        }
-                        _ => connection.mark_generating(),
-                    }
-                    encoder
-                        .encode(&ev)
-                        .map(|s| Ok::<Bytes, std::io::Error>(Bytes::from(s)))
-                }
-                Err(e) => {
-                    error!("proxy stream error: {e}");
-                    let payload = serde_json::json!({
-                        "error": {
-                            "message": e.to_string(),
-                            "type": "server_error",
-                            "code": "upstream_error",
-                        }
-                    });
-                    // No inline [DONE] here -- appended once, unconditionally,
-                    // after the wire stream is exhausted (see below).
-                    let frame = format!("data: {payload}\n\n");
-                    Some(Ok::<Bytes, std::io::Error>(Bytes::from(frame)))
-                }
-            }
-        }
-    });
-
-    let mut wire_stream = Box::pin(wire_stream);
     let mut client_connected = true;
-    while let Some(item) = wire_stream.next().await {
-        if tx.send(item).await.is_err() {
+    while let Some(event) = normalized.next().await {
+        let frame: Option<Bytes> = match event {
+            Ok(ev) => match &ev {
+                LlmStreamEvent::PromptProgress {
+                    processed,
+                    total,
+                    cached,
+                    time_ms,
+                } => {
+                    connection.update_progress(*processed, *total, *cached, *time_ms);
+                    encoder.encode(&ev).map(Bytes::from)
+                }
+                LlmStreamEvent::NormalizationError { kind, raw } => {
+                    // Surface the discarded body as visible assistant text
+                    // rather than dropping it silently (which manifested as an
+                    // empty response when the whole turn was one bad tool call).
+                    warn!(?kind, raw = %raw, "proxy: surfacing normalization issue as visible content");
+                    let recovered = LlmStreamEvent::TextDelta {
+                        content: format!("{NORMALIZATION_NOTICE_PREFIX}{raw}"),
+                    };
+                    encoder.encode(&recovered).map(Bytes::from)
+                }
+                _ => {
+                    connection.mark_generating();
+                    encoder.encode(&ev).map(Bytes::from)
+                }
+            },
+            Err(e) => {
+                error!("proxy stream error: {e}");
+                let payload = serde_json::json!({
+                    "error": {
+                        "message": e.to_string(),
+                        "type": "server_error",
+                        "code": "upstream_error",
+                    }
+                });
+                // No inline [DONE] here -- appended once, unconditionally,
+                // after the wire stream is exhausted (see below).
+                Some(Bytes::from(format!("data: {payload}\n\n")))
+            }
+        };
+
+        if let Some(bytes) = frame
+            && tx.send(Ok(bytes)).await.is_err()
+        {
             // Client disconnected; stop draining the upstream.
             client_connected = false;
             break;

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -80,6 +80,7 @@ use gglib_core::sse::{DONE_SENTINEL, SseEncoder, SseStreamDecoder};
 use crate::connections::ConnectionGuard;
 use crate::metrics::{ContextMetricsStore, ContextSnapshot};
 use crate::models::ErrorResponse;
+use crate::token_calibration::TokenCalibration;
 use crate::truncation::truncate_history;
 use crate::upstream_health::UpstreamHealth;
 
@@ -106,6 +107,9 @@ pub(crate) struct StreamOutcome {
     pub saw_output: bool,
     /// The `finish_reason` from the terminating `Done` event, if one arrived.
     pub finish_reason: Option<String>,
+    /// `usage.prompt_tokens` reported by the upstream, if a Usage frame
+    /// arrived. Feeds the per-model chars-per-token calibration.
+    pub prompt_tokens: Option<u32>,
 }
 
 /// Headers that should NOT be forwarded (hop-by-hop headers).
@@ -452,6 +456,7 @@ pub(crate) async fn forward_chat_completion(
     global_inference_defaults: Option<InferenceConfig>,
     connection: ConnectionGuard,
     upstream_health: Arc<UpstreamHealth>,
+    calibration: Arc<TokenCalibration>,
 ) -> Result<Response, ForwardError> {
     debug!("Forwarding to {upstream_url}, streaming={is_streaming}");
 
@@ -475,8 +480,11 @@ pub(crate) async fn forward_chat_completion(
     //    The budget scales with the live serving context so clients that
     //    plan against the advertised context window are never rejected by a
     //    smaller hidden ceiling (truncate_history floors it at the default).
-    let limit_chars =
-        (effective_ctx as usize).saturating_mul(crate::truncation::CHARS_PER_TOKEN_APPROX);
+    //    The chars-per-token factor is the model's calibrated ratio (learned
+    //    from prior usage frames), falling back to the static default until
+    //    the first observation lands.
+    let chars_per_token = calibration.chars_per_token(model_name);
+    let limit_chars = (effective_ctx as f64 * chars_per_token) as usize;
     let body = match truncate_history(body, limit_chars) {
         Ok((b, report)) => {
             if report.messages_truncated > 0 {
@@ -586,6 +594,11 @@ pub(crate) async fn forward_chat_completion(
         // doc comment for why each is needed.
         let body = inject_streaming_body_overrides(body);
 
+        // Byte count of the payload actually forwarded upstream, paired with
+        // the usage frame's prompt-token count after streaming to calibrate
+        // this model's chars-per-token ratio.
+        let forwarded_chars = body.len();
+
         // Phase 1 — TCP probe (1 s timeout).
         let probe_addr = host_port_from_url(upstream_url);
         let probe_result = tokio::time::timeout(
@@ -681,12 +694,22 @@ pub(crate) async fn forward_chat_completion(
                         status = resp.status().as_u16(),
                         "upstream accepted streaming request after slot-queue wait"
                     );
-                    let outcome =
-                        stream_response_to_channel(resp, model_name_owned, tags, tx, &connection)
-                            .await;
+                    let outcome = stream_response_to_channel(
+                        resp,
+                        model_name_owned.clone(),
+                        tags,
+                        tx,
+                        &connection,
+                    )
+                    .await;
                     // Feed the terminal outcome to the watchdog: an empty
                     // response is a strike, visible output resets the streak.
                     upstream_health.record_stream_outcome(outcome.saw_output);
+                    // Calibrate this model's chars-per-token ratio from the
+                    // real prompt-token count the upstream reported.
+                    if let Some(prompt_tokens) = outcome.prompt_tokens {
+                        calibration.record(&model_name_owned, forwarded_chars, prompt_tokens);
+                    }
                 }
                 Ok(resp) => {
                     let status = resp.status();
@@ -981,8 +1004,11 @@ async fn stream_response_to_channel(
                     outcome.finish_reason = Some(finish_reason.clone());
                     encoder.encode(&ev).map(Bytes::from)
                 }
-                _ => {
-                    connection.mark_generating();
+                LlmStreamEvent::Usage { prompt_tokens, .. } => {
+                    // Trailing usage frame — capture the real prompt-token
+                    // count for chars-per-token calibration. Not counted as
+                    // visible output (it carries an empty `choices` array).
+                    outcome.prompt_tokens = Some(*prompt_tokens);
                     encoder.encode(&ev).map(Bytes::from)
                 }
             },

--- a/crates/gglib-proxy/src/lib.rs
+++ b/crates/gglib-proxy/src/lib.rs
@@ -12,6 +12,7 @@ pub mod server;
 pub mod slots;
 pub mod slots_poller;
 pub mod truncation;
+pub mod upstream_health;
 
 pub use council_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};
 pub use server::serve;

--- a/crates/gglib-proxy/src/lib.rs
+++ b/crates/gglib-proxy/src/lib.rs
@@ -11,6 +11,7 @@ pub mod models;
 pub mod server;
 pub mod slots;
 pub mod slots_poller;
+pub mod token_calibration;
 pub mod truncation;
 pub mod upstream_health;
 

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -214,6 +214,23 @@ async fn health_check() -> impl IntoResponse {
     }))
 }
 
+/// Percentage shaved off a model's raw context window when advertised via
+/// `/v1/models`.
+///
+/// Reserves headroom for the tool-schema JSON and chat-template tokens that a
+/// client's own char→token budget estimate (e.g. the VS Code LLM Gateway's
+/// `CHARS_PER_TOKEN = 4`) does not account for. Advertising slightly less than
+/// the true ceiling makes such clients begin proactive context compaction
+/// before the real limit is hit, avoiding upstream context-overflow rejections
+/// on the final turns of a long session.
+const CONTEXT_WINDOW_SAFETY_MARGIN_PCT: u64 = 8;
+
+/// Apply [`CONTEXT_WINDOW_SAFETY_MARGIN_PCT`] to a raw context-window token
+/// count, returning the value to advertise to clients.
+fn advertised_context_window(raw_ctx: u64) -> u64 {
+    raw_ctx.saturating_mul(100 - CONTEXT_WINDOW_SAFETY_MARGIN_PCT) / 100
+}
+
 /// List all models from the catalog in OpenAI format.
 ///
 /// Appends the three virtual council model entries after the catalog models.
@@ -233,6 +250,10 @@ async fn health_check() -> impl IntoResponse {
 ///   the per-request truncation budget in
 ///   [`crate::forward::forward_chat_completion`] — advertised and enforced
 ///   values stay in lockstep.
+///
+/// Both are shaved by [`CONTEXT_WINDOW_SAFETY_MARGIN_PCT`] before being
+/// advertised, reserving headroom for tool-schema JSON and chat-template
+/// tokens that a client's own char→token budget does not account for.
 async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
     debug!("GET /v1/models");
 
@@ -241,13 +262,15 @@ async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
             let mut response = ModelsResponse::from_summaries(models);
 
             for model in &mut response.data {
-                model.context_window = model.context_window.map(|ctx| ctx.min(state.default_ctx));
+                model.context_window = model
+                    .context_window
+                    .map(|ctx| advertised_context_window(ctx.min(state.default_ctx)));
             }
 
             if let Some(target) = state.runtime_port.current_model().await
                 && let Some(model) = response.data.iter_mut().find(|m| m.id == target.model_name)
             {
-                model.context_window = Some(target.effective_ctx);
+                model.context_window = Some(advertised_context_window(target.effective_ctx));
             }
 
             // Append virtual council models.

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -33,6 +33,7 @@ use crate::mcp::session::SessionManager;
 use crate::metrics::ContextMetricsStore;
 use crate::models::{ChatRoutingEnvelope, ErrorResponse, ModelInfo, ModelsResponse};
 use crate::slots_poller::{SlotsCache, spawn_slots_poller};
+use crate::upstream_health::UpstreamHealth;
 use gglib_sse::SseOptions;
 
 /// Shared application state for the proxy server.
@@ -60,6 +61,10 @@ pub(crate) struct AppState {
     pub(crate) dashboard: Arc<DashboardState>,
     /// Settings repository for loading global inference defaults per-request.
     settings_repo: Arc<dyn SettingsRepository>,
+    /// Consecutive-failure watchdog: trips a proactive model recycle when the
+    /// upstream degrades to empty responses / first-byte timeouts while still
+    /// passing its `/health` check.
+    upstream_health: Arc<UpstreamHealth>,
 }
 
 /// Start the proxy server with a pre-bound listener.
@@ -153,6 +158,7 @@ pub async fn serve(
         council,
         dashboard,
         settings_repo,
+        upstream_health: Arc::new(UpstreamHealth::new()),
     };
 
     let app = Router::new()
@@ -347,6 +353,15 @@ async fn chat_completions(
         .await;
     }
 
+    // Watchdog: if the upstream tripped the consecutive-failure threshold on
+    // prior requests (empty responses / first-byte timeouts while still
+    // passing /health), recycle it now — before routing this request into a
+    // server that has proven it is not producing output.
+    if state.upstream_health.take_recycle_request() {
+        warn!("upstream watchdog: recycling degraded model before next request");
+        let _ = state.runtime_port.stop_current().await;
+    }
+
     // Ensure the model is running with specified context or default
     let target = match state
         .runtime_port
@@ -403,6 +418,7 @@ async fn chat_completions(
         state.dashboard.metrics.clone(),
         global_inference_defaults,
         connection,
+        state.upstream_health.clone(),
     )
     .await
     {
@@ -476,6 +492,7 @@ async fn chat_completions(
                 state.dashboard.metrics.clone(),
                 retry_defaults,
                 retry_connection,
+                state.upstream_health.clone(),
             )
             .await
             {

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -33,6 +33,7 @@ use crate::mcp::session::SessionManager;
 use crate::metrics::ContextMetricsStore;
 use crate::models::{ChatRoutingEnvelope, ErrorResponse, ModelInfo, ModelsResponse};
 use crate::slots_poller::{SlotsCache, spawn_slots_poller};
+use crate::token_calibration::TokenCalibration;
 use crate::upstream_health::UpstreamHealth;
 use gglib_sse::SseOptions;
 
@@ -65,6 +66,9 @@ pub(crate) struct AppState {
     /// upstream degrades to empty responses / first-byte timeouts while still
     /// passing its `/health` check.
     upstream_health: Arc<UpstreamHealth>,
+    /// Per-model chars-per-token calibration, learned from upstream usage
+    /// frames and used to size the truncation budget.
+    calibration: Arc<TokenCalibration>,
 }
 
 /// Start the proxy server with a pre-bound listener.
@@ -159,6 +163,7 @@ pub async fn serve(
         dashboard,
         settings_repo,
         upstream_health: Arc::new(UpstreamHealth::new()),
+        calibration: Arc::new(TokenCalibration::new()),
     };
 
     let app = Router::new()
@@ -442,6 +447,7 @@ async fn chat_completions(
         global_inference_defaults,
         connection,
         state.upstream_health.clone(),
+        state.calibration.clone(),
     )
     .await
     {
@@ -516,6 +522,7 @@ async fn chat_completions(
                 retry_defaults,
                 retry_connection,
                 state.upstream_health.clone(),
+                state.calibration.clone(),
             )
             .await
             {

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -390,7 +390,14 @@ async fn chat_completions(
     // prior requests (empty responses / first-byte timeouts while still
     // passing /health), recycle it now — before routing this request into a
     // server that has proven it is not producing output.
-    if state.upstream_health.take_recycle_request() {
+    //
+    // Gate the recycle on the upstream being idle: this check runs before the
+    // current request registers its connection, so a non-empty registry means
+    // another request is in flight. With `--parallel 1` that request owns the
+    // only slot, and stop_current() would kill its live generation. The `&&`
+    // short-circuits so the recycle flag is left un-consumed when busy and is
+    // honored by the next request that arrives while the upstream is idle.
+    if state.dashboard.connections.is_empty() && state.upstream_health.take_recycle_request() {
         warn!("upstream watchdog: recycling degraded model before next request");
         let _ = state.runtime_port.stop_current().await;
     }

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -141,10 +141,15 @@ pub async fn serve(
         cancel.clone(),
     );
 
+    // Upstream-degradation watchdog, shared between the request path (strike
+    // recording + recycle) and the dashboard (counter surfacing).
+    let upstream_health = Arc::new(UpstreamHealth::new());
+
     let dashboard = Arc::new(DashboardState::new(
         Arc::new(ActiveConnectionsRegistry::new()),
         slots_cache,
         Arc::new(ContextMetricsStore::new()),
+        Arc::clone(&upstream_health),
     ));
     // Second background task: periodically recomputes and broadcasts the
     // unified DashboardSnapshot for GET /v1/proxy/status/stream subscribers
@@ -162,7 +167,7 @@ pub async fn serve(
         council,
         dashboard,
         settings_repo,
-        upstream_health: Arc::new(UpstreamHealth::new()),
+        upstream_health,
         calibration: Arc::new(TokenCalibration::new()),
     };
 

--- a/crates/gglib-proxy/src/token_calibration.rs
+++ b/crates/gglib-proxy/src/token_calibration.rs
@@ -1,0 +1,131 @@
+//! Per-model chars-per-token calibration for the truncation budget.
+//!
+//! The truncation budget converts a **token** context size (`effective_ctx`)
+//! into a **character** budget by multiplying by a chars-per-token factor. The
+//! static default ([`crate::truncation::CHARS_PER_TOKEN_APPROX`] = 4) is
+//! deliberately matched to the VS Code LLM Gateway's own estimate, but real
+//! code/markup content tokenizes closer to ~3.3 chars/token, so the static
+//! factor *overestimates* the character budget and can let an over-long prompt
+//! through to the upstream.
+//!
+//! [`TokenCalibration`] closes the loop: every streamed response carries a
+//! `usage.prompt_tokens` count from llama.cpp. Paired with the number of
+//! characters actually forwarded, that yields an observed chars-per-token
+//! ratio for the model, smoothed with an exponentially-weighted moving average
+//! (EWMA). Subsequent requests use the calibrated ratio, so the budget tracks
+//! the model's real tokenizer instead of a fixed guess.
+//!
+//! ## Concurrency design
+//!
+//! `std::sync::Mutex` around a small `HashMap`; every critical section is a
+//! couple of map operations with no `.await`, matching the lock discipline of
+//! [`crate::metrics::ContextMetricsStore`].
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::truncation::CHARS_PER_TOKEN_APPROX;
+
+/// EWMA smoothing factor applied to each new observation (`0.0..=1.0`). Higher
+/// reacts faster; lower is steadier. 0.2 blends ~5 recent requests.
+const EWMA_ALPHA: f64 = 0.2;
+
+/// Lower/upper clamp on any observed or stored ratio, guarding against
+/// pathological single requests (e.g. a tiny prompt with a large fixed
+/// template) skewing the budget.
+const MIN_RATIO: f64 = 2.0;
+const MAX_RATIO: f64 = 8.0;
+
+/// Per-model rolling chars-per-token estimator.
+///
+/// Wrap in `Arc` and share across handler tasks.
+#[derive(Debug, Default)]
+pub struct TokenCalibration {
+    ratios: Mutex<HashMap<String, f64>>,
+}
+
+impl TokenCalibration {
+    /// Create an empty calibrator (every model falls back to the static
+    /// default until it sees its first observation).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one observation into `model`'s rolling ratio.
+    ///
+    /// `payload_chars` is the size of the body actually forwarded upstream;
+    /// `prompt_tokens` is the count llama.cpp reported for it. A zero token
+    /// count (or an out-of-range ratio) is ignored.
+    pub fn record(&self, model: &str, payload_chars: usize, prompt_tokens: u32) {
+        if prompt_tokens == 0 {
+            return;
+        }
+        let observed = (payload_chars as f64 / f64::from(prompt_tokens)).clamp(MIN_RATIO, MAX_RATIO);
+
+        let mut guard = self.ratios.lock().unwrap_or_else(|e| e.into_inner());
+        guard
+            .entry(model.to_owned())
+            .and_modify(|current| {
+                *current = (1.0 - EWMA_ALPHA) * *current + EWMA_ALPHA * observed;
+            })
+            .or_insert(observed);
+    }
+
+    /// The chars-per-token factor to use for `model`, or the static default
+    /// ([`CHARS_PER_TOKEN_APPROX`]) if the model has no observations yet.
+    #[must_use]
+    pub fn chars_per_token(&self, model: &str) -> f64 {
+        let guard = self.ratios.lock().unwrap_or_else(|e| e.into_inner());
+        guard
+            .get(model)
+            .copied()
+            .unwrap_or(CHARS_PER_TOKEN_APPROX as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_model_returns_static_default() {
+        let cal = TokenCalibration::new();
+        assert!((cal.chars_per_token("nope") - CHARS_PER_TOKEN_APPROX as f64).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn first_observation_sets_ratio() {
+        let cal = TokenCalibration::new();
+        // 33000 chars / 10000 tokens = 3.3 chars/token.
+        cal.record("m", 33_000, 10_000);
+        assert!((cal.chars_per_token("m") - 3.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_tokens_ignored() {
+        let cal = TokenCalibration::new();
+        cal.record("m", 5_000, 0);
+        assert!((cal.chars_per_token("m") - CHARS_PER_TOKEN_APPROX as f64).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ewma_moves_toward_new_observations() {
+        let cal = TokenCalibration::new();
+        cal.record("m", 40_000, 10_000); // 4.0
+        cal.record("m", 30_000, 10_000); // 3.0 → EWMA 0.8*4 + 0.2*3 = 3.8
+        let r = cal.chars_per_token("m");
+        assert!(r < 4.0 && r > 3.0, "ratio {r} should move toward 3.0");
+    }
+
+    #[test]
+    fn ratio_is_clamped_to_sane_bounds() {
+        let cal = TokenCalibration::new();
+        // 100 chars / 1 token = 100 → clamped to MAX_RATIO.
+        cal.record("hi", 100, 1);
+        assert!((cal.chars_per_token("hi") - MAX_RATIO).abs() < f64::EPSILON);
+        // 1 char / 1000 tokens ≈ 0 → clamped to MIN_RATIO.
+        cal.record("lo", 1, 1_000);
+        assert!((cal.chars_per_token("lo") - MIN_RATIO).abs() < f64::EPSILON);
+    }
+}

--- a/crates/gglib-proxy/src/token_calibration.rs
+++ b/crates/gglib-proxy/src/token_calibration.rs
@@ -61,7 +61,8 @@ impl TokenCalibration {
         if prompt_tokens == 0 {
             return;
         }
-        let observed = (payload_chars as f64 / f64::from(prompt_tokens)).clamp(MIN_RATIO, MAX_RATIO);
+        let observed =
+            (payload_chars as f64 / f64::from(prompt_tokens)).clamp(MIN_RATIO, MAX_RATIO);
 
         let mut guard = self.ratios.lock().unwrap_or_else(|e| e.into_inner());
         guard

--- a/crates/gglib-proxy/src/truncation.rs
+++ b/crates/gglib-proxy/src/truncation.rs
@@ -388,7 +388,10 @@ mod tests {
         ]);
         let original_len = body.len();
         let (out, report) = truncate_default(body).unwrap();
-        assert_eq!(report.messages_truncated, 0, "nothing truncated under budget");
+        assert_eq!(
+            report.messages_truncated, 0,
+            "nothing truncated under budget"
+        );
         assert_eq!(out.len(), original_len, "body forwarded byte-for-byte");
     }
 

--- a/crates/gglib-proxy/src/truncation.rs
+++ b/crates/gglib-proxy/src/truncation.rs
@@ -14,21 +14,31 @@
 //! pass applied to every inbound `/v1/chat/completions` request before it
 //! reaches the upstream inference engine:
 //!
-//! 1. **Per-message threshold** — any unprotected `role: "tool"` or
-//!    `role: "assistant"` message whose `content` string exceeds
-//!    [`TOOL_CONTENT_THRESHOLD_CHARS`] has its content replaced with
-//!    [`TRUNCATION_PLACEHOLDER`].
+//! 1. **Budget gate** — if the whole payload already fits within the
+//!    request's character budget (the `limit_chars` argument, floored at
+//!    [`TOTAL_PAYLOAD_LIMIT_CHARS`]) the body is forwarded **unchanged**. No
+//!    history is elided while there is room, so the model keeps maximum
+//!    context on every turn that does not actually need trimming.
 //!
-//! 2. **Total budget hard abort** — if the payload still exceeds the
-//!    request's character budget (the `limit_chars` argument to
-//!    [`truncate_history`], floored at [`TOTAL_PAYLOAD_LIMIT_CHARS`]) after
-//!    step 1, the request is rejected with HTTP 400 /
+//! 2. **Oldest-first trim** — only when the payload exceeds the budget are
+//!    messages elided, and then only as many as necessary: unprotected
+//!    `role: "tool"` / `role: "assistant"` messages whose `content` string
+//!    exceeds [`TOOL_CONTENT_THRESHOLD_CHARS`] are replaced with
+//!    [`TRUNCATION_PLACEHOLDER`] **from oldest to newest**, stopping as soon
+//!    as the running payload estimate drops back under budget. The freshest
+//!    tool outputs — the ones the model most likely still needs — are the
+//!    last to be sacrificed.
+//!
+//! 3. **Total budget hard abort** — if the payload still exceeds the budget
+//!    after every eligible message has been trimmed (e.g. an enormous
+//!    protected system prompt), the request is rejected with HTTP 400 /
 //!    `context_length_exceeded` rather than forwarding a prompt that would
 //!    cause the model to fail.
 //!
-//! 3. **Protected set** — `role: "system"` messages and the last
+//! 4. **Protected set** — `role: "system"` messages and the last
 //!    [`PROTECTED_TAIL_COUNT`] messages by index (the immediate
-//!    conversational context) are never modified.
+//!    conversational context, spanning several recent tool-call/result
+//!    pairs) are never modified.
 //!
 //! ## Zero blast radius
 //!
@@ -87,8 +97,10 @@ pub const TOTAL_PAYLOAD_LIMIT_TOKENS: usize = TOTAL_PAYLOAD_LIMIT_CHARS / CHARS_
 
 /// Number of trailing messages (by index) that are always preserved from
 /// truncation regardless of role or content size.  These represent the
-/// immediate conversational context the model needs to respond coherently.
-pub const PROTECTED_TAIL_COUNT: usize = 4;
+/// immediate conversational context the model needs to respond coherently —
+/// sized to span several recent tool-call/result pairs so a live tool
+/// exchange is never half-elided.
+pub const PROTECTED_TAIL_COUNT: usize = 8;
 
 /// Replacement string inserted in place of truncated message content.
 pub const TRUNCATION_PLACEHOLDER: &str = "[Raw tool output truncated by proxy to maintain context window. \
@@ -161,10 +173,12 @@ pub fn truncate_history(
     let limit_chars = limit_chars.max(TOTAL_PAYLOAD_LIMIT_CHARS);
     let payload_chars_before = body.len();
 
-    // ── Pre-parse fast path ───────────────────────────────────────────────────
-    // If the entire body is smaller than the per-message threshold no
-    // individual message could possibly need truncation.
-    if payload_chars_before <= TOOL_CONTENT_THRESHOLD_CHARS {
+    // ── Budget gate ───────────────────────────────────────────────────────────
+    // While the whole payload fits within budget there is nothing to do:
+    // forward it byte-for-byte and keep the model's full history intact. This
+    // is the common case and the reason truncation no longer mutilates history
+    // pre-emptively.
+    if payload_chars_before <= limit_chars {
         return Ok((body, TruncationReport::zeroed(payload_chars_before)));
     }
 
@@ -183,26 +197,21 @@ pub fn truncate_history(
     };
 
     let total = messages.len();
+    let placeholder_len = TRUNCATION_PLACEHOLDER.len();
 
-    // ── Post-parse fast path ──────────────────────────────────────────────────
-    // Avoid mutation and re-serialisation when the payload is under the total
-    // budget and no unprotected message has oversized string content.
-    if payload_chars_before <= limit_chars {
-        let has_oversized_candidate = messages
-            .iter()
-            .enumerate()
-            .filter(|(i, msg)| !is_tail_protected(*i, total) && is_truncation_candidate(msg))
-            .any(|(_, msg)| exceeds_threshold(msg));
-
-        if !has_oversized_candidate {
-            return Ok((body, TruncationReport::zeroed(payload_chars_before)));
-        }
-    }
-
-    // ── Mutate ────────────────────────────────────────────────────────────────
+    // ── Oldest-first trim ──────────────────────────────────────────────────────
+    // Walk from the oldest message toward the newest, eliding eligible
+    // oversized content only until the running payload estimate drops back
+    // under budget. `running` tracks the approximate payload size as each
+    // replacement shrinks it, so we stop at the minimum necessary and leave
+    // the freshest tool outputs intact.
     let mut messages_truncated = 0usize;
+    let mut running = payload_chars_before;
 
     for (i, msg) in messages.iter_mut().enumerate() {
+        if running <= limit_chars {
+            break;
+        }
         // Tail-protected messages and non-candidate roles (system, user) are
         // skipped entirely.
         if is_tail_protected(i, total) || !is_truncation_candidate(msg) {
@@ -212,16 +221,19 @@ pub fn truncate_history(
         // Only string-form content is replaced.  Array-form content
         // (multi-part messages) is left untouched.  `tool_calls` is never
         // modified regardless of role.
-        let should_truncate = msg
+        let Some(content_len) = msg
             .get("content")
             .and_then(|c| c.as_str())
-            .map(|s| s.len() > TOOL_CONTENT_THRESHOLD_CHARS)
-            .unwrap_or(false);
+            .map(str::len)
+            .filter(|len| *len > TOOL_CONTENT_THRESHOLD_CHARS)
+        else {
+            continue;
+        };
 
-        if should_truncate {
-            msg["content"] = serde_json::Value::String(TRUNCATION_PLACEHOLDER.to_string());
-            messages_truncated += 1;
-        }
+        msg["content"] = serde_json::Value::String(TRUNCATION_PLACEHOLDER.to_string());
+        messages_truncated += 1;
+        // Each replacement reclaims (content_len - placeholder_len) chars.
+        running = running.saturating_sub(content_len.saturating_sub(placeholder_len));
     }
 
     // ── Re-serialise ──────────────────────────────────────────────────────────
@@ -278,16 +290,6 @@ fn is_truncation_candidate(msg: &serde_json::Value) -> bool {
         msg.get("role").and_then(|r| r.as_str()).unwrap_or(""),
         "tool" | "assistant"
     )
-}
-
-/// Returns `true` if the message has string-form `content` that exceeds
-/// [`TOOL_CONTENT_THRESHOLD_CHARS`].
-#[inline]
-fn exceeds_threshold(msg: &serde_json::Value) -> bool {
-    msg.get("content")
-        .and_then(|c| c.as_str())
-        .map(|s| s.len() > TOOL_CONTENT_THRESHOLD_CHARS)
-        .unwrap_or(false)
 }
 
 // =============================================================================
@@ -357,136 +359,166 @@ mod tests {
         assert_eq!(report.messages_truncated, 0);
     }
 
-    // ── Basic truncation ──────────────────────────────────────────────────────
+    // ── Budget-gated, oldest-first truncation ─────────────────────────────────
+
+    /// Build a chat body with `leading_big` oversized tool messages (oldest,
+    /// outside the protected tail) followed by `tail` small user messages.
+    fn over_budget_body(leading_big: usize, big_chars: usize, tail: usize) -> Bytes {
+        let mut messages = Vec::new();
+        for _ in 0..leading_big {
+            messages.push(msg("tool", &big(big_chars)));
+        }
+        for _ in 0..tail {
+            messages.push(msg("user", "ok"));
+        }
+        make_body(messages)
+    }
 
     #[test]
-    fn oversized_tool_content_replaced_with_placeholder() {
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
+    fn under_budget_leaves_oversized_content_intact() {
+        // Behavioural guard: with room in the budget, even a giant tool output
+        // is forwarded untouched — history is no longer mutilated pre-emptively.
+        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS * 10);
         let body = make_body(vec![
-            msg("user", "run"),
-            msg("tool", &oversized), // index 1 — not in tail (6 messages, tail = 2..5)
+            msg("tool", &oversized),
             msg("user", "a"),
             msg("user", "b"),
             msg("user", "c"),
             msg("user", "d"),
         ]);
+        let original_len = body.len();
         let (out, report) = truncate_default(body).unwrap();
-        assert_eq!(report.messages_truncated, 1);
+        assert_eq!(report.messages_truncated, 0, "nothing truncated under budget");
+        assert_eq!(out.len(), original_len, "body forwarded byte-for-byte");
+    }
+
+    #[test]
+    fn over_budget_trims_oldest_first_and_stops_early() {
+        // 4 large tool messages (indices 0..3, outside the 8-message tail) plus
+        // 8 small tail messages → total 12, tail_start = 4. Each big message is
+        // 100k chars, so the payload (~400k) exceeds the 240k budget. Trimming
+        // the two oldest brings it back under budget; the two newer big
+        // messages must survive.
+        let body = over_budget_body(4, 100_000, 8);
+        let (out, report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
+
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(
+            report.messages_truncated, 2,
+            "only as many oldest messages as needed to get under budget"
+        );
+        assert_eq!(
+            parsed["messages"][0]["content"], TRUNCATION_PLACEHOLDER,
+            "oldest big message trimmed"
+        );
         assert_eq!(
             parsed["messages"][1]["content"], TRUNCATION_PLACEHOLDER,
-            "oversized tool content must be replaced"
+            "second-oldest big message trimmed"
         );
         assert_eq!(
-            parsed["messages"][0]["content"], "run",
-            "other messages must be untouched"
+            parsed["messages"][2]["content"].as_str().unwrap().len(),
+            100_000,
+            "newer big message preserved once under budget"
+        );
+        assert_eq!(
+            parsed["messages"][3]["content"].as_str().unwrap().len(),
+            100_000,
+            "newest unprotected big message preserved"
+        );
+        assert!(report.payload_chars_after <= TOTAL_PAYLOAD_LIMIT_CHARS);
+    }
+
+    #[test]
+    fn over_budget_trims_assistant_content_too() {
+        // Same shape but the oversized messages are assistant turns.
+        let mut messages = vec![
+            msg("assistant", &big(150_000)),
+            msg("assistant", &big(150_000)),
+        ];
+        for _ in 0..8 {
+            messages.push(msg("user", "ok"));
+        }
+        let body = make_body(messages);
+        let (_, report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
+        assert!(
+            report.messages_truncated >= 1,
+            "assistant content is an eligible truncation candidate"
         );
     }
 
     #[test]
-    fn oversized_assistant_content_replaced() {
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        let body = make_body(vec![
-            msg("assistant", &oversized), // index 0, not in tail
-            msg("user", "a"),
-            msg("user", "b"),
-            msg("user", "c"),
-            msg("user", "d"),
-            msg("user", "e"),
-        ]);
-        let (_, report) = truncate_default(body).unwrap();
-        assert_eq!(report.messages_truncated, 1);
-    }
-
-    #[test]
-    fn content_under_threshold_not_truncated() {
-        let under = big(TOOL_CONTENT_THRESHOLD_CHARS - 1);
-        let body = make_body(vec![
-            msg("tool", &under), // under threshold — must not be replaced
-            msg("user", "a"),
-            msg("user", "b"),
-            msg("user", "c"),
-            msg("user", "d"),
-            msg("user", "e"),
-        ]);
-        let (out, report) = truncate_default(body).unwrap();
-        assert_eq!(report.messages_truncated, 0);
-        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
-        assert_eq!(
-            parsed["messages"][0]["content"].as_str().unwrap().len(),
-            under.len()
+    fn content_under_threshold_not_truncated_even_over_budget() {
+        // A payload made entirely of many small tool messages exceeds budget by
+        // sheer count, but none individually exceeds the per-message threshold,
+        // so none is eligible — the request hard-aborts rather than trimming
+        // sub-threshold content.
+        let mut messages = Vec::new();
+        for _ in 0..300 {
+            messages.push(msg("tool", &big(TOOL_CONTENT_THRESHOLD_CHARS - 1)));
+        }
+        let body = make_body(messages);
+        let result = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS);
+        assert!(
+            result.is_err(),
+            "no eligible (over-threshold) content to trim → hard abort"
         );
     }
 
     // ── Protection ────────────────────────────────────────────────────────────
 
     #[test]
-    fn system_message_never_truncated() {
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        // System message at index 0 with oversized content — must never be touched.
-        let body = make_body(vec![
-            serde_json::json!({"role": "system", "content": oversized.clone()}),
-            msg("user", "a"),
-            msg("user", "b"),
-            msg("user", "c"),
-            msg("user", "d"),
-            msg("user", "e"),
-        ]);
-        let (out, report) = truncate_default(body).unwrap();
-        assert_eq!(report.messages_truncated, 0);
+    fn system_message_never_truncated_even_over_budget() {
+        // A huge system prompt plus enough oversized tool messages to blow the
+        // budget: the tools are trimmed, the system message is untouched.
+        let big_system = big(120_000);
+        let mut messages = vec![
+            serde_json::json!({"role": "system", "content": big_system.clone()}),
+            msg("tool", &big(120_000)),
+            msg("tool", &big(120_000)),
+        ];
+        for _ in 0..8 {
+            messages.push(msg("user", "ok"));
+        }
+        let body = make_body(messages);
+        let (out, _report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(
             parsed["messages"][0]["content"].as_str().unwrap().len(),
-            oversized.len(),
+            big_system.len(),
             "system message content must be preserved"
         );
     }
 
     #[test]
-    fn tail_messages_not_truncated() {
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        // Tool message sits entirely within the protected tail (≤ PROTECTED_TAIL_COUNT
-        // total messages → tail_start = 0 → every message is protected).
-        let body = make_body(vec![
-            msg("user", "hi"),
-            msg("tool", &oversized),
-            msg("assistant", "ok"),
-            msg("user", "thanks"),
-        ]);
-        let (_, report) = truncate_default(body).unwrap();
-        assert_eq!(
-            report.messages_truncated, 0,
-            "messages inside the protected tail must not be truncated"
-        );
-    }
-
-    #[test]
-    fn non_tail_tool_truncated_tail_tool_preserved() {
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        // 7 messages → tail starts at index 3.
-        // Index 0 tool: NOT in tail → truncated.
-        // Index 3 tool: in tail → preserved.
-        let body = make_body(vec![
-            msg("tool", &oversized), // index 0 — truncated
-            msg("user", "mid"),
-            msg("user", "mid2"),
-            msg("tool", &oversized), // index 3 — tail-protected
-            msg("user", "a"),
-            msg("user", "b"),
-            msg("user", "c"),
-        ]);
-        let (out, report) = truncate_default(body).unwrap();
-        assert_eq!(
-            report.messages_truncated, 1,
-            "only the non-tail tool must be truncated"
-        );
+    fn protected_tail_preserved_over_budget() {
+        // A single huge unprotected tool at index 0 (total = 9, tail_start = 1)
+        // plus two moderate oversized tools inside the protected tail. Trimming
+        // the index-0 message alone drops the payload under budget, so the tail
+        // tools must survive untouched.
+        let mut messages = vec![msg("tool", &big(300_000))];
+        messages.push(msg("tool", &big(30_000)));
+        messages.push(msg("tool", &big(30_000)));
+        for _ in 0..6 {
+            messages.push(msg("user", "ok"));
+        }
+        let body = make_body(messages);
+        let (out, report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
-        assert_eq!(parsed["messages"][0]["content"], TRUNCATION_PLACEHOLDER);
         assert_eq!(
-            parsed["messages"][3]["content"].as_str().unwrap().len(),
-            oversized.len(),
-            "tail tool content must be preserved"
+            parsed["messages"][0]["content"], TRUNCATION_PLACEHOLDER,
+            "the single unprotected tool must be trimmed"
         );
+        assert_eq!(
+            parsed["messages"][1]["content"].as_str().unwrap().len(),
+            30_000,
+            "tail tool #1 must be preserved"
+        );
+        assert_eq!(
+            parsed["messages"][2]["content"].as_str().unwrap().len(),
+            30_000,
+            "tail tool #2 must be preserved"
+        );
+        assert_eq!(report.messages_truncated, 1);
     }
 
     // ── Hard abort ────────────────────────────────────────────────────────────
@@ -515,29 +547,24 @@ mod tests {
 
     #[test]
     fn array_form_content_skipped() {
-        let oversized_str = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        // Index 0: string tool (forces mutation path by triggering truncation)
-        // Index 1: array-form tool (must not be truncated)
-        let body = Bytes::from(
-            serde_json::to_vec(&serde_json::json!({
-                "model": "test",
-                "messages": [
-                    {"role": "tool", "tool_call_id": "c1", "content": oversized_str},
-                    {"role": "tool", "tool_call_id": "c2", "content": [{"type": "text", "text": "big array content"}]},
-                    {"role": "user", "content": "a"},
-                    {"role": "user", "content": "b"},
-                    {"role": "user", "content": "c"},
-                    {"role": "user", "content": "d"},
-                ]
-            }))
-            .unwrap(),
-        );
-        let (out, report) = truncate_default(body).unwrap();
+        // Index 0: oversized string tool (eligible, will be trimmed once over
+        // budget). Index 1: array-form tool (must never be truncated). Padded
+        // with a protected tail; total payload exceeds budget.
+        let mut messages = vec![
+            serde_json::json!({"role": "tool", "tool_call_id": "c1", "content": big(250_000)}),
+            serde_json::json!({"role": "tool", "tool_call_id": "c2", "content": [{"type": "text", "text": "big array content"}]}),
+        ];
+        for _ in 0..8 {
+            messages.push(msg("user", "ok"));
+        }
+        let body = make_body(messages);
+        let (out, report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
         assert_eq!(
             report.messages_truncated, 1,
             "only the string-form tool should be counted"
         );
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed["messages"][0]["content"], TRUNCATION_PLACEHOLDER);
         assert!(
             parsed["messages"][1]["content"].is_array(),
             "array-form content must be left as an array"
@@ -571,28 +598,19 @@ mod tests {
 
     #[test]
     fn tool_calls_preserved_when_content_truncated() {
-        // An assistant message that has BOTH oversized content AND tool_calls.
-        // Content must be replaced; tool_calls must survive.
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        let body = Bytes::from(
-            serde_json::to_vec(&serde_json::json!({
-                "model": "test",
-                "messages": [
-                    {
-                        "role": "assistant",
-                        "content": oversized,
-                        "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "foo", "arguments": "{}"}}]
-                    },
-                    {"role": "user", "content": "a"},
-                    {"role": "user", "content": "b"},
-                    {"role": "user", "content": "c"},
-                    {"role": "user", "content": "d"},
-                    {"role": "user", "content": "e"},
-                ]
-            }))
-            .unwrap(),
-        );
-        let (out, report) = truncate_default(body).unwrap();
+        // An assistant message with BOTH oversized content AND tool_calls, old
+        // enough to be trimmed once the payload is over budget. Content must be
+        // replaced; tool_calls must survive.
+        let mut messages = vec![serde_json::json!({
+            "role": "assistant",
+            "content": big(250_000),
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "foo", "arguments": "{}"}}]
+        })];
+        for _ in 0..8 {
+            messages.push(msg("user", "ok"));
+        }
+        let body = make_body(messages);
+        let (out, report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
         assert_eq!(report.messages_truncated, 1);
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(parsed["messages"][0]["content"], TRUNCATION_PLACEHOLDER);
@@ -626,16 +644,8 @@ mod tests {
 
     #[test]
     fn report_chars_after_less_than_before_when_truncated() {
-        let oversized = big(TOOL_CONTENT_THRESHOLD_CHARS + 1);
-        let body = make_body(vec![
-            msg("tool", &oversized),
-            msg("user", "a"),
-            msg("user", "b"),
-            msg("user", "c"),
-            msg("user", "d"),
-            msg("user", "e"),
-        ]);
-        let (_, report) = truncate_default(body).unwrap();
+        let body = over_budget_body(4, 100_000, 8);
+        let (_, report) = truncate_history(body, TOTAL_PAYLOAD_LIMIT_CHARS).unwrap();
         assert!(
             report.payload_chars_after < report.payload_chars_before,
             "after must be smaller than before when content was replaced"

--- a/crates/gglib-proxy/src/upstream_health.rs
+++ b/crates/gglib-proxy/src/upstream_health.rs
@@ -1,0 +1,140 @@
+//! Consecutive-failure watchdog for the upstream llama-server.
+//!
+//! The `/health` fast-path check in `gglib_runtime`'s process manager catches
+//! a llama-server that has *crashed or wedged hard* (its `/health` endpoint
+//! stops returning `200`). It does **not** catch the subtler failure mode this
+//! module targets: a server whose `/health` is still green but which has
+//! degraded to the point of producing **empty responses** or never returning
+//! the first token. That manifests to the client as an unexplained "empty
+//! response".
+//!
+//! [`UpstreamHealth`] accumulates such degraded outcomes across requests. When
+//! [`STRIKE_THRESHOLD`] consecutive strikes occur it raises a one-shot
+//! "recycle requested" flag; the chat handler consumes that flag before the
+//! next request and proactively stops the current model, forcing a fresh
+//! respawn — the same cure a human applies by restarting the proxy, automated.
+//!
+//! ## Concurrency design
+//!
+//! Lock-free atomics only. Every operation is a handful of `Relaxed` atomic
+//! reads/writes with no `.await`, so it is cheap on the hot path and cannot
+//! hold anything across an await point.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+/// Number of *consecutive* degraded responses (empty streams or first-byte
+/// timeouts) that trip a proactive recycle of the upstream model server.
+///
+/// Two is deliberately low: a single empty response can be a legitimate model
+/// artefact, but two in a row is a strong signal the upstream has degraded and
+/// is worth the cost of a recycle.
+pub const STRIKE_THRESHOLD: u32 = 2;
+
+/// Lock-free tracker of consecutive degraded upstream responses.
+///
+/// Wrap in `Arc` and share across handler tasks.
+#[derive(Debug, Default)]
+pub struct UpstreamHealth {
+    /// Count of consecutive degraded outcomes since the last healthy one.
+    consecutive_strikes: AtomicU32,
+    /// One-shot flag: set when the strike threshold is reached, cleared by
+    /// [`UpstreamHealth::take_recycle_request`].
+    recycle_requested: AtomicBool,
+}
+
+impl UpstreamHealth {
+    /// Create a tracker with a zeroed strike counter.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the terminal outcome of a streamed response.
+    ///
+    /// `saw_output == true` resets the strike counter (the upstream is
+    /// producing output and is considered healthy); `false` counts as a
+    /// strike.
+    pub fn record_stream_outcome(&self, saw_output: bool) {
+        if saw_output {
+            self.consecutive_strikes.store(0, Ordering::Relaxed);
+        } else {
+            self.record_strike();
+        }
+    }
+
+    /// Record a first-byte deadline expiry — always a strike, since the
+    /// upstream failed to begin responding at all.
+    pub fn record_timeout(&self) {
+        self.record_strike();
+    }
+
+    fn record_strike(&self) {
+        let strikes = self.consecutive_strikes.fetch_add(1, Ordering::Relaxed) + 1;
+        if strikes >= STRIKE_THRESHOLD {
+            self.recycle_requested.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Consume the recycle request, if any.
+    ///
+    /// Returns `true` at most once per tripped threshold. On a `true` return
+    /// the strike counter is also reset, so the freshly recycled server starts
+    /// with a clean slate.
+    pub fn take_recycle_request(&self) -> bool {
+        let requested = self.recycle_requested.swap(false, Ordering::Relaxed);
+        if requested {
+            self.consecutive_strikes.store(0, Ordering::Relaxed);
+        }
+        requested
+    }
+
+    /// Current consecutive-strike count (for observability/tests).
+    #[must_use]
+    pub fn strikes(&self) -> u32 {
+        self.consecutive_strikes.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_outcome_keeps_strikes_zero() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(true);
+        h.record_stream_outcome(true);
+        assert_eq!(h.strikes(), 0);
+        assert!(!h.take_recycle_request());
+    }
+
+    #[test]
+    fn single_strike_does_not_trip_recycle() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(false);
+        assert_eq!(h.strikes(), 1);
+        assert!(!h.take_recycle_request());
+    }
+
+    #[test]
+    fn two_consecutive_strikes_trip_recycle_once() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(false);
+        h.record_timeout();
+        assert!(h.take_recycle_request());
+        // One-shot: a second consume returns false and the counter is reset.
+        assert!(!h.take_recycle_request());
+        assert_eq!(h.strikes(), 0);
+    }
+
+    #[test]
+    fn a_healthy_outcome_resets_the_strike_streak() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(false);
+        h.record_stream_outcome(true);
+        h.record_stream_outcome(false);
+        // Only one strike since the reset — threshold not reached.
+        assert!(!h.take_recycle_request());
+        assert_eq!(h.strikes(), 1);
+    }
+}

--- a/crates/gglib-proxy/src/upstream_health.rs
+++ b/crates/gglib-proxy/src/upstream_health.rs
@@ -20,7 +20,7 @@
 //! reads/writes with no `.await`, so it is cheap on the hot path and cannot
 //! hold anything across an await point.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 /// Number of *consecutive* degraded responses (empty streams or first-byte
 /// timeouts) that trip a proactive recycle of the upstream model server.
@@ -29,6 +29,22 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 /// artefact, but two in a row is a strong signal the upstream has degraded and
 /// is worth the cost of a recycle.
 pub const STRIKE_THRESHOLD: u32 = 2;
+
+/// Serializable, point-in-time view of the watchdog's cumulative counters.
+///
+/// Surfaced in the proxy dashboard so the degradation this crate guards
+/// against is diagnosable at a glance instead of only in logs.
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
+pub struct UpstreamHealthSnapshot {
+    /// Current consecutive-strike streak (resets on any healthy response).
+    pub consecutive_strikes: u32,
+    /// Total empty responses observed since the proxy started.
+    pub total_empty_responses: u64,
+    /// Total first-byte deadline expiries since the proxy started.
+    pub total_first_byte_timeouts: u64,
+    /// Total proactive recycles triggered since the proxy started.
+    pub total_recycles: u64,
+}
 
 /// Lock-free tracker of consecutive degraded upstream responses.
 ///
@@ -40,6 +56,10 @@ pub struct UpstreamHealth {
     /// One-shot flag: set when the strike threshold is reached, cleared by
     /// [`UpstreamHealth::take_recycle_request`].
     recycle_requested: AtomicBool,
+    /// Cumulative counters for observability (never reset).
+    total_empty_responses: AtomicU64,
+    total_first_byte_timeouts: AtomicU64,
+    total_recycles: AtomicU64,
 }
 
 impl UpstreamHealth {
@@ -58,6 +78,7 @@ impl UpstreamHealth {
         if saw_output {
             self.consecutive_strikes.store(0, Ordering::Relaxed);
         } else {
+            self.total_empty_responses.fetch_add(1, Ordering::Relaxed);
             self.record_strike();
         }
     }
@@ -65,6 +86,8 @@ impl UpstreamHealth {
     /// Record a first-byte deadline expiry — always a strike, since the
     /// upstream failed to begin responding at all.
     pub fn record_timeout(&self) {
+        self.total_first_byte_timeouts
+            .fetch_add(1, Ordering::Relaxed);
         self.record_strike();
     }
 
@@ -84,6 +107,7 @@ impl UpstreamHealth {
         let requested = self.recycle_requested.swap(false, Ordering::Relaxed);
         if requested {
             self.consecutive_strikes.store(0, Ordering::Relaxed);
+            self.total_recycles.fetch_add(1, Ordering::Relaxed);
         }
         requested
     }
@@ -92,6 +116,17 @@ impl UpstreamHealth {
     #[must_use]
     pub fn strikes(&self) -> u32 {
         self.consecutive_strikes.load(Ordering::Relaxed)
+    }
+
+    /// Serializable snapshot of the cumulative counters for the dashboard.
+    #[must_use]
+    pub fn snapshot(&self) -> UpstreamHealthSnapshot {
+        UpstreamHealthSnapshot {
+            consecutive_strikes: self.consecutive_strikes.load(Ordering::Relaxed),
+            total_empty_responses: self.total_empty_responses.load(Ordering::Relaxed),
+            total_first_byte_timeouts: self.total_first_byte_timeouts.load(Ordering::Relaxed),
+            total_recycles: self.total_recycles.load(Ordering::Relaxed),
+        }
     }
 }
 
@@ -136,5 +171,18 @@ mod tests {
         // Only one strike since the reset — threshold not reached.
         assert!(!h.take_recycle_request());
         assert_eq!(h.strikes(), 1);
+    }
+
+    #[test]
+    fn cumulative_counters_track_events() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(false); // empty #1, strike #1
+        h.record_timeout(); // timeout #1, strike #2 → recycle armed
+        assert!(h.take_recycle_request()); // recycle #1
+        let snap = h.snapshot();
+        assert_eq!(snap.total_empty_responses, 1);
+        assert_eq!(snap.total_first_byte_timeouts, 1);
+        assert_eq!(snap.total_recycles, 1);
+        assert_eq!(snap.consecutive_strikes, 0);
     }
 }

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -12,6 +12,22 @@ use std::sync::Arc;
 use tokio::process::Child;
 use tracing::{debug, info, warn};
 
+/// Whether the `GGLIB_DISABLE_MTP` environment variable requests that MTP
+/// speculative-decoding flags be suppressed.
+///
+/// Truthy values (case-insensitive): `1`, `true`, `yes`, `on`. Anything else
+/// (including unset) leaves MTP enabled.
+fn mtp_disabled_via_env() -> bool {
+    std::env::var("GGLIB_DISABLE_MTP")
+        .ok()
+        .is_some_and(|v| is_truthy_flag(&v))
+}
+
+/// Parse a string as a truthy on/off flag (case- and whitespace-insensitive).
+fn is_truthy_flag(v: &str) -> bool {
+    matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+}
+
 /// Select the llama-server path to use.
 ///
 /// This function implements the "bootstrap path wins" rule:
@@ -137,11 +153,22 @@ pub fn build_and_spawn(
     }
 
     // Add MTP speculative decoding flags if enabled
+    //
+    // A global kill switch — the `GGLIB_DISABLE_MTP` environment variable set
+    // to a truthy value (`1`, `true`, `yes`, case-insensitive) — forces these
+    // flags off even for an MTP-tagged model. This exists so speculative
+    // decoding can be A/B tested as a suspect for long-context degenerate
+    // generations without editing any per-model config: `GGLIB_DISABLE_MTP=1
+    // gglib proxy`.
     if let Some(n) = config.spec_draft_n_max {
-        cmd.arg("--spec-type").arg("draft-mtp");
-        cmd.arg("--spec-draft-n-max").arg(n.to_string());
-        if let Some(p) = config.spec_draft_p_min {
-            cmd.arg("--spec-draft-p-min").arg(p.to_string());
+        if mtp_disabled_via_env() {
+            info!("MTP speculative decoding suppressed via GGLIB_DISABLE_MTP");
+        } else {
+            cmd.arg("--spec-type").arg("draft-mtp");
+            cmd.arg("--spec-draft-n-max").arg(n.to_string());
+            if let Some(p) = config.spec_draft_p_min {
+                cmd.arg("--spec-draft-p-min").arg(p.to_string());
+            }
         }
     }
 
@@ -219,6 +246,16 @@ mod tests {
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn is_truthy_flag_recognises_on_values() {
+        for v in ["1", "true", "TRUE", " yes ", "On", "  on"] {
+            assert!(is_truthy_flag(v), "{v:?} should be truthy");
+        }
+        for v in ["0", "false", "no", "off", "", "2", "disable"] {
+            assert!(!is_truthy_flag(v), "{v:?} should be falsy");
+        }
+    }
 
     /// Test that a valid bootstrap path is used directly.
     #[test]

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -135,6 +135,22 @@ pub fn build_and_spawn(
         .arg(port.to_string())
         .arg("--metrics");
 
+    // Serialize concurrent requests onto a single slot.
+    //
+    // Recent llama.cpp builds default to `--parallel 4` with a *unified* KV
+    // cache: the `-c` context tokens become a single pool shared across all 4
+    // slots, not a per-request allocation. When a client (e.g. the VS Code LLM
+    // Gateway) fires two chat completions concurrently against a large-context
+    // model, their combined prompts can exceed that shared pool even though
+    // each individually fits — llama-server then aborts BOTH with
+    // "Context size has been exceeded", surfacing as an empty response.
+    //
+    // Forcing a single slot gives every request the full `-c` context
+    // exclusively; a second concurrent request queues inside llama-server
+    // until the slot frees, which the proxy's streaming keepalive path is
+    // built to wait out.
+    cmd.arg("--parallel").arg("1");
+
     // Add context size if specified
     if let Some(ctx) = config.context_size {
         cmd.arg("-c").arg(ctx.to_string());

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -25,7 +25,10 @@ fn mtp_disabled_via_env() -> bool {
 
 /// Parse a string as a truthy on/off flag (case- and whitespace-insensitive).
 fn is_truthy_flag(v: &str) -> bool {
-    matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    matches!(
+        v.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 /// Select the llama-server path to use.

--- a/crates/gglib-runtime/src/process/health.rs
+++ b/crates/gglib-runtime/src/process/health.rs
@@ -86,6 +86,32 @@ pub async fn wait_for_http_health(port: u16, timeout_secs: u64) -> Result<()> {
     }
 }
 
+/// Single-shot HTTP health probe of a llama-server `/health` endpoint.
+///
+/// Unlike [`wait_for_http_health`] this does **not** retry: it makes one
+/// request with a short timeout and reports whether the server responded
+/// `200 OK`. Used on the "already running" fast path to detect a cached
+/// server that has silently degraded or wedged, so the caller can recycle it
+/// instead of routing a request into a dead instance.
+///
+/// Never returns an error — any failure (connection refused, timeout,
+/// non-2xx) is reported as `false` so callers can treat "not healthy" and
+/// "unreachable" identically.
+pub async fn check_http_health(port: u16) -> bool {
+    let health_url = format!("http://127.0.0.1:{port}/health");
+    let Ok(client) = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    else {
+        return false;
+    };
+
+    matches!(
+        client.get(&health_url).send().await,
+        Ok(response) if response.status().is_success()
+    )
+}
+
 /// Check if a process is alive and healthy using sysinfo
 pub fn check_process_health(pid: u32) -> bool {
     let mut system = System::new_all();

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -5,7 +5,7 @@
 //! - **SingleSwap**: Auto-swapping single model with smart context handling (Proxy use case)
 
 use super::core::GuiProcessCore;
-use super::health::wait_for_http_health;
+use super::health::{check_http_health, wait_for_http_health};
 use super::types::ServerInfo;
 use anyhow::{Result, anyhow};
 use gglib_core::ports::{
@@ -213,28 +213,51 @@ impl ProcessManager {
             ));
         }
 
-        // 3. Compare by model_id (not name) + context for "already running"
-        {
+        // 3. Compare by model_id (not name) + context for "already running".
+        //    Snapshot the matching cached instance under the read lock, then
+        //    drop the lock before the (awaiting) health probe so we never hold
+        //    it across an await.
+        let cached = {
             let current_guard = current_lock.read().await;
-            if let Some(current) = current_guard.as_ref()
-                && current.model_id == launch_spec.id
-                && current.context_size == effective_ctx
-            {
-                // Same model, same context -> return existing
+            current_guard.as_ref().and_then(|current| {
+                (current.model_id == launch_spec.id && current.context_size == effective_ctx)
+                    .then(|| {
+                        (
+                            current.port,
+                            current.model_id,
+                            current.model_name.clone(),
+                            current.context_size,
+                        )
+                    })
+            })
+        };
+        if let Some((port, model_id, cached_name, context_size)) = cached {
+            // Verify the cached instance is actually healthy before routing to
+            // it. The in-memory bookkeeping only records that we *launched* a
+            // server — it says nothing about whether that process has since
+            // wedged or degraded. A silent health check here means a degraded
+            // server is recycled instead of receiving requests that would hang.
+            if check_http_health(port).await {
                 info!(
-                    model_id = %launch_spec.id,
-                    model_name = %launch_spec.name,
-                    port = %current.port,
-                    context = %current.context_size,
+                    model_id = %model_id,
+                    model_name = %cached_name,
+                    port = %port,
+                    context = %context_size,
                     "Model already running with correct context"
                 );
                 return Ok(RunningTarget::local(
-                    current.port,
-                    current.model_id,
-                    current.model_name.clone(),
-                    current.context_size,
+                    port,
+                    model_id,
+                    cached_name,
+                    context_size,
                 ));
             }
+            warn!(
+                model_id = %model_id,
+                port = %port,
+                "cached model failed health check; recycling degraded instance"
+            );
+            // Fall through to the restart path below.
         }
 
         // 4. Need restart: different model_id OR context mismatch

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -220,15 +220,16 @@ impl ProcessManager {
         let cached = {
             let current_guard = current_lock.read().await;
             current_guard.as_ref().and_then(|current| {
-                (current.model_id == launch_spec.id && current.context_size == effective_ctx)
-                    .then(|| {
+                (current.model_id == launch_spec.id && current.context_size == effective_ctx).then(
+                    || {
                         (
                             current.port,
                             current.model_id,
                             current.model_name.clone(),
                             current.context_size,
                         )
-                    })
+                    },
+                )
             })
         };
         if let Some((port, model_id, cached_name, context_size)) = cached {

--- a/crates/gglib-runtime/src/process/mod.rs
+++ b/crates/gglib-runtime/src/process/mod.rs
@@ -14,7 +14,9 @@ mod types;
 pub use broadcaster::{ServerEventBroadcaster, get_event_broadcaster};
 pub use core::GuiProcessCore;
 pub use events::{ServerEvent, ServerStateInfo, ServerStatus};
-pub use health::{check_http_health, check_process_health, update_health_batch, wait_for_http_health};
+pub use health::{
+    check_http_health, check_process_health, update_health_batch, wait_for_http_health,
+};
 pub use logs::{LogManagerSink, ServerLogEntry, ServerLogManager, get_log_manager};
 pub use manager::{CurrentModelState, ProcessManager, ProcessStrategy};
 pub use shutdown::{kill_pid, shutdown_child};

--- a/crates/gglib-runtime/src/process/mod.rs
+++ b/crates/gglib-runtime/src/process/mod.rs
@@ -14,7 +14,7 @@ mod types;
 pub use broadcaster::{ServerEventBroadcaster, get_event_broadcaster};
 pub use core::GuiProcessCore;
 pub use events::{ServerEvent, ServerStateInfo, ServerStatus};
-pub use health::{check_process_health, update_health_batch, wait_for_http_health};
+pub use health::{check_http_health, check_process_health, update_health_batch, wait_for_http_health};
 pub use logs::{LogManagerSink, ServerLogEntry, ServerLogManager, get_log_manager};
 pub use manager::{CurrentModelState, ProcessManager, ProcessStrategy};
 pub use shutdown::{kill_pid, shutdown_child};


### PR DESCRIPTION
## Summary

Fixes long-conversation **silent "empty response"** failures in the VS Code LLM Gateway workflow. Root cause was **not** context exhaustion — it was the proxy *masking real failures as silence* combined with **no detection or recovery for a degraded upstream llama-server** (the state a manual `gglib proxy` restart was proven to cure).

Investigation write-up and evidence: the failure signature (silent empty response, cured by a proxy restart, same chat then working at *larger* context) is only consistent with stateful upstream degradation + error masking. Verified in source across `forward.rs`, `truncation.rs`, `qwen_xml.rs`, and the process manager.

## Phases

**A — Make every failure visible**
- Surface unparsed/malformed tool-call output as visible text instead of dropping it
- Detect empty upstream streams and emit a diagnostic (with `finish_reason`)
- Surface upstream errors as visible chat content during the slot-queue wait

**E — Upstream health lifecycle (the actual fix)**
- First-byte deadline on the streaming keepalive wait (bounds pathological waits)
- Health-check the "already running" fast path before reusing a cached server
- Consecutive-failure watchdog: after 2 strikes (empty streams / timeouts) recycle the model before the next request — automating the manual restart

**B — Truncation redesign**
- Budget-gated + oldest-first: history is forwarded unchanged while within budget; only over-budget requests trim, oldest-first, stopping as soon as under budget
- `PROTECTED_TAIL_COUNT` 4 → 8; test suite rewritten around over-budget scenarios

**C — Honest token math**
- Per-model chars-per-token calibration (EWMA over real `usage.prompt_tokens`) sizes the truncation budget instead of a fixed ×4
- Advertise `/v1/models` context window with an 8% safety margin for tool-schema + template overhead

**D — Observability + MTP A/B**
- Upstream-degradation counters (empty responses, first-byte timeouts, recycles) surfaced on the proxy dashboard
- `GGLIB_DISABLE_MTP=1` global kill switch to A/B speculative decoding (dormant unless set — MTP stays fully automatic by default)

## Testing
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --exclude gglib-app --all-targets --all-features -- -D warnings` ✅
- full workspace test suite ✅ (new unit tests for truncation, `upstream_health`, `token_calibration`, MTP flag parser)
- `scripts/check_readmes.sh` + `scripts/check_boundaries.sh` ✅

## Notes
- Behaviour change: truncation no longer mutilates history pre-emptively while under budget (preserves more context on every turn).
- 13 atomic commits; no changes to DB schema or public wire contracts (the new `upstream_health` dashboard field is additive; the CLI client tolerates unknown fields).
- The MTP kill switch is the most speculative piece and is dormant by default; easy to drop if undesired.
---

## Update: confirmed root cause + fix (commits 22120ab, bbb8863, 69b3d3a)

A captured `gglib proxy` log pinned the actual trigger of the long-conversation
"empty response". It was **not** context exhaustion per request — it was a
**shared-KV-pool overflow across concurrent requests**:

- llama-server launched with the default `n_slots = 4, kv_unified = true` — the
  `-c 131072` tokens are a **single pool shared by all four slots**, not a
  per-request allocation.
- The VS Code LLM Gateway fired two chat completions in the same millisecond.
  Their combined KV occupancy (`95,797 + 35,389 = 131,186`) exceeded the pool:
  `decode: Context size has been exceeded` → llama-server aborted **both**
  tasks. Pre-Phase-A this surfaced as a silent empty response; Phase A already
  made it visible (the `⚠️ [proxy] produced no output` notice).

This also explains why "ample context remaining" was shown (true *per request*;
the **sum** overflowed) and why a proxy restart "fixed" it (cleared KV
occupancy).

**Fix (3 commits):**
1. `--parallel 1` on llama-server launch — one slot owns the full context;
   concurrent requests queue inside llama-server instead of corrupting the pool.
2. Busy-aware first-byte deadline — a request queued behind an active
   (minutes-long) prefill no longer trips the 300s deadline or feeds the
   watchdog; the deadline extends while another connection is active.
3. Idle-gated recycle — the watchdog never `stop_current()`s while a request is
   in flight on the single slot; the recycle flag is honored at the next idle
   moment.

Gates: fmt, strict clippy (`--all-targets --all-features -D warnings`), full
workspace test suite, and `check_boundaries.sh` all pass.
