### PR TITLE
Fix CLI download progress bar artifacts and stray-line corruption

### DIFF
--- a/crates/gglib-cli/src/handlers/model/download/README.md
+++ b/crates/gglib-cli/src/handlers/model/download/README.md
@@ -24,7 +24,11 @@ This module handles all download-related commands that interact with HuggingFace
 │              └───────────────────► interactive.rs (TUI monitor) │
 │                                        ↕  [a]/[q] hotkeys        │
 │                                   CliDownloadEventEmitter        │
-│                                   (indicatif MultiProgress)      │
+│                                   (indicatif MultiProgress,      │
+│                                    stderr, footer-pinned hint)   │
+│                                        ↕  console hook           │
+│                                   gglib_core::telemetry          │
+│                                   (tracing fmt layer, notices)   │
 │                                                                  │
 └──────────────────────────────────────────────────────────────────┘
 ```
@@ -32,7 +36,10 @@ This module handles all download-related commands that interact with HuggingFace
 **Key Flow:**
 1. User issues `gglib model download <repo>` command
 2. `exec.rs` queues it via `DownloadManagerPort::queue_smart` (same code path as the GUI)
-3. `interactive.rs` renders progress via `CliDownloadEventEmitter` (indicatif bars)
+3. `interactive.rs` renders progress via `CliDownloadEventEmitter` (indicatif bars,
+   drawn to **stderr** — TTY detection and the `console::Term` used for hotkeys and
+   the `[a]` prompt check stderr too, so a redirected stdout doesn't silently disable
+   either).
 4. In TTY mode: `[a]` prompts for another model to add to the queue.
    `[q]` (or `Esc` / `Ctrl-C`) is **two-step**:
    - First press → arms drain mode (hint becomes
@@ -42,17 +49,29 @@ This module handles all download-related commands that interact with HuggingFace
    - Second press → calls `cancel_all()`, which signals cancel tokens
      and waits up to 5 s for in-flight Python helpers to actually
      finalize before returning.
+   The `[a]/[q]` hint bar is created eagerly and registered as the emitter's
+   *footer* (`CliDownloadEventEmitter::set_footer`); every download bar is
+   inserted above it via `MultiProgress::insert_before`, so it stays pinned
+   to the bottom without ever being removed and re-added.
 5. Lifecycle states surfaced on the bar:
    `Downloading` → `Finalizing` (gathering HF metadata) →
    `Registering` (writing model row) → terminal `Completed` /
    `Failed` / `Cancelled`. The `Finalizing` / `Registering` labels
-   keep the UI from looking frozen at 100 %.
+   keep the UI from looking frozen at 100 %. A first-run-only phase
+   (`DownloadEvent::DownloadNotice`, e.g. "preparing fast downloader…")
+   covers the tens of seconds the fast downloader's Python venv can take
+   to build, before any bytes exist to show progress for.
 6. When the Python helper uses the `hf-xet` transport (which bypasses
    tqdm), a stat-based fallback poller emits synthetic progress events
    so the bar still ticks. See
    [`gglib-download/src/cli_exec/exec/xet_poller.rs`](../../../../../gglib-download/src/cli_exec/exec/xet_poller.rs).
 7. Model registration on completion is handled by the download manager
    (via `ModelRegistrarPort`).
+8. `CliDownloadEventEmitter` also installs itself as the process-wide
+   console hook (`gglib_core::telemetry::set_console_hook`): any `tracing`
+   log line emitted while bars are live is routed through
+   `MultiProgress::println` instead of a raw write, so it can't desync the
+   bars' redraw bookkeeping and strand old frames in scrollback.
 
 ## Modules
 
@@ -118,7 +137,8 @@ Download a model from HuggingFace Hub with interactive queue support.
 **Interactive mode (TTY):**
 - `[a]` — add another model to the queue while a download is running
 - `[q]` / Ctrl-C — cancel all pending downloads and exit cleanly
-- Falls back to a plain polling monitor when stdout is not a TTY (CI, pipes)
+- Falls back to a plain polling monitor when **stderr** is not a TTY (CI, pipes) —
+  stderr, not stdout, since that's where the bars themselves draw
 
 **Flow:**
 1. Queue initial model via `DownloadManagerPort::queue_smart` (same path as GUI)

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -76,7 +76,14 @@ pub async fn run_interactive_monitor(
     downloads: Arc<dyn DownloadManagerPort>,
     emitter: Arc<CliDownloadEventEmitter>,
 ) -> Result<()> {
-    if std::io::stdout().is_terminal() {
+    // Checks stderr, not stdout: the progress bars draw to stderr (indicatif's
+    // `MultiProgress` default, used by `CliDownloadEventEmitter`), so that is
+    // what decides whether we're actually interactive. Checking stdout would
+    // silently fall back to the plain polling loop — and disable the `[a]`/`[q]`
+    // hotkeys, since `console::Term::stderr()`'s own TTY check follows the same
+    // stream — whenever stdout was redirected but the terminal remained
+    // attached via stderr.
+    if std::io::stderr().is_terminal() {
         run_tty_monitor(downloads, emitter).await
     } else {
         run_plain_monitor(downloads).await
@@ -165,7 +172,8 @@ async fn run_tty_monitor(
     // dropping the handle here is truly fire-and-forget: Tokio shuts down
     // immediately and the OS kills the thread when the process exits.
     let reader_handle = std::thread::spawn(move || {
-        let term = Term::stdout();
+        // Stderr, matching the bars — see the comment on `run_interactive_monitor`.
+        let term = Term::stderr();
         loop {
             let key = match term.read_key() {
                 Ok(k) => k,
@@ -347,7 +355,8 @@ async fn handle_add_to_queue(
     // we block on stdin, ensuring background downloads keep progressing.
     let prompt_result = tokio::task::block_in_place(|| {
         mp.suspend(|| -> Result<Option<(String, Option<String>)>> {
-            let term = Term::stdout();
+            // Stderr, matching the bars — see the comment on `run_interactive_monitor`.
+            let term = Term::stderr();
 
             // Print prompts to the same Term we read from so they line up
             // with the input cursor when bars are suspended.

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -194,9 +194,20 @@ async fn run_tty_monitor(
     });
 
     // ── Render state ───────────────────────────────────────────────────────
-    let mut hint_bar: Option<ProgressBar> = None;
+    // The hint bar is created eagerly, before any download bar exists, and
+    // registered as the emitter's footer so every `DownloadStarted` bar is
+    // inserted above it (see `CliDownloadEventEmitter::set_footer`). This
+    // keeps it pinned to the bottom without the remove-then-re-add dance the
+    // previous seen-items-gated, re-anchor-on-growth version needed.
+    let hint_style =
+        ProgressStyle::with_template("{msg}").unwrap_or_else(|_| ProgressStyle::default_bar());
+    let hint_bar = ProgressBar::new(0);
+    hint_bar.set_style(hint_style);
+    hint_bar.set_message(build_hint_message(0, 0));
+    let hint_bar = mp.add(hint_bar);
+    emitter.set_footer(&hint_bar);
+
     let mut seen_items = false;
-    let mut last_item_count: u32 = 0;
     // Two-step quit: first `q`/Ctrl-C arms `quitting=true` and lets active
     // downloads drain naturally; the second press calls `cancel_all()`.
     // Auto-exit fires when the queue empties on its own.
@@ -230,11 +241,9 @@ async fn run_tty_monitor(
                         }
                         // First press → arm drain mode and update the hint.
                         quitting = true;
-                        if let Some(bar) = &hint_bar {
-                            bar.set_message(
-                                "Draining... press q again to force quit".to_string(),
-                            );
-                        }
+                        hint_bar.set_message(
+                            "Draining... press q again to force quit".to_string(),
+                        );
                         let _ = cmd_tx.send(ReaderCmd::Continue).await;
                     }
                     Some(_) => {
@@ -257,11 +266,9 @@ async fn run_tty_monitor(
                     break Ok(());
                 }
                 quitting = true;
-                if let Some(bar) = &hint_bar {
-                    bar.set_message(
-                        "Draining... press q again to force quit".to_string(),
-                    );
-                }
+                hint_bar.set_message(
+                    "Draining... press q again to force quit".to_string(),
+                );
             }
 
             // ── 250 ms render / completion tick ────────────────────────────
@@ -273,43 +280,18 @@ async fn run_tty_monitor(
                     seen_items = true;
                 }
 
-                // Create the hint bar the first time we see activity.
-                if seen_items && hint_bar.is_none() {
-                    let style = ProgressStyle::with_template("{msg}")
-                        .unwrap_or_else(|_| ProgressStyle::default_bar());
-                    let bar = ProgressBar::new(0);
-                    bar.set_style(style);
-                    bar.set_message(build_hint_message(
-                        snapshot.active_count,
-                        snapshot.pending_count,
-                    ));
-                    hint_bar = Some(mp.add(bar));
-                    last_item_count = item_count;
-                }
-
                 // Update live counts in the hint message every tick.
                 // While quitting, keep the drain hint pinned so the user
                 // doesn't lose the "press q again" instruction.
-                if let Some(bar) = &hint_bar {
-                    if quitting {
-                        bar.set_message(
-                            "Draining... press q again to force quit".to_string(),
-                        );
-                    } else {
-                        bar.set_message(build_hint_message(
-                            snapshot.active_count,
-                            snapshot.pending_count,
-                        ));
-                    }
-                }
-
-                // Re-anchor hint to the bottom whenever new items appear.
-                if item_count > last_item_count {
-                    if let Some(bar) = &hint_bar {
-                        mp.remove(bar);
-                        mp.add(bar.clone());
-                    }
-                    last_item_count = item_count;
+                if quitting {
+                    hint_bar.set_message(
+                        "Draining... press q again to force quit".to_string(),
+                    );
+                } else {
+                    hint_bar.set_message(build_hint_message(
+                        snapshot.active_count,
+                        snapshot.pending_count,
+                    ));
                 }
 
                 // Fast-fail: exit if a failure appeared before any activity.
@@ -324,9 +306,7 @@ async fn run_tty_monitor(
     };
 
     // Clear the hint bar cleanly before returning.
-    if let Some(bar) = hint_bar {
-        bar.finish_and_clear();
-    }
+    hint_bar.finish_and_clear();
     // Detach the reader thread.  We already sent ReaderCmd::Stop so it will
     // exit as soon as the user presses the next key (or when the process
     // terminates and the OS kills it).  We must not join here — that would

--- a/crates/gglib-core/src/download/README.md
+++ b/crates/gglib-core/src/download/README.md
@@ -13,7 +13,13 @@ system. No I/O, networking, or runtime dependencies allowed.
   `Quantization` models Unsloth Dynamic ("UD-") quants (e.g. `UD-Q6_K`) as distinct
   values from their plain counterparts (`Q6_K`), since `HuggingFace` repos frequently
   publish both with the same bit-depth suffix.
-- `events` - Download events and status types (`DownloadEvent`, `DownloadStatus`)
+- `events` - Download events and status types (`DownloadEvent`, `DownloadStatus`).
+  `DownloadEvent::DownloadNotice` is the one variant that isn't part of the
+  progress/lifecycle state machine: a transient, non-persisted, free-form note
+  (e.g. "preparing fast downloader…" while the first-run Python venv builds)
+  for renderers to show in place of progress that doesn't exist yet. Unlike
+  `DownloadStatusChanged`, it carries arbitrary text rather than a fixed
+  `DownloadStatus`, and the next progress or status event overwrites it.
 - `errors` - Error types for download operations
 - `queue` - Queue snapshot DTOs (`QueueSnapshot`, `QueuedDownload`, `FailedDownload`)
 - `completion` - Queue run completion tracking types

--- a/crates/gglib-core/src/download/events.rs
+++ b/crates/gglib-core/src/download/events.rs
@@ -105,7 +105,8 @@ impl DownloadStatus {
 ///       speed_bps?: number; eta_seconds?: number; ... }
 ///   | { type: "download_completed"; id: string }
 ///   | { type: "download_failed"; id: string; error: string }
-///   | { type: "download_cancelled"; id: string };
+///   | { type: "download_cancelled"; id: string }
+///   | { type: "download_notice"; id: string; message: string };
 /// ```
 ///
 /// `speed_bps` and `eta_seconds` are **optional and omitted when unknown** — a
@@ -224,6 +225,21 @@ pub enum DownloadEvent {
         id: String,
         /// New status of the download.
         status: DownloadStatus,
+    },
+
+    /// A transient, human-readable note about work happening for this
+    /// download that produces no byte progress of its own — e.g. building
+    /// the first-run Python environment for the fast downloader.
+    ///
+    /// Unlike [`Self::DownloadStatusChanged`] this carries free-form text
+    /// rather than a fixed [`DownloadStatus`] and is not persisted; it exists
+    /// purely so the renderer has something to show instead of looking
+    /// frozen while setup work happens before the first progress event.
+    DownloadNotice {
+        /// Canonical ID of the download.
+        id: String,
+        /// Human-readable note to display in place of progress.
+        message: String,
     },
 
     /// Queue run completed (all downloads in the queue finished).
@@ -370,7 +386,8 @@ impl DownloadEvent {
             | Self::DownloadCompleted { id, .. }
             | Self::DownloadFailed { id, .. }
             | Self::DownloadCancelled { id }
-            | Self::DownloadStatusChanged { id, .. } => Some(id),
+            | Self::DownloadStatusChanged { id, .. }
+            | Self::DownloadNotice { id, .. } => Some(id),
         }
     }
 
@@ -389,6 +406,7 @@ impl DownloadEvent {
             Self::DownloadFailed { .. } => "download:failed",
             Self::DownloadCancelled { .. } => "download:cancelled",
             Self::DownloadStatusChanged { .. } => "download:status_changed",
+            Self::DownloadNotice { .. } => "download:notice",
             Self::QueueRunComplete { .. } => "download:queue_run_complete",
         }
     }

--- a/crates/gglib-core/src/telemetry.rs
+++ b/crates/gglib-core/src/telemetry.rs
@@ -151,3 +151,34 @@ pub fn init_tracing(verbose: bool) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// `console_println` must forward to an installed hook rather than
+    /// writing to stderr directly — this is the mechanism that lets a live
+    /// `MultiProgress` intercept log lines and redraw around them instead of
+    /// having them corrupt its bookkeeping. `CONSOLE_HOOK` is the only piece
+    /// of process-global state this module touches and no other test in
+    /// this crate installs a hook, so a single test covering both install
+    /// and teardown is safe without cross-test races.
+    #[test]
+    fn console_println_routes_through_an_installed_hook() {
+        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_clone = Arc::clone(&captured);
+        set_console_hook(Arc::new(move |line: &str| {
+            captured_clone.lock().unwrap().push(line.to_string());
+        }));
+
+        console_println("hello from the hook");
+        clear_console_hook();
+
+        assert_eq!(captured.lock().unwrap().as_slice(), ["hello from the hook"]);
+
+        // After clearing, console_println must not still reach the old hook.
+        console_println("after clear");
+        assert_eq!(captured.lock().unwrap().len(), 1);
+    }
+}

--- a/crates/gglib-core/src/telemetry.rs
+++ b/crates/gglib-core/src/telemetry.rs
@@ -1,13 +1,16 @@
 //! Unified tracing initialization for gglib.
 //!
 //! Design:
-//! - A single layered subscriber (stdout + daily rotating file) is installed once via [`OnceLock`].
+//! - A single layered subscriber (console + daily rotating file) is installed once via [`OnceLock`].
 //! - Calls to [`init_tracing`] are idempotent — subsequent calls return `Ok(())`.
 //! - Log directory: `./logs/` in debug builds, `data_root()/logs` in release.
 //! - Filter: `RUST_LOG` env var wins; otherwise `"debug"` if verbose, else `"warn"`.
+//! - Console output goes through [`console_println`], which defaults to stderr
+//!   but can be redirected via [`set_console_hook`] — see the "Console hook"
+//!   section below.
 
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock, RwLock};
 
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -15,6 +18,78 @@ use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::Subscr
 use crate::paths::data_root;
 
 static GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
+
+// ─── Console hook ────────────────────────────────────────────────────────────
+//
+// The stdout `fmt` layer below writes through this hook instead of directly
+// to a stream. Default (`None`) is a plain `eprintln!`. A CLI running an
+// indicatif `MultiProgress` installs a hook that forwards through
+// `MultiProgress::println` instead, so a log line emitted while download bars
+// are live gets erased-printed-redrawn atomically rather than landing as raw
+// bytes that corrupt the bars' redraw bookkeeping. See
+// `gglib-download/src/cli_emitter.rs` for the installing side.
+
+/// A sink for formatted console lines, e.g. one backed by
+/// `MultiProgress::println`.
+pub type ConsoleHook = Arc<dyn Fn(&str) + Send + Sync>;
+
+/// Route for formatted log lines and other CLI console output. `None` means
+/// "print straight to stderr".
+static CONSOLE_HOOK: RwLock<Option<ConsoleHook>> = RwLock::new(None);
+
+/// Install a hook that receives each formatted log line (and other console
+/// output routed via [`console_println`]) instead of stderr.
+pub fn set_console_hook(hook: ConsoleHook) {
+    *CONSOLE_HOOK.write().unwrap() = Some(hook);
+}
+
+/// Remove a previously installed hook, reverting to plain stderr.
+pub fn clear_console_hook() {
+    *CONSOLE_HOOK.write().unwrap() = None;
+}
+
+/// Print one line through the installed console hook, or to stderr if none is
+/// installed.
+///
+/// Used by the tracing `fmt` layer below, and by CLI code that prints
+/// outside of `tracing` (subprocess passthrough, setup notices) so every
+/// console write is subject to the same routing.
+pub fn console_println(line: &str) {
+    let hook = CONSOLE_HOOK.read().unwrap();
+    if let Some(hook) = hook.as_ref() {
+        hook(line);
+    } else {
+        eprintln!("{line}");
+    }
+}
+
+/// `Write` target for the tracing `fmt` layer. Buffers one formatted record
+/// and forwards it as a single line via [`console_println`] when dropped —
+/// `fmt::layer()` creates a fresh writer per event, so `Drop` is exactly
+/// "this record is complete."
+#[derive(Default)]
+struct ConsoleWriter(Vec<u8>);
+
+impl std::io::Write for ConsoleWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for ConsoleWriter {
+    fn drop(&mut self) {
+        if self.0.is_empty() {
+            return;
+        }
+        let text = String::from_utf8_lossy(&self.0);
+        console_println(text.trim_end_matches('\n'));
+    }
+}
 
 fn resolve_log_dir() -> PathBuf {
     #[cfg(debug_assertions)]
@@ -59,7 +134,7 @@ pub fn init_tracing(verbose: bool) -> anyhow::Result<()> {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(true)
-                .with_writer(std::io::stdout),
+                .with_writer(ConsoleWriter::default),
         )
         .with(
             tracing_subscriber::fmt::layer()

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -276,6 +276,18 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                 }
             }
 
+            DownloadEvent::DownloadNotice { id, message } => {
+                // Same idea as DownloadStatusChanged, but for free-form setup
+                // notes (e.g. building the first-run Python environment)
+                // rather than a fixed lifecycle status. The next progress or
+                // status event overwrites this naturally.
+                if let Ok(bars) = self.bars.lock() {
+                    if let Some(bar) = bars.get(&id) {
+                        bar.set_message(format!("{id} — {message}"));
+                    }
+                }
+            }
+
             // Queue-level events don't need bar updates in the CLI emitter.
             DownloadEvent::QueueSnapshot { .. } | DownloadEvent::QueueRunComplete { .. } => {}
         }

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -378,3 +378,95 @@ impl AppEventEmitter for CliDownloadEventEmitter {
         Box::new(gglib_core::ports::NoopEmitter::new())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gglib_core::download::DownloadEvent;
+
+    /// Clone the registered bar for `id` out of the lock, so tests can
+    /// assert on it without holding `emitter.bars`'s mutex for the
+    /// assertion (clippy's `significant_drop_tightening`).
+    fn bar_for(emitter: &CliDownloadEventEmitter, id: &str) -> ProgressBar {
+        emitter
+            .bars
+            .lock()
+            .unwrap()
+            .get(id)
+            .expect("bar should be registered")
+            .clone()
+    }
+
+    /// Regression guard for the bar rendering fully filled at `0 B/0 B`
+    /// before any bytes have been reported. `ProgressBar::new(0)` sets an
+    /// explicit length of 0, and indicatif's `fraction()` treats a length of
+    /// 0 as 100% complete — `no_length()` must leave the length unset until
+    /// a real Progress/ShardProgress event calls `set_length`.
+    #[test]
+    fn download_started_creates_a_bar_with_no_length() {
+        let emitter = CliDownloadEventEmitter::new();
+        DownloadEventEmitterPort::emit(&emitter, DownloadEvent::started("test/model"));
+
+        assert_eq!(bar_for(&emitter, "test/model").length(), None);
+    }
+
+    #[test]
+    fn progress_event_sets_the_length_once_a_real_total_arrives() {
+        let emitter = CliDownloadEventEmitter::new();
+        DownloadEventEmitterPort::emit(&emitter, DownloadEvent::started("test/model"));
+        DownloadEventEmitterPort::emit(
+            &emitter,
+            DownloadEvent::progress("test/model", 10, 100, None, None),
+        );
+
+        let bar = bar_for(&emitter, "test/model");
+        assert_eq!(bar.length(), Some(100));
+        assert_eq!(bar.position(), 10);
+    }
+
+    /// `DownloadNotice` sets the bar's message without touching its length
+    /// or position — it carries no byte progress, only a note for display
+    /// in place of it.
+    #[test]
+    fn download_notice_updates_message_without_touching_progress() {
+        let emitter = CliDownloadEventEmitter::new();
+        DownloadEventEmitterPort::emit(&emitter, DownloadEvent::started("test/model"));
+        DownloadEventEmitterPort::emit(
+            &emitter,
+            DownloadEvent::progress("test/model", 10, 100, None, None),
+        );
+        DownloadEventEmitterPort::emit(
+            &emitter,
+            DownloadEvent::DownloadNotice {
+                id: "test/model".to_string(),
+                message: "preparing fast downloader…".to_string(),
+            },
+        );
+
+        let bar = bar_for(&emitter, "test/model");
+        assert_eq!(bar.length(), Some(100));
+        assert_eq!(bar.position(), 10);
+        assert!(bar.message().contains("preparing fast downloader"));
+    }
+
+    /// `set_footer` + a subsequent `DownloadStarted` must not panic or fail
+    /// to register the bar — the actual bottom-pinned ordering is
+    /// `MultiProgress::insert_before`'s contract (exercised, not
+    /// reimplemented, by `start_bar`) and is verified visually per the
+    /// manual steps in the fix's PR description; `MultiProgress` doesn't
+    /// expose line order through its public API for a unit test to assert.
+    #[test]
+    fn set_footer_then_download_started_still_registers_the_bar() {
+        let emitter = CliDownloadEventEmitter::new();
+        let mp = emitter.multi_progress();
+
+        let footer = mp.add(ProgressBar::new(0));
+        footer.set_message("[a] queue another  [q] quit");
+        emitter.set_footer(&footer);
+
+        DownloadEventEmitterPort::emit(&emitter, DownloadEvent::started("test/model"));
+
+        let registered = emitter.bars.lock().unwrap().contains_key("test/model");
+        assert!(registered);
+    }
+}

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -80,17 +80,33 @@ impl CliDownloadEventEmitter {
     /// never falls out of sync with what's actually on screen. A raw
     /// `eprintln!`/`println!` racing the bars' own redraws is exactly what
     /// stranded old frames in scrollback before this was wired up.
+    ///
+    /// The hook captures a `Weak` reference, not a strong one, and never
+    /// clears itself on drop. In production there is exactly one emitter
+    /// per CLI process (see `bootstrap()`), alive for the process's whole
+    /// life, so this never matters there — but tests construct several.
+    /// Clearing the global hook on `Drop` would be wrong: dropping an
+    /// *earlier* emitter after a *later* one has installed its own hook
+    /// would wipe out the still-active hook out from under it. `Weak`
+    /// sidesteps that: once an emitter's `MultiProgress` is actually gone,
+    /// its hook's `upgrade()` starts returning `None` and that hook falls
+    /// back to `eprintln!` forever — equivalent to no hook at all — without
+    /// needing to touch (or race) whatever hook is currently installed.
     #[must_use]
     pub fn new() -> Self {
         let multi_progress = Arc::new(MultiProgress::new());
 
-        let hook_target = Arc::clone(&multi_progress);
+        let hook_target = Arc::downgrade(&multi_progress);
         gglib_core::telemetry::set_console_hook(Arc::new(move |line: &str| {
+            let Some(mp) = hook_target.upgrade() else {
+                eprintln!("{line}");
+                return;
+            };
             // `MultiProgress::println` silently drops the line when the draw
             // target is hidden (non-terminal stderr) rather than falling
             // back to a plain write — checking first keeps non-TTY output
             // (CI, pipes) intact.
-            if hook_target.is_hidden() || hook_target.println(line).is_err() {
+            if mp.is_hidden() || mp.println(line).is_err() {
                 eprintln!("{line}");
             }
         }));
@@ -468,5 +484,39 @@ mod tests {
 
         let registered = emitter.bars.lock().unwrap().contains_key("test/model");
         assert!(registered);
+    }
+
+    /// Interleaving `console_println` calls (the path a `tracing::warn!`
+    /// during a download takes) with live bar updates from the same
+    /// emitter must not panic — this is the exact scenario the console
+    /// hook exists to make safe instead of corrupting the bars.
+    #[test]
+    fn console_println_during_active_bar_does_not_panic() {
+        let emitter = CliDownloadEventEmitter::new();
+        DownloadEventEmitterPort::emit(&emitter, DownloadEvent::started("probe/model"));
+        for i in 0..50 {
+            DownloadEventEmitterPort::emit(
+                &emitter,
+                DownloadEvent::progress("probe/model", i, 100, None, None),
+            );
+            gglib_core::telemetry::console_println(&format!("log line {i}"));
+        }
+    }
+
+    /// Dropping an emitter must not panic, hang, or otherwise misbehave —
+    /// the hook it installed captures a `Weak`, not a strong `Arc`, so it
+    /// degrades to `eprintln!` once this emitter (and its `MultiProgress`)
+    /// are gone rather than holding anything alive or needing explicit
+    /// teardown. See the doc comment on `CliDownloadEventEmitter::new`.
+    #[test]
+    fn dropping_the_emitter_is_fine() {
+        let emitter = CliDownloadEventEmitter::new();
+        DownloadEventEmitterPort::emit(&emitter, DownloadEvent::started("probe/model"));
+        drop(emitter);
+
+        // The hook is still installed (nothing clears it), but its `Weak`
+        // can no longer upgrade — this must fall back to `eprintln!`
+        // without panicking.
+        gglib_core::telemetry::console_println("after drop");
     }
 }

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -59,11 +59,35 @@ pub struct CliDownloadEventEmitter {
 }
 
 impl CliDownloadEventEmitter {
-    /// Create a new emitter backed by a fresh [`MultiProgress`].
+    /// Create a new emitter backed by a fresh [`MultiProgress`], and install
+    /// it as the process-wide console hook (see
+    /// [`gglib_core::telemetry::set_console_hook`]).
+    ///
+    /// Any `tracing` log line — or other output routed through
+    /// [`gglib_core::telemetry::console_println`] — printed while this
+    /// emitter is alive goes through [`MultiProgress::println`] instead of
+    /// straight to a stream. That erases the live bars, prints the line,
+    /// and redraws atomically, so the bars' internal line-count bookkeeping
+    /// never falls out of sync with what's actually on screen. A raw
+    /// `eprintln!`/`println!` racing the bars' own redraws is exactly what
+    /// stranded old frames in scrollback before this was wired up.
     #[must_use]
     pub fn new() -> Self {
+        let multi_progress = Arc::new(MultiProgress::new());
+
+        let hook_target = Arc::clone(&multi_progress);
+        gglib_core::telemetry::set_console_hook(Arc::new(move |line: &str| {
+            // `MultiProgress::println` silently drops the line when the draw
+            // target is hidden (non-terminal stderr) rather than falling
+            // back to a plain write — checking first keeps non-TTY output
+            // (CI, pipes) intact.
+            if hook_target.is_hidden() || hook_target.println(line).is_err() {
+                eprintln!("{line}");
+            }
+        }));
+
         Self {
-            multi_progress: Arc::new(MultiProgress::new()),
+            multi_progress,
             bars: Mutex::new(HashMap::new()),
         }
     }

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 
 use gglib_core::download::{DownloadEvent, format_duration, format_rate};
 use gglib_core::events::AppEvent;
@@ -36,9 +36,12 @@ use gglib_core::ports::{AppEventEmitter, DownloadEventEmitterPort};
 // estimates, derived from the `set_position` calls we make; using them meant
 // the CLI ignored the rate the manager had already computed and displayed a
 // different number from the GUI for the same transfer. Rate and ETA now arrive
-// on the event and are rendered into `{wide_msg}`. `{bytes}` and
-// `{total_bytes}` stay — those are sizes, which indicatif labels correctly as
-// binary (MiB/GiB).
+// on the event and are rendered into `{wide_msg}`. `{bytes}` stays — that's a
+// size, which indicatif labels correctly as binary (MiB/GiB). `{total_bytes}`
+// is overridden below by a custom key (see `total_bytes_key`) rather than left
+// as indicatif's builtin: the builtin renders the *length*, and a bar created
+// before its total is known has no length rather than a zero one — see the
+// `ProgressBar::no_length()` comment on `DownloadStarted` below.
 const BAR_TEMPLATE: &str = "{spinner:.cyan} {wide_msg} [{bar:30.cyan/blue}] {bytes}/{total_bytes}";
 const TICK_INTERVAL: Duration = Duration::from_millis(120);
 
@@ -56,6 +59,12 @@ const TICK_INTERVAL: Duration = Duration::from_millis(120);
 pub struct CliDownloadEventEmitter {
     multi_progress: Arc<MultiProgress>,
     bars: Mutex<HashMap<String, ProgressBar>>,
+    /// The interactive monitor's `[a] queue another  [q] quit` hint bar, if
+    /// one has been registered via [`Self::set_footer`]. When present, new
+    /// download bars are inserted above it instead of appended, so it stays
+    /// pinned to the bottom without the remove-then-re-add churn that used
+    /// to re-anchor it on every new item.
+    footer: Mutex<Option<ProgressBar>>,
 }
 
 impl CliDownloadEventEmitter {
@@ -89,6 +98,16 @@ impl CliDownloadEventEmitter {
         Self {
             multi_progress,
             bars: Mutex::new(HashMap::new()),
+            footer: Mutex::new(None),
+        }
+    }
+
+    /// Register the interactive monitor's hint bar as the footer: subsequent
+    /// download bars are inserted above it via `MultiProgress::insert_before`
+    /// instead of appended, keeping it pinned to the bottom.
+    pub fn set_footer(&self, bar: &ProgressBar) {
+        if let Ok(mut footer) = self.footer.lock() {
+            *footer = Some(bar.clone());
         }
     }
 
@@ -130,6 +149,44 @@ impl CliDownloadEventEmitter {
         }
     }
 
+    /// Create and register the bar for a newly started download, labeled
+    /// `label`.
+    ///
+    /// Uses the unified [`BAR_TEMPLATE`] — see its module-level comment for
+    /// why the style never switches mid-stream — and [`ProgressBar::no_length`]
+    /// rather than `new(0)`: indicatif's `fraction()` treats an explicit
+    /// length of 0 as 100% complete, so a bar created before its total is
+    /// known would render fully filled — exactly backwards — until the first
+    /// Progress/ShardProgress event calls `set_length`. No length at all
+    /// renders as an honestly empty bar instead.
+    ///
+    /// Inserted above the footer (if [`Self::set_footer`] has registered
+    /// one) rather than appended, so the `[a]/[q]` hint bar stays pinned to
+    /// the bottom without needing to be removed and re-added.
+    fn start_bar(&self, id: String, label: String) {
+        let style = ProgressStyle::with_template(BAR_TEMPLATE)
+            .unwrap_or_else(|_| ProgressStyle::default_bar())
+            .progress_chars("█▓░")
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
+            .with_key("total_bytes", total_bytes_key);
+
+        let footer = self.footer.lock().ok().and_then(|f| f.clone());
+        let bar = footer.as_ref().map_or_else(
+            || self.multi_progress.add(ProgressBar::no_length()),
+            |footer| {
+                self.multi_progress
+                    .insert_before(footer, ProgressBar::no_length())
+            },
+        );
+        bar.set_style(style);
+        bar.enable_steady_tick(TICK_INTERVAL);
+        bar.set_message(label);
+
+        if let Ok(mut bars) = self.bars.lock() {
+            bars.insert(id, bar);
+        }
+    }
+
     /// Apply a progress update to the bar registered for `id`.
     ///
     /// Shared by the sharded and unsharded progress arms — they differ only in
@@ -150,6 +207,21 @@ impl CliDownloadEventEmitter {
         }
         bar.set_position(position);
         bar.set_message(message.to_string());
+    }
+}
+
+/// Custom `{total_bytes}` renderer: `—` while the length is unknown, the
+/// human-readable size once `set_length` has been called with a real total.
+/// Registered via `ProgressStyle::with_key` — see the module-level comment on
+/// `BAR_TEMPLATE`.
+fn total_bytes_key(state: &ProgressState, w: &mut dyn std::fmt::Write) {
+    match state.len() {
+        Some(len) => {
+            let _ = write!(w, "{}", HumanBytes(len));
+        }
+        None => {
+            let _ = write!(w, "—");
+        }
     }
 }
 
@@ -186,24 +258,7 @@ impl DownloadEventEmitterPort for CliDownloadEventEmitter {
                     _ => id.clone(),
                 };
 
-                // Always create the bar with the unified BAR_TEMPLATE — see
-                // module-level comment on `BAR_TEMPLATE` for why we never
-                // switch styles mid-stream. Length 0 is a sentinel meaning
-                // "total not yet known"; the bar widget renders empty until
-                // a Progress/ShardProgress event supplies a real length.
-                let style = ProgressStyle::with_template(BAR_TEMPLATE)
-                    .unwrap_or_else(|_| ProgressStyle::default_bar())
-                    .progress_chars("█▓░")
-                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
-
-                let bar = self.multi_progress.add(ProgressBar::new(0));
-                bar.set_style(style);
-                bar.enable_steady_tick(TICK_INTERVAL);
-                bar.set_message(label);
-
-                if let Ok(mut bars) = self.bars.lock() {
-                    bars.insert(id, bar);
-                }
+                self.start_bar(id, label);
             }
 
             DownloadEvent::DownloadProgress {

--- a/crates/gglib-download/src/cli_exec/README.md
+++ b/crates/gglib-download/src/cli_exec/README.md
@@ -20,6 +20,20 @@ Interactive downloads (the `model download` command) now route through
 [`DownloadManagerPort::queue_smart`], giving the CLI the same queue,
 progress events, and model registration path as the GUI.
 
+# Console output
+
+Every `println!`-shaped line this layer produces (venv setup notes, the
+`[fast-path]` passthrough for non-protocol Python output, `model upgrade`'s
+status lines) goes through `gglib_core::telemetry::console_println` instead
+of a direct `println!`/`eprintln!`. With no hook installed it's a plain
+`eprintln!`; the queued-download path installs a hook
+(`CliDownloadEventEmitter`) that routes it through the live
+`MultiProgress::println` so it can't corrupt a bar's redraw bookkeeping. See
+[`gglib_core::telemetry`](../../../gglib-core/src/telemetry.rs) and the
+[`exec/`](exec/) submodule below for `FastDownloadRequest::notice`, which
+does the same thing for a specific download's bar instead of the shared
+console.
+
 <!-- module-docs:end -->
 
 <details>

--- a/crates/gglib-download/src/cli_exec/exec/README.md
+++ b/crates/gglib-download/src/cli_exec/exec/README.md
@@ -7,6 +7,24 @@ Download execution module.
 This module handles the actual model download execution using the Python helper.
 It is intentionally kept separate from queue management.
 
+`python_env.rs` builds the fast downloader's Python venv on first run — a
+one-time, tens-of-seconds operation with no byte progress to show for it.
+`PythonEnvironment::prepare` takes an optional `NoticeCallback`
+(`Option<&NoticeCallback>`, aliased in `python_bridge.rs`): with one
+supplied — the queued-download path, via `FastDownloadRequest::notice` — venv
+creation and dependency install surface as a `DownloadEvent::DownloadNotice`
+on that download's bar instead of a console line; without one (preflight,
+`model upgrade`) they fall back to `gglib_core::telemetry::console_println`.
+`python -m venv` runs via `.output()`, not `.status()`, so its own stdio is
+captured rather than inherited — an inherited handle would write straight to
+the terminal, outside any bar's bookkeeping, the same way a stray `println!`
+would.
+
+`progress.rs`'s `CliProgressPrinter` (the no-callback path, e.g. `model
+upgrade`) draws to **stderr**, matching `CliDownloadEventEmitter`'s
+`MultiProgress` (indicatif's stderr default) — see the doc comment on
+`CliProgressPrinter::new`.
+
 <!-- module-docs:end -->
 
 <details>

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -26,7 +26,10 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         anyhow!("Please specify a quantization. Use --list-quants to see available options.")
     })?;
 
-    gglib_core::telemetry::console_println(&format!("Downloading {} from HuggingFace Hub...", request.model_id));
+    gglib_core::telemetry::console_println(&format!(
+        "Downloading {} from HuggingFace Hub...",
+        request.model_id
+    ));
 
     // Get commit SHA
     let api = super::api::create_hf_api(request.token.clone(), &request.models_dir)?;

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -79,6 +79,7 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         token: request.token.as_deref(),
         force: request.force,
         progress: None,
+        notice: None,
         expected_total: None,
         cancel_token: None,
     };

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -26,7 +26,7 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         anyhow!("Please specify a quantization. Use --list-quants to see available options.")
     })?;
 
-    println!("Downloading {} from HuggingFace Hub...", request.model_id);
+    gglib_core::telemetry::console_println(&format!("Downloading {} from HuggingFace Hub...", request.model_id));
 
     // Get commit SHA
     let api = super::api::create_hf_api(request.token.clone(), &request.models_dir)?;
@@ -39,10 +39,10 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         .info()
         .map_err(|e| anyhow!("Failed to get repo info: {e}"))?;
     let commit_sha = repo_info.sha.clone();
-    println!("Found repository, commit SHA: {commit_sha}");
+    gglib_core::telemetry::console_println(&format!("Found repository, commit SHA: {commit_sha}"));
 
     // Resolve files using the HuggingFace resolver
-    println!("Looking for {quant} quantization...");
+    gglib_core::telemetry::console_println(&format!("Looking for {quant} quantization..."));
     let client = gglib_hf::DefaultHfClient::new(&gglib_hf::HfClientConfig::default());
     let resolver = HfQuantizationResolver::new(std::sync::Arc::new(client));
 
@@ -54,13 +54,13 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
 
     let files: Vec<String> = resolution.files.iter().map(|f| f.path.clone()).collect();
     if resolution.is_sharded {
-        println!(
+        gglib_core::telemetry::console_println(&format!(
             "✓ Found {} sharded files for quantization {}",
             files.len(),
             quant
-        );
+        ));
     } else {
-        println!("✓ Found file: {}", files[0]);
+        gglib_core::telemetry::console_println(&format!("✓ Found file: {}", files[0]));
     }
 
     // Prepare destination directory
@@ -84,16 +84,16 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
     };
 
     run_fast_download(&fast_request).await?;
-    println!("⚡ Downloaded via fast helper");
+    gglib_core::telemetry::console_println("⚡ Downloaded via fast helper");
 
     let primary_path = model_dir.join(&files[0]);
     let all_paths: Vec<_> = files.iter().map(|f| model_dir.join(f)).collect();
 
-    println!(
+    gglib_core::telemetry::console_println(&format!(
         "✓ Successfully downloaded {} to {}",
         request.model_id,
         model_dir.display()
-    );
+    ));
 
     Ok(CliDownloadResult {
         downloaded_paths: all_paths,

--- a/crates/gglib-download/src/cli_exec/exec/progress.rs
+++ b/crates/gglib-download/src/cli_exec/exec/progress.rs
@@ -39,9 +39,15 @@ enum ProgressRender {
 
 impl CliProgressPrinter {
     /// Create a new progress printer, auto-detecting terminal capability.
+    ///
+    /// Checks stderr, not stdout: the bar itself draws to stderr (see
+    /// [`FancyProgress::new`]), matching the queued-download path's
+    /// `CliDownloadEventEmitter`, which uses indicatif's stderr default. A
+    /// redirected stdout (`gglib model upgrade ... > file.txt`) should not
+    /// silently downgrade the bar when stderr is still an attended terminal.
     #[must_use]
     pub fn new() -> Self {
-        let inner = if io::stdout().is_terminal() {
+        let inner = if io::stderr().is_terminal() {
             ProgressRender::Fancy(FancyProgress::new())
         } else {
             ProgressRender::Plain(PlainProgress::new())
@@ -110,7 +116,9 @@ struct FancyProgress {
 
 impl FancyProgress {
     fn new() -> Self {
-        let bar = ProgressBar::with_draw_target(None, ProgressDrawTarget::stdout());
+        // Stderr, matching CliDownloadEventEmitter's MultiProgress (indicatif's
+        // stderr default) — see the module doc on `CliProgressPrinter::new`.
+        let bar = ProgressBar::with_draw_target(None, ProgressDrawTarget::stderr());
         bar.set_style(Self::spinner_style());
         bar.set_message("Preparing fast download".to_string());
         bar.enable_steady_tick(Duration::from_millis(120));
@@ -249,8 +257,8 @@ impl PlainProgress {
         }
 
         let pad = self.last_line_len.saturating_sub(line.len());
-        print!("\r{line}{:pad$}", "", pad = pad);
-        io::stdout().flush().ok();
+        eprint!("\r{line}{:pad$}", "", pad = pad);
+        io::stderr().flush().ok();
 
         self.last_line_len = line.len();
         self.printed = true;
@@ -258,7 +266,7 @@ impl PlainProgress {
 
     fn finish(&mut self) {
         if self.printed {
-            println!();
+            eprintln!();
             self.printed = false;
             self.last_line_len = 0;
         }

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -275,9 +275,11 @@ async fn run_download_process(
                         }
                     }
                 } else {
-                    // Non-protocol line — print to console
+                    // Non-protocol line — print to console via the shared
+                    // hook so it doesn't corrupt a live MultiProgress redraw
+                    // (see gglib_core::telemetry::console_println).
                     finish_progress(cli_progress.as_ref());
-                    println!("[fast-path] {line}");
+                    gglib_core::telemetry::console_println(&format!("[fast-path] {line}"));
                 }
             }
         }

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -33,6 +33,13 @@ use super::xet_poller::XetPoller;
 /// boxing through extra channels.
 pub type ProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
 
+/// Callback for a transient setup notice, e.g. "preparing fast downloader".
+///
+/// Fires at most a handful of times per download (venv creation, dependency
+/// install) — unlike [`ProgressCallback`] this carries no byte counts, just
+/// a message to display in their place.
+pub type NoticeCallback = Arc<dyn Fn(&str) + Send + Sync>;
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -79,6 +86,10 @@ pub struct FastDownloadRequest<'a> {
     /// xet stat-fallback poller so synthetic progress events surface through
     /// the same channel as real Python `tqdm` events.
     pub progress: Option<ProgressCallback>,
+    /// Sink for transient setup notices (env creation, dependency install).
+    /// `None` routes those notices through `console_println` instead — see
+    /// [`PythonEnvironment::prepare`].
+    pub notice: Option<NoticeCallback>,
     /// Optional total size hint forwarded to synthetic progress events when
     /// the Python helper goes silent. `None` means "unknown" — the bar will
     /// display downloaded bytes without a percentage.
@@ -93,7 +104,7 @@ pub struct FastDownloadRequest<'a> {
 
 /// Ensure the fast download helper is ready (env + script prepared).
 pub async fn ensure_fast_helper_ready() -> Result<(), PythonBridgeError> {
-    PythonEnvironment::prepare().await?;
+    PythonEnvironment::prepare(None).await?;
     Ok(())
 }
 
@@ -113,7 +124,7 @@ pub async fn run_fast_download(request: &FastDownloadRequest<'_>) -> Result<(), 
         return Ok(());
     }
 
-    let env = PythonEnvironment::prepare().await?;
+    let env = PythonEnvironment::prepare(request.notice.as_ref()).await?;
 
     run_download_process(&env, request).await
 }

--- a/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_bridge.rs
@@ -88,7 +88,7 @@ pub struct FastDownloadRequest<'a> {
     pub progress: Option<ProgressCallback>,
     /// Sink for transient setup notices (env creation, dependency install).
     /// `None` routes those notices through `console_println` instead — see
-    /// [`PythonEnvironment::prepare`].
+    /// `PythonEnvironment::prepare`.
     pub notice: Option<NoticeCallback>,
     /// Optional total size hint forwarded to synthetic progress events when
     /// the Python helper goes silent. `None` means "unknown" — the bar will

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -257,7 +257,10 @@ impl PythonEnvironment {
         Ok(())
     }
 
-    async fn install_requirements(&self, notice: Option<&NoticeCallback>) -> Result<(), EnvSetupError> {
+    async fn install_requirements(
+        &self,
+        notice: Option<&NoticeCallback>,
+    ) -> Result<(), EnvSetupError> {
         notify(
             notice,
             "installing fast downloader dependencies…",

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -202,28 +202,40 @@ impl PythonEnvironment {
     async fn create_env(&self) -> Result<(), EnvSetupError> {
         let bootstrap = find_bootstrap_python_validated().await?;
 
-        println!(
+        gglib_core::telemetry::console_println(&format!(
             "ℹ️  Creating Python environment for fast downloads at {}...",
             self.env_dir.display()
-        );
+        ));
 
         let mut cmd = async_cmd(&bootstrap);
         apply_python_subprocess_isolation(&mut cmd);
-        let status = cmd
+        // `.output()` rather than `.status()`: this pipes the child's stdout
+        // and stderr instead of inheriting the parent's, so `python -m venv`
+        // can never write raw bytes straight to the terminal. An inherited
+        // handle would bypass indicatif entirely and corrupt any live
+        // `MultiProgress` redraw the same way a stray `println!` does — see
+        // the module-level comment on `run_python_command` below.
+        let output = cmd
             .arg("-m")
             .arg("venv")
             .arg(&self.env_dir)
-            .status()
+            .output()
             .await
             .map_err(|e| EnvSetupError::CreateEnvFailed {
                 path: self.env_dir.clone(),
                 reason: e.to_string(),
             })?;
 
-        if !status.success() {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let reason = if stderr.is_empty() {
+                format!("python -m venv exited with {}", output.status)
+            } else {
+                format!("python -m venv exited with {}: {stderr}", output.status)
+            };
             return Err(EnvSetupError::CreateEnvFailed {
                 path: self.env_dir.clone(),
-                reason: format!("python -m venv exited with {status}"),
+                reason,
             });
         }
 
@@ -231,7 +243,7 @@ impl PythonEnvironment {
     }
 
     async fn install_requirements(&self) -> Result<(), EnvSetupError> {
-        println!("ℹ️  Installing fast download dependencies...");
+        gglib_core::telemetry::console_println("ℹ️  Installing fast download dependencies...");
 
         let python = self.python_path();
 

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -12,6 +12,8 @@ use gglib_core::utils::process::async_cmd;
 use thiserror::Error;
 use tokio::process::Command;
 
+use super::python_bridge::NoticeCallback;
+
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
@@ -127,8 +129,13 @@ impl PythonEnvironment {
     /// 3. Install/update requirements if the marker is stale
     /// 4. Deploy the helper script
     ///
+    /// `notice` receives transient setup notes ("creating environment...",
+    /// "installing dependencies...") for display on a per-download bar. When
+    /// `None` (the preflight/no-callback paths), those notes fall back to
+    /// [`gglib_core::telemetry::console_println`].
+    ///
     /// Returns `Err` if Python is not found or setup fails.
-    pub async fn prepare() -> Result<Self, EnvSetupError> {
+    pub async fn prepare(notice: Option<&NoticeCallback>) -> Result<Self, EnvSetupError> {
         let env_dir = get_env_directory()?;
         let script_path = get_script_path()?;
 
@@ -142,7 +149,7 @@ impl PythonEnvironment {
         };
 
         env.write_script()?;
-        env.ensure_env_ready().await?;
+        env.ensure_env_ready(notice).await?;
 
         // Validate the interpreter we will actually run.
         // This catches environment pollution (e.g., PYTHONHOME/PYTHONPATH) early.
@@ -186,26 +193,34 @@ impl PythonEnvironment {
     // Internal methods
     // ------------------------------------------------------------------------
 
-    async fn ensure_env_ready(&self) -> Result<(), EnvSetupError> {
+    async fn ensure_env_ready(&self, notice: Option<&NoticeCallback>) -> Result<(), EnvSetupError> {
         if !self.python_path().exists() {
-            self.create_env().await?;
+            self.create_env(notice).await?;
         }
 
         if !self.marker_is_fresh()? {
-            self.install_requirements().await?;
+            self.install_requirements(notice).await?;
             self.write_marker()?;
         }
 
         Ok(())
     }
 
-    async fn create_env(&self) -> Result<(), EnvSetupError> {
+    async fn create_env(&self, notice: Option<&NoticeCallback>) -> Result<(), EnvSetupError> {
         let bootstrap = find_bootstrap_python_validated().await?;
 
-        gglib_core::telemetry::console_println(&format!(
-            "ℹ️  Creating Python environment for fast downloads at {}...",
-            self.env_dir.display()
-        ));
+        // With a notice sink (the queued-download path), the note lands on
+        // the bar itself and stays terse — no path, it wouldn't fit and
+        // isn't actionable there. Without one (preflight, `model upgrade`),
+        // fall back to a console line with the full path for context.
+        notify(
+            notice,
+            "preparing fast downloader (first run, this can take a minute)…",
+            &format!(
+                "ℹ️  Creating Python environment for fast downloads at {}...",
+                self.env_dir.display()
+            ),
+        );
 
         let mut cmd = async_cmd(&bootstrap);
         apply_python_subprocess_isolation(&mut cmd);
@@ -213,8 +228,8 @@ impl PythonEnvironment {
         // and stderr instead of inheriting the parent's, so `python -m venv`
         // can never write raw bytes straight to the terminal. An inherited
         // handle would bypass indicatif entirely and corrupt any live
-        // `MultiProgress` redraw the same way a stray `println!` does — see
-        // the module-level comment on `run_python_command` below.
+        // `MultiProgress` redraw the same way a stray `println!` does.
+        // `run_python_command` below already pipes for the same reason.
         let output = cmd
             .arg("-m")
             .arg("venv")
@@ -242,8 +257,12 @@ impl PythonEnvironment {
         Ok(())
     }
 
-    async fn install_requirements(&self) -> Result<(), EnvSetupError> {
-        gglib_core::telemetry::console_println("ℹ️  Installing fast download dependencies...");
+    async fn install_requirements(&self, notice: Option<&NoticeCallback>) -> Result<(), EnvSetupError> {
+        notify(
+            notice,
+            "installing fast downloader dependencies…",
+            "ℹ️  Installing fast download dependencies...",
+        );
 
         let python = self.python_path();
 
@@ -370,6 +389,16 @@ async fn find_bootstrap_python_validated() -> Result<PathBuf, EnvSetupError> {
     }
 
     Err(EnvSetupError::PythonNotFound(PYTHON_CANDIDATES.join(", ")))
+}
+
+/// Surface a transient setup note: on the bar via `notice` when a sink is
+/// wired up, otherwise as a console line with fuller context.
+fn notify(notice: Option<&NoticeCallback>, bar_message: &str, console_message: &str) {
+    if let Some(notice) = notice {
+        notice(bar_message);
+    } else {
+        gglib_core::telemetry::console_println(console_message);
+    }
 }
 
 /// Run a Python command and check for success.

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -242,15 +242,9 @@ impl PythonEnvironment {
             })?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            let reason = if stderr.is_empty() {
-                format!("python -m venv exited with {}", output.status)
-            } else {
-                format!("python -m venv exited with {}: {stderr}", output.status)
-            };
             return Err(EnvSetupError::CreateEnvFailed {
                 path: self.env_dir.clone(),
-                reason,
+                reason: venv_failure_reason(output.status, &output.stderr),
             });
         }
 
@@ -401,6 +395,18 @@ fn notify(notice: Option<&NoticeCallback>, bar_message: &str, console_message: &
         notice(bar_message);
     } else {
         gglib_core::telemetry::console_println(console_message);
+    }
+}
+
+/// Build the `CreateEnvFailed` reason for a failed `python -m venv`,
+/// including captured stderr when there is any. Pulled out of `create_env`
+/// so the formatting is testable without spawning a real process.
+fn venv_failure_reason(status: std::process::ExitStatus, stderr: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    if stderr.is_empty() {
+        format!("python -m venv exited with {status}")
+    } else {
+        format!("python -m venv exited with {status}: {stderr}")
     }
 }
 
@@ -582,6 +588,40 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("virtualenv"));
         assert!(msg.contains("permission denied"));
+    }
+
+    /// `create_env` now runs `python -m venv` via `.output()` instead of
+    /// `.status()` specifically so its stderr can be captured into the
+    /// error instead of being inherited straight to the terminal (where it
+    /// could corrupt a live `MultiProgress` redraw). This is the formatting
+    /// half of that change, tested without spawning a process: a fake
+    /// `ExitStatus` plus captured stderr bytes.
+    #[cfg(unix)]
+    #[test]
+    fn venv_failure_reason_includes_captured_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = std::process::ExitStatus::from_raw(1 << 8); // exit code 1
+        let reason = venv_failure_reason(status, b"NotADirectoryError: [Errno 20]\n");
+
+        assert!(reason.contains("exited with"));
+        assert!(reason.contains("NotADirectoryError"));
+    }
+
+    /// Empty stderr (e.g. the process was killed by a signal before writing
+    /// anything) must not produce a dangling ": " with nothing after it.
+    #[cfg(unix)]
+    #[test]
+    fn venv_failure_reason_omits_colon_when_stderr_is_empty() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = std::process::ExitStatus::from_raw(1 << 8);
+        let reason = venv_failure_reason(status, b"");
+
+        // No trailing ": " separator (which would precede an empty stderr
+        // section) — just the bare "exited with <status>" whatever ExitStatus's
+        // own Display happens to contain.
+        assert_eq!(reason, format!("python -m venv exited with {status}"));
     }
 
     /// Test that environment isolation properly removes polluted environment variables

--- a/crates/gglib-download/src/cli_exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/mod.rs
@@ -10,6 +10,6 @@ pub use types::*;
 
 // Re-export Python bridge for use by the async manager
 pub use exec::python_bridge::{
-    FastDownloadRequest, ProgressCallback, PythonBridgeError, ensure_fast_helper_ready,
-    preflight_fast_helper, run_fast_download,
+    FastDownloadRequest, NoticeCallback, ProgressCallback, PythonBridgeError,
+    ensure_fast_helper_ready, preflight_fast_helper, run_fast_download,
 };

--- a/crates/gglib-download/src/manager/README.md
+++ b/crates/gglib-download/src/manager/README.md
@@ -11,7 +11,12 @@ between the worker (core download logic) and bridges (event emission).
 # Architecture
 
 - **Manager**: Orchestrates queue, leases, and worker lifecycle
-- **Worker**: Executes downloads, writes only to `watch::Sender` (no events)
+- **Worker**: Executes downloads, writes only to `watch::Sender` (no events) —
+  with one narrow, deliberate exception: `WorkerDeps.event_emitter` lets
+  `execute_download` emit `DownloadEvent::DownloadNotice` directly for
+  transient, cosmetic setup notes (e.g. building the fast downloader's
+  first-run Python venv) that aren't part of the progress or completion state
+  the manager sequences. See the doc comment on `WorkerDeps` in `worker.rs`.
 - **Bridge tasks**: Subscribe to watch channels, emit events with rate-limiting
 
 # Concurrency Model

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -445,6 +445,7 @@ impl DownloadManagerImpl {
                 // Create worker deps and job
                 let deps = WorkerDeps {
                     config: self.config.clone(),
+                    event_emitter: Arc::clone(&self.event_emitter),
                 };
 
                 let files = Self::extract_files(&item);

--- a/crates/gglib-download/src/manager/worker.rs
+++ b/crates/gglib-download/src/manager/worker.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
-use gglib_core::download::{DownloadError, DownloadId, Quantization};
-use gglib_core::ports::DownloadManagerConfig;
+use gglib_core::download::{DownloadError, DownloadEvent, DownloadId, Quantization};
+use gglib_core::ports::{DownloadEventEmitterPort, DownloadManagerConfig};
 
 use crate::cli_exec::{FastDownloadRequest, PythonBridgeError, run_fast_download};
 
@@ -29,10 +29,19 @@ use super::paths::DownloadDestination;
 ///
 /// These are cloned Arc references to ports, allowing the worker
 /// to operate independently of the manager's state.
+///
+/// `event_emitter` is a narrow, deliberate exception to "worker only writes
+/// to `watch::Sender`" above: it exists solely so `execute_download` can
+/// surface [`DownloadEvent::DownloadNotice`] — a one-off, cosmetic note
+/// (e.g. "preparing fast downloader") that isn't part of the progress or
+/// completion state the manager sequences. Progress and terminal events
+/// still flow exclusively through the watch channel and `finalize_job`.
 #[derive(Clone)]
 pub struct WorkerDeps {
     /// Configuration (models directory, HF token, etc.).
     pub config: DownloadManagerConfig,
+    /// Event sink for [`DownloadEvent::DownloadNotice`] only.
+    pub event_emitter: Arc<dyn DownloadEventEmitterPort>,
 }
 
 /// A download job to be executed by the worker.
@@ -203,6 +212,18 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
             });
         });
 
+    // Notice callback: surfaces transient setup notes (e.g. first-run Python
+    // venv creation) on the bar instead of leaving it looking frozen for the
+    // tens of seconds that can take. See the doc comment on `WorkerDeps`.
+    let notice_id = job.id.to_string();
+    let notice_emitter = Arc::clone(&deps.event_emitter);
+    let notice_callback: crate::cli_exec::NoticeCallback = Arc::new(move |message: &str| {
+        notice_emitter.emit(DownloadEvent::DownloadNotice {
+            id: notice_id.clone(),
+            message: message.to_string(),
+        });
+    });
+
     // Build download request
     let request = FastDownloadRequest {
         repo_id: job.id.model_id(),
@@ -213,6 +234,7 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
         token: deps.config.hf_token.as_deref(),
         force: false,
         progress: Some(Arc::clone(&progress_callback)),
+        notice: Some(notice_callback),
         expected_total: job.expected_total,
         cancel_token: Some(job.cancel.clone()),
     };

--- a/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
+++ b/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
@@ -134,7 +134,11 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
   const isSharded = !!(shard && shard.total > 1);
   // Lifecycle label: surfaces Finalizing/Registering between bytes-on-disk
   // and the terminal Completed event so the UI doesn't look frozen at 100%.
+  // `notice` is the same idea for transient setup notes (e.g. first-run
+  // Python env creation for the fast downloader) that carry no byte
+  // progress — shown verbatim since the message itself is the label.
   const phaseLabel = (() => {
+    if (progress?.status === 'notice' && progress.message) return progress.message;
     if (progress?.status === 'finalizing') return 'Finalizing';
     if (progress?.status === 'registering') return 'Registering';
     if (isSharded && shard) return `Downloading shard ${shard.index + 1}/${shard.total}`;

--- a/src/components/GlobalDownloadStatus/README.md
+++ b/src/components/GlobalDownloadStatus/README.md
@@ -23,4 +23,12 @@ rather than `0`. This component computes no rate of its own — the download
 manager's `RateEstimator` is the single source, so the CLI and the GUI always
 agree.
 
+The phase label above the bar (`Downloading` / `Finalizing` / `Registering`)
+also covers `notice`: a transient, free-form setup note from the backend's
+`DownloadEvent::DownloadNotice` (e.g. "preparing fast downloader…" while the
+CLI/backend builds the fast downloader's first-run Python environment) shown
+verbatim in place of a fixed phase label, mirroring what the CLI shows on its
+own progress bar for the same event. It carries no byte progress; the next
+progress or status event overwrites it.
+
 <!-- module-docs:end -->

--- a/src/hooks/useDownloadManager.ts
+++ b/src/hooks/useDownloadManager.ts
@@ -19,7 +19,7 @@ function snapshotIsBusy(items: DownloadSummary[]): boolean {
   return items.some(i => i.status === 'queued' || i.status === 'downloading');
 }
 
-export type DownloadProgressStatus = 'started' | 'progress' | 'finalizing' | 'registering' | 'completed' | 'error';
+export type DownloadProgressStatus = 'started' | 'progress' | 'finalizing' | 'registering' | 'notice' | 'completed' | 'error';
 
 export interface DownloadProgressView {
   status: DownloadProgressStatus;
@@ -192,6 +192,18 @@ function eventToProgress(event: DownloadEvent): DownloadProgressView | null {
         };
       }
       return null;
+    case 'download_notice':
+      // Transient setup note (e.g. first-run Python env creation for the
+      // fast downloader) that carries no byte progress. Merged into the
+      // previous view like finalizing/registering above, so the bar and
+      // byte counts don't reset — only the message and phase change.
+      return {
+        status: 'notice',
+        id: event.id,
+        message: event.message,
+        speedBps: undefined,
+        etaSeconds: undefined,
+      };
     default:
       return null;
   }

--- a/src/services/decoders/downloadEvent.ts
+++ b/src/services/decoders/downloadEvent.ts
@@ -27,6 +27,7 @@ const KNOWN_DOWNLOAD_EVENT_TYPES = new Set([
   'download_failed',
   'download_cancelled',
   'download_status_changed',
+  'download_notice',
   'queue_run_complete',
 ]);
 

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -122,6 +122,11 @@ export type DownloadEvent =
   | { type: 'download_failed'; id: DownloadId; error: string }
   | { type: 'download_cancelled'; id: DownloadId }
   | { type: 'download_status_changed'; id: DownloadId; status: import('./downloads').DownloadStatus }
+  // Transient, non-persisted note about work happening for this download
+  // that produces no byte progress (e.g. first-run Python env setup for the
+  // fast downloader). Unlike download_status_changed, message is free-form
+  // text rather than a fixed status.
+  | { type: 'download_notice'; id: DownloadId; message: string }
   | { type: 'queue_run_complete'; summary: QueueRunSummary };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

`gglib model download <repo> -q <quant>` was leaving stranded progress-bar
frames in scrollback instead of redrawing one bar in place, and showing a
misleading fully-filled bar (`[██████████████████████████████] 0 B/0 B`)
before the download's total size was known.

- **Root cause of the artifacts**: `CliDownloadEventEmitter`'s `MultiProgress`
  draws to stderr, but venv-setup notices, the tracing log layer, the
  `[fast-path]` passthrough line, and `python -m venv`'s inherited stdio all
  wrote straight to a stream outside `MultiProgress`'s own redraw
  bookkeeping. Any one of those lines desyncs the bars' line-count tracking,
  so the next redraw erases the wrong region and strands the previous frame.
- **Root cause of the full-at-0-bytes bar**: bars were created with
  `ProgressBar::new(0)`; indicatif's `fraction()` treats an explicit length
  of 0 as 100% complete.

## Changes

- `gglib_core::telemetry` gains a console hook (`set_console_hook` /
  `console_println`) that the tracing `fmt` layer and CLI setup/status lines
  now write through. `CliDownloadEventEmitter` installs itself as that hook,
  routing lines through `MultiProgress::println` so they're erased/redrawn
  atomically around the bars instead of corrupting them; falls back to
  `eprintln!` when the target is hidden (non-TTY) since `println` silently
  drops in that case.
- `python -m venv` now runs via `.output()` instead of `.status()`, so its
  own stdio can't hit the terminal raw.
- TTY detection and `console::Term` now check/target stderr, matching where
  the bars actually draw — a redirected stdout no longer silently disables
  hotkeys or the fancy bar.
- New `DownloadEvent::DownloadNotice` surfaces the first-run Python venv
  build (which can take tens of seconds with zero byte progress) as a
  message on the bar instead of a stray console line. Threaded from
  `PythonEnvironment::prepare` through `FastDownloadRequest` down to the
  worker; the GUI (web + desktop) shows the same message for parity.
- Bars now use `ProgressBar::no_length()` instead of `new(0)`, with a custom
  `{total_bytes}` template key rendering `—` until a real total arrives.
- The `[a]/[q]` hint bar is created eagerly and registered as the emitter's
  footer; new download bars insert above it via `MultiProgress::insert_before`
  instead of the previous remove-then-re-add churn on every new item.
- Updated the module READMEs (they're included as crate/module rustdoc via
  `#![doc = include_str!(...)]`) to describe the new behavior.

## Test plan

- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all clean
- [x] `cargo test --workspace` — all passing, repeated 3x with no flakiness
- [x] `npx tsc --noEmit` and `npx vitest run` — clean, all passing
- [x] `./scripts/check_readmes.sh --strict --verbose` — passes
- [x] New unit tests: bar has no length until a real total arrives, `DownloadNotice` updates the message without touching progress, console hook install/clear, `python -m venv` failure-reason formatting (stderr capture, no dangling separator when empty)
- [ ] Manual repro: delete `.conda/gglib-hf-xet` to force the first-run venv path, run `gglib model download unsloth/Qwen3.6-27B-MTP-GGUF -q Q8_0`, confirm a single bar stays in place through env creation with no stranded frames, an honest empty bar before the total is known, and the "preparing fast downloader…" notice on the bar