### PR TITLE
feat(models): track whether inference_defaults was user-set or auto-detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,10 @@ Request override  →  Inference profile  →  Per-model defaults  →  Global s
 The "Request override" level is gated by `trust_client_sampling` (see below) — untrusted by
 default, it drops out of the hierarchy entirely except for `max_tokens`.
 
+"Per-model defaults" isn't always one rung: it sits *above* global settings when a person set
+it, and *below* global settings when gglib auto-detected it — see "Reasoning model
+auto-defaults" and "Where a model's defaults came from" further down.
+
 The full set of configurable parameters:
 
 | Parameter | CLI flag | Range | Floor | Notes |
@@ -478,6 +482,37 @@ gglib model update <id> --clear-inference-defaults
 
 All the same flags are available on `gglib serve`, `gglib chat`, and `gglib q` as
 per-invocation overrides that sit at the top of the hierarchy.
+
+**Where a model's defaults came from.** gglib tracks whether a model's stored
+`inference_defaults` were set by a person or written automatically by the auto-default
+behaviour above, and the two rank differently:
+
+```
+Request override → Inference profile → Per-model defaults (user-set) → Global settings
+  → Per-model defaults (auto-detected) → Floor
+```
+
+A deliberate per-model choice (`gglib model update --presence-penalty …`, or an edit in
+the WebUI) keeps outranking global settings — that's what "per-model" is supposed to
+mean. An unreviewed guess from the `reasoning` tag does not: it ranks *below* global
+settings instead of silently shadowing them. Without this, a model tagged `reasoning`
+would always resolve its full auto-written recipe over anything configured globally, with
+no way to tell the two apart in the resolved output.
+
+```bash
+# Shows whether the current defaults are user-set or auto-detected
+gglib model inspect <id>
+
+# Any explicit edit marks the defaults user-set from then on, even if the
+# values happen to match what gglib would have guessed
+gglib model update <id> --presence-penalty 0.8
+```
+
+Rows written before this distinction existed have nothing stored for it — there's no
+migration that goes back and stamps every existing row, since the two backend service
+processes (`gglib-axum`, standalone `gglib`) don't share a single startup hook to run one
+in. Instead, every read derives the answer on the spot: a stored value that matches the
+reasoning recipe byte-for-byte is treated as auto-detected, and anything else as user-set.
 
 #### Client sampling authority
 

--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -355,19 +355,18 @@ fn build_compare_request_body(
     model: &gglib_core::domain::Model,
     global_inf: Option<&InferenceConfig>,
 ) -> serde_json::Value {
-    let model_is_reasoning = model
-        .tags
-        .iter()
-        .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
+    let model_ctx = gglib_core::domain::ModelSamplingContext {
+        is_reasoning: model
+            .tags
+            .iter()
+            .any(|tag| tag.eq_ignore_ascii_case("reasoning")),
+        defaults_origin: model.defaults_origin,
+    };
     let resolved = config
         .inference
         .clone()
         .unwrap_or_default()
-        .resolve_with_defaults(
-            model.inference_defaults.as_ref(),
-            global_inf,
-            model_is_reasoning,
-        );
+        .resolve_with_defaults(model.inference_defaults.as_ref(), global_inf, model_ctx);
 
     let mut body = serde_json::json!({
         "model": model.name,

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -561,6 +561,7 @@ mod tests {
             last_update_check: None,
             tags: vec![],
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
             capabilities: gglib_core::domain::capabilities::ModelCapabilities::default(),
             benchmark_summary: None,

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -151,6 +151,10 @@ impl ModelOps {
         }
         if let Some(inference_defaults) = request.inference_defaults {
             model.inference_defaults = Some(inference_defaults);
+            // A deliberate WebUI edit, so this is a user-set value from
+            // here on — even if it happens to land on the same numbers
+            // gglib would have guessed. See `DefaultsOrigin`.
+            model.defaults_origin = Some(gglib_core::domain::DefaultsOrigin::User);
         }
         match request.server_defaults {
             Some(Some(config)) => model.server_defaults = Some(config),

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -149,6 +149,10 @@ pub struct GuiModel {
     pub port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inference_defaults: Option<gglib_core::domain::InferenceConfig>,
+    /// Whether [`Self::inference_defaults`] was set by the user or
+    /// auto-detected at import time. See `gglib_core::domain::DefaultsOrigin`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub defaults_origin: Option<gglib_core::domain::DefaultsOrigin>,
     /// Per-model server defaults (port, URL overrides, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_defaults: Option<gglib_core::domain::ServerConfig>,
@@ -183,6 +187,7 @@ impl GuiModel {
             is_serving,
             port,
             inference_defaults: model.inference_defaults,
+            defaults_origin: model.defaults_origin,
             server_defaults: model.server_defaults,
             capabilities: model.capabilities,
             benchmark_summary: model.benchmark_summary,
@@ -272,6 +277,10 @@ pub struct ModelDetailDto {
     /// Per-model inference parameter overrides.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inference_defaults: Option<gglib_core::domain::InferenceConfig>,
+    /// Whether [`Self::inference_defaults`] was set by the user or
+    /// auto-detected at import time. See `gglib_core::domain::DefaultsOrigin`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub defaults_origin: Option<gglib_core::domain::DefaultsOrigin>,
     // ── Timestamps ────────────────────────────────────────────────────────────
     /// When the model was first added to the database (`"%Y-%m-%d %H:%M:%S"`).
     pub added_at: String,
@@ -320,6 +329,7 @@ impl ModelDetailDto {
             tags: model.tags,
             capabilities: model.capabilities,
             inference_defaults: model.inference_defaults,
+            defaults_origin: model.defaults_origin,
             added_at: model.added_at.format("%Y-%m-%d %H:%M:%S").to_string(),
             is_serving,
             port,

--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -392,7 +392,7 @@ pub async fn proxy_chat(
     let servers = state.servers.list_servers().await;
     let server = servers.iter().find(|s| s.port == request.port);
 
-    let (capabilities, model_defaults, model_is_reasoning) = if let Some(server) = server {
+    let (capabilities, model_defaults, model_ctx) = if let Some(server) = server {
         // Found the server, fetch the model to get its capabilities and inference_defaults
         match state.core.models().get_by_id(server.model_id).await {
             Ok(Some(model)) => {
@@ -405,11 +405,14 @@ pub async fn proxy_chat(
                     requires_strict_turns = model.capabilities.contains(gglib_core::domain::ModelCapabilities::REQUIRES_STRICT_TURNS),
                     "Model capabilities loaded for chat request"
                 );
-                let is_reasoning = model
-                    .tags
-                    .iter()
-                    .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
-                (model.capabilities, model.inference_defaults, is_reasoning)
+                let model_ctx = gglib_core::domain::ModelSamplingContext {
+                    is_reasoning: model
+                        .tags
+                        .iter()
+                        .any(|tag| tag.eq_ignore_ascii_case("reasoning")),
+                    defaults_origin: model.defaults_origin,
+                };
+                (model.capabilities, model.inference_defaults, model_ctx)
             }
             Ok(None) => {
                 tracing::warn!(
@@ -420,7 +423,7 @@ pub async fn proxy_chat(
                 (
                     gglib_core::domain::ModelCapabilities::default(),
                     None,
-                    false,
+                    gglib_core::domain::ModelSamplingContext::default(),
                 )
             }
             Err(e) => {
@@ -433,7 +436,7 @@ pub async fn proxy_chat(
                 (
                     gglib_core::domain::ModelCapabilities::default(),
                     None,
-                    false,
+                    gglib_core::domain::ModelSamplingContext::default(),
                 )
             }
         }
@@ -445,7 +448,7 @@ pub async fn proxy_chat(
         (
             gglib_core::domain::ModelCapabilities::default(),
             None,
-            false,
+            gglib_core::domain::ModelSamplingContext::default(),
         )
     };
 
@@ -469,11 +472,7 @@ pub async fn proxy_chat(
         presence_penalty: request.presence_penalty,
         min_p: request.min_p,
     }
-    .resolve_with_defaults(
-        model_defaults.as_ref(),
-        global_defaults.as_ref(),
-        model_is_reasoning,
-    );
+    .resolve_with_defaults(model_defaults.as_ref(), global_defaults.as_ref(), model_ctx);
 
     tracing::debug!(
         port = request.port,

--- a/crates/gglib-cli/src/handlers/inference/shared.rs
+++ b/crates/gglib-cli/src/handlers/inference/shared.rs
@@ -20,14 +20,17 @@ pub async fn resolve_inference_config(
     model: &gglib_core::Model,
 ) -> Result<InferenceConfig> {
     let settings = ctx.app.settings().get().await?;
-    let model_is_reasoning = model
-        .tags
-        .iter()
-        .any(|tag| tag.eq_ignore_ascii_case("reasoning"));
+    let model_ctx = gglib_core::domain::ModelSamplingContext {
+        is_reasoning: model
+            .tags
+            .iter()
+            .any(|tag| tag.eq_ignore_ascii_case("reasoning")),
+        defaults_origin: model.defaults_origin,
+    };
     Ok(config.resolve_with_defaults(
         model.inference_defaults.as_ref(),
         settings.inference_defaults.as_ref(),
-        model_is_reasoning,
+        model_ctx,
     ))
 }
 

--- a/crates/gglib-cli/src/handlers/model/update.rs
+++ b/crates/gglib-cli/src/handlers/model/update.rs
@@ -6,7 +6,10 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 
 use anyhow::{Result, anyhow};
-use gglib_core::{Model, domain::InferenceConfig};
+use gglib_core::{
+    Model,
+    domain::{DefaultsOrigin, InferenceConfig},
+};
 
 use crate::bootstrap::CliContext;
 
@@ -183,8 +186,10 @@ pub fn create_updated_model(
 
     // Handle inference parameter defaults
     if args.clear_inference_defaults {
-        // Clear all inference defaults (revert to inherit mode)
+        // Clear all inference defaults (revert to inherit mode). No value
+        // left to have an origin either.
         updated.inference_defaults = None;
+        updated.defaults_origin = None;
     } else {
         // Check if any inference parameters were provided
         let has_inference_updates = args.temperature.is_some()
@@ -221,6 +226,11 @@ pub fn create_updated_model(
             if let Some(min_p) = args.min_p {
                 inference_config.min_p = Some(min_p);
             }
+
+            // A deliberate flag from the user, so this is a user-set value
+            // from here on — even if it happens to land on the same
+            // numbers gglib would have guessed. See `DefaultsOrigin`.
+            updated.defaults_origin = Some(DefaultsOrigin::User);
 
             updated.inference_defaults = Some(inference_config);
         }
@@ -467,6 +477,7 @@ mod tests {
             file_path: PathBuf::from("/test/model.gguf"),
             param_count_b: 7.0,
             inference_defaults: None,
+            defaults_origin: None,
             architecture: Some("llama".to_string()),
             quantization: Some("Q4_0".to_string()),
             context_length: Some(4096),

--- a/crates/gglib-cli/src/presentation/inspect_display.rs
+++ b/crates/gglib-cli/src/presentation/inspect_display.rs
@@ -6,6 +6,7 @@
 
 use gglib_app_services::types::ModelDetailDto;
 use gglib_core::ModelCapabilities;
+use gglib_core::domain::DefaultsOrigin;
 
 use crate::presentation::{format_relative_time, print_separator};
 
@@ -118,8 +119,15 @@ pub fn print_model_detail(dto: &ModelDetailDto, show_metadata: bool) {
             || inf.min_p.is_some();
 
         if has_any {
+            let origin_suffix = match dto.defaults_origin {
+                Some(DefaultsOrigin::AutoDetected) => {
+                    " (auto-detected — ranks below global settings)"
+                }
+                Some(DefaultsOrigin::User) => " (user-set)",
+                None => "",
+            };
             println!();
-            println!("  Inference Defaults");
+            println!("  Inference Defaults{origin_suffix}");
             print_separator(SEP_WIDTH);
             print_opt_f32("  temperature      ", inf.temperature);
             print_opt_f32("  top_p            ", inf.top_p);

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -111,6 +111,78 @@ pub struct InferenceConfig {
     pub min_p: Option<f32>,
 }
 
+/// Whether a model's stored `inference_defaults` were set by the user or
+/// written automatically at import time.
+///
+/// `Model.inference_defaults` is populated two ways: a user explicitly
+/// tunes it (`gglib model update --presence-penalty …`, or the `WebUI` edit
+/// form), or [`crate::services`]'s import path auto-writes
+/// [`InferenceConfig::reasoning_profile`] onto any model carrying the
+/// `reasoning` tag — a reasonable guess, not a user decision. Both end up in
+/// the same column with nothing distinguishing them, which meant an
+/// auto-written guess silently outranked the user's own global settings in
+/// the resolution ladder ([`InferenceConfig::resolve_with_profile`]) exactly
+/// as if the user had tuned it themselves.
+///
+/// This type tracks which one actually happened, so resolution can rank
+/// [`AutoDetected`](Self::AutoDetected) below global settings while a real
+/// [`User`](Self::User) choice keeps outranking them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DefaultsOrigin {
+    /// Set explicitly by the user — a CLI flag, a model-update request, or a
+    /// `WebUI` edit. Outranks global settings, same as before this type
+    /// existed.
+    User,
+    /// Written automatically at import time from the model's `reasoning`
+    /// tag, never reviewed by a person. Ranks below global settings.
+    AutoDetected,
+}
+
+impl std::fmt::Display for DefaultsOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::User => write!(f, "user"),
+            Self::AutoDetected => write!(f, "auto_detected"),
+        }
+    }
+}
+
+impl std::str::FromStr for DefaultsOrigin {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "user" => Ok(Self::User),
+            "auto_detected" => Ok(Self::AutoDetected),
+            other => Err(format!(
+                "unknown defaults origin '{other}'; expected user or auto_detected"
+            )),
+        }
+    }
+}
+
+/// Everything about the target model that changes how sampling resolves,
+/// independent of any specific request.
+///
+/// Bundled rather than passed as separate parameters because both
+/// [`InferenceConfig::resolve_with_profile`] and
+/// [`crate::request_pipeline::sampling::resolve_sampling`] need the same two
+/// facts about the same model, and the list has already grown once (see
+/// #685) — a named struct reads at call sites instead of two easily
+/// transposed booleans.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ModelSamplingContext {
+    /// Whether the model carries gglib's `reasoning` capability tag. Selects
+    /// the coupled-trio floor — see [`InferenceConfig::reasoning_floor`].
+    pub is_reasoning: bool,
+    /// Whether the model's `inference_defaults` were user-set or
+    /// auto-detected. `None` when the model has no stored
+    /// `inference_defaults` at all, in which case it has no effect either
+    /// way. See [`DefaultsOrigin`].
+    pub defaults_origin: Option<DefaultsOrigin>,
+}
+
 /// Convert a camelCase string to `snake_case`.
 ///
 /// Used internally to rename `InferenceConfig`'s serde camelCase output to the
@@ -437,21 +509,19 @@ impl InferenceConfig {
     /// have no notion of a named profile (`gglib serve`, `gglib chat`,
     /// `gglib q`, the Web UI chat API).
     ///
-    /// `model_is_reasoning` selects the floor beneath every layer: pass
-    /// `true` when the target model carries gglib's `reasoning` capability
-    /// tag, so a request that ends up with no anti-repetition guard at all
-    /// still gets one, rather than the neutral floor that is right for every
-    /// other model. See [`resolve_layers`] and [`reasoning_floor`].
+    /// `model_ctx` carries the two facts about the target model that change
+    /// how resolution behaves — see [`ModelSamplingContext`],
+    /// [`resolve_layers`] and [`reasoning_floor`].
     ///
     /// # Example
     ///
     /// ```rust
-    /// use gglib_core::domain::InferenceConfig;
+    /// use gglib_core::domain::{InferenceConfig, ModelSamplingContext};
     ///
     /// let request = InferenceConfig { temperature: Some(0.9), ..Default::default() };
     /// let model   = InferenceConfig { temperature: Some(0.5), top_p: Some(0.8), ..Default::default() };
     ///
-    /// let resolved = request.resolve_with_defaults(Some(&model), None, false);
+    /// let resolved = request.resolve_with_defaults(Some(&model), None, ModelSamplingContext::default());
     /// assert_eq!(resolved.temperature, Some(0.9)); // request wins
     /// assert_eq!(resolved.top_p,       Some(0.8)); // model fills in
     /// assert_eq!(resolved.top_k,       Some(40));  // hardcoded fallback
@@ -465,9 +535,9 @@ impl InferenceConfig {
         self,
         model: Option<&Self>,
         global: Option<&Self>,
-        model_is_reasoning: bool,
+        model_ctx: ModelSamplingContext,
     ) -> Self {
-        self.resolve_with_profile(None, model, global, model_is_reasoning)
+        self.resolve_with_profile(None, model, global, model_ctx)
     }
 
     /// Resolve inference parameters using the full 5-level hierarchy.
@@ -477,16 +547,17 @@ impl InferenceConfig {
     ///
     /// 1. `self` — caller-supplied overrides (request params, CLI flags, etc.)
     /// 2. `profile` — the named profile the request selected, if any
-    /// 3. `model` — per-model stored defaults
+    /// 3. `model` — per-model stored defaults, *if user-set*
     /// 4. `global` — global settings defaults
-    /// 5. the model-class floor — [`reasoning_floor`] when `model_is_reasoning`,
-    ///    otherwise [`with_hardcoded_defaults`]
+    /// 5. `model` again, *if auto-detected* — see below
+    /// 6. the model-class floor — [`reasoning_floor`] when
+    ///    `model_ctx.is_reasoning`, otherwise [`with_hardcoded_defaults`]
     ///
     /// This is the single source of truth for inference parameter resolution
     /// across every gglib surface that does not need its own layer set;
     /// [`resolve_with_defaults`] delegates here so there is exactly one merge
     /// order to reason about and to test.
-    /// [`crate::request_pipeline::sampling`] needs a sixth layer (the
+    /// [`crate::request_pipeline::sampling`] needs a seventh layer (the
     /// client's own request, sitting between `self` and `profile`) and calls
     /// the underlying [`resolve_layers`] directly for that reason — the merge
     /// semantics are identical either way.
@@ -501,6 +572,20 @@ impl InferenceConfig {
     /// from the model, which is what keeps one global profile safe to apply
     /// across differing architectures.
     ///
+    /// # Why `model` can rank below `global`
+    ///
+    /// `model` is only ever a stand-in for `Model.inference_defaults`, which
+    /// gets written two different ways (see [`DefaultsOrigin`]): a person
+    /// tuning it deliberately, or gglib's own import-time guess for any
+    /// model tagged `reasoning`. Those deserve different authority. A
+    /// deliberate per-model choice should keep outranking the operator's
+    /// global defaults — that is what "per-model" means. A guess nobody
+    /// reviewed should not: it silently shadowed the user's own configured
+    /// global settings, which is how #685 happened. `model_ctx.defaults_origin`
+    /// decides which rung `model` occupies for this call — never both at
+    /// once, since only one of rungs 3 and 5 is ever populated for a given
+    /// model.
+    ///
     /// # Temperature-tuned parameters do not fall through
     ///
     /// See [`resolve_layers`] for the full rule. In short: once a layer
@@ -512,7 +597,7 @@ impl InferenceConfig {
     /// # Example
     ///
     /// ```rust
-    /// use gglib_core::domain::InferenceConfig;
+    /// use gglib_core::domain::{InferenceConfig, ModelSamplingContext};
     ///
     /// // A sparse profile: sets temperature, says nothing about anything else.
     /// let profile = InferenceConfig { temperature: Some(0.2), ..Default::default() };
@@ -523,9 +608,10 @@ impl InferenceConfig {
     ///     top_k: Some(20),
     ///     ..Default::default()
     /// };
+    /// let model_ctx = ModelSamplingContext { is_reasoning: true, ..Default::default() };
     ///
     /// let resolved = InferenceConfig::default()
-    ///     .resolve_with_profile(Some(&profile), Some(&model), None, true);
+    ///     .resolve_with_profile(Some(&profile), Some(&model), None, model_ctx);
     ///
     /// assert_eq!(resolved.temperature,      Some(0.2)); // profile beats model
     /// assert_eq!(resolved.presence_penalty, Some(1.0)); // reasoning floor, NOT the model's 1.5
@@ -542,14 +628,21 @@ impl InferenceConfig {
         profile: Option<&Self>,
         model: Option<&Self>,
         global: Option<&Self>,
-        model_is_reasoning: bool,
+        model_ctx: ModelSamplingContext,
     ) -> Self {
-        let floor = if model_is_reasoning {
+        let floor = if model_ctx.is_reasoning {
             Self::reasoning_floor()
         } else {
             Self::with_hardcoded_defaults()
         };
-        Self::resolve_layers(&[Some(&self), profile, model, global], &floor)
+        let (user_model, auto_model) = match model_ctx.defaults_origin {
+            Some(DefaultsOrigin::AutoDetected) => (None, model),
+            _ => (model, None),
+        };
+        Self::resolve_layers(
+            &[Some(&self), profile, user_model, global, auto_model],
+            &floor,
+        )
     }
 
     /// Parse inference parameters from an OpenAI-format JSON body (`snake_case` keys).
@@ -688,7 +781,7 @@ mod tests {
             Some(&profile),
             Some(&model),
             None,
-            false,
+            ModelSamplingContext::default(),
         );
 
         assert_eq!(resolved.temperature, Some(0.7), "hardcoded fallback");
@@ -711,7 +804,11 @@ mod tests {
     /// overrides even a per-request `-1`.
     #[test]
     fn test_unset_max_tokens_reaches_llama_server_by_neither_route() {
-        let resolved = InferenceConfig::default().resolve_with_defaults(None, None, false);
+        let resolved = InferenceConfig::default().resolve_with_defaults(
+            None,
+            None,
+            ModelSamplingContext::default(),
+        );
 
         assert!(
             !resolved.to_openai_json_patch().contains_key("max_tokens"),
@@ -731,7 +828,7 @@ mod tests {
             max_tokens: Some(512),
             ..Default::default()
         }
-        .resolve_with_defaults(None, None, false);
+        .resolve_with_defaults(None, None, ModelSamplingContext::default());
 
         assert_eq!(resolved.max_tokens, Some(512));
         assert_eq!(
@@ -811,7 +908,11 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved = request.resolve_with_defaults(Some(&model), Some(&global), false);
+        let resolved = request.resolve_with_defaults(
+            Some(&model),
+            Some(&global),
+            ModelSamplingContext::default(),
+        );
 
         assert_eq!(resolved.temperature, Some(0.9)); // request wins
         assert_eq!(resolved.top_p, Some(0.8)); // model fills in
@@ -823,7 +924,7 @@ mod tests {
     #[test]
     fn test_resolve_with_defaults_no_layers() {
         let base = InferenceConfig::default();
-        let resolved = base.resolve_with_defaults(None, None, false);
+        let resolved = base.resolve_with_defaults(None, None, ModelSamplingContext::default());
         // Should equal hardcoded defaults
         assert_eq!(resolved, InferenceConfig::with_hardcoded_defaults());
     }
@@ -852,8 +953,12 @@ mod tests {
             ..Default::default()
         };
 
-        let resolved =
-            request.resolve_with_profile(Some(&profile), Some(&model), Some(&global), false);
+        let resolved = request.resolve_with_profile(
+            Some(&profile),
+            Some(&model),
+            Some(&global),
+            ModelSamplingContext::default(),
+        );
 
         assert_eq!(resolved.temperature, Some(0.9)); // request beats profile
         assert_eq!(resolved.top_p, Some(0.85)); // profile beats model
@@ -882,7 +987,7 @@ mod tests {
             Some(&profile),
             Some(&model),
             None,
-            false,
+            ModelSamplingContext::default(),
         );
 
         assert_eq!(resolved.temperature, Some(0.2)); // the profile's one opinion
@@ -928,7 +1033,10 @@ mod tests {
             Some(&profile),
             Some(&model),
             None,
-            true,
+            ModelSamplingContext {
+                is_reasoning: true,
+                ..Default::default()
+            },
         );
 
         assert_eq!(resolved.temperature, Some(0.2));
@@ -961,7 +1069,10 @@ mod tests {
             Some(&profile),
             Some(&model),
             None,
-            true,
+            ModelSamplingContext {
+                is_reasoning: true,
+                ..Default::default()
+            },
         );
 
         assert_eq!(resolved.temperature, model.temperature);
@@ -985,10 +1096,17 @@ mod tests {
         };
 
         assert_eq!(
-            request
-                .clone()
-                .resolve_with_defaults(Some(&model), Some(&global), false),
-            request.resolve_with_profile(None, Some(&model), Some(&global), false),
+            request.clone().resolve_with_defaults(
+                Some(&model),
+                Some(&global),
+                ModelSamplingContext::default()
+            ),
+            request.resolve_with_profile(
+                None,
+                Some(&model),
+                Some(&global),
+                ModelSamplingContext::default()
+            ),
         );
     }
 

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -35,7 +35,7 @@ pub use benchmark::{
 };
 
 // Re-export inference types at the domain level for convenience
-pub use inference::InferenceConfig;
+pub use inference::{DefaultsOrigin, InferenceConfig, ModelSamplingContext};
 pub use inference_profile::{
     InferenceProfile, MAX_PROFILE_NAME_LEN, ProfileNameError, RESERVED_PROFILE_NAMES,
     builtin_templates, validate_name,

--- a/crates/gglib-core/src/domain/model.rs
+++ b/crates/gglib-core/src/domain/model.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use super::capabilities::ModelCapabilities;
-use super::inference::InferenceConfig;
+use super::inference::{DefaultsOrigin, InferenceConfig};
 use super::server_config::ServerConfig;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -118,6 +118,14 @@ pub struct Model {
     /// If not set, falls back to global settings or hardcoded defaults.
     #[serde(default)]
     pub inference_defaults: Option<InferenceConfig>,
+    /// Whether [`Self::inference_defaults`] was set by the user or
+    /// auto-detected at import time from the `reasoning` tag.
+    ///
+    /// Always `None` when [`Self::inference_defaults`] is `None` — there is
+    /// nothing to have an origin. See [`DefaultsOrigin`] for why this
+    /// changes how resolution ranks the field.
+    #[serde(default)]
+    pub defaults_origin: Option<DefaultsOrigin>,
     /// Per-model server-level defaults (`context_length`, etc.).
     ///
     /// Stored as JSON in the database. Overrides global settings but can
@@ -183,6 +191,9 @@ pub struct NewModel {
     /// If not set, falls back to global settings or hardcoded defaults.
     #[serde(default)]
     pub inference_defaults: Option<InferenceConfig>,
+    /// See [`Model::defaults_origin`].
+    #[serde(default)]
+    pub defaults_origin: Option<DefaultsOrigin>,
     /// Per-model server startup defaults.
     #[serde(default)]
     pub server_defaults: Option<ServerConfig>,
@@ -281,6 +292,7 @@ impl NewModel {
             file_paths: None,
             capabilities: ModelCapabilities::default(),
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         }
     }
@@ -313,6 +325,7 @@ impl Model {
             file_paths: None, // Not preserved in conversion
             capabilities: self.capabilities,
             inference_defaults: self.inference_defaults.clone(),
+            defaults_origin: self.defaults_origin,
             server_defaults: self.server_defaults.clone(),
         }
     }
@@ -362,6 +375,7 @@ mod tests {
             tags: vec!["chat".to_string()],
             capabilities: ModelCapabilities::default(),
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
             benchmark_summary: None,
         };

--- a/crates/gglib-core/src/domain/query.rs
+++ b/crates/gglib-core/src/domain/query.rs
@@ -279,6 +279,7 @@ mod tests {
             tags: vec![],
             capabilities: ModelCapabilities::default(),
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
             benchmark_summary: None,
         }

--- a/crates/gglib-core/src/ports/model_catalog.rs
+++ b/crates/gglib-core/src/ports/model_catalog.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::path::PathBuf;
 use thiserror::Error;
 
+use crate::domain::DefaultsOrigin;
 use crate::domain::InferenceConfig;
 use crate::domain::KvElemsPerToken;
 use crate::domain::ModelCapabilities;
@@ -64,6 +65,10 @@ pub struct ModelSummary {
     /// request bodies, and by the agentic loop (`gglib chat`, `gglib q`) to
     /// apply model-specific sampling parameters.
     pub inference_defaults: Option<InferenceConfig>,
+    /// Whether [`Self::inference_defaults`] was set by the user or
+    /// auto-detected. See [`DefaultsOrigin`] and
+    /// [`InferenceConfig::resolve_with_profile`](crate::domain::InferenceConfig::resolve_with_profile).
+    pub defaults_origin: Option<DefaultsOrigin>,
     /// Per-model server defaults (`context_length`, etc.) from the database.
     pub server_defaults: Option<ServerConfig>,
 }

--- a/crates/gglib-core/src/ports/model_repository.rs
+++ b/crates/gglib-core/src/ports/model_repository.rs
@@ -117,6 +117,7 @@ mod tests {
             tags: vec![],
             capabilities: ModelCapabilities::default(),
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
             benchmark_summary: None,
         }

--- a/crates/gglib-core/src/request_pipeline/mod.rs
+++ b/crates/gglib-core/src/request_pipeline/mod.rs
@@ -32,6 +32,7 @@ mod tests_support {
             file_size: 0,
             context_length: None,
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         }
     }

--- a/crates/gglib-core/src/request_pipeline/model_context.rs
+++ b/crates/gglib-core/src/request_pipeline/model_context.rs
@@ -1,20 +1,24 @@
 //! The resolved per-model context every request pipeline is built from.
 
 use super::truncation::CHARS_PER_TOKEN_APPROX;
-use crate::domain::{InferenceConfig, ModelCapabilities};
+use crate::domain::{DefaultsOrigin, InferenceConfig, ModelCapabilities};
 use crate::ports::ModelSummary;
 
 /// Everything a request pipeline needs to know about the target model,
 /// gathered in a single catalog round-trip.
 ///
-/// The four fields feed four different stages, which is why they travel
-/// together rather than being looked up where each is needed:
+/// The five fields feed the resolution and shaping stages, which is why they
+/// travel together rather than being looked up where each is needed:
 ///
 /// * [`capabilities`](Self::capabilities) — request-side transforms
 ///   (strict-turn coalescing and friends).
-/// * [`tags`](Self::tags) — response-stream parser selection.
+/// * [`tags`](Self::tags) — response-stream parser selection, and (via the
+///   `reasoning` tag) the sampling floor.
 /// * [`inference_defaults`](Self::inference_defaults) — the per-model layer of
 ///   the sampling hierarchy.
+/// * [`defaults_origin`](Self::defaults_origin) — which rung
+///   [`inference_defaults`](Self::inference_defaults) occupies in that
+///   hierarchy.
 /// * [`context_length`](Self::context_length) — the history-truncation budget.
 ///
 /// Before this type was shared, the proxy resolved all of them while every
@@ -28,6 +32,9 @@ pub struct ModelContext {
     pub tags: Vec<String>,
     /// Per-model inference defaults to merge into each request.
     pub inference_defaults: Option<InferenceConfig>,
+    /// Whether [`inference_defaults`](Self::inference_defaults) was set by
+    /// the user or auto-detected. See [`DefaultsOrigin`].
+    pub defaults_origin: Option<DefaultsOrigin>,
     /// Maximum context the model supports, in tokens — the history-truncation
     /// budget for every surface that cannot measure a live serving context.
     pub context_length: Option<u64>,
@@ -73,6 +80,7 @@ impl From<&ModelSummary> for ModelContext {
             capabilities: summary.capabilities,
             tags: summary.tags.clone(),
             inference_defaults: summary.inference_defaults.clone(),
+            defaults_origin: summary.defaults_origin,
             context_length: summary.context_length,
         }
     }
@@ -100,6 +108,7 @@ mod tests {
             temperature: Some(0.5),
             ..Default::default()
         });
+        summary.defaults_origin = Some(DefaultsOrigin::AutoDetected);
         summary.context_length = Some(32_768);
 
         let ctx = ModelContext::from(&summary);
@@ -109,6 +118,7 @@ mod tests {
             ctx.inference_defaults.and_then(|c| c.temperature),
             Some(0.5)
         );
+        assert_eq!(ctx.defaults_origin, Some(DefaultsOrigin::AutoDetected));
         assert_eq!(ctx.context_length, Some(32_768));
     }
 

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::ModelContext;
-use crate::domain::InferenceConfig;
+use crate::domain::{DefaultsOrigin, InferenceConfig};
 
 /// The sampling layers that sit *below* the client's own request parameters.
 ///
@@ -149,14 +149,24 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
         InferenceConfig::with_hardcoded_defaults()
     };
 
+    // `model` occupies one of two rungs depending on how it was set — never
+    // both — so an auto-detected guess can't silently outrank global
+    // settings the way a deliberate per-model choice should. See
+    // `DefaultsOrigin` and `InferenceConfig::resolve_with_profile`.
+    let (user_model, auto_model) = match ctx.defaults_origin {
+        Some(DefaultsOrigin::AutoDetected) => (None, ctx.inference_defaults.as_ref()),
+        _ => (ctx.inference_defaults.as_ref(), None),
+    };
+
     // Highest priority first. The single ordering both resolution and
     // provenance reporting read from, so they can never drift apart.
-    let ordered: [(&str, Option<&InferenceConfig>); 5] = [
+    let ordered: [(&str, Option<&InferenceConfig>); 6] = [
         ("cli", layers.cli_override.as_ref()),
         ("client", Some(&client_layer)),
         ("profile", layers.profile.as_ref()),
-        ("model", ctx.inference_defaults.as_ref()),
+        ("model", user_model),
         ("global", layers.global.as_ref()),
+        ("model (auto-detected)", auto_model),
     ];
     let layer_configs: Vec<Option<&InferenceConfig>> =
         ordered.iter().map(|(_, config)| *config).collect();
@@ -560,6 +570,66 @@ mod tests {
 
         assert_param(&body, "temperature", 0.4); // client's 0.9 dropped
         assert_param(&body, "max_tokens", 999.0); // client's budget still honoured
+    }
+
+    // ── Model defaults provenance (Model.defaults_origin) ───────────────────
+
+    /// A user's own global settings must win over gglib's unreviewed guess —
+    /// this is the actual regression this feature exists for. Without it, a
+    /// `reasoning`-tagged model's auto-written recipe always wins over
+    /// anything configured globally, with no way to tell the two apart in
+    /// the resolved output.
+    #[test]
+    fn an_auto_detected_models_recipe_ranks_below_global_settings() {
+        let mut body = json!({});
+        let ctx = ModelContext {
+            inference_defaults: Some(InferenceConfig::reasoning_profile()), // temp 1.0, presence 1.5
+            defaults_origin: Some(DefaultsOrigin::AutoDetected),
+            ..ModelContext::passthrough()
+        };
+        let layers = SamplingLayers {
+            global: Some(InferenceConfig {
+                temperature: Some(0.2),
+                top_k: Some(20),
+                min_p: Some(0.05),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        resolve_sampling(&mut body, &ctx, &layers);
+
+        assert_param(&body, "temperature", 0.2); // global beats the auto-detected guess
+        assert_param(&body, "top_k", 20.0);
+        assert_param(&body, "min_p", 0.05);
+        // The claiming layer (global) left presence_penalty unset, so it
+        // falls to the floor — never to the auto-detected model's 1.5,
+        // which was tuned for a temperature global didn't choose.
+        assert_param(&body, "presence_penalty", 0.0);
+    }
+
+    /// The same model, but with a deliberate per-model choice instead of an
+    /// auto-detected one: it keeps outranking global settings exactly as
+    /// before this feature existed — that is what "per-model" is supposed
+    /// to mean.
+    #[test]
+    fn a_user_set_models_recipe_still_beats_global_settings() {
+        let mut body = json!({});
+        let ctx = ModelContext {
+            inference_defaults: Some(InferenceConfig::reasoning_profile()),
+            defaults_origin: Some(DefaultsOrigin::User),
+            ..ModelContext::passthrough()
+        };
+        let layers = SamplingLayers {
+            global: Some(InferenceConfig {
+                temperature: Some(0.2),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        resolve_sampling(&mut body, &ctx, &layers);
+
+        assert_param(&body, "temperature", 1.0); // the user's own choice wins
+        assert_param(&body, "presence_penalty", 1.5); // travels with it, intact
     }
 
     /// The force-insert. An `or_insert` implementation passes every test above

--- a/crates/gglib-core/src/services/model_import.rs
+++ b/crates/gglib-core/src/services/model_import.rs
@@ -9,7 +9,9 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 
-use crate::domain::{GgufMetadata, InferenceConfig, NameSource, NewModel, resolve_model_name};
+use crate::domain::{
+    DefaultsOrigin, GgufMetadata, InferenceConfig, NameSource, NewModel, resolve_model_name,
+};
 use crate::download::Quantization;
 use crate::ports::GgufParserPort;
 
@@ -147,6 +149,10 @@ pub fn build_new_model(
     // the model has no explicit defaults already (always true here, since
     // `model` was just constructed) — this is where a future caller that
     // starts pre-populating `inference_defaults` would need to add a guard.
+    //
+    // `defaults_origin: AutoDetected` marks this as gglib's own guess, never
+    // reviewed by a person — see `DefaultsOrigin` for why that changes how
+    // resolution ranks it relative to the user's global settings.
     if model.inference_defaults.is_none()
         && model
             .tags
@@ -154,6 +160,7 @@ pub fn build_new_model(
             .any(|t| t.eq_ignore_ascii_case("reasoning"))
     {
         model.inference_defaults = Some(InferenceConfig::reasoning_profile());
+        model.defaults_origin = Some(DefaultsOrigin::AutoDetected);
     }
 
     // Infer capabilities from chat template OR architecture — OR'd so either
@@ -303,6 +310,11 @@ mod tests {
             hf_model.inference_defaults,
             Some(InferenceConfig::reasoning_profile())
         );
+        assert_eq!(
+            hf_model.defaults_origin,
+            Some(DefaultsOrigin::AutoDetected),
+            "gglib's own guess, not a user choice — must rank below global settings"
+        );
 
         let gguf = gguf_with(&[]);
         let local = ModelOrigin::LocalFile {
@@ -321,6 +333,7 @@ mod tests {
             Utc::now(),
         );
         assert_eq!(local_model.inference_defaults, None);
+        assert_eq!(local_model.defaults_origin, None);
     }
 
     #[test]

--- a/crates/gglib-core/src/services/model_registrar.rs
+++ b/crates/gglib-core/src/services/model_registrar.rs
@@ -188,6 +188,7 @@ mod tests {
                 last_update_check: model.last_update_check,
                 tags: model.tags.clone(),
                 inference_defaults: model.inference_defaults.clone(),
+                defaults_origin: model.defaults_origin,
                 server_defaults: model.server_defaults.clone(),
                 benchmark_summary: None,
             };

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -504,6 +504,7 @@ mod tests {
                 tags: model.tags.clone(),
                 capabilities: model.capabilities,
                 inference_defaults: model.inference_defaults.clone(),
+                defaults_origin: model.defaults_origin,
                 server_defaults: model.server_defaults.clone(),
                 benchmark_summary: None,
             };

--- a/crates/gglib-db/src/factory.rs
+++ b/crates/gglib-db/src/factory.rs
@@ -155,6 +155,7 @@ impl TestDb {
                 file_paths_json TEXT,
                 capabilities INTEGER DEFAULT 0,
                 inference_defaults TEXT,
+                defaults_origin TEXT,
                 server_defaults TEXT
             )
             "#,

--- a/crates/gglib-db/src/repositories/row_mappers.rs
+++ b/crates/gglib-db/src/repositories/row_mappers.rs
@@ -2,12 +2,13 @@
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use gglib_core::domain::benchmark::ModelBenchmarkSummary;
+use gglib_core::domain::{DefaultsOrigin, InferenceConfig};
 use gglib_core::{Model, ModelCapabilities, RepositoryError};
 use sqlx::Row;
 use std::path::Path;
 
 /// Shared SELECT column list for model queries (no table alias required).
-pub const MODEL_SELECT_COLUMNS: &str = "id, name, file_path, param_count_b, architecture, quantization, context_length, expert_count, expert_used_count, expert_shared_count, metadata, added_at, hf_repo_id, hf_commit_sha, hf_filename, download_date, last_update_check, tags, capabilities, inference_defaults, server_defaults, model_key";
+pub const MODEL_SELECT_COLUMNS: &str = "id, name, file_path, param_count_b, architecture, quantization, context_length, expert_count, expert_used_count, expert_shared_count, metadata, added_at, hf_repo_id, hf_commit_sha, hf_filename, download_date, last_update_check, tags, capabilities, inference_defaults, defaults_origin, server_defaults, model_key";
 
 /// Additional columns to SELECT when the model query includes a LEFT JOIN
 /// with `model_benchmark_summaries s`. All columns are aliased with an `s_`
@@ -59,6 +60,18 @@ pub fn row_to_model(row: &sqlx::sqlite::SqliteRow) -> Result<Model, RepositoryEr
     let last_update_check_str: Option<String> = row
         .try_get("last_update_check")
         .map_err(|e| RepositoryError::Storage(e.to_string()))?;
+
+    let inference_defaults: Option<InferenceConfig> = row
+        .try_get::<Option<String>, _>("inference_defaults")
+        .ok()
+        .flatten()
+        .and_then(|json| serde_json::from_str(&json).ok());
+    let defaults_origin = resolve_defaults_origin(
+        row.try_get::<Option<String>, _>("defaults_origin")
+            .ok()
+            .flatten(),
+        inference_defaults.as_ref(),
+    );
 
     Ok(Model {
         id: row
@@ -112,11 +125,8 @@ pub fn row_to_model(row: &sqlx::sqlite::SqliteRow) -> Result<Model, RepositoryEr
             .ok()
             .map(ModelCapabilities::from_bits_truncate)
             .unwrap_or_default(),
-        inference_defaults: row
-            .try_get::<Option<String>, _>("inference_defaults")
-            .ok()
-            .flatten()
-            .and_then(|json| serde_json::from_str(&json).ok()),
+        inference_defaults,
+        defaults_origin,
         server_defaults: row
             .try_get::<Option<String>, _>("server_defaults")
             .ok()
@@ -126,6 +136,37 @@ pub fn row_to_model(row: &sqlx::sqlite::SqliteRow) -> Result<Model, RepositoryEr
         // when the query includes a LEFT JOIN with model_benchmark_summaries).
         benchmark_summary: try_read_summary(row),
     })
+}
+
+/// Resolve a model's `defaults_origin`, backfilling rows written before the
+/// column existed.
+///
+/// `stored` is whatever is actually in the `defaults_origin` column,
+/// unparsed. When it names a known origin, that's the answer — no
+/// backfill needed. When it's absent (every row written before this column
+/// existed; there is no batch migration for them, deliberately — see
+/// `crates/gglib-db/src/setup.rs`'s `defaults_origin` `ALTER TABLE` comment)
+/// this derives one from `inference_defaults` itself: gglib has only ever
+/// auto-written one exact recipe
+/// ([`InferenceConfig::reasoning_profile`]), so a stored value that matches
+/// it precisely is that guess; anything else is something a person set.
+///
+/// Always `None` when there is no `inference_defaults` to have an origin at
+/// all, regardless of what the column says — a stale/orphaned value there
+/// would be meaningless.
+fn resolve_defaults_origin(
+    stored: Option<String>,
+    inference_defaults: Option<&InferenceConfig>,
+) -> Option<DefaultsOrigin> {
+    let inference_defaults = inference_defaults?;
+    if let Some(origin) = stored.and_then(|s| s.parse::<DefaultsOrigin>().ok()) {
+        return Some(origin);
+    }
+    if *inference_defaults == InferenceConfig::reasoning_profile() {
+        Some(DefaultsOrigin::AutoDetected)
+    } else {
+        Some(DefaultsOrigin::User)
+    }
 }
 
 /// Try to read benchmark summary columns from a row.
@@ -182,4 +223,58 @@ pub fn map_model_file_row(
             .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
             .map(|dt| dt.with_timezone(&Utc)),
     })
+}
+
+#[cfg(test)]
+mod defaults_origin_tests {
+    use super::*;
+
+    #[test]
+    fn stored_value_wins_when_present() {
+        let origin = resolve_defaults_origin(
+            Some("user".to_owned()),
+            Some(&InferenceConfig::reasoning_profile()),
+        );
+        assert_eq!(
+            origin,
+            Some(DefaultsOrigin::User),
+            "explicit column value must not be second-guessed, even though \
+             this inference_defaults matches the auto-detected recipe \
+             exactly — a user is free to set the same values by hand"
+        );
+    }
+
+    #[test]
+    fn legacy_row_matching_the_reasoning_recipe_backfills_to_auto_detected() {
+        let origin = resolve_defaults_origin(None, Some(&InferenceConfig::reasoning_profile()));
+        assert_eq!(origin, Some(DefaultsOrigin::AutoDetected));
+    }
+
+    #[test]
+    fn legacy_row_not_matching_the_reasoning_recipe_backfills_to_user() {
+        let custom = InferenceConfig {
+            temperature: Some(0.3),
+            ..Default::default()
+        };
+        let origin = resolve_defaults_origin(None, Some(&custom));
+        assert_eq!(origin, Some(DefaultsOrigin::User));
+    }
+
+    #[test]
+    fn no_inference_defaults_means_no_origin_regardless_of_the_column() {
+        assert_eq!(resolve_defaults_origin(Some("user".to_owned()), None), None);
+        assert_eq!(resolve_defaults_origin(None, None), None);
+    }
+
+    #[test]
+    fn unparseable_stored_value_falls_back_to_the_recipe_match() {
+        // A column value from some future, unrecognised variant must not
+        // panic or silently become `None` — it falls through to the same
+        // backfill a legacy NULL would get.
+        let origin = resolve_defaults_origin(
+            Some("not_a_real_variant".to_owned()),
+            Some(&InferenceConfig::reasoning_profile()),
+        );
+        assert_eq!(origin, Some(DefaultsOrigin::AutoDetected));
+    }
 }

--- a/crates/gglib-db/src/repositories/sqlite_model_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_model_repository.rs
@@ -121,6 +121,9 @@ impl ModelRepository for SqliteModelRepository {
             .as_ref()
             .and_then(|cfg| serde_json::to_string(cfg).ok());
 
+        // Serialize defaults_origin if present
+        let defaults_origin_str = model.defaults_origin.map(|o| o.to_string());
+
         // Serialize server_defaults if present
         let server_defaults_json = model
             .server_defaults
@@ -139,11 +142,11 @@ impl ModelRepository for SqliteModelRepository {
         // Use UPSERT to make registration idempotent
         let _result = sqlx::query(
             r#"INSERT INTO models (
-                name, file_path, param_count_b, architecture, quantization, 
+                name, file_path, param_count_b, architecture, quantization,
                 context_length, expert_count, expert_used_count, expert_shared_count,
-                metadata, added_at, hf_repo_id, hf_commit_sha, 
-                hf_filename, download_date, last_update_check, tags, model_key, file_paths_json, capabilities, inference_defaults, server_defaults
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                metadata, added_at, hf_repo_id, hf_commit_sha,
+                hf_filename, download_date, last_update_check, tags, model_key, file_paths_json, capabilities, inference_defaults, defaults_origin, server_defaults
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(model_key) DO UPDATE SET
                 file_path = excluded.file_path,
                 file_paths_json = excluded.file_paths_json,
@@ -156,7 +159,8 @@ impl ModelRepository for SqliteModelRepository {
                 last_update_check = excluded.last_update_check,
                 tags = excluded.tags,
                 capabilities = excluded.capabilities,
-                inference_defaults = COALESCE(models.inference_defaults, excluded.inference_defaults)
+                inference_defaults = COALESCE(models.inference_defaults, excluded.inference_defaults),
+                defaults_origin = COALESCE(models.defaults_origin, excluded.defaults_origin)
             "#,
         )
         .bind(&model.name)
@@ -180,6 +184,7 @@ impl ModelRepository for SqliteModelRepository {
         .bind(&file_paths_json)
         .bind(model.capabilities.bits() as i64)
         .bind(&inference_defaults_json)
+        .bind(&defaults_origin_str)
         .bind(&server_defaults_json)
         .execute(&self.pool)
         .await
@@ -210,13 +215,15 @@ impl ModelRepository for SqliteModelRepository {
             .as_ref()
             .and_then(|cfg| serde_json::to_string(cfg).ok());
 
+        let defaults_origin_str = model.defaults_origin.map(|o| o.to_string());
+
         let server_defaults_json = model
             .server_defaults
             .as_ref()
             .and_then(|cfg| serde_json::to_string(cfg).ok());
 
         let result = sqlx::query(
-            "UPDATE models SET name = ?, file_path = ?, param_count_b = ?, architecture = ?, quantization = ?, context_length = ?, metadata = ?, hf_repo_id = ?, hf_commit_sha = ?, hf_filename = ?, download_date = ?, last_update_check = ?, tags = ?, capabilities = ?, inference_defaults = ?, server_defaults = ? WHERE id = ?"
+            "UPDATE models SET name = ?, file_path = ?, param_count_b = ?, architecture = ?, quantization = ?, context_length = ?, metadata = ?, hf_repo_id = ?, hf_commit_sha = ?, hf_filename = ?, download_date = ?, last_update_check = ?, tags = ?, capabilities = ?, inference_defaults = ?, defaults_origin = ?, server_defaults = ? WHERE id = ?"
         )
             .bind(&model.name)
             .bind(model.file_path.to_string_lossy().as_ref())
@@ -233,6 +240,7 @@ impl ModelRepository for SqliteModelRepository {
             .bind(&tags_json)
             .bind(model.capabilities.bits() as i64)
             .bind(&inference_defaults_json)
+            .bind(&defaults_origin_str)
             .bind(&server_defaults_json)
             .bind(model.id)
             .execute(&self.pool)
@@ -388,6 +396,66 @@ mod tests {
         assert_eq!(
             refetched.inference_defaults.and_then(|c| c.temperature),
             Some(0.42)
+        );
+    }
+
+    /// `defaults_origin` must survive a re-import exactly like
+    /// `inference_defaults` does — it describes that field, so it has to
+    /// move with it, not get silently reset to whatever the fresh import
+    /// would have written.
+    #[tokio::test]
+    async fn upsert_preserves_defaults_origin_alongside_curated_defaults() {
+        use gglib_core::domain::{DefaultsOrigin, InferenceConfig};
+
+        let repo = repo().await;
+        let inserted = repo.insert(&make_model("Theta2")).await.unwrap();
+
+        let mut curated = inserted.clone();
+        curated.inference_defaults = Some(InferenceConfig {
+            temperature: Some(0.42),
+            ..Default::default()
+        });
+        curated.defaults_origin = Some(DefaultsOrigin::User);
+        repo.update(&curated).await.unwrap();
+
+        // Re-registering the same model must not reset the origin either.
+        repo.insert(&make_model("Theta2")).await.unwrap();
+
+        let refetched = repo.get_by_id(inserted.id).await.unwrap();
+        assert_eq!(refetched.defaults_origin, Some(DefaultsOrigin::User));
+    }
+
+    /// Rows written before the `defaults_origin` column existed have `NULL`
+    /// there forever — there is no batch backfill (see `setup.rs`). This
+    /// proves the read path derives the right answer anyway, through the
+    /// real repository rather than the isolated `resolve_defaults_origin`
+    /// unit tests in `row_mappers`.
+    #[tokio::test]
+    async fn a_legacy_row_with_the_reasoning_recipe_reads_back_as_auto_detected() {
+        use gglib_core::domain::{DefaultsOrigin, InferenceConfig};
+
+        let repo = repo().await;
+        let inserted = repo.insert(&make_model("LegacyReasoning")).await.unwrap();
+
+        // Simulate a row written before this column existed: set
+        // inference_defaults directly via SQL, leaving defaults_origin NULL
+        // — bypassing the repository's own (already-informed) write path.
+        let recipe_json = serde_json::to_string(&InferenceConfig::reasoning_profile()).unwrap();
+        sqlx::query("UPDATE models SET inference_defaults = ? WHERE id = ?")
+            .bind(&recipe_json)
+            .bind(inserted.id)
+            .execute(repo.pool())
+            .await
+            .unwrap();
+
+        let refetched = repo.get_by_id(inserted.id).await.unwrap();
+        assert_eq!(
+            refetched.inference_defaults,
+            Some(InferenceConfig::reasoning_profile())
+        );
+        assert_eq!(
+            refetched.defaults_origin,
+            Some(DefaultsOrigin::AutoDetected)
         );
     }
 

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -118,6 +118,7 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
             quantization TEXT,
             context_length INTEGER,
             inference_defaults TEXT,
+            defaults_origin TEXT,
             server_defaults TEXT,
             expert_count INTEGER,
             expert_used_count INTEGER,
@@ -138,6 +139,20 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
     )
     .execute(pool)
     .await?;
+
+    // Migration: add defaults_origin to models — tracks whether
+    // `inference_defaults` was set by the user or auto-detected at import
+    // time (see `gglib_core::domain::DefaultsOrigin`), so resolution can
+    // rank an auto-detected guess below the user's own global settings
+    // instead of silently outranking them. No batch backfill for rows
+    // written before this column existed — `row_to_model` derives an answer
+    // for those from `inference_defaults` itself on every read instead (see
+    // `row_mappers::resolve_defaults_origin`), so a backfill pass would only
+    // duplicate work every row already gets for free.
+    let _ = sqlx::query(r#"ALTER TABLE models ADD COLUMN defaults_origin TEXT"#)
+        .execute(pool)
+        .await;
+    // Ignore error if column already exists
 
     // Index on file path for lookups (no longer unique)
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_models_file_path ON models(file_path)")

--- a/crates/gglib-proxy/src/models_tests.rs
+++ b/crates/gglib-proxy/src/models_tests.rs
@@ -195,6 +195,7 @@ fn models_response_from_summaries_maps_fields() {
             file_size: 4_000_000_000,
             context_length: Some(8192),
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         },
         ModelSummary {
@@ -209,6 +210,7 @@ fn models_response_from_summaries_maps_fields() {
             file_size: 7_000_000_000,
             context_length: None,
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         },
     ];
@@ -237,6 +239,7 @@ fn models_response_serializes_to_openai_format() {
             file_size: 0,
             context_length: None,
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         }],
         DEFAULT_CONTEXT_SIZE,
@@ -267,6 +270,7 @@ fn model_info_description_includes_arch_and_quant() {
         file_size: 0,
         context_length: None,
         inference_defaults: None,
+        defaults_origin: None,
         server_defaults: None,
     };
     let resp = ModelsResponse::from_summaries(vec![summary], DEFAULT_CONTEXT_SIZE);
@@ -291,6 +295,7 @@ fn model_info_handles_missing_arch_and_quant() {
         file_size: 0,
         context_length: None,
         inference_defaults: None,
+        defaults_origin: None,
         server_defaults: None,
     };
     let resp = ModelsResponse::from_summaries(vec![summary], DEFAULT_CONTEXT_SIZE);
@@ -316,6 +321,7 @@ fn model_info_maps_context_length_to_context_window() {
         file_size: 0,
         context_length: Some(32_768),
         inference_defaults: None,
+        defaults_origin: None,
         server_defaults: None,
     };
     let resp = ModelsResponse::from_summaries(vec![summary], DEFAULT_CONTEXT_SIZE);
@@ -338,6 +344,7 @@ fn model_info_context_window_none_when_unknown() {
         file_size: 0,
         context_length: None,
         inference_defaults: None,
+        defaults_origin: None,
         server_defaults: None,
     };
     let resp = ModelsResponse::from_summaries(vec![summary], DEFAULT_CONTEXT_SIZE);
@@ -360,6 +367,7 @@ fn models_response_respects_server_defaults_context_length() {
         file_size: 0,
         context_length: Some(32_768), // GGUF ceiling is large
         inference_defaults: None,
+        defaults_origin: None,
         server_defaults: Some(ServerConfig {
             context_length: Some(8192),
         }),
@@ -386,6 +394,7 @@ fn models_response_falls_through_when_server_defaults_context_length_none() {
         file_size: 0,
         context_length: Some(32_768),
         inference_defaults: None,
+        defaults_origin: None,
         server_defaults: Some(ServerConfig {
             context_length: None, // exists but context_length is None
         }),

--- a/crates/gglib-proxy/src/profiles.rs
+++ b/crates/gglib-proxy/src/profiles.rs
@@ -234,6 +234,7 @@ mod tests {
                 file_size: 0,
                 context_length: None,
                 inference_defaults: None,
+                defaults_origin: None,
                 server_defaults: None,
             }))
         }

--- a/crates/gglib-proxy/tests/fixtures/common.rs
+++ b/crates/gglib-proxy/tests/fixtures/common.rs
@@ -178,6 +178,7 @@ impl StaticCatalog {
             file_size: 0,
             context_length: Some(8192),
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         }
     }
@@ -452,6 +453,7 @@ impl TaggedCatalog {
             file_size: 0,
             context_length: None,
             inference_defaults: None,
+            defaults_origin: None,
             server_defaults: None,
         }
     }

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -87,6 +87,7 @@ impl NamedCatalog {
             file_size: 0,
             context_length: None,
             inference_defaults: self.inference_defaults.clone(),
+            defaults_origin: None,
             server_defaults: None,
         }
     }

--- a/crates/gglib-runtime/src/ports_impl/model_catalog.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_catalog.rs
@@ -45,6 +45,7 @@ fn model_to_summary(m: &Model) -> ModelSummary {
         file_size,
         context_length: m.context_length,
         inference_defaults: m.inference_defaults.clone(),
+        defaults_origin: m.defaults_origin,
         server_defaults: m.server_defaults.clone(),
     }
 }
@@ -168,6 +169,7 @@ mod tests {
                 tags: vec!["format:qwen".to_string()],
                 capabilities: ModelCapabilities::default(),
                 inference_defaults: None,
+                defaults_origin: None,
                 server_defaults: None,
                 benchmark_summary: None,
             }

--- a/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
+++ b/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
@@ -114,6 +114,13 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model, detail })
 
       {hasInferenceDefaults && (
         <MetadataSection title="Inference Defaults">
+          {model.defaultsOrigin != null && (
+            <InfoRow label="Source">
+              {model.defaultsOrigin === 'auto_detected'
+                ? 'Auto-detected (ranks below global settings)'
+                : 'User-set'}
+            </InfoRow>
+          )}
           {inferenceDefaults.temperature != null && (
             <InfoRow label="Temperature">{inferenceDefaults.temperature}</InfoRow>
           )}
@@ -124,6 +131,12 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model, detail })
           )}
           {inferenceDefaults.repeatPenalty != null && (
             <InfoRow label="Repeat Penalty">{inferenceDefaults.repeatPenalty}</InfoRow>
+          )}
+          {inferenceDefaults.presencePenalty != null && (
+            <InfoRow label="Presence Penalty">{inferenceDefaults.presencePenalty}</InfoRow>
+          )}
+          {inferenceDefaults.minP != null && (
+            <InfoRow label="Min P">{inferenceDefaults.minP}</InfoRow>
           )}
         </MetadataSection>
       )}

--- a/src/components/ModelInspectorPanel/hooks/useServerActions.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServerActions.ts
@@ -133,6 +133,8 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
         topK: inferenceParams?.topK,
         maxTokens: inferenceParams?.maxTokens,
         repeatPenalty: inferenceParams?.repeatPenalty,
+        presencePenalty: inferenceParams?.presencePenalty,
+        minP: inferenceParams?.minP,
       };
 
       const result = await getTransport().serveModel(serveConfig);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,13 @@ export interface GgufModel {
   port?: number;
   // Inference defaults
   inferenceDefaults?: InferenceConfig;
+  /**
+   * Whether `inferenceDefaults` was set by the user or auto-detected at
+   * import time from the model's `reasoning` tag. Auto-detected values rank
+   * below the global inference defaults in the resolution hierarchy — see
+   * the `InferenceConfig` doc comment above.
+   */
+  defaultsOrigin?: 'user' | 'auto_detected' | null;
   // Per-model server defaults (overrides global settings for launch params)
   serverDefaults?: ServerConfig;
   // Benchmark summary (cached from benchmark_summaries table)
@@ -133,6 +140,8 @@ export interface ServeConfig {
   topK?: number;
   maxTokens?: number;
   repeatPenalty?: number;
+  presencePenalty?: number;
+  minP?: number;
 }
 
 export interface ServerInfo {


### PR DESCRIPTION
## Summary

Stacked on #687. Adds `DefaultsOrigin` (`User` | `AutoDetected`) tracking for `Model.inference_defaults`, and changes resolution so an auto-detected value ranks below global settings instead of always outranking them.

- **Root cause this closes:** `model_import.rs` auto-writes `InferenceConfig::reasoning_profile()` onto any model tagged `reasoning`, indistinguishable in storage from a value the user set deliberately. Per-model defaults outrank global settings by design, so an unreviewed guess could silently shadow the user's own configured global sampling — with no way to tell the two apart in the resolved output or the logs.
- `InferenceConfig::resolve_with_profile` and `resolve_sampling` both split the per-model layer into two rungs (user-set above global, auto-detected below). Bundled `is_reasoning` + `defaults_origin` into a new `ModelSamplingContext` rather than growing the parameter list a third time.
- `model_import.rs` stamps `AutoDetected` when it writes the auto-detected recipe; every explicit edit path (CLI `model update`, WebUI `PATCH /api/models/:id`) stamps `User`.
- **DB migration:** `ALTER TABLE models ADD COLUMN defaults_origin TEXT` for existing rows, but deliberately **no batch backfill**. `bootstrap_capabilities()` — the existing precedent for this kind of backfill — only runs from `gglib-axum`'s startup path, not the standalone CLI's, so a batch job would silently never run for CLI-only installs. Instead `row_to_model` derives the answer on every read when the column is `NULL`: a stored `InferenceConfig` matching `reasoning_profile()` byte-for-byte is treated as auto-detected, anything else as user-set.
- Full parity: `NewModel`, `ModelSummary`, `ModelContext`, both DB write paths (`insert`'s COALESCE-on-reimport semantics, `update`'s straight overwrite), `GuiModel`/`ModelDetailDto`, CLI `model inspect` (provenance suffix on the section header), WebUI (a "Source" row + badge in the model inspector).
- Also closes a pre-existing gap found along the way: `presencePenalty`/`minP` were missing from `ServeConfig`, `useServerActions.ts`'s serve payload, and `ModelMetadataGrid`'s read-only display — unrelated to this feature, but in the same fields, so fixed here rather than filed separately.

## Test plan

- [x] `cargo test --workspace` — 82/82 suites pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo doc --no-deps` — 139 warnings before and after (no regressions)
- [x] `cargo fmt --check` — clean
- [x] `./scripts/check_readmes.sh --strict` — passes
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run test:run` (646 passed), `npm run build` — all clean
- [x] New tests: `an_auto_detected_models_recipe_ranks_below_global_settings` / `a_user_set_models_recipe_still_beats_global_settings` (the end-to-end regression, at the `resolve_sampling` level), `resolve_defaults_origin`'s 5-case unit suite (stored value wins, legacy-row backfill both ways, no-inference-defaults ⇒ no-origin, unparseable-column fallback), `a_legacy_row_with_the_reasoning_recipe_reads_back_as_auto_detected` (through the real `SqliteModelRepository`, not just the isolated mapper function), `upsert_preserves_defaults_origin_alongside_curated_defaults` (COALESCE-on-reimport, mirroring the existing `inference_defaults` test), `reasoning_tag_sets_inference_defaults_on_both_origins` extended to assert the stamped origin

Part of the stack tracked in #685. Depends on #687.
