### PR TITLE
Secure default localhost bind and CORS configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ All interfaces share the same database and model directory. Pick whichever fits 
 |-----------|--------|---------|
 | **CLI** | `gglib <command>` | [gglib-cli](crates/gglib-cli/README.md) |
 | **Desktop GUI** | `gglib gui` | [gglib-tauri](crates/gglib-tauri/README.md), [src-tauri](src-tauri/README.md) |
-| **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `0.0.0.0:9887` |
+| **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `127.0.0.1:9887` |
 | **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — works with OpenWebUI, any OpenAI SDK |
 
 **Shell completions** — enable tab completion for your shell:
@@ -652,7 +652,7 @@ All interfaces share the same database and model directory. Pick whichever fits 
 <details>
 <summary><strong>Security notes</strong></summary>
 
-- Web server binds `0.0.0.0` (LAN-accessible); proxy binds `127.0.0.1` (local only) by default
+- Web server binds `127.0.0.1` (local only) by default; use `--host 0.0.0.0` for LAN access. Proxy also binds `127.0.0.1`
 - No authentication — designed for trusted networks
 - Use firewall rules, private subnets, or VPN; do not expose to the public internet without additional auth
 

--- a/README.md
+++ b/README.md
@@ -652,7 +652,8 @@ All interfaces share the same database and model directory. Pick whichever fits 
 <details>
 <summary><strong>Security notes</strong></summary>
 
-- Web server binds `127.0.0.1` (local only) by default; use `--host 0.0.0.0` for LAN access. Proxy also binds `127.0.0.1`
+- Web server binds `127.0.0.1` (local only) by default; use `--host 0.0.0.0` for LAN access. Proxy also binds `127.0.0.1` by default with the same `--host` flag.
+- Both `gglib web` and `gglib proxy` use `CorsConfig::LocalOnly` by default — only `localhost`, `127.0.0.1`, `::1`, and Tauri custom schemes (`tauri://localhost`, `http://tauri.localhost`) are accepted as valid CORS origins.
 - No authentication — designed for trusted networks
 - Use firewall rules, private subnets, or VPN; do not expose to the public internet without additional auth
 

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -101,6 +101,13 @@ impl ServerConfig {
         self
     }
 
+    /// Set the bind host (e.g. `127.0.0.1` for localhost-only).
+    #[must_use]
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+
     /// Set CORS to allow specific origins.
     #[must_use]
     pub fn with_allowed_origins(mut self, origins: Vec<String>) -> Self {

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -46,15 +46,19 @@ use gglib_core::paths::{
 #[derive(Debug, Clone, Default)]
 pub enum CorsConfig {
     /// Allow all origins (development mode).
-    #[default]
     AllowAll,
     /// Allow specific origins (production mode).
     AllowOrigins(Vec<String>),
+    /// Restrict to local-only access (localhost, 127.0.0.1, ::1).
+    #[default]
+    LocalOnly,
 }
 
 /// Server configuration for the Axum adapter.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
+    /// Host to bind the HTTP server.
+    pub host: String,
     /// Port for the HTTP server.
     pub port: u16,
     /// Base port for llama-server instances.
@@ -79,6 +83,7 @@ impl ServerConfig {
     /// Create config with default paths.
     pub fn with_defaults() -> Result<Self> {
         Ok(Self {
+            host: "127.0.0.1".into(),
             port: 9887,
             base_port: 9000,
             llama_server_path: llama_server_path()?,
@@ -414,7 +419,7 @@ pub async fn start_server(config: ServerConfig) -> Result<()> {
         crate::routes::create_router(ctx, &config.cors)
     };
 
-    let addr = format!("0.0.0.0:{}", config.port);
+    let addr = format!("{}:{}", config.host, config.port);
     let listener = TcpListener::bind(&addr).await?;
 
     if config.static_dir.is_some() {

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -41,18 +41,7 @@ use crate::sse::SseBroadcaster;
 use gglib_core::paths::{
     data_root, database_path, llama_server_path, resolve_models_dir, resource_root,
 };
-
-/// CORS configuration for the web server.
-#[derive(Debug, Clone, Default)]
-pub enum CorsConfig {
-    /// Allow all origins (development mode).
-    AllowAll,
-    /// Allow specific origins (production mode).
-    AllowOrigins(Vec<String>),
-    /// Restrict to local-only access (localhost, 127.0.0.1, ::1).
-    #[default]
-    LocalOnly,
-}
+use gglib_core::CorsConfig;
 
 /// Server configuration for the Axum adapter.
 #[derive(Debug, Clone)]

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -38,10 +38,10 @@ use gglib_runtime::system::DefaultSystemProbe;
 use crate::sse::SseBroadcaster;
 
 // Path utilities from core
+use gglib_core::CorsConfig;
 use gglib_core::paths::{
     data_root, database_path, llama_server_path, resolve_models_dir, resource_root,
 };
-use gglib_core::CorsConfig;
 
 /// Server configuration for the Axum adapter.
 #[derive(Debug, Clone)]

--- a/crates/gglib-axum/src/lib.rs
+++ b/crates/gglib-axum/src/lib.rs
@@ -40,7 +40,8 @@ pub mod sse;
 pub mod state;
 
 // Re-export primary types
-pub use bootstrap::{AxumContext, CorsConfig, ServerConfig, bootstrap, start_server};
+pub use bootstrap::{AxumContext, ServerConfig, bootstrap, start_server};
+pub use gglib_core::CorsConfig;
 pub use embedded::{EmbeddedApiInfo, EmbeddedServerConfig, start_embedded_server};
 pub use error::HttpError;
 pub use routes::{create_router, create_spa_router};

--- a/crates/gglib-axum/src/lib.rs
+++ b/crates/gglib-axum/src/lib.rs
@@ -41,8 +41,8 @@ pub mod state;
 
 // Re-export primary types
 pub use bootstrap::{AxumContext, ServerConfig, bootstrap, start_server};
-pub use gglib_core::CorsConfig;
 pub use embedded::{EmbeddedApiInfo, EmbeddedServerConfig, start_embedded_server};
 pub use error::HttpError;
+pub use gglib_core::CorsConfig;
 pub use routes::{create_router, create_spa_router};
 pub use state::AppState;

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -10,7 +10,7 @@ use axum::routing::{delete, get, post, put};
 use serde_json::{Value, json};
 use std::path::Path;
 use std::sync::Arc;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 
 use crate::bootstrap::{AxumContext, CorsConfig};
@@ -30,6 +30,18 @@ fn build_cors_layer(config: &CorsConfig) -> CorsLayer {
             let allowed: Vec<HeaderValue> = origins.iter().filter_map(|o| o.parse().ok()).collect();
             CorsLayer::new()
                 .allow_origin(allowed)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
+        CorsConfig::LocalOnly => {
+            let local = AllowOrigin::predicate(|origin: &axum::http::HeaderValue, _req_headers| {
+                let s = origin.to_str().unwrap_or("");
+                s.starts_with("http://localhost")
+                    || s.starts_with("http://127.0.0.1")
+                    || s.starts_with("http://[::1]")
+            });
+            CorsLayer::new()
+                .allow_origin(local)
                 .allow_methods(Any)
                 .allow_headers(Any)
         }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -35,10 +35,7 @@ fn build_cors_layer(config: &CorsConfig) -> CorsLayer {
         }
         CorsConfig::LocalOnly => {
             let local = AllowOrigin::predicate(|origin: &axum::http::HeaderValue, _req_headers| {
-                let s = origin.to_str().unwrap_or("");
-                s.starts_with("http://localhost")
-                    || s.starts_with("http://127.0.0.1")
-                    || s.starts_with("http://[::1]")
+                gglib_core::is_local_origin(origin.to_str().unwrap_or(""))
             });
             CorsLayer::new()
                 .allow_origin(local)

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -13,10 +13,11 @@ use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 
-use crate::bootstrap::{AxumContext, CorsConfig};
+use crate::bootstrap::AxumContext;
 use crate::chat_api::chat_routes_no_prefix;
 use crate::handlers;
 use crate::state::AppState;
+use gglib_core::CorsConfig;
 
 /// Build CORS layer from configuration.
 fn build_cors_layer(config: &CorsConfig) -> CorsLayer {

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -331,6 +331,11 @@ pub fn create_router(ctx: AxumContext, cors_config: &CorsConfig) -> Router {
     let cors = build_cors_layer(cors_config);
 
     Router::new()
+        // Intentionally placed outside the CORS layer — /health is a
+        // low-sensitivity health probe that should be accessible without
+        // origin restrictions (e.g. for container orchestration liveness checks).
+        // The proxy server applies CORS globally (including /health) via a
+        // router-level .layer(), but this Axum router scopes CORS to /api/* only.
         .route("/health", get(health_check))
         .nest("/api", api_routes().with_state(state).layer(cors))
 }

--- a/crates/gglib-axum/tests/cors_auth.rs
+++ b/crates/gglib-axum/tests/cors_auth.rs
@@ -28,6 +28,7 @@ static BOOTSTRAP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(()
 /// Helper to create a test config that doesn't require llama-server.
 fn test_config() -> ServerConfig {
     ServerConfig {
+        host: "127.0.0.1".into(),
         port: 0,
         base_port: TEST_BASE_PORT,
         llama_server_path: "/nonexistent/llama-server".into(),

--- a/crates/gglib-axum/tests/cors_auth.rs
+++ b/crates/gglib-axum/tests/cors_auth.rs
@@ -17,9 +17,10 @@ mod common;
 
 use common::ports::TEST_BASE_PORT;
 use gglib_axum::{
-    bootstrap::{CorsConfig, ServerConfig, bootstrap},
+    bootstrap::{ServerConfig, bootstrap},
     embedded::{EmbeddedServerConfig, default_embedded_cors_origins, start_embedded_server},
 };
+use gglib_core::CorsConfig;
 use reqwest::{Method, StatusCode, header};
 
 /// Process-level mutex that serialises concurrent `bootstrap()` calls.

--- a/crates/gglib-axum/tests/cors_local_only.rs
+++ b/crates/gglib-axum/tests/cors_local_only.rs
@@ -1,0 +1,151 @@
+//! Integration tests for CorsConfig::LocalOnly behavior.
+//!
+//! Verifies that the LocalOnly CORS policy correctly accepts localhost origins
+//! and rejects remote origins, and that ServerConfig defaults are correct.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::Request;
+use tower::ServiceExt;
+
+use common::ports::TEST_BASE_PORT;
+use gglib_axum::bootstrap::{CorsConfig, ServerConfig, bootstrap};
+use gglib_axum::routes::create_router;
+
+fn test_config() -> ServerConfig {
+    ServerConfig {
+        host: "127.0.0.1".into(),
+        port: 0,
+        base_port: TEST_BASE_PORT,
+        llama_server_path: "/nonexistent/llama-server".into(),
+        max_concurrent: 1,
+        max_concurrent_agent_loops: 1,
+        static_dir: None,
+        cors: CorsConfig::LocalOnly,
+    }
+}
+
+#[tokio::test]
+async fn local_only_rejects_remote_origin() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(ctx, &CorsConfig::LocalOnly);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/models")
+                .header("Origin", "http://evil.example.com")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let allow_origin = response.headers().get("Access-Control-Allow-Origin");
+    assert!(
+        allow_origin.is_none(),
+        "Remote origin should be rejected (no Access-Control-Allow-Origin header), got: {:?}",
+        allow_origin
+    );
+}
+
+#[tokio::test]
+async fn local_only_allows_localhost_origin() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(ctx, &CorsConfig::LocalOnly);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/models")
+                .header("Origin", "http://localhost:9887")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let allow_origin = response.headers().get("Access-Control-Allow-Origin");
+    assert!(allow_origin.is_some(), "Localhost origin should be allowed");
+    assert_eq!(
+        allow_origin.unwrap().to_str().unwrap(),
+        "http://localhost:9887",
+        "Origin should be reflected"
+    );
+}
+
+#[tokio::test]
+async fn local_only_allows_127_0_0_1_origin() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(ctx, &CorsConfig::LocalOnly);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/models")
+                .header("Origin", "http://127.0.0.1:3000")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let allow_origin = response.headers().get("Access-Control-Allow-Origin");
+    assert!(allow_origin.is_some(), "127.0.0.1 origin should be allowed");
+}
+
+#[tokio::test]
+async fn local_only_allows_ipv6_localhost() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(ctx, &CorsConfig::LocalOnly);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/models")
+                .header("Origin", "http://[::1]:8080")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let allow_origin = response.headers().get("Access-Control-Allow-Origin");
+    assert!(allow_origin.is_some(), "[::1] origin should be allowed");
+}
+
+#[tokio::test]
+async fn server_config_defaults_are_local_only() {
+    let config = ServerConfig::with_defaults().expect("defaults should build");
+
+    assert_eq!(config.host, "127.0.0.1", "Default host should be 127.0.0.1");
+    match config.cors {
+        CorsConfig::LocalOnly => {} // expected
+        other => panic!("Default CORS should be LocalOnly, got: {:?}", other),
+    }
+}

--- a/crates/gglib-axum/tests/cors_local_only.rs
+++ b/crates/gglib-axum/tests/cors_local_only.rs
@@ -145,8 +145,39 @@ async fn server_config_defaults_are_local_only() {
     let config = ServerConfig::with_defaults().expect("defaults should build");
 
     assert_eq!(config.host, "127.0.0.1", "Default host should be 127.0.0.1");
-    match config.cors {
-        CorsConfig::LocalOnly => {} // expected
-        other => panic!("Default CORS should be LocalOnly, got: {:?}", other),
-    }
+    assert!(matches!(config.cors, CorsConfig::LocalOnly));
+}
+
+#[tokio::test]
+async fn local_only_allows_tauri_localhost_origin() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(ctx, &CorsConfig::LocalOnly);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/api/models")
+                .header("Origin", "http://tauri.localhost")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let allow_origin = response.headers().get("Access-Control-Allow-Origin");
+    assert!(
+        allow_origin.is_some(),
+        "tauri.localhost origin should be allowed"
+    );
+    assert_eq!(
+        allow_origin.unwrap().to_str().unwrap(),
+        "http://tauri.localhost",
+        "Origin should be reflected"
+    );
 }

--- a/crates/gglib-axum/tests/cors_local_only.rs
+++ b/crates/gglib-axum/tests/cors_local_only.rs
@@ -10,8 +10,9 @@ use axum::http::Request;
 use tower::ServiceExt;
 
 use common::ports::TEST_BASE_PORT;
-use gglib_axum::bootstrap::{CorsConfig, ServerConfig, bootstrap};
+use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::routes::create_router;
+use gglib_core::CorsConfig;
 
 fn test_config() -> ServerConfig {
     ServerConfig {

--- a/crates/gglib-axum/tests/embedded_auth.rs
+++ b/crates/gglib-axum/tests/embedded_auth.rs
@@ -17,6 +17,7 @@ use gglib_axum::{
 /// Helper to create a test config that doesn't require llama-server.
 fn test_config() -> ServerConfig {
     ServerConfig {
+        host: "127.0.0.1".into(),
         port: 0,
         base_port: TEST_BASE_PORT,
         llama_server_path: "/nonexistent/llama-server".into(),

--- a/crates/gglib-axum/tests/embedded_auth.rs
+++ b/crates/gglib-axum/tests/embedded_auth.rs
@@ -10,9 +10,10 @@ mod common;
 
 use common::ports::{TEST_BASE_PORT, TEST_CORS_ORIGIN};
 use gglib_axum::{
-    bootstrap::{CorsConfig, ServerConfig, bootstrap},
+    bootstrap::{ServerConfig, bootstrap},
     embedded::{EmbeddedServerConfig, start_embedded_server},
 };
+use gglib_core::CorsConfig;
 
 /// Helper to create a test config that doesn't require llama-server.
 fn test_config() -> ServerConfig {

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -16,6 +16,7 @@ use gglib_axum::routes::create_router;
 /// Helper to create a test config that doesn't require llama-server.
 fn test_config() -> ServerConfig {
     ServerConfig {
+        host: "127.0.0.1".into(),
         port: 0, // Not used in tests
         base_port: TEST_BASE_PORT,
         llama_server_path: "/nonexistent/llama-server".into(),

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -10,8 +10,9 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 use common::ports::{TEST_BASE_PORT, TEST_MODEL_PORT};
-use gglib_axum::bootstrap::{CorsConfig, ServerConfig, bootstrap};
+use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::routes::create_router;
+use gglib_core::CorsConfig;
 
 /// Helper to create a test config that doesn't require llama-server.
 fn test_config() -> ServerConfig {

--- a/crates/gglib-axum/tests/mcp_contract_test.rs
+++ b/crates/gglib-axum/tests/mcp_contract_test.rs
@@ -18,6 +18,7 @@ use gglib_axum::routes::create_router;
 /// Helper to create a test config.
 fn test_config() -> ServerConfig {
     ServerConfig {
+        host: "127.0.0.1".into(),
         port: 0,
         base_port: TEST_BASE_PORT,
         llama_server_path: "/nonexistent/llama-server".into(),

--- a/crates/gglib-axum/tests/mcp_contract_test.rs
+++ b/crates/gglib-axum/tests/mcp_contract_test.rs
@@ -12,8 +12,9 @@ use serde_json::json;
 use tower::ServiceExt;
 
 use common::ports::TEST_BASE_PORT;
-use gglib_axum::bootstrap::{CorsConfig, ServerConfig, bootstrap};
+use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::routes::create_router;
+use gglib_core::CorsConfig;
 
 /// Helper to create a test config.
 fn test_config() -> ServerConfig {

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -385,6 +385,9 @@ pub enum Commands {
         /// Port to serve the web GUI on
         #[arg(short, long, env = "VITE_GGLIB_WEB_PORT", default_value = "9887")]
         port: u16,
+        /// Host to bind the web server
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
         /// Base port for llama-server instances (Note: Port 5000 conflicts with macOS AirPlay)
         #[arg(long, default_value = "9000")]
         base_port: u16,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -244,11 +244,12 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
         }
         Commands::Web {
             port,
+            host,
             base_port,
             api_only,
             static_dir,
         } => {
-            handlers::web::execute(port, base_port, api_only, static_dir).await?;
+            handlers::web::execute(port, host, base_port, api_only, static_dir).await?;
         }
         Commands::Proxy {
             host,

--- a/crates/gglib-cli/src/handlers/web.rs
+++ b/crates/gglib-cli/src/handlers/web.rs
@@ -75,8 +75,11 @@ pub async fn execute(
     if let Some(ref dir) = config.static_dir {
         style::print_info_banner("Web Server", "\u{1f680}");
         eprintln!("  \u{1f4c2} Serving UI from: {}", dir.display());
-        eprintln!("  \u{1f310} Local:   http://localhost:{}", port);
-        eprintln!("  \u{1f310} Network: http://0.0.0.0:{}", port);
+        if config.host == "0.0.0.0" {
+            eprintln!("  \u{1f310} Network: http://0.0.0.0:{}", port);
+        } else {
+            eprintln!("  \u{1f310} Local:   http://{}:{}", config.host, port);
+        }
         eprintln!(
             "  \u{1f4ca} Status:  http://localhost:{}/v1/proxy/status",
             port

--- a/crates/gglib-cli/src/handlers/web.rs
+++ b/crates/gglib-cli/src/handlers/web.rs
@@ -25,6 +25,7 @@ use crate::presentation::style;
 ///   auto-discovery when `api_only` is `false`.
 pub async fn execute(
     port: u16,
+    host: String,
     base_port: u16,
     api_only: bool,
     static_dir: Option<PathBuf>,
@@ -44,13 +45,14 @@ pub async fn execute(
     }
 
     let mut config = ServerConfig {
+        host,
         port,
         base_port,
         llama_server_path: llama_server_path()?,
         max_concurrent: 4,
         max_concurrent_agent_loops: 4,
         static_dir: None,
-        cors: CorsConfig::AllowAll,
+        cors: CorsConfig::LocalOnly,
     };
 
     // Resolve static directory: api-only flag > explicit flag > auto-discover > none

--- a/crates/gglib-cli/src/handlers/web.rs
+++ b/crates/gglib-cli/src/handlers/web.rs
@@ -30,8 +30,9 @@ pub async fn execute(
     api_only: bool,
     static_dir: Option<PathBuf>,
 ) -> Result<()> {
-    use gglib_axum::{CorsConfig, ServerConfig, start_server};
+    use gglib_axum::{ServerConfig, start_server};
     use gglib_core::paths::llama_server_path;
+    use gglib_core::CorsConfig;
 
     // Warn if the VITE env var is set but unparseable so the user knows
     // we are ignoring it rather than silently falling back to the default.

--- a/crates/gglib-cli/src/handlers/web.rs
+++ b/crates/gglib-cli/src/handlers/web.rs
@@ -31,8 +31,8 @@ pub async fn execute(
     static_dir: Option<PathBuf>,
 ) -> Result<()> {
     use gglib_axum::{ServerConfig, start_server};
-    use gglib_core::paths::llama_server_path;
     use gglib_core::CorsConfig;
+    use gglib_core::paths::llama_server_path;
 
     // Warn if the VITE env var is set but unparseable so the user knows
     // we are ignoring it rather than silently falling back to the default.

--- a/crates/gglib-core/Cargo.toml
+++ b/crates/gglib-core/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 sha2 = "0.10"
 futures-core = "0.3"
+url = "2.5"
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/gglib-core/src/cors.rs
+++ b/crates/gglib-core/src/cors.rs
@@ -10,7 +10,11 @@ pub enum CorsConfig {
     AllowAll,
     /// Allow specific origins (production mode).
     AllowOrigins(Vec<String>),
-    /// Restrict to local-only access (localhost, 127.0.0.1, `::1`).
+    /// Restrict to local-only access.
+    ///
+    /// Accepts `localhost`, `127.0.0.1`, `::1`, `tauri.localhost`,
+    /// and Tauri custom schemes (`tauri://localhost`, `asset://localhost`).
+    /// This is the default for both the web server and the proxy.
     #[default]
     LocalOnly,
 }

--- a/crates/gglib-core/src/cors.rs
+++ b/crates/gglib-core/src/cors.rs
@@ -1,0 +1,16 @@
+//! CORS configuration types.
+//!
+//! Provides [`CorsConfig`] to control which origins are allowed
+//! by the Axum web server's CORS middleware.
+
+/// CORS configuration for the web server.
+#[derive(Debug, Clone, Default)]
+pub enum CorsConfig {
+    /// Allow all origins (development mode).
+    AllowAll,
+    /// Allow specific origins (production mode).
+    AllowOrigins(Vec<String>),
+    /// Restrict to local-only access (localhost, 127.0.0.1, `::1`).
+    #[default]
+    LocalOnly,
+}

--- a/crates/gglib-core/src/is_local_origin.rs
+++ b/crates/gglib-core/src/is_local_origin.rs
@@ -1,0 +1,114 @@
+//! Origin validation utilities for CORS and similar security checks.
+//!
+//! Provides [`is_local_origin`] to determine whether a URL origin
+//! (e.g. from the `Origin` HTTP header) is a trusted local address.
+
+use url::Url;
+
+/// Returns `true` if the origin string resolves to a local host.
+///
+/// Accepted hosts: `localhost`, `127.0.0.1`, `::1`.
+///
+/// Schemes `http` and `https` are accepted; ports are ignored.
+/// Malformed URLs, missing hosts, and non-local hosts return `false`.
+pub fn is_local_origin(origin: &str) -> bool {
+    let Ok(parsed) = Url::parse(origin) else {
+        return false;
+    };
+
+    // Only allow http/https schemes
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return false;
+    }
+
+    let Some(host_str) = parsed.host_str() else {
+        return false;
+    };
+
+    // `url::Url::host_str()` returns IPv6 addresses with brackets (e.g. `[::1]`),
+    // so strip them for comparison.
+    let host = host_str.trim_start_matches('[').trim_end_matches(']');
+
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_localhost_http() {
+        assert!(is_local_origin("http://localhost"));
+    }
+
+    #[test]
+    fn accepts_localhost_https() {
+        assert!(is_local_origin("https://localhost"));
+    }
+
+    #[test]
+    fn accepts_localhost_with_port() {
+        assert!(is_local_origin("http://localhost:3000"));
+        assert!(is_local_origin("https://localhost:8080"));
+    }
+
+    #[test]
+    fn accepts_127_0_0_1() {
+        assert!(is_local_origin("http://127.0.0.1"));
+        assert!(is_local_origin("https://127.0.0.1"));
+        assert!(is_local_origin("http://127.0.0.1:9887"));
+    }
+
+    #[test]
+    fn accepts_ipv6_loopback() {
+        assert!(is_local_origin("http://[::1]"));
+        assert!(is_local_origin("https://[::1]"));
+        assert!(is_local_origin("http://[::1]:3000"));
+    }
+
+    #[test]
+    fn rejects_subdomain_of_localhost() {
+        assert!(!is_local_origin("http://localhost.evil.com"));
+    }
+
+    #[test]
+    fn rejects_notlocalhost() {
+        assert!(!is_local_origin("http://notlocalhost"));
+    }
+
+    #[test]
+    fn rejects_non_loopback_ip() {
+        assert!(!is_local_origin("http://127.0.0.2"));
+    }
+
+    #[test]
+    fn rejects_external_host() {
+        assert!(!is_local_origin("https://example.com"));
+    }
+
+    #[test]
+    fn rejects_non_loopback_ipv6() {
+        assert!(!is_local_origin("http://[::2]"));
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert!(!is_local_origin(""));
+    }
+
+    #[test]
+    fn rejects_malformed_url() {
+        assert!(!is_local_origin("not-a-url"));
+    }
+
+    #[test]
+    fn rejects_non_http_scheme() {
+        assert!(!is_local_origin("ftp://localhost"));
+    }
+
+    #[test]
+    fn rejects_url_encoded_bypass() {
+        // `http://localhost:8080@evil.com` parses with host = "evil.com"
+        assert!(!is_local_origin("http://localhost:8080@evil.com"));
+    }
+}

--- a/crates/gglib-core/src/is_local_origin.rs
+++ b/crates/gglib-core/src/is_local_origin.rs
@@ -7,11 +7,23 @@ use url::Url;
 
 /// Returns `true` if the origin string resolves to a local host.
 ///
-/// Accepted hosts: `localhost`, `127.0.0.1`, `::1`.
+/// Accepted hosts: `localhost`, `127.0.0.1`, `::1`, `tauri.localhost`.
 ///
 /// Schemes `http` and `https` are accepted; ports are ignored.
+/// Tauri custom schemes (`tauri://localhost`, `asset://localhost`) are also accepted.
+/// URLs with userinfo (e.g. `http://user@localhost`) are rejected to prevent
+/// credential-injection bypasses.
 /// Malformed URLs, missing hosts, and non-local hosts return `false`.
 pub fn is_local_origin(origin: &str) -> bool {
+    // Handle Tauri custom schemes that Url::parse cannot parse (not registered URI schemes).
+    if let Some(stripped) = origin
+        .strip_prefix("tauri://")
+        .or_else(|| origin.strip_prefix("asset://"))
+    {
+        let host = stripped.trim_end_matches('/');
+        return matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1");
+    }
+
     let Ok(parsed) = Url::parse(origin) else {
         return false;
     };
@@ -25,11 +37,17 @@ pub fn is_local_origin(origin: &str) -> bool {
         return false;
     };
 
+    // Reject URLs with userinfo (e.g. http://user@localhost) to prevent
+    // credential-injection bypasses.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return false;
+    }
+
     // `url::Url::host_str()` returns IPv6 addresses with brackets (e.g. `[::1]`),
     // so strip them for comparison.
     let host = host_str.trim_start_matches('[').trim_end_matches(']');
 
-    matches!(host, "localhost" | "127.0.0.1" | "::1")
+    matches!(host, "localhost" | "127.0.0.1" | "::1" | "tauri.localhost")
 }
 
 #[cfg(test)]
@@ -110,5 +128,33 @@ mod tests {
     fn rejects_url_encoded_bypass() {
         // `http://localhost:8080@evil.com` parses with host = "evil.com"
         assert!(!is_local_origin("http://localhost:8080@evil.com"));
+    }
+
+    #[test]
+    fn accepts_tauri_scheme_localhost() {
+        assert!(is_local_origin("tauri://localhost"));
+        assert!(is_local_origin("tauri://localhost/"));
+    }
+
+    #[test]
+    fn accepts_asset_scheme_localhost() {
+        assert!(is_local_origin("asset://localhost"));
+    }
+
+    #[test]
+    fn accepts_http_tauri_localhost() {
+        assert!(is_local_origin("http://tauri.localhost"));
+        assert!(is_local_origin("http://tauri.localhost:3000"));
+    }
+
+    #[test]
+    fn rejects_userinfo_localhost() {
+        // http://user@localhost parses with host="localhost" — must be rejected via userinfo guard
+        assert!(!is_local_origin("http://user@localhost"));
+    }
+
+    #[test]
+    fn rejects_userinfo_with_password() {
+        assert!(!is_local_origin("http://user:pass@localhost"));
     }
 }

--- a/crates/gglib-core/src/is_local_origin.rs
+++ b/crates/gglib-core/src/is_local_origin.rs
@@ -21,6 +21,11 @@ pub fn is_local_origin(origin: &str) -> bool {
         .or_else(|| origin.strip_prefix("asset://"))
     {
         let host = stripped.trim_end_matches('/');
+        // Reject userinfo in custom schemes (defensive symmetry with the
+        // standard URL userinfo guard below).
+        if host.contains('@') {
+            return false;
+        }
         return matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1");
     }
 
@@ -47,7 +52,9 @@ pub fn is_local_origin(origin: &str) -> bool {
     // so strip them for comparison.
     let host = host_str.trim_start_matches('[').trim_end_matches(']');
 
-    matches!(host, "localhost" | "127.0.0.1" | "::1" | "tauri.localhost")
+    // RFC 3986 §3.2.2: host comparison is case-insensitive for IPv4 and
+    // domain names. Normalizing to lowercase documents this intent.
+    matches!(host.to_lowercase().as_str(), "localhost" | "127.0.0.1" | "::1" | "tauri.localhost")
 }
 
 #[cfg(test)]
@@ -156,5 +163,25 @@ mod tests {
     #[test]
     fn rejects_userinfo_with_password() {
         assert!(!is_local_origin("http://user:pass@localhost"));
+    }
+
+    #[test]
+    fn rejects_tauri_scheme_userinfo() {
+        assert!(!is_local_origin("tauri://user@localhost"));
+    }
+
+    #[test]
+    fn rejects_asset_scheme_external_host() {
+        assert!(!is_local_origin("asset://evil.com"));
+    }
+
+    #[test]
+    fn accepts_https_tauri_localhost() {
+        assert!(is_local_origin("https://tauri.localhost"));
+    }
+
+    #[test]
+    fn accepts_uppercase_localhost() {
+        assert!(is_local_origin("http://LOCALHOST"));
     }
 }

--- a/crates/gglib-core/src/is_local_origin.rs
+++ b/crates/gglib-core/src/is_local_origin.rs
@@ -54,7 +54,10 @@ pub fn is_local_origin(origin: &str) -> bool {
 
     // RFC 3986 §3.2.2: host comparison is case-insensitive for IPv4 and
     // domain names. Normalizing to lowercase documents this intent.
-    matches!(host.to_lowercase().as_str(), "localhost" | "127.0.0.1" | "::1" | "tauri.localhost")
+    matches!(
+        host.to_lowercase().as_str(),
+        "localhost" | "127.0.0.1" | "::1" | "tauri.localhost"
+    )
 }
 
 #[cfg(test)]

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod contracts;
 pub mod domain;
 pub mod download;
 pub mod events;
+pub mod is_local_origin;
 pub mod normalize;
 pub mod paths;
 pub mod ports;
@@ -56,6 +57,9 @@ pub use settings::{
     DEFAULT_CONTEXT_SIZE, DEFAULT_LLAMA_BASE_PORT, DEFAULT_PROXY_PORT, Settings, SettingsError,
     SettingsUpdate, validate_settings,
 };
+
+// Re-export origin validation utility
+pub use is_local_origin::is_local_origin;
 
 // Re-export timing utility
 pub use utils::timing::{elapsed_ms, format_duration_human};

--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod cache_config;
 pub mod cache_metrics;
 pub mod contracts;
+pub mod cors;
 pub mod domain;
 pub mod download;
 pub mod events;
@@ -20,6 +21,7 @@ pub mod telemetry;
 pub mod utils;
 
 // Re-export commonly used types for convenience
+pub use cors::CorsConfig;
 pub use domain::{
     AGENT_EVENT_CHANNEL_CAPACITY, AgentConfig, AgentConfigError, AgentEvent, AgentMessage,
     ApprovalKind, AssistantContent, ChatMessage, Conversation, ConversationUpdate, CouncilEvent,

--- a/crates/gglib-proxy/src/mcp/handlers.rs
+++ b/crates/gglib-proxy/src/mcp/handlers.rs
@@ -361,16 +361,11 @@ async fn handle_notification(
 /// We reject requests from browser origins that don't match localhost.
 #[allow(clippy::result_large_err)]
 fn validate_origin(headers: &HeaderMap) -> Result<(), Response> {
-    if let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok()) {
-        let lower = origin.to_lowercase();
-        let allowed = lower.starts_with("http://localhost")
-            || lower.starts_with("http://127.0.0.1")
-            || lower.starts_with("https://localhost")
-            || lower.starts_with("https://127.0.0.1");
-        if !allowed {
-            warn!(origin, "MCP: rejected request with disallowed Origin");
-            return Err(StatusCode::FORBIDDEN.into_response());
-        }
+    if let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok())
+        && !gglib_core::is_local_origin(origin)
+    {
+        warn!(origin, "MCP: rejected request with disallowed Origin");
+        return Err(StatusCode::FORBIDDEN.into_response());
     }
     // No Origin header = non-browser client (curl, OpenWebUI server-side) — allow
     Ok(())

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -22,8 +22,8 @@ use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::{debug, error, info, warn};
 
-use gglib_core::cache_metrics::CacheMetricsStore;
 use gglib_core::CorsConfig;
+use gglib_core::cache_metrics::CacheMetricsStore;
 use gglib_core::ports::{
     ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository,
 };

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -19,10 +19,11 @@ use reqwest::Client;
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::{debug, error, info, warn};
 
 use gglib_core::cache_metrics::CacheMetricsStore;
+use gglib_core::CorsConfig;
 use gglib_core::ports::{
     ModelCatalogPort, ModelRuntimeError, ModelRuntimePort, SettingsRepository,
 };
@@ -125,6 +126,34 @@ pub(crate) struct AppState {
 /// # Returns
 ///
 /// Returns `Ok(())` on clean shutdown, or an error if the server fails.
+/// Build CORS layer from configuration.
+// TODO: Extract to a shared gglib-http crate if tracing/auth middleware is added to the proxy in the future.
+fn build_cors_layer(config: &CorsConfig) -> CorsLayer {
+    match config {
+        CorsConfig::AllowAll => CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any),
+        CorsConfig::AllowOrigins(origins) => {
+            use axum::http::HeaderValue;
+            let allowed: Vec<HeaderValue> = origins.iter().filter_map(|o| o.parse().ok()).collect();
+            CorsLayer::new()
+                .allow_origin(allowed)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
+        CorsConfig::LocalOnly => {
+            let local = AllowOrigin::predicate(|origin: &axum::http::HeaderValue, _req_headers| {
+                gglib_core::is_local_origin(origin.to_str().unwrap_or(""))
+            });
+            CorsLayer::new()
+                .allow_origin(local)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn serve(
     listener: TcpListener,
@@ -146,6 +175,7 @@ pub async fn serve(
     // single proxy run. Exposed on the dashboard as `agent_usage`, alongside
     // the proxied figure.
     agent_metrics: Arc<CacheMetricsStore>,
+    cors_config: &CorsConfig,
 ) -> anyhow::Result<()> {
     let addr = listener.local_addr()?;
     info!("Proxy server starting on {addr}");
@@ -257,21 +287,9 @@ pub async fn serve(
         .route("/v1/proxy/status/stream", get(handle_proxy_status_stream))
         .route("/v1/proxy/cache/clear", post(handle_proxy_cache_clear))
         .route("/mcp", post(post_mcp).get(get_mcp).delete(delete_mcp))
-        // Permissive CORS: this proxy only ever binds to 127.0.0.1 for local
-        // developer use (CLI or the Tauri GUI) and strips `Authorization`
-        // before forwarding upstream (see `forward.rs`), so there's no
-        // credentialed session to protect and no benefit to restricting
-        // origins — same rationale as `CorsConfig::AllowAll` in gglib-axum.
-        // Without this, browser-based clients (notably the Tauri webview,
-        // which runs on the `tauri://localhost` / `http://tauri.localhost`
-        // origin) are blocked from calling this proxy's endpoints, including
-        // the `EventSource` connection to `/v1/proxy/status/stream`.
-        .layer(
-            CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
-        )
+        // LocalOnly CORS: mirrors the Axum web server's default security posture.
+        // Only localhost, 127.0.0.1, ::1, and tauri://localhost origins are accepted.
+        .layer(build_cors_layer(cors_config))
         .with_state(state);
 
     info!("Proxy listening on {addr}");

--- a/crates/gglib-proxy/tests/integration_cache_clear.rs
+++ b/crates/gglib-proxy/tests/integration_cache_clear.rs
@@ -80,6 +80,7 @@ async fn spawn_proxy(
             slot_dir,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_cors.rs
+++ b/crates/gglib-proxy/tests/integration_cors.rs
@@ -343,3 +343,31 @@ async fn get_request_from_tauri_localhost_origin_receives_cors_header() {
 
     cancel.cancel();
 }
+
+/// A request from an external (non-local) origin must NOT receive the
+/// `access-control-allow-origin` header — the tower-http CORS layer
+/// silently omits it rather than returning 403; the browser enforces
+/// the block client-side.
+#[tokio::test]
+async fn get_request_from_external_origin_is_rejected() {
+    let (base_url, cancel) = spawn_proxy().await;
+
+    let resp = Client::new()
+        .get(format!("{base_url}/v1/proxy/status"))
+        .header("Origin", "http://evil.com")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    // The CORS layer does NOT return 403 for rejected origins — it returns
+    // 200 (or whatever the handler returns) but omits the CORS header.
+    assert!(resp.status().is_success());
+    let allow_origin = resp.headers().get("access-control-allow-origin");
+    assert!(
+        allow_origin.is_none(),
+        "Remote origin should be rejected (no access-control-allow-origin header), got: {:?}",
+        allow_origin
+    );
+
+    cancel.cancel();
+}

--- a/crates/gglib-proxy/tests/integration_cors.rs
+++ b/crates/gglib-proxy/tests/integration_cors.rs
@@ -1,8 +1,14 @@
-//! Verifies the proxy's permissive CORS layer, added specifically so the
-//! Tauri GUI's webview (origin `tauri://localhost` / `http://tauri.localhost`
-//! on Windows) can call this proxy's endpoints — including opening an
-//! `EventSource` connection to `GET /v1/proxy/status/stream` — without the
-//! browser blocking the request as cross-origin.
+//! Verifies the proxy's LocalOnly CORS layer.
+//!
+//! The proxy binds to 127.0.0.1 and accepts only local origins:
+//! `localhost`, `127.0.0.1`, `::1`, `tauri.localhost`, and Tauri custom
+//! schemes (`tauri://localhost`, `asset://localhost`).
+//! Non-local origins are rejected.
+//!
+//! This ensures the Tauri GUI's webview (origin `tauri://localhost` /
+//! `http://tauri.localhost` on Windows) can call this proxy's endpoints —
+//! including opening an `EventSource` connection to `GET /v1/proxy/status/stream`
+//! — without the browser blocking the request as cross-origin.
 //!
 //! Uses the real `gglib_proxy::serve` (not a hand-rolled router), following
 //! the same self-contained-harness pattern as the other integration tests in
@@ -208,6 +214,7 @@ async fn spawn_proxy() -> (String, CancellationToken) {
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();
@@ -242,10 +249,10 @@ async fn get_request_from_tauri_origin_receives_cors_header() {
         .expect("missing access-control-allow-origin header")
         .to_str()
         .unwrap();
-    // `Any` reflects as a literal `*` (no credentials involved), which is
-    // valid for a non-credentialed request from any origin, including
+    // LocalOnly reflects the requesting origin back (not `*`), which is
+    // valid for a non-credentialed request from a local origin like
     // `tauri://localhost`.
-    assert_eq!(allow_origin, "*");
+    assert_eq!(allow_origin, "tauri://localhost");
 
     cancel.cancel();
 }
@@ -287,7 +294,8 @@ async fn preflight_request_to_sse_endpoint_is_allowed() {
 }
 
 /// A request from a plain `http://localhost:5173` (Vite dev server) origin
-/// works identically — the permissive layer doesn't special-case Tauri.
+/// works identically — the LocalOnly layer accepts any localhost origin
+/// and reflects it back.
 #[tokio::test]
 async fn get_request_from_vite_dev_origin_receives_cors_header() {
     let (base_url, cancel) = spawn_proxy().await;
@@ -300,7 +308,38 @@ async fn get_request_from_vite_dev_origin_receives_cors_header() {
         .expect("request should succeed");
 
     assert!(resp.status().is_success());
-    assert!(resp.headers().contains_key("access-control-allow-origin"));
+    let allow_origin = resp
+        .headers()
+        .get("access-control-allow-origin")
+        .expect("missing access-control-allow-origin header")
+        .to_str()
+        .unwrap();
+    assert_eq!(allow_origin, "http://localhost:5173");
+
+    cancel.cancel();
+}
+
+/// A request from `http://tauri.localhost` (Tauri dev server on Windows)
+/// is accepted and reflected back by the LocalOnly CORS policy.
+#[tokio::test]
+async fn get_request_from_tauri_localhost_origin_receives_cors_header() {
+    let (base_url, cancel) = spawn_proxy().await;
+
+    let resp = Client::new()
+        .get(format!("{base_url}/v1/proxy/status"))
+        .header("Origin", "http://tauri.localhost")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert!(resp.status().is_success());
+    let allow_origin = resp
+        .headers()
+        .get("access-control-allow-origin")
+        .expect("missing access-control-allow-origin header")
+        .to_str()
+        .unwrap();
+    assert_eq!(allow_origin, "http://tauri.localhost");
 
     cancel.cancel();
 }

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -279,6 +279,7 @@ async fn spawn(
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -211,6 +211,7 @@ async fn start_proxy() -> (String, CancellationToken) {
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -328,6 +328,7 @@ async fn spawn_proxy(
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_slot_roundtrip.rs
+++ b/crates/gglib-proxy/tests/integration_slot_roundtrip.rs
@@ -288,6 +288,7 @@ async fn spawn_proxy_with_cache_for_model(
             Some(slot_dir),
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -241,6 +241,7 @@ async fn spawn_proxy_with(runner: Arc<dyn CouncilRunnerPort>) -> (String, Cancel
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
         )
         .await
         .ok();

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -282,6 +282,7 @@ impl ProxySupervisor {
                 slot_dir,
                 disk_budget,
                 agent_metrics,
+                &gglib_core::CorsConfig::LocalOnly,
             )
             .await;
 

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -278,7 +278,7 @@ gglib web --api-only --port 9887
 gglib web --port 9887 --base-port 9000
 ```
 
-The web server binds to `0.0.0.0` by default, making it accessible from your LAN. See [Interfaces](../README.md#interfaces) for details.
+The web server binds to `127.0.0.1` by default (local only). Use `--host 0.0.0.0` for LAN access. See [Interfaces](../README.md#interfaces) for details.
 
 ### llama.cpp Management
 


### PR DESCRIPTION
## Goal

Fixes #559
Resolves a security regression where `gglib web` binds to `0.0.0.0` by default, exposing the API to the local network. This PR secures the local development environment by enforcing a `127.0.0.1` default bind, providing a `--host` CLI escape hatch for intentional LAN testing, and unifying a strict localhost-only CORS policy across both the WebUI and Proxy servers.

## Context

See parent epic #558 and the Phase 1 architecture plan.

Previously, the Axum bootstrap hardcoded `0.0.0.0:{port}` and utilized a permissive CORS policy. Additionally, there was a parity gap: the Proxy server defaulted to `127.0.0.1` but still used a permissive `allow_origin(Any)` layer. To prevent cross-origin attacks from malicious sites, this PR centralizes our security posture to ensure both servers symmetrically reject non-localhost origins.

## Key Changes

* **Secure Network Bind:** Added a `with_host` builder to `ServerConfig` to support dynamic host binding. The `gglib web` command now defaults to `127.0.0.1` (configurable via `--host`), and the startup banner dynamically reflects the actual bind address.
* **Shared Security Utility:** Extracted `CorsConfig` and a new `is_local_origin` utility into `gglib-core`. The utility uses secure native URL parsing (via the `url` crate) to strictly reject userinfo injections (e.g., `http://user@localhost`).
* **Proxy Parity:** Both the Axum web server and the Proxy now use the shared `is_local_origin` logic for their CORS layers, fully respecting the `CorsConfig::LocalOnly` default. 
* **Tauri Compatibility:** Added explicit guards to `is_local_origin` to ensure Tauri's desktop schemes (`tauri://localhost`, `asset://localhost`) and standard webview origins (`http://tauri.localhost`) bypass strict web CORS restrictions natively.
* **Documentation & Testing:** Updated `README.md` and crate docs to reflect the new `127.0.0.1` defaults, and added comprehensive integration tests validating the `LocalOnly` CORS policy across both Axum and the Proxy.

## Acceptance Criteria

* [ ] `cargo run -- web --api-only --port 8080` binds **only** to `127.0.0.1:8080` (verified via `lsof -i :8080`).
* [ ] The Proxy server mirrors this security posture, strictly rejecting non-localhost origins by default.
* [ ] Cross-origin requests from non-localhost origins (e.g., `http://evil.example.com`) are rejected with a 403 or missing `Access-Control-Allow-Origin` header.
* [ ] Tauri embedded server origins (`tauri://localhost`, `asset://localhost`, `http://tauri.localhost`) are parsed correctly and bypass CORS restrictions.
* [ ] All existing tests pass, and the `check_boundaries.sh` script remains green.