### PR TITLE
refactor(ipc): serialize ModelRuntimeError as structured JSON over Tauri IPC

### DIFF
--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -803,7 +803,10 @@ mod tests {
         recorder.started(&summary);
         recorder.stopping(&summary);
         recorder.stopped(&summary);
-        recorder.error(&summary, &ModelRuntimeError::Internal("test error".to_string()));
+        recorder.error(
+            &summary,
+            &ModelRuntimeError::Internal("test error".to_string()),
+        );
 
         let calls = recorder.get_calls();
         assert_eq!(calls.len(), 4);

--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -244,9 +244,7 @@ impl ServerOps {
                     port: 0, // No port on failure
                     healthy: Some(false),
                 };
-                self.deps
-                    .server_events
-                    .error(&error_summary, &e.to_string());
+                self.deps.server_events.error(&error_summary, &e);
                 map_runtime_error(&e)
             })?;
 
@@ -376,7 +374,7 @@ impl ServerOps {
             .stop_current()
             .await
             .map_err(|e| {
-                self.deps.server_events.error(&summary, &e.to_string());
+                self.deps.server_events.error(&summary, &e);
                 GuiError::Internal(format!("Failed to stop server: {e}"))
             })?;
 
@@ -780,7 +778,7 @@ mod tests {
                 .push(format!("snapshot:{}", servers.len()));
         }
 
-        fn error(&self, server: &ServerSummary, error: &str) {
+        fn error(&self, server: &ServerSummary, error: &ModelRuntimeError) {
             self.calls
                 .lock()
                 .unwrap()
@@ -805,14 +803,14 @@ mod tests {
         recorder.started(&summary);
         recorder.stopping(&summary);
         recorder.stopped(&summary);
-        recorder.error(&summary, "test error");
+        recorder.error(&summary, &ModelRuntimeError::Internal("test error".to_string()));
 
         let calls = recorder.get_calls();
         assert_eq!(calls.len(), 4);
         assert_eq!(calls[0], "started:TestModel");
         assert_eq!(calls[1], "stopping:TestModel");
         assert_eq!(calls[2], "stopped:TestModel");
-        assert_eq!(calls[3], "error:TestModel:test error");
+        assert_eq!(calls[3], "error:TestModel:Internal error: test error");
     }
 
     // =========================================================================

--- a/crates/gglib-axum/src/sse.rs
+++ b/crates/gglib-axum/src/sse.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use axum::response::sse::{Event, Sse};
 use futures_util::stream::Stream;
 use gglib_core::events::{AppEvent, ServerEvents, ServerSummary};
-use gglib_core::ports::AppEventEmitter;
+use gglib_core::ports::{AppEventEmitter, ModelRuntimeError};
 use gglib_sse::{Broadcaster, SseOptions};
 
 /// SSE broadcaster that implements event emitter ports.
@@ -133,8 +133,8 @@ impl ServerEvents for AxumServerEvents {
         self.broadcaster.emit(event);
     }
 
-    fn error(&self, server: &ServerSummary, error: &str) {
-        let event = AppEvent::from_server_error(server, error);
+    fn error(&self, server: &ServerSummary, error: &ModelRuntimeError) {
+        let event = AppEvent::from_server_error(server, error.into());
         self.broadcaster.emit(event);
     }
 }

--- a/crates/gglib-core/src/events/README.md
+++ b/crates/gglib-core/src/events/README.md
@@ -22,6 +22,19 @@ Events are serialized with a `type` tag for TypeScript compatibility:
 { "type": "server_started", "modelName": "Llama-2-7B", "port": 8080 }
 ```
 
+`server_error` carries a structured error envelope (message, stable `type`
+discriminant, `retryable` flag) rather than a bare string, mirroring the HTTP
+layer's `ErrorResponse` shape so Tauri and HTTP clients agree on meaning:
+
+```json
+{
+  "type": "server_error",
+  "modelId": 1,
+  "modelName": "Llama-2-7B",
+  "error": { "message": "...", "type": "service_unavailable", "retryable": true }
+}
+```
+
 <!-- module-docs:end -->
 
 <details>

--- a/crates/gglib-core/src/events/mod.rs
+++ b/crates/gglib-core/src/events/mod.rs
@@ -6,7 +6,7 @@ mod server;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ports::McpErrorInfo;
+use crate::ports::{McpErrorInfo, RuntimeErrorEnvelope};
 
 // Re-export event types
 pub use app::ModelSummary;
@@ -55,8 +55,9 @@ pub enum AppEvent {
         /// Name of the model being served.
         #[serde(rename = "modelName")]
         model_name: String,
-        /// Error description.
-        error: String,
+        /// Structured error detail (message, type discriminant, retryable
+        /// flag), mirroring the HTTP layer's `ErrorResponse` shape.
+        error: RuntimeErrorEnvelope,
     },
 
     /// Snapshot of all currently running servers.

--- a/crates/gglib-core/src/events/server.rs
+++ b/crates/gglib-core/src/events/server.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::ports::model_runtime::{ModelRuntimeError, RuntimeErrorEnvelope};
+
 use super::AppEvent;
 
 /// Summary of a running server for event emission.
@@ -50,6 +52,7 @@ impl ServerSummary {
 ///
 /// ```rust
 /// use gglib_core::events::{ServerEvents, ServerSummary};
+/// use gglib_core::ports::ModelRuntimeError;
 ///
 /// struct LoggingEvents;
 ///
@@ -66,7 +69,7 @@ impl ServerSummary {
 ///     fn snapshot(&self, servers: &[ServerSummary]) {
 ///         println!("Server snapshot: {} running", servers.len());
 ///     }
-///     fn error(&self, server: &ServerSummary, error: &str) {
+///     fn error(&self, server: &ServerSummary, error: &ModelRuntimeError) {
 ///         eprintln!("Server {} error: {}", server.model_name, error);
 ///     }
 /// }
@@ -85,7 +88,7 @@ pub trait ServerEvents: Send + Sync {
     fn snapshot(&self, servers: &[ServerSummary]);
 
     /// Called when a server error occurs.
-    fn error(&self, server: &ServerSummary, error: &str);
+    fn error(&self, server: &ServerSummary, error: &ModelRuntimeError);
 }
 
 /// No-op implementation of `ServerEvents` for testing and non-GUI contexts.
@@ -100,7 +103,7 @@ impl ServerEvents for NoopServerEvents {
     fn stopping(&self, _server: &ServerSummary) {}
     fn stopped(&self, _server: &ServerSummary) {}
     fn snapshot(&self, _servers: &[ServerSummary]) {}
-    fn error(&self, _server: &ServerSummary, _error: &str) {}
+    fn error(&self, _server: &ServerSummary, _error: &ModelRuntimeError) {}
 }
 
 /// Entry in a server snapshot.
@@ -141,12 +144,12 @@ impl AppEvent {
     pub fn server_error(
         model_id: Option<i64>,
         model_name: impl Into<String>,
-        error: impl Into<String>,
+        error: RuntimeErrorEnvelope,
     ) -> Self {
         Self::ServerError {
             model_id,
             model_name: model_name.into(),
-            error: error.into(),
+            error,
         }
     }
 
@@ -168,7 +171,7 @@ impl AppEvent {
     }
 
     /// Build a `ServerError` event from a `ServerSummary`.
-    pub fn from_server_error(server: &ServerSummary, error: &str) -> Self {
+    pub fn from_server_error(server: &ServerSummary, error: RuntimeErrorEnvelope) -> Self {
         let model_id = server.model_id.parse::<i64>().ok();
         Self::server_error(model_id, &server.model_name, error)
     }
@@ -244,7 +247,8 @@ mod tests {
     #[test]
     fn test_from_server_error() {
         let server = make_server("srv-1", "42", "test-model", 8080);
-        let event = AppEvent::from_server_error(&server, "something failed");
+        let runtime_err = ModelRuntimeError::Internal("something failed".to_string());
+        let event = AppEvent::from_server_error(&server, RuntimeErrorEnvelope::from(&runtime_err));
         match event {
             AppEvent::ServerError {
                 model_id,
@@ -253,7 +257,9 @@ mod tests {
             } => {
                 assert_eq!(model_id, Some(42));
                 assert_eq!(model_name, "test-model");
-                assert_eq!(error, "something failed");
+                assert_eq!(error.message, "Internal error: something failed");
+                assert_eq!(error.r#type, "server_error");
+                assert!(!error.retryable);
             }
             _ => panic!("expected ServerError"),
         }
@@ -262,7 +268,8 @@ mod tests {
     #[test]
     fn test_from_server_error_invalid_model_id() {
         let server = make_server("srv-1", "abc", "test-model", 8080);
-        let event = AppEvent::from_server_error(&server, "something failed");
+        let runtime_err = ModelRuntimeError::Internal("something failed".to_string());
+        let event = AppEvent::from_server_error(&server, RuntimeErrorEnvelope::from(&runtime_err));
         match event {
             AppEvent::ServerError {
                 model_id,
@@ -271,7 +278,7 @@ mod tests {
             } => {
                 assert_eq!(model_id, None);
                 assert_eq!(model_name, "test-model");
-                assert_eq!(error, "something failed");
+                assert_eq!(error.message, "Internal error: something failed");
             }
             _ => panic!("expected ServerError"),
         }

--- a/crates/gglib-core/src/ports/mod.rs
+++ b/crates/gglib-core/src/ports/mod.rs
@@ -66,6 +66,7 @@ pub use model_registrar::{CompletedDownload, ModelRegistrarPort};
 pub use model_repository::ModelRepository;
 pub use model_runtime::{
     LaunchOverrides, ModelRuntimeError, ModelRuntimePort, NoopModelRuntime, RunningTarget,
+    RuntimeErrorEnvelope,
 };
 pub use process_runner::{ProcessHandle, ProcessRunner, ServerConfig, ServerHealth};
 pub use server_health::ServerHealthStatus;

--- a/crates/gglib-core/src/ports/model_runtime.rs
+++ b/crates/gglib-core/src/ports/model_runtime.rs
@@ -5,6 +5,7 @@
 //! details from the proxy layer.
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
@@ -184,6 +185,44 @@ impl ModelRuntimeError {
             | Self::ModelFileNotFound(_)
             | Self::PinnedModelMismatch { .. } => 404,
             Self::SpawnFailed(_) | Self::HealthCheckFailed(_) | Self::Internal(_) => 500,
+        }
+    }
+}
+
+/// Structured, serializable view of a [`ModelRuntimeError`].
+///
+/// For IPC boundaries (Tauri events, SSE) that need machine-readable type +
+/// retry hints alongside the human-readable message, mirroring the shape
+/// `gglib_proxy::models::ErrorResponse` already sends over HTTP.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RuntimeErrorEnvelope {
+    /// Human-readable error message.
+    pub message: String,
+    /// Stable error type discriminant, matching the `type` strings the HTTP
+    /// layer already sends for the same `ModelRuntimeError` variants (e.g.
+    /// `"service_unavailable"`), so GUI and HTTP clients agree on meaning.
+    pub r#type: String,
+    /// Whether retrying the same request may succeed.
+    pub retryable: bool,
+}
+
+impl From<&ModelRuntimeError> for RuntimeErrorEnvelope {
+    fn from(err: &ModelRuntimeError) -> Self {
+        let error_type = match err {
+            ModelRuntimeError::ModelLoading | ModelRuntimeError::ContentionTimeout(_) => {
+                "service_unavailable"
+            }
+            ModelRuntimeError::ModelNotFound(_)
+            | ModelRuntimeError::ModelFileNotFound(_)
+            | ModelRuntimeError::PinnedModelMismatch { .. } => "invalid_request_error",
+            ModelRuntimeError::SpawnFailed(_)
+            | ModelRuntimeError::HealthCheckFailed(_)
+            | ModelRuntimeError::Internal(_) => "server_error",
+        };
+        Self {
+            message: err.to_string(),
+            r#type: error_type.to_string(),
+            retryable: err.is_retryable(),
         }
     }
 }
@@ -444,5 +483,25 @@ mod tests {
         let rendered = pinned_mismatch().to_string();
         assert!(rendered.contains("qwen2.5"), "{rendered}");
         assert!(rendered.contains("llama-3-8b"), "{rendered}");
+    }
+
+    /// A retryable error's envelope must carry `retryable: true` and the
+    /// `service_unavailable` type, matching the HTTP layer's 503 mapping.
+    #[test]
+    fn envelope_for_contention_timeout_is_retryable_service_unavailable() {
+        let err = ModelRuntimeError::ContentionTimeout("waited too long".to_string());
+        let envelope = RuntimeErrorEnvelope::from(&err);
+        assert_eq!(envelope.r#type, "service_unavailable");
+        assert!(envelope.retryable);
+        assert_eq!(envelope.message, err.to_string());
+    }
+
+    /// A non-retryable error's envelope must say so, matching the HTTP
+    /// layer's non-503 mapping.
+    #[test]
+    fn envelope_for_pinned_mismatch_is_not_retryable_invalid_request() {
+        let envelope = RuntimeErrorEnvelope::from(&pinned_mismatch());
+        assert_eq!(envelope.r#type, "invalid_request_error");
+        assert!(!envelope.retryable);
     }
 }

--- a/crates/gglib-tauri/src/server_events.rs
+++ b/crates/gglib-tauri/src/server_events.rs
@@ -4,6 +4,7 @@
 //! to Tauri's `ServerEvent` types and emitting via the Tauri event system.
 
 use gglib_core::events::{AppEvent, ServerEvents, ServerSummary};
+use gglib_core::ports::ModelRuntimeError;
 use tauri::AppHandle;
 
 use crate::events::emit_or_log;
@@ -50,8 +51,8 @@ impl ServerEvents for TauriServerEvents {
         emit_or_log(&self.app, event.event_name(), &event);
     }
 
-    fn error(&self, server: &ServerSummary, error: &str) {
-        let event = AppEvent::from_server_error(server, error);
+    fn error(&self, server: &ServerSummary, error: &ModelRuntimeError) {
+        let event = AppEvent::from_server_error(server, error.into());
         emit_or_log(&self.app, event.event_name(), &event);
     }
 }

--- a/src/services/serverEvents.normalize.ts
+++ b/src/services/serverEvents.normalize.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ServerEvent } from './serverRegistry';
+import type { RuntimeErrorInfo } from '../types';
 
 export type CanonicalServerEventName =
   | 'server:snapshot'
@@ -99,6 +100,21 @@ function normalizeHealthChanged(data: Record<string, unknown>): ServerEvent | nu
   };
 }
 
+function toRuntimeErrorInfo(value: unknown): RuntimeErrorInfo | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const err = value as Record<string, unknown>;
+
+  if (
+    typeof err.message !== 'string' ||
+    typeof err.type !== 'string' ||
+    typeof err.retryable !== 'boolean'
+  ) {
+    return undefined;
+  }
+
+  return { message: err.message, type: err.type, retryable: err.retryable };
+}
+
 function normalizeLifecycle(
   kind: 'running' | 'stopped' | 'crashed',
   data: Record<string, unknown>
@@ -122,7 +138,7 @@ function normalizeLifecycle(
   if (kind === 'stopped') return { type: 'stopped', modelId, port, updatedAt, modelName };
 
   // server:error may omit modelId on the Rust side; ignore in that case.
-  return { type: 'crashed', modelId, port, updatedAt, modelName };
+  return { type: 'crashed', modelId, port, updatedAt, modelName, error: toRuntimeErrorInfo(data.error) };
 }
 
 /**

--- a/src/services/serverRegistry.ts
+++ b/src/services/serverRegistry.ts
@@ -13,7 +13,7 @@
  */
 
 import { useSyncExternalStore } from 'react';
-import type { ServerHealthStatus } from '../types';
+import type { RuntimeErrorInfo, ServerHealthStatus } from '../types';
 
 // Re-export for convenience
 export type { ServerHealthStatus } from '../types';
@@ -49,7 +49,7 @@ export type ServerEvent =
   | { type: 'running'; modelId: string; port?: number; updatedAt: number; modelName?: string }
   | { type: 'stopping'; modelId: string; port?: number; updatedAt: number; modelName?: string }
   | { type: 'stopped'; modelId: string; port?: number; updatedAt: number; modelName?: string }
-  | { type: 'crashed'; modelId: string; port?: number; updatedAt: number; modelName?: string }
+  | { type: 'crashed'; modelId: string; port?: number; updatedAt: number; modelName?: string; error?: RuntimeErrorInfo }
   | { type: 'server_health_changed'; modelId: string; status: ServerHealthStatus; detail?: string; updatedAt: number };
 
 // ============================================================================

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -5,6 +5,7 @@
 
 import type { Unsubscribe, EventHandler } from './common';
 import type { DownloadId } from './ids';
+import type { RuntimeErrorInfo } from '../../../types';
 
 // ============================================================================
 // Server Events
@@ -24,7 +25,7 @@ export type ServerEvent =
   | { type: 'running'; modelId: string; port?: number; updatedAt: number }
   | { type: 'stopping'; modelId: string; port?: number; updatedAt: number }
   | { type: 'stopped'; modelId: string; port?: number; updatedAt: number }
-  | { type: 'crashed'; modelId: string; port?: number; updatedAt: number };
+  | { type: 'crashed'; modelId: string; port?: number; updatedAt: number; error?: RuntimeErrorInfo };
 
 // ============================================================================
 // Download Events

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -241,6 +241,16 @@ export type ServerHealthStatus =
 export type HealthTone = 'healthy' | 'degraded' | 'failed' | 'unknown';
 
 /**
+ * Structured detail for a model runtime failure.
+ * Maps to gglib-core::ports::model_runtime::RuntimeErrorEnvelope.
+ */
+export interface RuntimeErrorInfo {
+  message: string;
+  type: string;
+  retryable: boolean;
+}
+
+/**
  * Get display info for a health status (tone, label, title).
  */
 export function getHealthDisplay(health?: ServerHealthStatus): { tone: HealthTone; label: string; title: string } {

--- a/tests/ts/services/server/serverEvents.normalize.test.ts
+++ b/tests/ts/services/server/serverEvents.normalize.test.ts
@@ -85,6 +85,33 @@ describe('serverEvents.normalize', () => {
     expect(evt).toBeNull();
   });
 
+  it('normalizes server_error into crashed with the structured error envelope', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_error',
+      modelId: 123,
+      modelName: 'TestModel',
+      error: { message: 'model is loading, try again', type: 'service_unavailable', retryable: true },
+    });
+
+    expect(evt).toMatchObject({
+      type: 'crashed',
+      modelId: '123',
+      error: { message: 'model is loading, try again', type: 'service_unavailable', retryable: true },
+    });
+  });
+
+  it('drops a malformed server_error error payload instead of throwing', () => {
+    const evt = normalizeServerEventFromAppEvent({
+      type: 'server_error',
+      modelId: 123,
+      modelName: 'TestModel',
+      error: 'legacy plain string',
+    });
+
+    expect(evt).toMatchObject({ type: 'crashed', modelId: '123' });
+    expect((evt as { error?: unknown }).error).toBeUndefined();
+  });
+
   it('normalizes server_health_changed using timestamp (ms)', () => {
     const evt = normalizeServerEventFromAppEvent({
       type: 'server_health_changed',


### PR DESCRIPTION
## Summary

- Adds `RuntimeErrorEnvelope { message, type, retryable }` next to `ModelRuntimeError` in `gglib-core`, mirroring the shape `gglib-proxy::models::ErrorResponse` already sends over HTTP, so the `type` discriminant (`service_unavailable` / `invalid_request_error` / `server_error`) agrees between the two transports.
- Changes `ServerEvents::error` to take `&ModelRuntimeError` instead of a pre-flattened `&str`, and updates both implementations (`TauriServerEvents`, `AxumServerEvents`) to build the envelope when constructing their `AppEvent`. `AppEvent::ServerError.error` is now the structured envelope instead of a bare string.
- Updates the two call sites in `gglib-app-services::servers` (`start`/`stop`) to pass the typed error directly instead of `.to_string()`-ing it away.
- Mirrors the new shape on the TypeScript side (`ServerEvent`'s `crashed` variant in `serverRegistry.ts` and `transport/types/events.ts`, plus a shared `RuntimeErrorInfo` type) and updates `serverEvents.normalize.ts` to actually lift the structured error out of the event payload instead of silently dropping it.

Fixes #590.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p gglib-core -p gglib-app-services -p gglib-tauri -p gglib-axum`
- [x] `cargo clippy --workspace --all-targets`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run`