### PR TITLE
feat: shared telemetry module with verbose logging flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,8 +1951,6 @@ dependencies = [
  "tauri-plugin-dialog",
  "tokio",
  "tracing",
- "tracing-appender",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,8 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ anyhow = "1.0"
 # Logging/tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = { version = "0.2" }
 
 # Async traits
 async-trait = "0.1.89"

--- a/README.md
+++ b/README.md
@@ -691,6 +691,23 @@ gglib bundles a managed Python helper for [hf_xet](https://github.com/huggingfac
 
 </details>
 
+## Troubleshooting & Debugging
+
+<details>
+<summary><strong>Verbose logging</strong></summary>
+
+Use `-v` / `--verbose` on any command to enable debug-level logging with file output:
+
+```bash
+gglib proxy -v
+```
+
+- **Log level:** `debug` (all targets). Override with `RUST_LOG=trace gglib proxy -v` for finer control.
+- **Log files:** Written to logs in development builds, or `<data_root>/logs/` in release builds (e.g., `~/.local/share/gglib/logs/`). Files rotate daily.
+- The `-v` flag is global — it works with any subcommand (`proxy`, `serve`, `question`, etc.).
+
+</details>
+
 ## Documentation
 
 **[View Full API Documentation →](https://mmogr.github.io/gglib)**

--- a/crates/gglib-cli/src/main.rs
+++ b/crates/gglib-cli/src/main.rs
@@ -12,10 +12,10 @@ use gglib_cli::{Cli, CliConfig, bootstrap, dispatch};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
+    gglib_core::telemetry::init_tracing(cli.verbose)?;
     let config = CliConfig::with_defaults()?;
     let ctx = bootstrap(config).await?;
 

--- a/crates/gglib-cli/src/parser.rs
+++ b/crates/gglib-cli/src/parser.rs
@@ -38,7 +38,7 @@ pub struct Cli {
     #[arg(long = "models-dir", global = true)]
     pub models_dir: Option<String>,
 
-    /// Enable verbose/debug output
+    /// Enable verbose logging (debug level + file output to logs/)
     #[arg(short = 'v', long = "verbose", global = true)]
     pub verbose: bool,
 

--- a/crates/gglib-core/Cargo.toml
+++ b/crates/gglib-core/Cargo.toml
@@ -19,6 +19,8 @@ bitflags = { version = "2.6", features = ["serde"] }
 uuid = { version = "1.11", features = ["serde", "v4"] }
 tokio = { workspace = true, features = ["process", "sync", "fs", "rt"] }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }
 sha2 = "0.10"
 futures-core = "0.3"
 

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod server_config;
 pub mod services;
 pub mod settings;
 pub mod sse;
+pub mod telemetry;
 pub mod utils;
 
 // Re-export commonly used types for convenience

--- a/crates/gglib-core/src/telemetry.rs
+++ b/crates/gglib-core/src/telemetry.rs
@@ -3,13 +3,13 @@
 //! Design:
 //! - A single layered subscriber (stdout + daily rotating file) is installed once via [`OnceLock`].
 //! - Calls to [`init_tracing`] are idempotent — subsequent calls return `Ok(())`.
-//! - Log directory: logs in debug builds, `data_root()/logs` in release.
+//! - Log directory: `./logs/` in debug builds, `data_root()/logs` in release.
 //! - Filter: `RUST_LOG` env var wins; otherwise `"debug"` if verbose, else `"info"`.
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[allow(unused_imports)] // only used in release builds via cfg(not(debug_assertions))
 use crate::paths::data_root;
@@ -21,19 +21,22 @@ fn resolve_log_dir() -> PathBuf {
     let dir = PathBuf::from("./logs");
 
     #[cfg(not(debug_assertions))]
-    let dir = data_root().unwrap_or_else(|_| PathBuf::from("./logs")).join("logs");
+    let dir = data_root()
+        .unwrap_or_else(|_| PathBuf::from("./logs"))
+        .join("logs");
 
     std::fs::create_dir_all(&dir).ok();
     dir
 }
 
 fn build_env_filter(verbose: bool) -> EnvFilter {
-    if let Ok(log_env) = std::env::var("RUST_LOG") {
-        EnvFilter::try_new(log_env).unwrap_or_default()
-    } else {
-        let level = if verbose { "debug" } else { "info" };
-        EnvFilter::try_new(level).unwrap_or_default()
-    }
+    std::env::var("RUST_LOG").map_or_else(
+        |_| {
+            let level = if verbose { "debug" } else { "info" };
+            EnvFilter::try_new(level).unwrap_or_default()
+        },
+        |log_env| EnvFilter::try_new(log_env).unwrap_or_default(),
+    )
 }
 
 /// Initialize the global tracing subscriber.

--- a/crates/gglib-core/src/telemetry.rs
+++ b/crates/gglib-core/src/telemetry.rs
@@ -4,7 +4,7 @@
 //! - A single layered subscriber (stdout + daily rotating file) is installed once via [`OnceLock`].
 //! - Calls to [`init_tracing`] are idempotent — subsequent calls return `Ok(())`.
 //! - Log directory: `./logs/` in debug builds, `data_root()/logs` in release.
-//! - Filter: `RUST_LOG` env var wins; otherwise `"debug"` if verbose, else `"info"`.
+//! - Filter: `RUST_LOG` env var wins; otherwise `"debug"` if verbose, else `"warn"`.
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -32,7 +32,7 @@ fn resolve_log_dir() -> PathBuf {
 fn build_env_filter(verbose: bool) -> EnvFilter {
     std::env::var("RUST_LOG").map_or_else(
         |_| {
-            let level = if verbose { "debug" } else { "info" };
+            let level = if verbose { "debug" } else { "warn" };
             EnvFilter::try_new(level).unwrap_or_default()
         },
         |log_env| EnvFilter::try_new(log_env).unwrap_or_default(),

--- a/crates/gglib-core/src/telemetry.rs
+++ b/crates/gglib-core/src/telemetry.rs
@@ -1,0 +1,75 @@
+//! Unified tracing initialization for gglib.
+//!
+//! Design:
+//! - A single layered subscriber (stdout + daily rotating file) is installed once via [`OnceLock`].
+//! - Calls to [`init_tracing`] are idempotent — subsequent calls return `Ok(())`.
+//! - Log directory: logs in debug builds, `data_root()/logs` in release.
+//! - Filter: `RUST_LOG` env var wins; otherwise `"debug"` if verbose, else `"info"`.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+
+#[allow(unused_imports)] // only used in release builds via cfg(not(debug_assertions))
+use crate::paths::data_root;
+
+static GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
+
+fn resolve_log_dir() -> PathBuf {
+    #[cfg(debug_assertions)]
+    let dir = PathBuf::from("./logs");
+
+    #[cfg(not(debug_assertions))]
+    let dir = data_root().unwrap_or_else(|_| PathBuf::from("./logs")).join("logs");
+
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+fn build_env_filter(verbose: bool) -> EnvFilter {
+    if let Ok(log_env) = std::env::var("RUST_LOG") {
+        EnvFilter::try_new(log_env).unwrap_or_default()
+    } else {
+        let level = if verbose { "debug" } else { "info" };
+        EnvFilter::try_new(level).unwrap_or_default()
+    }
+}
+
+/// Initialize the global tracing subscriber.
+///
+/// Safe to call multiple times; only the first call installs the subscriber.
+pub fn init_tracing(verbose: bool) -> anyhow::Result<()> {
+    // Idempotent: if already initialized, no-op
+    if GUARD.get().is_some() {
+        return Ok(());
+    }
+
+    let log_dir = resolve_log_dir();
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "gglib.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    let env_filter = build_env_filter(verbose);
+
+    let subscriber = Registry::default()
+        .with(env_filter)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .with_writer(std::io::stdout),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(non_blocking)
+                .with_target(false),
+        );
+
+    subscriber
+        .try_init()
+        .map_err(|e| anyhow::anyhow!("failed to set global tracer: {e}"))?;
+
+    // Ignore the Result since failure just means another thread set it concurrently
+    let _ = GUARD.set(guard);
+
+    Ok(())
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,8 +32,6 @@ tokio.workspace = true
 # Note: axum and tower-http are used via gglib-axum re-exports, no direct dependency needed
 dotenvy.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-appender = "0.2"
 open.workspace = true
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,68 +23,11 @@ use tauri::Wry;
 use tauri::menu::Menu;
 use tracing::{debug, error, info};
 
-/// Initialize tracing with file appender for persistent logs.
-///
-/// Logs are written to:
-/// - stdout (for console viewing)
-/// - {data_dir}/logs/gglib-{date}.log (daily rotation via tracing-appender)
-///
-/// Log level is controlled by RUST_LOG environment variable (default: warn).
-fn init_tracing() {
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
-
-    // Get data directory for logs
-    let log_dir = match gglib_core::paths::data_root() {
-        Ok(root) => root.join("logs"),
-        Err(e) => {
-            eprintln!("Failed to get data root for logs: {}", e);
-            // Fallback to current directory
-            std::path::PathBuf::from(".")
-        }
-    };
-
-    // Create log directory if it doesn't exist
-    if let Err(e) = std::fs::create_dir_all(&log_dir) {
-        eprintln!("Failed to create log directory: {}", e);
-    }
-
-    // Configure daily rotating file appender
-    let file_appender = tracing_appender::rolling::daily(&log_dir, "gglib");
-    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-
-    // Configure environment filter
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
-
-    // Build layered subscriber with both stdout and file output
-    tracing_subscriber::registry()
-        .with(env_filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_writer(std::io::stdout)
-                .compact(),
-        )
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_writer(non_blocking)
-                .with_ansi(false) // No ANSI colors in files
-                .compact(),
-        )
-        .try_init()
-        .ok(); // Ignore error if already initialized
-
-    // Store guard in static to prevent early drop
-    // Note: This leaks memory but ensures logs persist for app lifetime
-    std::mem::forget(_guard);
-}
-
 fn main() {
     let _ = dotenv();
 
-    // Initialize tracing/logging for the Tauri GUI with file appender
-    // Priority: RUST_LOG env var > default (warn)
-    init_tracing();
+    // Initialize shared tracing (idempotent; safe to call from multiple entry points)
+    let _ = gglib_core::telemetry::init_tracing(false);
 
     info!("Tauri application starting");
 


### PR DESCRIPTION
## Summary

Extracted tracing init from Tauri GUI into a shared `gglib_core::telemetry` module; wired the existing `-v`/`--verbose` CLI flag to control log level and file output.

## Changes

- **feat(core): add shared telemetry module** — New `gglib_core::telemetry` module with idempotent `init_tracing(verbose: bool)` using `OnceLock`, layered subscriber (stdout + daily rotating file), and `RUST_LOG` env var support.
- **feat(cli): wire verbose flag to shared telemetry** — Replaced bare `tracing_subscriber::fmt::init()` in CLI main.rs with shared module call; updated `-v`/`--verbose` help text.
- **refactor(tauri): migrate to shared telemetry module** — Deleted ~60 lines of inline tracing init from Tauri main.rs; removed now-unused `tracing-subscriber` and `tracing-appender` deps from src-tauri/Cargo.toml.
- **docs: add verbose logging troubleshooting section** — Added collapsible "Troubleshooting & Debugging" section to README.md explaining `-v` flag behavior, log levels, and file locations.

## Behavior

- **`-v` / `--verbose`** enables debug-level logging + daily rotating file output
- **`RUST_LOG` env var** takes precedence over the verbose flag for fine-grained control
- **Debug builds** write logs to `./logs/`; **release builds** write to `<data_root>/logs/` (e.g., `~/.local/share/gglib/logs/`)
- Calls to `init_tracing()` are idempotent — safe to call from multiple entry points (CLI, Tauri)

## Quality Gates

- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo test --workspace` (all tests pass)
- ✅ `cargo build --release`