### PR TITLE
refactor(proxy): collapse the 6 forward_chat_completion call sites

### DIFF
--- a/crates/gglib-proxy/src/cache_lifecycle.rs
+++ b/crates/gglib-proxy/src/cache_lifecycle.rs
@@ -285,6 +285,27 @@ pub async fn prepare_streaming_cycle(
     Ok((permit, sanitized, restore_result))
 }
 
+/// Resolve the `(permit, config, session_id)` triple [`crate::forward::ForwardRequest::send`]
+/// needs for a streaming forward attempt — either a request's primary
+/// attempt, or a fresh disk-cache retry after `UpstreamDead`. Fails open:
+/// any [`prepare_streaming_cycle`] error degrades to `(None, None, None)` —
+/// the caller proceeds without disk cache participation for this cycle.
+pub async fn resolve_cache_triple(
+    cfg: &StreamConfig,
+    slot_gate: Arc<Semaphore>,
+    session_id: &str,
+) -> (
+    Option<OwnedSemaphorePermit>,
+    Option<StreamConfig>,
+    Option<String>,
+) {
+    let sid = session_id.to_owned();
+    match prepare_streaming_cycle(cfg, slot_gate, &sid).await {
+        Ok((permit, _sanitized, _restore_result)) => (Some(permit), Some(cfg.clone()), Some(sid)),
+        Err(_) => (None, None, None), // fail-open — proceed without disk cache for this cycle
+    }
+}
+
 /// Clear slot files for a session (or all sessions if None).
 ///
 /// Deliberately does NOT acquire the semaphore (Design A) — clears are instant

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -290,76 +290,119 @@ fn shape_request_body(
     }
 }
 
+/// Bundles the arguments to [`forward_chat_completion`] that stay constant
+/// across the cache-branching in `chat_completions` — only the trailing
+/// `(permit, config, session_id)` triple passed to [`Self::send`] varies
+/// between the non-streaming/streaming/fail-open/cache-disabled branches, and
+/// between a request's primary attempt and its post-`UpstreamDead` retry.
+pub(crate) struct ForwardRequest<'a> {
+    /// HTTP client to use for the request.
+    pub client: &'a Client,
+    /// Full URL to the llama-server endpoint.
+    pub upstream_url: &'a str,
+    /// Original request headers.
+    pub headers: &'a HeaderMap,
+    /// Request body bytes.
+    pub body: Bytes,
+    /// Whether this is a streaming request (affects response handling).
+    pub is_streaming: bool,
+    /// Model name to advertise to the client (used in the SSE envelope).
+    pub model_name: &'a str,
+    /// Live context size (tokens) the target llama-server was launched
+    /// with. Converted to a character budget (`× CHARS_PER_TOKEN_APPROX`)
+    /// for the history-truncation hard-abort; floored at the historical
+    /// default inside [`truncate_history`].
+    pub effective_ctx: u64,
+    /// Catalog port used to resolve capabilities and `format:*` tags.
+    pub catalog: Arc<dyn ModelCatalogPort>,
+    /// Metrics store for recording per-request context snapshots.
+    pub metrics: Arc<ContextMetricsStore>,
+    /// The profile and global sampling layers to resolve beneath the
+    /// client's own request parameters.
+    pub sampling: SamplingLayers,
+    /// RAII dashboard-registry guard for this request. Moved into the
+    /// spawned streaming task for the streaming path (so it lives exactly
+    /// as long as that task); held for the duration of
+    /// [`forward_chat_completion`] for the non-streaming path. Dropping it
+    /// (by any path — completion, early return, or panic) unregisters the
+    /// connection from the dashboard.
+    pub connection: ConnectionGuard,
+    /// Consecutive-failure watchdog. The streaming task records each
+    /// terminal outcome (empty stream or first-byte timeout is a strike;
+    /// any visible output resets it) so the handler can recycle a
+    /// degraded-but-`/health`-green upstream before the next request.
+    pub upstream_health: Arc<UpstreamHealth>,
+    /// Per-model chars-per-token calibration store.
+    pub calibration: Arc<TokenCalibration>,
+    /// Session id used to look up/freeze this session's chars-per-token
+    /// snapshot (see
+    /// [`crate::token_calibration::TokenCalibration::session_chars_per_token`]);
+    /// `None` when no session id was resolved, which falls back to the live
+    /// per-model ratio exactly as before. Distinct from the `session_id`
+    /// parameter of [`Self::send`]: that one is only populated when disk
+    /// KV-slot caching is enabled, but this budget-stability fix must work
+    /// even when it's off (e.g. for hybrid/sliding-window-attention models,
+    /// where disk caching is disabled but the host-RAM prompt cache — the
+    /// thing this fix protects — still applies).
+    pub calibration_session_id: Option<&'a str>,
+    /// Cache-hit telemetry sink, fed from both the streaming and
+    /// non-streaming response paths.
+    pub cache_metrics: Arc<CacheMetricsStore>,
+}
+
+impl ForwardRequest<'_> {
+    /// Forward this request to the upstream llama-server, participating in
+    /// the disk KV cache according to `(permit, config, session_id)`.
+    ///
+    /// * `permit` - KV cache semaphore permit (streaming path only), moved
+    ///   into the spawned task and held for its entire lifetime. `None`
+    ///   when the KV cache is disabled.
+    /// * `config` - KV cache lifecycle configuration (streaming path only).
+    ///   `None` when the KV cache is disabled.
+    /// * `session_id` - Session identifier used to key the KV cache save
+    ///   (streaming path only). `None` when the KV cache is disabled.
+    ///
+    /// Returns the response from llama-server, with the streaming SSE body
+    /// re-emitted through the universal normalization pipeline when
+    /// `is_streaming` is true.
+    pub(crate) async fn send(
+        self,
+        permit: Option<tokio::sync::OwnedSemaphorePermit>,
+        config: Option<crate::cache_lifecycle::StreamConfig>,
+        session_id: Option<String>,
+    ) -> Result<Response, ForwardError> {
+        forward_chat_completion(self, permit, config, session_id).await
+    }
+}
+
 /// Forward a chat completion request to the upstream llama-server.
 ///
-/// # Arguments
-///
-/// * `client` - HTTP client to use for the request
-/// * `upstream_url` - Full URL to the llama-server endpoint
-/// * `headers` - Original request headers
-/// * `body` - Request body bytes
-/// * `is_streaming` - Whether this is a streaming request (affects response handling)
-/// * `model_name` - Model name to advertise to the client (used in SSE envelope)
-/// * `effective_ctx` - Live context size (tokens) the target llama-server
-///   was launched with. Converted to a character budget
-///   (`× CHARS_PER_TOKEN_APPROX`) for the history-truncation hard-abort;
-///   floored at the historical default inside [`truncate_history`].
-/// * `catalog` - Catalog port used to resolve capabilities and `format:*` tags
-/// * `metrics` - Metrics store for recording per-request context snapshots
-/// * `sampling` - The profile and global sampling layers to resolve beneath
-///   the client's own request parameters
-/// * `connection` - RAII dashboard-registry guard for this request. Moved
-///   into the spawned streaming task for the streaming path (so it lives
-///   exactly as long as that task); held for the duration of this function
-///   for the non-streaming path. Dropping it (by any path — completion,
-///   early return, or panic) unregisters the connection from the dashboard.
-/// * `upstream_health` - Consecutive-failure watchdog. The streaming task
-///   records each terminal outcome (empty stream or first-byte timeout is a
-///   strike; any visible output resets it) so the handler can recycle a
-///   degraded-but-`/health`-green upstream before the next request.
-/// * `permit` - KV cache semaphore permit (streaming path only), moved into
-///   the spawned task and held for its entire lifetime. `None` when the KV
-///   cache is disabled.
-/// * `config` - KV cache lifecycle configuration (streaming path only).
-///   `None` when the KV cache is disabled.
-/// * `session_id` - Session identifier used to key the KV cache save
-///   (streaming path only). `None` when the KV cache is disabled.
-/// * `calibration_session_id` - Session id used to look up/freeze this
-///   session's chars-per-token snapshot (see
-///   [`crate::token_calibration::TokenCalibration::session_chars_per_token`]);
-///   `None` when no session id was resolved, which falls back to the live
-///   per-model ratio exactly as before. Distinct from `session_id` above:
-///   that one is only populated when disk KV-slot caching is enabled, but
-///   this budget-stability fix must work even when it's off (e.g. for
-///   hybrid/sliding-window-attention models, where disk caching is disabled
-///   but the host-RAM prompt cache — the thing this fix protects — still
-///   applies).
-///
-/// # Returns
-///
-/// The response from llama-server, with the streaming SSE body re-emitted
-/// through the universal normalization pipeline when `is_streaming` is true.
-#[allow(clippy::too_many_arguments)]
+/// See [`ForwardRequest`] for what `req`'s fields mean, and
+/// [`ForwardRequest::send`] (its sole caller) for the trailing cache triple.
 pub(crate) async fn forward_chat_completion(
-    client: &Client,
-    upstream_url: &str,
-    headers: &HeaderMap,
-    body: Bytes,
-    is_streaming: bool,
-    model_name: &str,
-    effective_ctx: u64,
-    catalog: Arc<dyn ModelCatalogPort>,
-    metrics: Arc<ContextMetricsStore>,
-    sampling: SamplingLayers,
-    connection: ConnectionGuard,
-    upstream_health: Arc<UpstreamHealth>,
-    calibration: Arc<TokenCalibration>,
-    calibration_session_id: Option<&str>,
-    cache_metrics: Arc<CacheMetricsStore>,
+    req: ForwardRequest<'_>,
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
     config: Option<crate::cache_lifecycle::StreamConfig>,
     session_id: Option<String>,
 ) -> Result<Response, ForwardError> {
+    let ForwardRequest {
+        client,
+        upstream_url,
+        headers,
+        body,
+        is_streaming,
+        model_name,
+        effective_ctx,
+        catalog,
+        metrics,
+        sampling,
+        connection,
+        upstream_health,
+        calibration,
+        calibration_session_id,
+        cache_metrics,
+    } = req;
+
     debug!("Forwarding to {upstream_url}, streaming={is_streaming}");
 
     // Single catalog lookup — yields both capabilities (request preprocessing)

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -30,11 +30,11 @@ use gglib_core::ports::{
 use gglib_core::request_pipeline::SamplingLayers;
 use gglib_mcp::McpService;
 
-use crate::cache_lifecycle::{StreamConfig, clear_cache, run_with_cache};
+use crate::cache_lifecycle::{StreamConfig, clear_cache, resolve_cache_triple, run_with_cache};
 use crate::connections::ActiveConnectionsRegistry;
 use crate::council_proxy::{CouncilDeps, VIRTUAL_MODELS, handle_virtual_model, virtual_model_info};
 use crate::dashboard::{CacheStatus, CacheStatusCache, DashboardState, spawn_dashboard_publisher};
-use crate::forward::{ForwardError, forward_chat_completion};
+use crate::forward::{ForwardError, ForwardRequest};
 use crate::mcp::handlers::{delete_mcp, get_mcp, post_mcp};
 use crate::mcp::session::SessionManager;
 use crate::metrics::ContextMetricsStore;
@@ -101,6 +101,25 @@ pub(crate) struct AppState {
     /// when the same model+session is already hot.
     last_loaded_session:
         Arc<tokio::sync::RwLock<Option<crate::cache_lifecycle::LastLoadedSession>>>,
+}
+
+impl AppState {
+    /// Build a [`StreamConfig`] for `base_url`/`model_id`, sourced from this
+    /// state's cache-lifecycle fields. Returns `None` when `slot_dir` isn't
+    /// configured — the one condition under which a `StreamConfig` cannot be
+    /// built, since it holds `slot_dir` as an owned (not `Option`) `PathBuf`.
+    fn build_stream_config(&self, base_url: String, model_id: u32) -> Option<StreamConfig> {
+        self.slot_dir.as_ref().map(|dir| StreamConfig {
+            client: self.client.clone(),
+            base_url,
+            slot_dir: dir.clone(),
+            model_id,
+            clear_all_pending: self.clear_all_pending.clone(),
+            per_session_cleared: self.per_session_cleared.clone(),
+            server_start_time: self.server_start_time.clone(),
+            last_loaded_session: self.last_loaded_session.clone(),
+        })
+    }
 }
 
 /// Start the proxy server with a pre-bound listener.
@@ -506,23 +525,15 @@ async fn handle_proxy_cache_clear(
 
     // ── Disk slot layer ───────────────────────────────────────────────────
     let disk = if state.cache_enabled {
-        let Some(slot_dir) = state.slot_dir.clone() else {
+        // base_url is unused by clear_cache; model_id 0 is a sentinel — it only
+        // touches flags and hot-cache invalidation, not any specific model's slots.
+        let Some(config) = state.build_stream_config(String::new(), 0) else {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({
                     "error": "slot_dir not configured"
                 })),
             );
-        };
-        let config = StreamConfig {
-            client: state.client.clone(),
-            base_url: String::new(), // Not used by clear_cache
-            slot_dir,
-            model_id: 0, // Sentinel — clear_cache only uses flags and hot-cache invalidation
-            clear_all_pending: state.clear_all_pending.clone(),
-            per_session_cleared: state.per_session_cleared.clone(),
-            server_start_time: state.server_start_time.clone(),
-            last_loaded_session: state.last_loaded_session.clone(),
         };
         match clear_cache(&config, session_id.as_deref()).await {
             Ok(()) => {
@@ -838,160 +849,57 @@ async fn chat_completions(
     // takes every disk save/restore call out of the request path; the
     // host-RAM cache handles conversation switching by itself.
     let stream_config = if state.cache_enabled && target.slot_restore_supported {
-        state.slot_dir.as_ref().map(|dir| StreamConfig {
-            client: state.client.clone(),
-            base_url: target.base_url.clone(),
-            slot_dir: dir.clone(),
-            model_id: target.model_id,
-            clear_all_pending: state.clear_all_pending.clone(),
-            per_session_cleared: state.per_session_cleared.clone(),
-            server_start_time: state.server_start_time.clone(),
-            last_loaded_session: state.last_loaded_session.clone(),
-        })
+        state.build_stream_config(target.base_url.clone(), target.model_id)
     } else {
         None
     };
 
-    // Forward the request, optionally wrapped in cache lifecycle
-    let response = if state.cache_enabled {
-        if let (Some(sid), Some(cfg)) = (&sanitized_session_id, &stream_config) {
+    // Everything forward_chat_completion needs that doesn't vary across the
+    // cache-branching below — see `ForwardRequest` docs.
+    let req = ForwardRequest {
+        client: &state.client,
+        upstream_url: &upstream_url,
+        headers: &headers,
+        body,
+        is_streaming,
+        model_name: &model_name,
+        effective_ctx: target.effective_ctx,
+        catalog: state.catalog_port.clone(),
+        metrics: state.dashboard.metrics.clone(),
+        sampling,
+        connection,
+        upstream_health: state.upstream_health.clone(),
+        calibration: state.calibration.clone(),
+        calibration_session_id: sanitized_session_id.as_deref(),
+        cache_metrics: state.dashboard.cache_metrics.clone(),
+    };
+
+    // Forward the request, optionally wrapped in cache lifecycle. `Some(cfg)`
+    // in `stream_config` already implies `state.cache_enabled` (see its
+    // construction just above), so matching on `(session_id, stream_config)`
+    // alone — without a redundant outer `cache_enabled` check — covers every
+    // case: cache disabled, cache enabled but no session id/config, and
+    // cache enabled with both all fall into the same "no triple" arm below.
+    let response = match (&sanitized_session_id, &stream_config) {
+        (Some(sid), Some(cfg)) => {
             if !is_streaming {
                 // Non-streaming with cache: wrap in run_with_cache (fail-open internally)
-                let (resp, _restore_result) = run_with_cache(cfg, &state.slot_gate, sid, || async {
-                    forward_chat_completion(
-                        &state.client,
-                        &upstream_url,
-                        &headers,
-                        body,
-                        is_streaming,
-                        &model_name,
-                        target.effective_ctx,
-                        state.catalog_port.clone(),
-                        state.dashboard.metrics.clone(),
-                        sampling,
-                        connection,
-                        state.upstream_health.clone(),
-                        state.calibration.clone(),
-                        sanitized_session_id.as_deref(),
-                        state.dashboard.cache_metrics.clone(),
-                        None,
-                        None,
-                        None,
-                    )
-                    .await
-                })
-                .await
-                .expect(
-                    "run_with_cache only returns Err on sanitization failure, which is already checked",
-                );
+                let (resp, _restore_result) =
+                    run_with_cache(cfg, &state.slot_gate, sid, || req.send(None, None, None))
+                        .await
+                        .expect(
+                        "run_with_cache only returns Err on sanitization failure, which is already checked",
+                    );
                 resp
             } else {
                 // Streaming with cache: use prepare_streaming_cycle + sse_stream::spawn_and_return
-                let sid = sid.clone();
-                let cfg = cfg.clone();
-                match crate::cache_lifecycle::prepare_streaming_cycle(
-                    &cfg,
-                    state.slot_gate.clone(),
-                    &sid,
-                )
-                .await
-                {
-                    Ok((permit, _sanitized, _restore_result)) => {
-                        forward_chat_completion(
-                            &state.client,
-                            &upstream_url,
-                            &headers,
-                            body,
-                            is_streaming,
-                            &model_name,
-                            target.effective_ctx,
-                            state.catalog_port.clone(),
-                            state.dashboard.metrics.clone(),
-                            sampling,
-                            connection,
-                            state.upstream_health.clone(),
-                            state.calibration.clone(),
-                            sanitized_session_id.as_deref(),
-                            state.dashboard.cache_metrics.clone(),
-                            Some(permit),
-                            Some(cfg),
-                            Some(sid),
-                        )
-                        .await
-                    }
-                    Err(_) => {
-                        // Fail-open: proceed without cache for streaming too
-                        forward_chat_completion(
-                            &state.client,
-                            &upstream_url,
-                            &headers,
-                            body,
-                            is_streaming,
-                            &model_name,
-                            target.effective_ctx,
-                            state.catalog_port.clone(),
-                            state.dashboard.metrics.clone(),
-                            sampling,
-                            connection,
-                            state.upstream_health.clone(),
-                            state.calibration.clone(),
-                            sanitized_session_id.as_deref(),
-                            state.dashboard.cache_metrics.clone(),
-                            None,
-                            None,
-                            None,
-                        )
-                        .await
-                    }
-                }
+                let (permit, cfg, sid) =
+                    resolve_cache_triple(cfg, state.slot_gate.clone(), sid).await;
+                req.send(permit, cfg, sid).await
             }
-        } else {
-            // Cache enabled but no session ID or config: direct call
-            forward_chat_completion(
-                &state.client,
-                &upstream_url,
-                &headers,
-                body,
-                is_streaming,
-                &model_name,
-                target.effective_ctx,
-                state.catalog_port.clone(),
-                state.dashboard.metrics.clone(),
-                sampling,
-                connection,
-                state.upstream_health.clone(),
-                state.calibration.clone(),
-                sanitized_session_id.as_deref(),
-                state.dashboard.cache_metrics.clone(),
-                None,
-                None,
-                None,
-            )
-            .await
         }
-    } else {
-        // Cache disabled: direct call
-        forward_chat_completion(
-            &state.client,
-            &upstream_url,
-            &headers,
-            body,
-            is_streaming,
-            &model_name,
-            target.effective_ctx,
-            state.catalog_port.clone(),
-            state.dashboard.metrics.clone(),
-            sampling,
-            connection,
-            state.upstream_health.clone(),
-            state.calibration.clone(),
-            sanitized_session_id.as_deref(),
-            state.dashboard.cache_metrics.clone(),
-            None,
-            None,
-            None,
-        )
-        .await
+        // Cache disabled, or cache enabled but no session id/config: direct call
+        _ => req.send(None, None, None).await,
     };
 
     // Handle UpstreamDead from the primary forward (only possible when cache is disabled
@@ -1060,63 +968,44 @@ async fn chat_completions(
 
             // Compute cache-aware permit/config/session_id for the retry.
             // Mirrors the normal-path pattern: acquire permit via
-            // prepare_streaming_cycle, fail-open on error.
+            // prepare_streaming_cycle, fail-open on error. Deliberately does
+            // NOT branch on `is_streaming` the way the primary attempt does
+            // above — a non-streaming retry still resolves the triple this
+            // way rather than going through `run_with_cache`, matching this
+            // path's existing behavior.
             // The disk-layer gate also applies here: the retry targets a freshly
             // spawned instance of the same model, so a partial-KV model stays on
             // the RAM-cache-only path (see the initial attempt above).
-            let (retry_permit, retry_cfg, retry_session) =
-                if let (true, Some(sid), Some(slot_dir)) = (
-                    state.cache_enabled && new_target.slot_restore_supported,
-                    sanitized_session_id.as_ref(),
-                    state.slot_dir.as_ref(),
-                ) {
-                    let sid = sid.clone();
-                    let cfg = StreamConfig {
-                        client: state.client.clone(),
-                        base_url: new_target.base_url.clone(),
-                        slot_dir: slot_dir.clone(),
-                        model_id: new_target.model_id,
-                        clear_all_pending: state.clear_all_pending.clone(),
-                        per_session_cleared: state.per_session_cleared.clone(),
-                        server_start_time: state.server_start_time.clone(),
-                        last_loaded_session: state.last_loaded_session.clone(),
-                    };
-                    match crate::cache_lifecycle::prepare_streaming_cycle(
-                        &cfg,
-                        state.slot_gate.clone(),
-                        &sid,
-                    )
-                    .await
-                    {
-                        Ok((permit, _sanitized, _restore)) => (Some(permit), Some(cfg), Some(sid)),
-                        Err(_) => (None, None, None), // fail-open
-                    }
-                } else {
-                    (None, None, None)
-                };
+            let (retry_permit, retry_cfg, retry_session) = match (
+                state.cache_enabled && new_target.slot_restore_supported,
+                sanitized_session_id.as_ref(),
+                state.build_stream_config(new_target.base_url.clone(), new_target.model_id),
+            ) {
+                (true, Some(sid), Some(cfg)) => {
+                    resolve_cache_triple(&cfg, state.slot_gate.clone(), sid).await
+                }
+                _ => (None, None, None),
+            };
 
-            match forward_chat_completion(
-                &state.client,
-                &retry_url,
-                &headers,
-                body_for_retry,
+            let retry_req = ForwardRequest {
+                client: &state.client,
+                upstream_url: &retry_url,
+                headers: &headers,
+                body: body_for_retry,
                 is_streaming,
-                &model_name,
-                new_target.effective_ctx,
-                state.catalog_port.clone(),
-                state.dashboard.metrics.clone(),
-                retry_sampling,
-                retry_connection,
-                state.upstream_health.clone(),
-                state.calibration.clone(),
-                sanitized_session_id.as_deref(),
-                state.dashboard.cache_metrics.clone(),
-                retry_permit,
-                retry_cfg,
-                retry_session,
-            )
-            .await
-            {
+                model_name: &model_name,
+                effective_ctx: new_target.effective_ctx,
+                catalog: state.catalog_port.clone(),
+                metrics: state.dashboard.metrics.clone(),
+                sampling: retry_sampling,
+                connection: retry_connection,
+                upstream_health: state.upstream_health.clone(),
+                calibration: state.calibration.clone(),
+                calibration_session_id: sanitized_session_id.as_deref(),
+                cache_metrics: state.dashboard.cache_metrics.clone(),
+            };
+
+            match retry_req.send(retry_permit, retry_cfg, retry_session).await {
                 Ok(resp) => resp,
                 Err(_) => {
                     // Server failed immediately after a fresh restart —


### PR DESCRIPTION
## Summary

- `chat_completions` in `crates/gglib-proxy/src/server.rs` called `forward_chat_completion` six times with the same 18 positional arguments, differing only in a trailing `(permit, config, session_id)` cache triple, and built `StreamConfig { ... }` from scratch three separate times.
- Adds `ForwardRequest` (`forward.rs`) bundling the arguments that stay constant within one forward attempt, with a `.send(permit, config, session_id)` method; `forward_chat_completion` now takes the struct directly and destructures it internally — its own logic is unchanged.
- Adds `resolve_cache_triple` (`cache_lifecycle.rs`), replacing the duplicated `prepare_streaming_cycle` + fail-open logic that previously appeared once in the primary streaming branch and again, reimplemented, in the retry branch.
- Adds `AppState::build_stream_config` (`server.rs`), replacing all three `StreamConfig { ... }` literals (cache-clear handler, primary path, retry path).
- Collapses the primary path's `if cache_enabled { if let (Some,Some) = ... { ... } else { A } } else { B }` (where `A` and `B` were byte-identical) into a single flat `match` — provably a no-op, since `stream_config` can only be `Some` when `cache_enabled` already holds.

## What's preserved exactly

- The non-streaming path's `run_with_cache` wrapping and its `.expect(...)`-documented error semantics.
- The streaming path's fail-open on a `prepare_streaming_cycle` error.
- The retry path's fresh `ConnectionGuard` (the original is already dropped by the time `UpstreamDead` is returned) and its existing behavior of resolving the cache triple **without** branching on `is_streaming` — an asymmetry with the primary path that already existed and is not "fixed" here.

Fixes #644

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p gglib-proxy` — 227 unit tests + all integration suites pass unchanged, including `integration_slot_roundtrip.rs` and `integration_cache_clear.rs`, which exercise the non-streaming/streaming/retry cache paths this refactor touches
- [x] `cargo clippy -p gglib-proxy --all-targets` — clean; `#[allow(clippy::too_many_arguments)]` removed from `forward_chat_completion`
- [x] `cargo fmt -p gglib-proxy -- --check` — clean
- [x] Manual diff read-through of each of the 6 original call sites against its replacement, confirming the trailing triple matches exactly