### PR TITLE
KV cache: per-model slot namespacing + streaming retry re-enters slot gate

### DIFF
--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -64,7 +64,7 @@ pub use paths::{
     DirectoryCreationStrategy, ModelsDirResolution, ModelsDirSource, PathError, data_root,
     database_path, default_models_dir, ensure_directory, env_file_path, is_prebuilt_binary,
     llama_config_path, llama_cpp_dir, llama_server_path, persist_env_value, persist_models_dir,
-    resolve_models_dir, resource_root, verify_writable,
+    resolve_models_dir, resource_root, slot_model_dir, verify_writable,
 };
 
 // Silence unused dev-dependency warnings until we add mock-based tests

--- a/crates/gglib-core/src/paths/mod.rs
+++ b/crates/gglib-core/src/paths/mod.rs
@@ -8,6 +8,7 @@ mod models;
 mod pids;
 mod platform;
 mod resolver;
+mod slots;
 
 #[cfg(test)]
 mod test_utils;
@@ -44,3 +45,6 @@ pub use config::{env_file_path, persist_env_value, persist_models_dir};
 
 // Pure resolver for testing and CLI
 pub use resolver::ResolvedPaths;
+
+// Slot cache paths
+pub use slots::slot_model_dir;

--- a/crates/gglib-core/src/paths/slots.rs
+++ b/crates/gglib-core/src/paths/slots.rs
@@ -1,0 +1,34 @@
+//! Slot cache path helpers.
+//!
+//! Shared utilities for constructing per-model KV cache slot paths,
+//! used by both gglib-runtime (purge) and gglib-proxy (save/restore).
+
+use std::path::{Path, PathBuf};
+
+/// Return the per-model subdirectory path `{slot_dir}/{model_id}/`
+/// used by both gglib-runtime (purge) and gglib-proxy (save/restore).
+pub fn slot_model_dir(slot_dir: &Path, model_id: u32) -> PathBuf {
+    slot_dir.join(model_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slot_model_dir_appends_model_id() {
+        let base = Path::new("/tmp/slots");
+        let result = slot_model_dir(base, 42);
+        assert_eq!(result, PathBuf::from("/tmp/slots/42"));
+    }
+
+    #[test]
+    fn slot_model_dir_with_nested_path() {
+        let base = Path::new("/home/user/.local/share/gglib/cache");
+        let result = slot_model_dir(base, 7);
+        assert_eq!(
+            result,
+            PathBuf::from("/home/user/.local/share/gglib/cache/7")
+        );
+    }
+}

--- a/crates/gglib-proxy/src/cache_lifecycle.rs
+++ b/crates/gglib-proxy/src/cache_lifecycle.rs
@@ -16,6 +16,14 @@ use tracing::{debug, warn};
 
 use crate::slots::{self, SlotIoResult};
 
+/// Composite key for the hot-cache bypass: (model_id, session_id).
+/// Both fields must match to consider a session "hot" in RAM.
+#[derive(Clone, Debug)]
+pub struct LastLoadedSession {
+    pub model_id: u32,
+    pub session_id: String,
+}
+
 /// Maximum number of retry attempts for pre-generation restore failures.
 /// Total attempts = 1 (initial) + MAX_RETRIES = 3.
 const MAX_RETRIES: u32 = 2;
@@ -33,14 +41,18 @@ pub struct StreamConfig {
     pub client: Client,
     pub base_url: String,
     pub slot_dir: PathBuf,
+    /// Database ID of the model whose slots are being cached.
+    /// Used to namespace slot files under `{slot_dir}/{model_id}/`.
+    pub model_id: u32,
     pub clear_all_pending: Arc<AtomicBool>,
     pub per_session_cleared: Arc<DashSet<String>>,
     /// Unix timestamp (seconds) when the current llama-server process started.
     /// Used by mtime guard to skip restoring stale slot files.
     pub server_start_time: Arc<AtomicU64>,
-    /// Last session ID successfully loaded into RAM (hot in KV cache).
-    /// Used to bypass disk restore when the session is already hot.
-    pub last_loaded_session: Arc<tokio::sync::RwLock<Option<String>>>,
+    /// Last session successfully loaded into RAM (hot in KV cache).
+    /// Composite key (model_id + session_id) used to bypass disk restore
+    /// when the same model+session is already hot.
+    pub last_loaded_session: Arc<tokio::sync::RwLock<Option<LastLoadedSession>>>,
 }
 
 /// Restore KV cache for a session, with retry on transient failures.
@@ -58,13 +70,26 @@ pub async fn restore_with_retry(config: &StreamConfig, session_id: &str) -> Slot
     // mtime guard: skip restoring a slot file written by a prior llama-server
     // instance (see `slots::slot_file_is_stale` for the fail-open contract).
     let server_start_secs = config.server_start_time.load(Ordering::SeqCst);
-    let is_stale = slots::slot_file_is_stale(&config.slot_dir, &sanitized, server_start_secs).await;
+    let is_stale = slots::slot_file_is_stale(
+        &config.slot_dir,
+        config.model_id,
+        &sanitized,
+        server_start_secs,
+    )
+    .await;
 
     let mut result = if is_stale {
         debug!("skipping restore for {session_id} — slot file predates current server instance");
         SlotIoResult::NotFound
     } else {
-        slots::restore_slot(&config.client, &config.base_url, &sanitized).await
+        slots::restore_slot(
+            &config.client,
+            &config.base_url,
+            &config.slot_dir,
+            config.model_id,
+            &sanitized,
+        )
+        .await
     };
 
     // Retry only transient failures (UpstreamDead / timeout / network error)
@@ -75,7 +100,14 @@ pub async fn restore_with_retry(config: &StreamConfig, session_id: &str) -> Slot
                 attempt, MAX_RETRIES
             );
             sleep(RETRY_BACKOFF).await;
-            result = slots::restore_slot(&config.client, &config.base_url, &sanitized).await;
+            result = slots::restore_slot(
+                &config.client,
+                &config.base_url,
+                &config.slot_dir,
+                config.model_id,
+                &sanitized,
+            )
+            .await;
             if !matches!(result, SlotIoResult::Transient(_)) {
                 break;
             }
@@ -113,6 +145,8 @@ pub async fn save_after_generation(config: &StreamConfig, sanitized_session_id: 
     slots::attempt_save(
         &config.client,
         &config.base_url,
+        &config.slot_dir,
+        config.model_id,
         sanitized_session_id,
         &config.clear_all_pending,   // Arc<AtomicBool> → &AtomicBool
         &config.per_session_cleared, // Arc<DashSet<String>> → &DashSet<String>
@@ -121,7 +155,10 @@ pub async fn save_after_generation(config: &StreamConfig, sanitized_session_id: 
 
     // Mark this session as hot in RAM — next request for the same session
     // can skip the disk restore.
-    *config.last_loaded_session.write().await = Some(sanitized_session_id.to_string());
+    *config.last_loaded_session.write().await = Some(LastLoadedSession {
+        model_id: config.model_id,
+        session_id: sanitized_session_id.to_string(),
+    });
 }
 
 /// Non-streaming cache lifecycle: acquire permit, restore→generate→save, release.
@@ -150,7 +187,8 @@ where
     // Hot cache bypass: skip disk restore if session is already in RAM
     let is_hot = {
         let last = config.last_loaded_session.read().await;
-        last.as_deref() == Some(sanitized.as_str())
+        last.as_ref().map(|l| (l.model_id, l.session_id.as_str()))
+            == Some((config.model_id, sanitized.as_str()))
     };
 
     let restore_result = if is_hot {
@@ -214,7 +252,8 @@ pub async fn prepare_streaming_cycle(
     // Hot cache bypass: skip disk restore if session is already in RAM
     let is_hot = {
         let last = config.last_loaded_session.read().await;
-        last.as_deref() == Some(sanitized.as_str())
+        last.as_ref().map(|l| (l.model_id, l.session_id.as_str()))
+            == Some((config.model_id, sanitized.as_str()))
     };
 
     let restore_result = if is_hot {
@@ -251,7 +290,9 @@ pub async fn clear_cache(config: &StreamConfig, session_id: Option<&str>) -> std
                 config.per_session_cleared.insert(sanitized.clone());
                 // Invalidate hot cache if the cleared session was the one in RAM
                 let mut last = config.last_loaded_session.write().await;
-                if last.as_deref() == Some(sanitized.as_str()) {
+                if last.as_ref().map(|l| (l.model_id, l.session_id.as_str()))
+                    == Some((config.model_id, sanitized.as_str()))
+                {
                     *last = None;
                 }
             }
@@ -276,6 +317,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://localhost:8080".to_string(),
             slot_dir: PathBuf::from("/tmp/slots"),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(false)),
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(0)),
@@ -295,6 +337,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://localhost:8080".to_string(),
             slot_dir: PathBuf::from("/tmp/test-slots"),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(false)),
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(0)),
@@ -314,6 +357,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://localhost:8080".to_string(),
             slot_dir: PathBuf::from("/tmp/test-slots"),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(false)),
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(0)),
@@ -330,6 +374,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://127.0.0.1:0".to_string(), // Non-existent server
             slot_dir: PathBuf::from("/tmp/test-slots"),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(true)), // Simulate pending global clear
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(0)), // 0 → fail-open (always proceed)
@@ -360,8 +405,11 @@ mod tests {
     async fn test_restore_with_retry_skips_stale_slot_file() {
         let dir = tempfile::tempdir().unwrap();
         let session_id = "stale-session";
+        // Create file in model subdirectory (matching namespaced layout)
+        let model_subdir = dir.path().join("0");
+        std::fs::create_dir_all(&model_subdir).unwrap();
         std::fs::write(
-            dir.path().join(format!("{session_id}.bin")),
+            model_subdir.join(format!("{session_id}.bin")),
             b"old kv state",
         )
         .unwrap();
@@ -377,6 +425,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://127.0.0.1:0".to_string(), // refused if ever called
             slot_dir: dir.path().to_path_buf(),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(false)),
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(server_start_secs)),
@@ -407,7 +456,10 @@ mod tests {
     async fn test_restore_with_retry_does_not_skip_fresh_slot_file() {
         let dir = tempfile::tempdir().unwrap();
         let session_id = "fresh-session";
-        std::fs::write(dir.path().join(format!("{session_id}.bin")), b"kv state").unwrap();
+        // Create file in model subdirectory (matching namespaced layout)
+        let model_subdir = dir.path().join("0");
+        std::fs::create_dir_all(&model_subdir).unwrap();
+        std::fs::write(model_subdir.join(format!("{session_id}.bin")), b"kv state").unwrap();
 
         // Server "started" long before the file was written.
         let server_start_secs = std::time::SystemTime::now()
@@ -420,6 +472,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://127.0.0.1:0".to_string(), // refused — proves the call was attempted
             slot_dir: dir.path().to_path_buf(),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(false)),
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(server_start_secs)),
@@ -443,6 +496,7 @@ mod tests {
             client: Client::new(),
             base_url: "http://localhost:8080".to_string(),
             slot_dir: PathBuf::from("/tmp/test-slots"),
+            model_id: 0,
             clear_all_pending: Arc::new(AtomicBool::new(false)),
             per_session_cleared: Arc::new(DashSet::new()),
             server_start_time: Arc::new(AtomicU64::new(0)),

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -87,9 +87,11 @@ pub(crate) struct AppState {
     /// Unix timestamp (seconds) when the current llama-server process started.
     /// Updated on each restart detection. Used by mtime guard to skip stale slots.
     server_start_time: Arc<AtomicU64>,
-    /// Last session ID successfully loaded into RAM (hot in KV cache).
-    /// Used to bypass disk restore when the session is already hot.
-    last_loaded_session: Arc<tokio::sync::RwLock<Option<String>>>,
+    /// Last session successfully loaded into RAM (hot in KV cache).
+    /// Composite key (model_id + session_id) used to bypass disk restore
+    /// when the same model+session is already hot.
+    last_loaded_session:
+        Arc<tokio::sync::RwLock<Option<crate::cache_lifecycle::LastLoadedSession>>>,
 }
 
 /// Start the proxy server with a pre-bound listener.
@@ -450,6 +452,7 @@ async fn handle_proxy_cache_clear(
         client: state.client.clone(),
         base_url: String::new(), // Not used by clear_cache
         slot_dir,
+        model_id: 0, // Sentinel — clear_cache only uses flags and hot-cache invalidation
         clear_all_pending: state.clear_all_pending.clone(),
         per_session_cleared: state.per_session_cleared.clone(),
         server_start_time: state.server_start_time.clone(),
@@ -655,6 +658,7 @@ async fn chat_completions(
             client: state.client.clone(),
             base_url: target.base_url.clone(),
             slot_dir: dir.clone(),
+            model_id: target.model_id,
             clear_all_pending: state.clear_all_pending.clone(),
             per_session_cleared: state.per_session_cleared.clone(),
             server_start_time: state.server_start_time.clone(),

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -862,6 +862,38 @@ async fn chat_completions(
                 Some(new_target.effective_ctx),
             );
 
+            // Compute cache-aware permit/config/session_id for the retry.
+            // Mirrors the normal-path pattern: acquire permit via
+            // prepare_streaming_cycle, fail-open on error.
+            let (retry_permit, retry_cfg, retry_session) = if state.cache_enabled
+                && sanitized_session_id.is_some()
+                && state.slot_dir.is_some()
+            {
+                let sid = sanitized_session_id.clone().unwrap();
+                let cfg = StreamConfig {
+                    client: state.client.clone(),
+                    base_url: new_target.base_url.clone(),
+                    slot_dir: state.slot_dir.as_ref().unwrap().clone(),
+                    model_id: new_target.model_id,
+                    clear_all_pending: state.clear_all_pending.clone(),
+                    per_session_cleared: state.per_session_cleared.clone(),
+                    server_start_time: state.server_start_time.clone(),
+                    last_loaded_session: state.last_loaded_session.clone(),
+                };
+                match crate::cache_lifecycle::prepare_streaming_cycle(
+                    &cfg,
+                    state.slot_gate.clone(),
+                    &sid,
+                )
+                .await
+                {
+                    Ok((permit, _sanitized, _restore)) => (Some(permit), Some(cfg), Some(sid)),
+                    Err(_) => (None, None, None), // fail-open
+                }
+            } else {
+                (None, None, None)
+            };
+
             match forward_chat_completion(
                 &state.client,
                 &retry_url,
@@ -876,9 +908,9 @@ async fn chat_completions(
                 retry_connection,
                 state.upstream_health.clone(),
                 state.calibration.clone(),
-                None,
-                None,
-                None,
+                retry_permit,
+                retry_cfg,
+                retry_session,
             )
             .await
             {

--- a/crates/gglib-proxy/src/slots.rs
+++ b/crates/gglib-proxy/src/slots.rs
@@ -824,27 +824,29 @@ pub async fn restore_slot(
 }
 
 /// Clear per-slot cache files from disk. Uses tokio::fs for async safety.
+///
+/// Walks the namespaced `{slot_dir}/{model_id}/*.bin` layout via
+/// [`iter_all_slot_files`] rather than assuming a flat `slot_dir` — a plain
+/// `slot_dir.join(format!("{id}.bin"))` no longer matches where files
+/// actually live post-namespacing.
+///
+/// `session_id: Some(id)` removes every `.bin` file across all model
+/// subdirectories whose stem is `id` (a session could in principle have been
+/// cached under more than one model over its lifetime, so this doesn't
+/// assume a single owning subdirectory). `None` clears everything.
 pub async fn clear_slot_files(slot_dir: &Path, session_id: Option<&str>) -> std::io::Result<()> {
-    if let Some(id) = session_id {
-        let path = slot_dir.join(format!("{id}.bin"));
-        tokio::fs::remove_file(&path).await.ok(); // NotFound/PermissionDenied → silent skip
-        return Ok(());
-    }
-    let mut entries = match tokio::fs::read_dir(slot_dir).await {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        if entry.path().extension().and_then(|e| e.to_str()) == Some("bin")
-            && let Err(e) = tokio::fs::remove_file(entry.path()).await
+    let candidates = iter_all_slot_files(slot_dir).await;
+    for path in candidates {
+        let matches = match session_id {
+            Some(id) => path.file_stem().and_then(|s| s.to_str()) == Some(id),
+            None => true,
+        };
+        if matches
+            && let Err(e) = tokio::fs::remove_file(&path).await
             && e.kind() != std::io::ErrorKind::PermissionDenied
             && e.kind() != std::io::ErrorKind::NotFound
         {
-            warn!(
-                "failed to remove slot file {}: {}",
-                entry.path().display(),
-                e
-            );
+            warn!("failed to remove slot file {}: {}", path.display(), e);
         }
     }
     Ok(())
@@ -982,18 +984,18 @@ pub fn spawn_lru_eviction_task(
 ///
 /// Sorts `.bin` files by mtime (oldest first), removes the excess. Errors on
 /// individual file removal are silently skipped for NotFound/PermissionDenied.
+///
+/// Walks the namespaced `{slot_dir}/{model_id}/*.bin` layout via
+/// [`iter_all_slot_files`] — the cap is deliberately global across every
+/// model's subdirectory (a single size budget for the whole cache directory,
+/// not per-model).
 pub async fn evict_stale_slots(slot_dir: &Path, max_slots: usize) -> std::io::Result<()> {
-    let mut entries = match tokio::fs::read_dir(slot_dir).await {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
     let mut slots: Vec<(PathBuf, u64)> = Vec::new();
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        if entry.path().extension().and_then(|e| e.to_str()) == Some("bin")
-            && let Ok(metadata) = entry.metadata().await
+    for path in iter_all_slot_files(slot_dir).await {
+        if let Ok(metadata) = tokio::fs::metadata(&path).await
             && let Ok(mtime) = metadata.modified()
         {
-            slots.push((entry.path(), mtime.elapsed().unwrap_or_default().as_secs()));
+            slots.push((path, mtime.elapsed().unwrap_or_default().as_secs()));
         }
     }
 
@@ -1059,6 +1061,74 @@ mod slot_io_tests {
         // With max_slots=2, the single oldest slot (B) should be evicted
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0], PathBuf::from("B.bin"));
+    }
+
+    /// Regression test for the namespacing gap: `evict_stale_slots` must see
+    /// files across every model subdirectory, not just a flat `slot_dir`.
+    #[tokio::test]
+    async fn evict_stale_slots_sees_files_across_model_subdirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_a = dir.path().join("1");
+        let model_b = dir.path().join("2");
+        std::fs::create_dir_all(&model_a).unwrap();
+        std::fs::create_dir_all(&model_b).unwrap();
+
+        // Three files total across two model subdirectories, oldest first.
+        std::fs::write(model_a.join("oldest.bin"), b"x").unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        std::fs::write(model_b.join("middle.bin"), b"x").unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        std::fs::write(model_a.join("newest.bin"), b"x").unwrap();
+
+        evict_stale_slots(dir.path(), 2).await.unwrap();
+
+        // The single oldest file (model_a/oldest.bin) should have been evicted;
+        // the other two, across both subdirectories, must survive.
+        assert!(!model_a.join("oldest.bin").exists());
+        assert!(model_b.join("middle.bin").exists());
+        assert!(model_a.join("newest.bin").exists());
+    }
+
+    /// Regression test for the namespacing gap: clearing a specific session
+    /// must find its file regardless of which model subdirectory it lives
+    /// under, and must not touch other sessions or other models.
+    #[tokio::test]
+    async fn clear_slot_files_finds_session_across_model_subdirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_a = dir.path().join("1");
+        let model_b = dir.path().join("2");
+        std::fs::create_dir_all(&model_a).unwrap();
+        std::fs::create_dir_all(&model_b).unwrap();
+
+        std::fs::write(model_a.join("planner.bin"), b"x").unwrap();
+        std::fs::write(model_b.join("coder.bin"), b"x").unwrap();
+
+        clear_slot_files(dir.path(), Some("planner")).await.unwrap();
+
+        assert!(!model_a.join("planner.bin").exists());
+        assert!(
+            model_b.join("coder.bin").exists(),
+            "other session untouched"
+        );
+    }
+
+    /// Clearing all sessions (`None`) must remove every `.bin` file across
+    /// every model subdirectory, not just a flat `slot_dir`.
+    #[tokio::test]
+    async fn clear_slot_files_none_clears_every_model_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_a = dir.path().join("1");
+        let model_b = dir.path().join("2");
+        std::fs::create_dir_all(&model_a).unwrap();
+        std::fs::create_dir_all(&model_b).unwrap();
+
+        std::fs::write(model_a.join("planner.bin"), b"x").unwrap();
+        std::fs::write(model_b.join("coder.bin"), b"x").unwrap();
+
+        clear_slot_files(dir.path(), None).await.unwrap();
+
+        assert!(!model_a.join("planner.bin").exists());
+        assert!(!model_b.join("coder.bin").exists());
     }
 
     #[tokio::test]

--- a/crates/gglib-proxy/src/slots.rs
+++ b/crates/gglib-proxy/src/slots.rs
@@ -699,12 +699,39 @@ pub fn sanitize_session_id(id: &str) -> Result<String, String> {
     Ok(id.to_lowercase())
 }
 
+/// Return the full path to a slot `.bin` file for a given model and session.
+/// Uses the shared `slot_model_dir()` from gglib-core so both runtime (purge)
+/// and proxy (save/restore) agree on `{slot_dir}/{model_id}/{session}.bin`.
+pub fn slot_bin_path(slot_dir: &Path, model_id: u32, session_id: &str) -> PathBuf {
+    gglib_core::paths::slot_model_dir(slot_dir, model_id).join(format!("{session_id}.bin"))
+}
+
 /// Trigger a KV cache save for the current slot via llama-server's `/slots/0?action=save`.
 ///
+/// The `filename` sent to llama-server is relative to its `--slot-save-path`, so we
+/// pass `{model_id}/{session_id}.bin` (matching the namespaced layout on disk).
 /// Returns `SlotIoResult::Ok` on success, `NotFound` if the server returns 404,
 /// or `Transient` for timeout/network errors.
-pub async fn save_slot(client: &Client, base_url: &str, session_id: &str) -> SlotIoResult {
-    let payload = serde_json::json!({"filename": format!("{session_id}.bin")});
+pub async fn save_slot(
+    client: &Client,
+    base_url: &str,
+    slot_dir: &Path,
+    model_id: u32,
+    session_id: &str,
+) -> SlotIoResult {
+    // Ensure the per-model subdirectory exists before saving
+    let model_subdir = gglib_core::paths::slot_model_dir(slot_dir, model_id);
+    if let Err(e) = tokio::fs::create_dir_all(&model_subdir).await {
+        warn!(
+            "failed to create slot model directory {}: {}",
+            model_subdir.display(),
+            e
+        );
+        return SlotIoResult::Transient(format!("failed to create slot directory: {e}"));
+    }
+    // Filename is relative to --slot-save-path, so use {model_id}/{session}.bin
+    let filename = format!("{model_id}/{session_id}.bin");
+    let payload = serde_json::json!({"filename": &filename});
     match tokio_time::timeout(
         Duration::from_secs(3),
         client
@@ -738,13 +765,15 @@ pub async fn save_slot(client: &Client, base_url: &str, session_id: &str) -> Slo
 /// it can positively prove is stale; it never blocks one it can't evaluate.
 pub(crate) async fn slot_file_is_stale(
     slot_dir: &Path,
+    model_id: u32,
     session_id: &str,
     server_start_secs: u64,
 ) -> bool {
     if server_start_secs == 0 {
         return false;
     }
-    let Ok(metadata) = tokio::fs::metadata(slot_dir.join(format!("{session_id}.bin"))).await else {
+    let path = slot_bin_path(slot_dir, model_id, session_id);
+    let Ok(metadata) = tokio::fs::metadata(&path).await else {
         return false;
     };
     let Ok(modified) = metadata.modified() else {
@@ -764,8 +793,16 @@ pub(crate) async fn slot_file_is_stale(
 /// Returns `SlotIoResult::Ok` on success, `NotFound` if no cached file exists (404),
 /// or `Transient` for timeout/network errors. A 5-second timeout is used because
 /// restore may need to read a large file from disk.
-pub async fn restore_slot(client: &Client, base_url: &str, session_id: &str) -> SlotIoResult {
-    let payload = serde_json::json!({"filename": format!("{session_id}.bin")});
+pub async fn restore_slot(
+    client: &Client,
+    base_url: &str,
+    _slot_dir: &Path,
+    model_id: u32,
+    session_id: &str,
+) -> SlotIoResult {
+    // Filename is relative to --slot-save-path, so use {model_id}/{session}.bin
+    let filename = format!("{model_id}/{session_id}.bin");
+    let payload = serde_json::json!({"filename": &filename});
     match tokio_time::timeout(
         Duration::from_secs(5),
         client
@@ -834,6 +871,8 @@ const SAVE_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 pub async fn attempt_save(
     client: &Client,
     base_url: &str,
+    slot_dir: &Path,
+    model_id: u32,
     session_id: &str,
     clear_all_pending: &AtomicBool,
     per_session_cleared: &DashSet<String>,
@@ -847,7 +886,7 @@ pub async fn attempt_save(
         return;
     }
 
-    let mut result = save_slot(client, base_url, session_id).await;
+    let mut result = save_slot(client, base_url, slot_dir, model_id, session_id).await;
     if matches!(result, SlotIoResult::Transient(_)) {
         for attempt in 1..=SAVE_MAX_RETRIES {
             debug!(
@@ -855,7 +894,7 @@ pub async fn attempt_save(
                 attempt, SAVE_MAX_RETRIES
             );
             tokio_time::sleep(SAVE_RETRY_BACKOFF).await;
-            result = save_slot(client, base_url, session_id).await;
+            result = save_slot(client, base_url, slot_dir, model_id, session_id).await;
             if !matches!(result, SlotIoResult::Transient(_)) {
                 break;
             }
@@ -872,6 +911,40 @@ pub async fn attempt_save(
             warn!("save failed for {session_id} (permanent): {e}")
         }
     }
+}
+
+/// Iterate all `.bin` slot files across every model subdirectory.
+///
+/// Walks `{slot_dir}/{model_id}/*.bin` for each immediate subdirectory of
+/// `slot_dir`. Returns a flat `Vec<PathBuf>` sorted by mtime (oldest first).
+/// Used by LRU eviction and cache-clear operations that need to see the
+/// complete set of cached slots regardless of model.
+pub async fn iter_all_slot_files(slot_dir: &Path) -> Vec<PathBuf> {
+    let mut entries = match tokio::fs::read_dir(slot_dir).await {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut slots: Vec<PathBuf> = Vec::new();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        // Each immediate child is a model subdirectory
+        if !entry.path().is_dir() {
+            continue;
+        }
+        if let Ok(mut model_entries) = tokio::fs::read_dir(&entry.path()).await {
+            while let Ok(Some(me)) = model_entries.next_entry().await {
+                if me.path().extension().and_then(|e| e.to_str()) == Some("bin") {
+                    slots.push(me.path());
+                }
+            }
+        }
+    }
+    // Sort by mtime oldest-first so LRU eviction removes the least-recently-used first
+    slots.sort_by_key(|p| {
+        p.metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    slots
 }
 
 /// Default cap on cached session slot files before LRU eviction kicks in.
@@ -1000,6 +1073,8 @@ mod slot_io_tests {
         attempt_save(
             &client,
             "http://127.0.0.1:0",
+            Path::new("/tmp"),
+            0, // model_id
             "planner",
             &clear_all,
             &per_session,
@@ -1034,33 +1109,42 @@ mod slot_io_tests {
     #[tokio::test]
     async fn slot_file_is_stale_true_when_file_predates_server_start() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("s.bin"), b"x").unwrap();
+        // Create file in model subdirectory
+        let model_subdir = dir.path().join("42");
+        std::fs::create_dir_all(&model_subdir).unwrap();
+        std::fs::write(model_subdir.join("s.bin"), b"x").unwrap();
 
         let server_start = unix_secs_now() + 3600; // "started" after the file was written
-        assert!(slot_file_is_stale(dir.path(), "s", server_start).await);
+        assert!(slot_file_is_stale(dir.path(), 42, "s", server_start).await);
     }
 
     #[tokio::test]
     async fn slot_file_is_stale_false_when_file_is_newer_than_server_start() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("s.bin"), b"x").unwrap();
+        // Create file in model subdirectory
+        let model_subdir = dir.path().join("42");
+        std::fs::create_dir_all(&model_subdir).unwrap();
+        std::fs::write(model_subdir.join("s.bin"), b"x").unwrap();
 
         let server_start = unix_secs_now().saturating_sub(3600); // started well before the file
-        assert!(!slot_file_is_stale(dir.path(), "s", server_start).await);
+        assert!(!slot_file_is_stale(dir.path(), 42, "s", server_start).await);
     }
 
     #[tokio::test]
     async fn slot_file_is_stale_false_when_file_missing() {
         let dir = tempfile::tempdir().unwrap();
-        // no file written for "s"
-        assert!(!slot_file_is_stale(dir.path(), "s", unix_secs_now() + 3600).await);
+        // no file written for "s" in model subdir
+        assert!(!slot_file_is_stale(dir.path(), 42, "s", unix_secs_now() + 3600).await);
     }
 
     #[tokio::test]
     async fn slot_file_is_stale_false_when_guard_uninitialized() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("s.bin"), b"x").unwrap();
+        // Create file in model subdirectory
+        let model_subdir = dir.path().join("42");
+        std::fs::create_dir_all(&model_subdir).unwrap();
+        std::fs::write(model_subdir.join("s.bin"), b"x").unwrap();
         // server_start_secs == 0 means the guard hasn't been initialized yet — fail-open.
-        assert!(!slot_file_is_stale(dir.path(), "s", 0).await);
+        assert!(!slot_file_is_stale(dir.path(), 42, "s", 0).await);
     }
 }

--- a/crates/gglib-proxy/tests/integration_slot_roundtrip.rs
+++ b/crates/gglib-proxy/tests/integration_slot_roundtrip.rs
@@ -500,6 +500,7 @@ async fn retry_backoff_exhausts_max_retries_then_succeeds() {
         client: Client::new(),
         base_url: format!("http://127.0.0.1:{}", port),
         slot_dir: std::env::temp_dir().join("backoff-test"),
+        model_id: 0,
         clear_all_pending: Arc::new(AtomicBool::new(false)),
         per_session_cleared: Arc::new(DashSet::new()),
         server_start_time: Arc::new(AtomicU64::new(
@@ -594,6 +595,8 @@ async fn save_retry_backoff_exhausts_max_retries_then_succeeds() {
     attempt_save(
         &client,
         &base_url,
+        std::path::Path::new("/tmp"), // slot_dir (not used — DashSet guard fires first)
+        0,                            // model_id
         "save-backoff-session",
         &clear_all_pending,
         &per_session_cleared,

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -11,6 +11,7 @@ use anyhow::{Result, anyhow};
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelRuntimeError, RunningTarget, ServerConfig,
 };
+use gglib_core::slot_model_dir;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -366,7 +367,7 @@ impl ProcessManager {
                             if let Err(e) = std::fs::create_dir_all(slot_dir) {
                                 tracing::warn!("Failed to create slot directory: {}", e);
                             }
-                            purge_stale_slot_bin_files(slot_dir);
+                            purge_stale_slot_bin_files(slot_dir, launch_spec.id as u32);
                         }
 
                         let port = {
@@ -527,11 +528,11 @@ impl ProcessManager {
 // Arc<dyn ...> and RwLock which don't trivially clone in a meaningful way.
 // If you need shared access, wrap ProcessManager in Arc.
 
-/// Remove stale `.bin` slot files from the cache directory.
-/// Called on llama-server restart to invalidate slots that may have been
-/// written by a previous process (different model, context size, etc.).
-fn purge_stale_slot_bin_files(slot_dir: &std::path::Path) {
-    if let Ok(entries) = std::fs::read_dir(slot_dir) {
+/// Remove stale `.bin` slot files for the given model from `{slot_dir}/{model_id}/`.
+/// Called on llama-server restart when the model or context size changes.
+fn purge_stale_slot_bin_files(slot_dir: &std::path::Path, model_id: u32) {
+    let model_subdir = slot_model_dir(slot_dir, model_id);
+    if let Ok(entries) = std::fs::read_dir(&model_subdir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) == Some("bin") {
@@ -539,7 +540,7 @@ fn purge_stale_slot_bin_files(slot_dir: &std::path::Path) {
             }
         }
     }
-    // Silently skip if the directory doesn't exist or can't be read.
+    // Silently skip if the model subdirectory doesn't exist or can't be read.
 }
 
 #[cfg(test)]
@@ -553,27 +554,50 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now().elapsed().unwrap().as_nanos()
         ));
-        tokio::fs::create_dir_all(&dir).await.unwrap();
-        // Create .bin and non-.bin files
-        tokio::fs::write(dir.join("session1.bin"), &[0u8; 8])
+        let model_id: u32 = 42;
+        // Create model-specific subdirectory with .bin files
+        let model_subdir = dir.join(model_id.to_string());
+        tokio::fs::create_dir_all(&model_subdir).await.unwrap();
+        tokio::fs::write(model_subdir.join("session1.bin"), &[0u8; 8])
             .await
             .unwrap();
-        tokio::fs::write(dir.join("session2.bin"), &[0u8; 8])
+        tokio::fs::write(model_subdir.join("session2.bin"), &[0u8; 8])
             .await
             .unwrap();
-        tokio::fs::write(dir.join("notes.txt"), "keep me")
+        // Create a .txt file in the model subdir (should survive)
+        tokio::fs::write(model_subdir.join("notes.txt"), "keep me")
             .await
             .unwrap();
-        // Purge
-        purge_stale_slot_bin_files(&dir);
-        // Verify: .bin gone, .txt remains
-        let mut entries = tokio::fs::read_dir(&dir).await.unwrap();
+        // Create a .bin file in the flat dir (should survive — not our model)
+        tokio::fs::write(dir.join("orphan.bin"), &[0u8; 8])
+            .await
+            .unwrap();
+        // Create another model's subdir with a .bin (should survive)
+        let other_model_subdir = dir.join("99");
+        tokio::fs::create_dir_all(&other_model_subdir)
+            .await
+            .unwrap();
+        tokio::fs::write(other_model_subdir.join("session3.bin"), &[0u8; 8])
+            .await
+            .unwrap();
+        // Purge only model 42's slot files
+        purge_stale_slot_bin_files(&dir, model_id);
+        // Verify: model 42 subdir has only notes.txt
+        let mut entries = tokio::fs::read_dir(&model_subdir).await.unwrap();
         let mut remaining: Vec<std::ffi::OsString> = Vec::new();
         while let Ok(Some(e)) = entries.next_entry().await {
             remaining.push(e.file_name());
         }
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].to_str(), Some("notes.txt"));
+        // Verify: orphan.bin in flat dir still exists
+        assert!(tokio::fs::try_exists(dir.join("orphan.bin")).await.unwrap());
+        // Verify: other model's .bin still exists
+        assert!(
+            tokio::fs::try_exists(other_model_subdir.join("session3.bin"))
+                .await
+                .unwrap()
+        );
         // Cleanup
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }
@@ -585,8 +609,8 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now().elapsed().unwrap().as_nanos()
         ));
-        // Should not panic or error — just returns silently
-        purge_stale_slot_bin_files(&dir);
+        // Should not panic or error — just returns silently (dir doesn't exist)
+        purge_stale_slot_bin_files(&dir, 999);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Namespace slot files per model (`{slot_dir}/{model_id}/{session}.bin`) and key the hot-cache RAM bypass on `(model_id, session_id)` instead of `session_id` alone.
- Scope `purge_stale_slot_bin_files` to the swapped-out model's subdirectory only, so a multi-model workflow no longer purges every other model's cache on each swap.
- Route the streaming upstream-death transparent-restart retry through the same `prepare_streaming_cycle`/slot-semaphore machinery as the normal path, closing the window where an interleaved cached generation could corrupt which KV state gets saved.
- Finish the per-model namespacing work: `evict_stale_slots` and `clear_slot_files` now walk `iter_all_slot_files` across every model subdirectory instead of a flat `slot_dir` scan — previously a per-session cache-clear silently no-op'd post-namespacing, and LRU eviction only ever saw files in the (now unused) flat directory.

Closes #599.

## Test plan
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] New unit tests for eviction/clear across multiple model subdirectories (`evict_stale_slots_sees_files_across_model_subdirs`, `clear_slot_files_finds_session_across_model_subdirs`, `clear_slot_files_none_clears_every_model_subdir`)