### PR TITLE
fix: replace unbounded post-SIGKILL wait with bounded timeout (#591)

### DIFF
--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -199,6 +199,6 @@ runner.stop(&handle).await?;
 ## Design Decisions
 
 1. **Process Isolation** — Each llama-server runs as a separate process
-2. **Graceful Shutdown** — Sends SIGTERM before SIGKILL with timeout
+2. **Graceful Shutdown** — Sends SIGTERM before SIGKILL with bounded timeout (guards against D-state hang)
 3. **Port Management** — Auto-allocates ports to avoid conflicts
 4. **Proxy Architecture** — Single proxy endpoint routes to multiple backends

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -173,6 +173,14 @@ impl ProcessManager {
     /// # Errors
     ///
     /// Returns `ModelRuntimeError` if the model cannot be started.
+    ///
+    /// # Known limitations
+    ///
+    /// If a previous model's shutdown timed out (D-state process), the subsequent spawn
+    /// may fail with a port-in-use or CUDA OOM error. There is no automatic retry — the
+    /// caller receives the error and must retry manually. GPU memory availability is not
+    /// checked before spawn; failures surface as generic CUDA OOM rather than an
+    /// actionable "previous process may still hold resources" message.
     pub async fn ensure_model_running(
         &self,
         model_name: &str,

--- a/crates/gglib-runtime/src/process/shutdown/README.md
+++ b/crates/gglib-runtime/src/process/shutdown/README.md
@@ -5,8 +5,11 @@
 Graceful process shutdown for llama-server instances.
 
 Provides two shutdown strategies:
-- `shutdown_child`: For running processes with a `Child` handle (includes reaping)
+- `shutdown_child`: For running processes with a `Child` handle (SIGTERM → SIGKILL escalation with bounded timeout)
 - `kill_pid`: For orphaned processes from crashes (no reaping, PID-only)
+
+The bounded post-SIGKILL wait guards against D-state hangs (e.g., blocked CUDA driver ioctls).
+If the timeout expires, cleanup proceeds and Tokio's background reaper eventually collects the zombie.
 
 <!-- module-docs:end -->
 

--- a/crates/gglib-runtime/src/process/shutdown/child.rs
+++ b/crates/gglib-runtime/src/process/shutdown/child.rs
@@ -14,8 +14,6 @@ use nix::sys::signal::{self, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
 
-// TODO(#591): wired in Step 2 — remove #[allow(dead_code)] then
-#[allow(dead_code)]
 const SIGKILL_REAP_TIMEOUT_SECS: u64 = 2;
 
 /// Wait for a future with a bounded timeout, logging an error on expiry.
@@ -28,8 +26,6 @@ const SIGKILL_REAP_TIMEOUT_SECS: u64 = 2;
 /// is dropped by the caller. Tokio spawns a background reaper task to await
 /// the zombie process asynchronously — the reap is not lost, just detached
 /// from the blocking shutdown path.
-// TODO(#591): wired in Step 2 — remove #[allow(dead_code)] then
-#[allow(dead_code)]
 async fn bounded_wait<F>(fut: F, secs: u64, pid: Option<u32>) -> io::Result<ExitStatus>
 where
     F: Future<Output = io::Result<ExitStatus>>,
@@ -112,15 +108,16 @@ async fn shutdown_unix(child: &mut Child) -> io::Result<ExitStatus> {
     // Phase 2: SIGKILL (via Child::kill which uses SIGKILL on Unix)
     child.kill().await?;
 
-    // Phase 3: Wait for reaping (should be fast after SIGKILL)
-    child.wait().await
+    // Phase 3: Bounded wait for reaping (guards against D-state hang)
+    bounded_wait(child.wait(), SIGKILL_REAP_TIMEOUT_SECS, Some(pid)).await
 }
 
 #[cfg(not(unix))]
 async fn shutdown_windows(child: &mut Child) -> io::Result<ExitStatus> {
     // Windows has no SIGTERM equivalent - terminate immediately
+    let pid = child.id();
     child.kill().await?;
-    child.wait().await
+    bounded_wait(child.wait(), SIGKILL_REAP_TIMEOUT_SECS, pid).await
 }
 
 #[cfg(test)]

--- a/crates/gglib-runtime/src/process/shutdown/child.rs
+++ b/crates/gglib-runtime/src/process/shutdown/child.rs
@@ -171,4 +171,21 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("pid=999"), "error message should contain PID: {msg}");
     }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn shutdown_escalates_to_sigkill_when_sigterm_is_ignored() {
+        // Spawn a single process that ignores SIGTERM — forces escalation to SIGKILL.
+        // Uses python3 to avoid orphaning a subprocess (which bash -c 'sleep' would do).
+        let child = Command::new("python3")
+            .arg("-c")
+            .arg("import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)")
+            .spawn()
+            .expect("failed to spawn python3");
+
+        let result = shutdown_child(child).await;
+
+        // Should succeed: SIGTERM is ignored, so escalation sends SIGKILL which cannot be trapped.
+        assert!(result.is_ok(), "shutdown should succeed via SIGKILL escalation: {result:?}");
+    }
 }

--- a/crates/gglib-runtime/src/process/shutdown/child.rs
+++ b/crates/gglib-runtime/src/process/shutdown/child.rs
@@ -1,8 +1,8 @@
 //! Graceful shutdown logic for `tokio::process::Child` with SIGTERM → SIGKILL escalation.
 
+use std::future::Future;
 use std::io;
 use std::process::ExitStatus;
-use std::future::Future;
 
 use tokio::process::Child;
 
@@ -165,7 +165,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn bounded_wait_times_out_on_pending_future() {
         use std::future::pending;
-        use tokio::time::{advance, Duration as TokioDuration};
+        use tokio::time::{Duration as TokioDuration, advance};
 
         // Advance time past the 2-second timeout
         advance(TokioDuration::from_secs(3)).await;
@@ -177,7 +177,10 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
         let msg = err.to_string();
-        assert!(msg.contains("pid=999"), "error message should contain PID: {msg}");
+        assert!(
+            msg.contains("pid=999"),
+            "error message should contain PID: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -194,6 +197,9 @@ mod tests {
         let result = shutdown_child(child).await;
 
         // Should succeed: SIGTERM is ignored, so escalation sends SIGKILL which cannot be trapped.
-        assert!(result.is_ok(), "shutdown should succeed via SIGKILL escalation: {result:?}");
+        assert!(
+            result.is_ok(),
+            "shutdown should succeed via SIGKILL escalation: {result:?}"
+        );
     }
 }

--- a/crates/gglib-runtime/src/process/shutdown/child.rs
+++ b/crates/gglib-runtime/src/process/shutdown/child.rs
@@ -52,16 +52,24 @@ where
 /// Gracefully shut down a child process with SIGTERM, escalating to SIGKILL if needed.
 ///
 /// # Strategy
-/// 1. Send SIGTERM and wait up to 5 seconds for graceful exit
+/// 1. Send SIGTERM and wait for graceful exit (2s on Linux, 5s on other Unix)
 /// 2. If still running, send SIGKILL
-/// 3. Wait for process reaping (required to avoid zombies)
+/// 3. Wait for process reaping with a bounded timeout (guards against D-state hang)
 ///
 /// # Platform behavior
 /// - Unix: Uses nix crate for SIGTERM, then SIGKILL via `.kill()`
 /// - Windows: Immediately calls `.kill()` (no graceful shutdown available)
 ///
+/// # Residual risk
+/// If the process enters D-state (uninterruptible sleep) after SIGKILL — e.g., due to
+/// a blocked CUDA driver ioctl — the bounded wait will expire and this function returns
+/// an error. The caller proceeds with cleanup; resources (port, GPU memory) may remain
+/// held by the stuck process. Tokio's `Child` drop handler spawns a background reaper
+/// task, so the zombie is eventually collected asynchronously.
+///
 /// # Returns
 /// - `Ok(ExitStatus)` once the process has been reaped
+/// - `Err` with `io::ErrorKind::TimedOut` if the post-SIGKILL wait exceeds the bound
 /// - `Err` if process operations fail
 pub async fn shutdown_child(mut child: Child) -> io::Result<ExitStatus> {
     #[cfg(unix)]

--- a/crates/gglib-runtime/src/process/shutdown/child.rs
+++ b/crates/gglib-runtime/src/process/shutdown/child.rs
@@ -2,18 +2,56 @@
 
 use std::io;
 use std::process::ExitStatus;
+use std::future::Future;
 
 use tokio::process::Child;
 
-#[cfg(unix)]
 use std::time::Duration;
-#[cfg(unix)]
 use tokio::time::timeout;
 
 #[cfg(unix)]
 use nix::sys::signal::{self, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
+
+// TODO(#591): wired in Step 2 — remove #[allow(dead_code)] then
+#[allow(dead_code)]
+const SIGKILL_REAP_TIMEOUT_SECS: u64 = 2;
+
+/// Wait for a future with a bounded timeout, logging an error on expiry.
+///
+/// Used after SIGKILL to reap the child process. If the process is stuck in
+/// D-state (e.g., CUDA driver ioctl blocked in kernel), this prevents an
+/// indefinite hang by returning after `secs` with a TimedOut error.
+///
+/// Note: when this function returns due to timeout, the Tokio `Child` struct
+/// is dropped by the caller. Tokio spawns a background reaper task to await
+/// the zombie process asynchronously — the reap is not lost, just detached
+/// from the blocking shutdown path.
+// TODO(#591): wired in Step 2 — remove #[allow(dead_code)] then
+#[allow(dead_code)]
+async fn bounded_wait<F>(fut: F, secs: u64, pid: Option<u32>) -> io::Result<ExitStatus>
+where
+    F: Future<Output = io::Result<ExitStatus>>,
+{
+    match timeout(Duration::from_secs(secs), fut).await {
+        Ok(result) => result,
+        Err(_) => {
+            let pid_str = pid.map_or("unknown".to_string(), |p| p.to_string());
+            tracing::error!(
+                timeout_secs = secs,
+                pid = %pid_str,
+                "Process did not exit within bounded wait after SIGKILL; \
+                 it may be stuck in D-state (e.g., blocked CUDA driver ioctl). \
+                 Resources (port, GPU memory) may remain held. Proceeding with cleanup."
+            );
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("child did not exit within bounded wait after SIGKILL: pid={pid_str}"),
+            ))
+        }
+    }
+}
 
 /// Gracefully shut down a child process with SIGTERM, escalating to SIGKILL if needed.
 ///
@@ -117,5 +155,23 @@ mod tests {
 
         let result = shutdown_child(child).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn bounded_wait_times_out_on_pending_future() {
+        use std::future::pending;
+        use tokio::time::{advance, Duration as TokioDuration};
+
+        // Advance time past the 2-second timeout
+        advance(TokioDuration::from_secs(3)).await;
+
+        let result = bounded_wait(pending::<io::Result<ExitStatus>>(), 2, Some(999)).await;
+
+        // Should return TimedOut error
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        let msg = err.to_string();
+        assert!(msg.contains("pid=999"), "error message should contain PID: {msg}");
     }
 }


### PR DESCRIPTION
## Problem

`shutdown_unix()` sent SIGKILL to a stuck model process, then called `child.wait()` without a timeout. If the process entered D-state (e.g., blocked CUDA driver ioctl), `wait()` blocked indefinitely — hanging the entire shutdown path.

## Solution

Extracted a generic `bounded_wait` helper that wraps any `Future<Output = io::Result<ExitStatus>>` in `tokio::time::timeout`. Both `shutdown_unix` (Phase 3 post-SIGKILL reap) and `shutdown_windows` (post-kill wait) now use this with a 2-second bound.

On timeout: logs `tracing::error!` with PID context, returns `io::ErrorKind::TimedOut`. Callers already discard the result (`let _ = ...`) and have already removed the process from their tracking map, so cleanup proceeds regardless.

## Residual risk

If a D-state process holds resources (port, GPU memory) after timeout, subsequent spawn may fail with port-in-use or CUDA OOM. No automatic retry exists — caller must retry manually. Tokio's `Child` drop handler spawns a background reaper task for eventual zombie collection.

## Testing

- Time-travel test (`start_paused`) proves timeout branch fires deterministically
- SIGKILL escalation integration test (python3 ignoring SIGTERM) validates full sequence
- Full workspace test suite: 104 tests, 0 failures
- Clippy clean, fmt clean

## Files changed

- child.rs — bounded_wait helper, refactored shutdown_unix/windows, tests
- manager.rs — doc comment on ensure_model_running
- README.md — bounded wait description
- README.md — Graceful Shutdown section