### PR TITLE
refactor(inference): replace temperature-coupling latch with ordered-layer resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,20 +413,36 @@ These tags are **auto-detected at import time** by `gglib-gguf::capabilities::de
 Sampling parameters are resolved through a **5-level merge hierarchy** on every request. Each level fills in only the fields left unset by the previous level:
 
 ```
-Request override  →  Inference profile  →  Per-model defaults  →  Global settings  →  Hardcoded fallback
+Request override  →  Inference profile  →  Per-model defaults  →  Global settings  →  Floor
 ```
 
 The full set of configurable parameters:
 
-| Parameter | CLI flag | Range | Hardcoded fallback | Notes |
-|-----------|----------|-------|--------------------|-------|
+| Parameter | CLI flag | Range | Floor | Notes |
+|-----------|----------|-------|-------|-------|
 | `temperature` | `--temperature` | 0.0 – 2.0 | 0.7 | |
 | `top_p` | `--top-p` | 0.0 – 1.0 | 0.95 | |
 | `top_k` | `--top-k` | int | 40 | |
 | `max_tokens` | `--max-tokens` | int | *(none)* | Deliberately unset — see below |
 | `repeat_penalty` | `--repeat-penalty` | > 0.0 | 1.0 | |
-| `presence_penalty` | `--presence-penalty` | 0.0 – 2.0 | 0.0 (disabled) | Recommended 1.5 for reasoning models |
+| `presence_penalty` | `--presence-penalty` | 0.0 – 2.0 | 0.0, or 1.0 on a `reasoning`-tagged model | See below |
 | `min_p` | `--min-p` | 0.0 – 1.0 | 0.0 (disabled) | 0.05 is llama.cpp built-in default when omitted |
+
+**`temperature`, `presence_penalty`, `repeat_penalty` and `min_p` are coupled.**
+The last three are only meaningful relative to how sharp `temperature` makes the
+sampling distribution, so they always come from whichever layer supplied the
+`temperature` — never a lower layer, which would apply a penalty tuned for a
+distribution nothing above it asked for. If that layer left one of the three
+unset (or if no layer names a temperature at all, in which case the pair-up
+doesn't apply), it falls to the floor rather than to a lower layer's value.
+
+The floor itself is class-aware for exactly one field: a plain `0.0`
+`presence_penalty` is fine for most models, but a `reasoning`-tagged model
+(Qwen3.6, DeepSeek-R1, QwQ, …) degrades into repetitive reasoning loops under
+greedy or near-greedy decoding, so its floor is `1.0` — a real guard, without
+asserting the model's full tuned recipe onto a temperature it wasn't chosen
+for. `top_p`, `top_k` and `max_tokens` are uncoupled and fill from any layer
+independently regardless of temperature.
 
 **`max_tokens` has no fallback, by design.** Resolution force-writes every set
 parameter into the outgoing request, so a fallback here would cap *every* request
@@ -490,8 +506,15 @@ Profiles are **global** — one `coding` profile applies to every model — and
 deliberately **sparse**: only the parameters you set override anything, and the
 rest fall through to that model's own defaults. That is what makes a single
 profile safe across models with different architectures; a `coding` profile
-setting only `temperature` still lets a thinking model contribute its own
-`presence_penalty`.
+setting only `top_k` still lets a thinking model contribute its own `top_p`
+and `max_tokens`.
+
+One exception: a `coding` profile that sets `temperature` does **not** also
+inherit the model's `presence_penalty` — see the coupling rule above. A
+profile is presumed to be choosing its own distribution sharpness, so it gets
+the floor for the coupled parameters it doesn't name, not the model's recipe
+tuned for a different temperature. Set `presence_penalty` explicitly on the
+profile if it needs one.
 
 Key behaviours:
 

--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -355,11 +355,19 @@ fn build_compare_request_body(
     model: &gglib_core::domain::Model,
     global_inf: Option<&InferenceConfig>,
 ) -> serde_json::Value {
+    let model_is_reasoning = model
+        .tags
+        .iter()
+        .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
     let resolved = config
         .inference
         .clone()
         .unwrap_or_default()
-        .resolve_with_defaults(model.inference_defaults.as_ref(), global_inf);
+        .resolve_with_defaults(
+            model.inference_defaults.as_ref(),
+            global_inf,
+            model_is_reasoning,
+        );
 
     let mut body = serde_json::json!({
         "model": model.name,

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -392,7 +392,7 @@ pub async fn proxy_chat(
     let servers = state.servers.list_servers().await;
     let server = servers.iter().find(|s| s.port == request.port);
 
-    let (capabilities, model_defaults) = if let Some(server) = server {
+    let (capabilities, model_defaults, model_is_reasoning) = if let Some(server) = server {
         // Found the server, fetch the model to get its capabilities and inference_defaults
         match state.core.models().get_by_id(server.model_id).await {
             Ok(Some(model)) => {
@@ -405,7 +405,11 @@ pub async fn proxy_chat(
                     requires_strict_turns = model.capabilities.contains(gglib_core::domain::ModelCapabilities::REQUIRES_STRICT_TURNS),
                     "Model capabilities loaded for chat request"
                 );
-                (model.capabilities, model.inference_defaults)
+                let is_reasoning = model
+                    .tags
+                    .iter()
+                    .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
+                (model.capabilities, model.inference_defaults, is_reasoning)
             }
             Ok(None) => {
                 tracing::warn!(
@@ -413,7 +417,11 @@ pub async fn proxy_chat(
                     model_id = server.model_id,
                     "Model not found for capability detection; assuming default"
                 );
-                (gglib_core::domain::ModelCapabilities::default(), None)
+                (
+                    gglib_core::domain::ModelCapabilities::default(),
+                    None,
+                    false,
+                )
             }
             Err(e) => {
                 tracing::warn!(
@@ -422,7 +430,11 @@ pub async fn proxy_chat(
                     error = %e,
                     "Failed to fetch model for capability detection; assuming default"
                 );
-                (gglib_core::domain::ModelCapabilities::default(), None)
+                (
+                    gglib_core::domain::ModelCapabilities::default(),
+                    None,
+                    false,
+                )
             }
         }
     } else {
@@ -430,7 +442,11 @@ pub async fn proxy_chat(
             port = request.port,
             "No server found for port; assuming default capabilities"
         );
-        (gglib_core::domain::ModelCapabilities::default(), None)
+        (
+            gglib_core::domain::ModelCapabilities::default(),
+            None,
+            false,
+        )
     };
 
     // Load global settings for inference defaults
@@ -453,7 +469,11 @@ pub async fn proxy_chat(
         presence_penalty: request.presence_penalty,
         min_p: request.min_p,
     }
-    .resolve_with_defaults(model_defaults.as_ref(), global_defaults.as_ref());
+    .resolve_with_defaults(
+        model_defaults.as_ref(),
+        global_defaults.as_ref(),
+        model_is_reasoning,
+    );
 
     tracing::debug!(
         port = request.port,

--- a/crates/gglib-cli/src/handlers/inference/shared.rs
+++ b/crates/gglib-cli/src/handlers/inference/shared.rs
@@ -20,9 +20,14 @@ pub async fn resolve_inference_config(
     model: &gglib_core::Model,
 ) -> Result<InferenceConfig> {
     let settings = ctx.app.settings().get().await?;
+    let model_is_reasoning = model
+        .tags
+        .iter()
+        .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
     Ok(config.resolve_with_defaults(
         model.inference_defaults.as_ref(),
         settings.inference_defaults.as_ref(),
+        model_is_reasoning,
     ))
 }
 

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -199,73 +199,80 @@ impl InferenceConfig {
         }
     }
 
-    /// Fill `None` fields from `other`, except parameters tuned against a
-    /// temperature `self` has already claimed.
+    /// Resolve an ordered list of sampling layers (highest priority first)
+    /// into a single fully-resolved config, then fill anything still unset
+    /// from `floor`.
+    ///
+    /// This is the one fold every multi-layer resolution surface goes
+    /// through: [`resolve_with_profile`] wraps it for the simple
+    /// request/profile/model/global shape, and
+    /// [`crate::request_pipeline::sampling`] builds its own five-layer
+    /// (cli/client/profile/model/global) array and calls it directly. There
+    /// is exactly one place that decides what "wins" means.
+    ///
+    /// # Uncoupled parameters
+    ///
+    /// `top_p`, `top_k`, and `max_tokens` gap-fill independently: each takes
+    /// the first `Some` value found scanning the layers top to bottom.
+    ///
+    /// # Coupled parameters
     ///
     /// `presence_penalty`, `repeat_penalty` and `min_p` are only meaningful
     /// relative to how sharp the sampling distribution is, so they travel with
     /// the `temperature` they were chosen for. [`reasoning_profile`] pairs
     /// `temperature 1.0` with `presence_penalty 1.5` deliberately; a sparse
-    /// profile that sets `temperature 0.2` and leaves the penalty unset used to
-    /// inherit that 1.5 and run a recipe no layer ever intended — a penalty
-    /// tuned for a broad distribution applied to a near-greedy one.
+    /// profile that sets `temperature 0.2` and leaves the penalty unset must
+    /// not inherit that `1.5` — that would run a recipe no layer ever
+    /// intended, a penalty tuned for a broad distribution applied to a
+    /// near-greedy one.
     ///
-    /// So: once a layer declares a `temperature`, lower layers may no longer
-    /// contribute the parameters tuned against it. They fall through to the
-    /// neutral values in [`with_hardcoded_defaults`] instead, which is applied
-    /// with plain [`merge_with`] as an unconditional floor — it is a set of
-    /// neutral defaults, not a competing recipe.
+    /// So: `temperature` resolves to the first layer that sets one. If some
+    /// layer does, the coupled trio comes *only* from that same layer — never
+    /// a layer beneath it — falling to `floor` for anything that layer itself
+    /// left unset. If **no** layer sets a temperature at all, nothing has been
+    /// tuned against anything, so the coupled trio gap-fills normally, exactly
+    /// like the uncoupled parameters.
     ///
-    /// Parameters that do not interact with temperature this way (`top_p`,
-    /// `top_k`, `max_tokens`) are unaffected and still fill from any layer.
-    ///
-    /// [`reasoning_profile`]: Self::reasoning_profile
-    /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
-    /// [`merge_with`]: Self::merge_with
-    const fn merge_layer(&mut self, other: &Self) {
-        // Checked before any field is written, so a layer supplying both a
-        // temperature and its penalties still contributes them as a set.
-        let temperature_claimed = self.temperature.is_some();
-
-        if self.top_p.is_none() {
-            self.top_p = other.top_p;
-        }
-        if self.top_k.is_none() {
-            self.top_k = other.top_k;
-        }
-        if self.max_tokens.is_none() {
-            self.max_tokens = other.max_tokens;
-        }
-
-        if !temperature_claimed {
-            self.temperature = other.temperature;
-            if self.repeat_penalty.is_none() {
-                self.repeat_penalty = other.repeat_penalty;
-            }
-            if self.presence_penalty.is_none() {
-                self.presence_penalty = other.presence_penalty;
-            }
-            if self.min_p.is_none() {
-                self.min_p = other.min_p;
-            }
-        }
-    }
-
-    /// Stack `self` as the higher-priority layer above `lower`.
-    ///
-    /// Same rules as the resolution ladder — `self` wins where it speaks,
-    /// `lower` fills the rest, and a `temperature` declared by `self` blocks
-    /// `lower`'s temperature-tuned parameters (see [`merge_layer`]). Used to
-    /// place a layer *above* the client's own request parameters, which
-    /// [`resolve_with_profile`] cannot express since it treats `self` as the
-    /// top.
-    ///
-    /// [`merge_layer`]: Self::merge_layer
     /// [`resolve_with_profile`]: Self::resolve_with_profile
+    /// [`reasoning_profile`]: Self::reasoning_profile
     #[must_use]
-    pub const fn stacked_over(mut self, lower: &Self) -> Self {
-        self.merge_layer(lower);
-        self
+    pub fn resolve_layers(layers: &[Option<&Self>], floor: &Self) -> Self {
+        let mut result = Self::default();
+
+        for layer in layers.iter().flatten() {
+            if result.top_p.is_none() {
+                result.top_p = layer.top_p;
+            }
+            if result.top_k.is_none() {
+                result.top_k = layer.top_k;
+            }
+            if result.max_tokens.is_none() {
+                result.max_tokens = layer.max_tokens;
+            }
+        }
+
+        result.temperature = layers.iter().flatten().find_map(|l| l.temperature);
+
+        if let Some(claim) = layers.iter().flatten().find(|l| l.temperature.is_some()) {
+            result.repeat_penalty = claim.repeat_penalty;
+            result.presence_penalty = claim.presence_penalty;
+            result.min_p = claim.min_p;
+        } else {
+            for layer in layers.iter().flatten() {
+                if result.repeat_penalty.is_none() {
+                    result.repeat_penalty = layer.repeat_penalty;
+                }
+                if result.presence_penalty.is_none() {
+                    result.presence_penalty = layer.presence_penalty;
+                }
+                if result.min_p.is_none() {
+                    result.min_p = layer.min_p;
+                }
+            }
+        }
+
+        result.merge_with(floor);
+        result
     }
 
     /// Create a new config with all fields set to sensible defaults.
@@ -302,6 +309,29 @@ impl InferenceConfig {
             repeat_penalty: Some(1.0),
             presence_penalty: Some(0.0),
             min_p: Some(0.0),
+        }
+    }
+
+    /// The coupled-trio floor for models tagged `reasoning`.
+    ///
+    /// [`resolve_layers`] falls back to a floor once it has decided which
+    /// layer (if any) claims the coupled trio and that layer left a field
+    /// unset. [`with_hardcoded_defaults`]'s neutral `presence_penalty: 0.0` is
+    /// the right floor for most models, but wrong for a `reasoning`-tagged
+    /// one: those degrade under greedy or near-greedy decoding into
+    /// repetitive reasoning loops (see [`reasoning_profile`], which pairs
+    /// `presence_penalty: 1.5` with `temperature: 1.0` specifically to
+    /// prevent this). `1.0` keeps a real guard in place at the floor without
+    /// asserting the full recipe tuned for a different temperature.
+    ///
+    /// [`resolve_layers`]: Self::resolve_layers
+    /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
+    /// [`reasoning_profile`]: Self::reasoning_profile
+    #[must_use]
+    pub const fn reasoning_floor() -> Self {
+        Self {
+            presence_penalty: Some(1.0),
+            ..Self::with_hardcoded_defaults()
         }
     }
 
@@ -407,6 +437,12 @@ impl InferenceConfig {
     /// have no notion of a named profile (`gglib serve`, `gglib chat`,
     /// `gglib q`, the Web UI chat API).
     ///
+    /// `model_is_reasoning` selects the floor beneath every layer: pass
+    /// `true` when the target model carries gglib's `reasoning` capability
+    /// tag, so a request that ends up with no anti-repetition guard at all
+    /// still gets one, rather than the neutral floor that is right for every
+    /// other model. See [`resolve_layers`] and [`reasoning_floor`].
+    ///
     /// # Example
     ///
     /// ```rust
@@ -415,16 +451,23 @@ impl InferenceConfig {
     /// let request = InferenceConfig { temperature: Some(0.9), ..Default::default() };
     /// let model   = InferenceConfig { temperature: Some(0.5), top_p: Some(0.8), ..Default::default() };
     ///
-    /// let resolved = request.resolve_with_defaults(Some(&model), None);
+    /// let resolved = request.resolve_with_defaults(Some(&model), None, false);
     /// assert_eq!(resolved.temperature, Some(0.9)); // request wins
     /// assert_eq!(resolved.top_p,       Some(0.8)); // model fills in
     /// assert_eq!(resolved.top_k,       Some(40));  // hardcoded fallback
     /// ```
     ///
     /// [`resolve_with_profile`]: Self::resolve_with_profile
+    /// [`resolve_layers`]: Self::resolve_layers
+    /// [`reasoning_floor`]: Self::reasoning_floor
     #[must_use]
-    pub const fn resolve_with_defaults(self, model: Option<&Self>, global: Option<&Self>) -> Self {
-        self.resolve_with_profile(None, model, global)
+    pub fn resolve_with_defaults(
+        self,
+        model: Option<&Self>,
+        global: Option<&Self>,
+        model_is_reasoning: bool,
+    ) -> Self {
+        self.resolve_with_profile(None, model, global, model_is_reasoning)
     }
 
     /// Resolve inference parameters using the full 5-level hierarchy.
@@ -436,11 +479,17 @@ impl InferenceConfig {
     /// 2. `profile` — the named profile the request selected, if any
     /// 3. `model` — per-model stored defaults
     /// 4. `global` — global settings defaults
-    /// 5. [`with_hardcoded_defaults`] — compile-time fallback values
+    /// 5. the model-class floor — [`reasoning_floor`] when `model_is_reasoning`,
+    ///    otherwise [`with_hardcoded_defaults`]
     ///
     /// This is the single source of truth for inference parameter resolution
-    /// across every gglib surface; [`resolve_with_defaults`] delegates here so
-    /// there is exactly one merge order to reason about and to test.
+    /// across every gglib surface that does not need its own layer set;
+    /// [`resolve_with_defaults`] delegates here so there is exactly one merge
+    /// order to reason about and to test.
+    /// [`crate::request_pipeline::sampling`] needs a sixth layer (the
+    /// client's own request, sitting between `self` and `profile`) and calls
+    /// the underlying [`resolve_layers`] directly for that reason — the merge
+    /// semantics are identical either way.
     ///
     /// # Why the profile sits above the model
     ///
@@ -454,12 +503,11 @@ impl InferenceConfig {
     ///
     /// # Temperature-tuned parameters do not fall through
     ///
-    /// The one exception, enforced by [`merge_layer`]: once a layer declares a
-    /// `temperature`, lower layers may not contribute `presence_penalty`,
-    /// `repeat_penalty` or `min_p`. Those are tuned against a particular
-    /// distribution sharpness, so inheriting them across a temperature change
-    /// assembles a recipe no layer intended. They resolve to the neutral
-    /// hardcoded values instead.
+    /// See [`resolve_layers`] for the full rule. In short: once a layer
+    /// declares a `temperature`, lower layers may not contribute
+    /// `presence_penalty`, `repeat_penalty` or `min_p` — those resolve from
+    /// the claiming layer alone, falling to the class floor if it left them
+    /// unset.
     ///
     /// # Example
     ///
@@ -477,35 +525,31 @@ impl InferenceConfig {
     /// };
     ///
     /// let resolved = InferenceConfig::default()
-    ///     .resolve_with_profile(Some(&profile), Some(&model), None);
+    ///     .resolve_with_profile(Some(&profile), Some(&model), None, true);
     ///
     /// assert_eq!(resolved.temperature,      Some(0.2)); // profile beats model
-    /// assert_eq!(resolved.presence_penalty, Some(0.0)); // NOT the model's 1.5
+    /// assert_eq!(resolved.presence_penalty, Some(1.0)); // reasoning floor, NOT the model's 1.5
     /// assert_eq!(resolved.top_k,            Some(20));  // untuned: still fills
     /// ```
     ///
-    /// [`merge_layer`]: Self::merge_layer
-    ///
+    /// [`resolve_layers`]: Self::resolve_layers
+    /// [`reasoning_floor`]: Self::reasoning_floor
     /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     /// [`resolve_with_defaults`]: Self::resolve_with_defaults
     #[must_use]
-    pub const fn resolve_with_profile(
-        mut self,
+    pub fn resolve_with_profile(
+        self,
         profile: Option<&Self>,
         model: Option<&Self>,
         global: Option<&Self>,
+        model_is_reasoning: bool,
     ) -> Self {
-        if let Some(p) = profile {
-            self.merge_layer(p);
-        }
-        if let Some(m) = model {
-            self.merge_layer(m);
-        }
-        if let Some(g) = global {
-            self.merge_layer(g);
-        }
-        self.merge_with(&Self::with_hardcoded_defaults());
-        self
+        let floor = if model_is_reasoning {
+            Self::reasoning_floor()
+        } else {
+            Self::with_hardcoded_defaults()
+        };
+        Self::resolve_layers(&[Some(&self), profile, model, global], &floor)
     }
 
     /// Parse inference parameters from an OpenAI-format JSON body (`snake_case` keys).
@@ -606,6 +650,60 @@ mod tests {
         assert_eq!(config.min_p, Some(0.0));
     }
 
+    /// The reasoning floor differs from the hardcoded floor in exactly one
+    /// field — a real anti-repetition guard where the neutral floor has none.
+    #[test]
+    fn test_reasoning_floor_differs_only_in_presence_penalty() {
+        let neutral = InferenceConfig::with_hardcoded_defaults();
+        let reasoning = InferenceConfig::reasoning_floor();
+
+        assert_eq!(reasoning.presence_penalty, Some(1.0));
+        assert_ne!(reasoning.presence_penalty, neutral.presence_penalty);
+
+        assert_eq!(reasoning.temperature, neutral.temperature);
+        assert_eq!(reasoning.top_p, neutral.top_p);
+        assert_eq!(reasoning.top_k, neutral.top_k);
+        assert_eq!(reasoning.max_tokens, neutral.max_tokens);
+        assert_eq!(reasoning.repeat_penalty, neutral.repeat_penalty);
+        assert_eq!(reasoning.min_p, neutral.min_p);
+    }
+
+    /// If nothing in the stack ever declares a temperature, nothing has been
+    /// "tuned" against anything — the coupled trio must gap-fill exactly like
+    /// any other parameter, from whichever layer sets it first, rather than
+    /// jump straight to the floor.
+    #[test]
+    fn test_coupled_trio_gap_fills_normally_when_no_layer_sets_temperature() {
+        let profile = InferenceConfig {
+            presence_penalty: Some(0.3),
+            ..Default::default()
+        };
+        let model = InferenceConfig {
+            presence_penalty: Some(0.5),
+            repeat_penalty: Some(1.2),
+            ..Default::default()
+        };
+
+        let resolved = InferenceConfig::default().resolve_with_profile(
+            Some(&profile),
+            Some(&model),
+            None,
+            false,
+        );
+
+        assert_eq!(resolved.temperature, Some(0.7), "hardcoded fallback");
+        assert_eq!(
+            resolved.presence_penalty,
+            Some(0.3),
+            "profile's own value, not suppressed just because no layer set a temperature"
+        );
+        assert_eq!(
+            resolved.repeat_penalty,
+            Some(1.2),
+            "model fills in what the profile left unset"
+        );
+    }
+
     /// The two ways an unset `max_tokens` could still reach llama-server and
     /// cap generation: as a `max_tokens` key in the forwarded request body, or
     /// as a `-n` flag on the launch command line. `-n` is the more dangerous of
@@ -613,7 +711,7 @@ mod tests {
     /// overrides even a per-request `-1`.
     #[test]
     fn test_unset_max_tokens_reaches_llama_server_by_neither_route() {
-        let resolved = InferenceConfig::default().resolve_with_defaults(None, None);
+        let resolved = InferenceConfig::default().resolve_with_defaults(None, None, false);
 
         assert!(
             !resolved.to_openai_json_patch().contains_key("max_tokens"),
@@ -633,7 +731,7 @@ mod tests {
             max_tokens: Some(512),
             ..Default::default()
         }
-        .resolve_with_defaults(None, None);
+        .resolve_with_defaults(None, None, false);
 
         assert_eq!(resolved.max_tokens, Some(512));
         assert_eq!(
@@ -713,7 +811,7 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved = request.resolve_with_defaults(Some(&model), Some(&global));
+        let resolved = request.resolve_with_defaults(Some(&model), Some(&global), false);
 
         assert_eq!(resolved.temperature, Some(0.9)); // request wins
         assert_eq!(resolved.top_p, Some(0.8)); // model fills in
@@ -725,7 +823,7 @@ mod tests {
     #[test]
     fn test_resolve_with_defaults_no_layers() {
         let base = InferenceConfig::default();
-        let resolved = base.resolve_with_defaults(None, None);
+        let resolved = base.resolve_with_defaults(None, None, false);
         // Should equal hardcoded defaults
         assert_eq!(resolved, InferenceConfig::with_hardcoded_defaults());
     }
@@ -754,7 +852,8 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved = request.resolve_with_profile(Some(&profile), Some(&model), Some(&global));
+        let resolved =
+            request.resolve_with_profile(Some(&profile), Some(&model), Some(&global), false);
 
         assert_eq!(resolved.temperature, Some(0.9)); // request beats profile
         assert_eq!(resolved.top_p, Some(0.85)); // profile beats model
@@ -779,8 +878,12 @@ mod tests {
         };
         let model = InferenceConfig::reasoning_profile();
 
-        let resolved =
-            InferenceConfig::default().resolve_with_profile(Some(&profile), Some(&model), None);
+        let resolved = InferenceConfig::default().resolve_with_profile(
+            Some(&profile),
+            Some(&model),
+            None,
+            false,
+        );
 
         assert_eq!(resolved.temperature, Some(0.2)); // the profile's one opinion
         // Untuned parameters the profile stayed silent about still come from
@@ -797,6 +900,14 @@ mod tests {
     /// 1.5` deliberately. Applying that 1.5 to a near-greedy `temperature 0.2`
     /// request is a recipe no layer ever intended, and it reached production on
     /// every `:coding` request.
+    ///
+    /// The #621 fix originally floored `presence_penalty` to the universal
+    /// neutral `0.0` here — correct in that it stopped the wrong transplant,
+    /// but it also zeroed the model's only anti-repetition guard on a
+    /// reasoning model, which is a second failure mode of its own (see the
+    /// 2026-07-31 incident this floor was added for). `model_is_reasoning:
+    /// true` selects [`InferenceConfig::reasoning_floor`] instead, which keeps
+    /// a real, non-tuned-for-0.2 guard in place.
     #[test]
     fn test_profile_temperature_does_not_inherit_model_penalties() {
         let model = InferenceConfig::reasoning_profile();
@@ -813,11 +924,19 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved =
-            InferenceConfig::default().resolve_with_profile(Some(&profile), Some(&model), None);
+        let resolved = InferenceConfig::default().resolve_with_profile(
+            Some(&profile),
+            Some(&model),
+            None,
+            true,
+        );
 
         assert_eq!(resolved.temperature, Some(0.2));
-        assert_eq!(resolved.presence_penalty, Some(0.0), "must not inherit 1.5");
+        assert_eq!(
+            resolved.presence_penalty,
+            Some(1.0),
+            "must not inherit 1.5, but must not go silently to zero either"
+        );
         assert_eq!(
             resolved.repeat_penalty,
             Some(1.0),
@@ -838,8 +957,12 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved =
-            InferenceConfig::default().resolve_with_profile(Some(&profile), Some(&model), None);
+        let resolved = InferenceConfig::default().resolve_with_profile(
+            Some(&profile),
+            Some(&model),
+            None,
+            true,
+        );
 
         assert_eq!(resolved.temperature, model.temperature);
         assert_eq!(resolved.presence_penalty, model.presence_penalty);
@@ -864,8 +987,8 @@ mod tests {
         assert_eq!(
             request
                 .clone()
-                .resolve_with_defaults(Some(&model), Some(&global)),
-            request.resolve_with_profile(None, Some(&model), Some(&global)),
+                .resolve_with_defaults(Some(&model), Some(&global), false),
+            request.resolve_with_profile(None, Some(&model), Some(&global), false),
         );
     }
 

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -12,7 +12,7 @@ use crate::domain::InferenceConfig;
 /// The sampling layers that sit *below* the client's own request parameters.
 ///
 /// Grouped because they are only ever used together, at the single point where
-/// [`InferenceConfig::resolve_with_profile`] runs.
+/// [`resolve_sampling`] folds them through [`InferenceConfig::resolve_layers`].
 ///
 /// The per-model layer is deliberately absent: it arrives with the rest of the
 /// per-model facts, as
@@ -48,23 +48,16 @@ pub struct SamplingLayers {
 /// `presence_penalty` come from?" means probing llama-server's live `/slots`
 /// mid-generation — which is how the leak behind #621 had to be found.
 ///
-/// Mirrors the ladder in [`InferenceConfig::resolve_with_profile`], including
-/// the temperature coupling: once a layer declares a `temperature`, layers
-/// below it can no longer supply the parameters tuned against it, so those
-/// report `hardcoded` even though a lower layer names a value.
-fn describe_provenance(
-    client: &InferenceConfig,
-    model: Option<&InferenceConfig>,
-    layers: &SamplingLayers,
-) -> String {
-    let ordered: [(&str, Option<&InferenceConfig>); 5] = [
-        ("cli", layers.cli_override.as_ref()),
-        ("client", Some(client)),
-        ("profile", layers.profile.as_ref()),
-        ("model", model),
-        ("global", layers.global.as_ref()),
-    ];
-
+/// Takes the exact same ordered layer array [`resolve_sampling`] folds
+/// through [`InferenceConfig::resolve_layers`], so provenance can never
+/// drift from what was actually resolved — there is one ladder, read by both.
+/// Mirrors the coupling rule documented there: once a layer declares a
+/// `temperature`, layers below it can no longer supply the parameters tuned
+/// against it, so those report `floor` even though a lower layer names a
+/// value. A field with no layer naming it at all also reports `floor` — the
+/// two cases are indistinguishable from the wire body alone, which is the
+/// point: either way nothing above the floor spoke for it.
+fn describe_provenance(ordered: &[(&'static str, Option<&InferenceConfig>)]) -> String {
     // The highest layer naming a temperature; layers below it cannot supply
     // temperature-tuned parameters. `None` means nothing claimed it, so every
     // layer stays eligible.
@@ -78,7 +71,7 @@ fn describe_provenance(
             .iter()
             .take(limit)
             .find(|(_, c)| c.is_some_and(&declares))
-            .map_or("hardcoded", |(name, _)| name)
+            .map_or("floor", |(name, _)| name)
     };
 
     let all = ordered.len();
@@ -100,28 +93,46 @@ fn describe_provenance(
 ///
 /// # Force-insert, not `or_insert`
 ///
-/// The client's own parameters are extracted from `body` first, merged
-/// **beneath** profile / model / global by
-/// [`InferenceConfig::resolve_with_profile`], and the fully-resolved result is
-/// then written back over the top. Client parameters still win — they win by
-/// being the highest-priority layer *inside* the merge, not by surviving an
-/// `or_insert`. Rewriting this as `or_insert` looks equivalent and silently
-/// breaks the hierarchy: every layer below the client would stop applying to
-/// any key the client happened to send.
+/// The client's own parameters are extracted from `body` first, folded
+/// through [`InferenceConfig::resolve_layers`] alongside cli / profile /
+/// model / global, and the fully-resolved result is then written back over
+/// the top. Client parameters still win — they win by being the
+/// highest-priority *layer* in the fold, not by surviving an `or_insert`.
+/// Rewriting this as `or_insert` looks equivalent and silently breaks the
+/// hierarchy: every layer below the client would stop applying to any key
+/// the client happened to send.
 ///
 /// A body that is not a JSON object is left alone.
 pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingLayers) {
     let client_params = InferenceConfig::from_openai_json(body);
-    // Operator flags sit above the client, everything else below it.
-    let top = layers.cli_override.as_ref().map_or_else(
-        || client_params.clone(),
-        |o| o.clone().stacked_over(&client_params),
-    );
-    let resolved = top.resolve_with_profile(
-        layers.profile.as_ref(),
-        ctx.inference_defaults.as_ref(),
-        layers.global.as_ref(),
-    );
+
+    // The `reasoning` tag selects the floor beneath every layer here — a
+    // model that degrades into repetitive loops under greedy decoding still
+    // gets a real anti-repetition guard when nothing above the floor sets
+    // one, rather than the universal neutral default. See
+    // `InferenceConfig::reasoning_floor`.
+    let model_is_reasoning = ctx
+        .tags
+        .iter()
+        .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
+    let floor = if model_is_reasoning {
+        InferenceConfig::reasoning_floor()
+    } else {
+        InferenceConfig::with_hardcoded_defaults()
+    };
+
+    // Highest priority first. The single ordering both resolution and
+    // provenance reporting read from, so they can never drift apart.
+    let ordered: [(&str, Option<&InferenceConfig>); 5] = [
+        ("cli", layers.cli_override.as_ref()),
+        ("client", Some(&client_params)),
+        ("profile", layers.profile.as_ref()),
+        ("model", ctx.inference_defaults.as_ref()),
+        ("global", layers.global.as_ref()),
+    ];
+    let layer_configs: Vec<Option<&InferenceConfig>> =
+        ordered.iter().map(|(_, config)| *config).collect();
+    let resolved = InferenceConfig::resolve_layers(&layer_configs, &floor);
 
     if tracing::enabled!(tracing::Level::DEBUG) {
         debug!(
@@ -132,7 +143,7 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
             presence_penalty = ?resolved.presence_penalty,
             repeat_penalty = ?resolved.repeat_penalty,
             min_p = ?resolved.min_p,
-            from = %describe_provenance(&client_params, ctx.inference_defaults.as_ref(), layers),
+            from = %describe_provenance(&ordered),
             "sampling resolved"
         );
     }
@@ -288,27 +299,28 @@ mod tests {
     // ── Provenance ────────────────────────────────────────────────────────
 
     /// The `:coding` shape. The provenance string must say the penalty came
-    /// from the neutral floor, not from the model — otherwise the log would
-    /// assert exactly the leak the merge now prevents.
+    /// from the floor, not from the model — otherwise the log would assert
+    /// exactly the leak the merge now prevents.
     #[test]
-    fn provenance_reports_coupling_suppressed_layers_as_hardcoded() {
+    fn provenance_reports_coupling_suppressed_layers_as_floor() {
         let model = InferenceConfig {
             temperature: Some(1.0),
             presence_penalty: Some(1.5),
             top_k: Some(20),
             ..Default::default()
         };
-        let got = describe_provenance(
-            &InferenceConfig::default(),
-            Some(&model),
-            &SamplingLayers {
-                profile: Some(temp(0.2)),
-                ..Default::default()
-            },
-        );
+        let profile = temp(0.2);
+        let ordered: [(&str, Option<&InferenceConfig>); 5] = [
+            ("cli", None),
+            ("client", None),
+            ("profile", Some(&profile)),
+            ("model", Some(&model)),
+            ("global", None),
+        ];
+        let got = describe_provenance(&ordered);
 
         assert!(got.contains("temperature=profile"), "{got}");
-        assert!(got.contains("presence_penalty=hardcoded"), "{got}");
+        assert!(got.contains("presence_penalty=floor"), "{got}");
         // Untuned parameters are unaffected by the claim.
         assert!(got.contains("top_k=model"), "{got}");
     }
@@ -322,11 +334,14 @@ mod tests {
             presence_penalty: Some(1.5),
             ..Default::default()
         };
-        let got = describe_provenance(
-            &InferenceConfig::default(),
-            Some(&model),
-            &SamplingLayers::default(),
-        );
+        let ordered: [(&str, Option<&InferenceConfig>); 5] = [
+            ("cli", None),
+            ("client", None),
+            ("profile", None),
+            ("model", Some(&model)),
+            ("global", None),
+        ];
+        let got = describe_provenance(&ordered);
 
         assert!(got.contains("temperature=model"), "{got}");
         assert!(got.contains("presence_penalty=model"), "{got}");
@@ -335,14 +350,16 @@ mod tests {
     /// Operator flags are reported as their own layer, above the client.
     #[test]
     fn provenance_names_the_cli_layer() {
-        let got = describe_provenance(
-            &temp(0.9),
-            None,
-            &SamplingLayers {
-                cli_override: Some(temp(0.3)),
-                ..Default::default()
-            },
-        );
+        let cli = temp(0.3);
+        let client = temp(0.9);
+        let ordered: [(&str, Option<&InferenceConfig>); 5] = [
+            ("cli", Some(&cli)),
+            ("client", Some(&client)),
+            ("profile", None),
+            ("model", None),
+            ("global", None),
+        ];
+        let got = describe_provenance(&ordered);
 
         assert!(got.contains("temperature=cli"), "{got}");
     }
@@ -412,6 +429,46 @@ mod tests {
         );
 
         assert_param(&body, "temperature", 0.2);
+        assert_param(&body, "presence_penalty", 0.0);
+    }
+
+    /// The actual incident this refactor exists for: a client that always
+    /// sends `temperature: 0` (VS Code Copilot's LLM Gateway does, with no
+    /// user-facing control over it) must not silently zero out a reasoning
+    /// model's only anti-repetition guard. The client still wins the
+    /// temperature it asked for — it just doesn't also claim penalties it
+    /// never named an opinion on.
+    #[test]
+    fn client_temperature_zero_does_not_zero_a_reasoning_models_presence_penalty() {
+        let mut body = json!({"temperature": 0.0});
+        let ctx = ModelContext {
+            tags: vec!["reasoning".to_owned()],
+            inference_defaults: Some(InferenceConfig::reasoning_profile()),
+            ..ModelContext::passthrough()
+        };
+        resolve_sampling(&mut body, &ctx, &SamplingLayers::default());
+
+        assert_param(&body, "temperature", 0.0);
+        assert_param(&body, "presence_penalty", 1.0);
+    }
+
+    /// A non-reasoning model gets the plain neutral floor, not the reasoning
+    /// one — the class floor is opt-in via the tag, not a blanket change.
+    #[test]
+    fn client_temperature_zero_leaves_a_non_reasoning_model_at_the_neutral_floor() {
+        let mut body = json!({"temperature": 0.0});
+        let model = InferenceConfig {
+            temperature: Some(0.8),
+            presence_penalty: Some(0.6),
+            ..Default::default()
+        };
+        resolve_sampling(
+            &mut body,
+            &model_ctx(Some(model)),
+            &SamplingLayers::default(),
+        );
+
+        assert_param(&body, "temperature", 0.0);
         assert_param(&body, "presence_penalty", 0.0);
     }
 


### PR DESCRIPTION
## Summary

- Replaces `InferenceConfig::merge_layer`'s `temperature_claimed` latch with `InferenceConfig::resolve_layers`, an explicit fold over an ordered slice of layers plus a floor parameter — same coupling semantics, but the floor is now selectable instead of a single hardcoded universal.
- Adds `InferenceConfig::reasoning_floor()`: on a `reasoning`-tagged model, `presence_penalty` floors to `1.0` instead of the neutral `0.0`, so a client with no opinion on it (VS Code Copilot always sends `temperature: 0`) can no longer silently zero out the model's only anti-repetition guard.
- `request_pipeline::sampling::resolve_sampling` now builds its five-layer (cli/client/profile/model/global) array directly and folds it through `resolve_layers`, so `describe_provenance` reads the exact same ordering used for resolution instead of reconstructing it by hand — the two can no longer drift apart.
- Updates the #621 regression test: the original fix floored `presence_penalty` to a universal `0.0`, correct for stopping the wrong transplant but itself a second failure mode on reasoning models. Now asserts the reasoning floor (`1.0`) instead.
- Corrects `README.md`'s claim that a temperature-only profile still lets a model contribute its own `presence_penalty` — false both before and after this change.

## Why

Traced from a real incident: a VS Code Copilot agent session against a reasoning-tagged model degraded and dead-ended mid-run. Every request resolved to `presence_penalty=0.0 repeat_penalty=1.0 min_p=0.0` — greedy decoding with every anti-repetition guard neutralised — because Copilot's hardcoded `temperature: 0` claimed the coupled trio on every request and the old latch then floored the rest to the universal neutral, discarding the model's tuned `presence_penalty: 1.5` recipe entirely. Full root-cause writeup in #685.

## Test plan

- [x] `cargo test --workspace` — 82/82 suites pass, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo doc --no-deps` on touched crates — 99 warnings vs. 101 on `main` (net reduction, none introduced)
- [x] `cargo fmt --check` — clean
- [x] `./scripts/check_readmes.sh --strict` — passes
- [x] `npm run test:run` — 646 passed (frontend untouched by this PR, sanity-checked anyway)
- [x] New tests: `client_temperature_zero_does_not_zero_a_reasoning_models_presence_penalty` (the direct regression), `client_temperature_zero_leaves_a_non_reasoning_model_at_the_neutral_floor`, `test_coupled_trio_gap_fills_normally_when_no_layer_sets_temperature` (pins the pre-existing latch behavior this refactor had to preserve), `test_reasoning_floor_differs_only_in_presence_penalty`

## Note

`./scripts/generate_module_tables.sh --check` fails on `main` today (two stale `gglib-cli` READMEs) — confirmed pre-existing via `git stash`, unrelated to this change, not touched here.

Part of the stack tracked in #685. This PR (layer-resolution) is the base; `feat(settings)/client-sampling-authority` and `feat(models)/inference-defaults-origin` stack on top of it.
