### PR TITLE
test(proxy): migrate remaining integration tests to fixtures/common

### DIFF
--- a/crates/gglib-proxy/tests/integration_cors.rs
+++ b/crates/gglib-proxy/tests/integration_cors.rs
@@ -10,176 +10,22 @@
 //! including opening an `EventSource` connection to `GET /v1/proxy/status/stream`
 //! — without the browser blocking the request as cross-origin.
 //!
-//! Uses the real `gglib_proxy::serve` (not a hand-rolled router), following
-//! the same self-contained-harness pattern as the other integration tests in
-//! this crate (each file duplicates its own minimal mocks rather than
-//! sharing a `tests/common` module).
+//! Uses the real `gglib_proxy::serve` (not a hand-rolled router), sharing its
+//! mock ports with the other integration tests via `tests/fixtures` rather
+//! than duplicating them.
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use reqwest::Client;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-use gglib_core::Settings;
-use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
-use gglib_core::ports::{
-    ApprovalDecision, CatalogError, CouncilApprovalRegistryPort, CouncilRepositoryPort,
-    ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort, ModelSummary,
-    RepositoryError, RunningTarget, SettingsRepository,
+use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort};
+
+mod fixtures;
+use fixtures::common::{
+    EmptyCatalog, MockSettingsRepo, NoopRuntime, make_mcp_service, make_orchestrator_deps,
 };
-use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
-use gglib_mcp::McpService;
-use gglib_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};
-use tokio::sync::{mpsc, oneshot};
-
-// ─── Mock ports (trimmed to the bare minimum needed to boot `serve`) ──────
-
-#[derive(Debug)]
-struct NoopRunner;
-#[async_trait]
-impl CouncilRunnerPort for NoopRunner {
-    async fn run(
-        &self,
-        _: &str,
-        _: CouncilRunParams,
-        _: mpsc::Sender<CouncilEvent>,
-        _: CancellationToken,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-struct NoopApprovalRegistry;
-impl CouncilApprovalRegistryPort for NoopApprovalRegistry {
-    fn register(&self, _: String, _: oneshot::Sender<ApprovalDecision>) {}
-    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool {
-        false
-    }
-    fn is_pending(&self, _: &str) -> bool {
-        false
-    }
-}
-struct NoopOrchestratorRepo;
-#[async_trait]
-impl CouncilRepositoryPort for NoopOrchestratorRepo {
-    async fn create_run(&self, _: CouncilRun) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_run_status(&self, _: &str, _: CouncilRunStatus) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn append_event(&self, _: CouncilRunEvent) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn get_run(&self, _: &str) -> Result<Option<CouncilRun>, RepositoryError> {
-        Ok(None)
-    }
-    async fn list_runs(
-        &self,
-        _: Option<CouncilRunStatus>,
-    ) -> Result<Vec<CouncilRun>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn list_events(&self, _: &str) -> Result<Vec<CouncilRunEvent>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn truncate_events_after_wave(&self, _: &str, _: u32) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
-        Ok(0)
-    }
-}
-fn make_orchestrator_deps() -> CouncilDeps {
-    CouncilDeps {
-        runner: Arc::new(NoopRunner),
-        approval_registry: Arc::new(NoopApprovalRegistry),
-        council_repo: Arc::new(NoopOrchestratorRepo),
-    }
-}
-
-struct MockSettingsRepo;
-#[async_trait]
-impl SettingsRepository for MockSettingsRepo {
-    async fn load(&self) -> Result<Settings, RepositoryError> {
-        Ok(Settings::with_defaults())
-    }
-    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-}
-
-/// Runtime port that never actually launches anything — no test here
-/// exercises `/v1/chat/completions`, so `ensure_model_running` is never
-/// called in practice.
-#[derive(Debug)]
-struct NoopRuntime;
-#[async_trait]
-impl ModelRuntimePort for NoopRuntime {
-    async fn ensure_model_running(
-        &self,
-        _model_name: &str,
-        _num_ctx: Option<u64>,
-        _default_ctx: u64,
-    ) -> Result<RunningTarget, ModelRuntimeError> {
-        Ok(RunningTarget::local(0, 1, "mock".into(), 4096, false))
-    }
-    async fn current_model(&self) -> Option<RunningTarget> {
-        None
-    }
-    async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
-        Ok(())
-    }
-}
-
-/// Catalog port with no models — none of these tests call `/v1/models`.
-#[derive(Debug)]
-struct EmptyCatalog;
-#[async_trait]
-impl ModelCatalogPort for EmptyCatalog {
-    async fn list_models(&self) -> Result<Vec<ModelSummary>, CatalogError> {
-        Ok(vec![])
-    }
-    async fn resolve_model(&self, _name: &str) -> Result<Option<ModelSummary>, CatalogError> {
-        Ok(None)
-    }
-    async fn resolve_for_launch(
-        &self,
-        _name: &str,
-    ) -> Result<Option<ModelLaunchSpec>, CatalogError> {
-        Ok(None)
-    }
-}
-
-struct EmptyMcpRepo;
-#[async_trait]
-impl McpServerRepository for EmptyMcpRepo {
-    async fn insert(&self, _s: NewMcpServer) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::Internal("not implemented".into()))
-    }
-    async fn get_by_id(&self, id: i64) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(id.to_string()))
-    }
-    async fn get_by_name(&self, name: &str) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(name.into()))
-    }
-    async fn list(&self) -> Result<Vec<McpServer>, McpRepositoryError> {
-        Ok(vec![])
-    }
-    async fn update(&self, _s: &McpServer) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn delete(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn update_last_connected(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-}
 
 // ─── Proxy harness ─────────────────────────────────────────────────────────
 
@@ -192,10 +38,6 @@ async fn spawn_proxy() -> (String, CancellationToken) {
 
     let runtime: Arc<dyn ModelRuntimePort> = Arc::new(NoopRuntime);
     let catalog: Arc<dyn ModelCatalogPort> = Arc::new(EmptyCatalog);
-    let mcp = Arc::new(McpService::new(
-        Arc::new(EmptyMcpRepo),
-        Arc::new(NoopEmitter::new()),
-    ));
 
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
@@ -205,7 +47,7 @@ async fn spawn_proxy() -> (String, CancellationToken) {
             4096,
             runtime,
             catalog,
-            mcp,
+            make_mcp_service(),
             make_orchestrator_deps(),
             cancel_clone,
             Arc::new(MockSettingsRepo),

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -24,11 +24,9 @@ use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RepositoryError, RunningTarget, SettingsRepository,
 };
-use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
-use gglib_mcp::McpService;
 
 mod fixtures;
-use fixtures::common::make_orchestrator_deps;
+use fixtures::common::{make_mcp_service, make_orchestrator_deps};
 
 const MODEL: &str = "qwen";
 
@@ -128,33 +126,6 @@ impl SettingsRepository for ProfileSettings {
         })
     }
     async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-}
-
-struct EmptyMcpRepo;
-
-#[async_trait]
-impl McpServerRepository for EmptyMcpRepo {
-    async fn insert(&self, _s: NewMcpServer) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::Internal("not implemented".into()))
-    }
-    async fn get_by_id(&self, id: i64) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(id.to_string()))
-    }
-    async fn get_by_name(&self, name: &str) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(name.into()))
-    }
-    async fn list(&self) -> Result<Vec<McpServer>, McpRepositoryError> {
-        Ok(vec![])
-    }
-    async fn update(&self, _s: &McpServer) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn delete(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn update_last_connected(&self, _id: i64) -> Result<(), McpRepositoryError> {
         Ok(())
     }
 }
@@ -259,10 +230,7 @@ async fn spawn(
         names: catalog_names.iter().map(|n| (*n).to_owned()).collect(),
         inference_defaults: model_defaults,
     });
-    let mcp = Arc::new(McpService::new(
-        Arc::new(EmptyMcpRepo),
-        Arc::new(NoopEmitter::new()),
-    ));
+    let mcp = make_mcp_service();
     let proxy_cancel = cancel.clone();
     tokio::spawn(async move {
         gglib_proxy::serve(

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -5,179 +5,17 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-use gglib_core::Settings;
-use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
-use gglib_core::ports::{
-    ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
-    SettingsRepository,
+use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort};
+
+mod fixtures;
+use fixtures::common::{
+    EmptyCatalog, MockSettingsRepo, NoopRuntime, make_mcp_service, make_orchestrator_deps,
 };
-use gglib_core::ports::{
-    CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
-    ModelSummary, RunningTarget,
-};
-use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
-use gglib_mcp::McpService;
-use gglib_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};
-use tokio::sync::{mpsc, oneshot};
-
-#[derive(Debug)]
-struct NoopRunner;
-#[async_trait::async_trait]
-impl CouncilRunnerPort for NoopRunner {
-    async fn run(
-        &self,
-        _: &str,
-        _: CouncilRunParams,
-        _: mpsc::Sender<CouncilEvent>,
-        _: CancellationToken,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-struct NoopApprovalRegistry;
-impl CouncilApprovalRegistryPort for NoopApprovalRegistry {
-    fn register(&self, _: String, _: oneshot::Sender<ApprovalDecision>) {}
-    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool {
-        false
-    }
-    fn is_pending(&self, _: &str) -> bool {
-        false
-    }
-}
-struct NoopOrchestratorRepo;
-#[async_trait::async_trait]
-impl CouncilRepositoryPort for NoopOrchestratorRepo {
-    async fn create_run(&self, _: CouncilRun) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_run_status(&self, _: &str, _: CouncilRunStatus) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn append_event(&self, _: CouncilRunEvent) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn get_run(&self, _: &str) -> Result<Option<CouncilRun>, RepositoryError> {
-        Ok(None)
-    }
-    async fn list_runs(
-        &self,
-        _: Option<CouncilRunStatus>,
-    ) -> Result<Vec<CouncilRun>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn list_events(&self, _: &str) -> Result<Vec<CouncilRunEvent>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn truncate_events_after_wave(&self, _: &str, _: u32) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
-        Ok(0)
-    }
-}
-fn make_orchestrator_deps() -> CouncilDeps {
-    CouncilDeps {
-        runner: Arc::new(NoopRunner),
-        approval_registry: Arc::new(NoopApprovalRegistry),
-        council_repo: Arc::new(NoopOrchestratorRepo),
-    }
-}
-
-// ─── Mock ports ────────────────────────────────────────────────────────────
-
-struct MockSettingsRepo;
-#[async_trait::async_trait]
-impl SettingsRepository for MockSettingsRepo {
-    async fn load(&self) -> Result<Settings, RepositoryError> {
-        Ok(Settings::with_defaults())
-    }
-    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-struct MockRuntimePort;
-
-#[async_trait]
-impl ModelRuntimePort for MockRuntimePort {
-    async fn ensure_model_running(
-        &self,
-        _model_name: &str,
-        _num_ctx: Option<u64>,
-        _default_ctx: u64,
-    ) -> Result<RunningTarget, ModelRuntimeError> {
-        Ok(RunningTarget::local(
-            9999,
-            1,
-            "test-model".into(),
-            4096,
-            false,
-        ))
-    }
-    async fn current_model(&self) -> Option<RunningTarget> {
-        None
-    }
-    async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-struct MockCatalogPort;
-
-#[async_trait]
-impl ModelCatalogPort for MockCatalogPort {
-    async fn list_models(&self) -> Result<Vec<ModelSummary>, CatalogError> {
-        Ok(vec![])
-    }
-    async fn resolve_model(&self, _name: &str) -> Result<Option<ModelSummary>, CatalogError> {
-        Ok(None)
-    }
-    async fn resolve_for_launch(
-        &self,
-        _name: &str,
-    ) -> Result<Option<ModelLaunchSpec>, CatalogError> {
-        Ok(None)
-    }
-}
-
-/// Minimal in-memory MCP repository that always returns an empty server list.
-struct EmptyMcpRepo;
-
-#[async_trait]
-impl McpServerRepository for EmptyMcpRepo {
-    async fn insert(&self, _s: NewMcpServer) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::Internal("not implemented".into()))
-    }
-    async fn get_by_id(&self, id: i64) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(id.to_string()))
-    }
-    async fn get_by_name(&self, name: &str) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(name.into()))
-    }
-    async fn list(&self) -> Result<Vec<McpServer>, McpRepositoryError> {
-        Ok(vec![])
-    }
-    async fn update(&self, _s: &McpServer) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn delete(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn update_last_connected(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-}
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -186,12 +24,8 @@ async fn start_proxy() -> (String, CancellationToken) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let runtime: Arc<dyn ModelRuntimePort> = Arc::new(MockRuntimePort);
-    let catalog: Arc<dyn ModelCatalogPort> = Arc::new(MockCatalogPort);
-    let mcp = Arc::new(McpService::new(
-        Arc::new(EmptyMcpRepo),
-        Arc::new(NoopEmitter::new()),
-    ));
+    let runtime: Arc<dyn ModelRuntimePort> = Arc::new(NoopRuntime);
+    let catalog: Arc<dyn ModelCatalogPort> = Arc::new(EmptyCatalog);
 
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
@@ -202,7 +36,7 @@ async fn start_proxy() -> (String, CancellationToken) {
             4096,
             runtime,
             catalog,
-            mcp,
+            make_mcp_service(),
             make_orchestrator_deps(),
             cancel_clone,
             Arc::new(MockSettingsRepo),

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -29,99 +29,13 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-use gglib_core::Settings;
-use gglib_core::domain::council::{CouncilEvent, CouncilRun, CouncilRunEvent, CouncilRunStatus};
-use gglib_core::ports::{
-    ApprovalDecision, CouncilApprovalRegistryPort, CouncilRepositoryPort, RepositoryError,
-    SettingsRepository,
-};
 use gglib_core::ports::{
     CatalogError, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort,
     ModelSummary, RunningTarget,
 };
-use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
-use gglib_mcp::McpService;
-use gglib_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};
-use tokio::sync::{mpsc, oneshot};
-
-#[derive(Debug)]
-struct NoopRunner;
-#[async_trait]
-impl CouncilRunnerPort for NoopRunner {
-    async fn run(
-        &self,
-        _: &str,
-        _: CouncilRunParams,
-        _: mpsc::Sender<CouncilEvent>,
-        _: CancellationToken,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-struct NoopApprovalRegistry;
-impl CouncilApprovalRegistryPort for NoopApprovalRegistry {
-    fn register(&self, _: String, _: oneshot::Sender<ApprovalDecision>) {}
-    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool {
-        false
-    }
-    fn is_pending(&self, _: &str) -> bool {
-        false
-    }
-}
-struct NoopOrchestratorRepo;
-#[async_trait]
-impl CouncilRepositoryPort for NoopOrchestratorRepo {
-    async fn create_run(&self, _: CouncilRun) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_run_status(&self, _: &str, _: CouncilRunStatus) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn append_event(&self, _: CouncilRunEvent) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn get_run(&self, _: &str) -> Result<Option<CouncilRun>, RepositoryError> {
-        Ok(None)
-    }
-    async fn list_runs(
-        &self,
-        _: Option<CouncilRunStatus>,
-    ) -> Result<Vec<CouncilRun>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn list_events(&self, _: &str) -> Result<Vec<CouncilRunEvent>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn truncate_events_after_wave(&self, _: &str, _: u32) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
-        Ok(0)
-    }
-}
-fn make_orchestrator_deps() -> CouncilDeps {
-    CouncilDeps {
-        runner: Arc::new(NoopRunner),
-        approval_registry: Arc::new(NoopApprovalRegistry),
-        council_repo: Arc::new(NoopOrchestratorRepo),
-    }
-}
-
-struct MockSettingsRepo;
-#[async_trait]
-impl SettingsRepository for MockSettingsRepo {
-    async fn load(&self) -> Result<Settings, RepositoryError> {
-        Ok(Settings::with_defaults())
-    }
-    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-}
 
 mod fixtures;
+use fixtures::common::{MockSettingsRepo, make_mcp_service, make_orchestrator_deps};
 use fixtures::sse::{
     BASIC_TEXT, MALFORMED_JSON_RECOVERY, QWEN_XML_TOOL_CALL, REASONING_DEEPSEEK, REASONING_ONLY,
     STANDARD_OPENAI_TOOL_CALL, basic_text_split_chunks,
@@ -206,35 +120,6 @@ impl TaggedCatalog {
     }
 }
 
-/// Empty MCP repo — chat completion path doesn't touch MCP, but the proxy
-/// still wires it up.
-struct EmptyMcpRepo;
-
-#[async_trait]
-impl McpServerRepository for EmptyMcpRepo {
-    async fn insert(&self, _s: NewMcpServer) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::Internal("not implemented".into()))
-    }
-    async fn get_by_id(&self, id: i64) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(id.to_string()))
-    }
-    async fn get_by_name(&self, name: &str) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(name.into()))
-    }
-    async fn list(&self) -> Result<Vec<McpServer>, McpRepositoryError> {
-        Ok(vec![])
-    }
-    async fn update(&self, _s: &McpServer) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn delete(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn update_last_connected(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-}
-
 // ─── Mock upstream ─────────────────────────────────────────────────────────
 
 /// Spawn a mock upstream HTTP server that yields `chunks` (in order) when
@@ -306,10 +191,7 @@ async fn spawn_proxy(
         name: model_name.into(),
         tags,
     });
-    let mcp = Arc::new(McpService::new(
-        Arc::new(EmptyMcpRepo),
-        Arc::new(NoopEmitter::new()),
-    ));
+    let mcp = make_mcp_service();
 
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();

--- a/crates/gglib-proxy/tests/integration_virtual_models.rs
+++ b/crates/gglib-proxy/tests/integration_virtual_models.rs
@@ -20,105 +20,21 @@ use futures_util::StreamExt as _;
 use reqwest::Client;
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use gglib_core::Settings;
 use gglib_core::domain::council::events::{ApprovalKind, CouncilEvent};
-use gglib_core::domain::council::run::{CouncilRun, CouncilRunEvent, CouncilRunStatus};
 use gglib_core::domain::council::task_graph::{
     HitlMode, NodeId, NodeStatus, TaskGraph, TaskNode, TaskNodeKind,
 };
-use gglib_core::ports::{
-    ApprovalDecision, CatalogError, CouncilApprovalRegistryPort, CouncilRepositoryPort,
-    ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError, ModelRuntimePort, ModelSummary,
-    RunningTarget,
-};
-use gglib_core::ports::{RepositoryError, SettingsRepository};
-use gglib_core::{McpRepositoryError, McpServer, McpServerRepository, NewMcpServer, NoopEmitter};
-use gglib_mcp::McpService;
+use gglib_core::ports::{ModelCatalogPort, ModelRuntimePort};
 use gglib_proxy::{CouncilDeps, CouncilRunParams, CouncilRunnerPort};
 
-// =============================================================================
-// Minimal mock ports (runtime / catalog / MCP)
-// =============================================================================
-
-struct MockSettingsRepo;
-#[async_trait]
-impl SettingsRepository for MockSettingsRepo {
-    async fn load(&self) -> Result<Settings, RepositoryError> {
-        Ok(Settings::with_defaults())
-    }
-    async fn save(&self, _: &Settings) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-}
-
-/// Runtime that always returns an error — virtual model requests never reach it.
-#[derive(Debug)]
-struct NoopRuntime;
-
-#[async_trait]
-impl ModelRuntimePort for NoopRuntime {
-    async fn ensure_model_running(
-        &self,
-        model: &str,
-        _num_ctx: Option<u64>,
-        _default_ctx: u64,
-    ) -> Result<RunningTarget, ModelRuntimeError> {
-        Err(ModelRuntimeError::ModelNotFound(model.to_string()))
-    }
-    async fn current_model(&self) -> Option<RunningTarget> {
-        None
-    }
-    async fn stop_current(&self) -> Result<(), ModelRuntimeError> {
-        Ok(())
-    }
-}
-
-/// Catalog that returns an empty model list.
-#[derive(Debug)]
-struct EmptyCatalog;
-
-#[async_trait]
-impl ModelCatalogPort for EmptyCatalog {
-    async fn list_models(&self) -> Result<Vec<ModelSummary>, CatalogError> {
-        Ok(vec![])
-    }
-    async fn resolve_model(&self, _: &str) -> Result<Option<ModelSummary>, CatalogError> {
-        Ok(None)
-    }
-    async fn resolve_for_launch(&self, _: &str) -> Result<Option<ModelLaunchSpec>, CatalogError> {
-        Ok(None)
-    }
-}
-
-struct EmptyMcpRepo;
-
-#[async_trait]
-impl McpServerRepository for EmptyMcpRepo {
-    async fn insert(&self, _s: NewMcpServer) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::Internal("not implemented".into()))
-    }
-    async fn get_by_id(&self, id: i64) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(id.to_string()))
-    }
-    async fn get_by_name(&self, name: &str) -> Result<McpServer, McpRepositoryError> {
-        Err(McpRepositoryError::NotFound(name.into()))
-    }
-    async fn list(&self) -> Result<Vec<McpServer>, McpRepositoryError> {
-        Ok(vec![])
-    }
-    async fn update(&self, _s: &McpServer) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn delete(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-    async fn update_last_connected(&self, _id: i64) -> Result<(), McpRepositoryError> {
-        Ok(())
-    }
-}
+mod fixtures;
+use fixtures::common::{
+    EmptyCatalog, MockSettingsRepo, NoopApprovalRegistry, NoopOrchestratorRepo, NoopRuntime,
+    make_mcp_service,
+};
 
 // =============================================================================
 // Scripted runner — emits a fixed sequence of CouncilEvents
@@ -153,58 +69,6 @@ impl CouncilRunnerPort for ScriptedRunner {
 }
 
 // =============================================================================
-// Noop orchestrator registry and repository
-// =============================================================================
-
-struct NoopApprovalRegistry;
-
-impl CouncilApprovalRegistryPort for NoopApprovalRegistry {
-    fn register(&self, _: String, _: oneshot::Sender<ApprovalDecision>) {}
-    fn resolve(&self, _: &str, _: ApprovalDecision) -> bool {
-        false
-    }
-    fn is_pending(&self, _: &str) -> bool {
-        false
-    }
-}
-
-struct NoopOrchestratorRepo;
-
-#[async_trait]
-impl CouncilRepositoryPort for NoopOrchestratorRepo {
-    async fn create_run(&self, _: CouncilRun) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_run_status(&self, _: &str, _: CouncilRunStatus) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn update_graph(&self, _: &str, _: &str) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn append_event(&self, _: CouncilRunEvent) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn get_run(&self, _: &str) -> Result<Option<CouncilRun>, RepositoryError> {
-        Ok(None)
-    }
-    async fn list_runs(
-        &self,
-        _: Option<CouncilRunStatus>,
-    ) -> Result<Vec<CouncilRun>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn list_events(&self, _: &str) -> Result<Vec<CouncilRunEvent>, RepositoryError> {
-        Ok(vec![])
-    }
-    async fn truncate_events_after_wave(&self, _: &str, _: u32) -> Result<(), RepositoryError> {
-        Ok(())
-    }
-    async fn mark_interrupted_runs(&self) -> Result<u64, RepositoryError> {
-        Ok(0)
-    }
-}
-
-// =============================================================================
 // Proxy harness
 // =============================================================================
 
@@ -212,10 +76,7 @@ async fn spawn_proxy_with(runner: Arc<dyn CouncilRunnerPort>) -> (String, Cancel
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let mcp = Arc::new(McpService::new(
-        Arc::new(EmptyMcpRepo),
-        Arc::new(NoopEmitter::new()),
-    ));
+    let mcp = make_mcp_service();
     let orchestrator = CouncilDeps {
         runner,
         approval_registry: Arc::new(NoopApprovalRegistry),


### PR DESCRIPTION
## Summary
- Migrated `integration_cors.rs`, `integration_mcp_gateway.rs`, `integration_proxy_pipeline.rs`, `integration_virtual_models.rs`, and `integration_inference_profiles.rs` to import mock ports (`NoopRuntime`, `EmptyCatalog`, `MockSettingsRepo`, council no-op mocks, `make_mcp_service`) from `tests/fixtures/common.rs` instead of duplicating them inline.
- Test-specific mocks (`FixedUpstream`, `TaggedCatalog`, `ScriptedRunner`, `RecordingRuntime`, `NamedCatalog`, `ProfileSettings`) stayed local, since they aren't duplicated anywhere else.
- No behavior or assertion changes — pure dedup.
- Test directory LOC: 4770 → 4157 (613 lines removed).

Closes #596

## Test plan
- [x] `cargo test -p gglib-proxy` — all 273 tests pass, same names/counts as before
- [x] `cargo clippy -p gglib-proxy --tests` — clean
- [x] `cargo fmt -p gglib-proxy -- --check` — clean