### PR TITLE
chore: upgrade pinned Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.97.1
           components: rustfmt
 
       - name: Check formatting
@@ -94,7 +94,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.97.1
 
       - name: Lockfile guard
         run: |
@@ -229,7 +229,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.97.1
           components: clippy
 
       - name: Cache Cargo registry and target directory
@@ -278,7 +278,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.97.1
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Setup Rust cache
@@ -432,7 +432,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Setup Rust cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -498,7 +498,7 @@ To pre-generate badge structure for a new crate or update module tables, use `sc
 
 ### Prerequisites
 
-- Rust 1.91.0 (managed via `rust-toolchain.toml` — `rustup` will install it automatically)
+- Rust 1.97.1 (managed via `rust-toolchain.toml` — `rustup` will install it automatically)
 - Node.js 22.12+ (see below)
 - Platform system libraries (see `scripts/check-deps.sh` for a live dependency check)
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,17 @@ endif
 # Define cargo command that sources Rust environment if needed (for non-interactive shells like VS Code tasks)
 # This is a portable solution that works on Linux/macOS/Windows
 CARGO_ENV := $(shell if [ -f "$$HOME/.cargo/env" ]; then echo ". $$HOME/.cargo/env &&"; fi)
-CARGO := $(CARGO_ENV) cargo
+# Name rustup's shim explicitly rather than relying on PATH order.
+#
+# Sourcing ~/.cargo/env is not sufficient on its own: that script only prepends
+# ~/.cargo/bin when it is *absent* from PATH, so if it is present but ranked
+# below a standalone toolchain (Homebrew's `rust` formula installs one at
+# /opt/homebrew/bin), the script is a silent no-op and the standalone compiler
+# wins. Those do not honour rust-toolchain.toml, so the build quietly runs on
+# an unpinned rustc — and only in the shells that skip ~/.zshrc, which is
+# exactly the non-interactive case this block exists to handle.
+CARGO_BIN := $(shell if [ -x "$$HOME/.cargo/bin/cargo" ]; then echo "$$HOME/.cargo/bin/cargo"; else echo cargo; fi)
+CARGO := $(CARGO_ENV) $(CARGO_BIN)
 
 # Cargo Optimization Flags
 export CARGO_PROFILE_RELEASE_LTO := thin

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ make setup   # check deps → build frontend → install CLI → offer llama.cpp
 
 ### Prerequisites
 
-- **Rust** 1.70+ (MSRV). Tooling/CI currently pins Rust **1.91.0** via `rust-toolchain.toml` — using that version is recommended. — [rustup.rs](https://rustup.rs/)
+- **Rust** 1.70+ (MSRV). Tooling/CI currently pins Rust **1.97.1** via `rust-toolchain.toml` — using that version is recommended. — [rustup.rs](https://rustup.rs/)
 - **Python 3 via Miniconda** — [miniconda](https://docs.conda.io/en/latest/miniconda.html) (for hf_xet fast downloads)
 - **Node.js** 20.19+ (matches the `package.json` `engines` field) — [nodejs.org](https://nodejs.org/) (for web UI)
 - **SQLite** 3.x

--- a/crates/gglib-agent/src/council/executor.rs
+++ b/crates/gglib-agent/src/council/executor.rs
@@ -1013,7 +1013,7 @@ async fn run_wave_loop(
             let child_summary_line = format!(
                 "{} nodes for goal: {}",
                 child_graph.nodes.len(),
-                &spawn_req.goal
+                spawn_req.goal
             );
 
             // Emit SubteamSpawned event.

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -865,34 +865,36 @@ async fn chat_completions(
             // Compute cache-aware permit/config/session_id for the retry.
             // Mirrors the normal-path pattern: acquire permit via
             // prepare_streaming_cycle, fail-open on error.
-            let (retry_permit, retry_cfg, retry_session) = if state.cache_enabled
-                && sanitized_session_id.is_some()
-                && state.slot_dir.is_some()
-            {
-                let sid = sanitized_session_id.clone().unwrap();
-                let cfg = StreamConfig {
-                    client: state.client.clone(),
-                    base_url: new_target.base_url.clone(),
-                    slot_dir: state.slot_dir.as_ref().unwrap().clone(),
-                    model_id: new_target.model_id,
-                    clear_all_pending: state.clear_all_pending.clone(),
-                    per_session_cleared: state.per_session_cleared.clone(),
-                    server_start_time: state.server_start_time.clone(),
-                    last_loaded_session: state.last_loaded_session.clone(),
+            let (retry_permit, retry_cfg, retry_session) =
+                if let (true, Some(sid), Some(slot_dir)) = (
+                    state.cache_enabled,
+                    sanitized_session_id.as_ref(),
+                    state.slot_dir.as_ref(),
+                ) {
+                    let sid = sid.clone();
+                    let cfg = StreamConfig {
+                        client: state.client.clone(),
+                        base_url: new_target.base_url.clone(),
+                        slot_dir: slot_dir.clone(),
+                        model_id: new_target.model_id,
+                        clear_all_pending: state.clear_all_pending.clone(),
+                        per_session_cleared: state.per_session_cleared.clone(),
+                        server_start_time: state.server_start_time.clone(),
+                        last_loaded_session: state.last_loaded_session.clone(),
+                    };
+                    match crate::cache_lifecycle::prepare_streaming_cycle(
+                        &cfg,
+                        state.slot_gate.clone(),
+                        &sid,
+                    )
+                    .await
+                    {
+                        Ok((permit, _sanitized, _restore)) => (Some(permit), Some(cfg), Some(sid)),
+                        Err(_) => (None, None, None), // fail-open
+                    }
+                } else {
+                    (None, None, None)
                 };
-                match crate::cache_lifecycle::prepare_streaming_cycle(
-                    &cfg,
-                    state.slot_gate.clone(),
-                    &sid,
-                )
-                .await
-                {
-                    Ok((permit, _sanitized, _restore)) => (Some(permit), Some(cfg), Some(sid)),
-                    Err(_) => (None, None, None), // fail-open
-                }
-            } else {
-                (None, None, None)
-            };
 
             match forward_chat_completion(
                 &state.client,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.97.1"
 profile = "minimal"
 components = ["rustfmt", "clippy", "llvm-tools"]


### PR DESCRIPTION
Upgrades the pinned Rust toolchain from **1.91.0** to **1.97.1** (current stable), fixes the two clippy lints that version adds, and makes `make` resolve `cargo` in a way that cannot be shadowed by another toolchain on `PATH`.

## Why now

`make setup` started failing:

```
error: rustc 1.95.0 is not supported by the following package:
  kstring@2.0.4 requires rustc 1.96.0
```

`kstring` is a transitive build-dependency (`gglib-build-info` → `vergen-gix` → `gix-attributes`). The 0.9.2 version bump regenerated `Cargo.lock` wholesale — 645 changed lines for what should have been three version strings — and carried `kstring` from 2.0.2 to 2.0.4, whose MSRV is above the pin.

That was worked around on `issue/600-native-cache-tuning` by pinning `kstring` back to 2.0.2. On 1.97.1 no pin is needed, and future lockfile refreshes have headroom instead of tripping immediately.

This PR buys that headroom but does not fix the underlying automation — tracked in #605.

## Contents

| Commit | What |
|---|---|
| `fix(clippy):` | The two lints 1.97 adds — a redundant `&` in a `format!` arg, and an `is_some()`-then-`unwrap()` pair rewritten as `if let`. Neither is a latent bug; clippy just gained opinions. |
| `chore:` | The pin itself, plus all 8 hardcoded copies (4× `ci.yml`, 2× `release.yml`, README, CONTRIBUTING). |
| `fix(build):` | Makefile resolves `cargo` via rustup's shim by absolute path. |

## The Makefile fix

The Makefile already sourced `~/.cargo/env` "for non-interactive shells like VS Code tasks", but that script is a **no-op when `~/.cargo/bin` is already anywhere on `PATH`**:

```sh
case ":${PATH}:" in
    *:"$HOME/.cargo/bin":*) ;;          # already present -> do nothing
    *) export PATH="$HOME/.cargo/bin:$PATH" ;;
esac
```

On the affected machine `~/.cargo/bin` sat at position 20, behind a Homebrew `rust` install at position 1. Standalone toolchains don't read `rust-toolchain.toml`, so the build silently ran unpinned — and only in shells that skip `~/.zshrc`, which is where that `PATH` entry came from. The same command therefore succeeded or failed depending on how the shell was started.

Naming the shim by absolute path removes `PATH` ordering from the equation, with a fallback to bare `cargo` for non-rustup environments.

## Verification

All run on 1.97.1:

- `cargo build --workspace --all-targets`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `scripts/check_boundaries.sh`
- `npx tsc --noEmit`, `npx vitest run` (671 passed)
- Full `make build-tauri` — frontend build, release binaries, and bundling — from a **login non-interactive shell**, the mode that surfaced the original failure

Clippy was also run without `-D warnings` to get a complete inventory, since `-D warnings` aborts at the first failing crate and leaves everything downstream unlinted.

## Note for review

Interacts with `issue/600-native-cache-tuning`, which touches the same `server.rs` retry block. Whichever lands second rebases; that branch's version of the block is already lint-clean under 1.97.1.

## Follow-ups

Filed separately rather than bundled here:

- #605 — version-bump automation regenerates `Cargo.lock`, which is what caused this breakage and will recur on every release.
- #606 — `coverage.yml` and `docs.yml` float on `@stable` instead of the pin.