### PR TITLE
ci: replace dtolnay/rust-toolchain with native rustup (single source of truth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -89,7 +89,7 @@ jobs:
             libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Lockfile guard
         run: |
@@ -222,7 +222,7 @@ jobs:
             libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6
@@ -268,7 +268,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.97.1
-          components: rustfmt
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -93,8 +90,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.97.1
 
       - name: Lockfile guard
         run: |
@@ -228,9 +223,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.97.1
-          components: clippy
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6
@@ -277,8 +269,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.97.1
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,9 +28,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
+        uses: dtolnay/rust-toolchain@master
 
       - name: Cache Cargo registry and target directory
         uses: actions/cache@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           ref: main
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           ref: main
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
             libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        run: rustup show
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -315,9 +315,7 @@ jobs:
             pkg-config
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          targets: ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -429,9 +427,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          targets: ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Setup Rust cache
@@ -432,7 +431,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Setup Rust cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
             libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

Replaced all 9 `dtolnay/rust-toolchain` action steps with native `rustup` commands. GitHub-hosted runners have rustup pre-installed, and `rust-toolchain.toml` is read automatically — no action needed. This eliminates the redundant double-install entirely.

## Changes

- **ci.yml (4 jobs):** `uses: dtolnay/rust-toolchain@master` → `run: rustup show`
- **coverage.yml:** same replacement + removed deprecated `llvm-tools-preview` component
- **docs.yml:** same replacement
- **release.yml (deploy-docs):** same replacement
- **release.yml (build, build-gui):** replaced with `run: rustup target add ${{ matrix.target }}` (installs toolchain + cross-compilation target)

## Why

- Zero redundant toolchain installs — rustup reads rust-toolchain.toml directly
- No action dependency to maintain or pin
- Future version bumps touch exactly one file: rust-toolchain.toml
- Eliminates the PATH-shadowing class of bugs (standalone tools ignoring the override file)

Closes #606