### PR TITLE
docs(boundaries): document gglib-cli -> gglib-axum exception, close checker gap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,7 +287,7 @@ The CI runs `scripts/check_boundaries.sh` on every push and pull request. Violat
 
 **`gglib-app-services`** — Backend bridge used by both `gglib-axum` and `gglib-tauri`. No surface-specific code.
 
-**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) — May depend on anything in lower layers. Must not depend on each other.
+**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) — May depend on anything in lower layers. Must not depend on each other, with one documented exception: `gglib-cli` may depend on `gglib-axum` to start the Axum HTTP server for the `gglib web` command — splitting that single call site into a fourth surface crate would be more churn than the exception is worth. `scripts/check_boundaries.sh` allow-lists exactly this edge; any other surface-to-surface dependency is a violation.
 
 If your change requires adding a dependency from a lower layer to a higher layer, reconsider the design. The dependency should flow in the opposite direction via the channel/event pattern described above.
 

--- a/scripts/check_boundaries.sh
+++ b/scripts/check_boundaries.sh
@@ -71,6 +71,38 @@ check_crate_deps() {
     fi
 }
 
+check_surface_isolation() {
+    local crate=$1
+    local deps
+    deps=$(cargo tree -p "$crate" --depth 1 --prefix none 2>/dev/null | tail -n +2 | awk '{print $1}')
+
+    local violations=()
+    for dep in $deps; do
+        for sibling in "${SURFACE_CRATES[@]}"; do
+            if [[ "$dep" == "$sibling" && "$dep" != "$crate" ]]; then
+                local edge="$crate->$dep"
+                local allowed=0
+                for exception in "${SURFACE_ALLOWED_EXCEPTIONS[@]}"; do
+                    [[ "$edge" == "$exception" ]] && allowed=1
+                done
+                [[ $allowed -eq 0 ]] && violations+=("$dep")
+            fi
+        done
+    done
+
+    if [[ ${#violations[@]} -gt 0 ]]; then
+        log "${RED}FAIL${NC}: $crate"
+        log "  Undocumented surface-to-surface dependencies: ${violations[*]}"
+        local violations_json=$(printf '"%s",' "${violations[@]}" | sed 's/,$//')
+        RESULTS+=("{\"crate\": \"$crate-surface-isolation\", \"status\": \"fail\", \"violations\": [$violations_json]}")
+        return 1
+    else
+        log "${GREEN}PASS${NC}: $crate"
+        RESULTS+=("{\"crate\": \"$crate-surface-isolation\", \"status\": \"pass\", \"violations\": []}")
+        return 0
+    fi
+}
+
 main() {
     log "🔍 Checking workspace crate boundaries..."
     log ""
@@ -116,7 +148,23 @@ main() {
         FAILED=1
     fi
     log ""
-    
+
+    # Surface-to-surface isolation: CLI_FORBIDDEN/AXUM_FORBIDDEN/TAURI_FORBIDDEN
+    # above only match external crate names (e.g. `axum`), never sibling
+    # `gglib-*` crates, so they miss a direct surface-to-surface edge like
+    # `gglib-cli -> gglib-axum`. Check sibling names directly instead, with
+    # the one exception CONTRIBUTING.md documents.
+    SURFACE_CRATES=(gglib-cli gglib-axum gglib-tauri)
+    SURFACE_ALLOWED_EXCEPTIONS=("gglib-cli->gglib-axum")
+
+    log "📦 Surface-to-surface isolation (no undocumented cli/axum/tauri cross-deps)"
+    for surface_crate in "${SURFACE_CRATES[@]}"; do
+        if ! check_surface_isolation "$surface_crate"; then
+            FAILED=1
+        fi
+    done
+    log ""
+
     # Domain/service layer crates - no UI adapters
     DOMAIN_FORBIDDEN=(axum tower tower-http clap tauri hyper sqlx)
     


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md`'s surface-crate isolation rule said "must not depend on each other," but `gglib-cli` has depended directly on `gglib-axum` since the repo's first commit (needed to start the Axum server for `gglib web`).
- `scripts/check_boundaries.sh`'s forbidden lists (`CLI_FORBIDDEN`, etc.) only ever matched external crate names (`axum`, `tauri`, ...), never sibling `gglib-*` crates, so this real dependency passed silently — and any *future* undocumented surface-to-surface edge (e.g. `gglib-tauri -> gglib-axum`) would too.
- Documents the one legitimate exception in `CONTRIBUTING.md`, and adds an explicit surface-to-surface isolation check to `check_boundaries.sh` that allow-lists exactly that edge, failing CI on any other surface crate depending on another.

Closes #646.

## Test plan
- [x] `bash scripts/check_boundaries.sh` passes, including 3 new "Surface-to-surface isolation" checks
- [x] Verified the new check actually fails without the allowlist (temporarily emptied it, confirmed `gglib-cli` FAILs on the `gglib-axum` edge, then restored)
- [x] `cargo check --workspace --all-targets` clean