### PR TITLE
refactor(cli): dedupe SlotSnapshot/tokens_in_use by depending on gglib-proxy directly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,7 +287,7 @@ The CI runs `scripts/check_boundaries.sh` on every push and pull request. Violat
 
 **`gglib-app-services`** — Backend bridge used by both `gglib-axum` and `gglib-tauri`. No surface-specific code.
 
-**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) — May depend on anything in lower layers. Must not depend on each other.
+**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) — May depend on anything in lower layers. Must not depend on each other, with one documented exception: `gglib-cli` may depend on `gglib-axum` to start the Axum HTTP server for the `gglib web` command — splitting that single call site into a fourth surface crate would be more churn than the exception is worth. `scripts/check_boundaries.sh` allow-lists exactly this edge; any other surface-to-surface dependency is a violation.
 
 If your change requires adding a dependency from a lower layer to a higher layer, reconsider the design. The dependency should flow in the opposite direction via the channel/event pattern described above.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "gglib-download",
  "gglib-hf",
  "gglib-mcp",
+ "gglib-proxy",
  "gglib-runtime",
  "hf-hub",
  "indicatif 0.18.6",

--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -21,6 +21,7 @@ gglib-db = { path = "../gglib-db" }
 gglib-download = { path = "../gglib-download" }
 gglib-hf = { path = "../gglib-hf" }
 gglib-mcp = { path = "../gglib-mcp" }
+gglib-proxy = { path = "../gglib-proxy" }
 gglib-runtime = { path = "../gglib-runtime", features = ["cli"] }
 reqwest = { workspace = true }
 

--- a/crates/gglib-cli/src/handlers/proxy_dashboard.rs
+++ b/crates/gglib-cli/src/handlers/proxy_dashboard.rs
@@ -5,17 +5,24 @@
 //! `/v1/chat/completions` connections, per-slot context-window usage from
 //! llama.cpp's `/slots` endpoint, and a running request count.
 //!
-//! ## Decoupled JSON contract, not a shared Rust type
+//! ## Shared `SlotSnapshot`, local `DashboardSnapshot`
 //!
-//! This module does **not** depend on `gglib-proxy` (that would pull an
-//! Infrastructure-layer, axum-based crate into `gglib-cli`, which
-//! `scripts/check_boundaries.sh` treats as a web/gui dependency this crate
-//! must not have). Instead, [`DashboardSnapshot`] and friends are a local,
-//! `Deserialize`-only mirror of the JSON shape produced by
-//! `gglib_proxy::dashboard::DashboardSnapshot` — exactly the same relationship
-//! the TypeScript frontend has to that same endpoint. Unknown fields are
-//! ignored by default (no `deny_unknown_fields`), so this client tolerates
-//! additive changes to the server-side contract.
+//! [`DashboardSnapshot`] and friends stay a local, `Deserialize`-only mirror
+//! of the JSON shape produced by `gglib_proxy::dashboard::DashboardSnapshot`
+//! — the same relationship the TypeScript frontend has to that same
+//! endpoint. Unknown fields are ignored by default (no `deny_unknown_fields`),
+//! so this client tolerates additive changes to the server-side contract.
+//!
+//! `slots`, though, reuses [`gglib_proxy::slots::SlotSnapshot`] directly
+//! rather than a hand-copied mirror: llama.cpp's `/slots` schema has shifted
+//! shape more than once, and every shift previously meant editing the same
+//! `tokens_in_use()` fallback chain in two crates. `gglib-cli` already
+//! depends on `gglib-axum` — the one documented exception to
+//! CONTRIBUTING.md's surface-crate isolation rule, needed for `gglib web` —
+//! and was already pulling in `gglib-proxy` transitively via `gglib-runtime`
+//! and `gglib-app-services`, so a direct `gglib-proxy` dependency here adds
+//! nothing new to the build graph; it just lets this module use the
+//! canonical parser instead of maintaining its own.
 //!
 //! ## Redraw strategy: cursor movement, not raw mode
 //!
@@ -51,6 +58,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result};
 use crossterm::{cursor, execute, terminal};
 use futures_util::StreamExt;
+use gglib_proxy::slots::SlotSnapshot;
 use serde::Deserialize;
 
 /// Width (in bar cells) of every progress bar drawn by this dashboard.
@@ -149,89 +157,6 @@ impl ConnectionPhase {
             Self::ProcessingPrompt => "prompt",
             Self::Generating => "generating",
         }
-    }
-}
-
-/// Mirrors `gglib_proxy::slots::SlotSnapshot`'s wire shape, including its
-/// private-but-serialized legacy fields — see that type's doc comment for
-/// why `/slots`' schema needs this priority-fallback handling.
-#[derive(Debug, Deserialize)]
-struct SlotSnapshot {
-    id: i64,
-    #[serde(default)]
-    n_ctx: Option<u64>,
-    #[serde(default)]
-    n_past: Option<u64>,
-    #[serde(default)]
-    cache_tokens: Option<u64>,
-    #[serde(default)]
-    n_prompt_tokens: Option<u64>,
-    #[serde(default)]
-    n_prompt_tokens_processed: Option<u64>,
-    #[serde(default)]
-    n_prompt_tokens_cache: Option<u64>,
-    #[serde(default)]
-    next_token: Option<NextTokenField>,
-}
-
-#[derive(Debug, Deserialize)]
-struct NextTokenInfo {
-    #[serde(default)]
-    n_decoded: Option<u64>,
-}
-
-/// Mirrors `gglib_proxy::slots::NextTokenField` — `next_token` is a single
-/// object on regular llama-server builds, but an array of objects on builds
-/// with Multi-Token Prediction ("draft-mtp") enabled.
-///
-/// `Many` must come before `Single` — see the server-side type's doc
-/// comment for why (a single-element array can otherwise falsely match
-/// `Single` via serde's struct-from-seq deserialization).
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum NextTokenField {
-    Many(Vec<NextTokenInfo>),
-    Single(NextTokenInfo),
-}
-
-impl NextTokenField {
-    /// See `gglib_proxy::slots::NextTokenField::primary` — element 0 is the
-    /// accepted/main decode stream on MTP builds.
-    fn primary(&self) -> Option<&NextTokenInfo> {
-        match self {
-            Self::Single(info) => Some(info),
-            Self::Many(items) => items.first(),
-        }
-    }
-}
-
-impl SlotSnapshot {
-    /// Same additive logic as the server's `SlotSnapshot::tokens_in_use`:
-    /// when `n_prompt_tokens_processed` is present, combine it with
-    /// `n_prompt_tokens_cache` (tokens reused from KV cache this round) plus
-    /// `next_token.n_decoded`. The grand-total `n_prompt_tokens` fallback
-    /// (used only when `_processed` is absent) already includes any cached
-    /// prefix, so cache is not added on top of it. Only falls back to the
-    /// legacy `n_past`/`cache_tokens` chain (no addition) when neither
-    /// prompt-side field is present.
-    fn tokens_in_use(&self) -> Option<u64> {
-        let n_decoded = self
-            .next_token
-            .as_ref()
-            .and_then(NextTokenField::primary)
-            .and_then(|nt| nt.n_decoded);
-
-        let prompt_component = if let Some(processed) = self.n_prompt_tokens_processed {
-            Some(processed + self.n_prompt_tokens_cache.unwrap_or(0))
-        } else {
-            self.n_prompt_tokens
-        };
-
-        if let Some(prompt_tokens) = prompt_component {
-            return Some(prompt_tokens + n_decoded.unwrap_or(0));
-        }
-
-        self.n_past.or(self.cache_tokens).or(n_decoded)
     }
 }
 
@@ -754,16 +679,10 @@ mod tests {
                 prompt_total: Some(100),
             }],
             slots_available: true,
-            slots: vec![SlotSnapshot {
-                id: 0,
-                n_ctx: Some(4096),
-                n_past: Some(2048),
-                cache_tokens: None,
-                n_prompt_tokens: None,
-                n_prompt_tokens_processed: None,
-                n_prompt_tokens_cache: None,
-                next_token: None,
-            }],
+            slots: vec![
+                serde_json::from_str(r#"{"id": 0, "n_ctx": 4096, "n_past": 2048}"#)
+                    .expect("should parse"),
+            ],
             slots_status: None,
             total_requests: 3,
             cache: None,
@@ -779,61 +698,6 @@ mod tests {
         assert!(frame.contains("50%")); // 50/100 prompt progress
         assert!(frame.contains("slot 0"));
         assert!(frame.contains("Total requests served: 3"));
-    }
-
-    #[test]
-    fn slot_snapshot_parses_mtp_array_next_token_shape() {
-        // Same wire shape the proxy re-serializes for an MTP ("draft-mtp")
-        // llama-server build — `next_token` is an array, not a bare object.
-        let json = r#"{
-            "id": 3,
-            "n_ctx": 131072,
-            "next_token": [
-                { "n_decoded": 89 }
-            ]
-        }"#;
-        let slot: SlotSnapshot = serde_json::from_str(json).expect("should parse MTP shape");
-        assert_eq!(slot.tokens_in_use(), Some(89));
-    }
-
-    #[test]
-    fn slot_snapshot_tokens_in_use_is_additive_with_prompt_tokens() {
-        // Real payload shape: n_prompt_tokens_processed (prompt usage) and
-        // next_token.n_decoded (generated tokens) must be summed, not just
-        // read as n_decoded alone (which previously showed ~0% used for a
-        // 20k+-token prompt).
-        let json = r#"{
-            "id": 3,
-            "n_ctx": 131072,
-            "n_prompt_tokens": 20994,
-            "n_prompt_tokens_processed": 20906,
-            "next_token": [
-                { "n_decoded": 89 }
-            ]
-        }"#;
-        let slot: SlotSnapshot = serde_json::from_str(json).expect("should parse");
-        assert_eq!(slot.tokens_in_use(), Some(20906 + 89));
-    }
-
-    #[test]
-    fn slot_snapshot_tokens_in_use_adds_cache_reused_tokens() {
-        // KV-cache-reuse scenario: a follow-up prompt where llama-server
-        // found a large cached prefix match and only newly processed a
-        // small delta. n_prompt_tokens_cache must be added to
-        // n_prompt_tokens_processed, or context usage falsely collapses to
-        // just the tiny newly-processed delta.
-        let json = r#"{
-            "id": 0,
-            "n_ctx": 131072,
-            "n_prompt_tokens": 7981,
-            "n_prompt_tokens_processed": 1245,
-            "n_prompt_tokens_cache": 6736,
-            "next_token": [
-                { "n_decoded": 12 }
-            ]
-        }"#;
-        let slot: SlotSnapshot = serde_json::from_str(json).expect("should parse");
-        assert_eq!(slot.tokens_in_use(), Some(1245 + 6736 + 12));
     }
 
     #[test]

--- a/crates/gglib-cli/src/lib.rs
+++ b/crates/gglib-cli/src/lib.rs
@@ -23,6 +23,10 @@ use gglib_runtime as _;
 // gglib-axum used for web command in main.rs
 use gglib_axum as _;
 
+// gglib-proxy used for the shared SlotSnapshot/tokens_in_use parser in
+// handlers/proxy_dashboard.rs
+use gglib_proxy as _;
+
 pub mod assistant_ui_commands;
 pub mod benchmark_commands;
 pub mod bootstrap;

--- a/scripts/check_boundaries.sh
+++ b/scripts/check_boundaries.sh
@@ -71,6 +71,38 @@ check_crate_deps() {
     fi
 }
 
+check_surface_isolation() {
+    local crate=$1
+    local deps
+    deps=$(cargo tree -p "$crate" --depth 1 --prefix none 2>/dev/null | tail -n +2 | awk '{print $1}')
+
+    local violations=()
+    for dep in $deps; do
+        for sibling in "${SURFACE_CRATES[@]}"; do
+            if [[ "$dep" == "$sibling" && "$dep" != "$crate" ]]; then
+                local edge="$crate->$dep"
+                local allowed=0
+                for exception in "${SURFACE_ALLOWED_EXCEPTIONS[@]}"; do
+                    [[ "$edge" == "$exception" ]] && allowed=1
+                done
+                [[ $allowed -eq 0 ]] && violations+=("$dep")
+            fi
+        done
+    done
+
+    if [[ ${#violations[@]} -gt 0 ]]; then
+        log "${RED}FAIL${NC}: $crate"
+        log "  Undocumented surface-to-surface dependencies: ${violations[*]}"
+        local violations_json=$(printf '"%s",' "${violations[@]}" | sed 's/,$//')
+        RESULTS+=("{\"crate\": \"$crate-surface-isolation\", \"status\": \"fail\", \"violations\": [$violations_json]}")
+        return 1
+    else
+        log "${GREEN}PASS${NC}: $crate"
+        RESULTS+=("{\"crate\": \"$crate-surface-isolation\", \"status\": \"pass\", \"violations\": []}")
+        return 0
+    fi
+}
+
 main() {
     log "🔍 Checking workspace crate boundaries..."
     log ""
@@ -116,7 +148,23 @@ main() {
         FAILED=1
     fi
     log ""
-    
+
+    # Surface-to-surface isolation: CLI_FORBIDDEN/AXUM_FORBIDDEN/TAURI_FORBIDDEN
+    # above only match external crate names (e.g. `axum`), never sibling
+    # `gglib-*` crates, so they miss a direct surface-to-surface edge like
+    # `gglib-cli -> gglib-axum`. Check sibling names directly instead, with
+    # the one exception CONTRIBUTING.md documents.
+    SURFACE_CRATES=(gglib-cli gglib-axum gglib-tauri)
+    SURFACE_ALLOWED_EXCEPTIONS=("gglib-cli->gglib-axum")
+
+    log "📦 Surface-to-surface isolation (no undocumented cli/axum/tauri cross-deps)"
+    for surface_crate in "${SURFACE_CRATES[@]}"; do
+        if ! check_surface_isolation "$surface_crate"; then
+            FAILED=1
+        fi
+    done
+    log ""
+
     # Domain/service layer crates - no UI adapters
     DOMAIN_FORBIDDEN=(axum tower tower-http clap tauri hyper sqlx)
     


### PR DESCRIPTION
## Summary
- `proxy_dashboard.rs` hand-maintained a byte-for-byte copy of `gglib_proxy::slots::SlotSnapshot` and its `tokens_in_use()` fallback chain, justified by a boundary claim that #646 (base of this PR) establishes as already false: `gglib-cli` already depends on `gglib-axum` (the documented exception) and was already transitively pulling in `gglib-proxy` via `gglib-runtime`/`gglib-app-services`.
- Adds `gglib-proxy` as a direct dependency of `gglib-cli` and imports its `SlotSnapshot` directly instead of maintaining a second copy of llama.cpp `/slots` schema-fallback logic that needs editing in two crates every time upstream's shape shifts.
- Rewrites `proxy_dashboard.rs`'s module doc comment to reflect the corrected boundary rule instead of the stale "must not depend on gglib-proxy" claim.
- Converts the one test that built `SlotSnapshot` via struct literal to build it from JSON instead, since the fallback-chain fields are (correctly) private outside `gglib-proxy`.
- Drops 3 tests duplicating `tokens_in_use()` fallback coverage already exercised by `gglib-proxy/src/slots.rs`'s 17 tests.

Stacked on #659 (base branch is `refactor(cli)/update-boundaries`, not `main`) — merge that first.

Closes #645.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p gglib-proxy -p gglib-cli` passes (335 tests)
- [x] `cargo clippy -p gglib-cli -p gglib-proxy --all-targets` clean
- [x] `bash scripts/check_boundaries.sh` passes