### PR TITLE
Fix KV-cache reuse breaking across turns of the same session

### DIFF
--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -148,7 +148,7 @@ This crate provides an OpenAI-compatible HTTP server that:
 - **`metrics.rs`** — `ContextMetricsStore` ring buffer feeding `DashboardSnapshot.recent_requests`
 - **`connections.rs`** — `ActiveConnectionsRegistry` + RAII `ConnectionGuard`; tracks every in-flight `/v1/chat/completions` request (direct and council/virtual-model) through `Queued` → `ProcessingPrompt` → `Generating`, feeding `DashboardSnapshot.active_connections`
 - **`slots.rs`** — Fetch + defensive parsing of llama.cpp's native `GET /slots` endpoint into `SlotSnapshot`; also provides slot I/O primitives (`save_slot`, `restore_slot`, `clear_slot_files`, `sanitize_session_id`) and background LRU eviction
-- **`canonicalization.rs`** — System prompt normalization for cache key stability (whitespace, tool definition ordering)
+- **`canonicalization.rs`** — System prompt normalization and `tools[]` order canonicalization for cache key stability, plus content-hash session-id fallback derivation
 - **`cache_lifecycle.rs`** — KV cache save→forward→save orchestration with semaphore gating and retry logic
 - **`sse_stream.rs`** — SSE stream extraction helper for separating chat completion responses from Server-Sent Events
 - **`slots_poller.rs`** — Background task that polls `slots.rs` on an interval with exponential backoff, caching the latest `SlotsPollResult`

--- a/crates/gglib-proxy/src/canonicalization.rs
+++ b/crates/gglib-proxy/src/canonicalization.rs
@@ -119,6 +119,70 @@ pub fn canonicalize_system_prompt(body: Bytes) -> Bytes {
     }
 }
 
+/// Canonicalise the `tools[]` array into a stable, deterministic order.
+///
+/// llama.cpp's Jinja template renders tool/function schemas early in the
+/// prompt, right after the system message (see [`log_tool_names_for_diagnostics`]
+/// for how this was diagnosed). If the calling client sends `tools[]` in a
+/// different order between two turns of the same conversation, those early
+/// tokens change and llama.cpp's common-prefix match breaks for everything
+/// after — a full cold re-prefill even though the conversation didn't
+/// meaningfully change. Sorting by `function.name` before forwarding makes
+/// gglib's own request byte-stable regardless of what order the client sent,
+/// independent of genuine membership changes (adding/removing a tool), which
+/// remain a real client-side change this function cannot and must not hide.
+///
+/// # Sort key
+///
+/// `tools[].function.name`, ascending. A **stable** sort, so entries sharing
+/// a key — including any missing `function.name`, which sorts first as
+/// `None` — keep their relative order rather than being shuffled arbitrarily.
+///
+/// # Fail-open
+///
+/// No `tools` array, fewer than two entries, or a re-serialization failure
+/// all return the original `Bytes` unchanged.
+pub fn canonicalize_tool_order(body: Bytes) -> Bytes {
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return body;
+    };
+
+    let Some(tools) = value.get_mut("tools").and_then(|v| v.as_array_mut()) else {
+        return body;
+    };
+
+    if tools.len() < 2 {
+        return body;
+    }
+
+    let already_sorted = tools
+        .windows(2)
+        .all(|w| tool_name(&w[0]) <= tool_name(&w[1]));
+    if already_sorted {
+        return body;
+    }
+
+    tools.sort_by(|a, b| tool_name(a).cmp(&tool_name(b)));
+    debug!(
+        tool_count = tools.len(),
+        "canonicalised tools[] order for cache prefix stability"
+    );
+
+    match serde_json::to_vec(&value) {
+        Ok(v) => Bytes::from(v),
+        Err(e) => {
+            warn!(error = %e, "failed to re-serialize after tool-order canonicalisation; forwarding original");
+            body
+        }
+    }
+}
+
+/// `tools[N].function.name`, or `None` for a malformed entry. `Option<&str>`
+/// sorts `None` first — deterministic, never panics.
+fn tool_name(tool: &serde_json::Value) -> Option<&str> {
+    tool.get("function")?.get("name")?.as_str()
+}
+
 /// Number of leading digest bytes kept in [`derive_fallback_session_id`]'s
 /// identifier (16 bytes = 128 bits — ample collision resistance for a cache
 /// bucketing key that only needs fail-open behaviour on collision, not
@@ -200,11 +264,13 @@ pub fn derive_fallback_session_id(body: &Bytes) -> Option<String> {
 /// schemas are typically enumerated early), so when a restore's LCP
 /// similarity comes back low for a session that should be stable, the
 /// question is whether the *client* changed the tool list shape between
-/// turns (different membership or order) rather than anything gglib did.
-/// Comparing two consecutive log lines for the same session_id answers
-/// that directly: identical list → not the cause; same names, different
-/// order → fixable by canonicalizing the order; different names → a real
-/// client-side change, outside the proxy's control.
+/// turns rather than anything gglib did. Since [`canonicalize_tool_order`]
+/// now runs before this (see the call site in `chat_completions`), *order*
+/// drift is no longer a possible answer — it's structurally eliminated
+/// upstream. What's left for this log to diagnose is *membership* drift:
+/// comparing two consecutive log lines for the same session_id, identical
+/// list → not the cause; different names → a real client-side change
+/// (a tool added/removed), outside the proxy's control.
 ///
 /// A no-op (skips the parse entirely) unless DEBUG-level tracing is
 /// actually enabled, so this costs nothing outside `-v` investigations.
@@ -482,5 +548,114 @@ mod tests {
             .unwrap(),
         );
         assert_eq!(extract_tool_names(&body).unwrap(), vec!["read_file"]);
+    }
+
+    #[test]
+    fn canonicalize_tool_order_sorts_by_function_name() {
+        let body = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "messages": [],
+                "tools": [
+                    {"type": "function", "function": {"name": "create_pull_request"}},
+                    {"type": "function", "function": {"name": "create_branch"}},
+                    {"type": "function", "function": {"name": "read_file"}}
+                ]
+            }))
+            .unwrap(),
+        );
+        let result = canonicalize_tool_order(body);
+        let value: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        let names: Vec<&str> = value["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["function"]["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["create_branch", "create_pull_request", "read_file"]
+        );
+    }
+
+    #[test]
+    fn canonicalize_tool_order_is_idempotent_across_two_differently_ordered_turns() {
+        // The actual bug this fixes: two turns sending the same set in
+        // different order must forward byte-identically past the tools[]
+        // boundary, or llama.cpp's common-prefix match breaks right there.
+        let turn1 = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "tools": [
+                    {"type": "function", "function": {"name": "b_tool"}},
+                    {"type": "function", "function": {"name": "a_tool"}}
+                ]
+            }))
+            .unwrap(),
+        );
+        let turn2 = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "tools": [
+                    {"type": "function", "function": {"name": "a_tool"}},
+                    {"type": "function", "function": {"name": "b_tool"}}
+                ]
+            }))
+            .unwrap(),
+        );
+        assert_eq!(
+            canonicalize_tool_order(turn1),
+            canonicalize_tool_order(turn2)
+        );
+    }
+
+    #[test]
+    fn canonicalize_tool_order_already_sorted_is_byte_identical() {
+        let body = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "tools": [
+                    {"type": "function", "function": {"name": "a"}},
+                    {"type": "function", "function": {"name": "b"}}
+                ]
+            }))
+            .unwrap(),
+        );
+        assert_eq!(canonicalize_tool_order(body.clone()), body);
+    }
+
+    #[test]
+    fn canonicalize_tool_order_no_tools_field_unchanged() {
+        let body = Bytes::from(serde_json::to_vec(&serde_json::json!({"messages": []})).unwrap());
+        assert_eq!(canonicalize_tool_order(body.clone()), body);
+    }
+
+    #[test]
+    fn canonicalize_tool_order_single_tool_unchanged() {
+        let body = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "tools": [{"type": "function", "function": {"name": "only_one"}}]
+            }))
+            .unwrap(),
+        );
+        assert_eq!(canonicalize_tool_order(body.clone()), body);
+    }
+
+    #[test]
+    fn canonicalize_tool_order_malformed_entries_never_panic() {
+        let body = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "tools": [
+                    {"type": "function", "function": {"name": "z_tool"}},
+                    {"type": "function", "function": {}},
+                    "not even an object"
+                ]
+            }))
+            .unwrap(),
+        );
+        let result = canonicalize_tool_order(body); // must not panic
+        let _value: serde_json::Value = serde_json::from_slice(&result).unwrap();
+    }
+
+    #[test]
+    fn canonicalize_tool_order_invalid_json_passthrough() {
+        let body = Bytes::from(b"not json".to_vec());
+        assert_eq!(canonicalize_tool_order(body.clone()), body);
     }
 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -324,6 +324,16 @@ fn shape_request_body(
 ///   `None` when the KV cache is disabled.
 /// * `session_id` - Session identifier used to key the KV cache save
 ///   (streaming path only). `None` when the KV cache is disabled.
+/// * `calibration_session_id` - Session id used to look up/freeze this
+///   session's chars-per-token snapshot (see
+///   [`crate::token_calibration::TokenCalibration::session_chars_per_token`]);
+///   `None` when no session id was resolved, which falls back to the live
+///   per-model ratio exactly as before. Distinct from `session_id` above:
+///   that one is only populated when disk KV-slot caching is enabled, but
+///   this budget-stability fix must work even when it's off (e.g. for
+///   hybrid/sliding-window-attention models, where disk caching is disabled
+///   but the host-RAM prompt cache — the thing this fix protects — still
+///   applies).
 ///
 /// # Returns
 ///
@@ -344,6 +354,7 @@ pub(crate) async fn forward_chat_completion(
     connection: ConnectionGuard,
     upstream_health: Arc<UpstreamHealth>,
     calibration: Arc<TokenCalibration>,
+    calibration_session_id: Option<&str>,
     cache_metrics: Arc<CacheMetricsStore>,
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
     config: Option<crate::cache_lifecycle::StreamConfig>,
@@ -368,7 +379,18 @@ pub(crate) async fn forward_chat_completion(
     // approximation until the first observation lands. That is strictly better
     // information than `ModelContext::context_budget_chars()` — which is what
     // the agent path uses — so the proxy passes its own.
-    let chars_per_token = calibration.chars_per_token(model_name);
+    //
+    // When a session id is available, the ratio is frozen per-session rather
+    // than read live: the live EWMA updates after every request, so reading
+    // it fresh on every turn let the budget wobble turn-to-turn purely from
+    // calibration noise — which could flip whether the earliest eligible
+    // message gets elided below, breaking llama.cpp's common-prefix cache
+    // match for a conversation that didn't actually change. See
+    // `TokenCalibration::session_chars_per_token`.
+    let chars_per_token = calibration_session_id.map_or_else(
+        || calibration.chars_per_token(model_name),
+        |sid| calibration.session_chars_per_token(model_name, sid, std::time::Instant::now()),
+    );
     let budget_chars = Some((effective_ctx as f64 * chars_per_token) as usize);
 
     let (body, report) = match shape_request_body(body, &context, &sampling, budget_chars) {
@@ -861,6 +883,20 @@ async fn forward_non_streaming_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_aware_budget_falls_back_to_live_ratio_without_a_session_id() {
+        let cal = TokenCalibration::new();
+        cal.record("m", 40_000, 10_000);
+        let live = cal.chars_per_token("m");
+        // Mirrors the exact fallback expression used in
+        // forward_chat_completion's budget computation above.
+        let via_none: f64 = None::<&str>.map_or_else(
+            || cal.chars_per_token("m"),
+            |sid| cal.session_chars_per_token("m", sid, std::time::Instant::now()),
+        );
+        assert_eq!(live, via_none);
+    }
 
     #[test]
     fn test_should_forward_header() {

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -531,6 +531,22 @@ async fn handle_proxy_cache_clear(
         "RAM cache not flushed (request in flight; retry when idle)"
     };
 
+    // Drop any frozen per-session calibration snapshot too, so a session
+    // that explicitly cleared its cache re-baselines from the current
+    // global ratio on its next request instead of reusing a pre-clear one.
+    // Re-derive the sanitized (lowercased) form rather than reusing the raw
+    // header value above — the validation call earlier only checks
+    // `sanitize_session_id`'s `Err` case and discards its `Ok(String)`, so
+    // `session_id` itself is still whatever case the client sent, and
+    // `chat_completions` always keys snapshots by the lowercased form.
+    if let Some(ref sid) = session_id {
+        if let Ok(sanitized) = crate::slots::sanitize_session_id(sid) {
+            state.calibration.clear_session(&sanitized);
+        }
+    } else {
+        state.calibration.clear_all_sessions();
+    }
+
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -575,15 +591,26 @@ async fn chat_completions(
                     .unwrap();
             }
         }
-    } else if state.cache_enabled {
+    } else {
         // No explicit header — most clients (VS Code Copilot's LLM Gateway
         // extension, curl, anything else speaking plain OpenAI-compatible
         // chat completions) have no idea X-Gglib-Session-Id exists. Derive a
         // stable fallback from the request content itself so the cache
         // still works without any client cooperation.
+        //
+        // Derived unconditionally — not gated on `state.cache_enabled` — because
+        // this id now also keys `TokenCalibration`'s per-session budget
+        // snapshot (see `forward_chat_completion`'s `calibration_session_id`),
+        // which must work even when disk KV-slot caching is off. That's
+        // exactly the case for hybrid/sliding-window-attention models, where
+        // disk restore can't resume the prompt and is disabled by design (see
+        // `slot_restore` in `gglib_runtime::llama::args`) — but the host-RAM
+        // prompt cache this budget-stability fix protects still applies. The
+        // actual disk save/restore activation stays independently gated on
+        // `state.cache_enabled` at its own call site below, so widening where
+        // this id is *derived* doesn't turn on disk caching when the feature
+        // is off.
         crate::canonicalization::derive_fallback_session_id(&body)
-    } else {
-        None
     };
 
     if let Some(ref sid) = sanitized_session_id {
@@ -814,6 +841,7 @@ async fn chat_completions(
                         connection,
                         state.upstream_health.clone(),
                         state.calibration.clone(),
+                        sanitized_session_id.as_deref(),
                         state.dashboard.cache_metrics.clone(),
                         None,
                         None,
@@ -852,6 +880,7 @@ async fn chat_completions(
                             connection,
                             state.upstream_health.clone(),
                             state.calibration.clone(),
+                            sanitized_session_id.as_deref(),
                             state.dashboard.cache_metrics.clone(),
                             Some(permit),
                             Some(cfg),
@@ -875,6 +904,7 @@ async fn chat_completions(
                             connection,
                             state.upstream_health.clone(),
                             state.calibration.clone(),
+                            sanitized_session_id.as_deref(),
                             state.dashboard.cache_metrics.clone(),
                             None,
                             None,
@@ -900,6 +930,7 @@ async fn chat_completions(
                 connection,
                 state.upstream_health.clone(),
                 state.calibration.clone(),
+                sanitized_session_id.as_deref(),
                 state.dashboard.cache_metrics.clone(),
                 None,
                 None,
@@ -923,6 +954,7 @@ async fn chat_completions(
             connection,
             state.upstream_health.clone(),
             state.calibration.clone(),
+            sanitized_session_id.as_deref(),
             state.dashboard.cache_metrics.clone(),
             None,
             None,
@@ -1046,6 +1078,7 @@ async fn chat_completions(
                 retry_connection,
                 state.upstream_health.clone(),
                 state.calibration.clone(),
+                sanitized_session_id.as_deref(),
                 state.dashboard.cache_metrics.clone(),
                 retry_permit,
                 retry_cfg,

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -550,11 +550,13 @@ async fn chat_completions(
 ) -> Response {
     debug!("POST /v1/chat/completions");
 
-    // Canonicalize once, up front, and reuse the result for both the
-    // content-hash session id fallback below and the forwarded request
-    // (forward_chat_completion no longer re-canonicalizes) — avoids paying
-    // the parse/regex/serialize cost on this ~150KB+ body twice per request.
+    // Canonicalize the system prompt and tool order once, up front, and
+    // reuse the result for both the content-hash session id fallback below
+    // and the forwarded request (forward_chat_completion no longer
+    // re-canonicalizes) — avoids paying the parse/regex/serialize cost on
+    // this ~150KB+ body twice per request.
     let body = crate::canonicalization::canonicalize_system_prompt(body);
+    let body = crate::canonicalization::canonicalize_tool_order(body);
 
     // Extract and sanitize session ID from header (safety-critical: prevents path traversal)
     let session_id_from_header = headers

--- a/crates/gglib-proxy/src/token_calibration.rs
+++ b/crates/gglib-proxy/src/token_calibration.rs
@@ -21,8 +21,9 @@
 //! couple of map operations with no `.await`, matching the lock discipline of
 //! [`crate::metrics::ContextMetricsStore`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use gglib_core::request_pipeline::CHARS_PER_TOKEN_APPROX;
 
@@ -36,12 +37,70 @@ const EWMA_ALPHA: f64 = 0.2;
 const MIN_RATIO: f64 = 2.0;
 const MAX_RATIO: f64 = 8.0;
 
+/// Maximum number of distinct sessions [`TokenCalibration`] remembers a
+/// frozen snapshot for. Bounded the same way `ContextMetricsStore`'s ring
+/// buffer is (`crate::metrics::MAX_SNAPSHOTS`) — oldest evicted first,
+/// rather than growing without limit for the life of the process.
+const MAX_SESSION_SNAPSHOTS: usize = 256;
+
+/// How long a frozen per-session snapshot is trusted before a request for
+/// that session re-baselines it from the live ratio.
+///
+/// Long enough that no realistic back-to-back exchange within one chat
+/// session — the turn-to-turn cadence this snapshot exists to protect —
+/// ever crosses it; short enough that a session left open for hours
+/// eventually re-aligns with reality instead of carrying a first-request
+/// guess forever.
+const SESSION_SNAPSHOT_TTL: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// A chars-per-token ratio frozen at a point in time for one session.
+#[derive(Debug, Clone, Copy)]
+struct SessionSnapshot {
+    ratio: f64,
+    taken_at: Instant,
+}
+
+/// FIFO-bounded map: same eviction shape as `ContextMetricsStore`'s ring
+/// buffer, applied to session ids instead of per-request snapshots.
+#[derive(Debug, Default)]
+struct SessionSnapshots {
+    values: HashMap<String, SessionSnapshot>,
+    order: VecDeque<String>,
+}
+
+impl SessionSnapshots {
+    fn insert(&mut self, key: String, snap: SessionSnapshot) {
+        if !self.values.contains_key(&key) {
+            self.order.push_back(key.clone());
+            if self.order.len() > MAX_SESSION_SNAPSHOTS
+                && let Some(oldest) = self.order.pop_front()
+            {
+                self.values.remove(&oldest);
+            }
+        }
+        self.values.insert(key, snap);
+    }
+
+    fn remove_session(&mut self, session_id: &str) {
+        let prefix = format!("{session_id}\u{0}");
+        self.values.retain(|k, _| !k.starts_with(&prefix));
+        self.order.retain(|k| !k.starts_with(&prefix));
+    }
+}
+
+/// Composite key: a session that switches models mid-conversation must
+/// re-snapshot rather than reuse a ratio learned for a different tokenizer.
+fn session_key(session_id: &str, model: &str) -> String {
+    format!("{session_id}\u{0}{model}")
+}
+
 /// Per-model rolling chars-per-token estimator.
 ///
 /// Wrap in `Arc` and share across handler tasks.
 #[derive(Debug, Default)]
 pub struct TokenCalibration {
     ratios: Mutex<HashMap<String, f64>>,
+    session_snapshots: Mutex<SessionSnapshots>,
 }
 
 impl TokenCalibration {
@@ -82,6 +141,62 @@ impl TokenCalibration {
             .get(model)
             .copied()
             .unwrap_or(CHARS_PER_TOKEN_APPROX as f64)
+    }
+
+    /// The chars-per-token factor to use for `model` within `session_id`,
+    /// frozen at whatever [`Self::chars_per_token`] returned the first time
+    /// this (session, model) pair was seen — or the last time it went stale
+    /// past [`SESSION_SNAPSHOT_TTL`] — rather than the live, still-adapting
+    /// value every other request would read.
+    ///
+    /// This is what keeps two turns of one conversation from computing two
+    /// different truncation budgets purely from the EWMA settling in the
+    /// background: [`Self::record`] still updates on every request as before,
+    /// but a session that's already snapshotted doesn't see that drift again
+    /// until its snapshot expires or is explicitly cleared.
+    #[must_use]
+    pub fn session_chars_per_token(&self, model: &str, session_id: &str, now: Instant) -> f64 {
+        let key = session_key(session_id, model);
+        let mut guard = self
+            .session_snapshots
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        if let Some(snap) = guard.values.get(&key)
+            && now.duration_since(snap.taken_at) < SESSION_SNAPSHOT_TTL
+        {
+            return snap.ratio;
+        }
+
+        // Different mutex (`self.ratios`) — no self-deadlock nesting this
+        // call inside the `session_snapshots` guard.
+        let ratio = self.chars_per_token(model);
+        guard.insert(
+            key,
+            SessionSnapshot {
+                ratio,
+                taken_at: now,
+            },
+        );
+        ratio
+    }
+
+    /// Drop the frozen snapshot(s) for `session_id` (all models), so the next
+    /// request for it re-baselines from the current live ratio. Called when
+    /// that session's cache is explicitly cleared.
+    pub fn clear_session(&self, session_id: &str) {
+        self.session_snapshots
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove_session(session_id);
+    }
+
+    /// Drop every frozen snapshot. Called on a wholesale cache clear.
+    pub fn clear_all_sessions(&self) {
+        *self
+            .session_snapshots
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = SessionSnapshots::default();
     }
 }
 
@@ -128,5 +243,123 @@ mod tests {
         // 1 char / 1000 tokens ≈ 0 → clamped to MIN_RATIO.
         cal.record("lo", 1, 1_000);
         assert!((cal.chars_per_token("lo") - MIN_RATIO).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn session_snapshot_is_stable_while_the_global_ratio_keeps_drifting() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("m", 40_000, 10_000); // global ratio: 4.0
+        let frozen = cal.session_chars_per_token("m", "sess-1", t0);
+
+        // More turns land, each updating the global EWMA...
+        cal.record("m", 30_000, 10_000);
+        cal.record("m", 20_000, 10_000);
+        assert_ne!(
+            cal.chars_per_token("m"),
+            frozen,
+            "the global ratio really did move"
+        );
+
+        // ...but this session's snapshot must not.
+        assert_eq!(cal.session_chars_per_token("m", "sess-1", t0), frozen);
+    }
+
+    #[test]
+    fn different_sessions_get_independent_snapshots() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("m", 40_000, 10_000); // 4.0
+        let s1 = cal.session_chars_per_token("m", "sess-1", t0);
+
+        cal.record("m", 20_000, 10_000); // pulls global ratio down
+        let s2 = cal.session_chars_per_token("m", "sess-2", t0);
+
+        assert_eq!(s1, 4.0);
+        assert!(
+            s2 < 4.0,
+            "sess-2's first snapshot should see the drifted ratio"
+        );
+        assert_eq!(
+            cal.session_chars_per_token("m", "sess-1", t0),
+            s1,
+            "sess-1 unaffected"
+        );
+    }
+
+    #[test]
+    fn session_snapshot_is_keyed_per_model() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("model-a", 40_000, 10_000); // 4.0
+        cal.record("model-b", 20_000, 10_000); // 2.0
+        assert_eq!(cal.session_chars_per_token("model-a", "sess-1", t0), 4.0);
+        assert_eq!(cal.session_chars_per_token("model-b", "sess-1", t0), 2.0);
+    }
+
+    #[test]
+    fn clear_session_forces_a_fresh_snapshot() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("m", 40_000, 10_000);
+        let before = cal.session_chars_per_token("m", "sess-1", t0);
+
+        cal.record("m", 20_000, 10_000); // drift the global ratio
+        cal.clear_session("sess-1");
+        let after = cal.session_chars_per_token("m", "sess-1", t0);
+
+        assert_ne!(
+            before, after,
+            "clearing must pick up the drifted global ratio"
+        );
+    }
+
+    #[test]
+    fn clear_all_sessions_resets_every_session() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("m", 40_000, 10_000);
+        let _ = cal.session_chars_per_token("m", "sess-1", t0);
+        let _ = cal.session_chars_per_token("m", "sess-2", t0);
+
+        cal.record("m", 20_000, 10_000);
+        cal.clear_all_sessions();
+
+        let refreshed = cal.session_chars_per_token("m", "sess-1", t0 + Duration::from_secs(1));
+        assert_ne!(refreshed, 4.0);
+    }
+
+    #[test]
+    fn session_snapshot_expires_after_the_ttl() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("m", 40_000, 10_000); // 4.0
+        let frozen = cal.session_chars_per_token("m", "sess-1", t0);
+
+        cal.record("m", 20_000, 10_000); // drift while "frozen"
+        let still_frozen = cal.session_chars_per_token("m", "sess-1", t0 + Duration::from_secs(60));
+        assert_eq!(still_frozen, frozen, "well within the TTL");
+
+        let after_ttl = cal.session_chars_per_token(
+            "m",
+            "sess-1",
+            t0 + SESSION_SNAPSHOT_TTL + Duration::from_secs(1),
+        );
+        assert_ne!(
+            after_ttl, frozen,
+            "TTL expiry must pick up the drifted ratio"
+        );
+    }
+
+    #[test]
+    fn session_snapshots_are_bounded_by_max_session_snapshots() {
+        let cal = TokenCalibration::new();
+        let t0 = Instant::now();
+        cal.record("m", 40_000, 10_000);
+        for i in 0..(MAX_SESSION_SNAPSHOTS + 10) {
+            let _ = cal.session_chars_per_token("m", &format!("sess-{i}"), t0);
+        }
+        let guard = cal.session_snapshots.lock().unwrap();
+        assert!(guard.values.len() <= MAX_SESSION_SNAPSHOTS);
     }
 }


### PR DESCRIPTION
## Summary

Two independent, verified mechanisms in `gglib-proxy`'s request pipeline were
each corrupting the *start* of the rendered prompt turn-to-turn, breaking
llama.cpp's common-prefix cache match for the entire request even when a
conversation hadn't meaningfully changed. Confirmed directly from
llama-server's own timing log: one request reused 1,593 cached compute
graphs at 425 prompt tokens; the very next request in the same session, same
process, same slot — no restart — did a complete cold prefill climbing past
17,000 tokens with zero reuse.

### Fix 1 — `tools[]` array order forwarded verbatim

llama.cpp renders tool/function schemas early in the prompt, right after the
system message. If the calling client sends `tools[]` in a different order
between turns, those early tokens change and the whole downstream prefix
misses. `gglib` already suspected this (a diagnostic-only function's own doc
comment describes the exact failure mode) but never fixed it, and the README
falsely claimed it did. `canonicalize_tool_order` now sorts `tools[]` by
`function.name` (stable sort) before forwarding, so gglib's own request is
byte-stable regardless of client-side ordering. Genuine membership changes
(a tool actually added/removed) still surface as a real miss and are still
logged.

### Fix 2 — truncation budget drifts turn-to-turn on a live EWMA

The truncation budget (`effective_ctx * chars_per_token`) is recomputed on
every single request from a live, continuously-updating EWMA
(`TokenCalibration`). That let the budget wobble slightly every turn even
with an unchanged conversation, and if the wobble crossed the elision
threshold for the earliest eligible message, the shared prefix broke — same
symptom, different cause. `TokenCalibration` now freezes a snapshot per
`(session_id, model)` the first time a session is seen (2h TTL, bounded FIFO
eviction), so a session's budget stays stable across its own turns while the
live ratio keeps adapting in the background for everyone else.

A correction surfaced during implementation: the proxy's session-id
fallback derivation was gated on disk KV-slot caching being enabled, which
is off by design for hybrid/sliding-window-attention models — exactly where
Fix 2 needs to work. Derivation is now unconditional; actual disk
save/restore activation stays independently gated, so this doesn't turn
disk caching on when the feature flag is off.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p gglib-proxy --verbose` (225 passed, incl. 14 new tests across both fixes)
- [x] `cargo test --doc --verbose`
- [x] `./scripts/check_readmes.sh --strict`
- [x] `./scripts/check_boundaries.sh`
- [ ] Manual: drive two turns of a real VS Code Copilot session against the proxy and confirm via `RUST_LOG=debug` that the tool-list diagnostic log is identical turn-to-turn and llama-server's own `print_timing` output shows `graphs reused` on the second turn instead of a cold climb from low `n_tokens`