### PR TITLE
test: scratch PR to exercise label-check enrich paths

### DIFF
--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -377,3 +377,4 @@ pub enum ModelCommand {
         json: bool,
     },
 }
+// scratch test: ambiguous multi-component touch

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -1125,3 +1125,4 @@ mod tests {
         );
     }
 }
+// scratch test: ambiguous multi-component touch


### PR DESCRIPTION
Throwaway PR to verify the restructured label-check.yml live: ambiguous multi-component (cli+proxy) should get an ask-comment, not auto-apply; missing size: should get the historical-band comment. Will close without merging once confirmed.