### PR TITLE
feat(settings): add trust_client_sampling, defaulting to untrusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,9 @@ Sampling parameters are resolved through a **5-level merge hierarchy** on every 
 Request override  →  Inference profile  →  Per-model defaults  →  Global settings  →  Floor
 ```
 
+The "Request override" level is gated by `trust_client_sampling` (see below) — untrusted by
+default, it drops out of the hierarchy entirely except for `max_tokens`.
+
 The full set of configurable parameters:
 
 | Parameter | CLI flag | Range | Floor | Notes |
@@ -475,6 +478,40 @@ gglib model update <id> --clear-inference-defaults
 
 All the same flags are available on `gglib serve`, `gglib chat`, and `gglib q` as
 per-invocation overrides that sit at the top of the hierarchy.
+
+#### Client sampling authority
+
+By default, an external client's own sampling parameters (`temperature`, `top_p`,
+`top_k`, `presence_penalty`, `repeat_penalty`, `min_p`) are **not honoured** — they
+are read off the incoming request and then dropped, so the request resolves exactly
+as if the client had sent none of them. `max_tokens` is the one exception: it is a
+budget, not a taste, and ignoring it would silently truncate the client's own turns,
+so it is always forwarded regardless of this setting.
+
+This is the default because many OpenAI-compatible clients send fixed sampling
+values with no user-facing control behind them. VS Code Copilot's LLM Gateway, for
+one, hardcodes `temperature: 0` on every agent request — that is boilerplate the
+extension always sends, not a deliberate choice by whoever is using it. Trusting it
+by default would let that boilerplate silently outrank a model's own tuned defaults
+and this server's global settings, defeating the point of configuring either.
+
+```bash
+# Inspect the current setting
+gglib config settings show
+
+# Trust clients that expose real sampling controls to their user (e.g. OpenWebUI)
+gglib config settings set --trust-client-sampling true
+
+# Back to the default
+gglib config settings set --trust-client-sampling false
+```
+
+`{model}:{profile}` selection is unaffected either way — that is not a client
+sampling parameter, it is part of the requested model name, and profiles remain the
+sanctioned way for a client to express a sampling preference without needing to be
+trusted (see below). In-process callers (`gglib chat`, `gglib q`, council) are also
+unaffected: their sampling parameters are gglib's own typed configuration, not an
+external client's request body, so they are always honoured.
 
 #### Inference profiles (`<model>:<profile>`)
 

--- a/crates/gglib-app-services/src/settings.rs
+++ b/crates/gglib-app-services/src/settings.rs
@@ -119,6 +119,7 @@ impl SettingsOps {
             title_generation_prompt: settings.title_generation_prompt,
             bind_host: settings.bind_host,
             share_lan: settings.share_lan,
+            trust_client_sampling: settings.trust_client_sampling,
         })
     }
 
@@ -140,6 +141,7 @@ impl SettingsOps {
             title_generation_prompt: request.title_generation_prompt,
             bind_host: request.bind_host,
             share_lan: request.share_lan,
+            trust_client_sampling: request.trust_client_sampling,
         };
 
         let settings = self
@@ -170,6 +172,7 @@ impl SettingsOps {
             title_generation_prompt: settings.title_generation_prompt,
             bind_host: settings.bind_host,
             share_lan: settings.share_lan,
+            trust_client_sampling: settings.trust_client_sampling,
         })
     }
 
@@ -325,6 +328,7 @@ mod tests {
             title_generation_prompt: None,
             bind_host: None,
             share_lan: None,
+            trust_client_sampling: None,
         };
 
         let json = serde_json::to_value(&settings).expect("serializes");

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -489,6 +489,8 @@ pub struct AppSettings {
     // Network binding (see `gglib_core::Settings`)
     pub bind_host: Option<String>,
     pub share_lan: Option<bool>,
+    // Sampling authority (see `gglib_core::Settings`)
+    pub trust_client_sampling: Option<bool>,
 }
 
 /// Request body for updating application settings.
@@ -537,6 +539,9 @@ pub struct UpdateSettingsRequest {
     pub bind_host: Option<Option<String>>,
     #[serde(default, with = "serde_with::rust::double_option")]
     pub share_lan: Option<Option<bool>>,
+    // Sampling authority (see `gglib_core::Settings`)
+    #[serde(default, with = "serde_with::rust::double_option")]
+    pub trust_client_sampling: Option<Option<bool>>,
 }
 
 // ============================================================================

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -177,6 +177,14 @@ pub enum SettingsCommand {
         /// WARNING: makes GGLib visible to every device on your network.
         #[arg(long)]
         share_lan: Option<bool>,
+        /// Honour a client's own sampling parameters (temperature, top_p,
+        /// top_k, presence_penalty, repeat_penalty, min_p). Defaults to
+        /// false: most clients (e.g. VS Code Copilot) send fixed sampling
+        /// values with no user-facing control behind them, so this server's
+        /// own per-model and global defaults apply instead. `max_tokens` is
+        /// always honoured regardless of this setting.
+        #[arg(long)]
+        trust_client_sampling: Option<bool>,
     },
     /// Reset all settings to defaults
     Reset {

--- a/crates/gglib-cli/src/handlers/config/settings/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/settings/mod.rs
@@ -153,6 +153,7 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             show_memory_fit_indicators,
             bind_host,
             share_lan,
+            trust_client_sampling,
         } => {
             // Collect the kebab-case keys of every flag that was provided.
             let mut changed: BTreeSet<&str> = BTreeSet::new();
@@ -186,6 +187,9 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             if share_lan.is_some() {
                 changed.insert("share-lan");
             }
+            if trust_client_sampling.is_some() {
+                changed.insert("trust-client-sampling");
+            }
 
             if changed.is_empty() {
                 println!("No settings provided. Use --help to see available options.");
@@ -208,6 +212,7 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
                 title_generation_prompt: None,
                 bind_host: bind_host.map(Some),
                 share_lan: share_lan.map(Some),
+                trust_client_sampling: trust_client_sampling.map(Some),
             };
 
             // Pre-validate: merge the prospective update into a local copy and validate
@@ -242,6 +247,9 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             }
             if let Some(Some(v)) = update.share_lan {
                 prospective.share_lan = Some(v);
+            }
+            if let Some(Some(v)) = update.trust_client_sampling {
+                prospective.trust_client_sampling = Some(v);
             }
             validate_settings(&prospective)?;
 

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -39,6 +39,13 @@ pub struct SamplingLayers {
     pub profile: Option<InferenceConfig>,
     /// Global defaults from settings.
     pub global: Option<InferenceConfig>,
+    /// Whether the client's own sampling parameters are honoured at all.
+    /// From `Settings.trust_client_sampling`. `false` (the default) drops
+    /// everything the client sent except `max_tokens` — see the field doc on
+    /// `Settings` for why. This is read from the same settings snapshot as
+    /// [`Self::global`], which is why it lives here rather than as a
+    /// separate parameter threaded through every caller.
+    pub trust_client_sampling: bool,
 }
 
 /// Which layer supplied each resolved sampling value, as `field=layer` pairs.
@@ -102,9 +109,30 @@ fn describe_provenance(ordered: &[(&'static str, Option<&InferenceConfig>)]) -> 
 /// hierarchy: every layer below the client would stop applying to any key
 /// the client happened to send.
 ///
+/// # Client trust
+///
+/// `layers.trust_client_sampling` gates which of the client's own fields
+/// enter that layer at all. When `false` (the default — see
+/// `Settings::trust_client_sampling`), only `max_tokens` survives; the rest
+/// of `body`'s sampling keys are read but discarded before the fold, so a
+/// client with a hardcoded `temperature` can no longer outrank this
+/// server's own configuration, and every field it left unset still
+/// gap-fills from below exactly as if it had never sent that key.
+///
 /// A body that is not a JSON object is left alone.
 pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingLayers) {
     let client_params = InferenceConfig::from_openai_json(body);
+    // `max_tokens` stays client-authoritative regardless of trust: it is a
+    // budget, not a taste, and dropping it would silently truncate the
+    // client's own turns. See `Settings::trust_client_sampling`.
+    let client_layer = if layers.trust_client_sampling {
+        client_params
+    } else {
+        InferenceConfig {
+            max_tokens: client_params.max_tokens,
+            ..InferenceConfig::default()
+        }
+    };
 
     // The `reasoning` tag selects the floor beneath every layer here — a
     // model that degrades into repetitive loops under greedy decoding still
@@ -125,7 +153,7 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
     // provenance reporting read from, so they can never drift apart.
     let ordered: [(&str, Option<&InferenceConfig>); 5] = [
         ("cli", layers.cli_override.as_ref()),
-        ("client", Some(&client_params)),
+        ("client", Some(&client_layer)),
         ("profile", layers.profile.as_ref()),
         ("model", ctx.inference_defaults.as_ref()),
         ("global", layers.global.as_ref()),
@@ -260,6 +288,11 @@ mod tests {
                 cli_override: cli.map(temp),
                 profile: profile.map(temp),
                 global: global.map(temp),
+                // This table is specifically about layer precedence, not
+                // about the trust gate — trust it here so the "client beats
+                // profile" / "cli beats client" rows still exercise the
+                // client layer at all. See `client_sampling_is_ignored_by_default`.
+                trust_client_sampling: true,
             };
             resolve_sampling(&mut body, &model_ctx(model.map(temp)), &layers);
             assert_param(&body, "temperature", expected);
@@ -288,6 +321,7 @@ mod tests {
                 cli_override: None,
                 profile: Some(temp(0.2)),
                 global: None,
+                trust_client_sampling: false,
             },
         );
 
@@ -425,6 +459,7 @@ mod tests {
                 cli_override: None,
                 profile: Some(temp(0.2)),
                 global: None,
+                trust_client_sampling: false,
             },
         );
 
@@ -432,30 +467,39 @@ mod tests {
         assert_param(&body, "presence_penalty", 0.0);
     }
 
-    /// The actual incident this refactor exists for: a client that always
-    /// sends `temperature: 0` (VS Code Copilot's LLM Gateway does, with no
-    /// user-facing control over it) must not silently zero out a reasoning
-    /// model's only anti-repetition guard. The client still wins the
-    /// temperature it asked for — it just doesn't also claim penalties it
-    /// never named an opinion on.
+    /// When the client IS trusted (`trust_client_sampling: true` — an
+    /// `OpenWebUI`-style client with real sampling controls exposed to its
+    /// user), a client that sends `temperature: 0` must still not silently
+    /// zero out a reasoning model's only anti-repetition guard. The client
+    /// still wins the temperature it asked for — it just doesn't also claim
+    /// penalties it never named an opinion on. See `resolve_layers`'s
+    /// coupling rule.
     #[test]
-    fn client_temperature_zero_does_not_zero_a_reasoning_models_presence_penalty() {
+    fn trusted_client_temperature_zero_does_not_zero_a_reasoning_models_presence_penalty() {
         let mut body = json!({"temperature": 0.0});
         let ctx = ModelContext {
             tags: vec!["reasoning".to_owned()],
             inference_defaults: Some(InferenceConfig::reasoning_profile()),
             ..ModelContext::passthrough()
         };
-        resolve_sampling(&mut body, &ctx, &SamplingLayers::default());
+        resolve_sampling(
+            &mut body,
+            &ctx,
+            &SamplingLayers {
+                trust_client_sampling: true,
+                ..Default::default()
+            },
+        );
 
         assert_param(&body, "temperature", 0.0);
         assert_param(&body, "presence_penalty", 1.0);
     }
 
-    /// A non-reasoning model gets the plain neutral floor, not the reasoning
-    /// one — the class floor is opt-in via the tag, not a blanket change.
+    /// Same as above, but a non-reasoning model gets the plain neutral floor,
+    /// not the reasoning one — the class floor is opt-in via the tag, not a
+    /// blanket change.
     #[test]
-    fn client_temperature_zero_leaves_a_non_reasoning_model_at_the_neutral_floor() {
+    fn trusted_client_temperature_zero_leaves_a_non_reasoning_model_at_the_neutral_floor() {
         let mut body = json!({"temperature": 0.0});
         let model = InferenceConfig {
             temperature: Some(0.8),
@@ -465,15 +509,62 @@ mod tests {
         resolve_sampling(
             &mut body,
             &model_ctx(Some(model)),
-            &SamplingLayers::default(),
+            &SamplingLayers {
+                trust_client_sampling: true,
+                ..Default::default()
+            },
         );
 
         assert_param(&body, "temperature", 0.0);
         assert_param(&body, "presence_penalty", 0.0);
     }
 
+    // ── Client sampling authority (Settings.trust_client_sampling) ─────────
+
+    /// The default. This is the actual fix for the incident that motivated
+    /// this whole refactor: without a client-trust escape hatch, a client
+    /// hardcoding `temperature: 0` with no way for its user to change it (VS
+    /// Code Copilot's LLM Gateway) claims the coupled trio on every request
+    /// and supplies none of it — so the model's own tuned recipe never has a
+    /// chance to apply, no matter what `resolve_layers`'s coupling rule does.
+    /// With the client out of the ladder entirely, the model's full recipe —
+    /// temperature *and* the penalties tuned for it — resolves untouched.
+    #[test]
+    fn client_sampling_is_ignored_by_default() {
+        let mut body = json!({"temperature": 0.0});
+        let ctx = ModelContext {
+            tags: vec!["reasoning".to_owned()],
+            inference_defaults: Some(InferenceConfig::reasoning_profile()),
+            ..ModelContext::passthrough()
+        };
+        resolve_sampling(&mut body, &ctx, &SamplingLayers::default());
+
+        assert_param(&body, "temperature", 1.0); // the model's own, not the client's 0.0
+        assert_param(&body, "presence_penalty", 1.5); // the model's tuned recipe, intact
+    }
+
+    /// `max_tokens` is a budget, not a taste — it stays client-authoritative
+    /// even when nothing else about the client's request is trusted, because
+    /// dropping it would silently truncate that client's own turns.
+    #[test]
+    fn max_tokens_is_still_honoured_when_client_sampling_is_untrusted() {
+        let mut body = json!({"temperature": 0.9, "max_tokens": 999});
+        resolve_sampling(
+            &mut body,
+            &model_ctx(Some(InferenceConfig {
+                temperature: Some(0.4),
+                ..Default::default()
+            })),
+            &SamplingLayers::default(),
+        );
+
+        assert_param(&body, "temperature", 0.4); // client's 0.9 dropped
+        assert_param(&body, "max_tokens", 999.0); // client's budget still honoured
+    }
+
     /// The force-insert. An `or_insert` implementation passes every test above
-    /// and fails this one.
+    /// and fails this one. Trusted explicitly: this test is about force-insert
+    /// semantics, not about the trust gate.
     #[test]
     fn resolution_overwrites_a_partial_client_value_from_lower_layers() {
         // The client named only `temperature`. Every other key must still be
@@ -485,7 +576,10 @@ mod tests {
                 top_p: Some(0.42),
                 ..Default::default()
             })),
-            &SamplingLayers::default(),
+            &SamplingLayers {
+                trust_client_sampling: true,
+                ..Default::default()
+            },
         );
 
         assert_param(&body, "temperature", 0.11);

--- a/crates/gglib-core/src/settings.rs
+++ b/crates/gglib-core/src/settings.rs
@@ -85,6 +85,30 @@ pub struct Settings {
     /// `None`/`Some(false)` → localhost-only. The `--share-lan` flag can turn
     /// this on for a single run, but cannot turn it off — clear it here.
     pub share_lan: Option<bool>,
+
+    // ── Sampling authority ──────────────────────────────────────────
+    /// Whether a client's own sampling parameters (`temperature`, `top_p`,
+    /// `top_k`, `presence_penalty`, `repeat_penalty`, `min_p`) are honoured
+    /// by the proxy at all.
+    ///
+    /// `None`/`Some(false)` → the client's sampling opinions are dropped from
+    /// the resolution hierarchy entirely; the request falls straight through
+    /// to the profile / per-model / global / floor layers as if the client
+    /// had sent none of them. `max_tokens` is unaffected either way — it is
+    /// a budget, not a taste, and a client that names one still gets it
+    /// honoured; ignoring it would silently truncate that client's own
+    /// turns.
+    ///
+    /// Defaults to distrust because most clients that talk to this proxy
+    /// send fixed sampling values with no user-facing control behind them —
+    /// boilerplate the client always sends, not a deliberate choice by
+    /// whoever is using it (VS Code Copilot's LLM Gateway hardcodes
+    /// `temperature: 0` on every request, for one). Letting that boilerplate
+    /// silently outrank a model's own tuned defaults and this server's
+    /// global settings defeats the point of configuring either. Set `true`
+    /// for a client that does expose real sampling controls to its user
+    /// (`OpenWebUI`'s sliders, for instance).
+    pub trust_client_sampling: Option<bool>,
 }
 
 impl Settings {
@@ -109,6 +133,7 @@ impl Settings {
             title_generation_prompt: None,
             bind_host: None,
             share_lan: None,
+            trust_client_sampling: None,
         }
     }
 
@@ -177,6 +202,9 @@ impl Settings {
         if let Some(ref v) = other.share_lan {
             self.share_lan = *v;
         }
+        if let Some(ref v) = other.trust_client_sampling {
+            self.trust_client_sampling = *v;
+        }
     }
 }
 
@@ -203,6 +231,7 @@ pub struct SettingsUpdate {
     pub title_generation_prompt: Option<Option<String>>,
     pub bind_host: Option<Option<String>>,
     pub share_lan: Option<Option<bool>>,
+    pub trust_client_sampling: Option<Option<bool>>,
 }
 
 /// Settings validation error.
@@ -572,6 +601,25 @@ mod tests {
         assert_eq!(settings.default_context_size, Some(8192));
         assert_eq!(settings.proxy_port, None);
         assert_eq!(settings.llama_base_port, Some(DEFAULT_LLAMA_BASE_PORT)); // Unchanged
+    }
+
+    #[test]
+    fn test_trust_client_sampling_defaults_to_none_and_merges_like_any_bool_setting() {
+        let defaults = Settings::with_defaults();
+        assert_eq!(defaults.trust_client_sampling, None);
+
+        let mut settings = Settings::with_defaults();
+        settings.merge(&SettingsUpdate {
+            trust_client_sampling: Some(Some(true)),
+            ..Default::default()
+        });
+        assert_eq!(settings.trust_client_sampling, Some(true));
+
+        settings.merge(&SettingsUpdate {
+            trust_client_sampling: Some(None),
+            ..Default::default()
+        });
+        assert_eq!(settings.trust_client_sampling, None);
     }
 
     #[test]

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -853,6 +853,7 @@ async fn chat_completions(
         cli_override: state.inference_override.clone(),
         profile: request_profile.clone(),
         global: settings.inference_defaults.clone(),
+        trust_client_sampling: settings.trust_client_sampling.unwrap_or(false),
     };
 
     // Clone body before forwarding — Bytes is reference-counted so this is
@@ -970,10 +971,12 @@ async fn chat_completions(
             // Re-read settings for the retry: the model was just relaunched,
             // so this is a fresh point in time. The profile is deliberately
             // not re-resolved — the client asked for a specific one.
+            let retry_settings = state.settings.get().await;
             let retry_sampling = SamplingLayers {
                 cli_override: state.inference_override.clone(),
                 profile: request_profile.clone(),
-                global: state.settings.get().await.inference_defaults.clone(),
+                global: retry_settings.inference_defaults.clone(),
+                trust_client_sampling: retry_settings.trust_client_sampling.unwrap_or(false),
             };
 
             // Fresh connection for the retried attempt — the original guard

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -115,6 +115,7 @@ impl ModelCatalogPort for NamedCatalog {
 /// Settings repository serving a fixed profile list.
 struct ProfileSettings {
     profiles: Vec<InferenceProfile>,
+    trust_client_sampling: bool,
 }
 
 #[async_trait]
@@ -122,6 +123,7 @@ impl SettingsRepository for ProfileSettings {
     async fn load(&self) -> Result<Settings, RepositoryError> {
         Ok(Settings {
             inference_profiles: Some(self.profiles.clone()),
+            trust_client_sampling: Some(self.trust_client_sampling),
             ..Settings::with_defaults()
         })
     }
@@ -181,6 +183,7 @@ async fn spawn(
     profiles: Vec<InferenceProfile>,
     catalog_names: &[&str],
     model_defaults: Option<InferenceConfig>,
+    trust_client_sampling: bool,
 ) -> Harness {
     let forwarded: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
     let cancel = CancellationToken::new();
@@ -241,7 +244,10 @@ async fn spawn(
             mcp,
             make_orchestrator_deps(),
             proxy_cancel,
-            Arc::new(ProfileSettings { profiles }),
+            Arc::new(ProfileSettings {
+                profiles,
+                trust_client_sampling,
+            }),
             None, // inference_override
             false,
             None,
@@ -306,7 +312,7 @@ fn assert_param(body: &Value, key: &str, expected: f64) {
 /// what reaches llama-server.
 #[tokio::test]
 async fn profile_suffix_applies_its_sampling() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
 
     let resp = h.post(chat_request("qwen:coding")).await;
     assert_eq!(resp.status(), 200);
@@ -324,7 +330,7 @@ async fn profile_suffix_applies_its_sampling() {
 /// asked for rather than a silently rewritten one.
 #[tokio::test]
 async fn profile_suffix_is_stripped_before_the_model_is_launched() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
 
     h.post(chat_request("qwen:coding")).await;
 
@@ -339,7 +345,7 @@ async fn profile_suffix_is_stripped_before_the_model_is_launched() {
 /// A bare model name must behave exactly as before profiles existed.
 #[tokio::test]
 async fn bare_model_name_is_unaffected_by_a_configured_profile() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
 
     h.post(chat_request(MODEL)).await;
 
@@ -347,16 +353,35 @@ async fn bare_model_name_is_unaffected_by_a_configured_profile() {
     assert_param(&h.only_forwarded(), "temperature", 0.7);
 }
 
-/// The client's own parameters sit above the profile in the hierarchy.
+/// When the client is trusted (`Settings.trust_client_sampling: true` — an
+/// explicit choice by whoever operates this proxy, not the default), the
+/// client's own parameters sit above the profile in the hierarchy.
 #[tokio::test]
-async fn client_supplied_temperature_beats_the_profile() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+async fn a_trusted_clients_temperature_beats_the_profile() {
+    let h = spawn(vec![coding_profile()], &[MODEL], None, true).await;
 
     let mut body = chat_request("qwen:coding");
     body["temperature"] = json!(1.5);
     h.post(body).await;
 
     assert_param(&h.only_forwarded(), "temperature", 1.5);
+}
+
+/// The default (`trust_client_sampling` unset). A client's own `temperature`
+/// must NOT beat the profile — it is dropped from the hierarchy entirely, so
+/// the profile applies exactly as if the client had sent no sampling
+/// parameters at all. This is the actual end-to-end fix for a client that
+/// hardcodes a sampling value with no user-facing control behind it (VS Code
+/// Copilot's LLM Gateway sends `temperature: 0` on every request).
+#[tokio::test]
+async fn an_untrusted_clients_temperature_does_not_beat_the_profile() {
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
+
+    let mut body = chat_request("qwen:coding");
+    body["temperature"] = json!(1.5);
+    h.post(body).await;
+
+    assert_param(&h.only_forwarded(), "temperature", 0.2); // the profile's own value
 }
 
 /// The invariant that makes one global profile safe across models: a
@@ -370,7 +395,13 @@ async fn sparse_profile_leaves_model_defaults_intact() {
         top_k: Some(20),
         ..Default::default()
     };
-    let h = spawn(vec![coding_profile()], &[MODEL], Some(model_defaults)).await;
+    let h = spawn(
+        vec![coding_profile()],
+        &[MODEL],
+        Some(model_defaults),
+        false,
+    )
+    .await;
 
     h.post(chat_request("qwen:coding")).await;
 
@@ -392,7 +423,13 @@ async fn sparse_profile_does_not_forward_model_penalties() {
         presence_penalty: Some(1.5),
         ..Default::default()
     };
-    let h = spawn(vec![coding_profile()], &[MODEL], Some(model_defaults)).await;
+    let h = spawn(
+        vec![coding_profile()],
+        &[MODEL],
+        Some(model_defaults),
+        false,
+    )
+    .await;
 
     h.post(chat_request("qwen:coding")).await;
 
@@ -406,7 +443,7 @@ async fn sparse_profile_does_not_forward_model_penalties() {
 /// feature exists to prevent.
 #[tokio::test]
 async fn unknown_profile_suffix_is_rejected_without_calling_the_upstream() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
 
     let resp = h.post(chat_request("qwen:codeing")).await;
     assert_eq!(resp.status(), 404);
@@ -436,7 +473,7 @@ async fn unknown_profile_suffix_is_rejected_without_calling_the_upstream() {
 /// reinterpreted as a profile reference.
 #[tokio::test]
 async fn colon_bearing_model_name_still_resolves() {
-    let h = spawn(vec![coding_profile()], &["qwen:27b"], None).await;
+    let h = spawn(vec![coding_profile()], &["qwen:27b"], None, false).await;
 
     let resp = h.post(chat_request("qwen:27b")).await;
     assert_eq!(resp.status(), 200);
@@ -448,7 +485,7 @@ async fn colon_bearing_model_name_still_resolves() {
 /// setting it, no cap may be forwarded.
 #[tokio::test]
 async fn no_max_tokens_is_forwarded_when_nothing_sets_one() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
 
     h.post(chat_request("qwen:coding")).await;
 
@@ -465,7 +502,7 @@ async fn no_max_tokens_is_forwarded_when_nothing_sets_one() {
 async fn opted_in_profiles_are_listed_alongside_the_bare_model() {
     let mut listed = coding_profile();
     listed.list_in_models = true;
-    let h = spawn(vec![listed], &[MODEL], None).await;
+    let h = spawn(vec![listed], &[MODEL], None, false).await;
 
     let body = h.models().await;
     let ids: Vec<&str> = body["data"]
@@ -490,7 +527,7 @@ async fn opted_in_profiles_are_listed_alongside_the_bare_model() {
 async fn an_advertised_variant_can_be_selected_and_used() {
     let mut listed = coding_profile();
     listed.list_in_models = true;
-    let h = spawn(vec![listed], &[MODEL], None).await;
+    let h = spawn(vec![listed], &[MODEL], None, false).await;
 
     let ids: Vec<String> = h.models().await["data"]
         .as_array()
@@ -512,7 +549,7 @@ async fn an_advertised_variant_can_be_selected_and_used() {
 /// feature existed.
 #[tokio::test]
 async fn unlisted_profiles_do_not_appear_in_the_model_list() {
-    let h = spawn(vec![coding_profile()], &[MODEL], None).await;
+    let h = spawn(vec![coding_profile()], &[MODEL], None, false).await;
 
     let body = h.models().await;
     let ids: Vec<&str> = body["data"]

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -251,6 +251,14 @@ impl LlmCompletionAdapter {
         // settings layer is already folded into `sampling` by the callers that
         // have one.
         //
+        // `trust_client_sampling: true` unconditionally: `Settings.trust_client_sampling`
+        // gates an *external* client's request body against a boilerplate value it
+        // may have no user-facing control over (VS Code Copilot's hardcoded
+        // `temperature: 0`, for one). `self.sampling` is not that — it is gglib's own
+        // typed caller config (CLI flags, the agent loop's resolved settings), built by
+        // trusted in-process code, so it must always resolve as the top layer
+        // regardless of that setting.
+        //
         // The truncation budget comes from the model itself. There is no live
         // serving context to measure here and no learned chars-per-token ratio
         // — those belong to the proxy, which observes usage frames — so an
@@ -258,7 +266,10 @@ impl LlmCompletionAdapter {
         let report = request_pipeline::apply(
             &mut body,
             &self.model_context,
-            &SamplingLayers::default(),
+            &SamplingLayers {
+                trust_client_sampling: true,
+                ..Default::default()
+            },
             self.model_context.context_budget_chars(),
         )
         .map_err(|e| anyhow!("conversation exceeds the model's context budget: {e}"))?;

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -39,6 +39,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const [titlePromptInput, setTitlePromptInput] = useState("");
   const [maxToolIterationsInput, setMaxToolIterationsInput] = useState("");
   const [showFitIndicators, setShowFitIndicators] = useState(true);
+  const [trustClientSampling, setTrustClientSampling] = useState(false);
   const [defaultModelInput, setDefaultModelInput] = useState("");
   const [inferenceDefaultsInput, setInferenceDefaultsInput] = useState<InferenceConfig | undefined>(undefined);
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
@@ -69,6 +70,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       setTitlePromptInput(settings.titleGenerationPrompt || "");
       setMaxToolIterationsInput(settings.maxToolIterations?.toString() || "");
       setShowFitIndicators(settings.showMemoryFitIndicators !== false);
+      setTrustClientSampling(settings.trustClientSampling === true);
       setDefaultModelInput(settings.defaultModelId?.toString() || "");
       setInferenceDefaultsInput(settings.inferenceDefaults || undefined);
     }
@@ -103,10 +105,11 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           showMemoryFitIndicators: showFitIndicators,
           defaultModelId: parseNumericInput(defaultModelInput),
           inferenceDefaults: inferenceDefaultsInput,
+          trustClientSampling,
         };
 
         // Check if any updates were made
-        const hasUpdates = 
+        const hasUpdates =
           updates.defaultContextSize !== undefined ||
           updates.proxyPort !== undefined ||
           updates.llamaBasePort !== undefined ||
@@ -115,7 +118,8 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           updates.maxToolIterations !== undefined ||
           updates.showMemoryFitIndicators !== undefined ||
           updates.defaultModelId !== undefined ||
-          updates.inferenceDefaults !== undefined;
+          updates.inferenceDefaults !== undefined ||
+          updates.trustClientSampling !== undefined;
 
         if (hasUpdates) {
           await saveSettings(updates);
@@ -137,6 +141,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       showFitIndicators,
       defaultModelInput,
       inferenceDefaultsInput,
+      trustClientSampling,
       info,
       saveDir,
       saveSettings,
@@ -154,6 +159,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       setMaxQueueSizeInput(settings.maxDownloadQueueSize?.toString() ?? "");
       setTitlePromptInput(""); // Reset to default (empty uses DEFAULT_TITLE_GENERATION_PROMPT)
       setShowFitIndicators(true); // Default is enabled
+      setTrustClientSampling(false); // Default is disabled
     }
   }, [info, settings]);
 
@@ -242,6 +248,8 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
             setTitlePromptInput={setTitlePromptInput}
             inferenceDefaultsInput={inferenceDefaultsInput}
             setInferenceDefaultsInput={setInferenceDefaultsInput}
+            trustClientSampling={trustClientSampling}
+            setTrustClientSampling={setTrustClientSampling}
             onSubmit={handleSubmit}
             onReset={handleReset}
             onRefresh={handleRefresh}

--- a/src/components/SettingsModal/GeneralSettings.tsx
+++ b/src/components/SettingsModal/GeneralSettings.tsx
@@ -46,6 +46,8 @@ interface GeneralSettingsProps {
   // Inference defaults
   inferenceDefaultsInput: InferenceConfig | undefined;
   setInferenceDefaultsInput: (value: InferenceConfig | undefined) => void;
+  trustClientSampling: boolean;
+  setTrustClientSampling: (value: boolean) => void;
 
   // Actions
   onSubmit: (event: FormEvent) => Promise<void>;
@@ -87,6 +89,8 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
   setTitlePromptInput,
   inferenceDefaultsInput,
   setInferenceDefaultsInput,
+  trustClientSampling,
+  setTrustClientSampling,
   onSubmit,
   onReset,
   onRefresh,
@@ -157,6 +161,8 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         setTitlePromptInput={setTitlePromptInput}
         inferenceDefaultsInput={inferenceDefaultsInput}
         setInferenceDefaultsInput={setInferenceDefaultsInput}
+        trustClientSampling={trustClientSampling}
+        setTrustClientSampling={setTrustClientSampling}
         saving={saving}
       />
 

--- a/src/components/SettingsModal/fields/AdvancedSettings.tsx
+++ b/src/components/SettingsModal/fields/AdvancedSettings.tsx
@@ -18,6 +18,8 @@ interface AdvancedSettingsProps {
   setTitlePromptInput: (value: string) => void;
   inferenceDefaultsInput: InferenceConfig | undefined;
   setInferenceDefaultsInput: (value: InferenceConfig | undefined) => void;
+  trustClientSampling: boolean;
+  setTrustClientSampling: (value: boolean) => void;
   saving: boolean;
 }
 
@@ -34,6 +36,8 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
   setTitlePromptInput,
   inferenceDefaultsInput,
   setInferenceDefaultsInput,
+  trustClientSampling,
+  setTrustClientSampling,
   saving,
 }) => (
   <>
@@ -102,6 +106,28 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
           Default inference parameters for all models. Can be overridden per-model in the model
           inspector.
         </p>
+
+        <div className="border-t border-border my-md" />
+        <div>
+          <label className="flex items-center gap-sm cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="w-[18px] h-[18px] accent-primary cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
+              checked={trustClientSampling}
+              onChange={(event) => setTrustClientSampling(event.target.checked)}
+              disabled={saving}
+            />
+            <span className="font-semibold text-text">Trust client sampling parameters</span>
+          </label>
+          <p className="text-text-secondary text-sm mt-xs">
+            Off by default: most clients (VS Code Copilot's LLM Gateway, for one) send fixed
+            sampling values with no user-facing control behind them, so this server's own
+            per-model and global defaults apply instead of a request&apos;s temperature, top-p,
+            top-k, presence-penalty, repeat-penalty, or min-p. Max tokens is always honoured.
+            Turn this on only for a client that exposes real sampling controls to its user (e.g.
+            OpenWebUI).
+          </p>
+        </div>
       </div>
     )}
   </>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -170,6 +170,17 @@ export interface AppSettings {
   inferenceProfiles?: InferenceProfile[] | null;
   /** Whether the setup wizard has been completed */
   setupCompleted?: boolean | null;
+  /**
+   * Whether a client's own sampling parameters (temperature, topP, topK,
+   * presencePenalty, repeatPenalty, minP) are honoured by the proxy at all.
+   * `false`/unset (the default) drops them from the resolution hierarchy —
+   * only `maxTokens` still comes from the request. Most clients that talk to
+   * this proxy send fixed sampling values with no user-facing control behind
+   * them (VS Code Copilot's LLM Gateway, for one), so trusting them by
+   * default would let that boilerplate silently outrank this server's own
+   * per-model and global defaults.
+   */
+  trustClientSampling?: boolean | null;
 }
 
 export interface UpdateSettingsRequest {
@@ -194,6 +205,8 @@ export interface UpdateSettingsRequest {
   inferenceProfiles?: InferenceProfile[] | null | undefined;
   /** Whether the setup wizard has been completed */
   setupCompleted?: boolean | null | undefined;
+  /** See `AppSettings.trustClientSampling`. */
+  trustClientSampling?: boolean | null | undefined;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Stacked on #686. Adds `Settings.trust_client_sampling: Option<bool>` (default `false`).

- `resolve_sampling` now filters the client's request body through a trust gate before folding it into the layer array: untrusted (the default), only `max_tokens` survives — the rest of the client's sampling keys are read and discarded, so the request resolves as if the client sent no sampling parameters at all. `max_tokens` is unconditional because it's a budget, not a taste.
- CLI: `gglib config settings set --trust-client-sampling <bool>` / `gglib config settings show`.
- WebUI: a toggle in the Settings modal's advanced section, next to the global inference defaults it interacts with.
- Full parity: `Settings`/`SettingsUpdate` (core) → `AppSettings`/`UpdateSettingsRequest` (app-services) → Axum handlers (already generic, untouched) → CLI → WebUI.
- `LlmCompletionAdapter::shaped_body` (the in-process `gglib chat`/`gglib q`/council path) now explicitly sets `trust_client_sampling: true` — its "client" layer is gglib's own typed caller config built by trusted code, not an untrusted external request body, so this setting must never apply to it.

## Why

#686 fixed the coupling mechanics but left the client itself as the top layer below CLI overrides. A client that sends a fixed sampling value with no user-facing control behind it — VS Code Copilot's LLM Gateway hardcodes `temperature: 0` on every request — still outranks this server's own per-model and global sampling configuration on every field it happens to set. This closes that: by default, gglib's own configuration governs, and a client only gets a say if the operator explicitly says it should.

## Test plan

- [x] `cargo test --workspace` — 82/82 suites pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo doc --no-deps` — 139 warnings before and after (no regressions)
- [x] `cargo fmt --check` — clean
- [x] `./scripts/check_readmes.sh --strict` — passes
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run test:run` (646 passed), `npm run build` — all clean
- [x] New tests: `client_sampling_is_ignored_by_default` (client's `temperature: 0` no longer touches a reasoning model's tuned recipe at all — the actual end-to-end fix), `max_tokens_is_still_honoured_when_client_sampling_is_untrusted`, `test_trust_client_sampling_defaults_to_none_and_merges_like_any_bool_setting`, plus a new integration test (`an_untrusted_clients_temperature_does_not_beat_the_profile`) alongside the renamed trusted-client counterpart
- [x] Updated existing tests that assumed client-trusted-by-default (`each_layer_beats_the_ones_below_it`, the two `client_temperature_zero_*` tests from #686, `resolution_overwrites_a_partial_client_value_from_lower_layers`) to opt into `trust_client_sampling: true` explicitly, since that's what they're actually testing
- [x] Fixed the one production regression this surfaced: `LlmCompletionAdapter`'s internal agent path was reading its own typed config back through the same untrusted-by-default gate — explicitly trusted now, with a comment explaining why

Part of the stack tracked in #685. Depends on #686.
