### PR TITLE
fix(normalize): harden the Qwen function-XML dialect parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,12 +169,12 @@ Positive evidence wins: if a template contains `[SYSTEM_PROMPT]` **and** a gener
 
 If the architecture needs **response normalization** (e.g., XML-wrapped tool calls):
 
-1. Add a `format:myarch-xml` constant to `crates/gglib-proxy/src/normalize/tags.rs`.
-2. Add a parser module under `crates/gglib-proxy/src/normalize/parsers/`.
-3. Add an arm to `get_parser()` in `crates/gglib-proxy/src/normalize/registry.rs`.
+1. Add a `format:myarch-xml` constant to `crates/gglib-core/src/normalize/tags.rs`.
+2. Add a parser module under `crates/gglib-core/src/normalize/parsers/`.
+3. Add an arm to `get_parser()` in `crates/gglib-core/src/normalize/registry.rs`.
 4. Ensure models with this architecture receive the `format:myarch-xml` tag (add to `retag` logic if needed).
 
-No other files need to change.  The proxy's `normalize` pipeline picks up new parsers automatically via `get_parser()`.
+No other files need to change.  The `normalize` pipeline (shared by the proxy and the in-process agent path) picks up new parsers automatically via `get_parser()`.
 
 ### Capability overrides
 

--- a/crates/gglib-core/src/normalize/error.rs
+++ b/crates/gglib-core/src/normalize/error.rs
@@ -28,9 +28,13 @@ pub enum NormalizationErrorKind {
     /// empty if only the open tag was seen).
     UnclosedToolCallTag { partial: String },
 
-    /// A dialect-specific marker was recognised but its surrounding shape
-    /// did not match any known schema.  Reserved for future parsers.
-    UnknownMarkup { raw: String },
+    /// Found a complete `<tool_call>...</tool_call>` block whose body began
+    /// with `<function=` (the Qwen3/Hermes inner-XML dialect) but did not
+    /// match that dialect's `<function=NAME><parameter=KEY>VALUE</parameter>...</function>`
+    /// shape.
+    ///
+    /// `raw` holds the body bytes between the open and close tags.
+    MalformedFunctionXml { raw: String },
 }
 
 /// A non-fatal normalization issue surfaced from a parser.
@@ -67,6 +71,16 @@ impl NormalizationError {
                 partial: partial.clone(),
             },
             raw: partial,
+        }
+    }
+
+    /// Construct a `MalformedFunctionXml` error with the body as `raw`.
+    #[must_use]
+    pub fn malformed_function_xml(body: impl Into<String>) -> Self {
+        let raw = body.into();
+        Self {
+            kind: NormalizationErrorKind::MalformedFunctionXml { raw: raw.clone() },
+            raw,
         }
     }
 }

--- a/crates/gglib-core/src/normalize/parsers/qwen_xml.rs
+++ b/crates/gglib-core/src/normalize/parsers/qwen_xml.rs
@@ -1,9 +1,16 @@
 //! Qwen-style XML tool-call parser.
 //!
-//! Rewrites embedded `<tool_call>{json}</tool_call>` markup — emitted by
-//! Qwen 2 / 2.5 / 3 family models in either the text or reasoning channel —
-//! into proper [`ToolCall`] values.  Bytes outside of `<tool_call>` regions
-//! are forwarded verbatim on the channel they arrived on.
+//! Rewrites `<tool_call>...</tool_call>` markup — emitted by Qwen 2 / 2.5 / 3
+//! family models in either the text or reasoning channel — into proper
+//! [`ToolCall`] values.  Bytes outside of `<tool_call>` regions are forwarded
+//! verbatim on the channel they arrived on.
+//!
+//! Two body dialects are accepted inside the wrapper, tried in order — see
+//! `finalize_tool_call` for the detail:
+//! 1. **JSON** — `{"name":"foo","arguments":{...}}` (Qwen 2 / 2.5).
+//! 2. **Inner XML** — `<function=NAME><parameter=KEY>VALUE</parameter>...</function>`,
+//!    one or more back-to-back inside a single wrapper (Qwen 3 + `--jinja`,
+//!    Hermes-style).
 //!
 //! ## Chunk safety
 //!
@@ -189,29 +196,43 @@ fn forward(out: &mut ParserOutput, channel: Channel, bytes: &str) {
     }
 }
 
-/// Parse the accumulated tool-call body and push the resulting [`ToolCall`]
+/// Parse the accumulated tool-call body and push the resulting [`ToolCall`]s
 /// (or a [`NormalizationError`]) onto `out`.
 ///
 /// Two body shapes are accepted, in order:
 /// 1. **JSON** — `{"name":"foo","arguments":{...}}` (Qwen2/2.5 native).
-/// 2. **Inner XML** — `<function=NAME><parameter=KEY>VAL</parameter>...</function>`
+/// 2. **Inner XML** — one or more back-to-back
+///    `<function=NAME><parameter=KEY>VAL</parameter>...</function>` blocks
 ///    (Qwen3 + `--jinja`, Hermes-style).
 ///
 /// JSON is tried first because it is the historical Qwen format and is
 /// unambiguous; the XML form is the documented fallback for Qwen3 chat
 /// templates that emit nested function/parameter markup inside `<tool_call>`.
+///
+/// On failure, the error kind reflects which dialect was attempted: a body
+/// that looks like it opened the XML dialect (`<function=`) but didn't match
+/// its shape reports [`NormalizationErrorKind::MalformedFunctionXml`]
+/// instead of the generic JSON failure, since the two dialects fail for
+/// unrelated reasons and a log reader should not have to guess which one was
+/// in play.
+///
+/// [`NormalizationErrorKind::MalformedFunctionXml`]: crate::normalize::error::NormalizationErrorKind::MalformedFunctionXml
 fn finalize_tool_call(body: &str, out: &mut ParserOutput, mut mint_id: impl FnMut() -> String) {
     let trimmed = body.trim();
     if let Some(call) = parse_json_body(trimmed, &mut mint_id) {
         out.tool_calls.push(call);
         return;
     }
-    if let Some(call) = parse_function_xml_body(trimmed, &mut mint_id) {
-        out.tool_calls.push(call);
+    if let Some(calls) = parse_function_xml_body(trimmed, &mut mint_id) {
+        out.tool_calls.extend(calls);
         return;
     }
-    out.errors
-        .push(NormalizationError::malformed_tool_call(body.to_owned()));
+    let error = if trimmed.starts_with("<function=") {
+        NormalizationError::malformed_function_xml(body.to_owned())
+    } else {
+        NormalizationError::malformed_tool_call(body.to_owned())
+    };
+    out.errors.push(error);
 }
 
 /// Try to interpret `body` as a Qwen JSON tool call.
@@ -230,54 +251,108 @@ fn parse_json_body(body: &str, mint_id: &mut impl FnMut() -> String) -> Option<T
     })
 }
 
-/// Try to interpret `body` as the Hermes/Qwen3 inner-XML tool call:
-/// `<function=NAME><parameter=KEY>VALUE</parameter>...</function>`.
+/// Try to interpret `body` as one or more back-to-back Hermes/Qwen3
+/// inner-XML tool calls:
+/// `<function=NAME><parameter=KEY>VALUE</parameter>...</function>`, repeated.
 ///
-/// Whitespace between tags is tolerated.  Each parameter value is parsed as
+/// Whitespace between tags is tolerated. Each parameter value is parsed as
 /// JSON when it looks like a JSON literal (`{`, `[`, quoted string, number,
 /// `true`/`false`/`null`); otherwise it is forwarded as a string after
-/// trimming surrounding whitespace.
-fn parse_function_xml_body(body: &str, mint_id: &mut impl FnMut() -> String) -> Option<ToolCall> {
-    let body = body.trim();
-    let after_open = body.strip_prefix("<function=")?;
-    let name_end = after_open.find('>')?;
-    let name = after_open[..name_end].trim();
-    if name.is_empty() {
-        return None;
-    }
-    let inner = &after_open[name_end + 1..];
-    let inner = inner.strip_suffix("</function>")?.trim();
+/// trimming surrounding whitespace — see [`parse_param_value`]'s doc comment
+/// for the coercion's known limitation.
+///
+/// Returns `None` (not `Some(vec![])`) when `body` doesn't open with
+/// `<function=` at all or the very first block is malformed, so the caller
+/// can fall through to a "no dialect matched" error. A body that opens
+/// correctly but has a malformed *later* block currently stops at that point
+/// and returns `None` for the whole body, discarding any calls already
+/// parsed — the same fail-shut behaviour the single-call parser always had.
+fn parse_function_xml_body(
+    body: &str,
+    mint_id: &mut impl FnMut() -> String,
+) -> Option<Vec<ToolCall>> {
+    let mut calls = Vec::new();
+    let mut cursor = body.trim();
 
-    let mut args = serde_json::Map::new();
-    let mut cursor = inner;
     while !cursor.is_empty() {
-        cursor = cursor.trim_start();
-        if cursor.is_empty() {
-            break;
-        }
-        let after_param = cursor.strip_prefix("<parameter=")?;
-        let key_end = after_param.find('>')?;
-        let key = after_param[..key_end].trim().to_owned();
-        if key.is_empty() {
+        let after_open = cursor.strip_prefix("<function=")?;
+        let name_end = after_open.find('>')?;
+        let name = after_open[..name_end].trim();
+        if name.is_empty() {
             return None;
         }
-        let rest = &after_param[key_end + 1..];
-        let close_at = rest.find("</parameter>")?;
-        let raw_value = rest[..close_at].trim();
-        let value = parse_param_value(raw_value);
-        args.insert(key, value);
-        cursor = &rest[close_at + "</parameter>".len()..];
+        let after_name = &after_open[name_end + 1..];
+
+        // This block's own `</function>` is the LAST occurrence before the
+        // next sibling `<function=`, if any — never the first occurrence
+        // found anywhere in the remainder, which could belong to a
+        // parameter's own value (e.g. a `content` parameter whose text
+        // happens to mention "</function>"). See `find_own_close` for the
+        // same rule applied to `</parameter>`.
+        let close_at = find_own_close(after_name, "</function>", "<function=")?;
+        let inner = after_name[..close_at].trim();
+        let after_function = &after_name[close_at + "</function>".len()..];
+
+        let mut args = serde_json::Map::new();
+        let mut param_cursor = inner;
+        while !param_cursor.is_empty() {
+            param_cursor = param_cursor.trim_start();
+            if param_cursor.is_empty() {
+                break;
+            }
+            let after_param = param_cursor.strip_prefix("<parameter=")?;
+            let key_end = after_param.find('>')?;
+            let key = after_param[..key_end].trim().to_owned();
+            if key.is_empty() {
+                return None;
+            }
+            let rest = &after_param[key_end + 1..];
+            let close_at = find_own_close(rest, "</parameter>", "<parameter=")?;
+            let raw_value = rest[..close_at].trim();
+            args.insert(key, parse_param_value(raw_value));
+            param_cursor = &rest[close_at + "</parameter>".len()..];
+        }
+
+        calls.push(ToolCall {
+            id: mint_id(),
+            name: name.to_owned(),
+            arguments: Value::Object(args),
+        });
+
+        cursor = after_function.trim_start();
     }
 
-    Some(ToolCall {
-        id: mint_id(),
-        name: name.to_owned(),
-        arguments: Value::Object(args),
-    })
+    (!calls.is_empty()).then_some(calls)
 }
 
-/// Best-effort coercion of a `<parameter>` body to a JSON value.  Falls
-/// back to a string literal when the body is not valid JSON.
+/// Find this tag's own closing marker inside `rest`: the LAST occurrence of
+/// `close` before the next sibling `next_open` marker (or before the end of
+/// `rest`, if there is no next sibling).
+///
+/// A naive `rest.find(close)` truncates the value early whenever it happens
+/// to contain the literal closing-tag text — a real risk for a `content` or
+/// `code` parameter carrying anything that looks like markup. The tag's true
+/// close is always the one immediately before its next sibling opens (or the
+/// end of the block), never an earlier occurrence, so searching backward
+/// from that boundary finds it correctly even when the value embeds the
+/// marker text. This is not a complete fix — a value that also happens to
+/// contain the *next sibling's* open marker is still ambiguous, since this
+/// dialect has no escaping mechanism — but it is strictly more often correct
+/// than a forward search from the start.
+fn find_own_close(rest: &str, close: &str, next_open: &str) -> Option<usize> {
+    let boundary = rest.find(next_open).unwrap_or(rest.len());
+    rest[..boundary].rfind(close)
+}
+
+/// Best-effort coercion of a `<parameter>` body to a JSON value. Falls back
+/// to a string literal when the body is not valid JSON.
+///
+/// This is inherently lossy: the dialect gives no way to distinguish a
+/// parameter that is genuinely meant to be the *string* `"true"` or `"123"`
+/// from one meant to be the boolean or the number — both coerce to the typed
+/// value. There is no tool `input_schema` available here to disambiguate
+/// against (the parser has no access to the tool definitions that produced
+/// this call), so this is a best-effort guess, not a guarantee.
 fn parse_param_value(raw: &str) -> Value {
     if raw.is_empty() {
         return Value::String(String::new());
@@ -566,5 +641,119 @@ mod tests {
         assert_eq!(out.tool_calls.len(), 1);
         assert_eq!(out.tool_calls[0].name, "ping");
         assert_eq!(out.tool_calls[0].arguments, json!({}));
+    }
+
+    /// Multiple `<function=...>` blocks back-to-back inside one `<tool_call>`
+    /// wrapper (Hermes-style multi-call) must all be extracted, in order,
+    /// with distinct synthesised IDs.
+    #[test]
+    fn multiple_function_blocks_in_one_wrapper_are_all_extracted() {
+        let mut p = QwenXmlParser::new();
+        let body = concat!(
+            "<tool_call>",
+            "<function=get_weather><parameter=city>Paris</parameter></function>",
+            "<function=get_time><parameter=zone>UTC</parameter></function>",
+            "</tool_call>",
+        );
+        let out = collect(&mut p, &[body]);
+        assert!(out.errors.is_empty(), "errors: {:?}", out.errors);
+        assert_eq!(out.tool_calls.len(), 2);
+        assert_eq!(out.tool_calls[0].name, "get_weather");
+        assert_eq!(out.tool_calls[0].arguments, json!({"city": "Paris"}));
+        assert_eq!(out.tool_calls[1].name, "get_time");
+        assert_eq!(out.tool_calls[1].arguments, json!({"zone": "UTC"}));
+        assert_ne!(
+            out.tool_calls[0].id, out.tool_calls[1].id,
+            "each call in the block needs its own ID"
+        );
+    }
+
+    /// A value that happens to contain the literal text `</parameter>` must
+    /// not truncate the value early — the true close is the last occurrence
+    /// before the next sibling tag, not the first occurrence anywhere. This
+    /// is the naive-`find` bug: the old implementation would have stopped at
+    /// "Use ", left `to close a param` dangling as unparsed cursor bytes, and
+    /// failed the whole block.
+    #[test]
+    fn a_parameter_value_containing_the_literal_close_marker_does_not_truncate() {
+        let mut p = QwenXmlParser::new();
+        let body = concat!(
+            "<tool_call><function=write_doc>",
+            "<parameter=text>Use </parameter> to close a param</parameter>",
+            "<parameter=lang>en</parameter>",
+            "</function></tool_call>",
+        );
+        let out = collect(&mut p, &[body]);
+        assert!(out.errors.is_empty(), "errors: {:?}", out.errors);
+        assert_eq!(out.tool_calls.len(), 1);
+        assert_eq!(
+            out.tool_calls[0].arguments,
+            json!({"text": "Use </parameter> to close a param", "lang": "en"})
+        );
+    }
+
+    /// Same rule at the `</function>` boundary: a parameter value containing
+    /// the literal text `</function>` must not truncate the function body
+    /// early when another sibling function follows.
+    #[test]
+    fn a_parameter_value_containing_the_literal_function_close_does_not_truncate() {
+        let mut p = QwenXmlParser::new();
+        let body = concat!(
+            "<tool_call>",
+            "<function=write_doc><parameter=text>end with </function> tag</parameter></function>",
+            "<function=ping></function>",
+            "</tool_call>",
+        );
+        let out = collect(&mut p, &[body]);
+        assert!(out.errors.is_empty(), "errors: {:?}", out.errors);
+        assert_eq!(out.tool_calls.len(), 2);
+        assert_eq!(
+            out.tool_calls[0].arguments,
+            json!({"text": "end with </function> tag"})
+        );
+        assert_eq!(out.tool_calls[1].name, "ping");
+    }
+
+    /// A body that opens the XML dialect (`<function=`) but is structurally
+    /// broken must be reported with the XML-specific error kind, not the
+    /// generic JSON one — the two dialects fail for unrelated reasons.
+    #[test]
+    fn malformed_function_xml_gets_its_own_error_kind() {
+        let mut p = QwenXmlParser::new();
+        let out = collect(
+            &mut p,
+            &["<tool_call><function=oops(no closing angle</tool_call>"],
+        );
+        assert!(out.tool_calls.is_empty());
+        assert_eq!(out.errors.len(), 1);
+        assert!(matches!(
+            out.errors[0].kind,
+            crate::normalize::error::NormalizationErrorKind::MalformedFunctionXml { .. }
+        ));
+    }
+
+    /// Pinning the type-coercion limitation documented on
+    /// `parse_param_value`: a parameter meant to be the literal string
+    /// `"true"` or `"123"` is indistinguishable from one meant to be the
+    /// boolean or the number, since the dialect carries no schema. This is
+    /// not a bug to fix here — the parser has no `input_schema` to consult —
+    /// but the behaviour must not change silently.
+    #[test]
+    fn parameter_values_that_look_like_json_literals_are_coerced_not_kept_as_strings() {
+        let mut p = QwenXmlParser::new();
+        let body = concat!(
+            "<tool_call><function=configure>",
+            "<parameter=enabled>true</parameter>",
+            "<parameter=count>123</parameter>",
+            "<parameter=label>plain text</parameter>",
+            "</function></tool_call>",
+        );
+        let out = collect(&mut p, &[body]);
+        assert!(out.errors.is_empty());
+        assert_eq!(
+            out.tool_calls[0].arguments,
+            json!({"enabled": true, "count": 123, "label": "plain text"}),
+            "bool- and number-shaped strings coerce; only non-JSON-shaped text stays a string"
+        );
     }
 }

--- a/crates/gglib-proxy/tests/fixtures/sse.rs
+++ b/crates/gglib-proxy/tests/fixtures/sse.rs
@@ -47,6 +47,17 @@ data: {\"id\":\"u-3\",\"object\":\"chat.completion.chunk\",\"created\":172900000
 data: {\"id\":\"u-3\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n\
 data: [DONE]\n\n";
 
+/// Qwen3 + `--jinja` inner-XML tool call — the Hermes-style
+/// `<function=NAME><parameter=KEY>VALUE</parameter></function>` body inside
+/// the same `<tool_call>` wrapper, as opposed to [`QWEN_XML_TOOL_CALL`]'s
+/// JSON body.  Exercises `qwen_xml`'s second dialect through the full
+/// pipeline, not just the parser's own unit tests.
+pub const QWEN_FUNCTION_XML_TOOL_CALL: &[u8] = b"\
+data: {\"id\":\"u-10\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Looking it up. \"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"u-10\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"u-10\",\"object\":\"chat.completion.chunk\",\"created\":1729000000,\"model\":\"upstream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n\
+data: [DONE]\n\n";
+
 /// Standard OpenAI tool call (already strict / no dialect rewriting).  The
 /// proxy must round-trip this preserving `id`, `type:"function"`, `name`,
 /// `arguments`, and the `index`.

--- a/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
+++ b/crates/gglib-proxy/tests/integration_proxy_pipeline.rs
@@ -27,8 +27,8 @@ use fixtures::common::{
     assert_sse_canonical_envelope, parse_sse_frames, spawn_mock_upstream, spawn_proxy,
 };
 use fixtures::sse::{
-    BASIC_TEXT, MALFORMED_JSON_RECOVERY, QWEN_XML_TOOL_CALL, REASONING_DEEPSEEK, REASONING_ONLY,
-    STANDARD_OPENAI_TOOL_CALL, basic_text_split_chunks,
+    BASIC_TEXT, MALFORMED_JSON_RECOVERY, QWEN_FUNCTION_XML_TOOL_CALL, QWEN_XML_TOOL_CALL,
+    REASONING_DEEPSEEK, REASONING_ONLY, STANDARD_OPENAI_TOOL_CALL, basic_text_split_chunks,
 };
 
 // ─── End-to-end driver ─────────────────────────────────────────────────────
@@ -229,6 +229,78 @@ async fn qwen_xml_tool_call_is_normalized() {
     assert_eq!(parsed_args, json!({"city": "Paris"}));
 
     // Final chunk must announce finish_reason="tool_calls".
+    let stop = frames
+        .iter()
+        .find(|f| f["choices"][0]["finish_reason"] == "tool_calls")
+        .expect("missing tool_calls finish chunk");
+    assert!(
+        stop["choices"][0]["delta"]
+            .as_object()
+            .is_some_and(|o| o.is_empty())
+    );
+}
+
+/// The second `format:qwen-xml` body shape — Qwen3 + `--jinja`'s
+/// `<function=NAME><parameter=KEY>VALUE</parameter></function>` dialect,
+/// rather than [`qwen_xml_tool_call_is_normalized`]'s JSON body — must be
+/// rewritten into the same strict OpenAI `tool_calls` deltas, through the
+/// full proxy pipeline rather than just the parser's own unit tests.
+#[tokio::test]
+async fn qwen_function_xml_tool_call_is_normalized() {
+    let body = round_trip(
+        vec![QWEN_FUNCTION_XML_TOOL_CALL],
+        "qwen3.6",
+        vec!["format:qwen-xml".to_owned()],
+    )
+    .await;
+    let (frames, saw_done) = parse_sse_frames(&body);
+    assert!(saw_done);
+    assert_sse_canonical_envelope(&frames, "qwen3.6");
+
+    // The literal Qwen markup MUST NOT appear in the wire output.
+    assert!(
+        !body.contains("<tool_call>")
+            && !body.contains("</tool_call>")
+            && !body.contains("<function=")
+            && !body.contains("<parameter="),
+        "Qwen inner-XML markers leaked into wire output:\n{body}"
+    );
+
+    let content: String = frames
+        .iter()
+        .filter_map(|f| f["choices"][0]["delta"]["content"].as_str())
+        .collect();
+    assert_eq!(content, "Looking it up. ");
+
+    let tc_frames: Vec<&Value> = frames
+        .iter()
+        .filter(|f| f["choices"][0]["delta"]["tool_calls"].is_array())
+        .collect();
+    assert!(
+        !tc_frames.is_empty(),
+        "expected at least one tool_calls delta"
+    );
+
+    let first_tc = &tc_frames[0]["choices"][0]["delta"]["tool_calls"][0];
+    assert_eq!(first_tc["index"], json!(0));
+    assert!(
+        first_tc["id"].is_string(),
+        "first tool_call delta missing id"
+    );
+    assert_eq!(first_tc["type"], "function");
+    assert_eq!(first_tc["function"]["name"], "get_weather");
+
+    let mut args = String::new();
+    for f in &tc_frames {
+        if let Some(s) = f["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"].as_str()
+        {
+            args.push_str(s);
+        }
+    }
+    let parsed_args: Value =
+        serde_json::from_str(&args).expect("tool_call arguments should be JSON");
+    assert_eq!(parsed_args, json!({"city": "Paris"}));
+
     let stop = frames
         .iter()
         .find(|f| f["choices"][0]["finish_reason"] == "tool_calls")


### PR DESCRIPTION
## Summary

Independent of the sampling-resolution stack (#686, #687, #688) and the context-bookkeeping fix (#689) — this hardens a separately-discovered weak spot found while investigating the same incident (#685).

**Correction to the original triage in #685:** the issue assumed the Qwen3.6 `<function=...>` XML dialect was entirely unimplemented. It already existed — the module docs just didn't say so. The actual gaps were:

- **Single-function limit.** Only one `<function>` block per `<tool_call>` wrapper was supported. `parse_function_xml_body` now returns `Vec<ToolCall>` and loops, so Hermes-style multi-call bodies (several `<function>` blocks back-to-back in one wrapper) parse correctly.
- **Naive boundary matching.** A parameter or function value containing the literal text `</parameter>` or `</function>` truncated early — the old code took the *first* occurrence of the closing marker anywhere in the remainder, which could belong to the value itself. `find_own_close` now takes the *last* occurrence before the next sibling tag (or end of block), which is always the tag's true close.
- **Misleading error kind.** Structural XML failures surfaced as `MalformedToolCallJson`. Added `MalformedFunctionXml`; removed `UnknownMarkup`, which was declared but never constructed anywhere.
- **Undocumented type-coercion limitation.** `parse_param_value` can't tell a parameter meant to be the literal string `"true"`/`"123"` from the bool/number — there's no `input_schema` available to the parser to disambiguate. Not a fixable bug; now documented and pinned with a test so it can't silently change.
- **No integration coverage.** Added `QWEN_FUNCTION_XML_TOOL_CALL` fixture + `qwen_function_xml_tool_call_is_normalized`, mirroring the existing JSON-dialect integration test, so this dialect is exercised through the full proxy pipeline, not just the parser's own unit tests.

Also fixes a stale path in `CONTRIBUTING.md` — the `normalize` module moved from `gglib-proxy` to `gglib-core`; the "adding a dialect" instructions still pointed at the old location.

## Test plan

- [x] `cargo test --workspace` — 82/82 suites pass (one unrelated pre-existing flaky test, `contention::wait::wait_tests::contention_that_clears_inside_the_window_succeeds`, reproduces identically on `main` under load — untouched by this diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps -p gglib-core` — 35 warnings before and after (no regressions)
- [x] `./scripts/check_readmes.sh --strict` — passes
- [x] New unit tests: multiple `<function>` blocks in one wrapper, a value containing the literal `</parameter>` text, a value containing the literal `</function>` text, the new `MalformedFunctionXml` error kind, the type-coercion pin
- [x] New integration test: `qwen_function_xml_tool_call_is_normalized`, full proxy round-trip

Part of the incident tracked in #685, but lands independently.
