### PR TITLE
fix(ci): don't auto-create junk labels; stay silent when nothing's missing

### DIFF
--- a/.github/workflows/check-issue-form.yml
+++ b/.github/workflows/check-issue-form.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  issues: read # to list the repo's labels for the option-value check
 
 jobs:
   check:
@@ -26,4 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: node scripts/check_issue_form_mapping.mjs
+      # Fetching the real label list lets the script also verify that every dropdown
+      # OPTION resolves to a label that exists. Without this it only checks field ids.
+      # Worth the extra step: the labels API auto-creates unknown labels instead of
+      # erroring, so a typo'd option would otherwise silently produce a junk grey label.
+      - name: Fetch repo labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label list --repo "$GITHUB_REPOSITORY" --limit 300 --json name > /tmp/labels.json
+      - run: node scripts/check_issue_form_mapping.mjs /tmp/labels.json

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -198,8 +198,13 @@ jobs:
                 await github.rest.issues.createComment({ owner, repo, issue_number, body });
               }
             } else if (existing) {
-              const body = `${MARKER}\n### Label triage\n\nResolved — all required labels are present.`;
-              if (existing.body !== body) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              // Nothing missing any more, so say nothing at all — the labels themselves
+              // convey that. Delete rather than leaving the comment: its text lists the
+              // categories that *were* missing and would now be actively wrong.
+              try {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+                core.info('Removed the triage comment — all required labels present.');
+              } catch (e) {
+                core.warning(`Could not delete the triage comment: ${e.message}`);
               }
             }

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -118,11 +118,37 @@ jobs:
                   toApply.add('type: epic');
                 }
 
+                // Never let a form-option typo invent a label. The labels API CREATES a
+                // label that doesn't exist rather than erroring — verified directly:
+                // POSTing a nonexistent name returns 200 and yields a new label with
+                // default grey (#ededed) and no description. So a stray dropdown option
+                // (say `- clii`) would silently produce a junk `component: clii` label
+                // that then satisfies the gate and pollutes the taxonomy.
+                //
+                // Filter to labels that already exist and warn loudly about the rest.
+                // The issue then falls through to needs-triage below — flagged for a
+                // human, which is the correct failure direction.
                 if (toApply.size) {
-                  await github.rest.issues.addLabels({
-                    owner, repo, issue_number, labels: [...toApply],
-                  });
-                  core.info(`Applied from form: ${[...toApply].join(', ')}`);
+                  const repoLabels = new Set((await github.paginate(
+                    github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 },
+                  )).map(l => l.name));
+
+                  const unknown = [...toApply].filter(l => !repoLabels.has(l));
+                  const known = [...toApply].filter(l => repoLabels.has(l));
+
+                  if (unknown.length) {
+                    core.warning(
+                      `Refusing to create nonexistent label(s): ${unknown.join(', ')}. `
+                      + `Check .github/ISSUE_TEMPLATE/issue.yml's dropdown options against `
+                      + `the repo's actual labels — an option with no matching label would `
+                      + `otherwise be auto-created as an untitled grey label.`);
+                  }
+                  if (known.length) {
+                    await github.rest.issues.addLabels({
+                      owner, repo, issue_number, labels: known,
+                    });
+                    core.info(`Applied from form: ${known.join(', ')}`);
+                  }
                 }
               }
             }

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -178,8 +178,31 @@ jobs:
             if (derived.size === 1) {
               toAdd = [...derived].filter(l => !names.includes(l));
               if (toAdd.length) {
-                await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
-                core.info(`Applied: ${toAdd.join(', ')}`);
+                // Never let a stale COMPONENT_MAP entry invent a label. The labels API
+                // CREATES a nonexistent label rather than erroring (verified: POSTing an
+                // unknown name returns 200 and yields a default-grey, description-less
+                // label), so a renamed crate whose map row wasn't updated would silently
+                // manufacture junk. Filter to labels that exist; anything else warns and
+                // falls through to the ask-comment below, which is the safe direction.
+                //
+                // Inherited labels above need no such guard — they're read off a real
+                // issue, so they provably exist already.
+                const repoLabels = new Set((await github.paginate(
+                  github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 },
+                )).map(l => l.name));
+
+                const unknown = toAdd.filter(l => !repoLabels.has(l));
+                if (unknown.length) {
+                  core.warning(
+                    `COMPONENT_MAP refers to nonexistent label(s): ${unknown.join(', ')}. `
+                    + `Not creating them — update the map or create the labels.`);
+                }
+                toAdd = toAdd.filter(l => repoLabels.has(l));
+
+                if (toAdd.length) {
+                  await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+                  core.info(`Applied: ${toAdd.join(', ')}`);
+                }
               }
             }
             const componentSatisfied = has('component:') || toAdd.length > 0;

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -280,21 +280,34 @@ jobs:
               owner, repo, issue_number, per_page: 100,
             })).find(c => c.body?.includes(MARKER));
 
-            const body = asks.length
-              ? `${MARKER}\n### Label check\n\n${asks.join('\n\n---\n\n')}`
-              : `${MARKER}\n### Label check\n\nAll required labels are present.`;
-
+            // Only ever comment when something is actually needed. When nothing is
+            // missing, say nothing at all — a green check plus the labels themselves
+            // already convey "all present", so an extra comment is pure noise.
+            //
             // Update in place rather than posting again on every push. Comment edits
             // don't send notifications, so this stays quiet. (And comment activity fires
             // issue_comment, not pull_request, so it cannot re-trigger this workflow.)
-            if (existing) {
-              if (existing.body !== body) {
-                await github.rest.issues.updateComment({
-                  owner, repo, comment_id: existing.id, body,
-                });
+            if (asks.length) {
+              const body = `${MARKER}\n### Label check\n\n${asks.join('\n\n---\n\n')}`;
+              if (existing) {
+                if (existing.body !== body) {
+                  await github.rest.issues.updateComment({
+                    owner, repo, comment_id: existing.id, body,
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
               }
-            } else if (asks.length) {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            } else if (existing) {
+              // Delete rather than leaving it: the stale text says "Needs a size: label"
+              // and would now be actively wrong. Deleting is what "say nothing" actually
+              // means once a comment already exists.
+              try {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+                core.info('Removed the assist comment — nothing left to ask for.');
+              } catch (e) {
+                core.warning(`Could not delete the assist comment: ${e.message}`);
+              }
             }
 
   label-check:

--- a/scripts/check_issue_form_mapping.mjs
+++ b/scripts/check_issue_form_mapping.mjs
@@ -75,3 +75,65 @@ if (missingFromWorkflow.length || staleInWorkflow.length) {
 }
 
 console.log(`OK — issue.yml and issue-labels.yml agree on: ${mappableFormIds.join(', ')}`);
+
+// --- Optional second check: do the dropdown OPTIONS map to labels that exist? --------
+//
+// Field ids drifting is one failure mode; option values are another. The labels API
+// CREATES a label that doesn't exist rather than erroring (verified: POSTing an unknown
+// name returns 200 and yields a default-grey, description-less label), so an option like
+// `- clii` would silently manufacture a junk `component: clii`. issue-labels.yml now
+// refuses to create unknown labels at runtime, but catching it at PR time is better.
+//
+// Needs the repo's real label list, which this script can't know statically — so it's
+// opt-in via a JSON file argument (CI fetches it with `gh label list`). Without the
+// argument the check is skipped and the script stays pure/offline, runnable locally.
+const labelsFile = process.argv[2];
+if (!labelsFile) {
+  console.log('Skipping option-value check (no labels JSON passed — pass one to enable).');
+  process.exit(0);
+}
+
+const existingLabels = new Set(JSON.parse(readFileSync(labelsFile, 'utf8')).map(l => l.name ?? l));
+
+// Prefix per field id, mirroring issue-labels.yml's PREFIX_FIELDS.
+const OPTION_PREFIXES = { component: 'component: ', priority: 'priority: ', size: 'size: ', type: 'type: ' };
+
+function extractOptions(yamlText, fieldId) {
+  // Grab the `options:` list belonging to a given `id:`. Both live inside the same
+  // list item, so scan forward from the id until the next item at the same indent.
+  const lines = yamlText.split('\n');
+  const start = lines.findIndex(l => new RegExp(`^\\s{4}id:\\s*${fieldId}\\s*$`).test(l));
+  if (start === -1) return [];
+  const opts = [];
+  let inOptions = false;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s{2}- type:/.test(line)) break; // next field
+    if (/^\s+options:\s*$/.test(line)) { inOptions = true; continue; }
+    if (inOptions) {
+      const m = line.match(/^\s+-\s+(.+?)\s*$/);
+      if (m) opts.push(m[1]);
+      else if (line.trim() && !/^\s+-/.test(line)) inOptions = false;
+    }
+  }
+  return opts;
+}
+
+const formYaml = readFileSync(FORM_PATH, 'utf8');
+const badOptions = [];
+for (const [fieldId, prefix] of Object.entries(OPTION_PREFIXES)) {
+  for (const opt of extractOptions(formYaml, fieldId)) {
+    const label = prefix + opt;
+    if (!existingLabels.has(label)) badOptions.push(`${fieldId}: "${opt}" -> no such label "${label}"`);
+  }
+}
+
+if (badOptions.length) {
+  console.error('\nIssue form has dropdown option(s) with no matching repo label:\n');
+  for (const b of badOptions) console.error(`  ${b}`);
+  console.error('\nThese would be silently auto-created as untitled grey labels if applied.');
+  console.error('Either create the label or fix the option.');
+  process.exit(1);
+}
+
+console.log('OK — every dropdown option maps to an existing repo label.');


### PR DESCRIPTION
Two fixes to the label workflows.

## 1. Never auto-create a junk label

GitHub's add-labels API **creates** a label that doesn't exist rather than erroring. Verified directly against the real API — POSTing an unknown name returns 200 and yields a label with default grey `#ededed` and an empty description.

This already happened once: `migrate_labels.sh` applied `type: epic` to 26 items and silently created it as an untitled grey label (metadata since corrected).

The latent risk is worse than the cosmetic one. A stray dropdown option in `issue.yml` (`- clii`) or a stale `COMPONENT_MAP` row pointing at a renamed crate would silently manufacture a junk label that then **satisfies the required-label gate** — a wrong label that looks right, which is precisely what the rest of this system is designed to avoid.

Fixed in two layers:
- **Runtime** — both label-writing workflows fetch the repo's real labels and refuse to create unknown ones, warning loudly instead. The issue/PR falls through to `needs-triage` or the ask-comment: flagged for a human, the correct failure direction. Inherited labels are exempt (read off a real issue, so they provably exist).
- **PR time** — `check_issue_form_mapping.mjs` now also validates dropdown *options*, not just field ids. That needs the label list, so it's opt-in via an argument; CI passes it and the script stays pure/offline-runnable without it.

## 2. Stay silent when all labels are present

The bots were rewriting their comment to "All required labels are present" / "Resolved" once nothing was missing. That's noise — the green check and the labels themselves already say it.

They now comment **only** when something is actually needed. Where a comment already exists and there's nothing left to ask for, it's deleted rather than left in place: its text lists the categories that *were* missing, so leaving it would be actively wrong. Deletion is wrapped so a permissions failure warns instead of failing the job.

## Verification

- Confirmed the auto-create behavior against the real API, then deleted the test artifact.
- Negative-tested the option check: a typo'd `- clii` fails with exit 1, naming the offending option.
- Test suites extended and passing: **46/46** (`label-check`) and **21/21** (`issue-labels`) — including a stale map row, a typo'd form option, and the new "stays completely silent" cases.
- This PR's CI exercises the new `Fetch repo labels` step; the previous run confirmed `OK — every dropdown option maps to an existing repo label` ran for real against the live label list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)