### PR TITLE
feat(serve): catalog filtering, CLI parity, tests & docs (#633)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ gglib model list
 # Start chatting (launches llama-server automatically)
 gglib chat qwen2.5
 
-# Pin one model to an OpenAI-compatible endpoint (dashboard and cache included)
+# Pin one model to an OpenAI-compatible endpoint (same proxy stack, one model)
 gglib serve qwen2.5
+# API:       http://127.0.0.1:8080/v1/chat/completions
+# Dashboard: http://127.0.0.1:8080/v1/proxy/status
 
 # Pipe anything into a question
 cat error.log | gglib question "what went wrong?"
@@ -190,8 +192,10 @@ is forwarded to llama-server, a stateless truncation pass runs:
 **Proxy dashboard** — a unified `DashboardSnapshot` of active connections,
 per-slot context usage, and recent request history — is available at
 `GET /v1/proxy/status` (JSON) and `GET /v1/proxy/status/stream` (live SSE
-updates). It's consumed by both `gglib proxy dashboard` (a live terminal
-view) and the web GUI's Proxy Dashboard modal. See
+updates), on `gglib serve` as well as `gglib proxy`: `serve` runs the same
+stack pinned to one model, so it gets the same endpoints. It's consumed by
+both `gglib proxy dashboard` (a live terminal view) and the web GUI's Proxy
+Dashboard modal. See
 [`gglib-proxy`'s docs](crates/gglib-proxy/README.md#proxy-dashboard) for the
 full data contract.
 
@@ -202,7 +206,8 @@ gglib proxy dashboard --port 9887
 
 ### KV Cache Session Persistence
 
-For sequential multi-agent workflows, enable `--cache --slot-dir <path>` to persist
+Available on `gglib serve` and `gglib proxy` alike, and opt-in on both. For
+sequential multi-agent workflows, enable `--cache --slot-dir <path>` to persist
 KV cache state between requests. The proxy automatically saves and restores per-session
 slot files (saved atomically via a temp-then-rename), gated by a semaphore to prevent
 concurrent access. Stale caches are detected via mtime comparison and skipped
@@ -638,7 +643,7 @@ All interfaces share the same database and model directory. Pick whichever fits 
 | **Desktop GUI** | `gglib gui` | [gglib-tauri](crates/gglib-tauri/README.md), [src-tauri](src-tauri/README.md) |
 | **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `127.0.0.1:9887` |
 | **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — works with OpenWebUI, any OpenAI SDK |
-| **Pinned endpoint** | `gglib serve <id>` | The same proxy locked to one model, for clients that cannot switch via `/v1/models` |
+| **Pinned endpoint** | `gglib serve <id>` | The same proxy locked to one model — `/v1/models` advertises only that model, for clients that cannot switch |
 
 **Shell completions** — enable tab completion for your shell:
 

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -930,7 +930,11 @@ mod tests {
     /// matching the variant alone would do.
     #[test]
     fn unrelated_spawn_failures_stay_internal() {
-        for msg in ["OOM killed", "port already in use", "Failed to get child PID"] {
+        for msg in [
+            "OOM killed",
+            "port already in use",
+            "Failed to get child PID",
+        ] {
             let err = map_runtime_error(&ModelRuntimeError::SpawnFailed(msg.to_string()));
             assert!(
                 matches!(err, GuiError::Internal(_)),

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -397,6 +397,9 @@ gglib model list
 # Pin one model to an OpenAI-compatible endpoint (proxy stack, dashboard included)
 gglib serve 1 --port 8080 --llama-port 5500
 
+# Same, with KV cache session persistence on disk
+gglib serve 1 --cache --slot-dir ~/.gglib/slots
+
 # Search HuggingFace
 gglib model search "llama 3 GGUF"
 

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -7,13 +7,12 @@
 
 use clap::Subcommand;
 use clap_complete::Shell;
-use gglib_core::cache_config::KvCacheType;
 
 use crate::benchmark_commands::BenchmarkCommand;
 use crate::config_commands::ConfigCommand;
 use crate::mcp_commands::McpCommand;
 use crate::model_commands::ModelCommand;
-use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
+use crate::shared_args::{CacheArgs, ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
 
 /// Subcommands available under `gglib council`.
 #[derive(Subcommand)]
@@ -497,66 +496,8 @@ pub enum Commands {
         /// Set `0.0` to disable (recommended by Qwen3).
         #[arg(long)]
         min_p: Option<f32>,
-        /// Enable KV cache session persistence, saving/restoring llama-server
-        /// slot state to disk per session.
-        ///
-        /// Independent of the host-RAM prompt cache, which is auto-sized on
-        /// every launch whether or not this flag is set (see `--cache-ram-mb`).
-        #[arg(long)]
-        cache: bool,
-        /// Directory for KV cache slot files (defaults to <app-data-dir>/slots if --cache is set and this is omitted)
-        #[arg(long)]
-        slot_dir: Option<std::path::PathBuf>,
-        /// RAM budget in MiB for llama-server's own host-RAM prompt cache
-        /// (`--cache-ram`) — what makes switching between conversations fast.
-        ///
-        /// Omit to auto-size it from total system RAM, the model's weights, and
-        /// its KV footprint at the launch context size; the chosen budget and
-        /// its arithmetic are logged at startup.
-        ///
-        /// Pass a value to override — `0` disables the cache. Set
-        /// `GGLIB_DISABLE_CACHE_AUTOSIZE=1` to skip auto-sizing entirely and
-        /// use llama-server's built-in default. Independent of
-        /// `--cache`/`--slot-dir`.
-        #[arg(long)]
-        cache_ram_mb: Option<u64>,
-        /// Minimum chunk size in tokens for KV-shift cache reuse past the first
-        /// prefix divergence point (`--cache-reuse`). Helps a follow-up prompt
-        /// whose earlier messages were edited or summarized (e.g. a Copilot
-        /// history compaction), which plain prefix matching can't reuse at all.
-        /// Omit to disable. Can be suppressed at runtime without editing this
-        /// flag via `GGLIB_DISABLE_CACHE_REUSE=1`.
-        #[arg(long)]
-        cache_reuse: Option<u32>,
-        /// Byte budget, in GiB, for the on-disk KV cache slot file eviction
-        /// sweep. Only meaningful with `--cache`.
-        ///
-        /// Omit to auto-size from free disk space at `--slot-dir` (a quarter
-        /// of free space + the cache's own current footprint, recomputed on
-        /// every sweep so it tracks disk pressure from other applications).
-        /// Can also be set via `GGLIB_CACHE_DISK_GB` (e.g. in a `.env` file)
-        /// without editing this flag; the flag wins if both are set.
-        #[arg(long)]
-        cache_disk_gb: Option<u64>,
-        /// Override the K cache element type (`--cache-type-k`). One of:
-        /// `f32`, `f16`, `bf16`, `q8_0`, `q5_1`, `q5_0`, `q4_1`, `q4_0`.
-        ///
-        /// Omit to use the `q8_0` default, which roughly halves KV cache
-        /// bytes-per-token versus llama-server's own `f16` default. Set
-        /// `GGLIB_DISABLE_KV_QUANT=1` to fall back to `f16`/`f16` for any
-        /// axis not explicitly overridden here.
-        #[arg(long)]
-        cache_type_k: Option<KvCacheType>,
-        /// Override the V cache element type (`--cache-type-v`). Same values
-        /// as `--cache-type-k`.
-        ///
-        /// Quantizing V additionally requires Flash Attention to be active —
-        /// llama-server hard-errors at startup otherwise. gglib leaves
-        /// `--flash-attn` at llama-server's own `auto`; if that resolves off
-        /// for your model/backend, override this to `f16` or set
-        /// `GGLIB_DISABLE_KV_QUANT=1`.
-        #[arg(long)]
-        cache_type_v: Option<KvCacheType>,
+        #[command(flatten)]
+        cache: CacheArgs,
         /// Subcommand (e.g. `dashboard`)
         #[command(subcommand)]
         command: Option<ProxyCommand>,

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -233,6 +233,8 @@ pub enum Commands {
         sampling: SamplingArgs,
         #[command(flatten)]
         mtp: MtpArgs,
+        #[command(flatten)]
+        cache: CacheArgs,
     },
 
     /// Chat with a model interactively, or manage chat history

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -443,6 +443,11 @@ pub enum Commands {
     ///
     /// This is identical to the behaviour when starting a model from the GUI or
     /// CLI — all surfaces go through the same canonical config builder.
+    ///
+    /// The sampling flags apply as proxy-wide defaults: requests that don't
+    /// specify a value use them, while per-request and per-model values still
+    /// win. (On `gglib serve` the same flags ride on the pinned model's own
+    /// launch options instead, since there is exactly one model in scope.)
     #[command(display_order = 22)]
     Proxy {
         /// Host to bind to
@@ -462,40 +467,8 @@ pub enum Commands {
         #[arg(long)]
         default_context: Option<String>,
 
-        /// Override sampling temperature for this proxy session (0.0–2.0).
-        ///
-        /// Applied as a global default: requests that don't specify temperature
-        /// will use this value. Per-request and per-model values still win.
-        #[arg(long)]
-        temperature: Option<f32>,
-
-        /// Override nucleus sampling top-p for this proxy session (0.0–1.0).
-        #[arg(long)]
-        top_p: Option<f32>,
-
-        /// Override top-k sampling limit for this proxy session.
-        #[arg(long)]
-        top_k: Option<i32>,
-
-        /// Override max tokens to generate for this proxy session.
-        #[arg(long)]
-        max_tokens: Option<u32>,
-
-        /// Override repetition penalty for this proxy session (typically 1.0–1.3).
-        #[arg(long)]
-        repeat_penalty: Option<f32>,
-
-        /// Override presence penalty for this proxy session (0.0–2.0).
-        ///
-        /// Useful for reasoning/thinking models (e.g. `1.5` for Qwen3, DeepSeek-R1).
-        #[arg(long)]
-        presence_penalty: Option<f32>,
-
-        /// Override min-p sampling threshold for this proxy session (0.0–1.0).
-        ///
-        /// Set `0.0` to disable (recommended by Qwen3).
-        #[arg(long)]
-        min_p: Option<f32>,
+        #[command(flatten)]
+        sampling: SamplingArgs,
         #[command(flatten)]
         cache: CacheArgs,
         /// Subcommand (e.g. `dashboard`)

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -44,9 +44,12 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             options,
             sampling,
             mtp,
+            cache,
         } => {
-            handlers::inference::serve::execute(ctx, id, context, options, sampling, mtp, verbose)
-                .await?;
+            handlers::inference::serve::execute(
+                ctx, id, context, options, sampling, mtp, cache, verbose,
+            )
+            .await?;
         }
         Commands::Chat {
             identifier,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -10,7 +10,6 @@
 //! coupling between the dispatch layer and each handler as narrow as possible.
 
 use anyhow::Result;
-use gglib_core::domain::inference::InferenceConfig;
 use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
 use gglib_runtime::proxy::StandaloneProxyParams;
 
@@ -257,13 +256,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             port,
             llama_port,
             default_context,
-            temperature,
-            top_p,
-            top_k,
-            max_tokens,
-            repeat_penalty,
-            presence_penalty,
-            min_p,
+            sampling,
             cache,
             command,
         } => {
@@ -301,26 +294,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 global_default_ctx: settings.default_context_size,
                 ..Default::default()
             });
-            let inference_override = if temperature.is_some()
-                || top_p.is_some()
-                || top_k.is_some()
-                || max_tokens.is_some()
-                || repeat_penalty.is_some()
-                || presence_penalty.is_some()
-                || min_p.is_some()
-            {
-                Some(InferenceConfig {
-                    temperature,
-                    top_p,
-                    top_k,
-                    max_tokens,
-                    repeat_penalty,
-                    presence_penalty,
-                    min_p,
-                })
-            } else {
-                None
-            };
+            let inference_override = sampling.into_override();
             gglib_runtime::proxy::start_proxy_standalone(StandaloneProxyParams {
                 host,
                 port,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -12,7 +12,7 @@
 use anyhow::Result;
 use gglib_core::domain::inference::InferenceConfig;
 use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
-use gglib_runtime::proxy::{ProxyCacheOptions, StandaloneProxyParams};
+use gglib_runtime::proxy::StandaloneProxyParams;
 
 use crate::bootstrap::CliContext;
 use crate::commands::Commands;
@@ -265,12 +265,6 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             presence_penalty,
             min_p,
             cache,
-            slot_dir,
-            cache_ram_mb,
-            cache_reuse,
-            cache_disk_gb,
-            cache_type_k,
-            cache_type_v,
             command,
         } => {
             // Subcommand takes priority (e.g. `gglib proxy dashboard`) — it
@@ -337,15 +331,7 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
                 settings_repo: ctx.app.settings().repo(),
                 default_context: effective_context,
                 inference_override,
-                cache: ProxyCacheOptions {
-                    enabled: cache,
-                    slot_dir,
-                    ram_mb: cache_ram_mb,
-                    reuse: cache_reuse,
-                    disk_gb: cache_disk_gb,
-                    type_k: cache_type_k,
-                    type_v: cache_type_v,
-                },
+                cache: cache.into_proxy_cache_options(),
                 // `gglib proxy` serves the whole catalog and swaps on demand;
                 // `gglib serve` is the pinned mode of this same entry point.
                 pinned: None,

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 
 use crate::bootstrap::CliContext;
 use crate::presentation::style;
-use crate::shared_args::{ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
+use crate::shared_args::{CacheArgs, ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
 use gglib_core::server_config::{ServerConfigOptions, parse_ctx_size_flag, resolve_context_size};
 use gglib_runtime::llama::{ensure_llama_initialized, resolve_llama_server, resolve_mtp_args};
 use gglib_runtime::proxy::{
@@ -28,6 +28,7 @@ use super::shared::{log_inference_info, log_mlock_info, resolve_inference_config
 /// Execute the serve command.
 ///
 /// Starts the proxy pinned to the requested model and blocks until Ctrl-C.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     ctx: &CliContext,
     id: u32,
@@ -35,6 +36,7 @@ pub async fn execute(
     options: ServeOptions,
     sampling: SamplingArgs,
     mtp: MtpArgs,
+    cache: CacheArgs,
     verbose: bool,
 ) -> Result<()> {
     // Ensure llama.cpp is installed
@@ -89,10 +91,19 @@ pub async fn execute(
             mtp_draft_p_min: mtp_args.enabled.then_some(mtp_args.draft_p_min),
             ..Default::default()
         },
+        // The cache master switch and directory are tier 3: `resolved_options`
+        // applies `cache_enabled` over `slot_save_path`, which is how
+        // `--cache` reaches llama-server on the pinned model's launch options
+        // at all. The remaining cache flags carry no model-specific meaning
+        // and go straight to the proxy via `ProxyCacheOptions` — including
+        // `--cache-disk-gb`, which `start_proxy_standalone` resolves into a
+        // `DiskBudget` for both commands alike.
         globals: GlobalDefaults {
             proxy_port: options.port,
             llama_base_port: options.llama_port,
             default_ctx: settings.default_context_size,
+            cache_enabled: cache.cache,
+            slot_dir: cache.slot_dir.clone(),
             ..Default::default()
         },
         pinned: true,
@@ -142,10 +153,12 @@ pub async fn execute(
         // as a proxy-wide override, so it lands on the llama-server command
         // line exactly as every other launch surface applies it.
         inference_override: None,
+        // `slot_dir` comes from the cascade rather than the raw flag: it has
+        // already had the `cache_enabled` master switch applied and the
+        // default directory filled in.
         cache: ProxyCacheOptions {
-            enabled: proxy_config.cache_enabled,
             slot_dir: proxy_config.slot_dir,
-            ..Default::default()
+            ..cache.into_proxy_cache_options()
         },
         pinned: Some(PinnedModel {
             id: model.id,
@@ -158,6 +171,8 @@ pub async fn execute(
 
 #[cfg(test)]
 mod tests {
+    use crate::shared_args::CacheArgs;
+    use gglib_core::cache_config::KvCacheType;
     use gglib_core::server_config::{
         CtxSizeArg, ServerConfigOptions, parse_ctx_size_flag, resolve_context_size,
     };
@@ -263,5 +278,84 @@ mod tests {
     fn serve_binds_loopback_by_default() {
         let cfg = unified(ServerConfigOptions::default(), GlobalDefaults::default());
         assert_eq!(cfg.to_proxy_config().host, "127.0.0.1");
+    }
+
+    // ---------------------------------------------------------------
+    // Cache flags (#633 — parity with `gglib proxy`)
+    // ---------------------------------------------------------------
+
+    /// Without `--cache`, no `--slot-save-path` may reach llama-server even
+    /// when a directory was named: the master switch outranks the directory,
+    /// so "cache off" means byte-for-byte no cache flags.
+    #[test]
+    fn slot_dir_without_cache_flag_emits_no_slot_path() {
+        let cfg = unified(
+            ServerConfigOptions::default(),
+            GlobalDefaults {
+                cache_enabled: false,
+                slot_dir: Some(PathBuf::from("/custom/slots")),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(cfg.resolved_options().slot_save_path, None);
+        assert_eq!(cfg.to_proxy_config().slot_dir, None);
+    }
+
+    /// `--cache --slot-dir` must reach the pinned model's launch options —
+    /// the path by which disk KV-slot persistence works on `serve` at all.
+    #[test]
+    fn cache_flag_carries_the_slot_dir_into_launch_options() {
+        let cfg = unified(
+            ServerConfigOptions::default(),
+            GlobalDefaults {
+                cache_enabled: true,
+                slot_dir: Some(PathBuf::from("/custom/slots")),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            cfg.resolved_options().slot_save_path,
+            Some(PathBuf::from("/custom/slots"))
+        );
+    }
+
+    /// `--cache` with no directory falls back to the default rather than
+    /// silently disabling persistence.
+    #[test]
+    fn cache_flag_without_slot_dir_uses_the_default_directory() {
+        let cfg = unified(
+            ServerConfigOptions::default(),
+            GlobalDefaults {
+                cache_enabled: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(cfg.resolved_options().slot_save_path.is_some());
+    }
+
+    /// The model-independent cache flags ride `ProxyCacheOptions` rather than
+    /// the cascade, and must survive the conversion intact.
+    #[test]
+    fn model_independent_cache_flags_reach_the_proxy_options() {
+        let opts = CacheArgs {
+            cache: true,
+            cache_ram_mb: Some(4096),
+            cache_reuse: Some(256),
+            cache_disk_gb: Some(8),
+            cache_type_k: Some(KvCacheType::F16),
+            cache_type_v: Some(KvCacheType::Q8_0),
+            ..Default::default()
+        }
+        .into_proxy_cache_options();
+
+        assert!(opts.enabled);
+        assert_eq!(opts.ram_mb, Some(4096));
+        assert_eq!(opts.reuse, Some(256));
+        assert_eq!(opts.disk_gb, Some(8));
+        assert_eq!(opts.type_k, Some(KvCacheType::F16));
+        assert_eq!(opts.type_v, Some(KvCacheType::Q8_0));
     }
 }

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -188,7 +188,10 @@ pub struct ServeOptions {
     /// Force-enable Jinja template parsing for chat templates
     #[arg(long)]
     pub jinja: bool,
-    /// Port the OpenAI-compatible endpoint listens on
+    /// Port the OpenAI-compatible endpoint listens on.
+    ///
+    /// The proxy dashboard is served from the same port at
+    /// `/v1/proxy/status` (JSON) and `/v1/proxy/status/stream` (SSE).
     #[arg(short, long, default_value = "8080")]
     pub port: u16,
     /// Starting port for the underlying llama-server instance

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -142,25 +142,43 @@ pub struct CacheArgs {
     /// without editing this flag; the flag wins if both are set.
     #[arg(long)]
     pub cache_disk_gb: Option<u64>,
-    /// Override the K cache element type (`--cache-type-k`). One of:
-    /// `f32`, `f16`, `bf16`, `q8_0`, `q5_1`, `q5_0`, `q4_1`, `q4_0`.
+    /// Override the K cache element type (`--cache-type-k`).
     ///
     /// Omit to use the `q8_0` default, which roughly halves KV cache
     /// bytes-per-token versus llama-server's own `f16` default. Set
     /// `GGLIB_DISABLE_KV_QUANT=1` to fall back to `f16`/`f16` for any
     /// axis not explicitly overridden here.
-    #[arg(long)]
+    #[arg(long, value_parser = kv_cache_type_parser())]
     pub cache_type_k: Option<KvCacheType>,
-    /// Override the V cache element type (`--cache-type-v`). Same values
-    /// as `--cache-type-k`.
+    /// Override the V cache element type (`--cache-type-v`).
     ///
     /// Quantizing V additionally requires Flash Attention to be active —
     /// llama-server hard-errors at startup otherwise. gglib leaves
     /// `--flash-attn` at llama-server's own `auto`; if that resolves off
     /// for your model/backend, override this to `f16` or set
     /// `GGLIB_DISABLE_KV_QUANT=1`.
-    #[arg(long)]
+    #[arg(long, value_parser = kv_cache_type_parser())]
     pub cache_type_v: Option<KvCacheType>,
+}
+
+/// Value parser for `--cache-type-k`/`--cache-type-v`.
+///
+/// Built from [`KvCacheType::ALL`] so `--help` and shell completions list the
+/// accepted values instead of leaving users to discover them from a parse
+/// error. Wrapping the domain type's `FromStr` here rather than deriving
+/// `ValueEnum` on it keeps clap out of `gglib-core`, which has no CLI
+/// dependency and should not gain one to improve a help string.
+fn kv_cache_type_parser() -> impl clap::builder::TypedValueParser {
+    use clap::builder::TypedValueParser as _;
+
+    clap::builder::PossibleValuesParser::new(KvCacheType::ALL.iter().map(|t| t.as_llama_arg())).map(
+        |s| {
+            // Unreachable: clap has already rejected anything outside `ALL`,
+            // and every entry there round-trips through `as_llama_arg`.
+            s.parse::<KvCacheType>()
+                .expect("clap accepted a value outside KvCacheType::ALL")
+        },
+    )
 }
 
 impl CacheArgs {

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -5,6 +5,8 @@
 //! `Serve`, `Chat`, and `Question`.
 
 use clap::Args;
+use gglib_core::cache_config::KvCacheType;
+use gglib_runtime::proxy::ProxyCacheOptions;
 
 /// Sampling-parameter overrides common to all inference commands.
 ///
@@ -78,6 +80,95 @@ pub struct MtpArgs {
     /// cost of output quality. Recommended range: 0.5–0.95.
     #[arg(long)]
     pub mtp_draft_p_min: Option<f32>,
+}
+
+/// KV cache flags common to the proxy-backed commands.
+///
+/// Flattened into both `Serve` and `Proxy` so the two parse identically —
+/// `gglib serve` is the pinned mode of the same proxy stack, and a cache
+/// setting that only one of them could express would be a parity gap by
+/// construction.
+#[derive(Args, Debug, Clone, Default)]
+pub struct CacheArgs {
+    /// Enable KV cache session persistence, saving/restoring llama-server
+    /// slot state to disk per session.
+    ///
+    /// Independent of the host-RAM prompt cache, which is auto-sized on
+    /// every launch whether or not this flag is set (see `--cache-ram-mb`).
+    #[arg(long)]
+    pub cache: bool,
+    /// Directory for KV cache slot files (defaults to <app-data-dir>/slots if --cache is set and this is omitted)
+    #[arg(long)]
+    pub slot_dir: Option<std::path::PathBuf>,
+    /// RAM budget in MiB for llama-server's own host-RAM prompt cache
+    /// (`--cache-ram`) — what makes switching between conversations fast.
+    ///
+    /// Omit to auto-size it from total system RAM, the model's weights, and
+    /// its KV footprint at the launch context size; the chosen budget and
+    /// its arithmetic are logged at startup.
+    ///
+    /// Pass a value to override — `0` disables the cache. Set
+    /// `GGLIB_DISABLE_CACHE_AUTOSIZE=1` to skip auto-sizing entirely and
+    /// use llama-server's built-in default. Independent of
+    /// `--cache`/`--slot-dir`.
+    #[arg(long)]
+    pub cache_ram_mb: Option<u64>,
+    /// Minimum chunk size in tokens for KV-shift cache reuse past the first
+    /// prefix divergence point (`--cache-reuse`). Helps a follow-up prompt
+    /// whose earlier messages were edited or summarized (e.g. a Copilot
+    /// history compaction), which plain prefix matching can't reuse at all.
+    /// Omit to disable. Can be suppressed at runtime without editing this
+    /// flag via `GGLIB_DISABLE_CACHE_REUSE=1`.
+    #[arg(long)]
+    pub cache_reuse: Option<u32>,
+    /// Byte budget, in GiB, for the on-disk KV cache slot file eviction
+    /// sweep. Only meaningful with `--cache`.
+    ///
+    /// Omit to auto-size from free disk space at `--slot-dir` (a quarter
+    /// of free space + the cache's own current footprint, recomputed on
+    /// every sweep so it tracks disk pressure from other applications).
+    /// Can also be set via `GGLIB_CACHE_DISK_GB` (e.g. in a `.env` file)
+    /// without editing this flag; the flag wins if both are set.
+    #[arg(long)]
+    pub cache_disk_gb: Option<u64>,
+    /// Override the K cache element type (`--cache-type-k`). One of:
+    /// `f32`, `f16`, `bf16`, `q8_0`, `q5_1`, `q5_0`, `q4_1`, `q4_0`.
+    ///
+    /// Omit to use the `q8_0` default, which roughly halves KV cache
+    /// bytes-per-token versus llama-server's own `f16` default. Set
+    /// `GGLIB_DISABLE_KV_QUANT=1` to fall back to `f16`/`f16` for any
+    /// axis not explicitly overridden here.
+    #[arg(long)]
+    pub cache_type_k: Option<KvCacheType>,
+    /// Override the V cache element type (`--cache-type-v`). Same values
+    /// as `--cache-type-k`.
+    ///
+    /// Quantizing V additionally requires Flash Attention to be active —
+    /// llama-server hard-errors at startup otherwise. gglib leaves
+    /// `--flash-attn` at llama-server's own `auto`; if that resolves off
+    /// for your model/backend, override this to `f16` or set
+    /// `GGLIB_DISABLE_KV_QUANT=1`.
+    #[arg(long)]
+    pub cache_type_v: Option<KvCacheType>,
+}
+
+impl CacheArgs {
+    /// Convert into the runtime's cache options.
+    ///
+    /// The single construction point for [`ProxyCacheOptions`] on the CLI
+    /// side, so `serve` and `proxy` cannot drift in how a flag is mapped.
+    #[must_use]
+    pub fn into_proxy_cache_options(self) -> ProxyCacheOptions {
+        ProxyCacheOptions {
+            enabled: self.cache,
+            slot_dir: self.slot_dir,
+            ram_mb: self.cache_ram_mb,
+            reuse: self.cache_reuse,
+            disk_gb: self.cache_disk_gb,
+            type_k: self.cache_type_k,
+            type_v: self.cache_type_v,
+        }
+    }
 }
 
 /// Serve-command options that don't belong to another group.

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -64,6 +64,17 @@ impl SamplingArgs {
             min_p: self.min_p,
         }
     }
+
+    /// The overrides as a config, or `None` when no sampling flag was passed.
+    ///
+    /// An all-`None` config is not the same as no override at all: it sits at
+    /// the top of the merge hierarchy, so handing one down unconditionally
+    /// would announce an opinion the user never expressed.
+    #[must_use]
+    pub fn into_override(self) -> Option<gglib_core::domain::InferenceConfig> {
+        let config = self.into_inference_config();
+        (config != gglib_core::domain::InferenceConfig::default()).then_some(config)
+    }
 }
 
 /// MTP (Multi-Token Prediction) speculative-decoding overrides for the `serve` command.

--- a/crates/gglib-cli/tests/cli_parity.rs
+++ b/crates/gglib-cli/tests/cli_parity.rs
@@ -1,0 +1,219 @@
+//! Flag parity between `gglib serve` and `gglib proxy`.
+//!
+//! `serve` is the pinned mode of the same proxy stack (epic #630), so a cache
+//! or sampling knob available on one and not the other is a bug by
+//! construction — that divergence is exactly what the epic set out to remove.
+//!
+//! These assert on the parsed clap model rather than on `--help` text: the
+//! flag set is the contract, while the rendered help is formatting. That also
+//! keeps the test from failing on wording changes it has no opinion about.
+//!
+//! The groups are flattened from one shared definition each, so what is
+//! really guarded here is that both commands keep flattening them — a
+//! regression would take the form of a field moving back inline, or a
+//! `#[command(flatten)]` being dropped.
+
+use clap::{CommandFactory, Parser};
+use gglib_cli::{Cli, Commands};
+
+/// Every long flag on a subcommand, as clap resolved it.
+fn long_flags(subcommand: &str) -> Vec<String> {
+    let cli = Cli::command();
+    let cmd = cli
+        .get_subcommands()
+        .find(|c| c.get_name() == subcommand)
+        .unwrap_or_else(|| panic!("no `{subcommand}` subcommand"));
+
+    let mut flags: Vec<String> = cmd
+        .get_arguments()
+        .filter_map(|a| a.get_long().map(str::to_owned))
+        .collect();
+    flags.sort();
+    flags
+}
+
+/// The flags `CacheArgs` contributes.
+const CACHE_FLAGS: &[&str] = &[
+    "cache",
+    "cache-disk-gb",
+    "cache-ram-mb",
+    "cache-reuse",
+    "cache-type-k",
+    "cache-type-v",
+    "slot-dir",
+];
+
+/// The flags `SamplingArgs` contributes.
+const SAMPLING_FLAGS: &[&str] = &[
+    "max-tokens",
+    "min-p",
+    "presence-penalty",
+    "repeat-penalty",
+    "temperature",
+    "top-k",
+    "top-p",
+];
+
+// ─── Parity ───────────────────────────────────────────────────────────────
+
+#[test]
+fn serve_and_proxy_expose_the_same_cache_flags() {
+    let serve = long_flags("serve");
+    let proxy = long_flags("proxy");
+
+    for flag in CACHE_FLAGS {
+        assert!(
+            serve.contains(&(*flag).to_owned()),
+            "`serve` is missing --{flag}; it has {serve:?}"
+        );
+        assert!(
+            proxy.contains(&(*flag).to_owned()),
+            "`proxy` is missing --{flag}; it has {proxy:?}"
+        );
+    }
+}
+
+#[test]
+fn serve_and_proxy_expose_the_same_sampling_flags() {
+    let serve = long_flags("serve");
+    let proxy = long_flags("proxy");
+
+    for flag in SAMPLING_FLAGS {
+        assert!(
+            serve.contains(&(*flag).to_owned()),
+            "`serve` is missing --{flag}; it has {serve:?}"
+        );
+        assert!(
+            proxy.contains(&(*flag).to_owned()),
+            "`proxy` is missing --{flag}; it has {proxy:?}"
+        );
+    }
+}
+
+/// Guards the rename risk in flattening `SamplingArgs` onto `proxy`: the
+/// inline fields derived their long names from the field names, while
+/// `SamplingArgs` spells them out explicitly. Anything but an exact match
+/// would silently break every existing `gglib proxy` invocation.
+#[test]
+fn flattening_did_not_rename_any_proxy_flag() {
+    let proxy = long_flags("proxy");
+
+    for flag in SAMPLING_FLAGS.iter().chain(CACHE_FLAGS) {
+        assert!(
+            proxy.contains(&(*flag).to_owned()),
+            "--{flag} disappeared from `proxy`; it has {proxy:?}"
+        );
+    }
+}
+
+// ─── Parsing ──────────────────────────────────────────────────────────────
+
+/// The flags must not merely exist — they must land on the right fields.
+#[test]
+fn serve_parses_the_cache_and_sampling_flags() {
+    let cli = Cli::try_parse_from([
+        "gglib",
+        "serve",
+        "1",
+        "--cache",
+        "--slot-dir",
+        "/tmp/slots",
+        "--cache-ram-mb",
+        "4096",
+        "--cache-reuse",
+        "256",
+        "--cache-disk-gb",
+        "8",
+        "--cache-type-k",
+        "f16",
+        "--top-p",
+        "0.9",
+        "--max-tokens",
+        "100",
+    ])
+    .expect("serve should accept the full cache and sampling flag set");
+
+    let Some(Commands::Serve {
+        id,
+        cache,
+        sampling,
+        ..
+    }) = cli.command
+    else {
+        panic!("expected a Serve command");
+    };
+
+    assert_eq!(id, 1);
+    assert!(cache.cache);
+    assert_eq!(
+        cache.slot_dir.as_deref(),
+        Some(std::path::Path::new("/tmp/slots"))
+    );
+    assert_eq!(cache.cache_ram_mb, Some(4096));
+    assert_eq!(cache.cache_reuse, Some(256));
+    assert_eq!(cache.cache_disk_gb, Some(8));
+    assert_eq!(
+        cache.cache_type_k,
+        Some(gglib_core::cache_config::KvCacheType::F16)
+    );
+    assert_eq!(sampling.top_p, Some(0.9));
+    assert_eq!(sampling.max_tokens, Some(100));
+}
+
+/// The same invocation `gglib proxy` accepted before the refactor must still
+/// parse, and still reach the same fields.
+#[test]
+fn proxy_still_parses_its_sampling_and_cache_flags() {
+    let cli = Cli::try_parse_from([
+        "gglib",
+        "proxy",
+        "--temperature",
+        "0.7",
+        "--top-p",
+        "0.9",
+        "--min-p",
+        "0.05",
+        "--cache",
+        "--cache-type-v",
+        "q8_0",
+    ])
+    .expect("proxy should still accept its pre-refactor flags");
+
+    let Some(Commands::Proxy {
+        sampling, cache, ..
+    }) = cli.command
+    else {
+        panic!("expected a Proxy command");
+    };
+
+    assert_eq!(sampling.temperature, Some(0.7));
+    assert_eq!(sampling.top_p, Some(0.9));
+    assert_eq!(sampling.min_p, Some(0.05));
+    assert!(cache.cache);
+    assert_eq!(
+        cache.cache_type_v,
+        Some(gglib_core::cache_config::KvCacheType::Q8_0)
+    );
+}
+
+/// Absent flags must stay `None` rather than defaulting: on the sampling
+/// side an all-`None` config is what tells the merge hierarchy that the user
+/// expressed no opinion, and `--cache` off must mean no cache flags at all.
+#[test]
+fn omitted_flags_express_no_opinion() {
+    let cli = Cli::try_parse_from(["gglib", "serve", "1"]).expect("bare serve should parse");
+
+    let Some(Commands::Serve {
+        cache, sampling, ..
+    }) = cli.command
+    else {
+        panic!("expected a Serve command");
+    };
+
+    assert!(!cache.cache);
+    assert_eq!(cache.slot_dir, None);
+    assert_eq!(cache.cache_ram_mb, None);
+    assert_eq!(cache.cache_type_k, None);
+    assert_eq!(sampling.temperature, None);
+    assert_eq!(sampling.top_p, None);
+}

--- a/crates/gglib-core/src/cache_config.rs
+++ b/crates/gglib-core/src/cache_config.rs
@@ -54,6 +54,23 @@ pub enum KvCacheType {
 }
 
 impl KvCacheType {
+    /// Every accepted type, in the order they should be offered to a user.
+    ///
+    /// The one list: [`FromStr`] parses against it, its error message names
+    /// it, and the CLI builds `--cache-type-k`/`-v`'s possible values from
+    /// it. Adding a variant here is enough to make it parse, appear in
+    /// `--help` and appear in shell completions.
+    pub const ALL: &'static [Self] = &[
+        Self::F32,
+        Self::F16,
+        Self::Bf16,
+        Self::Q8_0,
+        Self::Q5_1,
+        Self::Q5_0,
+        Self::Q4_1,
+        Self::Q4_0,
+    ];
+
     /// The value passed on the command line (matches llama.cpp's own
     /// `ggml_type_name`).
     #[must_use]
@@ -100,19 +117,18 @@ impl FromStr for KvCacheType {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.trim().to_ascii_lowercase().as_str() {
-            "f32" => Ok(Self::F32),
-            "f16" => Ok(Self::F16),
-            "bf16" => Ok(Self::Bf16),
-            "q8_0" => Ok(Self::Q8_0),
-            "q5_1" => Ok(Self::Q5_1),
-            "q5_0" => Ok(Self::Q5_0),
-            "q4_1" => Ok(Self::Q4_1),
-            "q4_0" => Ok(Self::Q4_0),
-            other => Err(format!(
-                "unknown KV cache type {other:?} (expected one of: f32, f16, bf16, q8_0, q5_1, q5_0, q4_1, q4_0)"
-            )),
-        }
+        let normalized = s.trim().to_ascii_lowercase();
+        Self::ALL
+            .iter()
+            .find(|t| t.as_llama_arg() == normalized)
+            .copied()
+            .ok_or_else(|| {
+                let expected: Vec<&str> = Self::ALL.iter().map(|t| t.as_llama_arg()).collect();
+                format!(
+                    "unknown KV cache type {normalized:?} (expected one of: {})",
+                    expected.join(", ")
+                )
+            })
     }
 }
 

--- a/crates/gglib-core/src/ports/model_runtime.rs
+++ b/crates/gglib-core/src/ports/model_runtime.rs
@@ -273,6 +273,24 @@ pub trait ModelRuntimePort: Send + Sync + fmt::Debug {
     ///
     /// This is primarily for cleanup/shutdown scenarios.
     async fn stop_current(&self) -> Result<(), ModelRuntimeError>;
+
+    /// The one model this runtime is pinned to, if any.
+    ///
+    /// `Some(name)` means every other model is refused with
+    /// [`ModelRuntimeError::PinnedModelMismatch`] rather than swapped to —
+    /// the mode `gglib serve` runs in. `None` is the ordinary auto-swapping
+    /// runtime.
+    ///
+    /// Synchronous because pinning is fixed when the runtime is constructed
+    /// and never changes afterwards, unlike [`Self::current_model`], which
+    /// reports live process state.
+    ///
+    /// Defaults to unpinned so test doubles and remote backends need not
+    /// implement it. Callers use it to avoid offering a model that would only
+    /// be refused — `/v1/models` being the motivating case.
+    fn pinned_model(&self) -> Option<&str> {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -341,6 +359,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(target.effective_ctx, 4096);
+    }
+
+    /// Unpinned is the safe default: a runtime that says nothing about
+    /// pinning must not cause callers to narrow what they offer.
+    #[test]
+    fn pinned_model_defaults_to_unpinned() {
+        assert_eq!(MinimalRuntime.pinned_model(), None);
     }
 
     #[tokio::test]

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -263,7 +263,15 @@ auto-started by the proxy.
 `gglib serve <model>` is this same stack pinned to one model: it refuses
 requests for any other model rather than swapping, which gives clients that
 cannot switch via `/v1/models` a fixed endpoint without giving up the
-dashboard, cache lifecycle or request normalization.
+dashboard, cache lifecycle or request normalization. It takes the same cache
+flags (`--cache`, `--cache-ram-mb`, `--cache-reuse`, …) as `gglib proxy`,
+opt-in on both.
+
+In pinned mode `GET /v1/models` advertises only the pinned model, so a client
+is never offered a model the endpoint would refuse. Its `{model}:{profile}`
+variants and the council virtuals remain listed: a profile changes only the
+request body, and a council run dispatches to whatever model is loaded, so
+neither reaches the pinned guard.
 
 ### Inference Defaults Auto-Injection
 

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -370,7 +370,20 @@ async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
     debug!("GET /v1/models");
 
     match state.catalog_port.list_models().await {
-        Ok(models) => {
+        Ok(mut models) => {
+            // Pinned mode refuses every other model, so advertising the rest
+            // of the catalog would offer a BYOK client a choice that can only
+            // come back as PinnedModelMismatch. Filtering the summaries here
+            // rather than the finished response also keeps the variants below
+            // correct for free — they are built from what survives.
+            //
+            // Profile variants of the pinned model and the council virtuals
+            // both stay: neither changes which model actually runs, so
+            // neither can trip the guard.
+            if let Some(pinned) = state.runtime_port.pinned_model() {
+                models.retain(|m| m.name == pinned);
+            }
+
             let mut response = ModelsResponse::from_summaries(models, state.default_ctx);
 
             // Apply safety margin to every model's context_window.

--- a/crates/gglib-proxy/tests/fixtures/common.rs
+++ b/crates/gglib-proxy/tests/fixtures/common.rs
@@ -7,7 +7,9 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use gglib_core::Settings;
+use gglib_core::domain::InferenceConfig;
 use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
+use gglib_core::domain::inference_profile::InferenceProfile;
 use gglib_core::ports::{
     ApprovalDecision, CatalogError, CouncilApprovalRegistryPort, CouncilRepositoryPort,
     ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort, ModelSummary,
@@ -43,6 +45,39 @@ impl ModelRuntimePort for NoopRuntime {
     }
 }
 
+/// Runtime port that reports itself pinned to one model.
+///
+/// The read side of `gglib serve`: what a caller sees when the manager was
+/// built with `ProcessManager::new_pinned`. It does not enforce the pin —
+/// that guard lives in `gglib-runtime` and is tested there — so a test can
+/// tell the difference between "not advertised" and "refused".
+#[derive(Debug)]
+pub struct PinnedRuntime(pub &'static str);
+
+#[async_trait]
+impl ModelRuntimePort for PinnedRuntime {
+    async fn ensure_model_running(
+        &self,
+        _model_name: &str,
+        _num_ctx: Option<u64>,
+        _default_ctx: u64,
+    ) -> Result<RunningTarget, ModelRuntimeError> {
+        Ok(RunningTarget::local(0, 1, self.0.into(), 4096, false))
+    }
+
+    async fn current_model(&self) -> Option<RunningTarget> {
+        None
+    }
+
+    async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
+        Ok(())
+    }
+
+    fn pinned_model(&self) -> Option<&str> {
+        Some(self.0)
+    }
+}
+
 // ─── ModelCatalogPort mock ────────────────────────────────────────────────
 
 /// Catalog port with no models.
@@ -67,6 +102,64 @@ impl ModelCatalogPort for EmptyCatalog {
     }
 }
 
+/// Catalog port over a fixed set of model names.
+///
+/// Names are all `/v1/models` filtering cares about, so everything else is
+/// filled with plausible constants rather than made configurable.
+#[derive(Debug)]
+pub struct StaticCatalog(pub Vec<String>);
+
+impl StaticCatalog {
+    /// Build a catalog listing the given model names.
+    pub fn new(names: &[&str]) -> Self {
+        Self(names.iter().map(|n| (*n).to_string()).collect())
+    }
+
+    fn summary(id: u32, name: &str) -> ModelSummary {
+        ModelSummary {
+            id,
+            name: name.to_string(),
+            tags: vec![],
+            capabilities: Default::default(),
+            param_count: "7B".to_string(),
+            quantization: Some("Q4_K_M".to_string()),
+            architecture: Some("llama".to_string()),
+            created_at: 0,
+            file_size: 0,
+            context_length: Some(8192),
+            inference_defaults: None,
+            server_defaults: None,
+        }
+    }
+}
+
+#[async_trait]
+impl ModelCatalogPort for StaticCatalog {
+    async fn list_models(&self) -> Result<Vec<ModelSummary>, CatalogError> {
+        Ok(self
+            .0
+            .iter()
+            .enumerate()
+            .map(|(i, name)| Self::summary(u32::try_from(i).unwrap_or(0) + 1, name))
+            .collect())
+    }
+
+    async fn resolve_model(&self, name: &str) -> Result<Option<ModelSummary>, CatalogError> {
+        Ok(self
+            .0
+            .iter()
+            .position(|n| n == name)
+            .map(|i| Self::summary(u32::try_from(i).unwrap_or(0) + 1, name)))
+    }
+
+    async fn resolve_for_launch(
+        &self,
+        _name: &str,
+    ) -> Result<Option<ModelLaunchSpec>, CatalogError> {
+        Ok(None)
+    }
+}
+
 // ─── SettingsRepository mock ──────────────────────────────────────────────
 
 /// Returns default settings; save is a no-op.
@@ -76,6 +169,29 @@ pub struct MockSettingsRepo;
 impl SettingsRepository for MockSettingsRepo {
     async fn load(&self) -> Result<Settings, RepositoryError> {
         Ok(Settings::with_defaults())
+    }
+
+    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
+        Ok(())
+    }
+}
+
+/// Settings carrying one listed inference profile, so `/v1/models` emits
+/// `{model}:{name}` variant entries.
+pub struct ProfileSettingsRepo(pub &'static str);
+
+#[async_trait]
+impl SettingsRepository for ProfileSettingsRepo {
+    async fn load(&self) -> Result<Settings, RepositoryError> {
+        Ok(Settings {
+            inference_profiles: Some(vec![InferenceProfile {
+                name: self.0.to_string(),
+                description: None,
+                config: InferenceConfig::default(),
+                list_in_models: true,
+            }]),
+            ..Settings::with_defaults()
+        })
     }
 
     async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {

--- a/crates/gglib-proxy/tests/integration_pinned_models.rs
+++ b/crates/gglib-proxy/tests/integration_pinned_models.rs
@@ -1,0 +1,244 @@
+//! `/v1/models` and the dashboard on the pinned (`gglib serve`) path.
+//!
+//! Pinned mode refuses every model but one. These tests pin down the
+//! consequence for the catalog endpoint: it must advertise what the proxy
+//! will actually accept, and nothing else. A BYOK client that cannot switch
+//! models — VS Code Copilot being the motivating case — builds its picker
+//! from this list once, so an entry that can only come back as
+//! `PinnedModelMismatch` is worse than no entry at all.
+//!
+//! The pinned *guard* is tested in `gglib-runtime`; the mock here only
+//! reports pinning, so a failure means the catalog is wrong rather than the
+//! enforcement.
+
+mod fixtures;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort, SettingsRepository};
+use reqwest::Client;
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+use fixtures::common::{
+    MockSettingsRepo, NoopRuntime, PinnedRuntime, ProfileSettingsRepo, StaticCatalog,
+    make_mcp_service, make_orchestrator_deps,
+};
+
+const PINNED: &str = "qwen2.5";
+const FOREIGN: &str = "llama-3-8b";
+
+/// Spawn a proxy over the given runtime, catalog and settings.
+async fn spawn(
+    runtime: Arc<dyn ModelRuntimePort>,
+    catalog: Arc<dyn ModelCatalogPort>,
+    settings: Arc<dyn SettingsRepository>,
+) -> (String, CancellationToken) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let cancel = CancellationToken::new();
+    let proxy_cancel = cancel.clone();
+
+    tokio::spawn(async move {
+        gglib_proxy::serve(
+            listener,
+            4096,
+            runtime,
+            catalog,
+            make_mcp_service(),
+            make_orchestrator_deps(),
+            proxy_cancel,
+            settings,
+            None, // inference_override
+            false,
+            None,
+            gglib_proxy::slot_eviction::DiskBudget::Auto,
+            Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            &gglib_core::CorsConfig::LocalOnly,
+        )
+        .await
+        .ok();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (format!("http://{addr}"), cancel)
+}
+
+/// The `id` of every entry `/v1/models` advertised.
+async fn model_ids(base: &str) -> Vec<String> {
+    let resp = Client::new()
+        .get(format!("{base}/v1/models"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = resp.json().await.unwrap();
+    body["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|m| m["id"].as_str().map(str::to_owned))
+        .collect()
+}
+
+// ─── Catalog filtering ────────────────────────────────────────────────────
+
+/// The whole point: a pinned proxy must not advertise models it will refuse.
+#[tokio::test]
+async fn pinned_proxy_advertises_only_the_pinned_model() {
+    let (base, cancel) = spawn(
+        Arc::new(PinnedRuntime(PINNED)),
+        Arc::new(StaticCatalog::new(&[PINNED, FOREIGN, "mistral-7b"])),
+        Arc::new(MockSettingsRepo),
+    )
+    .await;
+
+    let ids = model_ids(&base).await;
+
+    assert!(ids.contains(&PINNED.to_owned()), "pinned model missing");
+    assert!(
+        !ids.iter().any(|id| id.starts_with(FOREIGN)),
+        "foreign model advertised on a pinned endpoint: {ids:?}"
+    );
+    assert!(
+        !ids.iter().any(|id| id.starts_with("mistral-7b")),
+        "foreign model advertised on a pinned endpoint: {ids:?}"
+    );
+
+    cancel.cancel();
+}
+
+/// Filtering must not leak into the ordinary proxy, whose entire job is to
+/// offer the catalog and swap on demand.
+#[tokio::test]
+async fn unpinned_proxy_advertises_the_whole_catalog() {
+    let (base, cancel) = spawn(
+        Arc::new(NoopRuntime),
+        Arc::new(StaticCatalog::new(&[PINNED, FOREIGN])),
+        Arc::new(MockSettingsRepo),
+    )
+    .await;
+
+    let ids = model_ids(&base).await;
+
+    assert!(
+        ids.contains(&PINNED.to_owned()),
+        "missing {PINNED}: {ids:?}"
+    );
+    assert!(
+        ids.contains(&FOREIGN.to_owned()),
+        "unpinned proxy dropped {FOREIGN}: {ids:?}"
+    );
+
+    cancel.cancel();
+}
+
+/// A profile changes the request body, never which model runs, so variants
+/// of the pinned model are servable and must survive the filter — while
+/// variants of a foreign model must not appear at all.
+#[tokio::test]
+async fn pinned_proxy_keeps_variants_of_the_pinned_model_only() {
+    let (base, cancel) = spawn(
+        Arc::new(PinnedRuntime(PINNED)),
+        Arc::new(StaticCatalog::new(&[PINNED, FOREIGN])),
+        Arc::new(ProfileSettingsRepo("coding")),
+    )
+    .await;
+
+    let ids = model_ids(&base).await;
+
+    assert!(
+        ids.contains(&format!("{PINNED}:coding")),
+        "pinned model's profile variant was filtered out: {ids:?}"
+    );
+    assert!(
+        !ids.contains(&format!("{FOREIGN}:coding")),
+        "foreign model's profile variant advertised: {ids:?}"
+    );
+
+    cancel.cancel();
+}
+
+/// Council runs dispatch to whatever model is loaded, which under pinning is
+/// the pinned model — so the virtuals stay servable and stay listed.
+#[tokio::test]
+async fn pinned_proxy_still_advertises_the_council_virtuals() {
+    let (base, cancel) = spawn(
+        Arc::new(PinnedRuntime(PINNED)),
+        Arc::new(StaticCatalog::new(&[PINNED, FOREIGN])),
+        Arc::new(MockSettingsRepo),
+    )
+    .await;
+
+    let ids = model_ids(&base).await;
+
+    for virtual_model in ["gglib-council", "gglib-council:interactive"] {
+        assert!(
+            ids.contains(&virtual_model.to_owned()),
+            "pinning dropped {virtual_model}, which it can still serve: {ids:?}"
+        );
+    }
+
+    cancel.cancel();
+}
+
+/// An empty catalog must not resurrect the filtered models — the pinned name
+/// is a filter, not a synthesized entry.
+#[tokio::test]
+async fn pinned_proxy_advertises_nothing_when_the_model_is_absent() {
+    let (base, cancel) = spawn(
+        Arc::new(PinnedRuntime(PINNED)),
+        Arc::new(StaticCatalog::new(&[FOREIGN])),
+        Arc::new(MockSettingsRepo),
+    )
+    .await;
+
+    let ids = model_ids(&base).await;
+
+    assert!(
+        !ids.contains(&FOREIGN.to_owned()),
+        "foreign model survived with the pinned model absent: {ids:?}"
+    );
+
+    cancel.cancel();
+}
+
+// ─── Dashboard ────────────────────────────────────────────────────────────
+
+/// `serve` runs the proxy stack, so it gets the dashboard — the observability
+/// gap that motivated epic #630. Asserts the contract clients read, not just
+/// a 200.
+#[tokio::test]
+async fn pinned_proxy_serves_the_dashboard() {
+    let (base, cancel) = spawn(
+        Arc::new(PinnedRuntime(PINNED)),
+        Arc::new(StaticCatalog::new(&[PINNED])),
+        Arc::new(MockSettingsRepo),
+    )
+    .await;
+
+    let resp = Client::new()
+        .get(format!("{base}/v1/proxy/status"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let snapshot: Value = resp.json().await.unwrap();
+    for field in [
+        "active_connections",
+        "slots",
+        "total_requests",
+        "upstream_health",
+    ] {
+        assert!(
+            snapshot.get(field).is_some(),
+            "dashboard snapshot missing {field}: {snapshot}"
+        );
+    }
+
+    cancel.cancel();
+}

--- a/crates/gglib-runtime/src/ports_impl/model_runtime.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_runtime.rs
@@ -110,6 +110,10 @@ impl ModelRuntimePort for RuntimePortImpl {
     async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
         self.mgr.stop_current().await
     }
+
+    fn pinned_model(&self) -> Option<&str> {
+        self.mgr.pinned_model()
+    }
 }
 
 #[cfg(test)]

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -426,6 +426,19 @@ impl ProcessManager {
         matches!(self.strategy, ProcessStrategy::SingleSwap(_))
     }
 
+    /// The single model this manager is pinned to, if any.
+    ///
+    /// `Some(name)` is `gglib serve`: every other model is refused rather
+    /// than swapped to. Only `SingleSwap` can be pinned — `Concurrent` serves
+    /// many models by design.
+    #[must_use]
+    pub fn pinned_model(&self) -> Option<&str> {
+        match &self.strategy {
+            ProcessStrategy::SingleSwap(state) => state.pinned_name(),
+            ProcessStrategy::Concurrent { .. } => None,
+        }
+    }
+
     /// Check if a model is currently loading (SingleSwap only).
     #[must_use]
     pub fn is_loading(&self) -> bool {
@@ -557,6 +570,37 @@ mod tests {
             matches!(err, ModelRuntimeError::ModelNotFound(_)),
             "unpinned manager must not reject on identity, got {err:?}"
         );
+    }
+
+    /// The read side of the guard: callers that want to avoid provoking a
+    /// mismatch — `/v1/models`, which should not advertise a model that can
+    /// only be refused — need the name without attempting a request.
+    #[test]
+    fn pinned_manager_reports_its_model() {
+        assert_eq!(pinned_manager().pinned_model(), Some("qwen2.5"));
+    }
+
+    /// Reporting must agree with admission: a manager that admits any model
+    /// must not name one, or callers would narrow what they offer for no
+    /// reason.
+    #[test]
+    fn single_swap_manager_reports_no_pinned_model() {
+        let manager = ProcessManager::new_single_swap(
+            9000,
+            "llama-server",
+            Arc::new(StubCatalog),
+            ServerConfigOptions::default(),
+            CacheRamSetting::Auto,
+        );
+
+        assert_eq!(manager.pinned_model(), None);
+    }
+
+    /// Concurrent serves many models by design and can never be pinned.
+    #[test]
+    fn concurrent_manager_reports_no_pinned_model() {
+        let manager = ProcessManager::new_concurrent(8080, 5, "llama-server");
+        assert_eq!(manager.pinned_model(), None);
     }
 
     #[tokio::test]

--- a/crates/gglib-runtime/src/process/swap_state.rs
+++ b/crates/gglib-runtime/src/process/swap_state.rs
@@ -120,6 +120,15 @@ impl SwapState {
         }
     }
 
+    /// The model this state is pinned to, if any.
+    ///
+    /// The read side of [`Self::check_pinned`]: callers that want to avoid
+    /// provoking a mismatch rather than handle one need to know the name up
+    /// front.
+    pub(super) fn pinned_name(&self) -> Option<&str> {
+        self.pinned.as_deref()
+    }
+
     /// Reject a request for any model other than the pinned one.
     ///
     /// Checked before the startup guard is consulted, so a foreign request

--- a/crates/gglib-runtime/src/proxy/README.md
+++ b/crates/gglib-runtime/src/proxy/README.md
@@ -22,10 +22,17 @@ is the only difference between them:
 | | `gglib proxy` | `gglib serve <model>` |
 |---|---|---|
 | `pinned` | `None` — auto-swap on request | `Some(PinnedModel)` — refuse others |
+| `/v1/models` | the whole catalog | the pinned model only |
 
 Everything else — the Axum layer, cache lifecycle, dashboard, SSE, MCP gateway,
 council wiring and shutdown — is shared verbatim. `serve` is a *mode* of the
 proxy, not a second stack.
+
+The catalog row follows from the first: a model the proxy would refuse should
+never be advertised, or a client that cannot switch models picks one and gets
+`PinnedModelMismatch` for something it was offered. Profile variants of the
+pinned model and the council virtuals are still listed — neither changes which
+model actually runs, so neither can trip the guard.
 
 <!-- module-docs:end -->
 


### PR DESCRIPTION
Closes #633. Phase 3 of epic #630 — the final phase.

Phase 2 put `gglib serve` and `gglib proxy` on one execution path. Phase 3 closes the contract around it: the two now parse identically, `/v1/models` advertises exactly what a pinned endpoint will accept, and both are guarded by tests that run in the existing CI job.

## Commits

Eight atomic commits, each compiling and passing the strict clippy gate on its own (verified with `git rebase --exec`).

| | |
|---|---|
| `refactor(cli)` | extract shared `CacheArgs` from the proxy command |
| `refactor(cli)` | flatten `SamplingArgs` into the proxy command |
| `feat(cli)` | give `gglib serve` the full cache flag set |
| `feat(core)` | expose the pinned model through `ModelRuntimePort` |
| `feat(proxy)` | filter `/v1/models` to the pinned model |
| `test(cli)` | pin serve/proxy flag parity |
| `feat(core)` | list `KvCacheType` values in `--help` |
| `docs` | record serve/proxy parity |

## Notable

**`serve` could not enable caching at all.** Not merely off by default — `GlobalDefaults::default()` left `cache_enabled` false with no flag able to set it, while the README already advertised caching as included. Now opt-in on both commands, one flag group, one behaviour.

**`/v1/models` filtering keeps more than "just the pinned model".** The rule applied is *advertise exactly what the endpoint will accept*. Foreign catalog models are filtered because they alone produce `PinnedModelMismatch`. Two kinds of entry survive:

- profile variants — a profile changes the request body, never which model runs;
- the council virtuals — `CouncilRunnerAdapter` dispatches to `current_model()`, i.e. whatever is loaded, which under pinning is the pinned model itself.

**Pinning reached the proxy via the port, not a `serve()` parameter.** `gglib-proxy` cannot depend on `gglib-runtime` (that cycle is why `CouncilRunnerPort` exists), `serve()` already takes fifteen positional arguments, and only the port reaches the live manager rather than startup-time config. Defaulted to `None` so every existing implementation adopts it unedited.

## Deviations from the issue text

Three, each deliberate:

- **The proposed test file and CI job would have been inert.** The root `Cargo.toml` has no `[package]` section, so root `tests/*.rs` are never compiled, and the proposed job ended in `|| echo "::warning::…"` — it could never fail. Tests instead go in `crates/gglib-proxy/tests/` and `crates/gglib-cli/tests/`, need no model file, and are already covered by CI's existing per-crate runs. No `ci.yml` change.
- **`#[arg(value_enum)]` on `KvCacheType` is not possible.** It lives in `gglib-core`, which has no clap dependency and should not gain one for a help string. A `PossibleValuesParser` built from a new `KvCacheType::ALL` gets `[possible values: …]` into `--help` and shell completions without crossing the boundary — and collapses a list that was written out three times.
- **§3a was already done.** Phase 2 rewrote the `Serve` doc comment; only `--port` needed the dashboard URLs.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace` — 69 suites, 0 failures; plus `--doc`
- `scripts/check_boundaries.sh` (strict README + `include_str!` parity) and the three enforcement scripts — pass
- The filtering tests were confirmed to **fail** without the filter: the three filtering assertions break while the unpinned, council and dashboard cases stay green, so they test the change and not the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)