### PR TITLE
fix(cli): read HF_TOKEN for model update requests

### DIFF
--- a/crates/gglib-cli/src/handlers/model/download/update_model.rs
+++ b/crates/gglib-cli/src/handlers/model/download/update_model.rs
@@ -58,7 +58,7 @@ pub async fn execute(ctx: &CliContext, identifier: &str) -> Result<()> {
         repo_id: hf_repo,
         quantization,
         models_dir,
-        token: None, // TODO: Get from config
+        token: std::env::var("HF_TOKEN").ok(),
     };
 
     // Execute update


### PR DESCRIPTION
## Summary
- `gglib model update <id>` built its `CliUpdateRequest` with `token: None` (hardcoded, `// TODO: Get from config`), so updating a model from a gated/private HuggingFace repo failed auth even though the initial `download` path already threads a real token through the same HF client.
- Reads `HF_TOKEN` from the environment inline in `update_model.rs`, mirroring the existing `std::env::var("HF_TOKEN").ok()` convention in `bootstrap.rs:129`.
- Intentionally does **not** add a token field to `CliContext` — that struct is being touched by an unrelated in-flight PR (#642), and the inline env read is simpler anyway.

## Test plan
- [x] `cargo check --workspace --all-targets` — clean
- No new tests added: `update_model::execute` isn't unit-testable in isolation (needs DB/resolver/network), and there's no existing test scaffolding at this layer or in `gglib-download::cli_exec` to extend for a one-line change.

Fixes #647