### PR TITLE
refactor: extract duplicated ServerEvents and helper mappings (Issue #460)

### DIFF
--- a/crates/gglib-app-services/src/helpers.rs
+++ b/crates/gglib-app-services/src/helpers.rs
@@ -1,0 +1,27 @@
+//! Shared helper functions for model resolution and process handle lookup.
+
+use gglib_core::domain::Model;
+use gglib_core::ports::{ProcessHandle, ProcessRunner};
+use gglib_core::services::ModelService;
+
+use crate::error::GuiError;
+
+/// Resolve model by ID, returning GUI error if not found.
+pub async fn resolve_model(models: &ModelService, id: i64) -> Result<Model, GuiError> {
+    models
+        .get_by_id(id)
+        .await
+        .map_err(|e| GuiError::Internal(format!("Failed to query model: {e}")))?
+        .ok_or_else(|| GuiError::NotFound {
+            entity: "model",
+            id: id.to_string(),
+        })
+}
+
+/// Find a running process handle for a model.
+pub async fn find_handle(runner: &dyn ProcessRunner, model_id: i64) -> Option<ProcessHandle> {
+    match runner.list_running().await {
+        Ok(handles) => handles.into_iter().find(|h| h.model_id == model_id),
+        Err(_) => None,
+    }
+}

--- a/crates/gglib-app-services/src/helpers.rs
+++ b/crates/gglib-app-services/src/helpers.rs
@@ -19,7 +19,10 @@ pub(crate) async fn resolve_model(models: &ModelService, id: i64) -> Result<Mode
 }
 
 /// Find a running process handle for a model.
-pub(crate) async fn find_handle(runner: &dyn ProcessRunner, model_id: i64) -> Option<ProcessHandle> {
+pub(crate) async fn find_handle(
+    runner: &dyn ProcessRunner,
+    model_id: i64,
+) -> Option<ProcessHandle> {
     match runner.list_running().await {
         Ok(handles) => handles.into_iter().find(|h| h.model_id == model_id),
         Err(_) => None,

--- a/crates/gglib-app-services/src/helpers.rs
+++ b/crates/gglib-app-services/src/helpers.rs
@@ -7,7 +7,7 @@ use gglib_core::services::ModelService;
 use crate::error::GuiError;
 
 /// Resolve model by ID, returning GUI error if not found.
-pub async fn resolve_model(models: &ModelService, id: i64) -> Result<Model, GuiError> {
+pub(crate) async fn resolve_model(models: &ModelService, id: i64) -> Result<Model, GuiError> {
     models
         .get_by_id(id)
         .await
@@ -19,7 +19,7 @@ pub async fn resolve_model(models: &ModelService, id: i64) -> Result<Model, GuiE
 }
 
 /// Find a running process handle for a model.
-pub async fn find_handle(runner: &dyn ProcessRunner, model_id: i64) -> Option<ProcessHandle> {
+pub(crate) async fn find_handle(runner: &dyn ProcessRunner, model_id: i64) -> Option<ProcessHandle> {
     match runner.list_running().await {
         Ok(handles) => handles.into_iter().find(|h| h.model_id == model_id),
         Err(_) => None,

--- a/crates/gglib-app-services/src/lib.rs
+++ b/crates/gglib-app-services/src/lib.rs
@@ -15,6 +15,7 @@ use tokio_test as _;
 mod test_support;
 
 mod error;
+mod helpers;
 
 pub mod benchmark;
 pub mod council_approvals;

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -3,7 +3,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use gglib_core::domain::Model;
 use gglib_core::ports::{GgufParserPort, ProcessRunner};
 use gglib_core::services::AppCore;
 use gglib_core::{
@@ -34,20 +33,6 @@ impl ModelOps {
         Self { deps }
     }
 
-    /// Resolve model by ID, returning GUI error if not found.
-    async fn resolve_model(&self, id: i64) -> Result<Model, GuiError> {
-        self.deps
-            .core
-            .models()
-            .get_by_id(id)
-            .await
-            .map_err(|e| GuiError::Internal(format!("Failed to query model: {e}")))?
-            .ok_or_else(|| GuiError::NotFound {
-                entity: "model",
-                id: id.to_string(),
-            })
-    }
-
     /// Check if a model is currently being served.
     async fn get_server_status(&self, model_id: i64) -> (bool, Option<u16>) {
         match self.deps.runner.list_running().await {
@@ -60,14 +45,6 @@ impl ModelOps {
                 (false, None)
             }
             Err(_) => (false, None),
-        }
-    }
-
-    /// Find a running process handle for a model.
-    async fn find_handle(&self, model_id: i64) -> Option<gglib_core::ports::ProcessHandle> {
-        match self.deps.runner.list_running().await {
-            Ok(handles) => handles.into_iter().find(|h| h.model_id == model_id),
-            Err(_) => None,
         }
     }
 
@@ -117,7 +94,7 @@ impl ModelOps {
 
     /// Get a specific model by ID.
     pub async fn get(&self, id: i64) -> Result<GuiModel, GuiError> {
-        let model = self.resolve_model(id).await?;
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
         let (is_serving, port) = self.get_server_status(id).await;
         Ok(GuiModel::from_model(model, is_serving, port))
     }
@@ -129,7 +106,7 @@ impl ModelOps {
     /// provenance.  This is the shared data source for the CLI
     /// `model inspect` command and the `GET /api/models/:id/detail` route.
     pub async fn get_detail(&self, id: i64) -> Result<ModelDetailDto, GuiError> {
-        let model = self.resolve_model(id).await?;
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
         let (is_serving, port) = self.get_server_status(id).await;
         Ok(ModelDetailDto::from_model(model, is_serving, port))
     }
@@ -162,7 +139,7 @@ impl ModelOps {
 
     /// Update a model in the database.
     pub async fn update(&self, id: i64, request: UpdateModelRequest) -> Result<GuiModel, GuiError> {
-        let mut model = self.resolve_model(id).await?;
+        let mut model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
 
         if let Some(name) = request.name {
             model.name = name;
@@ -194,9 +171,9 @@ impl ModelOps {
 
     /// Remove a model from the database.
     pub async fn remove(&self, id: i64, request: RemoveModelRequest) -> Result<String, GuiError> {
-        let model = self.resolve_model(id).await?;
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
 
-        if let Some(handle) = self.find_handle(id).await {
+        if let Some(handle) = crate::helpers::find_handle(&*self.deps.runner, id).await {
             if !request.force {
                 return Err(GuiError::Conflict(format!(
                     "Model is currently serving on port {}. Stop the server first or use force=true",
@@ -297,7 +274,7 @@ impl ModelOps {
         id: i64,
         request: SetCapabilitiesRequest,
     ) -> Result<GuiModel, GuiError> {
-        let mut model = self.resolve_model(id).await?;
+        let mut model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
 
         let mut caps = model.capabilities;
 

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -143,28 +143,6 @@ impl ServerOps {
         }
     }
 
-    /// Resolve model by ID, returning error if not found.
-    async fn resolve_model(&self, id: i64) -> Result<Model, GuiError> {
-        self.deps
-            .core
-            .models()
-            .get_by_id(id)
-            .await
-            .map_err(|e| GuiError::Internal(format!("Failed to query model: {e}")))?
-            .ok_or_else(|| GuiError::NotFound {
-                entity: "model",
-                id: id.to_string(),
-            })
-    }
-
-    /// Find a running process handle for a model.
-    async fn find_handle(&self, model_id: i64) -> Option<ProcessHandle> {
-        match self.deps.runner.list_running().await {
-            Ok(handles) => handles.into_iter().find(|h| h.model_id == model_id),
-            Err(_) => None,
-        }
-    }
-
     /// Build a [`ServerConfig`] from a model and GUI request.
     ///
     /// Delegates to [`build_server_config`] so that this path generates
@@ -210,14 +188,14 @@ impl ServerOps {
     ) -> Result<StartServerResponse, GuiError> {
         debug!(model_id = %id, "Starting server for model");
 
-        if let Some(handle) = self.find_handle(id).await {
+        if let Some(handle) = crate::helpers::find_handle(&*self.deps.runner, id).await {
             return Ok(StartServerResponse {
                 port: handle.port,
                 message: format!("Server already running on port {}", handle.port),
             });
         }
 
-        let model = self.resolve_model(id).await?;
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
 
         if !model.file_path.exists() {
             return Err(GuiError::ValidationFailed(format!(
@@ -390,8 +368,7 @@ impl ServerOps {
     pub async fn stop(&self, id: i64) -> Result<String, GuiError> {
         debug!(model_id = %id, "Stopping server");
 
-        let handle = self
-            .find_handle(id)
+        let handle = crate::helpers::find_handle(&*self.deps.runner, id)
             .await
             .ok_or_else(|| GuiError::NotFound {
                 entity: "server",
@@ -399,7 +376,7 @@ impl ServerOps {
             })?;
 
         // Get model info for event emission
-        let model = self.resolve_model(id).await?;
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
 
         // Emit stopping event
         let summary = ServerSummary {
@@ -546,7 +523,7 @@ impl ServerOps {
         use gglib_core::domain::ModelCapabilities;
         use gglib_core::ports::{ModelSource, ToolSupportDetectionInput};
 
-        let model = self.resolve_model(model_id).await?;
+        let model = crate::helpers::resolve_model(self.deps.core.models(), model_id).await?;
 
         // Primary boolean comes from the authoritative DB capabilities bitflag.
         let supports_tool_calls = model

--- a/crates/gglib-axum/src/sse.rs
+++ b/crates/gglib-axum/src/sse.rs
@@ -109,8 +109,7 @@ impl AxumServerEvents {
 
 impl ServerEvents for AxumServerEvents {
     fn started(&self, server: &ServerSummary) {
-        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
-        let event = AppEvent::server_started(model_id, &server.model_name, server.port);
+        let event = AppEvent::from_server_started(server);
         self.broadcaster.emit(event);
     }
 
@@ -125,33 +124,17 @@ impl ServerEvents for AxumServerEvents {
     }
 
     fn stopped(&self, server: &ServerSummary) {
-        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
-        let event = AppEvent::server_stopped(model_id, &server.model_name);
+        let event = AppEvent::from_server_stopped(server);
         self.broadcaster.emit(event);
     }
 
     fn snapshot(&self, servers: &[ServerSummary]) {
-        let entries: Vec<gglib_core::events::ServerSnapshotEntry> = servers
-            .iter()
-            .map(|s| gglib_core::events::ServerSnapshotEntry {
-                model_id: s.model_id.parse::<i64>().unwrap_or(0),
-                model_name: s.model_name.clone(),
-                port: s.port,
-                started_at: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-                healthy: s.healthy.unwrap_or(false),
-            })
-            .collect();
-
-        let event = AppEvent::server_snapshot(entries);
+        let event = AppEvent::from_server_snapshot(servers);
         self.broadcaster.emit(event);
     }
 
     fn error(&self, server: &ServerSummary, error: &str) {
-        let model_id = server.model_id.parse::<i64>().ok();
-        let event = AppEvent::server_error(model_id, &server.model_name, error);
+        let event = AppEvent::from_server_error(server, error);
         self.broadcaster.emit(event);
     }
 }

--- a/crates/gglib-core/src/events/server.rs
+++ b/crates/gglib-core/src/events/server.rs
@@ -158,30 +158,19 @@ impl AppEvent {
     /// Build a `ServerStarted` event from a `ServerSummary`.
     pub fn from_server_started(server: &ServerSummary) -> Self {
         let model_id = server.model_id.parse::<i64>().unwrap_or(0);
-        Self::ServerStarted {
-            model_id,
-            model_name: server.model_name.clone(),
-            port: server.port,
-        }
+        Self::server_started(model_id, &server.model_name, server.port)
     }
 
     /// Build a `ServerStopped` event from a `ServerSummary`.
     pub fn from_server_stopped(server: &ServerSummary) -> Self {
         let model_id = server.model_id.parse::<i64>().unwrap_or(0);
-        Self::ServerStopped {
-            model_id,
-            model_name: server.model_name.clone(),
-        }
+        Self::server_stopped(model_id, &server.model_name)
     }
 
     /// Build a `ServerError` event from a `ServerSummary`.
     pub fn from_server_error(server: &ServerSummary, error: &str) -> Self {
         let model_id = server.model_id.parse::<i64>().ok();
-        Self::ServerError {
-            model_id,
-            model_name: server.model_name.clone(),
-            error: error.to_string(),
-        }
+        Self::server_error(model_id, &server.model_name, error)
     }
 
     /// Build a `ServerSnapshot` event from a slice of `ServerSummary`.
@@ -200,6 +189,6 @@ impl AppEvent {
                 healthy: s.healthy.unwrap_or(false),
             })
             .collect();
-        Self::ServerSnapshot { servers: entries }
+        Self::server_snapshot(entries)
     }
 }

--- a/crates/gglib-core/src/events/server.rs
+++ b/crates/gglib-core/src/events/server.rs
@@ -212,7 +212,11 @@ mod tests {
         let server = make_server("srv-1", "42", "test-model", 8080);
         let event = AppEvent::from_server_started(&server);
         match event {
-            AppEvent::ServerStarted { model_id, model_name, port } => {
+            AppEvent::ServerStarted {
+                model_id,
+                model_name,
+                port,
+            } => {
                 assert_eq!(model_id, 42);
                 assert_eq!(model_name, "test-model");
                 assert_eq!(port, 8080);
@@ -226,7 +230,10 @@ mod tests {
         let server = make_server("srv-1", "42", "test-model", 8080);
         let event = AppEvent::from_server_stopped(&server);
         match event {
-            AppEvent::ServerStopped { model_id, model_name } => {
+            AppEvent::ServerStopped {
+                model_id,
+                model_name,
+            } => {
                 assert_eq!(model_id, 42);
                 assert_eq!(model_name, "test-model");
             }
@@ -239,7 +246,11 @@ mod tests {
         let server = make_server("srv-1", "42", "test-model", 8080);
         let event = AppEvent::from_server_error(&server, "something failed");
         match event {
-            AppEvent::ServerError { model_id, model_name, error } => {
+            AppEvent::ServerError {
+                model_id,
+                model_name,
+                error,
+            } => {
                 assert_eq!(model_id, Some(42));
                 assert_eq!(model_name, "test-model");
                 assert_eq!(error, "something failed");
@@ -253,7 +264,11 @@ mod tests {
         let server = make_server("srv-1", "abc", "test-model", 8080);
         let event = AppEvent::from_server_error(&server, "something failed");
         match event {
-            AppEvent::ServerError { model_id, model_name, error } => {
+            AppEvent::ServerError {
+                model_id,
+                model_name,
+                error,
+            } => {
                 assert_eq!(model_id, None);
                 assert_eq!(model_name, "test-model");
                 assert_eq!(error, "something failed");

--- a/crates/gglib-core/src/events/server.rs
+++ b/crates/gglib-core/src/events/server.rs
@@ -154,4 +154,52 @@ impl AppEvent {
     pub const fn server_snapshot(servers: Vec<ServerSnapshotEntry>) -> Self {
         Self::ServerSnapshot { servers }
     }
+
+    /// Build a `ServerStarted` event from a `ServerSummary`.
+    pub fn from_server_started(server: &ServerSummary) -> Self {
+        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
+        Self::ServerStarted {
+            model_id,
+            model_name: server.model_name.clone(),
+            port: server.port,
+        }
+    }
+
+    /// Build a `ServerStopped` event from a `ServerSummary`.
+    pub fn from_server_stopped(server: &ServerSummary) -> Self {
+        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
+        Self::ServerStopped {
+            model_id,
+            model_name: server.model_name.clone(),
+        }
+    }
+
+    /// Build a `ServerError` event from a `ServerSummary`.
+    pub fn from_server_error(server: &ServerSummary, error: &str) -> Self {
+        let model_id = server.model_id.parse::<i64>().ok();
+        Self::ServerError {
+            model_id,
+            model_name: server.model_name.clone(),
+            error: error.to_string(),
+        }
+    }
+
+    /// Build a `ServerSnapshot` event from a slice of `ServerSummary`.
+    pub fn from_server_snapshot(servers: &[ServerSummary]) -> Self {
+        let started_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let entries: Vec<ServerSnapshotEntry> = servers
+            .iter()
+            .map(|s| ServerSnapshotEntry {
+                model_id: s.model_id.parse::<i64>().unwrap_or(0),
+                model_name: s.model_name.clone(),
+                port: s.port,
+                started_at,
+                healthy: s.healthy.unwrap_or(false),
+            })
+            .collect();
+        Self::ServerSnapshot { servers: entries }
+    }
 }

--- a/crates/gglib-core/src/events/server.rs
+++ b/crates/gglib-core/src/events/server.rs
@@ -192,3 +192,92 @@ impl AppEvent {
         Self::server_snapshot(entries)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_server(id: &str, model_id: &str, name: &str, port: u16) -> ServerSummary {
+        ServerSummary {
+            id: id.to_string(),
+            model_id: model_id.to_string(),
+            model_name: name.to_string(),
+            port,
+            healthy: Some(true),
+        }
+    }
+
+    #[test]
+    fn test_from_server_started() {
+        let server = make_server("srv-1", "42", "test-model", 8080);
+        let event = AppEvent::from_server_started(&server);
+        match event {
+            AppEvent::ServerStarted { model_id, model_name, port } => {
+                assert_eq!(model_id, 42);
+                assert_eq!(model_name, "test-model");
+                assert_eq!(port, 8080);
+            }
+            _ => panic!("expected ServerStarted"),
+        }
+    }
+
+    #[test]
+    fn test_from_server_stopped() {
+        let server = make_server("srv-1", "42", "test-model", 8080);
+        let event = AppEvent::from_server_stopped(&server);
+        match event {
+            AppEvent::ServerStopped { model_id, model_name } => {
+                assert_eq!(model_id, 42);
+                assert_eq!(model_name, "test-model");
+            }
+            _ => panic!("expected ServerStopped"),
+        }
+    }
+
+    #[test]
+    fn test_from_server_error() {
+        let server = make_server("srv-1", "42", "test-model", 8080);
+        let event = AppEvent::from_server_error(&server, "something failed");
+        match event {
+            AppEvent::ServerError { model_id, model_name, error } => {
+                assert_eq!(model_id, Some(42));
+                assert_eq!(model_name, "test-model");
+                assert_eq!(error, "something failed");
+            }
+            _ => panic!("expected ServerError"),
+        }
+    }
+
+    #[test]
+    fn test_from_server_error_invalid_model_id() {
+        let server = make_server("srv-1", "abc", "test-model", 8080);
+        let event = AppEvent::from_server_error(&server, "something failed");
+        match event {
+            AppEvent::ServerError { model_id, model_name, error } => {
+                assert_eq!(model_id, None);
+                assert_eq!(model_name, "test-model");
+                assert_eq!(error, "something failed");
+            }
+            _ => panic!("expected ServerError"),
+        }
+    }
+
+    #[test]
+    fn test_from_server_snapshot() {
+        let servers = vec![
+            make_server("srv-a", "1", "model-a", 9001),
+            make_server("srv-b", "2", "model-b", 9002),
+        ];
+        let event = AppEvent::from_server_snapshot(&servers);
+        match event {
+            AppEvent::ServerSnapshot { servers: entries } => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].model_id, 1);
+                assert_eq!(entries[0].port, 9001);
+                assert_eq!(entries[1].model_id, 2);
+                assert_eq!(entries[1].port, 9002);
+            }
+            _ => panic!("expected ServerSnapshot"),
+        }
+    }
+}

--- a/crates/gglib-tauri/src/server_events.rs
+++ b/crates/gglib-tauri/src/server_events.rs
@@ -25,12 +25,9 @@ impl TauriServerEvents {
     }
 }
 
-// NOTE: This adapter mirrors the Axum ServerEvents implementation (gglib-axum/src/sse.rs).
-// All server lifecycle events for Tauri MUST flow through this port implementation.
 impl ServerEvents for TauriServerEvents {
     fn started(&self, server: &ServerSummary) {
-        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
-        let event = AppEvent::server_started(model_id, &server.model_name, server.port);
+        let event = AppEvent::from_server_started(server);
         emit_or_log(&self.app, event.event_name(), &event);
     }
 
@@ -44,35 +41,17 @@ impl ServerEvents for TauriServerEvents {
     }
 
     fn stopped(&self, server: &ServerSummary) {
-        let model_id = server.model_id.parse::<i64>().unwrap_or(0);
-        let event = AppEvent::server_stopped(model_id, &server.model_name);
+        let event = AppEvent::from_server_stopped(server);
         emit_or_log(&self.app, event.event_name(), &event);
     }
 
     fn snapshot(&self, servers: &[ServerSummary]) {
-        let started_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        let entries: Vec<gglib_core::events::ServerSnapshotEntry> = servers
-            .iter()
-            .map(|s| gglib_core::events::ServerSnapshotEntry {
-                model_id: s.model_id.parse::<i64>().unwrap_or(0),
-                model_name: s.model_name.clone(),
-                port: s.port,
-                started_at,
-                healthy: s.healthy.unwrap_or(false),
-            })
-            .collect();
-
-        let event = AppEvent::server_snapshot(entries);
+        let event = AppEvent::from_server_snapshot(servers);
         emit_or_log(&self.app, event.event_name(), &event);
     }
 
     fn error(&self, server: &ServerSummary, error: &str) {
-        let model_id = server.model_id.parse::<i64>().ok();
-        let event = AppEvent::server_error(model_id, &server.model_name, error);
+        let event = AppEvent::from_server_error(server, error);
         emit_or_log(&self.app, event.event_name(), &event);
     }
 }


### PR DESCRIPTION
## Issue #460 — Rust DRY Extractions

Two pure mechanical extractions with no behavior change.

### Part 1 — ServerEvents data-mapping duplication
- Added `AppEvent::from_server_started`, `from_server_stopped`, `from_server_error`, `from_server_snapshot` associated methods in `gglib-core/src/events/server.rs`
- Both `AxumServerEvents` and `TauriServerEvents` now delegate to these shared helpers
- Removed stale "mirrors Axum" comment from Tauri adapter

### Part 2 — resolve_model / find_handle duplication
- Created `gglib-app-services/src/helpers.rs` with `resolve_model` and `find_handle`
- Both `ModelOps` and `ServerOps` delegate to shared helpers
- Narrow dependencies: `&ModelService` and `&dyn ProcessRunner` (not full `Arc<AppCore>`)

### Verification
- All existing tests pass
- No public API changes
- CLI crate unaffected (no ServerEvents impl)

Fixes #460