### PR TITLE
Shared request shaping: one pipeline for the proxy and the agent path

### DIFF
--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -343,6 +343,13 @@ fn build_messages(config: &CompareConfig) -> serde_json::Value {
 ///   → hardcoded fallback (`InferenceConfig::with_hardcoded_defaults`).
 ///
 /// This mirrors the resolution the proxy performs for every routed request.
+///
+/// Serialization goes through [`InferenceConfig::to_openai_json_patch`] — the
+/// workspace's one sampling serializer — rather than a field-by-field copy.
+/// The copy that used to live here was complete, but it was the same shape that
+/// silently dropped `presence_penalty` and `min_p` from the LLM adapter when
+/// those fields were added (#611): a benchmark comparing sampling parameters
+/// while quietly omitting one of them is worse than useless.
 fn build_compare_request_body(
     config: &CompareConfig,
     model: &gglib_core::domain::Model,
@@ -360,26 +367,10 @@ fn build_compare_request_body(
         "stream": true
     });
 
-    if let Some(v) = resolved.temperature {
-        body["temperature"] = serde_json::json!(v);
-    }
-    if let Some(v) = resolved.max_tokens {
-        body["max_tokens"] = serde_json::json!(v);
-    }
-    if let Some(v) = resolved.top_p {
-        body["top_p"] = serde_json::json!(v);
-    }
-    if let Some(v) = resolved.top_k {
-        body["top_k"] = serde_json::json!(v);
-    }
-    if let Some(v) = resolved.repeat_penalty {
-        body["repeat_penalty"] = serde_json::json!(v);
-    }
-    if let Some(v) = resolved.presence_penalty {
-        body["presence_penalty"] = serde_json::json!(v);
-    }
-    if let Some(v) = resolved.min_p {
-        body["min_p"] = serde_json::json!(v);
+    if let Some(obj) = body.as_object_mut() {
+        for (key, value) in resolved.to_openai_json_patch() {
+            obj.insert(key, value);
+        }
     }
 
     body

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -491,13 +491,25 @@ pub async fn proxy_chat(
         ));
     }
 
-    // Convert to ChatMessage format and apply capability-aware transformations
+    // Convert to ChatMessage format and apply capability-aware transformations.
+    //
+    // `tool_call_id` travels in the core type's catch-all rather than being
+    // dropped and re-synthesized: it is required by the chat templates of the
+    // strict-turn models this transform exists for, so losing it here would
+    // break tool calling on exactly those models.
     let core_messages: Vec<gglib_core::ChatMessage> = valid_messages
         .into_iter()
-        .map(|m| gglib_core::ChatMessage {
-            role: m.role,
-            content: m.content.map(gglib_core::MessageContent::Text),
-            tool_calls: m.tool_calls.map(serde_json::Value::Array),
+        .map(|m| {
+            let mut extra = serde_json::Map::new();
+            if let Some(id) = m.tool_call_id {
+                extra.insert("tool_call_id".to_owned(), serde_json::Value::String(id));
+            }
+            gglib_core::ChatMessage {
+                role: m.role,
+                content: m.content.map(gglib_core::MessageContent::Text),
+                tool_calls: m.tool_calls.map(serde_json::Value::Array),
+                extra,
+            }
         })
         .collect();
 
@@ -506,7 +518,7 @@ pub async fn proxy_chat(
     // Convert back to ChatMessage
     let final_messages: Vec<ChatMessage> = transformed
         .into_iter()
-        .map(|m| ChatMessage {
+        .map(|mut m| ChatMessage {
             role: m.role,
             content: m.content.map(|c| c.into_string()),
             tool_calls: m.tool_calls.and_then(|v| {
@@ -516,7 +528,10 @@ pub async fn proxy_chat(
                     None
                 }
             }),
-            tool_call_id: None,
+            tool_call_id: m
+                .extra
+                .remove("tool_call_id")
+                .and_then(|v| v.as_str().map(str::to_owned)),
         })
         .collect();
 

--- a/crates/gglib-core/src/domain/capabilities.rs
+++ b/crates/gglib-core/src/domain/capabilities.rs
@@ -715,13 +715,34 @@ impl From<&str> for MessageContent {
 /// `content` uses [`MessageContent`] which accepts both a plain JSON string
 /// and a JSON array of content-part objects during deserialization, preserving
 /// the original form during serialization.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// # Lossless round-trip
+///
+/// [`transform_messages_for_capabilities`] is reached by deserializing a
+/// client's `messages` array into this type and re-serializing the result, so
+/// any field this struct does not model would be **deleted** on the way
+/// through.  Three fields are named because the transform reads them;
+/// everything else — `tool_call_id`, `name`, vendor extensions — is carried
+/// verbatim in [`extra`](Self::extra) and never interpreted.
+///
+/// This is not hypothetical tidiness.  `tool_call_id` is required by the Jinja
+/// templates of exactly the models that set
+/// [`REQUIRES_STRICT_TURNS`](ModelCapabilities::REQUIRES_STRICT_TURNS) — the
+/// Mistral family — so dropping it would break tool calling on the models the
+/// transform exists to serve.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<MessageContent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<serde_json::Value>,
+    /// Every other key the message carried, passed through untouched.
+    ///
+    /// Flattened, so these sit at the message's top level on the wire exactly
+    /// where they came from.  An empty map serializes to nothing.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 impl ChatMessage {
@@ -730,6 +751,13 @@ impl ChatMessage {
     /// Used during strict-turn coalescing to combine consecutive same-role
     /// messages.  Content is merged via [`MessageContent::merge_with`]; tool
     /// calls are concatenated as JSON arrays.
+    ///
+    /// For [`extra`](Self::extra) the surviving message's keys win and only
+    /// absent ones are adopted from `other`.  Only `user` / `assistant`
+    /// messages are ever merged and those rarely carry extras, so this is a
+    /// tie-break rule rather than a load-bearing one — but silently preferring
+    /// the *later* message's `name` over the one already in the merged text
+    /// would be the surprising choice.
     fn merge_into(&mut self, other: Self) {
         self.content = match (self.content.take(), other.content) {
             (None, b) => b,
@@ -744,6 +772,9 @@ impl ChatMessage {
                     la.extend_from_slice(ma);
                 }
             }
+        }
+        for (key, value) in other.extra {
+            self.extra.entry(key).or_insert(value);
         }
     }
 }
@@ -871,11 +902,13 @@ mod transform_tests {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Hello".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("Hi there".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let original = messages.clone();
@@ -893,6 +926,7 @@ mod transform_tests {
                     "You are a helpful assistant.".to_string(),
                 )),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "system".to_string(),
@@ -900,11 +934,13 @@ mod transform_tests {
                     "WORKING_MEMORY:\n- task1 (ok): done".to_string(),
                 )),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Hello".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let result = transform_messages_for_capabilities(messages, ModelCapabilities::empty());
@@ -925,16 +961,19 @@ mod transform_tests {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text("First.".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text("Second.".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text("Third.".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let result = transform_messages_for_capabilities(messages, ModelCapabilities::empty());
@@ -953,11 +992,13 @@ mod transform_tests {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text(String::new())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text("Actual content".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let result = transform_messages_for_capabilities(messages, ModelCapabilities::empty());
@@ -976,11 +1017,13 @@ mod transform_tests {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text("You are helpful".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Hello".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         // Use REQUIRES_STRICT_TURNS which doesn't support system but doesn't merge different roles
@@ -1000,6 +1043,7 @@ mod transform_tests {
             role: "system".to_string(),
             content: Some(MessageContent::Text("You are helpful".to_string())),
             tool_calls: None,
+            ..Default::default()
         }];
         let caps = ModelCapabilities::SUPPORTS_SYSTEM_ROLE;
         let result = transform_messages_for_capabilities(messages, caps);
@@ -1017,11 +1061,13 @@ mod transform_tests {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("First".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Second".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
@@ -1040,11 +1086,13 @@ mod transform_tests {
                 role: "tool".to_string(),
                 content: Some(MessageContent::Text("Result 1".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "tool".to_string(),
                 content: Some(MessageContent::Text("Result 2".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
@@ -1059,16 +1107,19 @@ mod transform_tests {
                 role: "system".to_string(),
                 content: Some(MessageContent::Text("Be helpful".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("First".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Second".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let caps = ModelCapabilities::REQUIRES_STRICT_TURNS; // No system support + strict turns
@@ -1111,16 +1162,19 @@ mod transform_tests {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("What's the weather?".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("Let me check...".to_string())),
                 tool_calls: Some(tool_call_1),
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("And the time...".to_string())),
                 tool_calls: Some(tool_call_2),
+                ..Default::default()
             },
         ];
 
@@ -1167,11 +1221,13 @@ mod transform_tests {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("Let me check...".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: None,
                 tool_calls: Some(tool_call),
+                ..Default::default()
             },
         ];
 
@@ -1205,11 +1261,13 @@ mod transform_tests {
                 role: "assistant".to_string(),
                 content: None,
                 tool_calls: Some(tool_call),
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("Result received".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
 
@@ -1247,11 +1305,13 @@ mod transform_tests {
                 role: "assistant".to_string(),
                 content: None,
                 tool_calls: Some(tool_call_1),
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: None,
                 tool_calls: Some(tool_call_2),
+                ..Default::default()
             },
         ];
 
@@ -1274,11 +1334,13 @@ mod transform_tests {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("First".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("Second".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
 
@@ -1305,16 +1367,19 @@ mod transform_tests {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Question".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: Some(MessageContent::Text("Answer".to_string())),
                 tool_calls: Some(tool_call),
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Follow-up".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
 
@@ -1358,11 +1423,13 @@ mod transform_tests {
                     serde_json::json!({"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}),
                 ])),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("What do you see?".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
@@ -1382,6 +1449,7 @@ mod transform_tests {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Run the tool".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "tool".to_string(),
@@ -1389,11 +1457,13 @@ mod transform_tests {
                     serde_json::json!({"type": "text", "text": "tool result here"}),
                 ])),
                 tool_calls: None,
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: Some(MessageContent::Text("Thanks".to_string())),
                 tool_calls: None,
+                ..Default::default()
             },
         ];
         let caps = ModelCapabilities::REQUIRES_STRICT_TURNS;
@@ -1404,5 +1474,121 @@ mod transform_tests {
         assert_eq!(result.len(), 3);
         assert_eq!(result[1].role, "tool");
         assert!(matches!(&result[1].content, Some(MessageContent::Parts(_))));
+    }
+}
+
+/// The JSON round-trip callers actually perform.
+///
+/// [`transform_messages_for_capabilities`] is reached by deserializing a
+/// client's `messages` array into [`ChatMessage`] and re-serializing the
+/// result, so anything the struct fails to model is deleted in transit. These
+/// tests pin the round-trip itself rather than the transform, because that is
+/// where fields go missing.
+#[cfg(test)]
+mod round_trip_tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    /// Deserialize → transform → serialize, exactly as the proxy and the
+    /// adapter do.
+    fn round_trip(messages: Value, capabilities: ModelCapabilities) -> Vec<Value> {
+        let parsed: Vec<ChatMessage> = serde_json::from_value(messages).expect("valid messages");
+        let transformed = transform_messages_for_capabilities(parsed, capabilities);
+        serde_json::to_value(&transformed)
+            .expect("serializable")
+            .as_array()
+            .expect("array")
+            .clone()
+    }
+
+    /// The regression this catch-all exists for.
+    ///
+    /// Mistral-family templates require `tool_call_id` on tool results and are
+    /// exactly the models that set `REQUIRES_STRICT_TURNS`, so a transform that
+    /// dropped it would break tool calling on the only models that need the
+    /// transform at all.
+    #[test]
+    fn tool_call_id_survives_strict_turn_coalescing() {
+        let out = round_trip(
+            json!([
+                {"role": "user", "content": "run it"},
+                {"role": "assistant", "tool_calls": [
+                    {"id": "call_1", "type": "function",
+                     "function": {"name": "f", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ]),
+            ModelCapabilities::REQUIRES_STRICT_TURNS,
+        );
+
+        let tool = out
+            .iter()
+            .find(|m| m["role"] == "tool")
+            .expect("tool message");
+        assert_eq!(
+            tool["tool_call_id"], "call_1",
+            "tool_call_id must survive the transform"
+        );
+    }
+
+    /// Every unmodelled key, not just the one that motivated the field.
+    #[test]
+    fn arbitrary_unknown_message_keys_are_preserved() {
+        let out = round_trip(
+            json!([{
+                "role": "user",
+                "content": "hi",
+                "name": "alice",
+                "x_vendor_extension": {"nested": [1, 2]},
+            }]),
+            ModelCapabilities::REQUIRES_STRICT_TURNS,
+        );
+
+        assert_eq!(out[0]["name"], "alice");
+        assert_eq!(out[0]["x_vendor_extension"], json!({"nested": [1, 2]}));
+    }
+
+    /// `#[serde(flatten)]` routes the whole struct through serde's buffered
+    /// content representation, and `MessageContent` is an untagged enum — the
+    /// combination that most often silently degrades. Both content forms must
+    /// still deserialize to the right variant and serialize back unchanged.
+    #[test]
+    fn flatten_does_not_disturb_untagged_content_forms() {
+        let out = round_trip(
+            json!([
+                {"role": "user", "content": "plain string"},
+                {"role": "assistant", "content": [{"type": "text", "text": "part"}]},
+            ]),
+            ModelCapabilities::empty(),
+        );
+
+        assert_eq!(out[0]["content"], json!("plain string"));
+        assert_eq!(out[1]["content"], json!([{"type": "text", "text": "part"}]));
+    }
+
+    /// A merged message keeps its own extras and adopts only what it lacks.
+    #[test]
+    fn merging_prefers_the_surviving_message_extras() {
+        let out = round_trip(
+            json!([
+                {"role": "user", "content": "one", "name": "first"},
+                {"role": "user", "content": "two", "name": "second", "only_on_later": true},
+            ]),
+            ModelCapabilities::REQUIRES_STRICT_TURNS,
+        );
+
+        assert_eq!(out.len(), 1, "consecutive user messages merge");
+        assert_eq!(out[0]["name"], "first", "the surviving message's key wins");
+        assert_eq!(out[0]["only_on_later"], true, "absent keys are adopted");
+    }
+
+    /// The catch-all must not invent keys for messages that had none.
+    #[test]
+    fn messages_without_extras_serialize_unchanged() {
+        let out = round_trip(
+            json!([{"role": "user", "content": "hi"}]),
+            ModelCapabilities::empty(),
+        );
+        assert_eq!(out[0], json!({"role": "user", "content": "hi"}));
     }
 }

--- a/crates/gglib-core/src/request_pipeline/README.md
+++ b/crates/gglib-core/src/request_pipeline/README.md
@@ -5,21 +5,42 @@
 
 <!-- module-docs:start -->
 
-Shared request-shaping inputs for every inference pipeline.
+Request shaping for every inference pipeline: what we know about the model, and
+what we do to the request because of it.
 
 `gglib` has two request paths that historically diverged: `gglib proxy`, which
 applied a full shaping pipeline, and the agent path used by `gglib chat`,
 `gglib q`, the web UI and council, which applied almost none of it. Both start
-from the same question — *what do we know about this model?* — and this module
-is the one place that answers it.
+from the same question — *what do we know about this model?* — and both need
+the same answer applied to the outgoing body. This module is the one place that
+does either.
 
 ## Module map
+
+**Resolution — what the model is**
 
 - [`model_context`] — [`ModelContext`], the resolved per-model facts
   (capabilities, `format:*` tags, inference defaults) that the request and
   response stages are built from, plus the inert
   [`ModelContext::passthrough`] fallback.
 - [`resolve`] — [`resolve()`], the single catalog round-trip that produces one.
+
+**Shaping — what happens to the request**
+
+- [`apply`] — [`apply()`], the whole ordered pipeline as one call, and the one
+  place the stage order and its rationale are written down. **Read this first.**
+- [`messages`] — [`shape_messages()`], stages 1–2: reasoning strip and
+  capability coalescing. Everything that rewrites the `messages` array.
+- [`sampling`] — [`resolve_sampling()`] and [`SamplingLayers`], stages 4–5: the
+  sampling hierarchy and the `cache_prompt` pin. Everything that touches
+  top-level keys.
+
+Stage 3, history truncation, is still `gglib-proxy`-local — it gates on the
+payload's size in wire bytes and can reject the request with an HTTP response,
+neither of which fits this crate. The proxy therefore calls
+[`shape_messages()`] and [`resolve_sampling()`] with its own truncation pass
+between them, rather than calling [`apply()`]; a test in [`apply`] pins the two
+routes to the same result.
 
 ## Why the three fields travel together
 
@@ -40,6 +61,11 @@ Exactly one, applied by [`resolve()`]: an unresolvable model yields
 nothing else. Unknown models log at `debug` (routine — clients name models the
 catalog has never seen); catalog errors log at `warn` (something is broken).
 
+Shaping inherits it for free: a passthrough context has empty capabilities, so
+every message-level stage is a no-op, and no per-model defaults, so the
+sampling hierarchy simply resolves one layer shallower. An unknown model never
+costs the request itself.
+
 <!-- module-docs:end -->
 
 <details>
@@ -48,8 +74,11 @@ catalog has never seen); catalog errors log at `warn` (something is broken).
 <!-- module-table:start -->
 | Module | LOC | Complexity | Coverage |
 |--------|-----|------------|----------|
+| [`apply.rs`](apply.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-apply-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-apply-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-apply-coverage.json) |
+| [`messages.rs`](messages.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-messages-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-messages-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-messages-coverage.json) |
 | [`model_context.rs`](model_context.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-model_context-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-model_context-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-model_context-coverage.json) |
 | [`resolve.rs`](resolve.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-resolve-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-resolve-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-resolve-coverage.json) |
+| [`sampling.rs`](sampling.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-sampling-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-sampling-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-request_pipeline-sampling-coverage.json) |
 <!-- module-table:end -->
 
 </details>

--- a/crates/gglib-core/src/request_pipeline/apply.rs
+++ b/crates/gglib-core/src/request_pipeline/apply.rs
@@ -1,0 +1,173 @@
+//! The ordered request-shaping pipeline, and the one statement of its order.
+//!
+//! # The stages
+//!
+//! | # | Stage | Lives in | Reads |
+//! |---|---|---|---|
+//! | 1 | Strip prior reasoning | [`super::messages`] | `messages` |
+//! | 2 | Coalesce for capabilities | [`super::messages`] | `messages` |
+//! | 3 | *(history truncation — still proxy-local, see below)* | | |
+//! | 4 | Resolve the sampling hierarchy | [`super::sampling`] | top-level keys |
+//! | 5 | Pin `cache_prompt` | [`super::sampling`] | top-level keys |
+//!
+//! # The order is load-bearing
+//!
+//! **1 before 2.** Coalescing merges message *content*. Stripping afterwards
+//! would have to find and excise `<think>` blocks inside text that has already
+//! been concatenated with `"\n\n"` separators from other turns.
+//!
+//! **2 before 4.** There is no data dependency — stage 4 never looks at
+//! `messages` and stages 1–2 never look at top-level keys — but this is the
+//! order the proxy has always applied, and keeping it removes the question of
+//! whether any future stage introduced one.
+//!
+//! **4 before 5.** `cache_prompt` is not an [`InferenceConfig`] field, so
+//! pinning it last means the resolved sampling patch can never overwrite it.
+//!
+//! [`InferenceConfig`]: crate::domain::InferenceConfig
+//!
+//! # Why the seam is `&mut Value` and not a typed request struct
+//!
+//! The proxy forwards requests from arbitrary external clients — IDE
+//! extensions, gateways — which send `OpenAI` parameters this workspace has
+//! never heard of. Round-tripping through a typed `ChatRequest` would silently
+//! drop every field the struct does not model: a passthrough regression that
+//! is invisible in tests and painful in the field. Mutating a `Value` in place
+//! preserves them by construction. The adapter builds its body with `json!` and
+//! already holds a `Value`, so this is also the cheaper side for it.
+//!
+//! # Why stage 3 is not here yet
+//!
+//! History truncation gates on the payload's size **in wire bytes** and can
+//! reject the request outright with an HTTP response. Neither fits a
+//! `&mut Value` pipeline in `gglib-core`: a `Value` has no byte length until it
+//! is serialized, and `gglib-core` cannot name an `axum` type. It therefore
+//! still runs in `gglib-proxy`, between stages 2 and 4, which is why the proxy
+//! calls [`super::shape_messages`] and [`super::resolve_sampling`] separately
+//! rather than calling [`apply`]. Splicing it in the middle is not cosmetic:
+//! inserting the stage-4 sampling keys first would change the very number
+//! truncation measures.
+
+use serde_json::Value;
+
+use super::{ModelContext, SamplingLayers, messages, sampling};
+
+/// Apply every request-shaping transform, in order, in place.
+///
+/// This is the whole pipeline as one call — the entry point for any caller that
+/// holds a request body and nothing else to interleave. See the [module
+/// docs](self) for the stage order and why it is fixed.
+///
+/// Unknown fields, top-level and per-message alike, are preserved.
+pub fn apply(body: &mut Value, ctx: &ModelContext, layers: &SamplingLayers) {
+    messages::shape_messages(body, ctx);
+    sampling::resolve_sampling(body, ctx, layers);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{InferenceConfig, ModelCapabilities};
+    use serde_json::json;
+
+    fn strict_turn_ctx() -> ModelContext {
+        ModelContext {
+            capabilities: ModelCapabilities::REQUIRES_STRICT_TURNS,
+            inference_defaults: Some(InferenceConfig {
+                temperature: Some(0.33),
+                ..Default::default()
+            }),
+            ..ModelContext::passthrough()
+        }
+    }
+
+    fn kitchen_sink() -> Value {
+        json!({
+            "model": "m",
+            "cache_prompt": false,
+            "messages": [
+                {"role": "assistant", "content": "<think>x</think>a", "reasoning_content": "r"},
+                {"role": "assistant", "content": "b"},
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+            "totally_made_up_key": {"nested": [1, 2]},
+        })
+    }
+
+    /// The contract the proxy depends on: it runs the two stages by hand, with
+    /// truncation between them, and must land exactly where `apply` would.
+    /// If a stage is ever added to `apply` without the proxy learning about it,
+    /// this fails.
+    #[test]
+    fn apply_equals_the_stages_run_in_sequence() {
+        let ctx = strict_turn_ctx();
+        let layers = SamplingLayers {
+            profile: Some(InferenceConfig {
+                top_p: Some(0.5),
+                ..Default::default()
+            }),
+            global: None,
+        };
+
+        let mut via_apply = kitchen_sink();
+        apply(&mut via_apply, &ctx, &layers);
+
+        let mut via_stages = kitchen_sink();
+        messages::shape_messages(&mut via_stages, &ctx);
+        sampling::resolve_sampling(&mut via_stages, &ctx, &layers);
+
+        assert_eq!(via_apply, via_stages);
+    }
+
+    /// Stage 1 must have already run when stage 2 merges: the merged text
+    /// contains no `<think>` remnant, which it would if the order were flipped.
+    #[test]
+    fn reasoning_is_stripped_before_messages_are_merged() {
+        let mut body = kitchen_sink();
+        apply(&mut body, &strict_turn_ctx(), &SamplingLayers::default());
+
+        let merged = body["messages"][0]["content"].as_str().unwrap();
+        assert_eq!(merged, "a\n\nb");
+        assert!(body["messages"][0].get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn every_stage_runs_in_one_call() {
+        let mut body = kitchen_sink();
+        apply(&mut body, &strict_turn_ctx(), &SamplingLayers::default());
+
+        // 1 + 2: reasoning gone, assistant turns merged, tool turn intact.
+        assert_eq!(body["messages"].as_array().unwrap().len(), 2);
+        assert_eq!(body["messages"][1]["tool_call_id"], "call_1");
+        // 4: the model's stored default resolved in.
+        assert!((body["temperature"].as_f64().unwrap() - 0.33).abs() < 1e-6);
+        // 5: pinned over the client's explicit `false`.
+        assert_eq!(body["cache_prompt"], true);
+        // …and nothing else was disturbed.
+        assert_eq!(body["model"], "m");
+        assert_eq!(body["totally_made_up_key"], json!({"nested": [1, 2]}));
+    }
+
+    /// A passthrough context must cost the request nothing but its
+    /// model-specific handling — the sampling stages still run.
+    #[test]
+    fn a_passthrough_context_still_resolves_sampling() {
+        let mut body = json!({"messages": [
+            {"role": "user", "content": "one"},
+            {"role": "user", "content": "two"},
+        ]});
+        apply(
+            &mut body,
+            &ModelContext::passthrough(),
+            &SamplingLayers::default(),
+        );
+
+        assert_eq!(
+            body["messages"].as_array().unwrap().len(),
+            2,
+            "unknown capabilities must not merge anything"
+        );
+        assert_eq!(body["cache_prompt"], true);
+        assert!(body["temperature"].as_f64().is_some());
+    }
+}

--- a/crates/gglib-core/src/request_pipeline/messages.rs
+++ b/crates/gglib-core/src/request_pipeline/messages.rs
@@ -1,0 +1,300 @@
+//! Stage 1–2: shaping the conversation itself.
+//!
+//! Both transforms rewrite the `messages` array and nothing else. They are
+//! paired in [`shape_messages`] because they are the contiguous run of
+//! message-level work in the pipeline — see [`super::apply`] for why the order
+//! within that run is fixed.
+
+use serde_json::Value;
+use tracing::{Level, debug, enabled, warn};
+
+use super::ModelContext;
+use crate::domain::{ChatMessage, ModelCapabilities, transform_messages_for_capabilities};
+use crate::normalize::strip_thinking_debt;
+
+/// Apply every message-level transform, in order.
+///
+/// Returns `true` when `body` was modified. Callers holding the request as
+/// bytes use this to skip a re-serialization and forward the client's original
+/// payload untouched — which is not merely an optimisation for the proxy,
+/// where history truncation measures the payload in **wire bytes** and would
+/// otherwise measure a re-encoded body instead of the one the client sent.
+pub fn shape_messages(body: &mut Value, ctx: &ModelContext) -> bool {
+    // Evaluated eagerly, not short-circuited: coalescing must run even when
+    // the reasoning strip found nothing to do.
+    let stripped = strip_prior_reasoning(body);
+    let coalesced = coalesce_for_capabilities(body, ctx.capabilities);
+    stripped || coalesced
+}
+
+/// Stage 1 — scrub reasoning artefacts from prior assistant turns.
+///
+/// Thin wrapper over [`strip_thinking_debt`], which owns the scrub rules; this
+/// exists only to locate the `messages` array and report whether anything
+/// changed. Reasoning models pattern-match their own past `<think>` traces
+/// when these are left in the history.
+fn strip_prior_reasoning(body: &mut Value) -> bool {
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return false;
+    };
+
+    let touched = strip_thinking_debt(messages);
+    if touched > 0 {
+        debug!(touched, "stripped prior reasoning from assistant messages");
+    }
+    touched > 0
+}
+
+/// Stage 2 — merge consecutive same-role messages for strict-turn models.
+///
+/// Mistral-family models (and anything else carrying
+/// [`ModelCapabilities::REQUIRES_STRICT_TURNS`]) enforce user/assistant
+/// alternation inside their Jinja chat templates and raise a hard 500 when
+/// consecutive same-role messages arrive. IDEs and gateway extensions routinely
+/// send multi-turn context that violates this, so coalescing here is the
+/// correct fix rather than constraining callers.
+///
+/// [`transform_messages_for_capabilities`] is the single source of truth for
+/// the merging rules. Returns `false` — leaving `body` untouched — for any
+/// model that needs no rewriting and for any request whose `messages` array
+/// cannot be read.
+fn coalesce_for_capabilities(body: &mut Value, capabilities: ModelCapabilities) -> bool {
+    // Fast paths: this model needs no rewriting, or we know nothing about it.
+    let needs_nothing =
+        !capabilities.requires_strict_turns() && capabilities.supports_system_role();
+    if needs_nothing || capabilities.is_empty() {
+        return false;
+    }
+
+    debug!(
+        requires_strict_turns = capabilities.requires_strict_turns(),
+        supports_system_role = capabilities.supports_system_role(),
+        "coalesce: entering message transformation"
+    );
+
+    let Some(messages_raw) = body.get("messages").and_then(Value::as_array) else {
+        debug!("coalesce: no messages array found in request body");
+        return false;
+    };
+
+    let before_count = messages_raw.len();
+
+    // Deserialise only the fields `transform_messages_for_capabilities` needs.
+    // `ChatMessage.content` accepts both a plain JSON string and a JSON array of
+    // content-part objects (e.g. VSCode LLM Gateway sends array-form content per
+    // the OpenAI spec), and every other key rides along in `ChatMessage.extra`,
+    // so this round-trip is lossless.
+    let messages: Vec<ChatMessage> =
+        match serde_json::from_value(Value::Array(messages_raw.clone())) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    before = before_count,
+                    "coalesce: failed to deserialise messages as Vec<ChatMessage>; \
+                     leaving the message array unchanged. \
+                     This usually means a message field has an unexpected type."
+                );
+                return false;
+            }
+        };
+
+    log_payload_shape(body, &messages, before_count);
+
+    let transformed = transform_messages_for_capabilities(messages, capabilities);
+    let after_count = transformed.len();
+
+    debug!(
+        before = before_count,
+        after = after_count,
+        merged = before_count.saturating_sub(after_count),
+        "coalesce: transformation complete"
+    );
+
+    match serde_json::to_value(&transformed) {
+        Ok(new_messages) => {
+            body["messages"] = new_messages;
+            true
+        }
+        Err(e) => {
+            warn!(error = %e, "coalesce: failed to serialise transformed messages; leaving them unchanged");
+            false
+        }
+    }
+}
+
+/// Diagnostics for tracking down oversized payloads: the byte cost of every
+/// non-message top-level field, and the content size of every message.
+///
+/// Gated on the log level as a whole because both loops serialise their way to
+/// a size — work the `debug!` macro would otherwise discard *after* paying for
+/// it on every strict-turn request.
+fn log_payload_shape(body: &Value, messages: &[ChatMessage], before_count: usize) {
+    if !enabled!(Level::DEBUG) {
+        return;
+    }
+
+    for (key, val) in body.as_object().into_iter().flatten() {
+        if key != "messages" {
+            let approx_bytes = serde_json::to_vec(val).map_or(0, |v| v.len());
+            debug!(key, approx_bytes, "coalesce: top-level field size");
+        }
+    }
+
+    debug!(
+        before = before_count,
+        roles = ?messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
+        "coalesce: parsed messages for transformation"
+    );
+    for (i, m) in messages.iter().enumerate() {
+        let content_bytes = m.content.as_ref().map_or(0, |c| {
+            c.as_str().map_or_else(|| format!("{c:?}").len(), str::len)
+        });
+        debug!(i, role = %m.role, content_bytes, "coalesce: message sizes");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx(capabilities: ModelCapabilities) -> ModelContext {
+        ModelContext {
+            capabilities,
+            ..ModelContext::passthrough()
+        }
+    }
+
+    // ── Stage 1 ───────────────────────────────────────────────────────────
+
+    /// The full scrub-rule matrix lives in `crate::normalize::history`; this
+    /// covers only the wiring.
+    #[test]
+    fn reasoning_is_stripped_and_reported() {
+        let mut body = json!({
+            "messages": [
+                {"role": "assistant", "content": "hello", "reasoning_content": "ramble"},
+            ]
+        });
+        assert!(shape_messages(&mut body, &ctx(ModelCapabilities::empty())));
+        assert!(body["messages"][0].get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn no_messages_array_reports_no_change() {
+        let mut body = json!({"model": "m"});
+        assert!(!shape_messages(&mut body, &ctx(ModelCapabilities::empty())));
+        assert_eq!(body, json!({"model": "m"}));
+    }
+
+    #[test]
+    fn clean_history_reports_no_change() {
+        let mut body = json!({"messages": [{"role": "user", "content": "hi"}]});
+        let before = body.clone();
+        assert!(!shape_messages(&mut body, &ctx(ModelCapabilities::empty())));
+        assert_eq!(body, before);
+    }
+
+    // ── Stage 2 fast paths ────────────────────────────────────────────────
+    // Each must leave the body alone: the proxy relies on a `false` return to
+    // forward the client's original bytes.
+
+    #[test]
+    fn unknown_capabilities_skip_coalescing() {
+        let mut body = json!({"messages": [
+            {"role": "user", "content": "one"},
+            {"role": "user", "content": "two"},
+        ]});
+        let before = body.clone();
+        assert!(!shape_messages(&mut body, &ctx(ModelCapabilities::empty())));
+        assert_eq!(body, before, "consecutive user messages must survive");
+    }
+
+    #[test]
+    fn system_role_without_strict_turns_skips_coalescing() {
+        let mut body = json!({"messages": [
+            {"role": "user", "content": "one"},
+            {"role": "user", "content": "two"},
+        ]});
+        let before = body.clone();
+        assert!(!shape_messages(
+            &mut body,
+            &ctx(ModelCapabilities::SUPPORTS_SYSTEM_ROLE)
+        ));
+        assert_eq!(body, before);
+    }
+
+    #[test]
+    fn undeserialisable_messages_are_left_alone() {
+        // `role` must be a string; a number makes the whole array unreadable.
+        let mut body = json!({"messages": [{"role": 7, "content": "x"}]});
+        let before = body.clone();
+        assert!(!shape_messages(
+            &mut body,
+            &ctx(ModelCapabilities::REQUIRES_STRICT_TURNS)
+        ));
+        assert_eq!(body, before);
+    }
+
+    // ── Stage 2 proper ────────────────────────────────────────────────────
+
+    #[test]
+    fn strict_turns_merges_consecutive_same_role_messages() {
+        let mut body = json!({"messages": [
+            {"role": "user", "content": "one"},
+            {"role": "user", "content": "two"},
+        ]});
+        assert!(shape_messages(
+            &mut body,
+            &ctx(ModelCapabilities::REQUIRES_STRICT_TURNS)
+        ));
+        assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(body["messages"][0]["content"], "one\n\ntwo");
+    }
+
+    #[test]
+    fn coalescing_preserves_tool_call_ids() {
+        let mut body = json!({"messages": [
+            {"role": "user", "content": "go"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]});
+        assert!(shape_messages(
+            &mut body,
+            &ctx(ModelCapabilities::REQUIRES_STRICT_TURNS)
+        ));
+        assert_eq!(body["messages"][1]["tool_call_id"], "call_1");
+    }
+
+    /// Both stages on one body: the strip must happen before the merge, or the
+    /// `<think>` block would be buried inside merged content.
+    #[test]
+    fn both_stages_apply_to_the_same_body() {
+        let mut body = json!({"messages": [
+            {"role": "assistant", "content": "<think>hidden</think>a"},
+            {"role": "assistant", "content": "b"},
+        ]});
+        assert!(shape_messages(
+            &mut body,
+            &ctx(ModelCapabilities::REQUIRES_STRICT_TURNS)
+        ));
+        assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(body["messages"][0]["content"], "a\n\nb");
+    }
+
+    /// Top-level fields are stage 4's business; stage 2 must not touch them.
+    #[test]
+    fn non_message_fields_are_untouched() {
+        let mut body = json!({
+            "model": "m",
+            "anything_at_all": {"deep": [1, 2]},
+            "messages": [
+                {"role": "user", "content": "one"},
+                {"role": "user", "content": "two"},
+            ],
+        });
+        shape_messages(&mut body, &ctx(ModelCapabilities::REQUIRES_STRICT_TURNS));
+        assert_eq!(body["model"], "m");
+        assert_eq!(body["anything_at_all"], json!({"deep": [1, 2]}));
+    }
+}

--- a/crates/gglib-core/src/request_pipeline/mod.rs
+++ b/crates/gglib-core/src/request_pipeline/mod.rs
@@ -1,9 +1,15 @@
 #![doc = include_str!("README.md")]
+pub mod apply;
+pub mod messages;
 pub mod model_context;
 pub mod resolve;
+pub mod sampling;
 
+pub use apply::apply;
+pub use messages::shape_messages;
 pub use model_context::ModelContext;
 pub use resolve::resolve;
+pub use sampling::{SamplingLayers, resolve_sampling};
 
 #[cfg(test)]
 mod tests_support {

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -1,0 +1,271 @@
+//! Stage 4–5: resolving what the model is asked to sample with.
+//!
+//! Unlike [`super::messages`], nothing here reads `messages` — these transforms
+//! only ever touch top-level keys.
+
+use serde_json::Value;
+
+use super::ModelContext;
+use crate::domain::InferenceConfig;
+
+/// The sampling layers that sit *below* the client's own request parameters.
+///
+/// Grouped because they are only ever used together, at the single point where
+/// [`InferenceConfig::resolve_with_profile`] runs.
+///
+/// The per-model layer is deliberately absent: it arrives with the rest of the
+/// per-model facts, as
+/// [`ModelContext::inference_defaults`](super::ModelContext::inference_defaults),
+/// so no caller has to look the model up twice. The client's own parameters are
+/// absent for a different reason — they are read back out of the request body
+/// itself, which is what lets one function serve a proxy forwarding an
+/// arbitrary client payload and an adapter that built the body from a typed
+/// config.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SamplingLayers {
+    /// The profile the request selected via `{model}:{profile}`, if any.
+    /// Sparse — see [`crate::domain::inference_profile`].
+    pub profile: Option<InferenceConfig>,
+    /// Global defaults from settings.
+    pub global: Option<InferenceConfig>,
+}
+
+/// Resolve the sampling hierarchy into `body`, then pin `cache_prompt`.
+///
+/// # Force-insert, not `or_insert`
+///
+/// The client's own parameters are extracted from `body` first, merged
+/// **beneath** profile / model / global by
+/// [`InferenceConfig::resolve_with_profile`], and the fully-resolved result is
+/// then written back over the top. Client parameters still win — they win by
+/// being the highest-priority layer *inside* the merge, not by surviving an
+/// `or_insert`. Rewriting this as `or_insert` looks equivalent and silently
+/// breaks the hierarchy: every layer below the client would stop applying to
+/// any key the client happened to send.
+///
+/// A body that is not a JSON object is left alone.
+pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingLayers) {
+    let client_params = InferenceConfig::from_openai_json(body);
+    let resolved = client_params.resolve_with_profile(
+        layers.profile.as_ref(),
+        ctx.inference_defaults.as_ref(),
+        layers.global.as_ref(),
+    );
+
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+
+    for (key, value) in resolved.to_openai_json_patch() {
+        obj.insert(key, value);
+    }
+
+    // Force-insert (not or_insert) llama-server's own `cache_prompt` flag.
+    // It defaults to true server-side, but nothing guarantees the calling
+    // client doesn't send `false` — and if it ever did, llama-server's
+    // n_past = get_common_prefix(...) reuse computation (server-context.cpp)
+    // is skipped entirely, silently discarding 100% of any restored/hot KV
+    // state and forcing a full re-prefill regardless of how well the prompt
+    // actually matches. The whole KV cache session persistence feature depends
+    // on this staying true, so pin it rather than trusting it implicitly.
+    obj.insert("cache_prompt".to_owned(), Value::Bool(true));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp(value: f32) -> InferenceConfig {
+        InferenceConfig {
+            temperature: Some(value),
+            ..Default::default()
+        }
+    }
+
+    fn model_ctx(defaults: Option<InferenceConfig>) -> ModelContext {
+        ModelContext {
+            inference_defaults: defaults,
+            ..ModelContext::passthrough()
+        }
+    }
+
+    /// `f32 → f64` widening makes exact literal comparison unreliable.
+    #[track_caller]
+    fn assert_param(body: &Value, key: &str, expected: f64) {
+        let actual = body
+            .get(key)
+            .and_then(Value::as_f64)
+            .unwrap_or_else(|| panic!("{key} missing from body: {body}"));
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "{key}: expected {expected}, got {actual}"
+        );
+    }
+
+    // ── The hierarchy ─────────────────────────────────────────────────────
+
+    /// One table, four rows: each layer wins only over the ones beneath it.
+    #[test]
+    fn each_layer_beats_the_ones_below_it() {
+        let cases = [
+            // (client temperature, profile, model, global, expected, why)
+            (
+                Some(0.11),
+                Some(0.22),
+                Some(0.33),
+                Some(0.44),
+                0.11,
+                "client beats profile",
+            ),
+            (
+                None,
+                Some(0.22),
+                Some(0.33),
+                Some(0.44),
+                0.22,
+                "profile beats model",
+            ),
+            (
+                None,
+                None,
+                Some(0.33),
+                Some(0.44),
+                0.33,
+                "model beats global",
+            ),
+            (None, None, None, Some(0.44), 0.44, "global beats hardcoded"),
+            (None, None, None, None, 0.7, "hardcoded fallback"),
+        ];
+
+        for (client, profile, model, global, expected, why) in cases {
+            let mut body = client.map_or_else(|| json!({}), |t| json!({"temperature": t}));
+            let layers = SamplingLayers {
+                profile: profile.map(temp),
+                global: global.map(temp),
+            };
+            resolve_sampling(&mut body, &model_ctx(model.map(temp)), &layers);
+            assert_param(&body, "temperature", expected);
+            assert!(
+                body["temperature"].as_f64().is_some(),
+                "{why}: temperature must be present"
+            );
+        }
+    }
+
+    /// Profiles are sparse: outranking the model layer must not blank out the
+    /// parameters the profile says nothing about.
+    #[test]
+    fn a_sparse_profile_leaves_other_model_defaults_intact() {
+        let mut body = json!({});
+        let model = InferenceConfig {
+            temperature: Some(1.0),
+            presence_penalty: Some(1.5),
+            ..Default::default()
+        };
+        resolve_sampling(
+            &mut body,
+            &model_ctx(Some(model)),
+            &SamplingLayers {
+                profile: Some(temp(0.2)),
+                global: None,
+            },
+        );
+
+        assert_param(&body, "temperature", 0.2);
+        assert_param(&body, "presence_penalty", 1.5);
+    }
+
+    /// The force-insert. An `or_insert` implementation passes every test above
+    /// and fails this one.
+    #[test]
+    fn resolution_overwrites_a_partial_client_value_from_lower_layers() {
+        // The client named only `temperature`. Every other key must still be
+        // written from the layers beneath it rather than left absent.
+        let mut body = json!({"temperature": 0.11});
+        resolve_sampling(
+            &mut body,
+            &model_ctx(Some(InferenceConfig {
+                top_p: Some(0.42),
+                ..Default::default()
+            })),
+            &SamplingLayers::default(),
+        );
+
+        assert_param(&body, "temperature", 0.11);
+        assert_param(&body, "top_p", 0.42);
+    }
+
+    // ── cache_prompt ──────────────────────────────────────────────────────
+
+    #[test]
+    fn cache_prompt_is_pinned_true_when_absent() {
+        let mut body = json!({});
+        resolve_sampling(
+            &mut body,
+            &ModelContext::passthrough(),
+            &SamplingLayers::default(),
+        );
+        assert_eq!(body["cache_prompt"], true);
+    }
+
+    /// The KV cache feature depends on this: a client that sends `false` must
+    /// not be able to discard the whole restored cache.
+    #[test]
+    fn cache_prompt_is_forced_true_over_an_explicit_false() {
+        let mut body = json!({"cache_prompt": false});
+        resolve_sampling(
+            &mut body,
+            &ModelContext::passthrough(),
+            &SamplingLayers::default(),
+        );
+        assert_eq!(body["cache_prompt"], true);
+    }
+
+    // ── Passthrough ───────────────────────────────────────────────────────
+
+    #[test]
+    fn unknown_fields_survive_untouched() {
+        let mut body = json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "totally_made_up_key": {"nested": [1, 2, {"deep": true}]},
+        });
+        resolve_sampling(
+            &mut body,
+            &ModelContext::passthrough(),
+            &SamplingLayers::default(),
+        );
+
+        assert_eq!(body["model"], "m");
+        assert_eq!(body["messages"][0]["content"], "hi");
+        assert_eq!(
+            body["totally_made_up_key"],
+            json!({"nested": [1, 2, {"deep": true}]})
+        );
+    }
+
+    /// `max_tokens` has no hardcoded fallback on purpose — a value here would
+    /// cap every request that did not name its own.
+    #[test]
+    fn no_max_tokens_is_written_when_nothing_sets_one() {
+        let mut body = json!({});
+        resolve_sampling(
+            &mut body,
+            &ModelContext::passthrough(),
+            &SamplingLayers::default(),
+        );
+        assert!(body.as_object().unwrap().get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn a_non_object_body_is_left_alone() {
+        let mut body = json!([1, 2, 3]);
+        resolve_sampling(
+            &mut body,
+            &ModelContext::passthrough(),
+            &SamplingLayers::default(),
+        );
+        assert_eq!(body, json!([1, 2, 3]));
+    }
+}

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -3,18 +3,16 @@
 //!
 //! ## Request pipeline
 //!
-//! Before the upstream call the proxy applies three stateless transforms to the
-//! request body, in order:
+//! The request-shaping transforms themselves live in
+//! [`gglib_core::request_pipeline`], which owns their order and its rationale
+//! — they are shared verbatim with the in-process agent path so the two cannot
+//! drift.  What is proxy-specific, and therefore still here, is the `Bytes` ⇄
+//! `Value` conversion at the HTTP boundary ([`edit_json_body`]) and one stage
+//! that cannot live in `gglib-core` at all:
 //!
-//! 1. [`strip_prior_reasoning`] — scrubs `<think>` / `reasoning_content`
-//!    artefacts from prior assistant turns so reasoning models don't
-//!    pattern-match their own past traces.
-//! 2. [`coalesce_for_capabilities`] — when a model's stored
-//!    [`ModelCapabilities`] includes [`REQUIRES_STRICT_TURNS`], merges
-//!    consecutive same-role user/assistant messages before they reach the
-//!    Jinja template.  Mistral-family models raise a hard 500 exception
-//!    without this.
-//! 3. [`truncate_history`] — defends against client-side context compaction
+//! 1. [`shape_messages`](gglib_core::request_pipeline::shape_messages) — the
+//!    reasoning strip and capability coalescing.
+//! 2. [`truncate_history`] — defends against client-side context compaction
 //!    failures.  While the request fits within the model's live context
 //!    budget it is forwarded **unchanged**; only when the payload exceeds the
 //!    budget are the **oldest** unprotected `role: "tool"` / `role:
@@ -24,6 +22,14 @@
 //!    the budget after every eligible message is trimmed, the request is
 //!    rejected with HTTP 400 / `context_length_exceeded`.  The last eight
 //!    messages and all `role: "system"` messages are always preserved.
+//! 3. [`resolve_sampling`](gglib_core::request_pipeline::resolve_sampling) —
+//!    the sampling hierarchy and the `cache_prompt` pin.
+//!
+//! Truncation is what keeps this a three-call sequence rather than a single
+//! [`apply`](gglib_core::request_pipeline::apply): it gates on the payload's
+//! size in **wire bytes** and can reject the request with an HTTP response, so
+//! it can neither move into `gglib-core` nor be reordered around the sampling
+//! stage without changing the number it measures.
 //!
 //! Capabilities are resolved with a **single** catalog lookup per request
 //! (via [`gglib_core::request_pipeline::resolve`]) that yields both the
@@ -56,8 +62,6 @@
 //! Non-streaming responses are forwarded verbatim for now — the dialects
 //! we currently rewrite (Qwen XML tool calls, bare `<think>` tags) only
 //! manifest in streaming clients today.
-//!
-//! [`REQUIRES_STRICT_TURNS`]: gglib_core::ModelCapabilities
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -73,11 +77,9 @@ use reqwest::Client;
 use tracing::{debug, error, info, warn};
 
 use gglib_core::LlmStreamEvent;
-use gglib_core::ModelCapabilities;
-use gglib_core::domain::{ChatMessage, InferenceConfig, transform_messages_for_capabilities};
 use gglib_core::normalize::{NormalizingStream, get_parser};
 use gglib_core::ports::ModelCatalogPort;
-use gglib_core::request_pipeline;
+use gglib_core::request_pipeline::{self, SamplingLayers};
 use gglib_core::sse::{DONE_SENTINEL, SseEncoder, SseStreamDecoder};
 
 use crate::cache_metrics::CacheMetricsStore;
@@ -224,174 +226,33 @@ fn inject_streaming_body_overrides(body: Bytes) -> Bytes {
     }
 }
 
-/// The sampling layers that sit *below* the client's own request parameters.
+/// Run one `gglib-core` request-shaping stage over a body held as `Bytes`.
 ///
-/// Grouped because they are only ever used together, at the single point where
-/// [`InferenceConfig::resolve_with_profile`] runs. Passing them as one argument
-/// also keeps [`forward_chat_completion`]'s already-long parameter list from
-/// growing.
+/// The shared stages operate on a `&mut serde_json::Value` — the seam that
+/// preserves unknown client fields, which a typed request struct would silently
+/// drop.  This is the whole of what the proxy adds on top: the conversion at
+/// the HTTP boundary, with zero blast radius at each step.
 ///
-/// The per-model layer is not here: it comes from the catalog lookup this
-/// function already performs, as
-/// [`ModelContext::inference_defaults`](gglib_core::request_pipeline::ModelContext::inference_defaults).
-pub(crate) struct SamplingLayers {
-    /// The profile the request selected via `{model}:{profile}`, if any.
-    /// Sparse — see `gglib_core::domain::inference_profile`.
-    pub profile: Option<InferenceConfig>,
-    /// Global defaults from settings.
-    pub global: Option<InferenceConfig>,
-}
-
-/// Strip prior reasoning artifacts from assistant messages in the request body.
-///
-/// Thin adapter over [`gglib_core::normalize::history::strip_thinking_debt`]
-/// — that module is the single source of truth for the scrub rules.  This
-/// function exists only to handle the bytes ⇄ JSON conversion at the proxy
-/// boundary:
-///
-/// * On parse failure, the original `Bytes` are returned unchanged (zero
-///   blast radius for non-JSON or unexpected request shapes).
-/// * When the shared scrubber reports zero changes, the original `Bytes`
-///   are returned to avoid a needless re-serialization.
-fn strip_prior_reasoning(body: Bytes) -> Bytes {
+/// * A body that is not JSON is forwarded byte-for-byte.
+/// * `edit` reports whether it changed anything; when it did not, the original
+///   `Bytes` are returned rather than a re-encoding of the same value.  That
+///   matters beyond saving a serialization — [`truncate_history`] sizes its
+///   budget from `body.len()`, so re-encoding an untouched body would have it
+///   measure something the client never sent.
+/// * A re-serialization failure forwards the original and logs.
+fn edit_json_body(body: Bytes, edit: impl FnOnce(&mut serde_json::Value) -> bool) -> Bytes {
     let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
         return body;
     };
 
-    let Some(messages) = value.get_mut("messages").and_then(|v| v.as_array_mut()) else {
-        return body;
-    };
-
-    let touched = gglib_core::normalize::strip_thinking_debt(messages);
-    if touched == 0 {
+    if !edit(&mut value) {
         return body;
     }
 
     match serde_json::to_vec(&value) {
-        Ok(v) => {
-            debug!(touched, "stripped prior reasoning from assistant messages");
-            Bytes::from(v)
-        }
+        Ok(v) => Bytes::from(v),
         Err(e) => {
-            warn!(error = %e, "failed to re-serialize request after reasoning strip; forwarding original");
-            body
-        }
-    }
-}
-
-/// Coalesce consecutive same-role messages when the model requires strict
-/// turn alternation.
-///
-/// Mistral-family models (and any architecture with
-/// [`ModelCapabilities::REQUIRES_STRICT_TURNS`]) enforce user/assistant
-/// alternation inside their Jinja chat templates and raise a hard 500
-/// exception when consecutive same-role messages are present.  IDEs and
-/// gateway extensions (e.g. the VSCode LLM Gateway) routinely send
-/// multi-turn context that violates this — coalescing here is the correct
-/// fix rather than constraining callers.
-///
-/// Uses [`transform_messages_for_capabilities`] from `gglib-core` as the
-/// single source of truth for the merging rules, exactly as the internal
-/// `chat_api` path does.  When capabilities are empty (unknown model) this
-/// function is a zero-cost no-op.
-///
-/// On parse failure the original bytes are returned unchanged.
-fn coalesce_for_capabilities(body: Bytes, capabilities: ModelCapabilities) -> Bytes {
-    // Fast path: no preprocessing needed for this model.
-    if !capabilities.requires_strict_turns() && capabilities.supports_system_role() {
-        return body;
-    }
-    // Also fast path when capabilities are completely unknown.
-    if capabilities.is_empty() {
-        return body;
-    }
-
-    debug!(
-        requires_strict_turns = capabilities.requires_strict_turns(),
-        supports_system_role = capabilities.supports_system_role(),
-        "coalesce: entering message transformation"
-    );
-
-    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
-        warn!("coalesce: failed to parse request body as JSON; forwarding original");
-        return body;
-    };
-
-    let Some(messages_raw) = value.get("messages").and_then(|v| v.as_array()) else {
-        debug!("coalesce: no messages array found in request body");
-        return body;
-    };
-
-    let before_count = messages_raw.len();
-
-    // Log size of non-message top-level fields to identify what's inflating the body.
-    for (key, val) in value.as_object().into_iter().flatten() {
-        if key != "messages" {
-            let approx_bytes = serde_json::to_vec(val).map(|v| v.len()).unwrap_or(0);
-            debug!(key, approx_bytes, "coalesce: top-level field size");
-        }
-    }
-
-    // Deserialise only the fields `transform_messages_for_capabilities` needs.
-    // `ChatMessage.content` accepts both a plain JSON string and a JSON array of
-    // content-part objects (e.g. VSCode LLM Gateway sends array-form content per
-    // the OpenAI spec).  Using `MessageContent` ensures we can always round-trip.
-    let messages: Vec<ChatMessage> =
-        match serde_json::from_value(serde_json::Value::Array(messages_raw.clone())) {
-            Ok(m) => m,
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    before = before_count,
-                    "coalesce: failed to deserialise messages as Vec<ChatMessage>; \
-                     forwarding original body unchanged. \
-                     This usually means a message field has an unexpected type."
-                );
-                return body;
-            }
-        };
-
-    debug!(
-        before = before_count,
-        roles = ?messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
-        "coalesce: parsed messages for transformation"
-    );
-    for (i, m) in messages.iter().enumerate() {
-        let content_bytes = m
-            .content
-            .as_ref()
-            .map(|c| {
-                c.as_str()
-                    .map(|s| s.len())
-                    .unwrap_or_else(|| format!("{:?}", c).len())
-            })
-            .unwrap_or(0);
-        debug!(i, role = %m.role, content_bytes, "coalesce: message sizes");
-    }
-
-    let transformed = transform_messages_for_capabilities(messages, capabilities);
-    let after_count = transformed.len();
-
-    debug!(
-        before = before_count,
-        after = after_count,
-        merged = before_count.saturating_sub(after_count),
-        "coalesce: transformation complete"
-    );
-
-    match serde_json::to_value(&transformed) {
-        Ok(new_messages) => {
-            value["messages"] = new_messages;
-            match serde_json::to_vec(&value) {
-                Ok(v) => Bytes::from(v),
-                Err(e) => {
-                    warn!(error = %e, "coalesce: failed to re-serialize; forwarding original");
-                    body
-                }
-            }
-        }
-        Err(e) => {
-            warn!(error = %e, "coalesce: failed to serialise transformed messages; forwarding original");
+            warn!(error = %e, "failed to re-serialize request body after shaping; forwarding original");
             body
         }
     }
@@ -469,15 +330,12 @@ pub(crate) async fn forward_chat_completion(
     // BPE stability) already happened once in `chat_completions` before this
     // function was called, so the body arriving here doesn't need it again.
     //
-    // 1. Strip reasoning artefacts from prior assistant turns so reasoning
-    //    models don't pattern-match their own past <think> traces.
-    let body = strip_prior_reasoning(body);
+    // 1. Message-level shaping: strip prior-turn reasoning artefacts, then
+    //    coalesce consecutive same-role messages for strict-turn models.
+    //    Shared with the agent path — see `gglib_core::request_pipeline`.
+    let body = edit_json_body(body, |v| request_pipeline::shape_messages(v, &context));
 
-    // 2. Coalesce consecutive same-role messages for strict-turn models
-    //    (e.g. Mistral/Devstral).  No-op when capabilities are empty/unknown.
-    let body = coalesce_for_capabilities(body, context.capabilities);
-
-    // 3. Truncate stale tool/large-assistant history to prevent local model
+    // 2. Truncate stale tool/large-assistant history to prevent local model
     //    context-window overflow caused by broken client-side compaction.
     //    The budget scales with the live serving context so clients that
     //    plan against the advertised context window are never rejected by a
@@ -533,40 +391,13 @@ pub(crate) async fn forward_chat_completion(
         "sending request to upstream (post-transform)"
     );
 
-    // 4. Inject resolved inference defaults.
-    //
-    // Extract any params the client already sent, then merge model-level and
-    // global defaults behind them via the 4-level hierarchy.  The resolved
-    // values are aggressively inserted (not `or_insert`) so that every
-    // param in the final config is forwarded to llama-server.
-    let body = if let Ok(mut body_value) = serde_json::from_slice::<serde_json::Value>(&body) {
-        let client_params = InferenceConfig::from_openai_json(&body_value);
-        let resolved = client_params.resolve_with_profile(
-            sampling.profile.as_ref(),
-            context.inference_defaults.as_ref(),
-            sampling.global.as_ref(),
-        );
-        if let Some(body_obj) = body_value.as_object_mut() {
-            for (k, v) in resolved.to_openai_json_patch() {
-                body_obj.insert(k, v);
-            }
-            // Force-insert (not or_insert) llama-server's own `cache_prompt`
-            // flag. It defaults to true server-side, but nothing guarantees
-            // the calling client doesn't send `false` — and if it ever did,
-            // llama-server's n_past = get_common_prefix(...) reuse computation
-            // (server-context.cpp) is skipped entirely, silently discarding
-            // 100% of any restored/hot KV state and forcing a full re-prefill
-            // regardless of how well the prompt actually matches. The whole
-            // KV cache session persistence feature depends on this staying
-            // true, so pin it rather than trusting it implicitly.
-            body_obj.insert("cache_prompt".to_owned(), serde_json::Value::Bool(true));
-        }
-        serde_json::to_vec(&body_value)
-            .map(Bytes::from)
-            .unwrap_or(body)
-    } else {
-        body
-    };
+    // 3. Resolve the sampling hierarchy into the body and pin `cache_prompt`.
+    //    Both are force-inserts, and both must stay that way — see
+    //    `gglib_core::request_pipeline::resolve_sampling`.
+    let body = edit_json_body(body, |v| {
+        request_pipeline::resolve_sampling(v, &context, &sampling);
+        true
+    });
 
     // Build the request builder with all forwarded headers.
     let mut req_builder = client
@@ -1068,46 +899,42 @@ mod tests {
         assert_eq!(out, body, "non-JSON bodies must pass through unchanged");
     }
 
-    fn parse(b: &Bytes) -> serde_json::Value {
-        serde_json::from_slice(b).expect("valid json")
-    }
-
-    // The full scrub-rule matrix lives in `gglib_core::normalize::history`
-    // tests.  These tests cover only the bytes ⇄ JSON adapter behaviour
-    // that is unique to the proxy boundary.
+    // The transforms themselves are tested in `gglib_core::request_pipeline`.
+    // What is left here is the bytes ⇄ JSON conversion unique to the proxy
+    // boundary — specifically, the conditions under which the client's
+    // original payload must be forwarded rather than a re-encoding of it.
 
     #[test]
-    fn strip_delegates_and_reserializes_when_changes_made() {
-        let body = Bytes::from(
-            r#"{"model":"m","messages":[
-                {"role":"assistant","content":"hello","reasoning_content":"long ramble..."}
-            ]}"#,
-        );
-        let out = parse(&strip_prior_reasoning(body));
-        assert!(out["messages"][0].get("reasoning_content").is_none());
-        assert_eq!(out["messages"][0]["content"], "hello");
+    fn edit_json_body_reserializes_when_the_stage_reports_a_change() {
+        let body = Bytes::from(r#"{"model":"m","keep":1}"#);
+        let out = edit_json_body(body, |v| {
+            v["added"] = serde_json::Value::Bool(true);
+            true
+        });
+        let parsed: serde_json::Value = serde_json::from_slice(&out).expect("valid json");
+        assert_eq!(parsed["added"], true);
+        assert_eq!(parsed["keep"], 1, "untouched fields survive");
+    }
+
+    /// A stage reporting no change must cost the body nothing — not even a
+    /// re-encoding, which would reorder keys and change `body.len()` under
+    /// `truncate_history`.
+    #[test]
+    fn edit_json_body_returns_the_original_bytes_when_nothing_changed() {
+        // Deliberately not in the canonical form `serde_json` would emit:
+        // whitespace and key order both differ from a round-trip.
+        let body = Bytes::from(r#"{ "zeta": 1,  "alpha": 2 }"#);
+        let out = edit_json_body(body.clone(), |_| false);
+        assert_eq!(out, body, "must be the same bytes, not the same value");
     }
 
     #[test]
-    fn strip_returns_original_bytes_on_invalid_json() {
+    fn edit_json_body_leaves_non_json_bodies_alone() {
         let body = Bytes::from_static(b"not json");
-        let out = strip_prior_reasoning(body.clone());
-        assert_eq!(out, body);
-    }
-
-    #[test]
-    fn strip_returns_original_bytes_when_messages_missing() {
-        let body = Bytes::from(r#"{"model":"m"}"#);
-        let out = strip_prior_reasoning(body.clone());
-        assert_eq!(out, body);
-    }
-
-    #[test]
-    fn strip_returns_original_bytes_when_no_changes_needed() {
-        // When no reasoning content is present the body should pass through
-        // byte-for-byte unchanged.
-        let body = Bytes::from(r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#);
-        let out = strip_prior_reasoning(body.clone());
+        let out = edit_json_body(body.clone(), |v| {
+            *v = serde_json::json!({"should": "never happen"});
+            true
+        });
         assert_eq!(out, body);
     }
 }

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -25,13 +25,14 @@ use tracing::{debug, error, info, warn};
 use gglib_core::ports::{
     ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository,
 };
+use gglib_core::request_pipeline::SamplingLayers;
 use gglib_mcp::McpService;
 
 use crate::cache_lifecycle::{StreamConfig, clear_cache, run_with_cache};
 use crate::connections::ActiveConnectionsRegistry;
 use crate::council_proxy::{CouncilDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info};
 use crate::dashboard::{CacheStatus, CacheStatusCache, DashboardState, spawn_dashboard_publisher};
-use crate::forward::{ForwardError, SamplingLayers, forward_chat_completion};
+use crate::forward::{ForwardError, forward_chat_completion};
 use crate::mcp::handlers::{delete_mcp, get_mcp, post_mcp};
 use crate::mcp::session::SessionManager;
 use crate::metrics::ContextMetricsStore;

--- a/crates/gglib-runtime/src/compose.rs
+++ b/crates/gglib-runtime/src/compose.rs
@@ -15,9 +15,11 @@
 //!
 //! Every entry point hands in a [`ModelContext`] resolved by
 //! [`gglib_core::request_pipeline::resolve`] rather than a bare tag list, so
-//! the agent path carries the same per-model facts the proxy does. Only `tags`
-//! is read here so far; capabilities and inference defaults are along for the
-//! ride until the request-shaping step consumes them.
+//! the agent path carries the same per-model facts the proxy does — and now
+//! acts on all of them: capabilities drive request-side message coalescing,
+//! inference defaults are a layer of the sampling hierarchy, and `format:*`
+//! tags select the response parser. The context is handed to the adapter whole
+//! rather than being taken apart here.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -40,11 +42,10 @@ use crate::LlmCompletionAdapter;
 /// * `http_client` — shared `reqwest::Client` (connection-pooled).
 /// * `model` — optional model-name override forwarded to llama-server.
 /// * `model_context` — resolved per-model facts from
-///   [`gglib_core::request_pipeline::resolve`]. Only `tags` is consumed today
-///   (to select a dialect-specific normalization parser at adapter
-///   construction time); capabilities and inference defaults ride along for
-///   the request-shaping step that follows. Pass
-///   [`ModelContext::passthrough`] for the identity parser.
+///   [`gglib_core::request_pipeline::resolve`], driving both request shaping
+///   and response-parser selection. Pass [`ModelContext::passthrough`] when the
+///   model is unknown: every transform becomes a no-op and the identity parser
+///   is selected.
 /// * `mcp` — handle to the running MCP service (for tool discovery/execution).
 /// * `tool_filter` — `Some(set)` restricts the visible tools to the named
 ///   allowlist; `None` exposes all tools from all connected MCP servers.
@@ -126,7 +127,7 @@ pub fn compose_council_ports(
     let llm: Arc<dyn LlmCompletionPort> = Arc::new(
         LlmCompletionAdapter::with_client(base_url, http_client, model)
             .with_sampling(sampling)
-            .with_tags(model_context.tags),
+            .with_model_context(model_context),
     );
     let tool_executor: Arc<dyn ToolExecutorPort> = match sandbox_root {
         Some(root) => Arc::new(CombinedToolExecutor::with_sandbox(mcp, root)),
@@ -149,7 +150,7 @@ fn compose_agent_loop_inner(
     let llm: Arc<dyn LlmCompletionPort> = Arc::new(
         LlmCompletionAdapter::with_client(base_url, http_client, model)
             .with_sampling(sampling)
-            .with_tags(model_context.tags),
+            .with_model_context(model_context),
     );
     let tool_executor: Arc<dyn ToolExecutorPort> = match sandbox_root {
         Some(root) => Arc::new(CombinedToolExecutor::with_sandbox(mcp, root)),

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/README.md
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/README.md
@@ -38,6 +38,7 @@ let agent   = AgentLoop::build(Arc::new(adapter), tool_executor, None);
 | Module | LOC | Complexity | Coverage |
 |--------|-----|------------|----------|
 | [`body.rs`](body.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-body-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-body-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-body-coverage.json) |
+| [`shaping_tests.rs`](shaping_tests.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-shaping_tests-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-shaping_tests-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-llm_completion-shaping_tests-coverage.json) |
 <!-- module-table:end -->
 
 </details>

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/body.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/body.rs
@@ -5,6 +5,13 @@
 //! [`super`] so the resulting body can be asserted on directly in tests
 //! without an HTTP round trip.
 //!
+//! **Translation only.** Every transform that *reshapes* a request — the
+//! reasoning strip, capability coalescing, resolving the sampling hierarchy —
+//! belongs to [`gglib_core::request_pipeline`] and runs on the finished body in
+//! [`super::LlmCompletionAdapter::chat_stream`], so the agent path and the proxy
+//! apply the same ones in the same order. What this module writes is only what
+//! the *caller* asked for.
+//!
 //! [`LlmCompletionAdapter`]: super::LlmCompletionAdapter
 
 use serde_json::{Value, json};
@@ -107,14 +114,8 @@ pub(super) fn build_chat_body(
     sampling: Option<&InferenceConfig>,
     response_format: Option<&ResponseFormat>,
 ) -> Value {
-    let mut openai_messages: Vec<Value> = messages.iter().map(message_to_openai).collect();
+    let openai_messages: Vec<Value> = messages.iter().map(message_to_openai).collect();
     let openai_tools: Vec<Value> = tools.iter().map(tool_def_to_openai).collect();
-
-    // Scrub prior-turn reasoning artifacts before the model sees them.
-    // Shared with the proxy via gglib-core so the in-process agent loop
-    // (CLI / Tauri direct path) gets identical protection against the
-    // small-reasoning-model multi-turn `<think>` loop bug.
-    gglib_core::normalize::strip_thinking_debt(&mut openai_messages);
 
     let mut body = json!({
         "model": model,
@@ -126,11 +127,15 @@ pub(super) fn build_chat_body(
         body["tools"] = json!(openai_tools);
         body["tool_choice"] = json!("auto");
     }
-    // Apply sampling through the same serde-driven helper the proxy uses
-    // (`forward_chat_completion`), so the two request paths cannot drift.  A
-    // hand-rolled field-by-field copy here is what silently dropped
-    // `presence_penalty` and `min_p` when they were added to InferenceConfig.
-    // `to_openai_json_patch` emits only `Some` fields, already snake_cased.
+    // Write the caller's own sampling parameters — the top layer of the
+    // hierarchy, in the same place an external client would put them, so the
+    // shared pipeline can read them back and resolve the rest beneath them.
+    //
+    // Applied through the same serde-driven helper the proxy uses, so the two
+    // request paths cannot drift.  A hand-rolled field-by-field copy here is
+    // what silently dropped `presence_penalty` and `min_p` when they were added
+    // to InferenceConfig.  `to_openai_json_patch` emits only `Some` fields,
+    // already snake_cased.
     if let Some(s) = sampling
         && let Some(obj) = body.as_object_mut()
     {

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -12,6 +12,7 @@ use gglib_core::{
     domain::agent::{AgentMessage, LlmStreamEvent, ToolDefinition},
     normalize::{NormalizingStream, get_parser},
     ports::{LlmCompletionPort, ResponseFormat},
+    request_pipeline::{self, ModelContext, SamplingLayers},
     sse::SseStreamDecoder,
 };
 
@@ -46,15 +47,20 @@ pub struct LlmCompletionAdapter {
     /// by model name.
     model: String,
     client: Client,
-    /// Optional sampling overrides injected into every request body.
+    /// The caller's own sampling parameters — the top layer of the hierarchy,
+    /// equivalent to what an external client sends the proxy. Written into the
+    /// body by [`body::build_chat_body`] and read back out by
+    /// [`request_pipeline::apply`], which resolves the layers beneath them.
     sampling: Option<InferenceConfig>,
     /// Timeout (seconds) for the `.send()` phase (connect through response
     /// headers).  Defaults to [`DEFAULT_SEND_TIMEOUT_SECS`].
     send_timeout_secs: u64,
-    /// Model `format:*` tags consulted by [`gglib_core::normalize::get_parser`]
-    /// when wrapping the SSE-derived stream in a [`NormalizingStream`].
-    /// Empty (the default) selects the identity-passthrough parser.
-    tags: Vec<String>,
+    /// The resolved per-model facts, from
+    /// [`gglib_core::request_pipeline::resolve`].  Drives request shaping
+    /// (capabilities, inference defaults) and response-parser selection
+    /// (`format:*` tags).  [`ModelContext::passthrough`] — the default —
+    /// makes every transform a no-op and selects the identity parser.
+    model_context: ModelContext,
 }
 
 /// Build the completions endpoint URL from a base URL.
@@ -103,11 +109,15 @@ impl LlmCompletionAdapter {
             client,
             sampling: None,
             send_timeout_secs: DEFAULT_SEND_TIMEOUT_SECS,
-            tags: Vec::new(),
+            model_context: ModelContext::passthrough(),
         }
     }
 
-    /// Set optional sampling parameters injected into every request body.
+    /// Set the caller's own sampling parameters.
+    ///
+    /// These are the *highest* layer of the hierarchy, not the final word: the
+    /// model's stored defaults and the hardcoded fallbacks still fill in every
+    /// field left unset. Pass `None` to resolve entirely from those layers.
     #[must_use]
     pub fn with_sampling(mut self, sampling: Option<InferenceConfig>) -> Self {
         self.sampling = sampling;
@@ -122,17 +132,53 @@ impl LlmCompletionAdapter {
         self
     }
 
-    /// Set the model's `format:*` tags so the adapter can pick a
-    /// dialect-specific parser when wrapping the SSE-derived stream in a
-    /// [`NormalizingStream`].
+    /// Set the resolved per-model context, from
+    /// [`gglib_core::request_pipeline::resolve`].
     ///
-    /// Pass an empty `Vec` (the default) to select the identity-passthrough
-    /// parser, which is the right choice for any model that already speaks
-    /// strict OpenAI tool-calling.
+    /// This is what gives the in-process agent path the same per-model handling
+    /// the proxy has always had: capability-aware message coalescing, the
+    /// per-model layer of the sampling hierarchy, and a dialect-specific
+    /// response parser. Pass [`ModelContext::passthrough`] (the default) when
+    /// the model is unknown — every transform becomes a no-op and the identity
+    /// parser is selected, which is the right choice for any model that already
+    /// speaks strict `OpenAI` tool-calling.
     #[must_use]
-    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
-        self.tags = tags;
+    pub fn with_model_context(mut self, model_context: ModelContext) -> Self {
+        self.model_context = model_context;
         self
+    }
+
+    /// Build the request body and run the shared request-shaping pipeline over
+    /// it — everything that happens before the bytes leave this process.
+    ///
+    /// Separate from [`chat_stream`](LlmCompletionPort::chat_stream) so the
+    /// outgoing body can be asserted on directly, without an HTTP round trip.
+    fn shaped_body(
+        &self,
+        messages: &[AgentMessage],
+        tools: &[ToolDefinition],
+        response_format: Option<&ResponseFormat>,
+    ) -> serde_json::Value {
+        let mut body = body::build_chat_body(
+            &self.model,
+            messages,
+            tools,
+            self.sampling.as_ref(),
+            response_format,
+        );
+
+        // The same pipeline, in the same order, that the proxy runs.
+        // `build_chat_body` has already written the caller's sampling
+        // parameters into the body, which is exactly where an external client's
+        // would be, so `apply` reads them back as the top layer and resolves
+        // the model and hardcoded layers beneath them.
+        //
+        // Neither remaining layer applies in-process: there is no
+        // `{model}:{profile}` suffix to select a profile, and the global
+        // settings layer is already folded into `sampling` by the callers that
+        // have one.
+        request_pipeline::apply(&mut body, &self.model_context, &SamplingLayers::default());
+        body
     }
 }
 
@@ -148,13 +194,7 @@ impl LlmCompletionPort for LlmCompletionAdapter {
         tools: &[ToolDefinition],
         response_format: Option<&ResponseFormat>,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<LlmStreamEvent>> + Send>>> {
-        let body = body::build_chat_body(
-            &self.model,
-            messages,
-            tools,
-            self.sampling.as_ref(),
-            response_format,
-        );
+        let body = self.shaped_body(messages, tools, response_format);
 
         // Gate the connect + first-byte phase with a hard timeout so a
         // stalled or unresponsive llama-server doesn't hang the agent task
@@ -212,8 +252,12 @@ impl LlmCompletionPort for LlmCompletionAdapter {
         // Wrap the raw SSE-derived stream in the universal normalization
         // layer.  Empty `tags` selects the identity-passthrough parser so
         // models that already emit strict OpenAI tool calls are unaffected.
-        let parser = get_parser(&self.tags);
+        let parser = get_parser(&self.model_context.tags);
         let normalized = NormalizingStream::new(Box::pin(stream), parser);
         Ok(Box::pin(normalized))
     }
 }
+
+#[cfg(test)]
+#[path = "shaping_tests.rs"]
+mod shaping_tests;

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs
@@ -1,0 +1,171 @@
+//! What the adapter actually puts on the wire.
+//!
+//! [`super::LlmCompletionAdapter::shaped_body`] is the whole pre-transport
+//! path: translation in `body`, then the shared pipeline. The rules themselves
+//! are tested in `gglib_core::request_pipeline`; these assert that the agent
+//! path is genuinely wired to them, which is the thing that had drifted.
+
+use super::*;
+use gglib_core::domain::agent::{AssistantContent, ToolCall};
+use gglib_core::domain::{InferenceConfig, ModelCapabilities};
+use serde_json::{Value, json};
+
+fn adapter(model_context: ModelContext, sampling: Option<InferenceConfig>) -> LlmCompletionAdapter {
+    LlmCompletionAdapter::new("http://127.0.0.1:0", Some("m".to_owned()))
+        .with_model_context(model_context)
+        .with_sampling(sampling)
+}
+
+fn strict_turns() -> ModelContext {
+    ModelContext {
+        capabilities: ModelCapabilities::REQUIRES_STRICT_TURNS,
+        ..ModelContext::passthrough()
+    }
+}
+
+fn user(text: &str) -> AgentMessage {
+    AgentMessage::User {
+        content: text.to_owned(),
+    }
+}
+
+fn body_of(adapter: &LlmCompletionAdapter, messages: &[AgentMessage]) -> Value {
+    adapter.shaped_body(messages, &[], None)
+}
+
+// ── Stage 1: reasoning strip ──────────────────────────────────────────────
+
+/// Moved out of `build_chat_body` into the shared pipeline; it must still run.
+#[test]
+fn prior_turn_reasoning_is_stripped() {
+    let messages = vec![
+        user("hi"),
+        AgentMessage::Assistant {
+            content: AssistantContent {
+                text: Some("<think>ramble</think>answer".to_owned()),
+                tool_calls: vec![],
+            },
+        },
+    ];
+    let body = body_of(&adapter(ModelContext::passthrough(), None), &messages);
+    assert_eq!(body["messages"][1]["content"], "answer");
+}
+
+// ── Stage 2: capability coalescing ────────────────────────────────────────
+
+/// The capability the agent path never had. A strict-turn model receiving
+/// consecutive same-role messages raises a hard 500 from its Jinja template.
+#[test]
+fn strict_turn_models_get_consecutive_messages_merged() {
+    let body = body_of(
+        &adapter(strict_turns(), None),
+        &[user("one"), user("two"), user("three")],
+    );
+
+    let messages = body["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 1, "three user turns merge into one");
+    assert_eq!(messages[0]["content"], "one\n\ntwo\n\nthree");
+}
+
+/// Coalescing must not cost the agent loop its tool wiring — the merge runs
+/// through a typed round-trip, and `tool_call_id` is not one of the fields it
+/// models.
+#[test]
+fn coalescing_preserves_tool_call_ids() {
+    let messages = vec![
+        user("run it"),
+        AgentMessage::Assistant {
+            content: AssistantContent {
+                text: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_1".to_owned(),
+                    name: "f".to_owned(),
+                    arguments: json!({}),
+                }],
+            },
+        },
+        AgentMessage::Tool {
+            tool_call_id: "call_1".to_owned(),
+            content: "result".to_owned(),
+        },
+    ];
+    let body = body_of(&adapter(strict_turns(), None), &messages);
+
+    let tool = body["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["role"] == "tool")
+        .expect("tool message survives");
+    assert_eq!(tool["tool_call_id"], "call_1");
+    assert_eq!(tool["content"], "result");
+}
+
+/// A model the catalog could not resolve must lose its model-specific
+/// handling and nothing else.
+#[test]
+fn a_passthrough_context_merges_nothing() {
+    let body = body_of(
+        &adapter(ModelContext::passthrough(), None),
+        &[user("one"), user("two")],
+    );
+    assert_eq!(body["messages"].as_array().unwrap().len(), 2);
+}
+
+// ── Stages 4–5: sampling and cache_prompt ─────────────────────────────────
+
+/// The per-model layer the agent path never applied.
+#[test]
+fn per_model_inference_defaults_reach_the_body() {
+    let ctx = ModelContext {
+        inference_defaults: Some(InferenceConfig {
+            temperature: Some(0.42),
+            ..Default::default()
+        }),
+        ..ModelContext::passthrough()
+    };
+    let body = body_of(&adapter(ctx, None), &[user("hi")]);
+    assert!((body["temperature"].as_f64().unwrap() - 0.42).abs() < 1e-6);
+}
+
+/// The caller's own parameters are the top layer: they beat the model's
+/// stored defaults, and the model still fills in what they left unset.
+#[test]
+fn caller_sampling_beats_model_defaults_without_erasing_them() {
+    let ctx = ModelContext {
+        inference_defaults: Some(InferenceConfig {
+            temperature: Some(0.42),
+            presence_penalty: Some(1.5),
+            ..Default::default()
+        }),
+        ..ModelContext::passthrough()
+    };
+    let caller = InferenceConfig {
+        temperature: Some(0.11),
+        ..Default::default()
+    };
+    let body = body_of(&adapter(ctx, Some(caller)), &[user("hi")]);
+
+    assert!((body["temperature"].as_f64().unwrap() - 0.11).abs() < 1e-6);
+    assert!((body["presence_penalty"].as_f64().unwrap() - 1.5).abs() < 1e-6);
+}
+
+/// Pinned here for the same reason it is pinned in the proxy: the agent path
+/// benefits from the same KV reuse, and the two bodies should not differ.
+#[test]
+fn cache_prompt_is_pinned() {
+    let body = body_of(&adapter(ModelContext::passthrough(), None), &[user("hi")]);
+    assert_eq!(body["cache_prompt"], true);
+}
+
+// ── Transport fields ──────────────────────────────────────────────────────
+
+/// The pipeline touches `messages` and sampling keys; everything the adapter
+/// needs for transport must come through untouched.
+#[test]
+fn transport_fields_survive_the_pipeline() {
+    let body = body_of(&adapter(strict_turns(), None), &[user("hi")]);
+    assert_eq!(body["model"], "m");
+    assert_eq!(body["stream"], true);
+    assert_eq!(body["return_progress"], true);
+}


### PR DESCRIPTION
Closes #613. Step 3 of epic #610.

## What

`gglib_core::request_pipeline` gains the request-shaping transforms themselves,
alongside the `ModelContext` resolution #612 put there. Three new files:

| File | LOC | |
|---|---|---|
| `apply.rs` | 173 | `apply()`, and the one place stage order and its rationale are written down |
| `messages.rs` | 300 | `shape_messages()` — reasoning strip, capability coalescing |
| `sampling.rs` | 271 | `SamplingLayers`, `resolve_sampling()` — the hierarchy and the `cache_prompt` pin |

The **proxy** runs `shape_messages` → `truncate_history` → `resolve_sampling`,
each through one `edit_json_body` shim doing the `Bytes` ⇄ `Value` conversion.
`forward.rs` 1113 → 940 LOC.

The **adapter** calls `apply()` and now carries a `ModelContext` instead of a
bare `tags: Vec<String>`, so CLI / web UI / Tauri / council get capability
coalescing and per-model inference defaults for the first time. No `compose_*`
call site changed — #612 already threaded the context through all ten.

## Why it isn't a single `apply()` call in the proxy

The issue asked for one. It isn't achievable: `truncate_history` runs *between*
stages 2 and 4 and sizes its budget from `body.len()` — wire bytes. Folding
sampling in ahead of it would change `payload_chars_before` (surfaced on
`/v1/proxy/status`) on every request and could flip the hard-abort gate at the
margin. A byte-length gate also can't live inside a `&mut Value` pipeline: a
`Value` has no byte length until serialized, and the serialized form differs
from what the client sent.

So the logic lives once per stage and the proxy composes them itself. A test
asserts `apply()` == `shape_messages` then `resolve_sampling`, so the two routes
can't drift. #614 inherits the decision about what truncation should measure.

## The bug this surfaced

`gglib_core::ChatMessage` modelled only `role`/`content`/`tool_calls` with no
catch-all, so the coalescing round-trip **deleted `tool_call_id`**. Latent while
coalescing was proxy-only — but the agent path is the tool-calling loop, and
Mistral/Devstral set `REQUIRES_STRICT_TURNS` *and* require `tool_call_id` in
their Jinja templates, so shipping coalescing there without this would have
broken tool calling on precisely the models the transform exists to serve.

Fixed with a flattened `extra` map. `chat_api.rs` stops hard-coding
`tool_call_id: None` on the way out.

## Verification

```
cargo build --workspace --all-targets   Finished dev profile, no errors, no warnings
cargo fmt --all --check                 clean, exit 0
cargo clippy --workspace --all-targets -- -D warnings   zero warnings
cargo test --workspace                  1788 passed, 0 failed
./scripts/check_boundaries.sh           ✅ All boundary checks passed
./scripts/check-tauri-commands.sh       exit 0
./scripts/check-frontend-ipc.sh         exit 0
./scripts/check_transport_branching.sh  exit 0
```

`check_file_complexity.sh` exits 1 on 37 files — output is byte-identical to a
stashed tree, so all pre-existing. It doesn't walk Rust; every new file here is
under the 300 budget.

### Byte-identity

A throwaway capture harness drove ten input shapes through the real
`gglib_proxy::serve` against a recording upstream — plain chat, prior-turn
reasoning artefacts, strict-turn model with tool messages, the coalesce fast
path, `cache_prompt: false`, arbitrary unknown top-level keys, the full
hierarchy with and without a client param, array-form content — recording exact
forwarded bytes on clean `main` and again after each change.

**9 of 10 byte-identical.** The tenth:

```diff
-{"content":"result","role":"tool"}
+{"content":"result","role":"tool","tool_call_id":"call_1"}
```

The pipeline move itself is provably a pure refactor: every capture is identical
across the last four commits, so the whole diff is attributable to the
`ChatMessage` fix.

All six proxy integration suites pass **unmodified**, including
`integration_inference_profiles.rs` (11 tests pinning the 4-level hierarchy
end-to-end through the forwarded body).

## Reviewer's attention

- **`gglib chat` output will shift subtly.** The adapter now always emits
  resolved sampling, so unset params get gglib's fallbacks rather than
  llama.cpp's: `temperature` 0.7 vs 0.8, `repeat_penalty` 1.0 vs 1.1, `min_p`
  0.0 vs 0.05. Intended by the epic, but it's a real change to local inference.
- **Four proxy tests were retargeted, net −1.** `forward.rs`'s four
  `strip_prior_reasoning` tests covered a deleted function; the transform logic
  is tested in core now, and the boundary behaviour they pinned ("no change →
  forward the client's original bytes") is `edit_json_body`'s. That's the only
  place existing proxy tests were touched.
- **Not done:** the live `RUST_LOG=debug` proxy diff against a real LLM Gateway
  request. The harness is stronger for the request body but doesn't exercise the
  streaming path's `inject_streaming_body_overrides`, which runs after
  everything here and is unmodified. Worth one real request before merge.