### PR TITLE
Proxy: rescue reasoning-only turns, re-arm the recycle watchdog, and stop sampling params leaking across layers

### DIFF
--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -162,7 +162,14 @@ pub enum ProxyCommand {
         #[arg(short, long, default_value = "8080")]
         port: u16,
     },
-    /// Clear KV cache for a session or all sessions on an already-running proxy
+    /// Clear KV cache on an already-running proxy
+    ///
+    /// Without `--session-id` this clears every disk slot *and* recycles
+    /// llama-server, which is the only way to drop its host-RAM prompt cache
+    /// (`--cache-ram`). The recycle is skipped while a request is in flight.
+    ///
+    /// With `--session-id` only that session's disk slots are cleared; the
+    /// shared RAM cache is left alone.
     CacheClear {
         /// Host of the already-running proxy to connect to
         #[arg(long, default_value = "127.0.0.1")]

--- a/crates/gglib-cli/src/handlers/proxy_cache_clear.rs
+++ b/crates/gglib-cli/src/handlers/proxy_cache_clear.rs
@@ -26,7 +26,16 @@ pub async fn execute(host: &str, port: u16, session_id: Option<&str>) -> Result<
 
     match status.as_u16() {
         200 => {
-            println!("Cache cleared: {}", body.unwrap_or_default());
+            // Prefer the human-readable summary; fall back to the raw body if
+            // the response shape is ever something we don't recognise.
+            let summary = body
+                .as_deref()
+                .and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok())
+                .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(str::to_owned));
+            match summary {
+                Some(msg) => println!("Cache cleared: {msg}"),
+                None => println!("Cache cleared: {}", body.unwrap_or_default()),
+            }
             Ok(())
         }
         400 => {

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -199,6 +199,58 @@ impl InferenceConfig {
         }
     }
 
+    /// Fill `None` fields from `other`, except parameters tuned against a
+    /// temperature `self` has already claimed.
+    ///
+    /// `presence_penalty`, `repeat_penalty` and `min_p` are only meaningful
+    /// relative to how sharp the sampling distribution is, so they travel with
+    /// the `temperature` they were chosen for. [`reasoning_profile`] pairs
+    /// `temperature 1.0` with `presence_penalty 1.5` deliberately; a sparse
+    /// profile that sets `temperature 0.2` and leaves the penalty unset used to
+    /// inherit that 1.5 and run a recipe no layer ever intended — a penalty
+    /// tuned for a broad distribution applied to a near-greedy one.
+    ///
+    /// So: once a layer declares a `temperature`, lower layers may no longer
+    /// contribute the parameters tuned against it. They fall through to the
+    /// neutral values in [`with_hardcoded_defaults`] instead, which is applied
+    /// with plain [`merge_with`] as an unconditional floor — it is a set of
+    /// neutral defaults, not a competing recipe.
+    ///
+    /// Parameters that do not interact with temperature this way (`top_p`,
+    /// `top_k`, `max_tokens`) are unaffected and still fill from any layer.
+    ///
+    /// [`reasoning_profile`]: Self::reasoning_profile
+    /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
+    /// [`merge_with`]: Self::merge_with
+    const fn merge_layer(&mut self, other: &Self) {
+        // Checked before any field is written, so a layer supplying both a
+        // temperature and its penalties still contributes them as a set.
+        let temperature_claimed = self.temperature.is_some();
+
+        if self.top_p.is_none() {
+            self.top_p = other.top_p;
+        }
+        if self.top_k.is_none() {
+            self.top_k = other.top_k;
+        }
+        if self.max_tokens.is_none() {
+            self.max_tokens = other.max_tokens;
+        }
+
+        if !temperature_claimed {
+            self.temperature = other.temperature;
+            if self.repeat_penalty.is_none() {
+                self.repeat_penalty = other.repeat_penalty;
+            }
+            if self.presence_penalty.is_none() {
+                self.presence_penalty = other.presence_penalty;
+            }
+            if self.min_p.is_none() {
+                self.min_p = other.min_p;
+            }
+        }
+    }
+
     /// Create a new config with all fields set to sensible defaults.
     ///
     /// These are the hardcoded fallback values used when no other
@@ -383,6 +435,15 @@ impl InferenceConfig {
     /// from the model, which is what keeps one global profile safe to apply
     /// across differing architectures.
     ///
+    /// # Temperature-tuned parameters do not fall through
+    ///
+    /// The one exception, enforced by [`merge_layer`]: once a layer declares a
+    /// `temperature`, lower layers may not contribute `presence_penalty`,
+    /// `repeat_penalty` or `min_p`. Those are tuned against a particular
+    /// distribution sharpness, so inheriting them across a temperature change
+    /// assembles a recipe no layer intended. They resolve to the neutral
+    /// hardcoded values instead.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -390,10 +451,11 @@ impl InferenceConfig {
     ///
     /// // A sparse profile: sets temperature, says nothing about anything else.
     /// let profile = InferenceConfig { temperature: Some(0.2), ..Default::default() };
-    /// // A thinking model's stored defaults.
+    /// // A thinking model's stored defaults: 1.5 is tuned for temperature 1.0.
     /// let model = InferenceConfig {
     ///     temperature: Some(1.0),
     ///     presence_penalty: Some(1.5),
+    ///     top_k: Some(20),
     ///     ..Default::default()
     /// };
     ///
@@ -401,8 +463,11 @@ impl InferenceConfig {
     ///     .resolve_with_profile(Some(&profile), Some(&model), None);
     ///
     /// assert_eq!(resolved.temperature,      Some(0.2)); // profile beats model
-    /// assert_eq!(resolved.presence_penalty, Some(1.5)); // model still fills in
+    /// assert_eq!(resolved.presence_penalty, Some(0.0)); // NOT the model's 1.5
+    /// assert_eq!(resolved.top_k,            Some(20));  // untuned: still fills
     /// ```
+    ///
+    /// [`merge_layer`]: Self::merge_layer
     ///
     /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     /// [`resolve_with_defaults`]: Self::resolve_with_defaults
@@ -414,13 +479,13 @@ impl InferenceConfig {
         global: Option<&Self>,
     ) -> Self {
         if let Some(p) = profile {
-            self.merge_with(p);
+            self.merge_layer(p);
         }
         if let Some(m) = model {
-            self.merge_with(m);
+            self.merge_layer(m);
         }
         if let Some(g) = global {
-            self.merge_with(g);
+            self.merge_layer(g);
         }
         self.merge_with(&Self::with_hardcoded_defaults());
         self
@@ -676,14 +741,19 @@ mod tests {
 
         assert_eq!(resolved.temperature, Some(0.9)); // request beats profile
         assert_eq!(resolved.top_p, Some(0.85)); // profile beats model
-        assert_eq!(resolved.presence_penalty, Some(1.5)); // model fills in
         assert_eq!(resolved.top_k, Some(10)); // global fills in
+        // The request claimed the temperature, so the model's 1.5 — tuned for
+        // its own 0.5 — must not fall through. Neutral hardcoded value instead.
+        assert_eq!(resolved.presence_penalty, Some(0.0));
         assert_eq!(resolved.repeat_penalty, Some(1.0)); // hardcoded fallback
     }
 
     /// The invariant that makes one global profile safe across differing
     /// architectures: parameters the profile leaves `None` still resolve from
     /// the model, so selecting a profile cannot erase per-model tuning.
+    ///
+    /// The exception is parameters tuned against temperature — see
+    /// [`test_profile_temperature_does_not_inherit_model_penalties`].
     #[test]
     fn test_sparse_profile_does_not_erase_model_defaults() {
         let profile = InferenceConfig {
@@ -696,12 +766,64 @@ mod tests {
             InferenceConfig::default().resolve_with_profile(Some(&profile), Some(&model), None);
 
         assert_eq!(resolved.temperature, Some(0.2)); // the profile's one opinion
-        // Everything the profile stayed silent about comes from the model.
-        assert_eq!(resolved.presence_penalty, model.presence_penalty);
+        // Untuned parameters the profile stayed silent about still come from
+        // the model — this is what keeps one profile safe across architectures.
         assert_eq!(resolved.top_k, model.top_k);
         assert_eq!(resolved.top_p, model.top_p);
         assert_eq!(resolved.max_tokens, model.max_tokens);
-        assert_eq!(resolved.min_p, model.min_p);
+    }
+
+    /// Regression for #621: a sparse profile that lowers the temperature must
+    /// not inherit penalties the model tuned for a much broader distribution.
+    ///
+    /// `reasoning_profile()` pairs `temperature 1.0` with `presence_penalty
+    /// 1.5` deliberately. Applying that 1.5 to a near-greedy `temperature 0.2`
+    /// request is a recipe no layer ever intended, and it reached production on
+    /// every `:coding` request.
+    #[test]
+    fn test_profile_temperature_does_not_inherit_model_penalties() {
+        let model = InferenceConfig::reasoning_profile();
+        assert_eq!(model.temperature, Some(1.0), "guards the premise");
+        assert_eq!(model.presence_penalty, Some(1.5), "guards the premise");
+
+        // Mirrors the shipped `coding` profile.
+        let profile = InferenceConfig {
+            temperature: Some(0.2),
+            top_p: Some(0.95),
+            top_k: Some(20),
+            max_tokens: Some(8192),
+            min_p: Some(0.05),
+            ..Default::default()
+        };
+
+        let resolved =
+            InferenceConfig::default().resolve_with_profile(Some(&profile), Some(&model), None);
+
+        assert_eq!(resolved.temperature, Some(0.2));
+        assert_eq!(resolved.presence_penalty, Some(0.0), "must not inherit 1.5");
+        assert_eq!(resolved.repeat_penalty, Some(1.0), "neutral, not the model's");
+        assert_eq!(resolved.min_p, Some(0.05), "the profile's own value stands");
+    }
+
+    /// The coupling is directional: a layer that supplies a temperature *and*
+    /// its penalties still contributes them together, so a coherent recipe
+    /// stored on a model is untouched when nothing above it sets a temperature.
+    #[test]
+    fn test_model_recipe_applies_intact_when_no_layer_sets_temperature() {
+        let model = InferenceConfig::reasoning_profile();
+        // A profile with opinions only about untuned parameters.
+        let profile = InferenceConfig {
+            top_k: Some(64),
+            ..Default::default()
+        };
+
+        let resolved =
+            InferenceConfig::default().resolve_with_profile(Some(&profile), Some(&model), None);
+
+        assert_eq!(resolved.temperature, model.temperature);
+        assert_eq!(resolved.presence_penalty, model.presence_penalty);
+        assert_eq!(resolved.repeat_penalty, model.repeat_penalty);
+        assert_eq!(resolved.top_k, Some(64)); // profile still wins where it spoke
     }
 
     /// `resolve_with_defaults` delegates to `resolve_with_profile`, so the two

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -818,7 +818,11 @@ mod tests {
 
         assert_eq!(resolved.temperature, Some(0.2));
         assert_eq!(resolved.presence_penalty, Some(0.0), "must not inherit 1.5");
-        assert_eq!(resolved.repeat_penalty, Some(1.0), "neutral, not the model's");
+        assert_eq!(
+            resolved.repeat_penalty,
+            Some(1.0),
+            "neutral, not the model's"
+        );
         assert_eq!(resolved.min_p, Some(0.05), "the profile's own value stands");
     }
 

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -251,6 +251,23 @@ impl InferenceConfig {
         }
     }
 
+    /// Stack `self` as the higher-priority layer above `lower`.
+    ///
+    /// Same rules as the resolution ladder — `self` wins where it speaks,
+    /// `lower` fills the rest, and a `temperature` declared by `self` blocks
+    /// `lower`'s temperature-tuned parameters (see [`merge_layer`]). Used to
+    /// place a layer *above* the client's own request parameters, which
+    /// [`resolve_with_profile`] cannot express since it treats `self` as the
+    /// top.
+    ///
+    /// [`merge_layer`]: Self::merge_layer
+    /// [`resolve_with_profile`]: Self::resolve_with_profile
+    #[must_use]
+    pub const fn stacked_over(mut self, lower: &Self) -> Self {
+        self.merge_layer(lower);
+        self
+    }
+
     /// Create a new config with all fields set to sensible defaults.
     ///
     /// These are the hardcoded fallback values used when no other

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -4,6 +4,7 @@
 //! only ever touch top-level keys.
 
 use serde_json::Value;
+use tracing::debug;
 
 use super::ModelContext;
 use crate::domain::InferenceConfig;
@@ -40,6 +41,61 @@ pub struct SamplingLayers {
     pub global: Option<InferenceConfig>,
 }
 
+/// Which layer supplied each resolved sampling value, as `field=layer` pairs.
+///
+/// Nothing else records this. Without it the effective sampling config is
+/// invisible at every log level, and answering "where did this
+/// `presence_penalty` come from?" means probing llama-server's live `/slots`
+/// mid-generation — which is how the leak behind #621 had to be found.
+///
+/// Mirrors the ladder in [`InferenceConfig::resolve_with_profile`], including
+/// the temperature coupling: once a layer declares a `temperature`, layers
+/// below it can no longer supply the parameters tuned against it, so those
+/// report `hardcoded` even though a lower layer names a value.
+fn describe_provenance(
+    client: &InferenceConfig,
+    model: Option<&InferenceConfig>,
+    layers: &SamplingLayers,
+) -> String {
+    let ordered: [(&str, Option<&InferenceConfig>); 5] = [
+        ("cli", layers.cli_override.as_ref()),
+        ("client", Some(client)),
+        ("profile", layers.profile.as_ref()),
+        ("model", model),
+        ("global", layers.global.as_ref()),
+    ];
+
+    // The highest layer naming a temperature; layers below it cannot supply
+    // temperature-tuned parameters. `None` means nothing claimed it, so every
+    // layer stays eligible.
+    let claim = ordered
+        .iter()
+        .position(|(_, c)| c.is_some_and(|c| c.temperature.is_some()))
+        .unwrap_or(ordered.len());
+
+    let source = |declares: &dyn Fn(&InferenceConfig) -> bool, limit: usize| -> &'static str {
+        ordered
+            .iter()
+            .take(limit)
+            .find(|(_, c)| c.is_some_and(|c| declares(c)))
+            .map_or("hardcoded", |(name, _)| name)
+    };
+
+    let all = ordered.len();
+    // Tuned parameters are eligible only up to and including the claiming layer.
+    let tuned = claim.saturating_add(1).min(all);
+    format!(
+        "temperature={} top_p={} top_k={} max_tokens={} presence_penalty={} repeat_penalty={} min_p={}",
+        source(&|c| c.temperature.is_some(), all),
+        source(&|c| c.top_p.is_some(), all),
+        source(&|c| c.top_k.is_some(), all),
+        source(&|c| c.max_tokens.is_some(), all),
+        source(&|c| c.presence_penalty.is_some(), tuned),
+        source(&|c| c.repeat_penalty.is_some(), tuned),
+        source(&|c| c.min_p.is_some(), tuned),
+    )
+}
+
 /// Resolve the sampling hierarchy into `body`, then pin `cache_prompt`.
 ///
 /// # Force-insert, not `or_insert`
@@ -59,13 +115,27 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
     // Operator flags sit above the client, everything else below it.
     let top = match layers.cli_override.as_ref() {
         Some(o) => o.clone().stacked_over(&client_params),
-        None => client_params,
+        None => client_params.clone(),
     };
     let resolved = top.resolve_with_profile(
         layers.profile.as_ref(),
         ctx.inference_defaults.as_ref(),
         layers.global.as_ref(),
     );
+
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        debug!(
+            temperature = ?resolved.temperature,
+            top_p = ?resolved.top_p,
+            top_k = ?resolved.top_k,
+            max_tokens = ?resolved.max_tokens,
+            presence_penalty = ?resolved.presence_penalty,
+            repeat_penalty = ?resolved.repeat_penalty,
+            min_p = ?resolved.min_p,
+            from = %describe_provenance(&client_params, ctx.inference_defaults.as_ref(), layers),
+            "sampling resolved"
+        );
+    }
 
     let Some(obj) = body.as_object_mut() else {
         return;
@@ -213,6 +283,68 @@ mod tests {
         assert_param(&body, "temperature", 0.2);
         assert_param(&body, "top_p", 0.87);
         assert_param(&body, "top_k", 20.0);
+    }
+
+    // ── Provenance ────────────────────────────────────────────────────────
+
+    /// The `:coding` shape. The provenance string must say the penalty came
+    /// from the neutral floor, not from the model — otherwise the log would
+    /// assert exactly the leak the merge now prevents.
+    #[test]
+    fn provenance_reports_coupling_suppressed_layers_as_hardcoded() {
+        let model = InferenceConfig {
+            temperature: Some(1.0),
+            presence_penalty: Some(1.5),
+            top_k: Some(20),
+            ..Default::default()
+        };
+        let got = describe_provenance(
+            &InferenceConfig::default(),
+            Some(&model),
+            &SamplingLayers {
+                profile: Some(temp(0.2)),
+                ..Default::default()
+            },
+        );
+
+        assert!(got.contains("temperature=profile"), "{got}");
+        assert!(got.contains("presence_penalty=hardcoded"), "{got}");
+        // Untuned parameters are unaffected by the claim.
+        assert!(got.contains("top_k=model"), "{got}");
+    }
+
+    /// With nothing above it claiming a temperature, the model's own recipe is
+    /// reported intact.
+    #[test]
+    fn provenance_attributes_an_unclaimed_recipe_to_the_model() {
+        let model = InferenceConfig {
+            temperature: Some(1.0),
+            presence_penalty: Some(1.5),
+            ..Default::default()
+        };
+        let got = describe_provenance(
+            &InferenceConfig::default(),
+            Some(&model),
+            &SamplingLayers::default(),
+        );
+
+        assert!(got.contains("temperature=model"), "{got}");
+        assert!(got.contains("presence_penalty=model"), "{got}");
+    }
+
+    /// Operator flags are reported as their own layer, above the client.
+    #[test]
+    fn provenance_names_the_cli_layer() {
+        let got = describe_provenance(
+            &temp(0.9),
+            None,
+            &SamplingLayers {
+                cli_override: Some(temp(0.3)),
+                ..Default::default()
+            },
+        );
+
+        assert!(got.contains("temperature=cli"), "{got}");
     }
 
     /// Regression for #621: operator flags must beat the per-model layer.

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -23,6 +23,16 @@ use crate::domain::InferenceConfig;
 /// config.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SamplingLayers {
+    /// Operator-supplied overrides from the process's own command line
+    /// (`gglib proxy --temperature …`), applied *above* the client's request
+    /// parameters.
+    ///
+    /// Above the client deliberately: this is the person running the server
+    /// stating what the server does, which cannot be true if any client can
+    /// silently outrank it. These previously merged into [`Self::global`],
+    /// which sits below the per-model layer — so on any model with stored
+    /// `inference_defaults` the flags did nothing at all.
+    pub cli_override: Option<InferenceConfig>,
     /// The profile the request selected via `{model}:{profile}`, if any.
     /// Sparse — see [`crate::domain::inference_profile`].
     pub profile: Option<InferenceConfig>,
@@ -46,7 +56,12 @@ pub struct SamplingLayers {
 /// A body that is not a JSON object is left alone.
 pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingLayers) {
     let client_params = InferenceConfig::from_openai_json(body);
-    let resolved = client_params.resolve_with_profile(
+    // Operator flags sit above the client, everything else below it.
+    let top = match layers.cli_override.as_ref() {
+        Some(o) => o.clone().stacked_over(&client_params),
+        None => client_params,
+    };
+    let resolved = top.resolve_with_profile(
         layers.profile.as_ref(),
         ctx.inference_defaults.as_ref(),
         layers.global.as_ref(),
@@ -105,12 +120,22 @@ mod tests {
 
     // ── The hierarchy ─────────────────────────────────────────────────────
 
-    /// One table, four rows: each layer wins only over the ones beneath it.
+    /// One table, one row per layer: each wins only over the ones beneath it.
     #[test]
     fn each_layer_beats_the_ones_below_it() {
         let cases = [
-            // (client temperature, profile, model, global, expected, why)
+            // (cli, client temperature, profile, model, global, expected, why)
             (
+                Some(0.05),
+                Some(0.11),
+                Some(0.22),
+                Some(0.33),
+                Some(0.44),
+                0.05,
+                "cli override beats client",
+            ),
+            (
+                None,
                 Some(0.11),
                 Some(0.22),
                 Some(0.33),
@@ -119,6 +144,7 @@ mod tests {
                 "client beats profile",
             ),
             (
+                None,
                 None,
                 Some(0.22),
                 Some(0.33),
@@ -129,18 +155,28 @@ mod tests {
             (
                 None,
                 None,
+                None,
                 Some(0.33),
                 Some(0.44),
                 0.33,
                 "model beats global",
             ),
-            (None, None, None, Some(0.44), 0.44, "global beats hardcoded"),
-            (None, None, None, None, 0.7, "hardcoded fallback"),
+            (
+                None,
+                None,
+                None,
+                None,
+                Some(0.44),
+                0.44,
+                "global beats hardcoded",
+            ),
+            (None, None, None, None, None, 0.7, "hardcoded fallback"),
         ];
 
-        for (client, profile, model, global, expected, why) in cases {
+        for (cli, client, profile, model, global, expected, why) in cases {
             let mut body = client.map_or_else(|| json!({}), |t| json!({"temperature": t}));
             let layers = SamplingLayers {
+                cli_override: cli.map(temp),
                 profile: profile.map(temp),
                 global: global.map(temp),
             };
@@ -168,6 +204,7 @@ mod tests {
             &mut body,
             &model_ctx(Some(model)),
             &SamplingLayers {
+                cli_override: None,
                 profile: Some(temp(0.2)),
                 global: None,
             },
@@ -176,6 +213,49 @@ mod tests {
         assert_param(&body, "temperature", 0.2);
         assert_param(&body, "top_p", 0.87);
         assert_param(&body, "top_k", 20.0);
+    }
+
+    /// Regression for #621: operator flags must beat the per-model layer.
+    ///
+    /// These previously merged into the *global* layer, which sits below the
+    /// model — so on any model with stored `inference_defaults`, every
+    /// `gglib proxy --temperature …` style flag silently did nothing.
+    #[test]
+    fn a_cli_override_beats_the_model_layer() {
+        let mut body = json!({});
+        resolve_sampling(
+            &mut body,
+            &model_ctx(Some(InferenceConfig {
+                temperature: Some(1.0),
+                top_k: Some(20),
+                ..Default::default()
+            })),
+            &SamplingLayers {
+                cli_override: Some(temp(0.3)),
+                ..Default::default()
+            },
+        );
+
+        assert_param(&body, "temperature", 0.3);
+        // Untuned parameters the operator said nothing about still resolve.
+        assert_param(&body, "top_k", 20.0);
+    }
+
+    /// The operator runs the server, so their flags also outrank the client's
+    /// own request parameters — otherwise any caller could quietly ignore them.
+    #[test]
+    fn a_cli_override_beats_client_request_params() {
+        let mut body = json!({"temperature": 0.9});
+        resolve_sampling(
+            &mut body,
+            &model_ctx(None),
+            &SamplingLayers {
+                cli_override: Some(temp(0.3)),
+                ..Default::default()
+            },
+        );
+
+        assert_param(&body, "temperature", 0.3);
     }
 
     /// Regression for #621, at the pipeline level: the `:coding` shape — a
@@ -193,6 +273,7 @@ mod tests {
             &mut body,
             &model_ctx(Some(model)),
             &SamplingLayers {
+                cli_override: None,
                 profile: Some(temp(0.2)),
                 global: None,
             },

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -154,9 +154,35 @@ mod tests {
     }
 
     /// Profiles are sparse: outranking the model layer must not blank out the
-    /// parameters the profile says nothing about.
+    /// untuned parameters the profile says nothing about.
     #[test]
     fn a_sparse_profile_leaves_other_model_defaults_intact() {
+        let mut body = json!({});
+        let model = InferenceConfig {
+            temperature: Some(1.0),
+            top_p: Some(0.87),
+            top_k: Some(20),
+            ..Default::default()
+        };
+        resolve_sampling(
+            &mut body,
+            &model_ctx(Some(model)),
+            &SamplingLayers {
+                profile: Some(temp(0.2)),
+                global: None,
+            },
+        );
+
+        assert_param(&body, "temperature", 0.2);
+        assert_param(&body, "top_p", 0.87);
+        assert_param(&body, "top_k", 20.0);
+    }
+
+    /// Regression for #621, at the pipeline level: the `:coding` shape — a
+    /// profile that lowers the temperature — must not carry the model's
+    /// `presence_penalty`, which was tuned for the model's own temperature.
+    #[test]
+    fn a_profile_temperature_does_not_carry_model_penalties() {
         let mut body = json!({});
         let model = InferenceConfig {
             temperature: Some(1.0),
@@ -173,7 +199,7 @@ mod tests {
         );
 
         assert_param(&body, "temperature", 0.2);
-        assert_param(&body, "presence_penalty", 1.5);
+        assert_param(&body, "presence_penalty", 0.0);
     }
 
     /// The force-insert. An `or_insert` implementation passes every test above

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -77,7 +77,7 @@ fn describe_provenance(
         ordered
             .iter()
             .take(limit)
-            .find(|(_, c)| c.is_some_and(|c| declares(c)))
+            .find(|(_, c)| c.is_some_and(&declares))
             .map_or("hardcoded", |(name, _)| name)
     };
 
@@ -113,10 +113,10 @@ fn describe_provenance(
 pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingLayers) {
     let client_params = InferenceConfig::from_openai_json(body);
     // Operator flags sit above the client, everything else below it.
-    let top = match layers.cli_override.as_ref() {
-        Some(o) => o.clone().stacked_over(&client_params),
-        None => client_params.clone(),
-    };
+    let top = layers.cli_override.as_ref().map_or_else(
+        || client_params.clone(),
+        |o| o.clone().stacked_over(&client_params),
+    );
     let resolved = top.resolve_with_profile(
         layers.profile.as_ref(),
         ctx.inference_defaults.as_ref(),

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -158,6 +158,17 @@ fn should_forward_header(name: &str) -> bool {
 /// proxy could not parse.
 const NORMALIZATION_NOTICE_PREFIX: &str = "\n\n⚠️ [proxy: unparsed tool-call output] ";
 
+/// Prefix prepended to reasoning text that is promoted into the content
+/// channel because the turn produced no visible output of its own.
+///
+/// Same rescue as [`NORMALIZATION_NOTICE_PREFIX`], one channel over: a model
+/// that never closes its `<think>` block leaves a complete, often correct
+/// answer stranded in `reasoning_content`, which clients that collapse
+/// reasoning render as an empty response. Promoting it makes the turn usable;
+/// the flag keeps the underlying degradation visible instead of silently
+/// papering over it.
+const REASONING_ONLY_NOTICE_PREFIX: &str = "\n\n⚠️ [proxy: reasoning-only response] ";
+
 /// Diagnostic text synthesized and sent to the client when an upstream
 /// streaming response completes without emitting a single visible frame.
 ///
@@ -659,6 +670,9 @@ pub(crate) async fn stream_response_to_channel(
 
     let mut outcome = StreamOutcome::default();
     let mut client_connected = true;
+    // Accumulates reasoning text for the promotion path below. Bounded in
+    // practice by the request's `max_tokens`.
+    let mut reasoning_buf = String::new();
     while let Some(event) = normalized.next().await {
         let frame: Option<Bytes> = match event {
             Ok(ev) => match &ev {
@@ -682,11 +696,14 @@ pub(crate) async fn stream_response_to_channel(
                     };
                     encoder.encode(&recovered).map(Bytes::from)
                 }
-                LlmStreamEvent::ReasoningDelta { .. } => {
+                LlmStreamEvent::ReasoningDelta { content } => {
                     // Forwarded unchanged, but NOT counted as visible output —
                     // clients that collapse reasoning render this as empty.
+                    // Buffered so it can be promoted if the turn ends without
+                    // ever producing content of its own.
                     connection.mark_generating();
                     outcome.saw_reasoning = true;
+                    reasoning_buf.push_str(content);
                     encoder.encode(&ev).map(Bytes::from)
                 }
                 LlmStreamEvent::TextDelta { .. }
@@ -740,17 +757,28 @@ pub(crate) async fn stream_response_to_channel(
         }
     }
 
-    // Empty-stream detector: if the upstream completed without emitting a
-    // single visible frame, synthesize a diagnostic so the client never sees
-    // an unexplained empty response. Skipped when the client already
-    // disconnected (nothing to send) or when output was surfaced.
-    if client_connected && !outcome.saw_visible_output && !outcome.saw_reasoning {
+    // No visible output: either rescue the turn or explain it. Skipped when the
+    // client already disconnected (nothing to send).
+    if client_connected && !outcome.saw_visible_output {
         let reason = outcome.finish_reason.as_deref().unwrap_or("none");
-        warn!(
-            finish_reason = %reason,
-            "proxy: upstream stream produced no visible output; emitting diagnostic"
-        );
-        let notice = format!("{EMPTY_STREAM_NOTICE} (finish_reason: {reason})");
+        let notice = if outcome.saw_reasoning {
+            // Reasoning-only: the answer is usually complete and correct, just
+            // stranded in the wrong channel. Promote it rather than letting the
+            // client see an empty turn and retry a prompt that will deterministically
+            // strand it again.
+            warn!(
+                finish_reason = %reason,
+                reasoning_bytes = reasoning_buf.len(),
+                "proxy: response was reasoning-only; promoting reasoning to content"
+            );
+            format!("{REASONING_ONLY_NOTICE_PREFIX}{reasoning_buf}")
+        } else {
+            warn!(
+                finish_reason = %reason,
+                "proxy: upstream stream produced no visible output; emitting diagnostic"
+            );
+            format!("{EMPTY_STREAM_NOTICE} (finish_reason: {reason})")
+        };
         if let Some(s) = encoder.encode(&LlmStreamEvent::TextDelta { content: notice }) {
             let _ = tx.send(Ok(Bytes::from(s))).await;
         }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -96,10 +96,22 @@ pub(crate) enum ForwardError {
 /// (no output at all) for upstream-health bookkeeping.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct StreamOutcome {
-    /// `true` if at least one visible frame (content, reasoning, tool call,
-    /// recovered normalization text, or an error frame) was emitted to the
-    /// client. `false` means the model produced a completely empty response.
-    pub saw_output: bool,
+    /// `true` if at least one *client-renderable* frame (content, tool call,
+    /// recovered normalization text, or an error frame) was emitted.
+    ///
+    /// Reasoning deliberately does not count. A turn whose entire output landed
+    /// in `reasoning_content` renders as an empty response in every client that
+    /// treats reasoning as a collapsed side-channel (notably the VS Code LLM
+    /// Gateway), so scoring it as output made a hard failure indistinguishable
+    /// from success — and, via [`crate::upstream_health`], reset the strike
+    /// counter that arms the recycle watchdog. See [`Self::saw_reasoning`].
+    pub saw_visible_output: bool,
+    /// `true` if at least one `ReasoningDelta` was emitted.
+    ///
+    /// Tracked separately from [`Self::saw_visible_output`] so a reasoning-only
+    /// turn is distinguishable both from a healthy response and from a wholly
+    /// empty one.
+    pub saw_reasoning: bool,
     /// The `finish_reason` from the terminating `Done` event, if one arrived.
     pub finish_reason: Option<String>,
     /// `usage.prompt_tokens` reported by the upstream, if a Usage frame
@@ -664,18 +676,24 @@ pub(crate) async fn stream_response_to_channel(
                     // rather than dropping it silently (which manifested as an
                     // empty response when the whole turn was one bad tool call).
                     warn!(?kind, raw = %raw, "proxy: surfacing normalization issue as visible content");
-                    outcome.saw_output = true;
+                    outcome.saw_visible_output = true;
                     let recovered = LlmStreamEvent::TextDelta {
                         content: format!("{NORMALIZATION_NOTICE_PREFIX}{raw}"),
                     };
                     encoder.encode(&recovered).map(Bytes::from)
                 }
+                LlmStreamEvent::ReasoningDelta { .. } => {
+                    // Forwarded unchanged, but NOT counted as visible output —
+                    // clients that collapse reasoning render this as empty.
+                    connection.mark_generating();
+                    outcome.saw_reasoning = true;
+                    encoder.encode(&ev).map(Bytes::from)
+                }
                 LlmStreamEvent::TextDelta { .. }
-                | LlmStreamEvent::ReasoningDelta { .. }
                 | LlmStreamEvent::ToolCallDelta { .. }
                 | LlmStreamEvent::UpstreamError { .. } => {
                     connection.mark_generating();
-                    outcome.saw_output = true;
+                    outcome.saw_visible_output = true;
                     encoder.encode(&ev).map(Bytes::from)
                 }
                 LlmStreamEvent::Done { finish_reason } => {
@@ -699,7 +717,7 @@ pub(crate) async fn stream_response_to_channel(
             },
             Err(e) => {
                 error!("proxy stream error: {e}");
-                outcome.saw_output = true;
+                outcome.saw_visible_output = true;
                 let payload = serde_json::json!({
                     "error": {
                         "message": e.to_string(),
@@ -726,7 +744,7 @@ pub(crate) async fn stream_response_to_channel(
     // single visible frame, synthesize a diagnostic so the client never sees
     // an unexplained empty response. Skipped when the client already
     // disconnected (nothing to send) or when output was surfaced.
-    if client_connected && !outcome.saw_output {
+    if client_connected && !outcome.saw_visible_output && !outcome.saw_reasoning {
         let reason = outcome.finish_reason.as_deref().unwrap_or("none");
         warn!(
             finish_reason = %reason,

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -79,6 +79,9 @@ pub(crate) struct AppState {
     /// Per-model chars-per-token calibration, learned from upstream usage
     /// frames and used to size the truncation budget.
     calibration: Arc<TokenCalibration>,
+    /// Operator overrides from the command line, applied above the client's
+    /// own request parameters when resolving sampling.
+    inference_override: Option<gglib_core::domain::InferenceConfig>,
     /// Whether KV cache persistence is enabled (opt-in via --cache).
     cache_enabled: bool,
     /// Resolved slot directory path (Some only when cache_enabled).
@@ -132,6 +135,9 @@ pub async fn serve(
     council: CouncilDeps,
     cancel: CancellationToken,
     settings_repo: Arc<dyn SettingsRepository>,
+    // Operator overrides from this process's command line, applied above the
+    // client's own request parameters. See `SamplingLayers::cli_override`.
+    inference_override: Option<gglib_core::domain::InferenceConfig>,
     cache_enabled: bool,
     slot_dir: Option<PathBuf>,
     disk_budget: crate::slot_eviction::DiskBudget,
@@ -233,6 +239,7 @@ pub async fn serve(
         settings: Arc::new(SettingsCache::new(settings_repo)),
         upstream_health,
         calibration: Arc::new(TokenCalibration::new()),
+        inference_override,
         cache_enabled,
         slot_dir,
         slot_gate,
@@ -730,6 +737,7 @@ async fn chat_completions(
 
     // Global defaults come from the same snapshot the profile list did.
     let sampling = SamplingLayers {
+        cli_override: state.inference_override.clone(),
         profile: request_profile.clone(),
         global: settings.inference_defaults.clone(),
     };
@@ -948,6 +956,7 @@ async fn chat_completions(
             // so this is a fresh point in time. The profile is deliberately
             // not re-resolved — the client asked for a specific one.
             let retry_sampling = SamplingLayers {
+                cli_override: state.inference_override.clone(),
                 profile: request_profile.clone(),
                 global: state.settings.get().await.inference_defaults.clone(),
             };

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -437,23 +437,24 @@ async fn handle_proxy_status_stream(State(state): State<AppState>) -> impl IntoR
 
 /// Handle cache clear requests via `POST /v1/proxy/cache/clear`.
 ///
-/// Optionally accepts `X-Gglib-Session-Id` header to clear a single session;
-/// without it, all slot files are cleared. Returns 200 OK with status JSON.
+/// Two independent caches sit behind this endpoint:
+///
+/// * the **disk slot** layer, opt-in via `--cache`, cleared per-session with
+///   `X-Gglib-Session-Id` or wholesale without it;
+/// * llama-server's **host-RAM prompt cache** (`--cache-ram`), which has no
+///   clear API of its own — recycling the process is the only way to drop it.
+///
+/// A global clear therefore also recycles the model. Without that, the common
+/// configuration (RAM cache on, disk layer off) had no way to clear the only
+/// cache it actually had: the endpoint reported `cache not enabled` and did
+/// nothing, which is the least useful answer available.
+///
+/// A session-scoped clear is deliberately disk-only. Recycling the process to
+/// service one session would discard every other session's cached prefix too.
 async fn handle_proxy_cache_clear(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
-    // Cache disabled → skip (idempotent no-op)
-    if !state.cache_enabled {
-        return (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "skipped",
-                "message": "cache not enabled"
-            })),
-        );
-    }
-
     // Extract optional session ID from header
     let session_id = headers
         .get("x-gglib-session-id")
@@ -472,51 +473,73 @@ async fn handle_proxy_cache_clear(
         );
     }
 
-    let slot_dir = match &state.slot_dir {
-        Some(d) => d.clone(),
-        None => {
+    // ── Disk slot layer ───────────────────────────────────────────────────
+    let disk = if state.cache_enabled {
+        let Some(slot_dir) = state.slot_dir.clone() else {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({
                     "error": "slot_dir not configured"
                 })),
             );
+        };
+        let config = StreamConfig {
+            client: state.client.clone(),
+            base_url: String::new(), // Not used by clear_cache
+            slot_dir,
+            model_id: 0, // Sentinel — clear_cache only uses flags and hot-cache invalidation
+            clear_all_pending: state.clear_all_pending.clone(),
+            per_session_cleared: state.per_session_cleared.clone(),
+            server_start_time: state.server_start_time.clone(),
+            last_loaded_session: state.last_loaded_session.clone(),
+        };
+        match clear_cache(&config, session_id.as_deref()).await {
+            Ok(()) => {
+                if session_id.is_some() {
+                    "session cleared"
+                } else {
+                    "all slots cleared"
+                }
+            }
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": e.to_string() })),
+                );
+            }
         }
+    } else {
+        "disk cache not enabled"
     };
 
-    let config = StreamConfig {
-        client: state.client.clone(),
-        base_url: String::new(), // Not used by clear_cache
-        slot_dir,
-        model_id: 0, // Sentinel — clear_cache only uses flags and hot-cache invalidation
-        clear_all_pending: state.clear_all_pending.clone(),
-        per_session_cleared: state.per_session_cleared.clone(),
-        server_start_time: state.server_start_time.clone(),
-        last_loaded_session: state.last_loaded_session.clone(),
+    // ── Host-RAM prompt cache ─────────────────────────────────────────────
+    let ram = if session_id.is_some() {
+        "RAM cache kept (session-scoped clear)"
+    } else if state.dashboard.connections.is_empty() {
+        // Gated on idle for the same reason as the watchdog recycle in
+        // `chat_completions`: with `--parallel 1` an in-flight request owns the
+        // only slot, and stop_current() would kill its live generation.
+        info!("cache clear: recycling model to flush the host-RAM prompt cache");
+        match state.runtime_port.stop_current().await {
+            Ok(()) => "model recycled, RAM cache flushed",
+            Err(e) => {
+                warn!(error = %e, "cache clear: model recycle failed");
+                "RAM cache not flushed (recycle failed)"
+            }
+        }
+    } else {
+        "RAM cache not flushed (request in flight; retry when idle)"
     };
 
-    match clear_cache(&config, session_id.as_deref()).await {
-        Ok(()) => {
-            let msg = if session_id.is_some() {
-                "session cleared"
-            } else {
-                "all slots cleared"
-            };
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({
-                    "status": "ok",
-                    "message": msg
-                })),
-            )
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "error": e.to_string()
-            })),
-        ),
-    }
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "status": "ok",
+            "message": format!("{disk}; {ram}"),
+            "disk": disk,
+            "ram": ram,
+        })),
+    )
 }
 
 /// Handle chat completions - ensure model is running and proxy to llama-server.

--- a/crates/gglib-proxy/src/sse_stream.rs
+++ b/crates/gglib-proxy/src/sse_stream.rs
@@ -183,7 +183,12 @@ pub fn spawn_and_return(
                 .await;
                 // Feed the terminal outcome to the watchdog: an empty
                 // response is a strike, visible output resets the streak.
-                upstream_health.record_stream_outcome(outcome.saw_output);
+                //
+                // Deliberately `saw_visible_output`, not "produced any frame":
+                // a reasoning-only turn is a failed turn from the client's
+                // point of view, and counting it as success reset this streak
+                // on every retry, so the recycle watchdog never fired.
+                upstream_health.record_stream_outcome(outcome.saw_visible_output);
                 // Calibrate this model's chars-per-token ratio from the
                 // real prompt-token count the upstream reported.
                 if let Some(prompt_tokens) = outcome.prompt_tokens {

--- a/crates/gglib-proxy/src/upstream_health.rs
+++ b/crates/gglib-proxy/src/upstream_health.rs
@@ -71,11 +71,20 @@ impl UpstreamHealth {
 
     /// Record the terminal outcome of a streamed response.
     ///
-    /// `saw_output == true` resets the strike counter (the upstream is
+    /// `saw_visible_output == true` resets the strike counter (the upstream is
     /// producing output and is considered healthy); `false` counts as a
     /// strike.
-    pub fn record_stream_outcome(&self, saw_output: bool) {
-        if saw_output {
+    ///
+    /// "Visible" is load-bearing: callers must pass
+    /// [`StreamOutcome::saw_visible_output`], not "the upstream emitted some
+    /// frame". A turn whose entire output arrived as `reasoning_content`
+    /// renders as an empty response in clients that collapse reasoning, so
+    /// counting it healthy resets this streak on every retry and the recycle
+    /// threshold is never reached.
+    ///
+    /// [`StreamOutcome::saw_visible_output`]: crate::forward::StreamOutcome
+    pub fn record_stream_outcome(&self, saw_visible_output: bool) {
+        if saw_visible_output {
             self.consecutive_strikes.store(0, Ordering::Relaxed);
         } else {
             self.total_empty_responses.fetch_add(1, Ordering::Relaxed);

--- a/crates/gglib-proxy/tests/fixtures/sse.rs
+++ b/crates/gglib-proxy/tests/fixtures/sse.rs
@@ -26,6 +26,17 @@ data: {\"id\":\"u-2\",\"object\":\"chat.completion.chunk\",\"created\":172900000
 data: {\"id\":\"u-2\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
 data: [DONE]\n\n";
 
+/// Reasoning model that never leaves the thinking channel: `reasoning_content`
+/// only, `finish_reason: "stop"`, and no `content` at all.  This is what a
+/// model that fails to close its `<think>` block looks like on the wire, and it
+/// renders as an empty response in clients that collapse reasoning.  The proxy
+/// must promote the stranded text into the content channel.
+pub const REASONING_ONLY: &[u8] = b"\
+data: {\"id\":\"u-9\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"The answer \"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"u-9\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"is 42.\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"u-9\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: [DONE]\n\n";
+
 /// Qwen-family model emitting an XML-wrapped tool call inside the text
 /// channel.  With `format:qwen-xml` tags the pipeline must rewrite this into
 /// strict OpenAI `tool_calls` deltas — the external client should never see

--- a/crates/gglib-proxy/tests/integration_cache_clear.rs
+++ b/crates/gglib-proxy/tests/integration_cache_clear.rs
@@ -42,6 +42,7 @@ async fn spawn_proxy(
             fixtures::common::make_orchestrator_deps(),
             cancel_clone,
             Arc::new(fixtures::common::MockSettingsRepo),
+            None, // inference_override
             cache_enabled,
             slot_dir,
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-proxy/tests/integration_cache_clear.rs
+++ b/crates/gglib-proxy/tests/integration_cache_clear.rs
@@ -12,21 +12,54 @@ use reqwest::Client;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
 use gglib_core::ports::ModelCatalogPort;
-use gglib_core::ports::ModelRuntimePort;
+use gglib_core::ports::{ModelRuntimeError, ModelRuntimePort, RunningTarget};
+
+/// Runtime port that counts `stop_current()` calls, so a test can assert the
+/// model was actually recycled — the only way to drop llama-server's host-RAM
+/// prompt cache.
+#[derive(Debug, Default)]
+struct RecordingRuntime {
+    stops: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ModelRuntimePort for RecordingRuntime {
+    async fn ensure_model_running(
+        &self,
+        _model_name: &str,
+        _num_ctx: Option<u64>,
+        _default_ctx: u64,
+    ) -> Result<RunningTarget, ModelRuntimeError> {
+        Ok(RunningTarget::local(0, 1, "mock".into(), 4096, false))
+    }
+    async fn current_model(&self) -> Option<RunningTarget> {
+        None
+    }
+    async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
+        self.stops.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
 
 // ─── Proxy harness ─────────────────────────────────────────────────────────
 
 /// Spawn the real `gglib_proxy::serve` with the given cache settings.
-/// Returns `(proxy_base_url, cancel_token)`.
+/// Returns `(proxy_base_url, cancel_token, stop_current_counter)`.
 async fn spawn_proxy(
     cache_enabled: bool,
     slot_dir: Option<std::path::PathBuf>,
-) -> (String, CancellationToken) {
+) -> (String, CancellationToken, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let runtime: Arc<dyn ModelRuntimePort> = Arc::new(fixtures::common::NoopRuntime);
+    let stops = Arc::new(AtomicUsize::new(0));
+    let runtime: Arc<dyn ModelRuntimePort> = Arc::new(RecordingRuntime {
+        stops: Arc::clone(&stops),
+    });
     let catalog: Arc<dyn ModelCatalogPort> = Arc::new(fixtures::common::EmptyCatalog);
     let mcp = fixtures::common::make_mcp_service();
 
@@ -53,16 +86,18 @@ async fn spawn_proxy(
     });
 
     tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-    (format!("http://{addr}"), cancel)
+    (format!("http://{addr}"), cancel, stops)
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────
 
-/// When cache is disabled, the handler should return 200 with a "skipped"
-/// status — it's an idempotent no-op rather than an error.
+/// With the disk layer off — the common configuration — a global clear must
+/// still recycle the model, because that is the only way to drop llama-server's
+/// host-RAM prompt cache. Previously this reported "cache not enabled" and did
+/// nothing at all, leaving the only cache actually in use unclearable.
 #[tokio::test]
-async fn cache_clear_returns_skipped_when_cache_disabled() {
-    let (base_url, cancel) = spawn_proxy(false, None).await;
+async fn cache_clear_recycles_the_model_when_disk_cache_is_disabled() {
+    let (base_url, cancel, stops) = spawn_proxy(false, None).await;
 
     let resp = Client::new()
         .post(format!("{base_url}/v1/proxy/cache/clear"))
@@ -72,12 +107,36 @@ async fn cache_clear_returns_skipped_when_cache_disabled() {
 
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.expect("json response");
-    assert_eq!(body["status"], "skipped");
-    assert!(
-        body["message"]
-            .as_str()
-            .expect("message is string")
-            .contains("cache not enabled")
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["disk"], "disk cache not enabled");
+    assert_eq!(
+        stops.load(Ordering::SeqCst),
+        1,
+        "a global clear must recycle the model to flush the RAM cache"
+    );
+
+    cancel.cancel();
+}
+
+/// A session-scoped clear is disk-only: recycling the process to service one
+/// session would discard every other session's cached prefix too.
+#[tokio::test]
+async fn cache_clear_with_session_id_does_not_recycle_the_model() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let (base_url, cancel, stops) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
+
+    let resp = Client::new()
+        .post(format!("{base_url}/v1/proxy/cache/clear"))
+        .header("X-Gglib-Session-Id", "some_session")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        stops.load(Ordering::SeqCst),
+        0,
+        "session-scoped clear must leave the shared RAM cache alone"
     );
 
     cancel.cancel();
@@ -88,7 +147,7 @@ async fn cache_clear_returns_skipped_when_cache_disabled() {
 #[tokio::test]
 async fn cache_clear_returns_400_on_invalid_session_id() {
     let tmp_dir = tempfile::tempdir().unwrap();
-    let (base_url, cancel) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
+    let (base_url, cancel, _stops) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
 
     let resp = Client::new()
         .post(format!("{base_url}/v1/proxy/cache/clear"))
@@ -114,7 +173,7 @@ async fn cache_clear_returns_400_on_invalid_session_id() {
 #[tokio::test]
 async fn cache_clear_clears_all_when_no_session_id() {
     let tmp_dir = tempfile::tempdir().unwrap();
-    let (base_url, cancel) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
+    let (base_url, cancel, _stops) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
 
     let resp = Client::new()
         .post(format!("{base_url}/v1/proxy/cache/clear"))
@@ -140,7 +199,7 @@ async fn cache_clear_clears_all_when_no_session_id() {
 #[tokio::test]
 async fn cache_clear_populates_per_session_cleared() {
     let tmp_dir = tempfile::tempdir().unwrap();
-    let (base_url, cancel) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
+    let (base_url, cancel, _stops) = spawn_proxy(true, Some(tmp_dir.path().to_path_buf())).await;
 
     let resp = Client::new()
         .post(format!("{base_url}/v1/proxy/cache/clear"))
@@ -168,7 +227,7 @@ async fn cache_clear_populates_per_session_cleared() {
 /// should return 500 Internal Server Error.
 #[tokio::test]
 async fn cache_clear_returns_500_when_slot_dir_missing() {
-    let (base_url, cancel) = spawn_proxy(true, None).await;
+    let (base_url, cancel, _stops) = spawn_proxy(true, None).await;
 
     let resp = Client::new()
         .post(format!("{base_url}/v1/proxy/cache/clear"))

--- a/crates/gglib-proxy/tests/integration_cors.rs
+++ b/crates/gglib-proxy/tests/integration_cors.rs
@@ -203,6 +203,7 @@ async fn spawn_proxy() -> (String, CancellationToken) {
             make_orchestrator_deps(),
             cancel_clone,
             Arc::new(MockSettingsRepo),
+            None, // inference_override
             false,
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -397,7 +397,8 @@ async fn client_supplied_temperature_beats_the_profile() {
 async fn sparse_profile_leaves_model_defaults_intact() {
     let model_defaults = InferenceConfig {
         temperature: Some(1.0),
-        presence_penalty: Some(1.5),
+        top_p: Some(0.87),
+        top_k: Some(20),
         ..Default::default()
     };
     let h = spawn(vec![coding_profile()], &[MODEL], Some(model_defaults)).await;
@@ -407,7 +408,28 @@ async fn sparse_profile_leaves_model_defaults_intact() {
     let body = h.only_forwarded();
     // Profile wins where it speaks; the model default survives where it is silent.
     assert_param(&body, "temperature", 0.2);
-    assert_param(&body, "presence_penalty", 1.5);
+    assert_param(&body, "top_p", 0.87);
+    assert_param(&body, "top_k", 20.0);
+}
+
+/// Regression for #621, end to end: a `:coding` request must not reach the
+/// upstream carrying a `presence_penalty` the model tuned for its own, much
+/// higher, temperature. This is the exact request shape that failed in
+/// production.
+#[tokio::test]
+async fn sparse_profile_does_not_forward_model_penalties() {
+    let model_defaults = InferenceConfig {
+        temperature: Some(1.0),
+        presence_penalty: Some(1.5),
+        ..Default::default()
+    };
+    let h = spawn(vec![coding_profile()], &[MODEL], Some(model_defaults)).await;
+
+    h.post(chat_request("qwen:coding")).await;
+
+    let body = h.only_forwarded();
+    assert_param(&body, "temperature", 0.2);
+    assert_param(&body, "presence_penalty", 0.0);
 }
 
 /// A profile that was renamed or deleted must fail loudly, and must not reach

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -274,6 +274,7 @@ async fn spawn(
             make_orchestrator_deps(),
             proxy_cancel,
             Arc::new(ProfileSettings { profiles }),
+            None, // inference_override
             false,
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -206,6 +206,7 @@ async fn start_proxy() -> (String, CancellationToken) {
             make_orchestrator_deps(),
             cancel_clone,
             Arc::new(MockSettingsRepo),
+            None, // inference_override
             false,
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -123,7 +123,7 @@ impl SettingsRepository for MockSettingsRepo {
 
 mod fixtures;
 use fixtures::sse::{
-    BASIC_TEXT, MALFORMED_JSON_RECOVERY, QWEN_XML_TOOL_CALL, REASONING_DEEPSEEK,
+    BASIC_TEXT, MALFORMED_JSON_RECOVERY, QWEN_XML_TOOL_CALL, REASONING_DEEPSEEK, REASONING_ONLY,
     STANDARD_OPENAI_TOOL_CALL, basic_text_split_chunks,
 };
 
@@ -493,6 +493,42 @@ async fn reasoning_content_round_trip() {
         .collect();
     assert_eq!(reasoning, "Let me think.");
     assert_eq!(content, "42");
+}
+
+/// A turn that produces `reasoning_content` but never any `content` renders as
+/// an empty response in clients that collapse reasoning. The proxy must promote
+/// the stranded text into the content channel, flagged, so the turn is usable.
+#[tokio::test]
+async fn reasoning_only_response_is_promoted_to_content() {
+    let body = round_trip(vec![REASONING_ONLY], "r1-test", vec![]).await;
+    let (frames, saw_done) = parse_frames(&body);
+    assert!(saw_done);
+
+    let reasoning: String = frames
+        .iter()
+        .filter_map(|f| f["choices"][0]["delta"]["reasoning_content"].as_str())
+        .collect();
+    let content: String = frames
+        .iter()
+        .filter_map(|f| f["choices"][0]["delta"]["content"].as_str())
+        .collect();
+
+    // Reasoning still reaches the client untouched on its own channel.
+    assert_eq!(reasoning, "The answer is 42.");
+    // ...and is also promoted into content, so the turn is not empty.
+    assert!(
+        content.contains("The answer is 42."),
+        "stranded reasoning should be promoted into content, got {content:?}"
+    );
+    assert!(
+        content.contains("reasoning-only response"),
+        "promotion must be flagged so the degradation stays visible, got {content:?}"
+    );
+    // The wholly-empty diagnostic is a different path and must not fire here.
+    assert!(
+        !content.contains("produced no output"),
+        "empty-stream notice must not fire for a reasoning-only turn, got {content:?}"
+    );
 }
 
 /// Qwen XML tool calls must be rewritten into strict OpenAI `tool_calls`

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -323,6 +323,7 @@ async fn spawn_proxy(
             make_orchestrator_deps(),
             cancel_clone,
             Arc::new(MockSettingsRepo),
+            None, // inference_override
             false,
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-proxy/tests/integration_slot_roundtrip.rs
+++ b/crates/gglib-proxy/tests/integration_slot_roundtrip.rs
@@ -283,6 +283,7 @@ async fn spawn_proxy_with_cache_for_model(
             fixtures::common::make_orchestrator_deps(),
             cancel_clone,
             Arc::new(fixtures::common::MockSettingsRepo),
+            None, // inference_override
             true, // cache_enabled
             Some(slot_dir),
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -236,6 +236,7 @@ async fn spawn_proxy_with(runner: Arc<dyn CouncilRunnerPort>) -> (String, Cancel
             orchestrator,
             cancel_clone,
             Arc::new(MockSettingsRepo),
+            None, // inference_override
             false,
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs
@@ -129,9 +129,33 @@ fn per_model_inference_defaults_reach_the_body() {
 }
 
 /// The caller's own parameters are the top layer: they beat the model's
-/// stored defaults, and the model still fills in what they left unset.
+/// stored defaults, and the model still fills in the untuned ones they left
+/// unset.
 #[test]
 fn caller_sampling_beats_model_defaults_without_erasing_them() {
+    let ctx = ModelContext {
+        inference_defaults: Some(InferenceConfig {
+            temperature: Some(0.42),
+            top_p: Some(0.87),
+            ..Default::default()
+        }),
+        ..ModelContext::passthrough()
+    };
+    let caller = InferenceConfig {
+        temperature: Some(0.11),
+        ..Default::default()
+    };
+    let body = body_of(&adapter(ctx, Some(caller)), &[user("hi")]);
+
+    assert!((body["temperature"].as_f64().unwrap() - 0.11).abs() < 1e-6);
+    assert!((body["top_p"].as_f64().unwrap() - 0.87).abs() < 1e-6);
+}
+
+/// The agent path resolves through the same ladder as the proxy, so #621's
+/// coupling holds here too: a caller-supplied temperature must not drag along
+/// the model's `presence_penalty`, which was tuned for a different one.
+#[test]
+fn caller_temperature_does_not_inherit_model_penalties() {
     let ctx = ModelContext {
         inference_defaults: Some(InferenceConfig {
             temperature: Some(0.42),
@@ -147,7 +171,7 @@ fn caller_sampling_beats_model_defaults_without_erasing_them() {
     let body = body_of(&adapter(ctx, Some(caller)), &[user("hi")]);
 
     assert!((body["temperature"].as_f64().unwrap() - 0.11).abs() < 1e-6);
-    assert!((body["presence_penalty"].as_f64().unwrap() - 1.5).abs() < 1e-6);
+    assert!((body["presence_penalty"].as_f64().unwrap() - 0.0).abs() < 1e-6);
 }
 
 /// Pinned here for the same reason it is pinned in the proxy: the agent path

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -24,7 +24,6 @@ use gglib_core::ports::{
     ModelRepository, RepositoryError, SettingsRepository,
 };
 use gglib_core::server_config::CacheRamSetting;
-use gglib_core::settings::Settings;
 use gglib_mcp::McpService;
 use gglib_proxy::CouncilDeps;
 
@@ -193,33 +192,6 @@ impl CouncilRepositoryPort for InMemoryCouncilRepository {
 // start_proxy_standalone
 // =============================================================================
 
-/// Wraps a `SettingsRepository` and overlays a CLI-supplied `InferenceConfig`
-/// on top of whatever the persisted settings contain.
-///
-/// Fields present in `override_config` win; any field that is `None` there
-/// falls back to the persisted global defaults.
-struct CliOverrideSettingsRepo {
-    inner: Arc<dyn SettingsRepository>,
-    override_config: InferenceConfig,
-}
-
-#[async_trait]
-impl SettingsRepository for CliOverrideSettingsRepo {
-    async fn load(&self) -> Result<Settings, RepositoryError> {
-        let mut settings = self.inner.load().await?;
-        let merged = self
-            .override_config
-            .clone()
-            .resolve_with_defaults(None, settings.inference_defaults.as_ref());
-        settings.inference_defaults = Some(merged);
-        Ok(settings)
-    }
-
-    async fn save(&self, settings: &Settings) -> Result<(), RepositoryError> {
-        self.inner.save(settings).await
-    }
-}
-
 /// Start the OpenAI-compatible proxy as a standalone server (CLI usage).
 ///
 /// This is the main entry point for CLI usage. It creates all required
@@ -338,16 +310,6 @@ pub async fn start_proxy_standalone(
     // Create supervisor
     let supervisor = ProxySupervisor::new();
 
-    // Wrap settings_repo with CLI override if any inference flags were supplied
-    let effective_settings_repo: Arc<dyn SettingsRepository> =
-        if let Some(override_config) = inference_override.clone() {
-            Arc::new(CliOverrideSettingsRepo {
-                inner: settings_repo,
-                override_config,
-            })
-        } else {
-            settings_repo
-        };
 
     // Start proxy
     let config = ProxyConfig {
@@ -357,6 +319,9 @@ pub async fn start_proxy_standalone(
         cache_enabled,
         slot_dir: slot_save_path,
         disk_budget: gglib_proxy::slot_eviction::resolve_disk_budget(cache_disk_gb),
+        // Passed as its own top-priority sampling layer rather than folded into
+        // the persisted global defaults, which sit below the per-model layer.
+        inference_override: inference_override.clone(),
     };
 
     // Initialize MCP service (validates servers and auto-starts enabled ones)
@@ -431,7 +396,7 @@ pub async fn start_proxy_standalone(
             catalog_port,
             mcp,
             orchestrator_deps,
-            effective_settings_repo,
+            settings_repo,
         )
         .await
         .map_err(|e| anyhow!("{e}"))?;

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -310,7 +310,6 @@ pub async fn start_proxy_standalone(
     // Create supervisor
     let supervisor = ProxySupervisor::new();
 
-
     // Start proxy
     let config = ProxyConfig {
         host: host.clone(),

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -24,6 +24,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use gglib_core::cache_metrics::CacheMetricsStore;
+use gglib_core::domain::InferenceConfig;
 use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort, SettingsRepository};
 use gglib_core::settings::{DEFAULT_CONTEXT_SIZE, DEFAULT_PROXY_PORT};
 use gglib_mcp::McpService;
@@ -103,6 +104,10 @@ pub struct ProxyConfig {
     /// Byte budget for the on-disk slot cache eviction sweep. Only consulted
     /// when `cache_enabled` is `true`.
     pub disk_budget: DiskBudget,
+    /// Operator overrides supplied on this process's command line
+    /// (`gglib proxy --temperature …`), applied above the client's own request
+    /// parameters. `None` means the client and the stored layers decide.
+    pub inference_override: Option<InferenceConfig>,
 }
 
 impl Default for ProxyConfig {
@@ -114,6 +119,7 @@ impl Default for ProxyConfig {
             cache_enabled: false,
             slot_dir: None,
             disk_budget: DiskBudget::Auto,
+            inference_override: None,
         }
     }
 }
@@ -249,6 +255,7 @@ impl ProxySupervisor {
         let cache_enabled = config.cache_enabled;
         let slot_dir = config.slot_dir;
         let disk_budget = config.disk_budget;
+        let inference_override = config.inference_override;
         let agent_metrics = Arc::clone(&self.agent_metrics);
         let exit_tx = self.exit_tx.clone();
 
@@ -270,6 +277,7 @@ impl ProxySupervisor {
                 orchestrator,
                 cancel_clone,
                 settings_repo,
+                inference_override,
                 cache_enabled,
                 slot_dir,
                 disk_budget,


### PR DESCRIPTION
Closes #621.

A Copilot agent session against `gglib proxy` failed after 87 minutes with `"Sorry, no response was returned."` The model had produced a complete, correct answer — entirely inside `reasoning_content`, with `content` empty, because it never closed its `<think>` block.

**Why the model does that is still open** and tracked separately (see *Not in scope*). This PR fixes the proxy and config defects the investigation turned up along the way, all of which are independent of it.

## What was wrong

**The proxy scored the failure as a success.** `ReasoningDelta` shared a match arm with `TextDelta` and set a single `saw_output` flag. That flag feeds `record_stream_outcome`, which resets the consecutive-strike counter — so each of the 8 reasoning-only generations reset the streak and the **auto-recycle watchdog that already exists** never approached its threshold. The loop-breaker was there; one match arm disarmed it.

**Sampling values leaked across merge layers.** Measured against llama-server's live `/slots` with a request carrying no sampling fields:

| model id | temperature | leaked from model layer |
|---|---|---|
| no profile | 1.0 (model) | — none; the model recipe is self-consistent |
| `:chat` | 0.7 (profile) | `top_k`, `min_p`, `presence_penalty`, `repeat_penalty`, `n_predict` |
| `:coding` | 0.2 (profile) | **`presence_penalty` 1.5, `repeat_penalty` 1.0** |

`reasoning_profile()` pairs `temperature 1.0` with `presence_penalty 1.5` deliberately. The defect is that a *partial* override lets a profile replace the temperature a penalty was tuned against and inherit the penalty anyway.

**The CLI's inference flags did nothing.** `CliOverrideSettingsRepo` merged them into the *global* layer, below the model layer — so on any model with stored `inference_defaults`, `--presence-penalty` and friends were silently inert.

**The RAM prompt cache could not be cleared.** With the disk layer off — the common configuration — `POST /v1/proxy/cache/clear` returned `{"status":"skipped","message":"cache not enabled"}` and did nothing, leaving the only cache actually in use unclearable short of restarting the proxy.

## Commits

| | |
|---|---|
| `e8537bd` | Split `saw_output` into `saw_visible_output` / `saw_reasoning`; feed only the former to the watchdog |
| `44f5bc3` | Promote stranded reasoning into content behind `⚠️ [proxy: reasoning-only response]` |
| `f69924d` | Temperature-tuned penalties no longer fall through across layers |
| `2025ed8` | CLI inference overrides get their own layer, above the client |
| `cd18406` | `debug!` the resolved sampling params with per-field layer provenance |
| `b5605db` | A global cache-clear also recycles the model, flushing the RAM cache |
| `2e0cb92` | Remaining suites that asserted the old merge behaviour |

## Design notes

**Promotion is flagged, not silent.** Following the existing `NORMALIZATION_NOTICE_PREFIX` convention. A silent promotion would hide exactly the model degradation still being chased.

**The temperature coupling is directional.** A layer that supplies a temperature *and* its penalties still contributes them as a set — the claim is checked before any field is written. Untuned parameters (`top_p`, `top_k`, `max_tokens`) fall through from any layer as before, which is what keeps one profile safe across architectures.

**CLI overrides sit above the client body.** The operator running the server states what the server does; that cannot be true if any caller silently outranks them.

**Session-scoped clears stay disk-only.** Recycling the process to service one session would discard every other session's cached prefix. The global recycle is gated on the connection registry being empty, for the same reason as the watchdog recycle: with `--parallel 1`, an in-flight request owns the only slot.

## Tests

Full suite: **1814 passing, 0 failures.** `cargo fmt` and `cargo clippy --workspace --all-targets` clean.

Four tests encoded the old leak as the expected result. All four are **rewritten, not deleted** — each still covers the invariant it was protecting (untuned parameters fall through), with the penalty assertions moved into new tests pinning the corrected behaviour:

- `test_resolve_with_profile_full_precedence_ladder`, `test_sparse_profile_does_not_erase_model_defaults` (core)
- `a_sparse_profile_leaves_other_model_defaults_intact` (pipeline)
- `sparse_profile_leaves_model_defaults_intact` (proxy, end-to-end)
- `caller_sampling_beats_model_defaults_without_erasing_them` (agent path)

The `resolve_with_profile` doctest asserting `presence_penalty == Some(1.5)` is likewise rewritten to teach the new rule.

New coverage includes a `REASONING_ONLY` SSE fixture and an end-to-end promotion test, a runtime mock counting `stop_current()` calls, provenance attribution including the coupling-suppressed case, and the regression on each of the three paths that resolve sampling.

## Not in scope

The model-side root cause — **why the model stops closing `<think>` at ~74k tokens** — is unresolved. Ruled out with evidence: `presence_penalty` as sole cause (4-cell sweep 0.0→1.5, all pass), reasoning-strip/imitation, flash-attention incompatibility, and RoPE/trained-context extrapolation. Remaining candidates (KV `q8_0` at depth, MTP speculative decoding, hybrid-attention behaviour at depth) need a long-context reproducer that does not yet exist.

Worth noting the promotion in `44f5bc3` is defensive regardless of that outcome: any reasoning model that drops a `</think>` under pressure hits the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
