### PR TITLE
chore(deps/security): override brace-expansion to ^5.0.8 to resolve DoS advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "typescript-eslint": "^8.18.1",
     "vite": "^8.0.0",
     "vitest": "^4.0.16"
-  }
+  },
+  "overrides": {
+  "brace-expansion": "^5.0.8"
+}
 }


### PR DESCRIPTION
## Summary
Patches a high-severity Denial of Service (DoS) vulnerability in `brace-expansion` ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)) across transitive dev dependencies without triggering breaking toolchain upgrades.

## Context & Problem
- `npm audit` flagged 6 high-severity vulnerabilities in `brace-expansion` ($\le$ 5.0.7) nested under `minimatch` and `eslint`.
- Running `npm audit fix --force` attempts to resolve this by upgrading ESLint to v10. However, ESLint v10 drops support for older linter configurations and causes peer dependency conflicts with `eslint-plugin-react` (breaking `make setup` and local builds).

## Solution
Added an `overrides` entry in `package.json` targeting `"brace-expansion": "^5.0.8"`. 
This forces `npm` to resolve all transitive `brace-expansion` dependencies to the safe, patched version while keeping ESLint locked safely on v9 (`^9.17.0`).

## Verification
- [x] Ran `rm -rf node_modules package-lock.json && npm install`
- [x] Verified `npm audit` reports **0 vulnerabilities**
- [x] Confirmed `make setup` passes and frontend UI builds without errors