### PR TITLE
feat(core): wire mlock through canonical config pipeline (#631)

### DIFF
--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -181,7 +181,7 @@ impl ServerOps {
             cache_reuse: None,
             cache_type_k: None,
             cache_type_v: None,
-            mlock: None,
+            mlock: Some(request.mlock),
         };
 
         // Resolve KV cache types once so the RAM budget below reflects the

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -181,6 +181,7 @@ impl ServerOps {
             cache_reuse: None,
             cache_type_k: None,
             cache_type_v: None,
+            mlock: None,
         };
 
         // Resolve KV cache types once so the RAM budget below reflects the

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -356,6 +356,9 @@ pub struct StartServerRequest {
     /// Inference parameters for this serve session (overrides model/global defaults).
     #[serde(default)]
     pub inference_params: Option<gglib_core::domain::InferenceConfig>,
+    /// Memory-lock the model into RAM (`--mlock`).
+    #[serde(default)]
+    pub mlock: bool,
 }
 
 /// Response for starting a server.
@@ -708,5 +711,24 @@ mod update_model_request_tests {
             })),
             "populated object must resolve to Some(Some(config))"
         );
+    }
+}
+
+#[cfg(test)]
+mod start_server_request_tests {
+    //! JSON-boundary tests for `StartServerRequest.mlock`.
+
+    use super::StartServerRequest;
+
+    #[test]
+    fn mlock_deserializes_from_json() {
+        let req: StartServerRequest = serde_json::from_str(r#"{"mlock": true}"#).unwrap();
+        assert!(req.mlock, "explicit true must deserialize");
+    }
+
+    #[test]
+    fn mlock_defaults_to_false_when_omitted() {
+        let req: StartServerRequest = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(!req.mlock, "omitted key must default to false via #[serde(default)]");
     }
 }

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -729,6 +729,9 @@ mod start_server_request_tests {
     #[test]
     fn mlock_defaults_to_false_when_omitted() {
         let req: StartServerRequest = serde_json::from_str(r#"{}"#).unwrap();
-        assert!(!req.mlock, "omitted key must default to false via #[serde(default)]");
+        assert!(
+            !req.mlock,
+            "omitted key must default to false via #[serde(default)]"
+        );
     }
 }

--- a/crates/gglib-core/src/ports/process_runner.rs
+++ b/crates/gglib-core/src/ports/process_runner.rs
@@ -81,6 +81,8 @@ pub struct ServerConfig {
     /// V cache element type (`--cache-type-v`). Same semantics as
     /// [`Self::cache_type_k`].
     pub cache_type_v: Option<crate::cache_config::KvCacheType>,
+    /// Whether to lock the model in RAM (`--mlock`). Default: `false`.
+    pub mlock: bool,
 }
 
 impl ServerConfig {
@@ -111,6 +113,7 @@ impl ServerConfig {
             cache_reuse: None,
             cache_type_k: None,
             cache_type_v: None,
+            mlock: false,
         }
     }
 
@@ -222,6 +225,13 @@ impl ServerConfig {
     #[must_use]
     pub const fn with_cache_type_v(mut self, t: crate::cache_config::KvCacheType) -> Self {
         self.cache_type_v = Some(t);
+        self
+    }
+
+    /// Enable memory lock (`--mlock`).
+    #[must_use]
+    pub const fn with_mlock(mut self) -> Self {
+        self.mlock = true;
         self
     }
 }

--- a/crates/gglib-core/src/server_config.rs
+++ b/crates/gglib-core/src/server_config.rs
@@ -152,6 +152,10 @@ pub struct ServerConfigOptions {
     /// Inference parameter overrides (temperature, top-p, etc.) forwarded
     /// directly to llama-server.
     pub inference_params: Option<InferenceConfig>,
+
+    /// Whether to memory-lock the model into RAM (`--mlock`).
+    /// `None` defaults to `false` in `build_server_config()`.
+    pub mlock: Option<bool>,
 }
 
 // =============================================================================

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -265,6 +265,11 @@ fn build_command(validated_path: &Path, config: &ServerConfig, port: u16) -> std
         }
     }
 
+    // Memory lock
+    if config.mlock {
+        cmd.arg("--mlock");
+    }
+
     // Add inference parameters if specified
     if let Some(ref inference) = config.inference_config {
         for arg in inference.to_cli_args() {
@@ -530,6 +535,7 @@ mod tests {
             cache_reuse: None,
             cache_type_k: None,
             cache_type_v: None,
+            mlock: false,
         };
 
         // Should use the bootstrap path (will spawn then immediately exit)
@@ -539,6 +545,31 @@ mod tests {
         assert!(
             result.is_ok(),
             "build_and_spawn should succeed with valid bootstrap path"
+        );
+    }
+
+    #[test]
+    fn mlock_omitted_by_default() {
+        let config = minimal_config(); // mlock defaults to false
+        let cmd = build_command(Path::new("/fake/llama-server"), &config, 5500);
+        let args = args_of(&cmd);
+        assert!(
+            !args.contains(&"--mlock".to_string()),
+            "--mlock should not be present by default"
+        );
+    }
+
+    #[test]
+    fn mlock_emits_flag_when_enabled() {
+        let config = ServerConfig {
+            mlock: true,
+            ..minimal_config()
+        };
+        let cmd = build_command(Path::new("/fake/llama-server"), &config, 5500);
+        let args = args_of(&cmd);
+        assert!(
+            args.contains(&"--mlock".to_string()),
+            "--mlock should be present when enabled"
         );
     }
 }

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -353,6 +353,7 @@ mod tests {
             cache_reuse: None,
             cache_type_k: None,
             cache_type_v: None,
+            mlock: false,
         }
     }
 

--- a/crates/gglib-runtime/src/server_config.rs
+++ b/crates/gglib-runtime/src/server_config.rs
@@ -158,5 +158,10 @@ pub fn build_server_config(
             .with_spec_draft_p_min(mtp.draft_p_min);
     }
 
+    // --- Memory lock (--mlock) -------------------------------------------------
+    if opts.mlock.unwrap_or(false) {
+        config = config.with_mlock();
+    }
+
     config
 }


### PR DESCRIPTION
## Summary

Wire the missing `mlock` field through the canonical config pipeline so the GUI frontend's `mlock` setting reaches `llama-server` via `--mlock`. Purely internal plumbing — no user-visible behavior changes.

**References:** Issue #631, Epic #630

## Data Flow

```
Frontend mlock setting
  → StartServerRequest.mlock (bool, serde default: false)
  → ServerConfigOptions.mlock (Option<bool>)
  → build_server_config() → config.with_mlock()
  → ServerConfig.mlock (bool)
  → build_command() → --mlock flag
  → llama-server
```

## Commits

| # | Commit | Description |
|---|--------|-------------|
| 1 | `8af971fc` | feat(core): add mlock field to StartServerRequest with serde tests |
| 2 | `b6776da1` | feat(core): add mlock field to ServerConfigOptions |
| 3 | `7dd2dd07` | feat(core): add mlock field and with_mlock builder to ServerConfig |
| 4 | `f6b07394` | feat(runtime): wire mlock through build_server_config |
| 5 | `254a39e5` | feat(runtime): emit --mlock flag in build_command with tests |
| 6 | `2ad6cd42` | feat(servers): wire mlock from StartServerRequest through ServerConfigOptions |
| 7 | `f58d360a` | style: fix formatting in start_server_request_tests |

## Files Changed

- `crates/gglib-app-services/src/types.rs` — `mlock: bool` field + serde round-trip tests
- `crates/gglib-core/src/server_config.rs` — `mlock: Option<bool>` in ServerConfigOptions
- `crates/gglib-core/src/ports/process_runner.rs` — `mlock: bool` in ServerConfig + `with_mlock()` builder
- `crates/gglib-runtime/src/server_config.rs` — mlock resolution in `build_server_config()`
- `crates/gglib-runtime/src/command.rs` — `--mlock` flag emission + unit tests
- `crates/gglib-app-services/src/servers.rs` — wire `request.mlock` into ServerConfigOptions

## Verification

- `cargo fmt -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace` ✅ (all tests passing)

## Deferred to Phase 2

- `UnifiedServerConfig` struct
- `resolve_unified_config()` function
- `ServerOps` → `ProxyOps` delegation
- Bootstrap wiring changes
- `#[deprecated]` on `build_server_config()`
