### PR TITLE
Delete dead legacy_path/legacyPath plumbing

### DIFF
--- a/crates/gglib-app-services/src/error.rs
+++ b/crates/gglib-app-services/src/error.rs
@@ -35,8 +35,6 @@ pub enum GuiError {
     LlamaServerNotInstalled {
         /// The path where llama-server was expected
         expected_path: String,
-        /// Optional legacy path where an old installation was detected
-        legacy_path: Option<String>,
         /// Suggested command to fix the issue
         suggested_command: String,
         /// Reason for the failure (NotFound, NotExecutable, PermissionDenied)
@@ -56,7 +54,6 @@ impl fmt::Display for GuiError {
             Self::Unavailable(msg) => write!(f, "service unavailable: {msg}"),
             Self::LlamaServerNotInstalled {
                 expected_path,
-                legacy_path,
                 suggested_command,
                 reason,
             } => {
@@ -64,11 +61,7 @@ impl fmt::Display for GuiError {
                     f,
                     "llama-server not installed: {} at {}\nRun: {}",
                     reason, expected_path, suggested_command
-                )?;
-                if let Some(legacy) = legacy_path {
-                    write!(f, "\nFound older installation at: {}", legacy)?;
-                }
-                Ok(())
+                )
             }
             Self::Internal(msg) => write!(f, "internal error: {msg}"),
         }

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -584,7 +584,6 @@ fn map_runtime_error(err: &ModelRuntimeError) -> GuiError {
             || GuiError::Internal(format!("Failed to start server: {err}")),
             |reason| GuiError::LlamaServerNotInstalled {
                 expected_path: "~/.local/share/gglib/.llama/bin/llama-server".to_string(),
-                legacy_path: None,
                 suggested_command: "gglib config llama install".to_string(),
                 reason: reason.to_string(),
             },

--- a/crates/gglib-axum/src/error.rs
+++ b/crates/gglib-axum/src/error.rs
@@ -35,7 +35,6 @@ pub enum HttpError {
     LlamaServerNotInstalled {
         message: String,
         expected_path: String,
-        legacy_path: Option<String>,
         suggested_command: String,
         reason: String,
     },
@@ -74,13 +73,11 @@ impl IntoResponse for HttpError {
             HttpError::LlamaServerNotInstalled {
                 message,
                 expected_path,
-                legacy_path,
                 suggested_command,
                 reason,
             } => {
                 let metadata_json = serde_json::json!({
                     "expectedPath": expected_path,
-                    "legacyPath": legacy_path,
                     "suggestedCommand": suggested_command,
                     "reason": reason,
                 });
@@ -164,7 +161,6 @@ impl From<GuiError> for HttpError {
             GuiError::Unavailable(msg) => HttpError::ServiceUnavailable(msg),
             GuiError::LlamaServerNotInstalled {
                 expected_path,
-                legacy_path,
                 suggested_command,
                 reason,
             } => HttpError::LlamaServerNotInstalled {
@@ -173,7 +169,6 @@ impl From<GuiError> for HttpError {
                     reason, suggested_command
                 ),
                 expected_path,
-                legacy_path,
                 suggested_command,
                 reason,
             },

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -104,16 +104,11 @@ pub fn build_and_spawn(
         .map_err(|e| {
             // Convert LlamaServerError to anyhow with full context
             match e {
-                LlamaServerError::NotFound { path, legacy_path } => {
-                    let mut msg = format!("llama-server binary not found at: {}", path.display());
-                    if let Some(legacy) = legacy_path {
-                        msg.push_str(&format!(
-                            "\n\nFound an older installation at: {}\nConsider moving or symlinking it to the new location.",
-                            legacy.display()
-                        ));
-                    }
-                    msg.push_str("\n\nPlease install llama.cpp by running:\n  gglib config llama install");
-                    anyhow::anyhow!("{}", msg)
+                LlamaServerError::NotFound { path } => {
+                    anyhow::anyhow!(
+                        "llama-server binary not found at: {}\n\nPlease install llama.cpp by running:\n  gglib config llama install",
+                        path.display()
+                    )
                 }
                 LlamaServerError::NotExecutable { path } => {
                     anyhow::anyhow!(

--- a/crates/gglib-runtime/src/llama/server_availability.rs
+++ b/crates/gglib-runtime/src/llama/server_availability.rs
@@ -1,7 +1,7 @@
 //! llama-server binary availability checking and path resolution.
 //!
 //! This module provides centralized logic for resolving the llama-server binary path
-//! with support for multiple resolution strategies and legacy path migration.
+//! with support for multiple resolution strategies.
 
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -16,8 +16,6 @@ pub enum LlamaServerError {
     NotFound {
         /// The path where the binary was expected
         path: PathBuf,
-        /// Optional legacy path where an old installation was detected
-        legacy_path: Option<PathBuf>,
     },
 
     /// The binary exists but is not executable (permission denied).
@@ -51,7 +49,6 @@ pub type LlamaServerResult<T> = Result<T, LlamaServerError>;
 /// This function applies the following precedence order:
 /// 1. `GGLIB_LLAMA_SERVER_PATH` environment variable (explicit override)
 /// 2. Default path from `gglib_core::paths::llama_server_path()`
-/// 3. Legacy paths (pre-refactor locations) with migration hints
 ///
 /// After resolving a candidate path, this function validates that:
 /// - The file exists
@@ -84,22 +81,7 @@ pub fn resolve_llama_server() -> LlamaServerResult<PathBuf> {
         .map_err(|e| LlamaServerError::PathResolution(e.to_string()))?;
 
     // Check if default path works
-    match validate_binary(&default_path) {
-        Ok(path) => Ok(path),
-        Err(default_err) => {
-            // Strategy 3: Probe legacy paths for migration hints
-            if let Some(legacy_path) = probe_legacy_paths() {
-                // Found a legacy installation - return error with migration hint
-                Err(LlamaServerError::NotFound {
-                    path: default_path,
-                    legacy_path: Some(legacy_path),
-                })
-            } else {
-                // No legacy path found - return original validation error
-                Err(default_err)
-            }
-        }
-    }
+    validate_binary(&default_path)
 }
 
 /// Validate that a binary exists and is executable.
@@ -108,7 +90,6 @@ fn validate_binary(path: &Path) -> LlamaServerResult<PathBuf> {
     if !path.exists() {
         return Err(LlamaServerError::NotFound {
             path: path.to_path_buf(),
-            legacy_path: None,
         });
     }
 
@@ -152,24 +133,6 @@ fn validate_binary(path: &Path) -> LlamaServerResult<PathBuf> {
     Ok(path.to_path_buf())
 }
 
-/// Probe for legacy llama-server installation paths.
-///
-/// This function checks common locations where llama-server may have been
-/// installed in previous versions of gglib, before recent path refactors.
-///
-/// Returns `Some(PathBuf)` if a valid legacy binary is found, `None` otherwise.
-fn probe_legacy_paths() -> Option<PathBuf> {
-    // Legacy path candidates (add more as needed based on historical locations)
-    let legacy_candidates: Vec<PathBuf> = vec![
-        // Example legacy paths - adjust based on actual refactor history
-        // These would be paths used before PRs #226-227
-    ];
-
-    legacy_candidates
-        .into_iter()
-        .find(|candidate| candidate.exists() && validate_binary(candidate).is_ok())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,12 +142,5 @@ mod tests {
         let nonexistent = PathBuf::from("/nonexistent/path/to/llama-server");
         let result = validate_binary(&nonexistent);
         assert!(matches!(result, Err(LlamaServerError::NotFound { .. })));
-    }
-
-    #[test]
-    fn test_legacy_path_probe_returns_none_for_empty_candidates() {
-        // With no legacy candidates defined, should return None
-        let result = probe_legacy_paths();
-        assert_eq!(result, None);
     }
 }

--- a/crates/gglib-runtime/tests/llama_server_availability_tests.rs
+++ b/crates/gglib-runtime/tests/llama_server_availability_tests.rs
@@ -58,37 +58,6 @@ fn test_error_messages_include_install_instructions() {
     }
 }
 
-#[test]
-fn test_legacy_path_detection_logic() {
-    // This test verifies that probe_legacy_paths() returns None
-    // when no legacy candidates exist (current implementation)
-    //
-    // If legacy paths are added in the future, this test should be updated
-    // to verify proper detection and migration hints
-
-    let result = resolve_llama_server();
-
-    // Should fail with NotFound or PathResolution, not with legacy path hint
-    // (since no legacy paths are configured yet)
-    if let Err(err) = result {
-        match err {
-            LlamaServerError::NotFound { legacy_path, .. } => {
-                // Legacy path should be None in current implementation
-                assert!(
-                    legacy_path.is_none(),
-                    "No legacy paths should be detected yet"
-                );
-            }
-            LlamaServerError::PathResolution(_) => {
-                // Also acceptable - path couldn't be resolved
-            }
-            _ => {
-                // Other errors are fine too in test environment
-            }
-        }
-    }
-}
-
 /// Integration test: validate full error propagation chain
 #[test]
 fn test_error_has_all_required_fields() {
@@ -96,11 +65,9 @@ fn test_error_has_all_required_fields() {
 
     if let Err(err) = result {
         match err {
-            LlamaServerError::NotFound { path, legacy_path } => {
+            LlamaServerError::NotFound { path } => {
                 // Path should be populated
                 assert!(!path.as_os_str().is_empty());
-                // Legacy path should be None or Some depending on detection
-                let _ = legacy_path; // Just verify it exists
             }
             LlamaServerError::NotExecutable { path } => {
                 assert!(!path.as_os_str().is_empty());

--- a/src/components/LlamaInstallModal.tsx
+++ b/src/components/LlamaInstallModal.tsx
@@ -20,7 +20,6 @@ interface LlamaInstallModalProps {
   // New props for error-triggered mode
   metadata?: {
     expectedPath: string;
-    legacyPath?: string;
     suggestedCommand: string;
     reason: string;
   };
@@ -149,13 +148,6 @@ export const LlamaInstallModal: FC<LlamaInstallModalProps> = ({
       <div className="flex flex-col gap-2">
         <p className="m-0 text-text-secondary leading-normal">The llama-server binary was not found at:</p>
         <code className="block bg-background-tertiary border border-border rounded-md py-2 px-3 font-mono text-[0.9rem] text-text break-all">{metadata?.expectedPath}</code>
-        {metadata?.legacyPath && (
-          <div className="p-3 rounded-lg border border-border bg-background-secondary flex flex-col gap-[0.35rem]">
-            <p className="m-0 font-semibold text-text">Older installation detected</p>
-            <code className="block bg-background-tertiary border border-border rounded-md py-2 px-3 font-mono text-[0.9rem] text-text break-all">{metadata.legacyPath}</code>
-            <p className="m-0 text-[0.9rem] text-text-secondary">Move or symlink it to the expected path to reuse.</p>
-          </div>
-        )}
       </div>
 
       {error ? <div className="bg-danger-subtle border border-danger-border rounded-lg py-3 px-4 text-danger text-[0.95rem]">{error}</div> : null}

--- a/src/services/transport/errors.ts
+++ b/src/services/transport/errors.ts
@@ -26,7 +26,6 @@ export type TransportErrorCode =
  */
 export interface LlamaServerNotInstalledMetadata {
   expectedPath: string;
-  legacyPath?: string;
   suggestedCommand: string;
   reason: string;
 }
@@ -79,7 +78,6 @@ export class TransportError extends Error {
     
     return {
       expectedPath: (details.expectedPath || details.expected_path || '') as string,
-      legacyPath: (details.legacyPath || details.legacy_path) as string | undefined,
       suggestedCommand: (details.suggestedCommand || details.suggested_command || 'gglib config llama install') as string,
       reason: (details.reason || 'not found') as string,
     };


### PR DESCRIPTION
## Summary

Closes #643.

`legacy_path` / `legacyPath` was threaded through 5 layers (Rust error types, HTTP JSON, TypeScript, a rendered React block), sourced from `probe_legacy_paths()` in `server_availability.rs`, which iterated an empty `Vec` and therefore always returned `None`. Every downstream branch depending on `Some(legacy_path)` was unreachable dead code, including a JSX block in `LlamaInstallModal.tsx` that had never had anything to render.

Deleted bottom-up, per CONTRIBUTING.md's no-backwards-compatibility principle — straight deletion, no deprecation shim:

- `crates/gglib-runtime/src/llama/server_availability.rs` — removed `probe_legacy_paths()`, the `legacy_path` field on `LlamaServerError::NotFound`, and the now-dead test
- `crates/gglib-runtime/src/command.rs` — dropped the `legacy_path` formatting branch
- `crates/gglib-runtime/tests/llama_server_availability_tests.rs` — removed the test asserting `legacy_path.is_none()`
- `crates/gglib-app-services/src/error.rs` / `servers.rs` — removed `legacy_path` from `GuiError::LlamaServerNotInstalled`
- `crates/gglib-axum/src/error.rs` — removed `legacy_path` from `HttpError::LlamaServerNotInstalled` and the `"legacyPath"` JSON key
- `src/services/transport/errors.ts` — removed `legacyPath` from `LlamaServerNotInstalledMetadata` and its parsing
- `src/components/LlamaInstallModal.tsx` — removed the dead `metadata?.legacyPath` conditional block

Swept `gglib-tauri` and `gglib-cli` for GUI parity — neither references this field (Tauri has no `LlamaServerNotInstalled` mapping at all, since this feature is served over HTTP per the GUI Parity principle). Swept all `*.md` docs — no references found.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy -p gglib-runtime -p gglib-app-services -p gglib-axum --all-targets` — clean
- [x] `cargo test -p gglib-runtime -p gglib-app-services -p gglib-axum` — all passing
- [x] `npm run build` (tsc + vite) — clean
- [x] Repo-wide grep for `legacy_path`/`legacyPath`/`probe_legacy_paths` — no remaining references