### PR TITLE
ci(label-check): inherit component/priority/type from linked issues

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -5,7 +5,9 @@
 #   size:*       — estimated effort (hours/days, NOT diff volume — see the note below)
 #
 # Two jobs in ONE workflow, deliberately:
-#   enrich       — applies what can be derived, and asks for what can't
+#   enrich       — applies what can be derived (including inheriting component:/
+#                  priority:/type: from any issue this PR closes), and asks for
+#                  what can't
 #   label-check  — the required status check; verifies and reports
 #
 # Why one workflow and not two: label changes made with GITHUB_TOKEN do NOT trigger new
@@ -48,6 +50,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
+      issues: read # to fetch labels from issues linked via Closes/Fixes/Resolves
     steps:
       - name: Derive component labels and request a size
         uses: actions/github-script@v7
@@ -76,6 +79,47 @@ jobs:
                 || EXEMPT_TITLES.some(re => re.test(pr.title))) {
               core.info(`PR #${issue_number} is exempt from label enrichment.`);
               return;
+            }
+
+            // --- Inherit component:/priority:/type: from linked issues -----------
+            // The original label audit's top finding: labels don't propagate from a
+            // fully-labelled issue to the PR that closes it (e.g. issue #640 had
+            // component: core; its PR #657 didn't). size: is deliberately excluded —
+            // issue size is a triage estimate, PR size is the measured diff, and these
+            // legitimately differ (see the size: section below).
+            const INHERITABLE_PREFIXES = ['component:', 'priority:', 'type:'];
+            const LINK_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)\b/gi;
+            const url = `github\\.com/${owner}/${repo}/issues/(\\d+)`;
+            const URL_RE = new RegExp(url, 'gi');
+
+            const linkedNumbers = new Set();
+            for (const m of (pr.body || '').matchAll(LINK_RE)) linkedNumbers.add(Number(m[1]));
+            for (const m of (pr.body || '').matchAll(URL_RE)) linkedNumbers.add(Number(m[1]));
+
+            const inheritable = new Set();
+            for (const num of linkedNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: num });
+                for (const l of issue.labels) {
+                  const label = typeof l === 'string' ? l : l.name;
+                  if (INHERITABLE_PREFIXES.some(p => label.startsWith(p))) inheritable.add(label);
+                }
+              } catch (e) {
+                // A closing reference to a deleted issue, or one in another repo that
+                // happens to match the #N shorthand, shouldn't break enrichment.
+                core.warning(`Could not fetch linked issue #${num}: ${e.message}`);
+              }
+            }
+
+            // A prefix the PR already carries is a deliberate override — never replaced.
+            const toInherit = [...inheritable].filter(l => {
+              const prefix = INHERITABLE_PREFIXES.find(p => l.startsWith(p));
+              return !has(prefix);
+            });
+            if (toInherit.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toInherit });
+              names.push(...toInherit); // keep `has()` current for the checks below
+              core.info(`Inherited from linked issue(s): ${toInherit.join(', ')}`);
             }
 
             // --- Changed files --------------------------------------------------


### PR DESCRIPTION
Stacked on #670 — adds inheritance to the same \`enrich\` job.

## Summary
- Parses \`Closes/Fixes/Resolves #N\` (and full issue URLs) from the PR body.
- Inherits \`component:\`/\`priority:\`/\`type:\` from each linked issue, skipping any prefix the PR already has.
- \`size:\` is deliberately never inherited — issue size is a triage estimate, PR size is the measured diff (see #670's backtest).

Direct fix for the original audit's top finding: issue #640 had \`component: core\`; PR #657, which closed it, had none.

Verified with 41 tests against the actual extracted script (9 new for this change) — linked-issue inheritance, URL-form references, a 404 on one reference not aborting the run, override-wins when the PR already has a label, and inherited labels correctly satisfying the ambiguous-multi-component check so path-derivation doesn't also fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)