### PR TITLE
fix(runtime): LlmCompletionAdapter silently drops --presence-penalty and --min-p

### DIFF
--- a/crates/gglib-runtime/src/ports_impl/llm_completion/README.md
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/README.md
@@ -37,6 +37,7 @@ let agent   = AgentLoop::build(Arc::new(adapter), tool_executor, None);
 <!-- module-table:start -->
 | Module | LOC | Complexity | Coverage |
 |--------|-----|------------|----------|
+| [`body.rs`](body.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-body-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-body-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-body-coverage.json) |
 <!-- module-table:end -->
 
 </details>

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/body.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/body.rs
@@ -1,0 +1,268 @@
+//! OpenAI request-body construction for [`LlmCompletionAdapter`].
+//!
+//! Pure translation from domain types to the OpenAI-compatible JSON wire
+//! format, kept separate from the transport concerns in
+//! [`super`] so the resulting body can be asserted on directly in tests
+//! without an HTTP round trip.
+//!
+//! [`LlmCompletionAdapter`]: super::LlmCompletionAdapter
+
+use serde_json::{Value, json};
+
+use gglib_core::{
+    domain::InferenceConfig,
+    domain::agent::{AgentMessage, ToolCall, ToolDefinition},
+    ports::ResponseFormat,
+};
+
+// =============================================================================
+// Wire-format helpers
+// =============================================================================
+
+/// Map a domain [`AgentMessage`] to the OpenAI `messages` array element.
+fn message_to_openai(msg: &AgentMessage) -> Value {
+    match msg {
+        AgentMessage::System { content } => {
+            json!({ "role": "system", "content": content })
+        }
+        AgentMessage::User { content } => {
+            json!({ "role": "user", "content": content })
+        }
+        AgentMessage::Assistant { content } => {
+            // When tool_calls are present but text is None, omit the
+            // "content" field entirely rather than sending `"content": null`.
+            // Some LLM backends do not handle an explicit null well when
+            // tool_calls is populated.  When there are no tool_calls and
+            // text is None, we still send null to signal an empty reply.
+            let has_tool_calls = !content.tool_calls.is_empty();
+            let mut obj = if content.text.is_none() && has_tool_calls {
+                json!({ "role": "assistant" })
+            } else {
+                json!({
+                    "role": "assistant",
+                    "content": content.text.as_deref().map_or(Value::Null, |s| Value::String(s.to_owned())),
+                })
+            };
+            if has_tool_calls {
+                let calls: Vec<Value> =
+                    content.tool_calls.iter().map(tool_call_to_openai).collect();
+                obj["tool_calls"] = Value::Array(calls);
+            }
+            obj
+        }
+        AgentMessage::Tool {
+            tool_call_id,
+            content,
+        } => {
+            json!({ "role": "tool", "tool_call_id": tool_call_id, "content": content })
+        }
+    }
+}
+
+/// Map a domain [`ToolCall`] to the OpenAI `tool_calls` array element.
+///
+/// The OpenAI API requires `arguments` to be a **JSON string**, not an object.
+fn tool_call_to_openai(tc: &ToolCall) -> Value {
+    json!({
+        "id": tc.id,
+        "type": "function",
+        "function": {
+            "name": tc.name,
+            // arguments must be a JSON *string* per OpenAI spec
+            "arguments": tc.arguments.to_string(),
+        },
+    })
+}
+
+/// Map a domain [`ToolDefinition`] to the OpenAI `tools` array element.
+fn tool_def_to_openai(def: &ToolDefinition) -> Value {
+    let parameters = def
+        .input_schema
+        .clone()
+        .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
+
+    json!({
+        "type": "function",
+        "function": {
+            "name": def.name,
+            "description": def.description,
+            "parameters": parameters,
+        },
+    })
+}
+
+// =============================================================================
+// Body construction
+// =============================================================================
+
+/// Build the full OpenAI `/v1/chat/completions` request body.
+///
+/// Always emits `model`, `messages`, `stream` and `return_progress`.  `tools` /
+/// `tool_choice` are added only when `tools` is non-empty, and sampling keys
+/// only for the `Some` fields of `sampling`.
+pub(super) fn build_chat_body(
+    model: &str,
+    messages: &[AgentMessage],
+    tools: &[ToolDefinition],
+    sampling: Option<&InferenceConfig>,
+    response_format: Option<&ResponseFormat>,
+) -> Value {
+    let mut openai_messages: Vec<Value> = messages.iter().map(message_to_openai).collect();
+    let openai_tools: Vec<Value> = tools.iter().map(tool_def_to_openai).collect();
+
+    // Scrub prior-turn reasoning artifacts before the model sees them.
+    // Shared with the proxy via gglib-core so the in-process agent loop
+    // (CLI / Tauri direct path) gets identical protection against the
+    // small-reasoning-model multi-turn `<think>` loop bug.
+    gglib_core::normalize::strip_thinking_debt(&mut openai_messages);
+
+    let mut body = json!({
+        "model": model,
+        "messages": openai_messages,
+        "stream": true,
+        "return_progress": true,
+    });
+    if !openai_tools.is_empty() {
+        body["tools"] = json!(openai_tools);
+        body["tool_choice"] = json!("auto");
+    }
+    // Apply sampling through the same serde-driven helper the proxy uses
+    // (`forward_chat_completion`), so the two request paths cannot drift.  A
+    // hand-rolled field-by-field copy here is what silently dropped
+    // `presence_penalty` and `min_p` when they were added to InferenceConfig.
+    // `to_openai_json_patch` emits only `Some` fields, already snake_cased.
+    if let Some(s) = sampling
+        && let Some(obj) = body.as_object_mut()
+    {
+        for (k, v) in s.to_openai_json_patch() {
+            obj.insert(k, v);
+        }
+    }
+
+    // Inject structured-output constraints when requested.
+    if let Some(fmt) = response_format {
+        match fmt {
+            ResponseFormat::JsonSchema { schema, strict } => {
+                body["response_format"] = json!({
+                    "type": "json_schema",
+                    "json_schema": { "schema": schema, "strict": strict }
+                });
+            }
+            ResponseFormat::Grammar { gbnf } => {
+                body["grammar"] = json!(gbnf);
+            }
+        }
+    }
+
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every value is exactly representable in both `f32` and `f64`, so the
+    /// `f32 → f64` widening `serde_json` performs is lossless and the values
+    /// can be compared against `json!` literals directly.
+    fn full_config() -> InferenceConfig {
+        InferenceConfig {
+            temperature: Some(0.5),
+            top_p: Some(0.75),
+            top_k: Some(20),
+            max_tokens: Some(512),
+            repeat_penalty: Some(1.25),
+            presence_penalty: Some(1.5),
+            min_p: Some(0.0625),
+        }
+    }
+
+    fn messages() -> Vec<AgentMessage> {
+        vec![AgentMessage::User {
+            content: "hello".to_string(),
+        }]
+    }
+
+    /// Regression guard for #611.
+    ///
+    /// `presence_penalty` and `min_p` were added to [`InferenceConfig`] after
+    /// this adapter was written, and the hand-rolled serialization that used to
+    /// live here silently dropped them while the proxy sent them.  Sampling is
+    /// now applied via [`InferenceConfig::to_openai_json_patch`] — the proxy's
+    /// own helper — so the two cannot diverge again.
+    #[test]
+    fn sampling_emits_all_seven_openai_keys() {
+        let config = full_config();
+        let body = build_chat_body("m", &messages(), &[], Some(&config), None);
+
+        assert_eq!(body["temperature"], json!(0.5));
+        assert_eq!(body["top_p"], json!(0.75));
+        assert_eq!(body["top_k"], json!(20));
+        assert_eq!(body["max_tokens"], json!(512));
+        assert_eq!(body["repeat_penalty"], json!(1.25));
+        assert_eq!(body["presence_penalty"], json!(1.5));
+        assert_eq!(body["min_p"], json!(0.0625));
+    }
+
+    #[test]
+    fn sampling_none_fields_are_omitted() {
+        let config = InferenceConfig {
+            temperature: Some(0.5),
+            presence_penalty: Some(1.5),
+            ..Default::default()
+        };
+        let body = build_chat_body("m", &messages(), &[], Some(&config), None);
+        let obj = body.as_object().expect("body is an object");
+
+        assert!(obj.contains_key("temperature"));
+        assert!(obj.contains_key("presence_penalty"));
+        for key in ["top_p", "top_k", "max_tokens", "repeat_penalty", "min_p"] {
+            assert!(!obj.contains_key(key), "{key} should be absent, not null");
+        }
+        // Unset fields must be omitted entirely rather than sent as `null`.
+        assert!(obj.values().all(|v| !v.is_null()));
+    }
+
+    #[test]
+    fn sampling_absent_emits_no_sampling_keys() {
+        let body = build_chat_body("m", &messages(), &[], None, None);
+        let obj = body.as_object().expect("body is an object");
+
+        for key in [
+            "temperature",
+            "top_p",
+            "top_k",
+            "max_tokens",
+            "repeat_penalty",
+            "presence_penalty",
+            "min_p",
+        ] {
+            assert!(!obj.contains_key(key));
+        }
+    }
+
+    #[test]
+    fn sampling_does_not_clobber_transport_fields() {
+        let config = full_config();
+        let tools = vec![ToolDefinition::new("read_file")];
+        let format = ResponseFormat::Grammar {
+            gbnf: "root ::= \"ok\"".to_string(),
+        };
+        let body = build_chat_body(
+            "my-model",
+            &messages(),
+            &tools,
+            Some(&config),
+            Some(&format),
+        );
+
+        assert_eq!(body["model"], json!("my-model"));
+        assert_eq!(body["stream"], json!(true));
+        assert_eq!(body["return_progress"], json!(true));
+        assert_eq!(body["tool_choice"], json!("auto"));
+        assert_eq!(body["tools"][0]["function"]["name"], json!("read_file"));
+        assert_eq!(body["grammar"], json!("root ::= \"ok\""));
+        assert_eq!(body["messages"][0]["content"], json!("hello"));
+        // …and the sampling keys still landed alongside them.
+        assert_eq!(body["min_p"], json!(0.0625));
+    }
+}

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -6,15 +6,16 @@ use async_trait::async_trait;
 use futures_core::Stream;
 use futures_util::StreamExt as _;
 use reqwest::Client;
-use serde_json::{Value, json};
 
 use gglib_core::{
     domain::InferenceConfig,
-    domain::agent::{AgentMessage, LlmStreamEvent, ToolCall, ToolDefinition},
+    domain::agent::{AgentMessage, LlmStreamEvent, ToolDefinition},
     normalize::{NormalizingStream, get_parser},
     ports::{LlmCompletionPort, ResponseFormat},
     sse::SseStreamDecoder,
 };
+
+mod body;
 
 /// Default timeout (seconds) for the `.send()` phase of each LLM request.
 ///
@@ -136,82 +137,6 @@ impl LlmCompletionAdapter {
 }
 
 // =============================================================================
-// Wire-format helpers
-// =============================================================================
-
-/// Map a domain [`AgentMessage`] to the OpenAI `messages` array element.
-fn message_to_openai(msg: &AgentMessage) -> Value {
-    match msg {
-        AgentMessage::System { content } => {
-            json!({ "role": "system", "content": content })
-        }
-        AgentMessage::User { content } => {
-            json!({ "role": "user", "content": content })
-        }
-        AgentMessage::Assistant { content } => {
-            // When tool_calls are present but text is None, omit the
-            // "content" field entirely rather than sending `"content": null`.
-            // Some LLM backends do not handle an explicit null well when
-            // tool_calls is populated.  When there are no tool_calls and
-            // text is None, we still send null to signal an empty reply.
-            let has_tool_calls = !content.tool_calls.is_empty();
-            let mut obj = if content.text.is_none() && has_tool_calls {
-                json!({ "role": "assistant" })
-            } else {
-                json!({
-                    "role": "assistant",
-                    "content": content.text.as_deref().map_or(Value::Null, |s| Value::String(s.to_owned())),
-                })
-            };
-            if has_tool_calls {
-                let calls: Vec<Value> =
-                    content.tool_calls.iter().map(tool_call_to_openai).collect();
-                obj["tool_calls"] = Value::Array(calls);
-            }
-            obj
-        }
-        AgentMessage::Tool {
-            tool_call_id,
-            content,
-        } => {
-            json!({ "role": "tool", "tool_call_id": tool_call_id, "content": content })
-        }
-    }
-}
-
-/// Map a domain [`ToolCall`] to the OpenAI `tool_calls` array element.
-///
-/// The OpenAI API requires `arguments` to be a **JSON string**, not an object.
-fn tool_call_to_openai(tc: &ToolCall) -> Value {
-    json!({
-        "id": tc.id,
-        "type": "function",
-        "function": {
-            "name": tc.name,
-            // arguments must be a JSON *string* per OpenAI spec
-            "arguments": tc.arguments.to_string(),
-        },
-    })
-}
-
-/// Map a domain [`ToolDefinition`] to the OpenAI `tools` array element.
-fn tool_def_to_openai(def: &ToolDefinition) -> Value {
-    let parameters = def
-        .input_schema
-        .clone()
-        .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
-
-    json!({
-        "type": "function",
-        "function": {
-            "name": def.name,
-            "description": def.description,
-            "parameters": parameters,
-        },
-    })
-}
-
-// =============================================================================
 // LlmCompletionPort implementation
 // =============================================================================
 
@@ -223,58 +148,13 @@ impl LlmCompletionPort for LlmCompletionAdapter {
         tools: &[ToolDefinition],
         response_format: Option<&ResponseFormat>,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<LlmStreamEvent>> + Send>>> {
-        let openai_messages: Vec<Value> = messages.iter().map(message_to_openai).collect();
-        let openai_tools: Vec<Value> = tools.iter().map(tool_def_to_openai).collect();
-
-        // Scrub prior-turn reasoning artifacts before the model sees them.
-        // Shared with the proxy via gglib-core so the in-process agent loop
-        // (CLI / Tauri direct path) gets identical protection against the
-        // small-reasoning-model multi-turn `<think>` loop bug.
-        let mut openai_messages = openai_messages;
-        gglib_core::normalize::strip_thinking_debt(&mut openai_messages);
-
-        let mut body = json!({
-            "model": self.model,
-            "messages": openai_messages,
-            "stream": true,
-            "return_progress": true,
-        });
-        if !openai_tools.is_empty() {
-            body["tools"] = json!(openai_tools);
-            body["tool_choice"] = json!("auto");
-        }
-        if let Some(ref s) = self.sampling {
-            if let Some(t) = s.temperature {
-                body["temperature"] = json!(t);
-            }
-            if let Some(p) = s.top_p {
-                body["top_p"] = json!(p);
-            }
-            if let Some(k) = s.top_k {
-                body["top_k"] = json!(k);
-            }
-            if let Some(m) = s.max_tokens {
-                body["max_tokens"] = json!(m);
-            }
-            if let Some(r) = s.repeat_penalty {
-                body["repeat_penalty"] = json!(r);
-            }
-        }
-
-        // Inject structured-output constraints when requested.
-        if let Some(fmt) = response_format {
-            match fmt {
-                ResponseFormat::JsonSchema { schema, strict } => {
-                    body["response_format"] = json!({
-                        "type": "json_schema",
-                        "json_schema": { "schema": schema, "strict": strict }
-                    });
-                }
-                ResponseFormat::Grammar { gbnf } => {
-                    body["grammar"] = json!(gbnf);
-                }
-            }
-        }
+        let body = body::build_chat_body(
+            &self.model,
+            messages,
+            tools,
+            self.sampling.as_ref(),
+            response_format,
+        );
 
         // Gate the connect + first-byte phase with a hard timeout so a
         // stalled or unresponsive llama-server doesn't hang the agent task


### PR DESCRIPTION
## Context

`InferenceConfig` has 7 sampling fields. Two consumers serialize it into an OpenAI
request body, and they did it differently:

- **The proxy** — serde-driven, cannot drift (`forward.rs:592`):
  `for (k, v) in resolved.to_openai_json_patch() { … }`
- **The adapter** — hand-rolled, covered 5 of 7.

`presence_penalty` and `min_p` were added to `InferenceConfig` after the adapter was
written, and nothing is compiler-enforced, so the drift was silent. `gglib chat
--presence-penalty 1.5` and `--min-p 0.05` were accepted, documented, and discarded — no
error, no warning. The help text for `--presence-penalty` actively recommends the value
it then threw away. The same settings worked through `gglib proxy`, so behaviour differed
between a first-party surface and an external client hitting the same model.

Step 1 of #610. Self-contained; changes no proxy behaviour.

## The fix

Route the adapter through `InferenceConfig::to_openai_json_patch()` — the proxy's own
helper — rather than adding two more `if let` arms. Two more arms would fix today's
symptom and guarantee the same bug on the next field added; going through the shared
helper makes the adapter structurally incapable of drifting from the proxy, which is the
point. `to_openai_json_patch` itself is untouched, since the proxy depends on it.

The body construction moved into a sibling `body.rs` behind `build_chat_body()`.
`chat_stream` built the request inline and POSTed it immediately, so the body could not be
asserted on without an HTTP round trip — and `mod.rs` was already 339 LOC, over the repo's
300 budget. It is now 219 and transport-only. The `&mut serde_json::Value` shape is
deliberate: it is the seam `request_pipeline::apply()` plugs into in #613.

## How this happened

Traced through `git log -S`. The adapter was not written wrong — it was written right and
then left behind, twice.

| When | | What |
|---|---|---|
| 2026-04-03 | 9b1d9058 (#362) | Adapter created with the hand-rolled sampling block. `InferenceConfig` had exactly 5 fields then — `temperature`, `top_p`, `top_k`, `max_tokens`, `repeat_penalty` — so the block was **complete and correct**, and was the only serializer in the tree. |
| 2026-06-20 | 175c3cba (#541) | Added `presence_penalty` + `min_p` to `InferenceConfig` and to `SamplingArgs`. Titled *"with full-stack parity"*, but it touched no serializer at all — and the adapter was the only one that existed. **The bug starts here.** |
| 2026-06-24 | 9d68496b (#548) | Introduced `to_openai_json_patch()` and gave the proxy sampling serialization for the first time (`forward.rs` had none before this), correctly, over all 7. The adapter was not migrated. **This is where the two paths structurally diverged.** Titled *"unified inference defaults across all surfaces (proxy, chat, q, agent REPL)"* — among serializers, only `forward.rs` changed. |
| 2026-07-21 | 51f0f2ec (#609) | Added the profile layer to the hierarchy — again only in `forward.rs`, so profile-supplied `presence_penalty`/`min_p` also reached proxy clients only. |
| 2026-07-21 | this PR | Adapter routed through the same helper. Bug was live **31 days**. |

The two titles are the interesting part. #541 claimed full-stack parity and #548 claimed
all surfaces including `chat` and `q`; both were accurate about the *hierarchy* and wrong
about the *wire*. That is exactly the failure mode #610 exists to close, and it is why
this went in as a shared-helper migration rather than two more `if let` arms.

### The impact was wider than the CLI flags

Reasoning models get `InferenceConfig::reasoning_profile()` written into their
`inference_defaults` automatically at registration (`model_registrar.rs:166`, added by
\#541), and that profile sets `presence_penalty: 1.5` — documented in-tree as *"Prevents
repetitive reasoning loops"*. The CLI resolves model defaults into the sampling it hands
the adapter, so **every `gglib chat` / `gglib q` / `gglib council` session against a
reasoning model has been running without that anti-loop penalty since #541**, while proxy
clients hitting the same model got it. Nobody had to type a flag to be affected.

Sharpening it further: the adapter already carried a comment about protecting against
"the small-reasoning-model multi-turn `<think>` loop bug" via `strip_thinking_debt` — and
was silently discarding the other half of that protection three lines below it.

## Two corrections to the issue

Traced every `with_sampling` / `compose_*` call site, and the affected-surface list in
\#611 is wrong in one direction and incomplete in the other.

**The web UI is not affected.** #611 says the bug hits "the CLI, the Axum web UI, AND
council." It does not hit the web UI. `AgentChatRequest` carries `port`, `messages`,
`config`, `tool_filter`, `model` — and `config` is `AgentRequestConfig`, loop tuning only
(`max_iterations`, `max_parallel_tools`, `tool_timeout_ms`, …). There is no inference
field anywhere in it, and `handlers/agent/mod.rs:85` calls `compose_agent_loop`, which has
no `sampling` parameter at all. The GUI drops all 7 fields because nothing ever wires
them, not because of serialization drift. This PR changes nothing there.

That remains a live parity gap — CLI users can set sampling, GUI users cannot — and
deserves its own issue. Since Tauri has no agent-chat command of its own (the desktop GUI
goes through the embedded axum server), fixing axum would fix both GUI surfaces at once.

**`gglib tune` is affected, and #611 never mentions it.** Arguably the worse consequence.
`build_candidate_grid` sweeps `min_p` as a real grid dimension, and the `qwen-coding`
family preset sets `min_p: Some(0.0)`. Candidates reach llama-server through this same
adapter, so **every `min_p` grid point ran with identical sampling** — the tuner was
scoring noise on that dimension and reporting it as signal. Any stored tune result that
ranked on `min_p` is suspect and worth re-running. Fixed automatically here; `tune` itself
is untouched.

| Surface | Sampling passed? | Was affected |
|---|---|---|
| `gglib chat` / `gglib q` | all 7, resolved | yes |
| `gglib council` | yes | yes |
| `gglib tune` | yes | yes |
| Axum web UI / GUI | **none — no param** | no |
| `gglib plan` | `None` hardcoded | no |
| Council orchestrator | `None` hardcoded | no |

## Testing

Four tests in `body.rs`, written and run **against the unfixed hand-rolled logic before
the fix was applied** — the neutralize-and-confirm-failure technique. Three failed, on
exactly the two dropped fields:

```
sampling_does_not_clobber_transport_fields ... FAILED  left: Null  right: Number(0.0625)  (min_p)
sampling_emits_all_seven_openai_keys       ... FAILED  left: Null  right: Number(1.5)     (presence_penalty)
sampling_none_fields_are_omitted           ... FAILED  assertion failed: obj.contains_key("presence_penalty")
sampling_absent_emits_no_sampling_keys     ... ok
test result: FAILED. 1 passed; 3 failed
```

After the fix: `4 passed; 0 failed`. They cover all 7 keys with correct snake_case names
and values, `None` fields omitted entirely rather than sent as `null`, absent sampling
emitting no keys at all, and sampling not clobbering `model` / `stream` /
`return_progress` / `tools` / `tool_choice` / `response_format`.

One trap worth knowing for future fixtures: `InferenceConfig` fields are `f32` and
`serde_json` widens to `f64`, so test values must be exactly representable in binary
(0.5, 0.75, 1.25, 1.5, 0.0625) or the assertions fail on representation noise.

## Verification

```
cargo build --workspace --all-targets    Finished dev profile in 13.88s
cargo fmt --all --check                  clean, exit 0
cargo clippy --workspace --all-targets -- -D warnings    Finished in 5.83s, zero warnings
cargo test --workspace                   1739 passed, 0 failed
./scripts/check_boundaries.sh            all checks passed (incl. check_readmes --strict)
./scripts/check-tauri-commands.sh        exit 0
./scripts/check-frontend-ipc.sh          exit 0
./scripts/check_transport_branching.sh   exit 0
```

`check_file_complexity.sh` exits 1 on two pre-existing frontend files
(`src/services/transport/events/sse.ts` 353 LOC, `src/styles/tailwind.css` 394) —
confirmed byte-identical on a clean tree, neither touched here. Worth noting separately:
that script only walks the frontend `src/` tree and has never checked Rust at all, which
is how `mod.rs` reached 339 LOC unflagged.

No boundary change — `gglib-runtime` already depended on `gglib-core`. No new dependency.
`llm_completion/README.md`'s module table was regenerated for the new file.

Fixes #611