### PR TITLE
feat(web): opt-in LAN sharing for gglib web (#560, #561, #562)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2075,7 @@ dependencies = [
  "gglib-runtime",
  "hf-hub",
  "indicatif 0.18.6",
+ "mdns-sd",
  "reqwest 0.13.4",
  "rustyline",
  "serde",
@@ -3642,6 +3654,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "imara-diff"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,6 +4189,21 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dbb9f00c8c367f75ed3a775d3eb31d0375a72f58275ef64a1bc53c255a2ce2"
+dependencies = [
+ "fastrand",
+ "flume 0.12.0",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
 ]
 
 [[package]]
@@ -6132,6 +6169,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612942246d0cc239cfd83af1dfd39be47f649208a3524e5e9da651910128e0ac"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6396,7 +6444,7 @@ checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",

--- a/crates/gglib-app-services/src/settings.rs
+++ b/crates/gglib-app-services/src/settings.rs
@@ -117,6 +117,8 @@ impl SettingsOps {
             inference_profiles: settings.inference_profiles,
             setup_completed: settings.setup_completed,
             title_generation_prompt: settings.title_generation_prompt,
+            bind_host: settings.bind_host,
+            share_lan: settings.share_lan,
         })
     }
 
@@ -136,6 +138,8 @@ impl SettingsOps {
             inference_profiles: request.inference_profiles,
             setup_completed: request.setup_completed,
             title_generation_prompt: request.title_generation_prompt,
+            bind_host: request.bind_host,
+            share_lan: request.share_lan,
         };
 
         let settings = self
@@ -164,6 +168,8 @@ impl SettingsOps {
             inference_profiles: settings.inference_profiles,
             setup_completed: settings.setup_completed,
             title_generation_prompt: settings.title_generation_prompt,
+            bind_host: settings.bind_host,
+            share_lan: settings.share_lan,
         })
     }
 
@@ -317,6 +323,8 @@ mod tests {
             inference_profiles: Some(vec![profile("coding", 0.2)]),
             setup_completed: None,
             title_generation_prompt: None,
+            bind_host: None,
+            share_lan: None,
         };
 
         let json = serde_json::to_value(&settings).expect("serializes");

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -486,6 +486,9 @@ pub struct AppSettings {
     pub setup_completed: Option<bool>,
     // Title generation
     pub title_generation_prompt: Option<String>,
+    // Network binding (see `gglib_core::Settings`)
+    pub bind_host: Option<String>,
+    pub share_lan: Option<bool>,
 }
 
 /// Request body for updating application settings.
@@ -529,6 +532,11 @@ pub struct UpdateSettingsRequest {
     // Title generation
     #[serde(default, with = "serde_with::rust::double_option")]
     pub title_generation_prompt: Option<Option<String>>,
+    // Network binding (see `gglib_core::Settings`)
+    #[serde(default, with = "serde_with::rust::double_option")]
+    pub bind_host: Option<Option<String>>,
+    #[serde(default, with = "serde_with::rust::double_option")]
+    pub share_lan: Option<Option<bool>>,
 }
 
 // ============================================================================

--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -51,6 +51,10 @@ tracing-subscriber = { workspace = true }
 # Streams the SSE body for `gglib proxy dashboard` (crossterm-based redraw,
 # no ratatui — see handlers/proxy_dashboard.rs module docs).
 futures-util = { workspace = true }
+# Pure-Rust mDNS/DNS-SD responder for `gglib web --share-lan`; no system daemon
+# dependency. Deliberately scoped to this crate — LAN advertising is a CLI
+# concern and must not reach the shared axum/app-services/Tauri layers.
+mdns-sd = "0.20"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -399,9 +399,22 @@ pub enum Commands {
         /// Port to serve the web GUI on
         #[arg(short, long, env = "VITE_GGLIB_WEB_PORT", default_value = "9887")]
         port: u16,
-        /// Host to bind the web server
-        #[arg(long, default_value = "127.0.0.1")]
-        host: String,
+        /// Host address to bind the server to (overrides the stored `bind-host` setting)
+        ///
+        /// Falls back to the stored setting, then to 127.0.0.1 when neither is set.
+        /// This is a per-run override — it is not written back to settings.
+        #[arg(long)]
+        host: Option<String>,
+        /// Expose the server on all LAN interfaces (0.0.0.0) and enable mDNS broadcasting
+        ///
+        /// WARNING: Makes GGLib visible to every device on your local network and
+        /// relaxes CORS to allow all origins. Off by default.
+        ///
+        /// Combine with --host to share on one interface only. Combining it with a
+        /// loopback address is rejected, since nothing on the LAN could reach it.
+        /// Persist the preference with `gglib config settings set --share-lan true`.
+        #[arg(long)]
+        share_lan: bool,
         /// Base port for llama-server instances (Note: Port 5000 conflicts with macOS AirPlay)
         #[arg(long, default_value = "9000")]
         base_port: u16,

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -169,6 +169,14 @@ pub enum SettingsCommand {
         /// Show memory fit indicators in HuggingFace browser
         #[arg(long)]
         show_memory_fit_indicators: Option<bool>,
+        /// Host address `gglib web` binds to (an IP, e.g. 127.0.0.1 or 0.0.0.0).
+        /// The `--host` flag overrides this for a single run.
+        #[arg(long)]
+        bind_host: Option<String>,
+        /// Expose `gglib web` on all LAN interfaces and broadcast over mDNS.
+        /// WARNING: makes GGLib visible to every device on your network.
+        #[arg(long)]
+        share_lan: Option<bool>,
     },
     /// Reset all settings to defaults
     Reset {

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -251,7 +251,8 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             api_only,
             static_dir,
         } => {
-            handlers::web::execute(port, host, share_lan, base_port, api_only, static_dir).await?;
+            handlers::web::execute(ctx, port, host, share_lan, base_port, api_only, static_dir)
+                .await?;
         }
         Commands::Proxy {
             host,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -246,11 +246,12 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
         Commands::Web {
             port,
             host,
+            share_lan,
             base_port,
             api_only,
             static_dir,
         } => {
-            handlers::web::execute(port, host, base_port, api_only, static_dir).await?;
+            handlers::web::execute(port, host, share_lan, base_port, api_only, static_dir).await?;
         }
         Commands::Proxy {
             host,

--- a/crates/gglib-cli/src/handlers/config/settings/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/settings/mod.rs
@@ -151,6 +151,8 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             max_tool_iterations,
             max_stagnation_steps,
             show_memory_fit_indicators,
+            bind_host,
+            share_lan,
         } => {
             // Collect the kebab-case keys of every flag that was provided.
             let mut changed: BTreeSet<&str> = BTreeSet::new();
@@ -178,6 +180,12 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             if show_memory_fit_indicators.is_some() {
                 changed.insert("show-memory-fit-indicators");
             }
+            if bind_host.is_some() {
+                changed.insert("bind-host");
+            }
+            if share_lan.is_some() {
+                changed.insert("share-lan");
+            }
 
             if changed.is_empty() {
                 println!("No settings provided. Use --help to see available options.");
@@ -198,6 +206,8 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
                 inference_profiles: None,
                 setup_completed: None,
                 title_generation_prompt: None,
+                bind_host: bind_host.map(Some),
+                share_lan: share_lan.map(Some),
             };
 
             // Pre-validate: merge the prospective update into a local copy and validate
@@ -226,6 +236,12 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             }
             if let Some(Some(v)) = update.show_memory_fit_indicators {
                 prospective.show_memory_fit_indicators = Some(v);
+            }
+            if let Some(Some(v)) = &update.bind_host {
+                prospective.bind_host = Some(v.clone());
+            }
+            if let Some(Some(v)) = update.share_lan {
+                prospective.share_lan = Some(v);
             }
             validate_settings(&prospective)?;
 

--- a/crates/gglib-cli/src/handlers/web/README.md
+++ b/crates/gglib-cli/src/handlers/web/README.md
@@ -1,0 +1,33 @@
+# web
+
+![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-loc.json)
+![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-complexity.json)
+
+<!-- module-docs:start -->
+
+Web server command handler.
+
+Handles starting the Axum HTTP server with optional static file serving.
+Discovers frontend build artifacts automatically from well-known paths,
+or falls back to API-only mode when no frontend is present.
+
+Bind-address and CORS resolution lives in `bind`; this module orchestrates
+it, prints the startup banner, and blocks on the server. When LAN sharing is
+active it also advertises the server over mDNS (`mdns`) and races the server
+against a shutdown signal (`shutdown`) so the record is withdrawn on the way
+out.
+
+<!-- module-docs:end -->
+
+<details>
+<summary><h2>Modules</h2></summary>
+
+<!-- module-table:start -->
+| Module | LOC | Complexity | Coverage |
+|--------|-----|------------|----------|
+| [`bind.rs`](bind.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-bind-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-bind-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-bind-coverage.json) |
+| [`mdns.rs`](mdns.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-mdns-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-mdns-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-mdns-coverage.json) |
+| [`shutdown.rs`](shutdown.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-shutdown-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-shutdown-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-handlers-web-shutdown-coverage.json) |
+<!-- module-table:end -->
+
+</details>

--- a/crates/gglib-cli/src/handlers/web/bind.rs
+++ b/crates/gglib-cli/src/handlers/web/bind.rs
@@ -38,6 +38,25 @@ fn is_loopback(host: &str) -> bool {
     host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
+/// Whether `host` is a wildcard ("all interfaces") address.
+///
+/// True for both `0.0.0.0` and its IPv6 equivalent `::`, so the two are treated
+/// alike when deciding how to describe the bind and how to advertise it.
+pub fn is_wildcard(host: &str) -> bool {
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_unspecified())
+}
+
+/// Format `host:port` as an HTTP authority, bracketing IPv6 literals.
+///
+/// A bare IPv6 address is ambiguous in a URL (`http://::1:9887`), so anything
+/// that parses as IPv6 is wrapped: `http://[::1]:9887`.
+pub fn http_authority(host: &str, port: u16) -> String {
+    match host.parse::<IpAddr>() {
+        Ok(IpAddr::V6(ip)) => format!("[{ip}]:{port}"),
+        _ => format!("{host}:{port}"),
+    }
+}
+
 /// Resolve the effective bind address and CORS policy.
 ///
 /// Host precedence is CLI flag → stored `bind_host` → [`DEFAULT_BIND_HOST`].
@@ -187,13 +206,38 @@ mod tests {
         }
     }
 
-    /// An explicit `0.0.0.0` is not loopback, so it passes the conflict check.
+    /// An explicit wildcard is not loopback, so it passes the conflict check —
+    /// for both address families.
     #[test]
     fn test_explicit_wildcard_is_allowed_with_share_lan() {
-        let decision =
-            resolve_bind(Some("0.0.0.0".to_owned()), true, &stored(None, None)).expect("resolves");
-        assert_eq!(decision.host, "0.0.0.0");
-        assert!(decision.share_lan);
+        for host in ["0.0.0.0", "::"] {
+            let decision =
+                resolve_bind(Some(host.to_owned()), true, &stored(None, None)).expect("resolves");
+            assert_eq!(decision.host, host);
+            assert!(decision.share_lan);
+        }
+    }
+
+    /// `::` is the IPv6 "all interfaces" address and must be classified the
+    /// same as `0.0.0.0` — it drives both the startup banner and whether mDNS
+    /// auto-detects addresses.
+    #[test]
+    fn test_is_wildcard_covers_both_families() {
+        assert!(is_wildcard("0.0.0.0"));
+        assert!(is_wildcard("::"));
+        assert!(!is_wildcard("127.0.0.1"));
+        assert!(!is_wildcard("::1"));
+        assert!(!is_wildcard("192.168.1.50"));
+        assert!(!is_wildcard("localhost"));
+    }
+
+    /// A bare IPv6 authority is ambiguous in a URL, so it gets bracketed.
+    #[test]
+    fn test_http_authority_brackets_ipv6() {
+        assert_eq!(http_authority("127.0.0.1", 9887), "127.0.0.1:9887");
+        assert_eq!(http_authority("localhost", 9887), "localhost:9887");
+        assert_eq!(http_authority("::1", 9887), "[::1]:9887");
+        assert_eq!(http_authority("::", 9887), "[::]:9887");
     }
 
     // ── Settings fallback ───────────────────────────────────────────────

--- a/crates/gglib-cli/src/handlers/web/bind.rs
+++ b/crates/gglib-cli/src/handlers/web/bind.rs
@@ -1,13 +1,13 @@
 //! Bind-address resolution for `gglib web`.
 //!
-//! Pure decision logic: given the CLI flags, work out which host to bind,
-//! whether LAN sharing is active, and which CORS policy that implies. Kept free
-//! of I/O so the precedence rules are unit-testable.
+//! Pure decision logic: given the CLI flags and the stored settings, work out
+//! which host to bind, whether LAN sharing is active, and which CORS policy
+//! that implies. Kept free of I/O so the precedence rules are unit-testable.
 
 use std::net::IpAddr;
 
 use anyhow::{Result, bail};
-use gglib_core::CorsConfig;
+use gglib_core::{CorsConfig, Settings};
 
 /// Compiled-in fallback used when the flag says nothing.
 /// Matches `ServerConfig::with_defaults`.
@@ -40,18 +40,35 @@ fn is_loopback(host: &str) -> bool {
 
 /// Resolve the effective bind address and CORS policy.
 ///
-/// The host comes from the flag, falling back to [`DEFAULT_BIND_HOST`]. When
-/// sharing is on and no host was named, the bind widens to `0.0.0.0`; an
-/// explicitly named non-loopback host wins over that widening, so a multi-homed
-/// machine can share on a single interface.
+/// Host precedence is CLI flag → stored `bind_host` → [`DEFAULT_BIND_HOST`].
+/// Sharing is on when the flag is passed, or when the stored `share_lan` says
+/// so; a bare `--share-lan` is the only thing clap can report, so the flag
+/// alone cannot turn sharing *off* — use `gglib config settings set
+/// --share-lan false` to clear a stored preference.
+///
+/// Neither flag is written back to settings; both are per-run overrides.
+///
+/// When sharing is on and no host was named anywhere, the bind widens to
+/// `0.0.0.0`; an explicitly named non-loopback host wins over that widening, so
+/// a multi-homed machine can share on a single interface.
 ///
 /// # Errors
 ///
 /// Returns an error when LAN sharing is requested against a loopback address —
 /// nothing on the network could reach it, and mDNS would advertise a dead
 /// address.
-pub fn resolve_bind(cli_host: Option<String>, share_lan: bool) -> Result<BindDecision> {
-    let host = match (&cli_host, share_lan) {
+pub fn resolve_bind(
+    cli_host: Option<String>,
+    cli_share_lan: bool,
+    settings: &Settings,
+) -> Result<BindDecision> {
+    let share_lan = cli_share_lan || settings.share_lan.unwrap_or(false);
+
+    // Only a host nobody named gets widened to the wildcard address; a stored
+    // `bind_host` counts as named, exactly like the flag.
+    let named_host = cli_host.or_else(|| settings.bind_host.clone());
+
+    let host = match (&named_host, share_lan) {
         (Some(host), true) if is_loopback(host) => {
             bail!(
                 "--share-lan cannot be combined with the loopback address '{host}': \
@@ -80,10 +97,20 @@ pub fn resolve_bind(cli_host: Option<String>, share_lan: bool) -> Result<BindDec
 mod tests {
     use super::*;
 
-    /// No flags is the secure default: loopback bind, localhost-only CORS.
+    /// Stored settings with only the two binding fields set.
+    fn stored(bind_host: Option<&str>, share_lan: Option<bool>) -> Settings {
+        Settings {
+            bind_host: bind_host.map(ToOwned::to_owned),
+            share_lan,
+            ..Settings::default()
+        }
+    }
+
+    /// Nothing set anywhere is the secure default: loopback bind,
+    /// localhost-only CORS.
     #[test]
     fn test_defaults_to_localhost_only() {
-        let decision = resolve_bind(None, false).expect("resolves");
+        let decision = resolve_bind(None, false, &stored(None, None)).expect("resolves");
         assert_eq!(decision.host, "127.0.0.1");
         assert!(!decision.share_lan);
         assert_eq!(decision.cors, CorsConfig::LocalOnly);
@@ -91,15 +118,20 @@ mod tests {
 
     #[test]
     fn test_share_lan_flag_widens_to_all_interfaces() {
-        let decision = resolve_bind(None, true).expect("resolves");
+        let decision = resolve_bind(None, true, &stored(None, None)).expect("resolves");
         assert_eq!(decision.host, "0.0.0.0");
         assert!(decision.share_lan);
         assert_eq!(decision.cors, CorsConfig::AllowAll);
     }
 
     #[test]
-    fn test_cli_host_is_used_verbatim() {
-        let decision = resolve_bind(Some("192.168.1.100".to_owned()), false).expect("resolves");
+    fn test_cli_host_overrides_stored_setting() {
+        let decision = resolve_bind(
+            Some("192.168.1.100".to_owned()),
+            false,
+            &stored(Some("10.0.0.1"), None),
+        )
+        .expect("resolves");
         assert_eq!(decision.host, "192.168.1.100");
         assert_eq!(decision.cors, CorsConfig::LocalOnly);
     }
@@ -108,7 +140,7 @@ mod tests {
     /// so it wins over the wildcard widening while sharing stays on.
     #[test]
     fn test_explicit_host_wins_over_share_lan_widening() {
-        let decision = resolve_bind(Some("192.168.1.50".to_owned()), true)
+        let decision = resolve_bind(Some("192.168.1.50".to_owned()), true, &stored(None, None))
             .expect("a non-loopback host combined with --share-lan is a legitimate narrowing");
         assert_eq!(decision.host, "192.168.1.50");
         assert!(decision.share_lan);
@@ -118,7 +150,7 @@ mod tests {
     #[test]
     fn test_share_lan_with_loopback_is_rejected() {
         for host in ["127.0.0.1", "localhost", "::1", "127.0.0.2"] {
-            let err = resolve_bind(Some(host.to_owned()), true)
+            let err = resolve_bind(Some(host.to_owned()), true, &stored(None, None))
                 .expect_err("loopback + --share-lan must be rejected");
             assert!(
                 err.to_string().contains("--share-lan"),
@@ -130,8 +162,63 @@ mod tests {
     /// An explicit `0.0.0.0` is not loopback, so it passes the conflict check.
     #[test]
     fn test_explicit_wildcard_is_allowed_with_share_lan() {
-        let decision = resolve_bind(Some("0.0.0.0".to_owned()), true).expect("resolves");
+        let decision =
+            resolve_bind(Some("0.0.0.0".to_owned()), true, &stored(None, None)).expect("resolves");
         assert_eq!(decision.host, "0.0.0.0");
         assert!(decision.share_lan);
+    }
+
+    // ── Settings fallback ───────────────────────────────────────────────
+
+    #[test]
+    fn test_stored_bind_host_used_when_flag_absent() {
+        let decision = resolve_bind(None, false, &stored(Some("10.0.0.5"), None)).expect("resolves");
+        assert_eq!(decision.host, "10.0.0.5");
+    }
+
+    /// `gglib config settings set --share-lan true` must make a later bare
+    /// `gglib web` bind the wildcard address — the persistence path #561 asks
+    /// for, routed through settings rather than through the flag.
+    #[test]
+    fn test_stored_share_lan_used_when_flag_absent() {
+        let decision = resolve_bind(None, false, &stored(None, Some(true))).expect("resolves");
+        assert_eq!(decision.host, "0.0.0.0");
+        assert!(decision.share_lan);
+        assert_eq!(decision.cors, CorsConfig::AllowAll);
+    }
+
+    /// A stored host is "named", so sharing does not widen it to the wildcard.
+    #[test]
+    fn test_stored_host_and_stored_share_lan_combine() {
+        let decision =
+            resolve_bind(None, false, &stored(Some("192.168.1.50"), Some(true))).expect("resolves");
+        assert_eq!(decision.host, "192.168.1.50");
+        assert!(decision.share_lan);
+    }
+
+    /// The loopback conflict applies to stored values too, so a bare
+    /// `gglib web` cannot silently advertise an unreachable address.
+    #[test]
+    fn test_stored_loopback_conflicts_with_share_lan() {
+        resolve_bind(None, false, &stored(Some("127.0.0.1"), Some(true)))
+            .expect_err("stored loopback host must conflict with stored share_lan");
+    }
+
+    /// Setting `share-lan false` returns the server to localhost-only.
+    #[test]
+    fn test_stored_share_lan_false_restores_localhost_only() {
+        let decision = resolve_bind(None, false, &stored(None, Some(false))).expect("resolves");
+        assert!(!decision.share_lan);
+        assert_eq!(decision.host, "127.0.0.1");
+        assert_eq!(decision.cors, CorsConfig::LocalOnly);
+    }
+
+    /// A bare `--share-lan` cannot express "off", so the flag still wins over
+    /// a stored `false`.
+    #[test]
+    fn test_flag_turns_sharing_on_over_stored_false() {
+        let decision = resolve_bind(None, true, &stored(None, Some(false))).expect("resolves");
+        assert!(decision.share_lan);
+        assert_eq!(decision.host, "0.0.0.0");
     }
 }

--- a/crates/gglib-cli/src/handlers/web/bind.rs
+++ b/crates/gglib-cli/src/handlers/web/bind.rs
@@ -49,14 +49,20 @@ fn is_loopback(host: &str) -> bool {
 /// Neither flag is written back to settings; both are per-run overrides.
 ///
 /// When sharing is on and no host was named anywhere, the bind widens to
-/// `0.0.0.0`; an explicitly named non-loopback host wins over that widening, so
-/// a multi-homed machine can share on a single interface.
+/// `0.0.0.0`; a named non-loopback host wins over that widening, so a
+/// multi-homed machine can share on a single interface.
+///
+/// A loopback host cannot be combined with sharing — nothing on the network
+/// could reach it, and mDNS would advertise a dead address. When the loopback
+/// host came from *stored settings* but sharing was asked for on the command
+/// line, the command line is the fresher intent: the stored host is dropped and
+/// the bind widens. A stale saved preference must not veto an explicit flag.
 ///
 /// # Errors
 ///
-/// Returns an error when LAN sharing is requested against a loopback address —
-/// nothing on the network could reach it, and mDNS would advertise a dead
-/// address.
+/// Returns an error when sharing is combined with a loopback host that the user
+/// named on the command line, or when both values come from stored settings and
+/// contradict each other.
 pub fn resolve_bind(
     cli_host: Option<String>,
     cli_share_lan: bool,
@@ -64,12 +70,10 @@ pub fn resolve_bind(
 ) -> Result<BindDecision> {
     let share_lan = cli_share_lan || settings.share_lan.unwrap_or(false);
 
-    // Only a host nobody named gets widened to the wildcard address; a stored
-    // `bind_host` counts as named, exactly like the flag.
-    let named_host = cli_host.or_else(|| settings.bind_host.clone());
-
-    let host = match (&named_host, share_lan) {
-        (Some(host), true) if is_loopback(host) => {
+    // A host nobody named gets widened to the wildcard when sharing.
+    let host = match (cli_host, settings.bind_host.clone()) {
+        // Named on the command line: authoritative, so a conflict is an error.
+        (Some(host), _) if share_lan && is_loopback(&host) => {
             bail!(
                 "--share-lan cannot be combined with the loopback address '{host}': \
                  no other device on the network could reach it. \
@@ -77,9 +81,33 @@ pub fn resolve_bind(
                  (e.g. --host 0.0.0.0)."
             );
         }
-        (Some(host), _) => host.clone(),
-        (None, true) => ALL_INTERFACES.to_owned(),
-        (None, false) => DEFAULT_BIND_HOST.to_owned(),
+        (Some(host), _) => host,
+
+        // Stored loopback host, sharing asked for on the command line: the flag
+        // wins over the saved fallback, exactly as --host would.
+        (None, Some(host)) if cli_share_lan && is_loopback(&host) => {
+            tracing::info!(
+                "ignoring stored bind-host '{host}' because --share-lan was passed; \
+                 binding {ALL_INTERFACES} instead"
+            );
+            ALL_INTERFACES.to_owned()
+        }
+
+        // Both stored and contradictory — the saved configuration cannot be
+        // satisfied, and no command-line input says which side to prefer.
+        (None, Some(host)) if share_lan && is_loopback(&host) => {
+            bail!(
+                "stored settings are contradictory: share-lan is enabled but \
+                 bind-host is the loopback address '{host}', which no other device \
+                 on the network can reach. \
+                 Fix with `gglib config settings set --bind-host 0.0.0.0`, or \
+                 `--share-lan false` for localhost-only access."
+            );
+        }
+        (None, Some(host)) => host,
+
+        (None, None) if share_lan => ALL_INTERFACES.to_owned(),
+        (None, None) => DEFAULT_BIND_HOST.to_owned(),
     };
 
     Ok(BindDecision {
@@ -196,12 +224,44 @@ mod tests {
         assert!(decision.share_lan);
     }
 
-    /// The loopback conflict applies to stored values too, so a bare
-    /// `gglib web` cannot silently advertise an unreachable address.
+    /// Two stored values that contradict each other cannot be satisfied, and
+    /// nothing on the command line says which to prefer — so a bare `gglib web`
+    /// errors rather than silently advertising an unreachable address.
     #[test]
-    fn test_stored_loopback_conflicts_with_share_lan() {
-        resolve_bind(None, false, &stored(Some("127.0.0.1"), Some(true)))
+    fn test_contradictory_stored_settings_are_rejected() {
+        let err = resolve_bind(None, false, &stored(Some("127.0.0.1"), Some(true)))
             .expect_err("stored loopback host must conflict with stored share_lan");
+        assert!(
+            err.to_string().contains("contradictory"),
+            "error should point at the saved configuration: {err}"
+        );
+    }
+
+    /// A stored loopback host is only a fallback for "no --host given", so it
+    /// must not veto an explicit `--share-lan`; the flag is the fresher intent
+    /// and the bind widens instead of erroring.
+    #[test]
+    fn test_cli_share_lan_overrides_stored_loopback_host() {
+        let decision = resolve_bind(None, true, &stored(Some("127.0.0.1"), None))
+            .expect("an explicit flag outranks a stale stored fallback");
+        assert_eq!(decision.host, "0.0.0.0");
+        assert!(decision.share_lan);
+        assert_eq!(decision.cors, CorsConfig::AllowAll);
+
+        // Also when the stored preference already had sharing on.
+        let decision = resolve_bind(None, true, &stored(Some("localhost"), Some(true)))
+            .expect("the flag still wins");
+        assert_eq!(decision.host, "0.0.0.0");
+    }
+
+    /// The override is narrow: a stored *non*-loopback host is still honoured
+    /// when --share-lan is passed, so single-interface sharing keeps working.
+    #[test]
+    fn test_cli_share_lan_keeps_stored_non_loopback_host() {
+        let decision =
+            resolve_bind(None, true, &stored(Some("192.168.1.50"), None)).expect("resolves");
+        assert_eq!(decision.host, "192.168.1.50");
+        assert!(decision.share_lan);
     }
 
     /// Setting `share-lan false` returns the server to localhost-only.

--- a/crates/gglib-cli/src/handlers/web/bind.rs
+++ b/crates/gglib-cli/src/handlers/web/bind.rs
@@ -244,7 +244,8 @@ mod tests {
 
     #[test]
     fn test_stored_bind_host_used_when_flag_absent() {
-        let decision = resolve_bind(None, false, &stored(Some("10.0.0.5"), None)).expect("resolves");
+        let decision =
+            resolve_bind(None, false, &stored(Some("10.0.0.5"), None)).expect("resolves");
         assert_eq!(decision.host, "10.0.0.5");
     }
 

--- a/crates/gglib-cli/src/handlers/web/bind.rs
+++ b/crates/gglib-cli/src/handlers/web/bind.rs
@@ -1,0 +1,137 @@
+//! Bind-address resolution for `gglib web`.
+//!
+//! Pure decision logic: given the CLI flags, work out which host to bind,
+//! whether LAN sharing is active, and which CORS policy that implies. Kept free
+//! of I/O so the precedence rules are unit-testable.
+
+use std::net::IpAddr;
+
+use anyhow::{Result, bail};
+use gglib_core::CorsConfig;
+
+/// Compiled-in fallback used when the flag says nothing.
+/// Matches `ServerConfig::with_defaults`.
+pub const DEFAULT_BIND_HOST: &str = "127.0.0.1";
+
+/// Wildcard address used when LAN sharing is on and no host was named.
+const ALL_INTERFACES: &str = "0.0.0.0";
+
+/// The resolved binding decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindDecision {
+    /// Address to bind the HTTP listener to.
+    pub host: String,
+    /// Whether LAN sharing is active (drives the warning banner and mDNS).
+    pub share_lan: bool,
+    /// CORS policy implied by `share_lan`.
+    pub cors: CorsConfig,
+}
+
+/// Whether `host` refers to the loopback interface.
+///
+/// Covers the literal `localhost` alongside any address that parses as an IP
+/// and is loopback, so `::1` and `127.0.0.2` are caught as well as `127.0.0.1`.
+fn is_loopback(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Resolve the effective bind address and CORS policy.
+///
+/// The host comes from the flag, falling back to [`DEFAULT_BIND_HOST`]. When
+/// sharing is on and no host was named, the bind widens to `0.0.0.0`; an
+/// explicitly named non-loopback host wins over that widening, so a multi-homed
+/// machine can share on a single interface.
+///
+/// # Errors
+///
+/// Returns an error when LAN sharing is requested against a loopback address —
+/// nothing on the network could reach it, and mDNS would advertise a dead
+/// address.
+pub fn resolve_bind(cli_host: Option<String>, share_lan: bool) -> Result<BindDecision> {
+    let host = match (&cli_host, share_lan) {
+        (Some(host), true) if is_loopback(host) => {
+            bail!(
+                "--share-lan cannot be combined with the loopback address '{host}': \
+                 no other device on the network could reach it. \
+                 Drop --share-lan for localhost-only access, or bind a LAN address \
+                 (e.g. --host 0.0.0.0)."
+            );
+        }
+        (Some(host), _) => host.clone(),
+        (None, true) => ALL_INTERFACES.to_owned(),
+        (None, false) => DEFAULT_BIND_HOST.to_owned(),
+    };
+
+    Ok(BindDecision {
+        host,
+        share_lan,
+        cors: if share_lan {
+            CorsConfig::AllowAll
+        } else {
+            CorsConfig::LocalOnly
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// No flags is the secure default: loopback bind, localhost-only CORS.
+    #[test]
+    fn test_defaults_to_localhost_only() {
+        let decision = resolve_bind(None, false).expect("resolves");
+        assert_eq!(decision.host, "127.0.0.1");
+        assert!(!decision.share_lan);
+        assert_eq!(decision.cors, CorsConfig::LocalOnly);
+    }
+
+    #[test]
+    fn test_share_lan_flag_widens_to_all_interfaces() {
+        let decision = resolve_bind(None, true).expect("resolves");
+        assert_eq!(decision.host, "0.0.0.0");
+        assert!(decision.share_lan);
+        assert_eq!(decision.cors, CorsConfig::AllowAll);
+    }
+
+    #[test]
+    fn test_cli_host_is_used_verbatim() {
+        let decision = resolve_bind(Some("192.168.1.100".to_owned()), false).expect("resolves");
+        assert_eq!(decision.host, "192.168.1.100");
+        assert_eq!(decision.cors, CorsConfig::LocalOnly);
+    }
+
+    /// An explicitly named LAN address is a narrower form of the same intent,
+    /// so it wins over the wildcard widening while sharing stays on.
+    #[test]
+    fn test_explicit_host_wins_over_share_lan_widening() {
+        let decision = resolve_bind(Some("192.168.1.50".to_owned()), true)
+            .expect("a non-loopback host combined with --share-lan is a legitimate narrowing");
+        assert_eq!(decision.host, "192.168.1.50");
+        assert!(decision.share_lan);
+        assert_eq!(decision.cors, CorsConfig::AllowAll);
+    }
+
+    #[test]
+    fn test_share_lan_with_loopback_is_rejected() {
+        for host in ["127.0.0.1", "localhost", "::1", "127.0.0.2"] {
+            let err = resolve_bind(Some(host.to_owned()), true)
+                .expect_err("loopback + --share-lan must be rejected");
+            assert!(
+                err.to_string().contains("--share-lan"),
+                "error should name the offending flag: {err}"
+            );
+        }
+    }
+
+    /// An explicit `0.0.0.0` is not loopback, so it passes the conflict check.
+    #[test]
+    fn test_explicit_wildcard_is_allowed_with_share_lan() {
+        let decision = resolve_bind(Some("0.0.0.0".to_owned()), true).expect("resolves");
+        assert_eq!(decision.host, "0.0.0.0");
+        assert!(decision.share_lan);
+    }
+}

--- a/crates/gglib-cli/src/handlers/web/mdns.rs
+++ b/crates/gglib-cli/src/handlers/web/mdns.rs
@@ -51,13 +51,9 @@ impl MdnsAdvertiser {
             }
         };
 
-        // An unspecified address means "every interface" — hand address
-        // selection to mdns-sd rather than guessing a primary NIC.
-        let wildcard = host
-            .parse::<std::net::IpAddr>()
-            .is_ok_and(|ip| ip.is_unspecified());
-
-        let service = if wildcard {
+        // A wildcard address (`0.0.0.0` or `::`) means "every interface" — hand
+        // address selection to mdns-sd rather than guessing a primary NIC.
+        let service = if super::bind::is_wildcard(host) {
             ServiceInfo::new(SERVICE_TYPE, INSTANCE_NAME, HOSTNAME, "", port, None)
                 .map(ServiceInfo::enable_addr_auto)
         } else {

--- a/crates/gglib-cli/src/handlers/web/mdns.rs
+++ b/crates/gglib-cli/src/handlers/web/mdns.rs
@@ -89,7 +89,10 @@ impl MdnsAdvertiser {
         match self.daemon.unregister(&self.fullname) {
             Ok(rx) => {
                 if let Err(e) = rx.recv_async().await {
-                    tracing::warn!("mDNS: unregister of {} was not confirmed ({e})", self.fullname);
+                    tracing::warn!(
+                        "mDNS: unregister of {} was not confirmed ({e})",
+                        self.fullname
+                    );
                 }
             }
             Err(e) => tracing::warn!("mDNS: could not unregister {} ({e})", self.fullname),

--- a/crates/gglib-cli/src/handlers/web/mdns.rs
+++ b/crates/gglib-cli/src/handlers/web/mdns.rs
@@ -1,0 +1,106 @@
+//! mDNS/DNS-SD service advertising for `gglib web --share-lan`.
+//!
+//! Registers `_gglib._tcp.local.` so the server is reachable at `gglib.local`
+//! from any device on the LAN without anyone having to look up an IP address.
+//!
+//! Advertising is strictly opt-in: [`MdnsAdvertiser::start`] is only ever
+//! called when LAN sharing resolved to `true`, so localhost-only runs (and
+//! every test) never spawn a daemon. Every failure here is non-fatal — the HTTP
+//! server is still perfectly usable by IP, so problems are logged and startup
+//! continues.
+
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+
+/// DNS-SD service type for GGLib web servers.
+const SERVICE_TYPE: &str = "_gglib._tcp.local.";
+
+/// Instance name, and the label of the advertised hostname.
+///
+/// Fixed rather than derived from the machine's hostname so the address is
+/// predictably `gglib.local` regardless of what the host calls itself.
+const INSTANCE_NAME: &str = "gglib";
+
+/// Hostname the address record is published under → resolves as `gglib.local`.
+const HOSTNAME: &str = "gglib.local.";
+
+/// An active mDNS registration, unregistered on [`shutdown`](Self::shutdown).
+pub struct MdnsAdvertiser {
+    daemon: ServiceDaemon,
+    fullname: String,
+}
+
+impl MdnsAdvertiser {
+    /// Start advertising the web server on the local network.
+    ///
+    /// Returns `None` if the daemon could not be started or the service could
+    /// not be registered; the caller carries on serving over HTTP either way.
+    ///
+    /// When `host` is the wildcard address, `enable_addr_auto` lets mdns-sd
+    /// discover the machine's interface addresses and keep the record current
+    /// as they change. A specific `host` is advertised verbatim, so a server
+    /// narrowed to one interface does not advertise the others.
+    pub fn start(host: &str, port: u16) -> Option<Self> {
+        let daemon = match ServiceDaemon::new() {
+            Ok(daemon) => daemon,
+            Err(e) => {
+                tracing::warn!(
+                    "mDNS: could not start the responder ({e}); \
+                     the server is still reachable by IP address"
+                );
+                return None;
+            }
+        };
+
+        // An unspecified address means "every interface" — hand address
+        // selection to mdns-sd rather than guessing a primary NIC.
+        let wildcard = host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_unspecified());
+
+        let service = if wildcard {
+            ServiceInfo::new(SERVICE_TYPE, INSTANCE_NAME, HOSTNAME, "", port, None)
+                .map(ServiceInfo::enable_addr_auto)
+        } else {
+            ServiceInfo::new(SERVICE_TYPE, INSTANCE_NAME, HOSTNAME, host, port, None)
+        };
+
+        let service = match service {
+            Ok(service) => service,
+            Err(e) => {
+                tracing::warn!("mDNS: could not build the service record ({e}); not advertising");
+                return None;
+            }
+        };
+
+        let fullname = service.get_fullname().to_owned();
+        if let Err(e) = daemon.register(service) {
+            tracing::warn!("mDNS: could not register {fullname} ({e}); not advertising");
+            return None;
+        }
+
+        tracing::info!("mDNS: advertising {fullname} as http://{INSTANCE_NAME}.local:{port}");
+        eprintln!("  \u{1f4e1} Discoverable at: http://{INSTANCE_NAME}.local:{port}");
+
+        Some(Self { daemon, fullname })
+    }
+
+    /// Withdraw the record and stop the responder.
+    ///
+    /// Awaits the unregister acknowledgement before shutting the daemon down —
+    /// dropping it immediately would leave the goodbye packet unsent and the
+    /// stale record cached by every resolver on the network.
+    pub async fn shutdown(self) {
+        match self.daemon.unregister(&self.fullname) {
+            Ok(rx) => {
+                if let Err(e) = rx.recv_async().await {
+                    tracing::warn!("mDNS: unregister of {} was not confirmed ({e})", self.fullname);
+                }
+            }
+            Err(e) => tracing::warn!("mDNS: could not unregister {} ({e})", self.fullname),
+        }
+
+        if let Err(e) = self.daemon.shutdown() {
+            tracing::warn!("mDNS: responder shutdown failed ({e})");
+        }
+    }
+}

--- a/crates/gglib-cli/src/handlers/web/mod.rs
+++ b/crates/gglib-cli/src/handlers/web/mod.rs
@@ -3,6 +3,11 @@
 //! Handles starting the Axum HTTP server with optional static file serving.
 //! Discovers frontend build artifacts automatically from well-known paths,
 //! or falls back to API-only mode when no frontend is present.
+//!
+//! Bind-address and CORS resolution lives in [`bind`]; this module orchestrates
+//! it, prints the startup banner, and blocks on the server.
+
+mod bind;
 
 use std::path::PathBuf;
 
@@ -12,26 +17,29 @@ use crate::presentation::style;
 
 /// Execute the `web` command.
 ///
-/// Builds the Axum `ServerConfig`, resolves the static-files directory
-/// (explicit flag → auto-discovery → API-only), prints startup information,
-/// and then blocks until the server shuts down.
+/// Resolves the bind address and CORS policy from the flags, builds the Axum
+/// `ServerConfig`, resolves the static-files directory (explicit flag →
+/// auto-discovery → API-only), prints startup information, and then blocks
+/// until the server shuts down.
 ///
 /// # Arguments
 ///
 /// * `port`       — TCP port to listen on for HTTP requests.
+/// * `host`       — Explicit bind address; `None` uses the compiled-in default.
+/// * `share_lan`  — Expose on all LAN interfaces and relax CORS to allow all.
 /// * `base_port`  — Starting port range for llama-server subprocess allocation.
 /// * `api_only`   — When `true`, skip static-file serving regardless of flags.
 /// * `static_dir` — Explicit path to a built frontend; takes priority over
 ///   auto-discovery when `api_only` is `false`.
 pub async fn execute(
     port: u16,
-    host: String,
+    host: Option<String>,
+    share_lan: bool,
     base_port: u16,
     api_only: bool,
     static_dir: Option<PathBuf>,
 ) -> Result<()> {
     use gglib_axum::{ServerConfig, start_server};
-    use gglib_core::CorsConfig;
     use gglib_core::paths::llama_server_path;
 
     // Warn if the VITE env var is set but unparseable so the user knows
@@ -45,15 +53,17 @@ pub async fn execute(
         );
     }
 
+    let decision = bind::resolve_bind(host, share_lan)?;
+
     let mut config = ServerConfig {
-        host,
+        host: decision.host.clone(),
         port,
         base_port,
         llama_server_path: llama_server_path()?,
         max_concurrent: 4,
         max_concurrent_agent_loops: 4,
         static_dir: None,
-        cors: CorsConfig::LocalOnly,
+        cors: decision.cors,
     };
 
     // Resolve static directory: api-only flag > explicit flag > auto-discover > none
@@ -100,6 +110,24 @@ pub async fn execute(
         style::print_banner_close();
     }
 
+    if decision.share_lan {
+        print_share_lan_warning(&decision.host, port);
+    }
+
     start_server(config).await?;
     Ok(())
+}
+
+/// Print the LAN-exposure warning.
+///
+/// Sharing drops the server out of its localhost-only posture and allows every
+/// origin through CORS, so it is called out explicitly rather than buried in
+/// the startup log.
+fn print_share_lan_warning(host: &str, port: u16) {
+    eprintln!();
+    eprintln!("  \u{26a0}\u{fe0f}  LAN SHARING ENABLED (--share-lan)");
+    eprintln!("     Bound to {host}:{port} — reachable by every device on your network.");
+    eprintln!("     CORS is relaxed to allow all origins.");
+    eprintln!("     GGLib has no authentication: only use this on networks you trust.");
+    eprintln!();
 }

--- a/crates/gglib-cli/src/handlers/web/mod.rs
+++ b/crates/gglib-cli/src/handlers/web/mod.rs
@@ -95,10 +95,16 @@ pub async fn execute(
     if let Some(ref dir) = config.static_dir {
         style::print_info_banner("Web Server", "\u{1f680}");
         eprintln!("  \u{1f4c2} Serving UI from: {}", dir.display());
-        if config.host == "0.0.0.0" {
-            eprintln!("  \u{1f310} Network: http://0.0.0.0:{}", port);
+        if bind::is_wildcard(&config.host) {
+            eprintln!(
+                "  \u{1f310} Network: http://{}",
+                bind::http_authority(&config.host, port)
+            );
         } else {
-            eprintln!("  \u{1f310} Local:   http://{}:{}", config.host, port);
+            eprintln!(
+                "  \u{1f310} Local:   http://{}",
+                bind::http_authority(&config.host, port)
+            );
         }
         eprintln!(
             "  \u{1f4ca} Status:  http://localhost:{}/v1/proxy/status",
@@ -134,6 +140,15 @@ pub async fn execute(
     // closing it would mean threading a callback through gglib-axum, which the
     // Tauri adapter also consumes.
     let advertiser = mdns::MdnsAdvertiser::start(&decision.host, port);
+    if advertiser.is_none() {
+        // The technical cause is logged by the advertiser; say plainly here what
+        // it means, since the user asked for discovery and is not getting it.
+        eprintln!(
+            "  \u{26a0}\u{fe0f}  mDNS advertising unavailable — 'gglib.local' will not resolve."
+        );
+        eprintln!("     The server is still reachable at its IP address.");
+        eprintln!();
+    }
 
     let outcome = tokio::select! {
         res = start_server(config) => res,

--- a/crates/gglib-cli/src/handlers/web/mod.rs
+++ b/crates/gglib-cli/src/handlers/web/mod.rs
@@ -13,25 +13,28 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
+use crate::bootstrap::CliContext;
 use crate::presentation::style;
 
 /// Execute the `web` command.
 ///
-/// Resolves the bind address and CORS policy from the flags, builds the Axum
-/// `ServerConfig`, resolves the static-files directory (explicit flag →
-/// auto-discovery → API-only), prints startup information, and then blocks
-/// until the server shuts down.
+/// Resolves the bind address and CORS policy from the flags and stored
+/// settings, builds the Axum `ServerConfig`, resolves the static-files
+/// directory (explicit flag → auto-discovery → API-only), prints startup
+/// information, and then blocks until the server shuts down.
 ///
 /// # Arguments
 ///
+/// * `ctx`        — CLI context; supplies the stored binding preferences.
 /// * `port`       — TCP port to listen on for HTTP requests.
-/// * `host`       — Explicit bind address; `None` uses the compiled-in default.
+/// * `host`       — Explicit bind address; `None` falls back to settings.
 /// * `share_lan`  — Expose on all LAN interfaces and relax CORS to allow all.
 /// * `base_port`  — Starting port range for llama-server subprocess allocation.
 /// * `api_only`   — When `true`, skip static-file serving regardless of flags.
 /// * `static_dir` — Explicit path to a built frontend; takes priority over
 ///   auto-discovery when `api_only` is `false`.
 pub async fn execute(
+    ctx: &CliContext,
     port: u16,
     host: Option<String>,
     share_lan: bool,
@@ -53,7 +56,8 @@ pub async fn execute(
         );
     }
 
-    let decision = bind::resolve_bind(host, share_lan)?;
+    let settings = ctx.app.settings().get().await?;
+    let decision = bind::resolve_bind(host, share_lan, &settings)?;
 
     let mut config = ServerConfig {
         host: decision.host.clone(),

--- a/crates/gglib-cli/src/handlers/web/mod.rs
+++ b/crates/gglib-cli/src/handlers/web/mod.rs
@@ -5,9 +5,14 @@
 //! or falls back to API-only mode when no frontend is present.
 //!
 //! Bind-address and CORS resolution lives in [`bind`]; this module orchestrates
-//! it, prints the startup banner, and blocks on the server.
+//! it, prints the startup banner, and blocks on the server. When LAN sharing is
+//! active it also advertises the server over mDNS ([`mdns`]) and races the
+//! server against a shutdown signal ([`shutdown`]) so the record is withdrawn
+//! on the way out.
 
 mod bind;
+mod mdns;
+mod shutdown;
 
 use std::path::PathBuf;
 
@@ -114,11 +119,38 @@ pub async fn execute(
         style::print_banner_close();
     }
 
-    if decision.share_lan {
-        print_share_lan_warning(&decision.host, port);
+    if !decision.share_lan {
+        // Localhost-only: no advertising, and nothing to tear down, so the
+        // server owns the process until it exits.
+        start_server(config).await?;
+        return Ok(());
     }
 
-    start_server(config).await?;
+    print_share_lan_warning(&decision.host, port);
+
+    // Registered just before the listener opens. `start_server` owns the bind,
+    // so "after bind" is not observable from here; the resulting window where
+    // the service is advertised but not yet accepting is sub-millisecond, and
+    // closing it would mean threading a callback through gglib-axum, which the
+    // Tauri adapter also consumes.
+    let advertiser = mdns::MdnsAdvertiser::start(&decision.host, port);
+
+    let outcome = tokio::select! {
+        res = start_server(config) => res,
+        () = shutdown::shutdown_signal() => {
+            eprintln!();
+            eprintln!("  Shutting down web server...");
+            Ok(())
+        }
+    };
+
+    // Withdraw the record before propagating any server error, so a crash does
+    // not leave a stale `gglib.local` cached across the network.
+    if let Some(advertiser) = advertiser {
+        advertiser.shutdown().await;
+    }
+
+    outcome?;
     Ok(())
 }
 

--- a/crates/gglib-cli/src/handlers/web/mod.rs
+++ b/crates/gglib-cli/src/handlers/web/mod.rs
@@ -1,14 +1,4 @@
-//! Web server command handler.
-//!
-//! Handles starting the Axum HTTP server with optional static file serving.
-//! Discovers frontend build artifacts automatically from well-known paths,
-//! or falls back to API-only mode when no frontend is present.
-//!
-//! Bind-address and CORS resolution lives in [`bind`]; this module orchestrates
-//! it, prints the startup banner, and blocks on the server. When LAN sharing is
-//! active it also advertises the server over mDNS ([`mdns`]) and races the
-//! server against a shutdown signal ([`shutdown`]) so the record is withdrawn
-//! on the way out.
+#![doc = include_str!("README.md")]
 
 mod bind;
 mod mdns;

--- a/crates/gglib-cli/src/handlers/web/shutdown.rs
+++ b/crates/gglib-cli/src/handlers/web/shutdown.rs
@@ -1,0 +1,44 @@
+//! Shutdown-signal handling for `gglib web`.
+//!
+//! `axum::serve` is awaited to completion by `gglib_axum::start_server`, so the
+//! web handler has no shutdown hook of its own. Racing the server against this
+//! future gives the handler a chance to run its own teardown — withdrawing the
+//! mDNS record — instead of the process simply dying with the record still
+//! advertised.
+
+/// Resolve when the process is asked to stop.
+///
+/// Completes on SIGINT (Ctrl-C) on every platform, and additionally on SIGTERM
+/// on Unix, which is what a service manager sends.
+pub async fn shutdown_signal() {
+    let interrupt = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::warn!("could not listen for Ctrl-C ({e}); shutdown will not be graceful");
+            // Never resolve: let the other branch (or the server) decide.
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    {
+        let terminate = async {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sig) => {
+                    sig.recv().await;
+                }
+                Err(e) => {
+                    tracing::warn!("could not listen for SIGTERM ({e})");
+                    std::future::pending::<()>().await;
+                }
+            }
+        };
+
+        tokio::select! {
+            () = interrupt => {}
+            () = terminate => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    interrupt.await;
+}

--- a/crates/gglib-core/src/cors.rs
+++ b/crates/gglib-core/src/cors.rs
@@ -4,7 +4,7 @@
 //! by the Axum web server's CORS middleware.
 
 /// CORS configuration for the web server.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum CorsConfig {
     /// Allow all origins (development mode).
     AllowAll,

--- a/crates/gglib-core/src/settings.rs
+++ b/crates/gglib-core/src/settings.rs
@@ -72,6 +72,19 @@ pub struct Settings {
 
     /// Custom prompt template for generating chat titles.
     pub title_generation_prompt: Option<String>,
+
+    // ── Network binding ─────────────────────────────────────────────
+    /// Override the bind host for `gglib web`.
+    ///
+    /// `None` → use the compiled-in default (`127.0.0.1`). The `--host` flag
+    /// takes precedence for a single run without changing this value.
+    pub bind_host: Option<String>,
+
+    /// Whether `gglib web` binds all LAN interfaces and broadcasts over mDNS.
+    ///
+    /// `None`/`Some(false)` → localhost-only. The `--share-lan` flag can turn
+    /// this on for a single run, but cannot turn it off — clear it here.
+    pub share_lan: Option<bool>,
 }
 
 impl Settings {
@@ -94,6 +107,8 @@ impl Settings {
             inference_profiles: None,
             setup_completed: None,
             title_generation_prompt: None,
+            bind_host: None,
+            share_lan: None,
         }
     }
 
@@ -156,6 +171,12 @@ impl Settings {
         if let Some(ref v) = other.title_generation_prompt {
             self.title_generation_prompt.clone_from(v);
         }
+        if let Some(ref v) = other.bind_host {
+            self.bind_host.clone_from(v);
+        }
+        if let Some(ref v) = other.share_lan {
+            self.share_lan = *v;
+        }
     }
 }
 
@@ -180,6 +201,8 @@ pub struct SettingsUpdate {
     pub inference_profiles: Option<Option<Vec<InferenceProfile>>>,
     pub setup_completed: Option<Option<bool>>,
     pub title_generation_prompt: Option<Option<String>>,
+    pub bind_host: Option<Option<String>>,
+    pub share_lan: Option<Option<bool>>,
 }
 
 /// Settings validation error.
@@ -202,6 +225,9 @@ pub enum SettingsError {
 
     #[error("Invalid inference profile: {0}")]
     InvalidInferenceProfile(String),
+
+    #[error("Bind host must be an IP address (e.g. 127.0.0.1 or 0.0.0.0), got '{0}'")]
+    InvalidBindHost(String),
 }
 
 /// Validate settings values.
@@ -241,6 +267,15 @@ pub fn validate_settings(settings: &Settings) -> Result<(), SettingsError> {
         .is_some_and(|p| p.trim().is_empty())
     {
         return Err(SettingsError::EmptyDownloadPath);
+    }
+
+    // Validate the bind host if specified. Requiring a literal IP (rather than
+    // accepting a name) keeps the value unambiguous for both the TCP bind and
+    // the mDNS address record.
+    if let Some(ref host) = settings.bind_host
+        && host.parse::<std::net::IpAddr>().is_err()
+    {
+        return Err(SettingsError::InvalidBindHost(host.clone()));
     }
 
     // Validate inference defaults if specified

--- a/crates/gglib-db/src/repositories/sqlite_settings_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_settings_repository.rs
@@ -145,6 +145,81 @@ mod tests {
         assert_eq!(loaded.proxy_port, Some(9090));
     }
 
+    /// The settings table is key-value, so a new field needs no DDL — it
+    /// round-trips as its own row keyed by the serde field name.
+    #[tokio::test]
+    async fn test_save_and_load_bind_host() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let repo = SqliteSettingsRepository::new(pool.clone());
+        repo.ensure_table().await.unwrap();
+
+        let settings = Settings {
+            bind_host: Some("0.0.0.0".to_owned()),
+            ..Settings::default()
+        };
+        repo.save(&settings).await.unwrap();
+
+        assert_eq!(
+            repo.load().await.unwrap().bind_host,
+            Some("0.0.0.0".to_owned())
+        );
+
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT value FROM settings_kv WHERE key = 'bind_host'")
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            row.map(|r| r.0),
+            Some("\"0.0.0.0\"".to_owned()),
+            "bind_host is stored under its serde field name as compact JSON"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_share_lan() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let repo = SqliteSettingsRepository::new(pool);
+        repo.ensure_table().await.unwrap();
+
+        let mut settings = Settings {
+            share_lan: Some(true),
+            ..Settings::default()
+        };
+        repo.save(&settings).await.unwrap();
+        assert_eq!(repo.load().await.unwrap().share_lan, Some(true));
+
+        // `--share-lan false` must be persistable as a real value, not erased:
+        // it is the documented way to switch LAN sharing back off.
+        settings.share_lan = Some(false);
+        repo.save(&settings).await.unwrap();
+        assert_eq!(repo.load().await.unwrap().share_lan, Some(false));
+    }
+
+    /// A database written before these fields existed has no rows for them.
+    /// `Settings` is `#[serde(default)]` with `Option` fields, so the absent
+    /// rows deserialize to `None` rather than failing the whole load — which
+    /// is why no migration is needed for the new columns.
+    #[tokio::test]
+    async fn test_load_tolerates_rows_written_before_new_fields_existed() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let repo = SqliteSettingsRepository::new(pool.clone());
+        repo.ensure_table().await.unwrap();
+
+        // Simulate a pre-existing DB: only an old key is present.
+        sqlx::query(
+            "INSERT INTO settings_kv (key, value, updated_at) VALUES ('proxy_port', '9090', '')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let loaded = repo.load().await.expect("older row sets still load");
+        assert_eq!(loaded.proxy_port, Some(9090));
+        assert_eq!(loaded.bind_host, None);
+        assert_eq!(loaded.share_lan, None);
+    }
+
     #[tokio::test]
     async fn test_none_fields_are_deleted_from_db() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();


### PR DESCRIPTION
Phase 1b–1d of the GGLib Home Server epic (#558). Phase 1a (#559) made `gglib web` localhost-only; this adds the supported way to opt back out for a home-server install, so the box is reachable from a phone or laptop at `gglib.local` with no IP lookup.

Three commits, one per issue, sequential because all three touch the web handler, plus a follow-up fixing CI (formatting and a missing module README) and an IPv6/mDNS-visibility edge-case pass.

## What landed

**#560 — `--share-lan` flag.** Widens the bind to `0.0.0.0`, switches CORS `LocalOnly` → `AllowAll`, prints an exposure warning. Bind resolution moves into a pure `resolve_bind` (`handlers/web/bind.rs`), splitting `web.rs` into a directory as it takes on more decisions.

**#561 — `bind_host` / `share_lan` settings.** Added to `Settings` and the app-services DTOs, exposed on `gglib config settings set`, used as the fallback when the matching flag is absent.

**#562 — mDNS.** Registers `_gglib._tcp.local.` while sharing is active, withdrawn on SIGINT/SIGTERM.

## Deviations from the issue bodies

Worth reading before diffing against the issue text — three details had drifted.

1. **`--host` already existed** on the `Web` command (landed with #636), so #560 reduced to `--share-lan`. It changed from `String` to `Option<String>`: the clap `default_value` made "not passed" indistinguishable from "passed the default", which blocked #561's fallback.

2. **#561 needs no migration.** The issue assumed a wide `settings` table wanting `ALTER TABLE ... ADD COLUMN`. The schema is key-value (`settings_kv`) — `SqliteSettingsRepository` serdes the whole `Settings` struct and writes one row per field. New fields get their own rows, and an absent row already means "use default", so fresh and pre-existing databases both work with zero DDL. Covered by `test_load_tolerates_rows_written_before_new_fields_existed`.

3. **mdns-sd is 0.20, not 0.13.** `enable_addr_auto` discovers and tracks interface addresses, dropping the issue's proposed `local-ip-address`/`gethostname` deps and its UDP-connect fallback. `mdns-sd` is the only crate added, scoped to `gglib-cli`.

## Decisions

**Neither flag persists.** `--host` and `--share-lan` are per-run overrides; `config settings set` is the only writer. This changes #561's first acceptance criterion — the persistence path is `config settings set --share-lan true` → subsequent bare `gglib web` binds `0.0.0.0`, verified below. A bare `--share-lan` cannot express "off", so `config settings set --share-lan false` clears it.

**Explicit `--host` wins over `--share-lan`'s implied `0.0.0.0`.** `--share-lan --host 192.168.1.50` is not a conflict — binding a LAN IP *is* sharing, narrowed to one interface, which is what a multi-homed box wants. Only a *loopback* host is genuinely contradictory (nothing on the LAN can reach it, and mDNS would advertise a dead address), and that errors. A stored loopback `bind_host` does not veto an explicit `--share-lan`: the stored value is a fallback, so the flag wins and the bind widens. Two stored values that contradict each other still error.

## Architecture

The precedence rules above are the least obvious part of this PR, so here's the decision `resolve_bind` (`handlers/web/bind.rs`) makes:

```mermaid
flowchart TD
    A(["gglib web invoked"]) --> B{"share_lan?<br/>--share-lan OR settings.share_lan"}

    B -->|"false"| C["host = --host<br/>→ settings.bind_host<br/>→ 127.0.0.1"]
    C --> D["CORS: LocalOnly"]

    B -->|"true"| E{"host named?<br/>by flag or settings"}

    E -->|"no"| F["host = 0.0.0.0 / ::"]

    E -->|"named on --host"| G{"loopback?"}
    G -->|"yes"| H["error:<br/>reject the combination"]
    G -->|"no"| I["host = the named value"]

    E -->|"named only in settings.bind_host"| J{"loopback?"}
    J -->|"no"| I
    J -->|"yes, --share-lan was passed"| K["override:<br/>ignore the stale stored host,<br/>host = 0.0.0.0"]
    J -->|"yes, share_lan also from settings"| L["error:<br/>contradictory stored settings"]

    F --> M["CORS: AllowAll"]
    I --> M
    K --> M
```

The rule worth calling out: a host named **on the command line** is authoritative, so a loopback conflict there is a hard error. A host that's only in *stored settings* is a weaker fallback — if `--share-lan` shows up on the command line, that's the fresher intent, so the stale stored loopback host is overridden rather than blocking the flag. Two stored values that disagree with each other still error, since nothing on the command line says which one to trust.

mDNS lifecycle added in #562 — `start_server` owns the axum future with no shutdown hook of its own, so the handler races it against a signal to get a chance to withdraw the record on the way out:

```mermaid
sequenceDiagram
    participant User
    participant Handler as web::execute
    participant Mdns as mdns::MdnsAdvertiser
    participant Axum as gglib_axum::start_server
    participant Sig as shutdown::shutdown_signal

    User->>Handler: gglib web --share-lan
    Handler->>Handler: resolve_bind(...) -> BindDecision
    Handler->>Mdns: start(host, port)
    alt registration succeeds
        Mdns-->>Handler: Some(advertiser)
    else registration fails
        Mdns-->>Handler: None (logged + user-facing warning, server still usable by IP)
    end

    par serving
        Handler->>Axum: start_server(config)
        Axum->>Axum: accept requests
    and waiting for signal
        Handler->>Sig: shutdown_signal()
        Sig->>Sig: block on SIGINT / SIGTERM
    end

    Sig-->>Handler: signal received (tokio::select! resolves)
    Handler->>Mdns: advertiser.shutdown()
    Mdns->>Mdns: unregister() + await ack
    Mdns->>Mdns: daemon.shutdown()
    Handler-->>User: process exits, record withdrawn
```

## Verification

`cargo check --workspace --all-targets` clean; clippy clean on the touched crates; full test suites pass. CI: Format, Clippy, Check Boundaries, Enforce Architecture, Test (Frontend) all green.

Binds confirmed with `lsof`: default → `127.0.0.1`, `--share-lan` → `*`, `--host <lan-ip>` → that IP, `--share-lan --host 127.0.0.1` → error. CORS confirmed by header: `LocalOnly` omits `access-control-allow-origin` for a foreign origin and reflects a localhost one; `AllowAll` returns `*`.

Settings fallback: `config settings set --share-lan true` → bare `gglib web` bound `*`; `--share-lan false --bind-host 127.0.0.1` returned it to loopback. A non-IP `bind-host` is rejected before any write.

mDNS: an independent mDNS client resolved `gglib._gglib._tcp.local.` → host `gglib.local.` at the LAN address on `en0`. Both SIGINT and SIGTERM exited cleanly and the record was gone on re-browse. Without `--share-lan` no 5353 socket is opened and nothing is advertised. `--host ::` (IPv6 wildcard) binds and advertises identically to `0.0.0.0`.

Two caveats on #562's acceptance criteria, both environmental rather than defects:

- `dns-sd -B` does **not** show the service when run on the same machine. macOS's `mDNSResponder` already owns port 5353, and two responders on one host do not cooperate. Publishing is correct — an independent mDNS client sees it, and `dig @224.0.0.251 -p 5353` gets a reply. A device on the LAN receives the `en0` announcement directly and is unaffected. The cross-device `curl` was not run, as it needs a second machine.
- The health endpoint is `/health`, not `/api/health` as the issue states; `/health` sits outside the CORS layer by design. Confirmed `200`.

Closes #560
Closes #561
Closes #562
