### PR TITLE
fix(deps): scope the brace-expansion override so eslint runs again

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,11 @@
     "vite": "^8.0.0",
     "vitest": "^4.0.16"
   },
+  "//overrides": "brace-expansion is forced to ^5.0.8 for GHSA-mh99-v99m-4gvg, EXCEPT under minimatch@3, which requires the 1.x CommonJS function export and throws 'expand is not a function' on 5.x — that breaks eslint before it reads a single file. minimatch@3 reaches us through eslint-plugin-react, whose latest release still pins ^3.1.2. Do not flatten this back to a blanket override (npm audit fix --force will try); it takes `npm run lint` down completely.",
   "overrides": {
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.8",
+    "minimatch@3": {
+      "brace-expansion": "^1.1.17"
+    }
   }
 }


### PR DESCRIPTION
`npm run lint` has been completely broken since #634 — on `main`, for everyone, before eslint
reads a single source file:

```
TypeError: expand is not a function
  at Minimatch.braceExpand (node_modules/minimatch/minimatch.js:271)
  at doMatch (node_modules/@eslint/config-array/dist/cjs/index.cjs:422)
```

## Cause

The blanket `"brace-expansion": "^5.0.8"` override added in #634 to clear
[GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) also lands on
`minimatch@3`, which declares `^1.1.7` and does `const expand = require('brace-expansion')`.
brace-expansion 5.x no longer exports a bare function, so the call throws while eslint is
building its config array.

## Fix

Scope the override. Everything still gets `^5.0.8`; only `minimatch@3` falls back to
`^1.1.17`, the newest release its API contract actually allows:

```json
"overrides": {
  "brace-expansion": "^5.0.8",
  "minimatch@3": { "brace-expansion": "^1.1.17" }
}
```

Resolved tree:

```
eslint-plugin-react → minimatch@3.1.5  → brace-expansion@1.1.17
typescript-estree   → minimatch@10.2.6 → brace-expansion@5.0.8
```

A `"//overrides"` note sits next to it, because `npm audit fix --force` will try to flatten
this back and takes lint down again when it does.

## On the remaining audit findings

`npm audit` still reports 6 high, all reaching brace-expansion through `minimatch@3`. That
path cannot be closed right now:

- `minimatch@3` comes from `eslint-plugin-react`, and 7.37.5 — the latest release — still
  pins `^3.1.2`.
- Bumping to eslint 10 does not close it either. `eslint-plugin-react` caps its peer range at
  `^9.7`, so eslint@10 fails to resolve without `--force`/`--legacy-peer-deps`, and the plugin
  would still drag `minimatch@3` in behind it.
- The 1.x line has no patched release; the advisory's only fix is ≥5.0.8.

So the choice is a working lint or a quiet `npm audit`, not both. The findings are all
devDependencies in the lint toolchain, the advisory is a DoS on brace patterns, and the only
patterns reaching it are the glob strings in our own eslint config — nothing attacker-supplied,
nothing in the shipped bundle. Worth revisiting when eslint-plugin-react ships a release off
`minimatch@3`.

## Verification

From a clean `node_modules` with no lockfile: `npm run lint` exits 0, `npm run build`
succeeds, and the full `tests/ts` suite passes (691 tests).

`package-lock.json` is gitignored here and CI runs `npm install`, so this is a `package.json`
change only.
