### PR TITLE
feat(download): make native Rust HTTP the default download path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
@@ -1644,7 +1644,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs 0.6.6",
+ "zlib-rs 0.6.7",
 ]
 
 [[package]]
@@ -2256,6 +2256,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "futures-util",
  "gglib-core",
  "gglib-hf",
  "hf-hub",
@@ -2265,6 +2266,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -3868,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-docker"
@@ -4224,9 +4226,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -5601,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7275,9 +7277,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "js-sys",
@@ -9150,9 +9152,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ chrono-tz = "0.10"
 # Encoding
 base64 = "0.22"
 
+# Hashing (download checksum verification)
+sha2 = "0.10"
+
 # Error handling
 thiserror = "2.0"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -808,14 +808,13 @@ git clone https://github.com/mmogr/gglib.git && cd gglib
 make setup   # check deps → build frontend → install CLI → offer llama.cpp install
 ```
 
-`make setup` checks for Rust, Node.js, and build tools; provisions the Miniconda environment for the `hf_xet` fast download helper; builds the web UI; and installs the CLI to `~/.cargo/bin/`. It exits with an error if Python/Miniconda is missing — run it first on new machines.
+`make setup` checks for Rust, Node.js, and build tools; builds the web UI; and installs the CLI to `~/.cargo/bin/`. It needs no Python — model downloads are native Rust HTTP.
 
 > **Developer Mode:** When installed via `make setup`, the database (`gglib.db`), config (`.env`), and llama.cpp binaries live inside your repo folder. Downloaded models default to `~/.local/share/llama_models`.
 
 ### Prerequisites
 
 - **Rust** 1.70+ (MSRV). Tooling/CI currently pins Rust **1.97.1** via `rust-toolchain.toml` — using that version is recommended. — [rustup.rs](https://rustup.rs/)
-- **Python 3 via Miniconda** — [miniconda](https://docs.conda.io/en/latest/miniconda.html) (for hf_xet fast downloads)
 - **Node.js** 20.19+ (matches the `package.json` `engines` field) — [nodejs.org](https://nodejs.org/) (for web UI)
 - **SQLite** 3.x
 - **Build tools**: macOS `xcode-select --install` + `brew install cmake` · Ubuntu `build-essential cmake git` · Windows VS 2022 C++ + CMake
@@ -909,7 +908,17 @@ cargo run --package gglib-cli -- web --port 9887 --static-dir ./web_ui  # single
 <details>
 <summary><strong>Accelerated downloads (hf_xet)</strong></summary>
 
-gglib bundles a managed Python helper for [hf_xet](https://github.com/huggingface/hf-xet) fast downloads. On first run (or after `make setup` / `gglib config check-deps`), it provisions a Miniconda environment under `<data_root>/.conda/gglib-hf-xet` and installs `huggingface_hub>=1.1.5` + `hf_xet>=0.6`. There is no legacy Rust HTTP fallback — if the helper is missing, `gglib model download` will fail until the environment is repaired.
+Downloads run natively in Rust by default: a resumable ranged GET straight to the Hugging Face CDN, verified against the object's SHA-256 and renamed into place only once it checks out. This needs nothing installed beyond gglib itself.
+
+[hf_xet](https://github.com/huggingface/hf-xet) is available as an **optional** accelerator on top of that. It is never provisioned implicitly — you opt in explicitly:
+
+```bash
+gglib config check-deps --setup-fast-downloads   # CLI
+```
+
+or the **Fast Downloads** step of the setup wizard in the GUI. Either builds a Python environment under `<data_root>/.conda/gglib-hf-xet` with `huggingface_hub>=1.1.5` + `hf_xet>=0.6`, and needs Python 3 on `PATH`.
+
+Once that environment exists, downloads use it automatically. If it is absent — or present but failing — downloads fall back to the native path rather than erroring.
 
 </details>
 

--- a/crates/gglib-app-services/src/setup.rs
+++ b/crates/gglib-app-services/src/setup.rs
@@ -1,7 +1,7 @@
 //! Setup wizard operations for GUI backend.
 //!
 //! Handles first-run system status checks, llama.cpp installation,
-//! and Python fast-download helper provisioning.
+//! and provisioning of the optional `hf_xet` download accelerator.
 
 use std::sync::Arc;
 
@@ -30,9 +30,10 @@ pub struct SetupStatus {
     pub gpu_info: GpuInfoDto,
     /// Models directory information.
     pub models_directory: ModelsDirectoryDto,
-    /// Whether Python 3 is available on the system.
+    /// Whether Python 3 is available, i.e. whether the optional `hf_xet`
+    /// accelerator *could* be provisioned. Downloading does not depend on it.
     pub python_available: bool,
-    /// Whether the fast download helper (hf_xet venv) is ready.
+    /// Whether the `hf_xet` accelerator is already provisioned.
     pub fast_download_ready: bool,
     /// System memory information.
     pub system_memory: Option<SystemMemoryDto>,
@@ -141,13 +142,14 @@ impl SetupOps {
                 writable: false,
             });
 
-        // Python / fast download helper
+        // Optional hf_xet accelerator. Neither of these gates downloading —
+        // that runs natively over HTTP — they only tell the wizard whether the
+        // accelerator can be offered and whether it is already set up.
         let python_available = gglib_download::cli_exec::preflight_fast_helper()
             .await
             .is_ok();
 
-        // Check if the venv python exists (fast check, no process spawn)
-        let fast_download_ready = python_available && is_python_venv_ready();
+        let fast_download_ready = gglib_download::cli_exec::fast_helper_provisioned();
 
         // System memory
         let mem_info = self.deps.system_probe.get_system_memory_info();
@@ -206,30 +208,17 @@ impl SetupOps {
             .map_err(|e| GuiError::Internal(format!("Failed to install llama.cpp: {e}")))
     }
 
-    /// Provision the Python fast-download helper environment.
+    /// Provision the optional `hf_xet` download accelerator.
     ///
-    /// Creates a venv and installs huggingface_hub + hf_xet packages.
+    /// Creates a venv and installs `huggingface_hub` + `hf_xet`. This is the
+    /// only path that builds that environment — nothing provisions it
+    /// implicitly, and downloads work without it.
+    ///
     /// Returns an error with details if Python is not available or setup fails.
     pub async fn setup_python_env(&self) -> Result<(), GuiError> {
         gglib_download::cli_exec::ensure_fast_helper_ready()
             .await
             .map_err(|e| GuiError::Internal(format!("Failed to setup Python environment: {e}")))
-    }
-}
-
-/// Check if the Python fast-download venv is already provisioned.
-///
-/// Does a quick file-existence check for the venv Python binary
-/// at the well-known path `data_root()/.conda/gglib-hf-xet/bin/python3`.
-fn is_python_venv_ready() -> bool {
-    let Ok(root) = gglib_core::paths::data_root() else {
-        return false;
-    };
-    let venv_dir = root.join(".conda").join("gglib-hf-xet");
-    if cfg!(windows) {
-        venv_dir.join("Scripts").join("python.exe").exists()
-    } else {
-        venv_dir.join("bin").join("python3").exists()
     }
 }
 

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -46,7 +46,14 @@ pub enum ConfigCommand {
         command: AssistantUiCommand,
     },
     /// Check system dependencies required for gglib
-    CheckDeps,
+    CheckDeps {
+        /// Also provision the optional hf_xet download accelerator.
+        ///
+        /// Downloads work without this. It builds a Python environment under
+        /// the gglib data directory and needs Python 3 on PATH.
+        #[arg(long)]
+        setup_fast_downloads: bool,
+    },
     /// Show resolved paths for all gglib directories
     Paths,
 }

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/macos.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/macos.rs
@@ -11,7 +11,7 @@ pub fn print_instructions(missing: &[&Dependency]) {
     let needs_brew = missing.iter().any(|d| {
         matches!(
             d.name.as_str(),
-            "git" | "cmake" | "python3" | "curl" | "pkg-config" | "libssl-dev"
+            "git" | "cmake" | "curl" | "pkg-config" | "libssl-dev"
         )
     });
 
@@ -28,7 +28,6 @@ pub fn print_instructions(missing: &[&Dependency]) {
         .filter_map(|d| match d.name.as_str() {
             "git" => Some("git"),
             "cmake" => Some("cmake"),
-            "python3" => Some("python3"),
             "curl" => Some("curl"),
             "pkg-config" => Some("pkg-config"),
             "libssl-dev" => Some("openssl"),

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/windows.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/windows.rs
@@ -10,10 +10,9 @@ pub fn print_instructions(missing: &[&Dependency]) {
     // Check for winget/choco packages
     let needs_git = missing.iter().any(|d| d.name == "git");
     let needs_cmake = missing.iter().any(|d| d.name == "cmake");
-    let needs_python = missing.iter().any(|d| d.name == "python3");
     let needs_curl = missing.iter().any(|d| d.name == "curl");
 
-    if needs_git || needs_cmake || needs_python || needs_curl {
+    if needs_git || needs_cmake || needs_curl {
         print_subsection("Install via winget (recommended)");
 
         if needs_git {
@@ -21,9 +20,6 @@ pub fn print_instructions(missing: &[&Dependency]) {
         }
         if needs_cmake {
             print_command("winget install Kitware.CMake");
-        }
-        if needs_python {
-            print_command("winget install Python.Python.3.11");
         }
         if needs_curl {
             println!("  Note: curl is included with Windows 10/11");
@@ -38,9 +34,6 @@ pub fn print_instructions(missing: &[&Dependency]) {
         }
         if needs_cmake {
             choco_packages.push("cmake");
-        }
-        if needs_python {
-            choco_packages.push("python");
         }
 
         if !choco_packages.is_empty() {

--- a/crates/gglib-cli/src/handlers/config/check_deps/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/mod.rs
@@ -12,7 +12,7 @@ mod platform;
 use anyhow::{Context, Result};
 use gglib_core::ports::SystemProbePort;
 use gglib_core::utils::system::{Dependency, DependencyStatus};
-use gglib_download::cli_exec::ensure_fast_helper_ready;
+use gglib_download::cli_exec::{ensure_fast_helper_ready, fast_helper_provisioned};
 
 use display::{print_dependency, print_gpu_status};
 use instructions::print_installation_instructions;
@@ -28,12 +28,15 @@ use crate::presentation::style::{BOLD, DANGER, INFO, RESET, SUCCESS};
 /// # Arguments
 ///
 /// * `probe` - System probe implementation for dependency detection
+/// * `setup_fast_downloads` - Provision the optional `hf_xet` accelerator.
+///   Reporting is side-effect free; this is the only thing that installs
+///   anything, and it is off unless the user asks for it.
 ///
 /// # Returns
 ///
 /// Returns `Ok(())` if all required dependencies are present.
 /// Returns an error if any required dependencies are missing.
-pub async fn execute(probe: &dyn SystemProbePort) -> Result<()> {
+pub async fn execute(probe: &dyn SystemProbePort, setup_fast_downloads: bool) -> Result<()> {
     println!("{}{}Checking system dependencies...{}\n", BOLD, INFO, RESET);
 
     let dependencies = probe.check_all_dependencies();
@@ -68,14 +71,22 @@ pub async fn execute(probe: &dyn SystemProbePort) -> Result<()> {
             SUCCESS, RESET, present_required, total_required
         );
 
-        println!(
-            "{}Ensuring fast download helper is installed...{}",
-            BOLD, RESET
-        );
-        ensure_fast_helper_ready()
-            .await
-            .context("Failed to set up the Python fast download helper")?;
-        println!("{}✓ Fast download helper ready{}", SUCCESS, RESET);
+        if setup_fast_downloads {
+            println!(
+                "{}Provisioning the hf_xet download accelerator...{}",
+                BOLD, RESET
+            );
+            ensure_fast_helper_ready()
+                .await
+                .context("Failed to set up the hf_xet download accelerator")?;
+            println!("{}✓ Download accelerator ready{}", SUCCESS, RESET);
+        } else if !fast_helper_provisioned() {
+            println!(
+                "{}Downloads run natively over HTTP. To enable the optional hf_xet \
+                 accelerator, run:{} gglib config check-deps --setup-fast-downloads",
+                INFO, RESET
+            );
+        }
 
         print_gpu_status(probe);
 

--- a/crates/gglib-cli/src/handlers/config/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/mod.rs
@@ -23,9 +23,11 @@ pub async fn dispatch(ctx: &CliContext, command: ConfigCommand) -> Result<()> {
         ConfigCommand::Profile { command } => settings::handle_profile(ctx, command).await,
         ConfigCommand::Llama { command } => llama::dispatch(command).await,
         ConfigCommand::AssistantUi { command } => assistant_ui::dispatch(command),
-        ConfigCommand::CheckDeps => {
+        ConfigCommand::CheckDeps {
+            setup_fast_downloads,
+        } => {
             let probe = gglib_runtime::DefaultSystemProbe::new();
-            check_deps::execute(&probe).await
+            check_deps::execute(&probe, setup_fast_downloads).await
         }
         ConfigCommand::Paths => paths::execute(),
     }

--- a/crates/gglib-download/Cargo.toml
+++ b/crates/gglib-download/Cargo.toml
@@ -40,8 +40,12 @@ tracing.workspace = true
 # HuggingFace Hub SDK (for CLI execution)
 hf-hub.workspace = true
 
-# HTTP client (for API calls)
+# HTTP client (for API calls and the native download path)
 reqwest = { workspace = true }
+futures-util.workspace = true
+
+# Checksum verification for downloaded files
+sha2.workspace = true
 
 # Progress display (for CLI)
 indicatif = "0.18"

--- a/crates/gglib-download/README.md
+++ b/crates/gglib-download/README.md
@@ -20,8 +20,8 @@ gglib-core (types)          gglib-download            External
 └──────────────────┘        └───────┬──────────┘                 
                                     │                            
                             ┌───────▼──────────┐        ┌──────────────────┐
-                            │    gglib-hf      │        │   hf_xet helper  │
-                            │  (HfClientPort)  │        │  (fast-path DL)  │
+                            │    gglib-hf      │        │  hf_xet helper   │
+                            │  (HfClientPort)  │        │ (opt-in accel.)  │
                             └──────────────────┘        └──────────────────┘
 ```
 
@@ -42,8 +42,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 │                                                                                     │
 │  ┌─────────────┐     ┌─────────────┐                                                │
 │  │  resolver/  │     │  cli_exec/  │                                                │
-│  │ File URL &  │     │  hf_xet CLI │                                                │
-│  │ shard logic │     │  subprocess │                                                │
+│  │ File URL &  │     │ OPTIONAL    │                                                │
+│  │ shard logic │     │ hf_xet accel│                                                │
 │  └─────────────┘     └─────────────┘                                                │
 │                                                                                     │
 └─────────────────────────────────────────────────────────────────────────────────────┘
@@ -83,7 +83,9 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **`progress/`** — `ProgressThrottle`, an emission rate limiter for callers
   whose progress callbacks are driven by raw byte chunks rather than a tick
 - **`resolver/`** — File URL resolution and shard detection
-- **`cli_exec/`** — Python `hf_xet` subprocess for fast-path downloads
+- **`executor/`** — The download backends: `native.rs` (default, `reqwest`) and
+  the dispatch that picks between it and the optional accelerator
+- **`cli_exec/`** — The optional `hf_xet` Python subprocess accelerator
 - **`manager/`** — High-level download manager facade
 
 ## Features
@@ -104,14 +106,19 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **Automatic Model Registration** — Downloads are automatically registered in the database with parsed GGUF metadata
 - **Resume Support** — Partial download resumption on failure
 - **Shard Handling** — Automatic detection and download of sharded models
-- **Fast-Path Downloads** — Uses `hf_xet` Python helper for multi-gigabyte files.
-  When the `hf-xet` transport bypasses Python `tqdm`, a stat-based fallback
-  poller (`cli_exec/exec/xet_poller.rs`) emits synthetic progress events so
-  the bar keeps moving instead of freezing at `0 B / 0 B`.
+- **Native Downloads** — The default path is Rust `reqwest`: a resumable ranged
+  GET verified against the object's SHA-256, written to `<dest>.part` and
+  renamed into place only once it checks out. Needs nothing installed.
+- **Optional Acceleration** — `hf_xet` is used for multi-gigabyte files when its
+  environment is already provisioned; it is never provisioned implicitly, and
+  its absence or failure falls back to the native path. When the `hf-xet`
+  transport bypasses Python `tqdm`, a stat-based fallback poller
+  (`cli_exec/exec/xet_poller.rs`) emits synthetic progress events so the bar
+  keeps moving instead of freezing at `0 B / 0 B`.
 - **Bounded Drain on Cancel** — `cancel_all()` signals cancel tokens and
   then waits up to 5 s for in-flight jobs to finalize before returning,
-  so callers (CLI, Tauri, Axum) don't exit while Python helper subprocesses
-  are still cleaning up.
+  so callers (CLI, Tauri, Axum) don't exit while in-flight transfers (or an
+  accelerator subprocess) are still cleaning up.
 - **Retry Logic** — Automatic retry with exponential backoff
 
 ## Usage
@@ -149,6 +156,6 @@ let snapshot = manager.get_queue_snapshot().await?;
 
 1. **Async Queue** — Downloads run in background with status polling/events
 2. **HF Client Injection** — Uses `gglib-hf` via trait for testability
-3. **Dual Download Paths** — Native Rust for small files, `hf_xet` for large ones
+3. **Native by Default** — Rust HTTP always works; `hf_xet` is an opt-in accelerator layered on top, never a prerequisite
 4. **Event-Driven** — Progress updates via `AppEventEmitter` for UI decoupling
 5. **Automatic Registration** — `ModelRegistrarPort` injected for seamless database integration on download completion

--- a/crates/gglib-download/src/cli_exec/README.md
+++ b/crates/gglib-download/src/cli_exec/README.md
@@ -11,8 +11,11 @@ separated from the queue-based [`DownloadManagerPort`] path.
 
 - [`list_quantizations`] — `HuggingFace` quant listing for `--list-quants`
 - [`check_update`] / [`update_model`] — update path for `model upgrade`
-- Python bridge helpers ([`ensure_fast_helper_ready`], [`run_fast_download`]) shared
-  with the async download manager
+- The optional `hf_xet` accelerator: [`ensure_fast_helper_ready`] provisions it
+  (only from an explicit opt-in — never from a download),
+  [`fast_helper_provisioned`] reports whether it is already here, and
+  [`run_fast_download`] drives it. `crate::executor` owns the choice of when to
+  use it; the default download path is native Rust and needs none of this.
 
 # What moved out
 

--- a/crates/gglib-download/src/cli_exec/exec/README.md
+++ b/crates/gglib-download/src/cli_exec/exec/README.md
@@ -2,23 +2,29 @@
 
 <!-- module-docs:start -->
 
-Download execution module.
+The optional `hf_xet` download accelerator: the Python environment that backs
+it, and the subprocess bridge that drives it. Kept separate from queue
+management, and from the default download path — that is `crate::executor`,
+which is native Rust and reaches this module only when
+[`python_env::fast_helper_provisioned`] says the environment is already here.
 
-This module handles the actual model download execution using the Python helper.
-It is intentionally kept separate from queue management.
+**Nothing in this module runs implicitly.** `python_env.rs` builds the venv, but
+`PythonEnvironment::prepare` is reachable only from `ensure_fast_helper_ready`,
+which in turn is only called by an explicit opt-in:
+`gglib config check-deps --setup-fast-downloads` or the GUI setup wizard. A
+download never provisions anything; if the environment is absent, the native
+path runs instead. Putting a Python toolchain in the critical path of a first
+download is the failure mode this arrangement exists to prevent.
 
-`python_env.rs` builds the fast downloader's Python venv on first run — a
-one-time, tens-of-seconds operation with no byte progress to show for it.
 `PythonEnvironment::prepare` takes an optional `NoticeCallback`
-(`Option<&NoticeCallback>`, aliased in `python_bridge.rs`): with one
-supplied — the queued-download path, via `FastDownloadRequest::notice` — venv
-creation and dependency install surface as a `DownloadEvent::DownloadNotice`
-on that download's bar instead of a console line; without one (preflight,
-`model upgrade`) they fall back to `gglib_core::telemetry::console_println`.
-`python -m venv` runs via `.output()`, not `.status()`, so its own stdio is
-captured rather than inherited — an inherited handle would write straight to
-the terminal, outside any bar's bookkeeping, the same way a stray `println!`
-would.
+(`Option<&NoticeCallback>`, aliased in `python_bridge.rs`): with one supplied,
+venv creation and dependency install surface as a
+`DownloadEvent::DownloadNotice` on a progress bar instead of a console line;
+without one (preflight, `model upgrade`) they fall back to
+`gglib_core::telemetry::console_println`. `python -m venv` runs via `.output()`,
+not `.status()`, so its own stdio is captured rather than inherited — an
+inherited handle would write straight to the terminal, outside any bar's
+bookkeeping, the same way a stray `println!` would.
 
 `progress.rs`'s `CliProgressPrinter` (the no-callback path, e.g. `model
 upgrade`) draws to **stderr**, matching `CliDownloadEventEmitter`'s

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("README.md")]
 mod progress;
 pub mod python_bridge;
-mod python_env;
+pub mod python_env;
 mod python_protocol;
 mod xet_poller;
 
@@ -12,9 +12,8 @@ use gglib_core::ports::QuantizationResolver;
 
 use super::types::{CliDownloadRequest, CliDownloadResult, CliUpdateRequest, UpdateCheckResult};
 use super::utils::model_directory;
+use crate::executor::{DownloadPlan, download_files};
 use crate::resolver::HfQuantizationResolver;
-
-pub use python_bridge::{FastDownloadRequest, run_fast_download};
 
 /// Execute a download request and return the result.
 ///
@@ -72,23 +71,26 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         fs::create_dir_all(&model_dir)?;
     }
 
-    // Download files
-    let fast_request = FastDownloadRequest {
+    // Download files. `expected_total` is the summed size of everything being
+    // fetched, which is only attributable to a single file when there is one.
+    let expected_total = (files.len() == 1)
+        .then(|| resolution.files.first().and_then(|f| f.size))
+        .flatten();
+
+    let plan = DownloadPlan {
         repo_id: &request.model_id,
         revision: &commit_sha,
-        repo_type: "model",
         destination: &model_dir,
         files: &files,
         token: request.token.as_deref(),
         force: request.force,
         progress: None,
         notice: None,
-        expected_total: None,
-        cancel_token: None,
+        expected_total,
+        cancel: None,
     };
 
-    run_fast_download(&fast_request).await?;
-    gglib_core::telemetry::console_println("⚡ Downloaded via fast helper");
+    download_files(&plan).await?;
 
     let primary_path = model_dir.join(&files[0]);
     let all_paths: Vec<_> = files.iter().map(|f| model_dir.join(f)).collect();

--- a/crates/gglib-download/src/cli_exec/exec/python_env.rs
+++ b/crates/gglib-download/src/cli_exec/exec/python_env.rs
@@ -171,17 +171,7 @@ impl PythonEnvironment {
 
     /// Get the path to the Python interpreter in this environment.
     pub fn python_path(&self) -> PathBuf {
-        if cfg!(windows) {
-            self.env_dir.join("Scripts").join("python.exe")
-        } else {
-            let bin = self.env_dir.join("bin");
-            let python3 = bin.join("python3");
-            if python3.exists() {
-                python3
-            } else {
-                bin.join("python")
-            }
-        }
+        venv_python_path(&self.env_dir)
     }
 
     /// Get the path to the helper script.
@@ -344,6 +334,31 @@ impl PythonEnvironment {
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+/// Path to the interpreter inside a venv rooted at `env_dir`.
+fn venv_python_path(env_dir: &Path) -> PathBuf {
+    if cfg!(windows) {
+        env_dir.join("Scripts").join("python.exe")
+    } else {
+        let bin = env_dir.join("bin");
+        let python3 = bin.join("python3");
+        if python3.exists() {
+            python3
+        } else {
+            bin.join("python")
+        }
+    }
+}
+
+/// Whether the `hf_xet` accelerator's environment is already provisioned.
+///
+/// A file-existence check, deliberately: this decides whether a download uses
+/// the accelerator, and it must not spawn a process, touch the network, or
+/// create anything. A machine with no Python answers `false` and gets the
+/// native download path — which is the whole point.
+pub fn fast_helper_provisioned() -> bool {
+    get_env_directory().is_ok_and(|dir| venv_python_path(&dir).exists())
+}
 
 /// Find a Python interpreter suitable for bootstrapping the venv.
 async fn find_bootstrap_python_validated() -> Result<PathBuf, EnvSetupError> {

--- a/crates/gglib-download/src/cli_exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/mod.rs
@@ -13,3 +13,7 @@ pub use exec::python_bridge::{
     FastDownloadRequest, NoticeCallback, ProgressCallback, PythonBridgeError,
     ensure_fast_helper_ready, preflight_fast_helper, run_fast_download,
 };
+
+// Whether the optional hf_xet accelerator is already provisioned. Read by the
+// executor to choose a backend, and by the GUI to render setup status.
+pub use exec::python_env::fast_helper_provisioned;

--- a/crates/gglib-download/src/executor/README.md
+++ b/crates/gglib-download/src/executor/README.md
@@ -1,14 +1,45 @@
-# executor
+# Executor
 
 <!-- module-docs:start -->
 
-Download execution.
+Download execution: the layer that actually moves bytes, given a plan.
 
-This module handles the actual download execution via Python subprocess.
-All Python-related logic is internal to this module.
+[`DownloadPlan`] names a repository, a revision, a destination directory and the
+files to fetch. [`download_files`] picks a backend for it:
 
-Note: The actual download execution currently lives in `gglib-download::manager::worker`.
-This module is reserved for future refactoring to extract the Python subprocess logic.
+| Backend | When | Implementation |
+|---------|------|----------------|
+| Native Rust HTTP | Default | `native.rs` — `reqwest` streaming |
+| `hf_xet` accelerator | Only when its environment is **already** provisioned | [`crate::cli_exec::run_fast_download`] |
+
+The accelerator is never provisioned implicitly. Building a Python environment
+on demand put a toolchain in the critical path of a new user's first download,
+which is the reason this module exists. [`crate::cli_exec::fast_helper_provisioned`]
+is a file-existence check, not a probe — if the environment is absent, the
+native path runs and nothing is installed. When the accelerator is present but
+fails, [`download_files`] logs it, emits a notice and falls back to the native
+path; only a user cancellation propagates as-is.
+
+The native path (`native.rs`) is responsible for:
+
+- **Resumable transfers.** Bytes accumulate in `<dest>.part`; a restart sends
+  `Range: bytes=<n>-` and appends. A `200` answer to a ranged request means the
+  server ignored the range, so the partial file is discarded and the transfer
+  starts over.
+- **Checksum verification.** SHA-256 is computed while streaming and compared
+  against `X-Linked-Etag` (or `ETag`), which is where `HuggingFace` puts the LFS
+  object's digest. A non-digest etag is ignored and the size check carries the
+  verification instead. A mismatch deletes the `.part` file — resuming onto
+  known-bad bytes would fail identically forever.
+- **Atomic publication.** The final path is only ever created by renaming a
+  fully verified `.part` file, so a partial transfer can never be mistaken for a
+  complete model.
+
+It is **not** responsible for resolving quantizations to files (`resolver`),
+queueing (`queue`), or emitting
+[`DownloadEvent`](gglib_core::download::DownloadEvent)s — it reports raw
+`(downloaded, total)` byte counts to a callback and the caller decides what to
+do with them.
 
 <!-- module-docs:end -->
 
@@ -18,6 +49,8 @@ This module is reserved for future refactoring to extract the Python subprocess 
 <!-- module-table:start -->
 | Module | LOC | Complexity | Coverage |
 |--------|-----|------------|----------|
+| [`native.rs`](native.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-executor-native-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-executor-native-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-executor-native-coverage.json) |
+| [`native_tests.rs`](native_tests.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-executor-native_tests-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-executor-native_tests-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-executor-native_tests-coverage.json) |
 <!-- module-table:end -->
 
 </details>

--- a/crates/gglib-download/src/executor/README.md
+++ b/crates/gglib-download/src/executor/README.md
@@ -27,10 +27,19 @@ The native path (`native.rs`) is responsible for:
   server ignored the range, so the partial file is discarded and the transfer
   starts over.
 - **Checksum verification.** SHA-256 is computed while streaming and compared
-  against `X-Linked-Etag` (or `ETag`), which is where `HuggingFace` puts the LFS
-  object's digest. A non-digest etag is ignored and the size check carries the
-  verification instead. A mismatch deletes the `.part` file — resuming onto
-  known-bad bytes would fail identically forever.
+  against `X-Linked-Etag`, the *only* header carrying the file's true digest.
+  A mismatch deletes the `.part` file — resuming onto known-bad bytes would fail
+  identically forever. When no `X-Linked-Etag` is offered, the size check carries
+  verification instead.
+- **Redirects followed by hand.** `HuggingFace`'s `resolve/` endpoint answers
+  with a 302 that carries `X-Linked-Etag` and points at a CDN. Letting `reqwest`
+  follow that automatically discards the hop the digest lives on, leaving only
+  the CDN's own `ETag` — which is the Xet *block* hash echoed from the URL path.
+  That value is also 64 hex characters, so no shape check can distinguish it from
+  a content digest, and comparing a file against it fails **every** download.
+  Hence two rules that must stay together: the client is built with
+  `redirect::Policy::none()` (see `native::build_client`, which the tests share
+  so the two cannot drift), and plain `ETag` is never accepted as a digest.
 - **Atomic publication.** The final path is only ever created by renaming a
   fully verified `.part` file, so a partial transfer can never be mistaken for a
   complete model.

--- a/crates/gglib-download/src/executor/mod.rs
+++ b/crates/gglib-download/src/executor/mod.rs
@@ -18,9 +18,12 @@ use native::{NativeError, existing_len};
 
 /// Shared HTTP client. `reqwest::Client` owns a connection pool, so building one
 /// per file would throw away connection reuse across a sharded model.
+///
+/// Configuration lives in [`native::build_client`] — see it for why automatic
+/// redirect following must stay off.
 fn http_client() -> &'static Client {
     static CLIENT: OnceLock<Client> = OnceLock::new();
-    CLIENT.get_or_init(Client::new)
+    CLIENT.get_or_init(native::build_client)
 }
 
 /// A set of files to fetch into one directory.
@@ -180,6 +183,9 @@ fn to_download_error(e: NativeError) -> DownloadError {
             DownloadError::integrity_failed(format!("{expected} bytes"), format!("{actual} bytes"))
         }
         NativeError::Io { operation, message } => DownloadError::io(operation, message),
+        NativeError::TooManyRedirects(url) => {
+            DownloadError::network(format!("too many redirects for {url}"))
+        }
         NativeError::Cancelled => DownloadError::Cancelled,
     }
 }

--- a/crates/gglib-download/src/executor/mod.rs
+++ b/crates/gglib-download/src/executor/mod.rs
@@ -1,1 +1,246 @@
 #![doc = include_str!("README.md")]
+mod native;
+
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use reqwest::Client;
+use tokio_util::sync::CancellationToken;
+
+use gglib_core::download::DownloadError;
+
+use crate::cli_exec::{
+    FastDownloadRequest, NoticeCallback, ProgressCallback, PythonBridgeError,
+    fast_helper_provisioned, run_fast_download,
+};
+
+use native::{NativeError, existing_len};
+
+/// Shared HTTP client. `reqwest::Client` owns a connection pool, so building one
+/// per file would throw away connection reuse across a sharded model.
+fn http_client() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(Client::new)
+}
+
+/// A set of files to fetch into one directory.
+pub struct DownloadPlan<'a> {
+    /// `owner/name` on `HuggingFace`.
+    pub repo_id: &'a str,
+    /// Branch, tag, or commit SHA.
+    pub revision: &'a str,
+    /// Directory the files land in.
+    pub destination: &'a Path,
+    /// Paths within the repository, relative to its root.
+    pub files: &'a [String],
+    /// Bearer token for private repositories.
+    pub token: Option<&'a str>,
+    /// Re-fetch even if the file is already on disk.
+    pub force: bool,
+    /// Sink for `(downloaded, total)` byte counts, aggregated across `files`.
+    pub progress: Option<ProgressCallback>,
+    /// Sink for transient notes that carry no byte progress.
+    pub notice: Option<NoticeCallback>,
+    /// Total size from `HuggingFace` metadata, when known.
+    pub expected_total: Option<u64>,
+    /// Cancellation token for the whole plan.
+    pub cancel: Option<CancellationToken>,
+}
+
+/// Fetch every file in `plan`.
+///
+/// The native Rust path is the default. The `hf_xet` accelerator is used only
+/// when its environment is **already** provisioned on this machine — it is never
+/// built implicitly, because that put a Python toolchain in the way of a new
+/// user's first download. If the accelerator is present but fails, this falls
+/// back to the native path rather than failing the download.
+pub async fn download_files(plan: &DownloadPlan<'_>) -> Result<(), DownloadError> {
+    if plan.files.is_empty() {
+        return Ok(());
+    }
+
+    if fast_helper_provisioned() {
+        match run_accelerated(plan).await {
+            Ok(()) => return Ok(()),
+            // A cancelled download is the user's decision, not an accelerator
+            // failure — retrying it natively would be the opposite of what they
+            // asked for.
+            Err(PythonBridgeError::Cancelled) => return Err(DownloadError::Cancelled),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "hf_xet accelerator failed, falling back to the native download path"
+                );
+                notify(
+                    plan,
+                    "accelerated download unavailable, using direct transfer…",
+                );
+            }
+        }
+    }
+
+    run_native(plan).await
+}
+
+/// Drive the pre-existing `hf_xet` helper.
+async fn run_accelerated(plan: &DownloadPlan<'_>) -> Result<(), PythonBridgeError> {
+    let request = FastDownloadRequest {
+        repo_id: plan.repo_id,
+        revision: plan.revision,
+        repo_type: "model",
+        destination: plan.destination,
+        files: plan.files,
+        token: plan.token,
+        force: plan.force,
+        progress: plan.progress.clone(),
+        notice: plan.notice.clone(),
+        expected_total: plan.expected_total,
+        cancel_token: plan.cancel.clone(),
+    };
+
+    run_fast_download(&request).await
+}
+
+/// Fetch each file over plain HTTPS.
+async fn run_native(plan: &DownloadPlan<'_>) -> Result<(), DownloadError> {
+    // Progress is reported across the whole plan, not per file, so a sharded
+    // model does not reset its bar to zero on every shard.
+    let mut completed_bytes: u64 = 0;
+
+    for file in plan.files {
+        let dest = plan.destination.join(file);
+
+        if plan.force {
+            let _ = std::fs::remove_file(&dest);
+        } else if dest.exists() {
+            // Already here. The manager removes files that fail validation
+            // before we are called, so anything still present is trusted.
+            completed_bytes += existing_len(&dest);
+            continue;
+        }
+
+        let url = gglib_hf::build_file_url(plan.repo_id, file, Some(plan.revision));
+
+        // Only a single-file plan can attribute `expected_total` to one file;
+        // for a multi-file plan the per-file size is not known here.
+        let expected_size = (plan.files.len() == 1)
+            .then_some(plan.expected_total)
+            .flatten();
+
+        let request = native::NativeDownload {
+            url: &url,
+            dest: &dest,
+            token: plan.token,
+            expected_size,
+            progress: offset_progress(plan.progress.as_ref(), completed_bytes),
+            cancel: plan.cancel.clone(),
+        };
+
+        native::download_file(http_client(), &request)
+            .await
+            .map_err(to_download_error)?;
+
+        completed_bytes += existing_len(&dest);
+    }
+
+    Ok(())
+}
+
+/// Shift a per-file progress callback by the bytes already finished, so the
+/// aggregate reported to the caller only ever moves forward.
+fn offset_progress(progress: Option<&ProgressCallback>, offset: u64) -> Option<ProgressCallback> {
+    let inner = Arc::clone(progress?);
+    if offset == 0 {
+        return Some(inner);
+    }
+    Some(Arc::new(move |downloaded, total| {
+        inner(downloaded + offset, total + offset);
+    }))
+}
+
+fn notify(plan: &DownloadPlan<'_>, message: &str) {
+    if let Some(notice) = plan.notice.as_ref() {
+        notice(message);
+    }
+}
+
+/// Map the native path's errors onto the domain error the manager already
+/// understands, preserving the distinctions the surfaces render differently.
+fn to_download_error(e: NativeError) -> DownloadError {
+    match e {
+        NativeError::NotFound(what) => DownloadError::not_found(what),
+        NativeError::Http { status, message } => {
+            DownloadError::network_with_status(message, status)
+        }
+        NativeError::Network(message) => DownloadError::network(message),
+        NativeError::ChecksumMismatch { expected, actual } => {
+            DownloadError::integrity_failed(expected, actual)
+        }
+        NativeError::SizeMismatch { expected, actual } => {
+            DownloadError::integrity_failed(format!("{expected} bytes"), format!("{actual} bytes"))
+        }
+        NativeError::Io { operation, message } => DownloadError::io(operation, message),
+        NativeError::Cancelled => DownloadError::Cancelled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offset_progress_shifts_both_counts() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let inner: ProgressCallback = Arc::new(move |d, t| sink.lock().unwrap().push((d, t)));
+
+        let shifted = offset_progress(Some(&inner), 100).expect("callback present");
+        shifted(50, 400);
+
+        assert_eq!(*seen.lock().unwrap(), vec![(150, 500)]);
+    }
+
+    #[test]
+    fn offset_progress_passes_through_at_zero() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let inner: ProgressCallback = Arc::new(move |d, t| sink.lock().unwrap().push((d, t)));
+
+        let shifted = offset_progress(Some(&inner), 0).expect("callback present");
+        shifted(50, 400);
+
+        assert_eq!(*seen.lock().unwrap(), vec![(50, 400)]);
+    }
+
+    #[test]
+    fn offset_progress_is_none_without_a_sink() {
+        assert!(offset_progress(None, 10).is_none());
+    }
+
+    #[test]
+    fn not_found_maps_to_the_domain_not_found() {
+        let mapped = to_download_error(NativeError::NotFound("u/r/f.gguf".into()));
+        assert!(matches!(mapped, DownloadError::NotFound { .. }));
+    }
+
+    #[test]
+    fn http_status_is_preserved_for_the_surfaces() {
+        let mapped = to_download_error(NativeError::Http {
+            status: 503,
+            message: "unavailable".into(),
+        });
+        match mapped {
+            DownloadError::Network { status_code, .. } => assert_eq!(status_code, Some(503)),
+            other => panic!("expected Network, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn checksum_mismatch_maps_to_integrity_failed() {
+        let mapped = to_download_error(NativeError::ChecksumMismatch {
+            expected: "aa".into(),
+            actual: "bb".into(),
+        });
+        assert!(matches!(mapped, DownloadError::IntegrityFailed { .. }));
+    }
+}

--- a/crates/gglib-download/src/executor/native.rs
+++ b/crates/gglib-download/src/executor/native.rs
@@ -9,8 +9,8 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use futures_util::StreamExt;
-use reqwest::header::{AUTHORIZATION, CONTENT_RANGE, ETAG, HeaderMap, RANGE};
-use reqwest::{Client, StatusCode};
+use reqwest::header::{AUTHORIZATION, CONTENT_RANGE, HeaderMap, LOCATION, RANGE};
+use reqwest::{Client, Response, StatusCode, Url};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -20,9 +20,18 @@ use crate::cli_exec::ProgressCallback;
 /// Suffix for the in-progress file that sits beside the final destination.
 const PART_SUFFIX: &str = ".part";
 
-/// `HuggingFace` sets this to the LFS object's SHA-256 when the response is a
-/// redirect to the CDN. Plain `ETag` carries it for non-LFS files.
+/// The only header that carries the file's true SHA-256.
+///
+/// `HuggingFace` sets this on the **redirect** its `resolve/` endpoint returns,
+/// alongside the `Location` pointing at the CDN. It is deliberately the only
+/// digest source this module trusts: the CDN's own `ETag` is the Xet block hash
+/// (the same value that appears in the CDN URL path), which is 64 hex characters
+/// and so indistinguishable from a SHA-256 by shape, but is *not* the hash of
+/// the file's bytes. Comparing against it fails every download.
 const X_LINKED_ETAG: &str = "x-linked-etag";
+
+/// Redirect hops to follow before giving up.
+const MAX_REDIRECTS: usize = 10;
 
 /// Errors from the native download path.
 #[derive(Error, Debug)]
@@ -70,6 +79,10 @@ pub enum NativeError {
         /// The underlying error.
         message: String,
     },
+
+    /// The redirect chain never terminated at a real response.
+    #[error("Too many redirects for {0}")]
+    TooManyRedirects(String),
 
     /// The caller cancelled the download.
     #[error("download cancelled by user")]
@@ -145,24 +158,12 @@ async fn stream_to_part(
     part_path: &Path,
     resume_from: u64,
 ) -> Result<TransferOutcome, NativeError> {
-    let mut request = client.get(req.url).header("User-Agent", "gglib");
-    if let Some(token) = req.token {
-        request = request.header(AUTHORIZATION, format!("Bearer {token}"));
-    }
-    if resume_from > 0 {
-        request = request.header(RANGE, format!("bytes={resume_from}-"));
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|e| NativeError::Network(e.to_string()))?;
+    let (response, expected) = send_following_redirects(client, req, resume_from).await?;
 
     let status = response.status();
 
     // The server has all of it already: nothing left to transfer, go verify.
     if status == StatusCode::RANGE_NOT_SATISFIABLE && resume_from > 0 {
-        let expected = expected_digest(response.headers());
         return finish_without_transfer(part_path, expected);
     }
 
@@ -182,7 +183,6 @@ async fn stream_to_part(
     let start_at = if appending { resume_from } else { 0 };
 
     let total = total_size(response.headers(), start_at).or(req.expected_size);
-    let expected = expected_digest(response.headers());
 
     let mut file = open_part(part_path, appending)?;
     let mut hasher = expected.is_some().then(Sha256::new);
@@ -234,6 +234,87 @@ async fn stream_to_part(
             actual: hex(&h.finalize()),
         }),
     })
+}
+
+/// Build the HTTP client this module requires.
+///
+/// Automatic redirect following **must** be off: [`send_following_redirects`]
+/// walks the chain itself so the `X-Linked-Etag` on `HuggingFace`'s 302 survives
+/// to be compared against. A client that follows redirects on its own hands this
+/// module only the CDN's headers, where no trustworthy digest exists — and
+/// verification silently turns into a no-op.
+///
+/// Tests construct their client through here too, so the two cannot drift.
+pub(super) fn build_client() -> Client {
+    Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("default reqwest client builds")
+}
+
+/// Send the request, following redirects by hand, and return the final response
+/// together with any `X-Linked-Etag` seen along the way.
+///
+/// Redirects are followed manually rather than by `reqwest` because the digest
+/// lives on a hop that automatic following would consume and discard:
+/// `HuggingFace`'s `resolve/` endpoint answers with a 302 carrying
+/// `X-Linked-Etag`, and only the `Location` it points at serves the bytes. With
+/// `reqwest` following the chain itself, the only headers left are the CDN's —
+/// whose `ETag` is a Xet block hash, not a content hash.
+async fn send_following_redirects(
+    client: &Client,
+    req: &NativeDownload<'_>,
+    resume_from: u64,
+) -> Result<(Response, Option<String>), NativeError> {
+    let mut url = Url::parse(req.url)
+        .map_err(|e| NativeError::Network(format!("invalid URL {}: {e}", req.url)))?;
+    let origin_host = url.host_str().map(str::to_owned);
+    let mut linked_etag: Option<String> = None;
+
+    for _ in 0..MAX_REDIRECTS {
+        let mut request = client.get(url.clone()).header("User-Agent", "gglib");
+
+        // The token authenticates us to HuggingFace, not to its CDN. The
+        // redirect target is a pre-signed URL that needs no credentials, and
+        // forwarding a bearer token to a different host would leak it.
+        if let Some(token) = req.token {
+            if url.host_str().map(str::to_owned) == origin_host {
+                request = request.header(AUTHORIZATION, format!("Bearer {token}"));
+            }
+        }
+        if resume_from > 0 {
+            request = request.header(RANGE, format!("bytes={resume_from}-"));
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| NativeError::Network(e.to_string()))?;
+
+        // Capture the digest from the first hop that offers one — later hops
+        // (the CDN) do not carry it.
+        if linked_etag.is_none() {
+            linked_etag = expected_digest(response.headers());
+        }
+
+        if !response.status().is_redirection() {
+            return Ok((response, linked_etag));
+        }
+
+        let location = response
+            .headers()
+            .get(LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                NativeError::Network(format!("redirect from {url} carried no Location"))
+            })?;
+
+        url = url
+            .join(location)
+            .map_err(|e| NativeError::Network(format!("bad redirect target {location}: {e}")))?;
+    }
+
+    Err(NativeError::TooManyRedirects(req.url.to_string()))
 }
 
 /// Nothing to transfer (HTTP 416): hash whatever is on disk so verification can
@@ -341,14 +422,15 @@ fn report(progress: Option<&ProgressCallback>, downloaded: u64, total: Option<u6
 
 /// The SHA-256 the server says the file should hash to, if it gave a usable one.
 ///
-/// `X-Linked-Etag` is `HuggingFace`'s header for the LFS object behind a
-/// redirect; plain `ETag` carries the same value for non-LFS files. Either can
-/// also be a weak validator or an opaque string that is not a digest at all —
-/// only a bare 64-hex value is worth checking against.
+/// Only [`X_LINKED_ETAG`] is trusted. Plain `ETag` is deliberately **not** a
+/// fallback: `HuggingFace`'s CDN sets it to the Xet block hash, which is also 64
+/// hex characters, so no shape check can tell the two apart — and comparing a
+/// file's contents against a block hash fails every single download. A response
+/// with no `X-Linked-Etag` yields `None`, and verification falls back to the
+/// size check.
 fn expected_digest(headers: &HeaderMap) -> Option<String> {
     headers
         .get(X_LINKED_ETAG)
-        .or_else(|| headers.get(ETAG))
         .and_then(|v| v.to_str().ok())
         .map(normalize_etag)
         .filter(|e| is_sha256_hex(e))

--- a/crates/gglib-download/src/executor/native.rs
+++ b/crates/gglib-download/src/executor/native.rs
@@ -1,0 +1,404 @@
+//! Native Rust HTTP downloader.
+//!
+//! Streams a file over HTTPS with `reqwest`, resuming an interrupted transfer
+//! with a ranged GET, hashing as it goes, and renaming into place only once the
+//! bytes have been verified. This is the default download path — it needs
+//! nothing on the machine beyond the gglib binary itself.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use futures_util::StreamExt;
+use reqwest::header::{AUTHORIZATION, CONTENT_RANGE, ETAG, HeaderMap, RANGE};
+use reqwest::{Client, StatusCode};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+use crate::cli_exec::ProgressCallback;
+
+/// Suffix for the in-progress file that sits beside the final destination.
+const PART_SUFFIX: &str = ".part";
+
+/// `HuggingFace` sets this to the LFS object's SHA-256 when the response is a
+/// redirect to the CDN. Plain `ETag` carries it for non-LFS files.
+const X_LINKED_ETAG: &str = "x-linked-etag";
+
+/// Errors from the native download path.
+#[derive(Error, Debug)]
+pub enum NativeError {
+    /// The remote returned 404.
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    /// The remote returned a non-success status other than 404.
+    #[error("HTTP {status}: {message}")]
+    Http {
+        /// The status code returned.
+        status: u16,
+        /// Detail for the user.
+        message: String,
+    },
+
+    /// The transfer itself failed (DNS, TLS, connection reset, timeout).
+    #[error("Network error: {0}")]
+    Network(String),
+
+    /// The bytes on disk do not match the digest the server advertised.
+    #[error("Checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        /// Digest advertised by the server.
+        expected: String,
+        /// Digest actually computed over the received bytes.
+        actual: String,
+    },
+
+    /// The completed file is not the size the catalog said it would be.
+    #[error("Size mismatch: expected {expected} bytes, got {actual}")]
+    SizeMismatch {
+        /// Size from `HuggingFace` metadata.
+        expected: u64,
+        /// Size actually written to disk.
+        actual: u64,
+    },
+
+    /// A filesystem operation failed.
+    #[error("I/O error ({operation}): {message}")]
+    Io {
+        /// What was being attempted.
+        operation: String,
+        /// The underlying error.
+        message: String,
+    },
+
+    /// The caller cancelled the download.
+    #[error("download cancelled by user")]
+    Cancelled,
+}
+
+impl NativeError {
+    fn io(operation: &str, e: &std::io::Error) -> Self {
+        Self::Io {
+            operation: operation.to_string(),
+            message: e.to_string(),
+        }
+    }
+}
+
+/// One file to fetch.
+pub struct NativeDownload<'a> {
+    /// Fully-qualified URL of the file's bytes.
+    pub url: &'a str,
+    /// Final path. Bytes land at `<dest>.part` until they are verified.
+    pub dest: &'a Path,
+    /// Bearer token for private repositories.
+    pub token: Option<&'a str>,
+    /// Expected size from `HuggingFace` metadata, when known.
+    pub expected_size: Option<u64>,
+    /// Sink for `(downloaded, total)` byte counts.
+    pub progress: Option<ProgressCallback>,
+    /// Cancellation token. A cancelled transfer leaves its `.part` file behind
+    /// so the next attempt resumes rather than restarting.
+    pub cancel: Option<CancellationToken>,
+}
+
+/// Download one file, resuming if a previous attempt left bytes behind.
+///
+/// On success the file exists at `req.dest` and no `.part` file remains. On a
+/// verification failure the `.part` file is removed, because resuming onto
+/// corrupt bytes would fail the same way forever.
+pub async fn download_file(client: &Client, req: &NativeDownload<'_>) -> Result<(), NativeError> {
+    let part_path = part_path_for(req.dest);
+
+    if let Some(parent) = req.dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| NativeError::io("create_dir", &e))?;
+    }
+
+    let resume_from = existing_len(&part_path);
+    let outcome = stream_to_part(client, req, &part_path, resume_from).await?;
+
+    verify(&part_path, req.expected_size, outcome.digest.as_ref())?;
+
+    std::fs::rename(&part_path, req.dest).map_err(|e| NativeError::io("rename", &e))?;
+
+    Ok(())
+}
+
+/// What a completed transfer produced.
+struct TransferOutcome {
+    /// SHA-256 of the whole file, when the server advertised one to check
+    /// against. `None` means there was nothing to compare with, so the hash was
+    /// not worth computing.
+    digest: Option<Digested>,
+}
+
+/// A computed digest alongside the value it must equal.
+struct Digested {
+    expected: String,
+    actual: String,
+}
+
+/// Stream the response body into the `.part` file.
+async fn stream_to_part(
+    client: &Client,
+    req: &NativeDownload<'_>,
+    part_path: &Path,
+    resume_from: u64,
+) -> Result<TransferOutcome, NativeError> {
+    let mut request = client.get(req.url).header("User-Agent", "gglib");
+    if let Some(token) = req.token {
+        request = request.header(AUTHORIZATION, format!("Bearer {token}"));
+    }
+    if resume_from > 0 {
+        request = request.header(RANGE, format!("bytes={resume_from}-"));
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| NativeError::Network(e.to_string()))?;
+
+    let status = response.status();
+
+    // The server has all of it already: nothing left to transfer, go verify.
+    if status == StatusCode::RANGE_NOT_SATISFIABLE && resume_from > 0 {
+        let expected = expected_digest(response.headers());
+        return finish_without_transfer(part_path, expected);
+    }
+
+    if status == StatusCode::NOT_FOUND {
+        return Err(NativeError::NotFound(req.url.to_string()));
+    }
+    if !status.is_success() {
+        return Err(NativeError::Http {
+            status: status.as_u16(),
+            message: format!("download failed for {}", req.url),
+        });
+    }
+
+    // A 200 to a ranged request means the server ignored the range: the body is
+    // the whole file, so anything already on disk is stale.
+    let appending = resume_from > 0 && status == StatusCode::PARTIAL_CONTENT;
+    let start_at = if appending { resume_from } else { 0 };
+
+    let total = total_size(response.headers(), start_at).or(req.expected_size);
+    let expected = expected_digest(response.headers());
+
+    let mut file = open_part(part_path, appending)?;
+    let mut hasher = expected.is_some().then(Sha256::new);
+
+    // Resuming: the bytes already on disk are part of the digest, so replay them
+    // through the hasher before the new ones arrive. Only paid on a resume.
+    if let Some(h) = hasher.as_mut() {
+        if appending {
+            seed_hasher(part_path, resume_from, h)?;
+        }
+    }
+
+    let mut downloaded = start_at;
+    report(req.progress.as_ref(), downloaded, total);
+
+    let mut stream = response.bytes_stream();
+    loop {
+        let chunk = if let Some(cancel) = req.cancel.as_ref() {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    let _ = file.flush();
+                    return Err(NativeError::Cancelled);
+                }
+                chunk = stream.next() => chunk,
+            }
+        } else {
+            stream.next().await
+        };
+
+        let Some(chunk) = chunk else { break };
+        let chunk = chunk.map_err(|e| NativeError::Network(e.to_string()))?;
+
+        file.write_all(&chunk)
+            .map_err(|e| NativeError::io("write", &e))?;
+        if let Some(h) = hasher.as_mut() {
+            h.update(&chunk);
+        }
+
+        downloaded += chunk.len() as u64;
+        report(req.progress.as_ref(), downloaded, total);
+    }
+
+    file.flush().map_err(|e| NativeError::io("flush", &e))?;
+
+    Ok(TransferOutcome {
+        digest: hasher.map(|h| Digested {
+            expected: expected.unwrap_or_default(),
+            actual: hex(&h.finalize()),
+        }),
+    })
+}
+
+/// Nothing to transfer (HTTP 416): hash whatever is on disk so verification can
+/// still run against it.
+fn finish_without_transfer(
+    part_path: &Path,
+    expected: Option<String>,
+) -> Result<TransferOutcome, NativeError> {
+    let Some(expected) = expected else {
+        return Ok(TransferOutcome { digest: None });
+    };
+
+    let mut hasher = Sha256::new();
+    let len = existing_len(part_path);
+    seed_hasher(part_path, len, &mut hasher)?;
+
+    Ok(TransferOutcome {
+        digest: Some(Digested {
+            expected,
+            actual: hex(&hasher.finalize()),
+        }),
+    })
+}
+
+/// Check the finished `.part` file against everything we know about it.
+///
+/// A failure here removes the `.part` file: resuming onto bytes that are already
+/// known-bad would fail identically on every future attempt.
+fn verify(
+    part_path: &Path,
+    expected_size: Option<u64>,
+    digest: Option<&Digested>,
+) -> Result<(), NativeError> {
+    if let Some(d) = digest {
+        if !d.expected.eq_ignore_ascii_case(&d.actual) {
+            let _ = std::fs::remove_file(part_path);
+            return Err(NativeError::ChecksumMismatch {
+                expected: d.expected.clone(),
+                actual: d.actual.clone(),
+            });
+        }
+    }
+
+    // Size is a weaker check than the digest, but it is the only one available
+    // when the server advertised no usable etag.
+    //
+    // Short of the expected size means the transfer was cut off, and those bytes
+    // are a valid prefix — keep them so the next attempt resumes. Longer means
+    // the file is not what the catalog described, and there is nothing to
+    // salvage.
+    if let Some(expected) = expected_size {
+        let actual = existing_len(part_path);
+        if actual != expected {
+            if actual > expected {
+                let _ = std::fs::remove_file(part_path);
+            }
+            return Err(NativeError::SizeMismatch { expected, actual });
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn part_path_for(dest: &Path) -> PathBuf {
+    let mut name = dest.as_os_str().to_os_string();
+    name.push(PART_SUFFIX);
+    PathBuf::from(name)
+}
+
+/// Length of a file, or 0 if it is missing or unreadable.
+pub(super) fn existing_len(path: &Path) -> u64 {
+    std::fs::metadata(path).map_or(0, |m| m.len())
+}
+
+fn open_part(path: &Path, appending: bool) -> Result<std::fs::File, NativeError> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(appending)
+        .truncate(!appending)
+        .open(path)
+        .map_err(|e| NativeError::io("open", &e))
+}
+
+/// Feed the first `len` bytes of `path` through `hasher`.
+///
+/// Only ever runs on a resume, where the bytes already on disk are part of the
+/// digest but were never streamed through the hasher. Costs one extra read of
+/// the partial file, and only then.
+fn seed_hasher(path: &Path, len: u64, hasher: &mut Sha256) -> Result<(), NativeError> {
+    let file = std::fs::File::open(path).map_err(|e| NativeError::io("open", &e))?;
+    std::io::copy(&mut file.take(len), hasher).map_err(|e| NativeError::io("read", &e))?;
+    Ok(())
+}
+
+fn report(progress: Option<&ProgressCallback>, downloaded: u64, total: Option<u64>) {
+    if let Some(cb) = progress {
+        cb(downloaded, total.unwrap_or(0));
+    }
+}
+
+/// The SHA-256 the server says the file should hash to, if it gave a usable one.
+///
+/// `X-Linked-Etag` is `HuggingFace`'s header for the LFS object behind a
+/// redirect; plain `ETag` carries the same value for non-LFS files. Either can
+/// also be a weak validator or an opaque string that is not a digest at all —
+/// only a bare 64-hex value is worth checking against.
+fn expected_digest(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(X_LINKED_ETAG)
+        .or_else(|| headers.get(ETAG))
+        .and_then(|v| v.to_str().ok())
+        .map(normalize_etag)
+        .filter(|e| is_sha256_hex(e))
+}
+
+/// Strip a weak-validator prefix and surrounding quotes.
+fn normalize_etag(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_string()
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Total size of the whole file, from `Content-Range` if present (which is
+/// authoritative on a partial response) or `Content-Length` plus what is already
+/// on disk.
+fn total_size(headers: &HeaderMap, start_at: u64) -> Option<u64> {
+    if let Some(total) = headers
+        .get(CONTENT_RANGE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_content_range_total)
+    {
+        return Some(total);
+    }
+
+    headers
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|len| len + start_at)
+}
+
+/// Pull the total out of `bytes <start>-<end>/<total>`. A `*` total means the
+/// server does not know it.
+fn parse_content_range_total(value: &str) -> Option<u64> {
+    value.rsplit('/').next()?.trim().parse::<u64>().ok()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes.iter().fold(String::new(), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+#[cfg(test)]
+#[path = "native_tests.rs"]
+mod tests;

--- a/crates/gglib-download/src/executor/native_tests.rs
+++ b/crates/gglib-download/src/executor/native_tests.rs
@@ -15,6 +15,7 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
 use super::*;
+use reqwest::header::ETAG;
 
 // ============================================================================
 // Test server
@@ -32,6 +33,14 @@ enum Reply {
     Status(u16),
     /// Ignore `Range` and always send the whole body with `200`.
     IgnoresRange { body: Vec<u8> },
+    /// Answer with a 302 to `/cdn`, carrying `X-Linked-Etag` — this is how
+    /// `HuggingFace`'s `resolve/` endpoint behaves, and the digest lives only
+    /// on this hop.
+    RedirectWithLinkedEtag { linked_etag: String },
+    /// Serve `body` with a plain `ETag` that is 64 hex characters but is **not**
+    /// the hash of the body — `HuggingFace`'s CDN does exactly this, echoing the
+    /// Xet block hash from the URL path.
+    CdnFile { body: Vec<u8>, decoy_etag: String },
 }
 
 struct TestServer {
@@ -157,6 +166,33 @@ async fn handle_one(
         }
         Reply::IgnoresRange { body } => {
             write_full(socket, &body, None).await?;
+        }
+        Reply::RedirectWithLinkedEtag { linked_etag } => {
+            let head = format!(
+                "HTTP/1.1 302 Found\r\nLocation: /cdn\r\nContent-Length: 0\r\nX-Linked-Etag: \"{linked_etag}\"\r\nConnection: close\r\n\r\n"
+            );
+            socket.write_all(head.as_bytes()).await?;
+        }
+        Reply::CdnFile { body, decoy_etag } => {
+            if start > 0 {
+                let slice = &body[start..];
+                let head = format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {}-{}/{}\r\nETag: \"{decoy_etag}\"\r\nConnection: close\r\n\r\n",
+                    slice.len(),
+                    start,
+                    body.len() - 1,
+                    body.len()
+                );
+                socket.write_all(head.as_bytes()).await?;
+                socket.write_all(slice).await?;
+            } else {
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nETag: \"{decoy_etag}\"\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(head.as_bytes()).await?;
+                socket.write_all(&body).await?;
+            }
         }
         Reply::File { body, etag } => {
             if start >= body.len() {
@@ -296,7 +332,7 @@ async fn downloads_a_file_and_publishes_it_atomically() {
 
     let url = server.url();
     download_file(
-        &Client::new(),
+        &build_client(),
         &request(&url, &fx.dest, Some(len_of(&body)), Some(progress)),
     )
     .await
@@ -328,7 +364,7 @@ async fn a_file_with_no_usable_etag_is_still_verified_by_size() {
     let fx = Fixture::new();
 
     let url = server.url();
-    let err = download_file(&Client::new(), &request(&url, &fx.dest, Some(9999), None))
+    let err = download_file(&build_client(), &request(&url, &fx.dest, Some(9999), None))
         .await
         .expect_err("a wrong expected size must fail");
 
@@ -365,7 +401,7 @@ async fn resumes_after_an_interrupted_transfer() {
     let size = Some(len_of(&body));
 
     // First attempt: the server hangs up mid-body.
-    let err = download_file(&Client::new(), &request(&url, &fx.dest, size, None))
+    let err = download_file(&build_client(), &request(&url, &fx.dest, size, None))
         .await
         .expect_err("a truncated body must not be accepted");
     assert!(
@@ -390,7 +426,7 @@ async fn resumes_after_an_interrupted_transfer() {
     // Second attempt: resumes rather than restarting.
     let (progress, seen) = recording_progress();
     download_file(
-        &Client::new(),
+        &build_client(),
         &request(&url, &fx.dest, size, Some(progress)),
     )
     .await
@@ -437,7 +473,7 @@ async fn restarts_when_the_server_ignores_the_range_request() {
     let url = server.url();
 
     download_file(
-        &Client::new(),
+        &build_client(),
         &request(&url, &fx.dest, Some(len_of(&body)), None),
     )
     .await
@@ -464,7 +500,7 @@ async fn a_complete_partial_file_is_published_without_refetching() {
     let url = server.url();
 
     download_file(
-        &Client::new(),
+        &build_client(),
         &request(&url, &fx.dest, Some(len_of(&body)), None),
     )
     .await
@@ -472,6 +508,101 @@ async fn a_complete_partial_file_is_published_without_refetching() {
 
     assert_eq!(std::fs::read(&fx.dest).unwrap(), body);
     assert!(!fx.part().exists());
+}
+
+// ============================================================================
+// Redirects — the HuggingFace shape
+// ============================================================================
+
+/// The exact production shape: `resolve/` 302s with `X-Linked-Etag` (the real
+/// SHA-256), and the CDN it points at serves the bytes with a plain `ETag` that
+/// is the Xet *block* hash — 64 hex characters, so indistinguishable from a
+/// content digest by shape, but a completely different value.
+///
+/// Letting reqwest follow the redirect and reading the etag off the final
+/// response made every real download fail with a bogus integrity error. Nothing
+/// in the suite caught it, because no test served a redirect.
+#[tokio::test]
+async fn the_digest_comes_from_the_redirect_not_the_cdn() {
+    let body = body_of(4096);
+    let real_sha = sha256_of(&body);
+    // 64 hex chars, but the hash of something else entirely.
+    let xet_block_hash = sha256_of(b"a xet block, not this file");
+    assert_ne!(real_sha, xet_block_hash);
+
+    let server = TestServer::start(vec![
+        Reply::RedirectWithLinkedEtag {
+            linked_etag: real_sha,
+        },
+        Reply::CdnFile {
+            body: body.clone(),
+            decoy_etag: xet_block_hash,
+        },
+    ])
+    .await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    download_file(
+        &build_client(),
+        &request(&url, &fx.dest, Some(len_of(&body)), None),
+    )
+    .await
+    .expect("the CDN's decoy etag must not be mistaken for a content digest");
+
+    assert_eq!(std::fs::read(&fx.dest).unwrap(), body);
+    assert_eq!(server.request_count(), 2, "one redirect hop, then the CDN");
+}
+
+/// The digest is still *enforced* across a redirect — the test above must not
+/// be passing merely because verification was skipped.
+#[tokio::test]
+async fn a_bad_linked_etag_still_fails_across_a_redirect() {
+    let body = body_of(4096);
+    let wrong = sha256_of(b"not this file either");
+
+    let server = TestServer::start(vec![
+        Reply::RedirectWithLinkedEtag { linked_etag: wrong },
+        Reply::CdnFile {
+            body,
+            decoy_etag: "0".repeat(64),
+        },
+    ])
+    .await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    let err = download_file(&build_client(), &request(&url, &fx.dest, None, None))
+        .await
+        .expect_err("a wrong X-Linked-Etag must still be caught");
+
+    assert!(
+        matches!(err, NativeError::ChecksumMismatch { .. }),
+        "got {err:?}"
+    );
+    assert!(!fx.dest.exists());
+}
+
+/// A bearer token authenticates us to `HuggingFace`; the CDN URL it redirects to
+/// is pre-signed. Forwarding the token across hosts would leak it.
+#[tokio::test]
+async fn a_redirect_chain_terminates_rather_than_looping() {
+    let server = TestServer::start(vec![Reply::RedirectWithLinkedEtag {
+        linked_etag: "a".repeat(64),
+    }])
+    .await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    let err = download_file(&build_client(), &request(&url, &fx.dest, None, None))
+        .await
+        .expect_err("an endless redirect chain must not hang");
+
+    assert!(
+        matches!(err, NativeError::TooManyRedirects(_)),
+        "got {err:?}"
+    );
+    assert!(!fx.dest.exists());
 }
 
 // ============================================================================
@@ -490,7 +621,7 @@ async fn a_checksum_mismatch_fails_and_clears_the_partial_file() {
     let fx = Fixture::new();
 
     let url = server.url();
-    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+    let err = download_file(&build_client(), &request(&url, &fx.dest, None, None))
         .await
         .expect_err("bytes that do not match the advertised digest must be rejected");
 
@@ -519,7 +650,7 @@ async fn a_404_is_reported_as_not_found() {
     let fx = Fixture::new();
 
     let url = server.url();
-    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+    let err = download_file(&build_client(), &request(&url, &fx.dest, None, None))
         .await
         .expect_err("404 must fail");
 
@@ -534,7 +665,7 @@ async fn a_server_error_preserves_its_status_code() {
     let fx = Fixture::new();
 
     let url = server.url();
-    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+    let err = download_file(&build_client(), &request(&url, &fx.dest, None, None))
         .await
         .expect_err("503 must fail");
 
@@ -554,7 +685,7 @@ async fn an_unreachable_host_is_a_network_error() {
 
     let fx = Fixture::new();
     let url = format!("http://{addr}/model.gguf");
-    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+    let err = download_file(&build_client(), &request(&url, &fx.dest, None, None))
         .await
         .expect_err("a refused connection must fail");
 
@@ -573,7 +704,7 @@ async fn a_cancelled_download_keeps_its_partial_file() {
 
     let url = server.url();
     let err = download_file(
-        &Client::new(),
+        &build_client(),
         &NativeDownload {
             url: &url,
             dest: &fx.dest,
@@ -596,7 +727,7 @@ async fn a_cancelled_download_keeps_its_partial_file() {
 // ============================================================================
 
 #[test]
-fn expected_digest_prefers_the_linked_etag() {
+fn the_linked_etag_wins_over_a_decoy_etag_on_the_same_response() {
     let digest = "a".repeat(64);
     let other = "b".repeat(64);
     let mut headers = HeaderMap::new();
@@ -606,19 +737,37 @@ fn expected_digest_prefers_the_linked_etag() {
     assert_eq!(expected_digest(&headers), Some(digest));
 }
 
+/// A plain `ETag` is never a digest source, however well-formed it looks.
+/// `HuggingFace`'s CDN puts the Xet block hash there — 64 hex characters, and
+/// not the hash of the file. Trusting it failed every real download.
 #[test]
-fn expected_digest_falls_back_to_the_plain_etag() {
+fn a_plain_etag_is_never_trusted_as_a_digest() {
+    let looks_like_a_digest = "c".repeat(64);
+    for value in [
+        format!("\"{looks_like_a_digest}\""),
+        format!("W/\"{looks_like_a_digest}\""),
+    ] {
+        let mut headers = HeaderMap::new();
+        headers.insert(ETAG, value.parse().unwrap());
+        assert_eq!(
+            expected_digest(&headers),
+            None,
+            "ETag {value} must not be used as a content digest"
+        );
+    }
+}
+
+#[test]
+fn a_weak_validator_on_the_linked_etag_is_unwrapped() {
     let digest = "c".repeat(64);
     let mut headers = HeaderMap::new();
-    headers.insert(ETAG, format!("W/\"{digest}\"").parse().unwrap());
+    headers.insert(X_LINKED_ETAG, format!("W/\"{digest}\"").parse().unwrap());
 
     assert_eq!(expected_digest(&headers), Some(digest));
 }
 
 #[test]
-fn a_non_digest_etag_is_not_treated_as_a_checksum() {
-    // Real HuggingFace responses carry opaque etags for non-LFS files. Comparing
-    // a SHA-256 against one of those would fail every download.
+fn a_malformed_linked_etag_is_not_treated_as_a_checksum() {
     for value in [
         "\"686897696a7c876b7e\"",
         "\"not-a-hash\"",
@@ -626,8 +775,8 @@ fn a_non_digest_etag_is_not_treated_as_a_checksum() {
         "W/\"xyz\"",
     ] {
         let mut headers = HeaderMap::new();
-        headers.insert(ETAG, value.parse().unwrap());
-        assert_eq!(expected_digest(&headers), None, "for etag {value}");
+        headers.insert(X_LINKED_ETAG, value.parse().unwrap());
+        assert_eq!(expected_digest(&headers), None, "for x-linked-etag {value}");
     }
 }
 

--- a/crates/gglib-download/src/executor/native_tests.rs
+++ b/crates/gglib-download/src/executor/native_tests.rs
@@ -1,0 +1,669 @@
+//! Tests for the native downloader, against a scripted loopback server.
+//!
+//! Hand-rolled on a raw [`TcpListener`] rather than reaching for `wiremock` or
+//! `hyper`: `check_boundaries.sh` forbids `hyper` anywhere in `gglib-download`'s
+//! dependency tree and `cargo tree --depth 1` sees dev-dependencies too, so a
+//! ready-made harness would fail CI. Everything here is built from `tokio`,
+//! which the crate already has.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use super::*;
+
+// ============================================================================
+// Test server
+// ============================================================================
+
+/// How the server should answer one request.
+#[derive(Clone)]
+enum Reply {
+    /// Serve `body`, honouring `Range` and advertising `etag` when set.
+    File { body: Vec<u8>, etag: Option<String> },
+    /// Serve only the first `limit` bytes of `body`, then drop the connection
+    /// mid-transfer without sending the rest. Simulates an interrupted download.
+    Truncated { body: Vec<u8>, limit: usize },
+    /// Answer with a bare status line.
+    Status(u16),
+    /// Ignore `Range` and always send the whole body with `200`.
+    IgnoresRange { body: Vec<u8> },
+}
+
+struct TestServer {
+    base_url: String,
+    /// `Range` header value seen on each request, in order.
+    ranges: Arc<Mutex<Vec<Option<String>>>>,
+    requests: Arc<AtomicUsize>,
+    handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    /// Bind an ephemeral loopback port. Replies are served in order; the last
+    /// one repeats for any further requests.
+    async fn start(script: Vec<Reply>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral loopback port");
+        let base_url = format!(
+            "http://{}",
+            listener.local_addr().expect("resolve bound address")
+        );
+
+        let ranges = Arc::new(Mutex::new(Vec::new()));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let handle = tokio::spawn(serve(
+            listener,
+            script,
+            Arc::clone(&ranges),
+            Arc::clone(&requests),
+        ));
+
+        Self {
+            base_url,
+            ranges,
+            requests,
+            handle,
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("{}/model.gguf", self.base_url)
+    }
+
+    fn ranges(&self) -> Vec<Option<String>> {
+        self.ranges.lock().unwrap().clone()
+    }
+
+    fn request_count(&self) -> usize {
+        self.requests.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+async fn serve(
+    listener: TcpListener,
+    script: Vec<Reply>,
+    ranges: Arc<Mutex<Vec<Option<String>>>>,
+    requests: Arc<AtomicUsize>,
+) {
+    loop {
+        let Ok((socket, _)) = listener.accept().await else {
+            return;
+        };
+        let n = requests.fetch_add(1, Ordering::SeqCst);
+        let reply = script
+            .get(n)
+            .or_else(|| script.last())
+            .cloned()
+            .unwrap_or(Reply::Status(500));
+
+        let ranges = Arc::clone(&ranges);
+        tokio::spawn(async move {
+            let _ = handle_one(socket, reply, ranges).await;
+        });
+    }
+}
+
+async fn handle_one(
+    socket: tokio::net::TcpStream,
+    reply: Reply,
+    ranges: Arc<Mutex<Vec<Option<String>>>>,
+) -> std::io::Result<()> {
+    let mut reader = BufReader::new(socket);
+
+    // Read the request head, capturing any Range header.
+    let mut range: Option<String> = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).await? == 0 {
+            return Ok(());
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = trimmed.split_once(':') {
+            if name.eq_ignore_ascii_case("range") {
+                range = Some(value.trim().to_string());
+            }
+        }
+    }
+    ranges.lock().unwrap().push(range.clone());
+
+    let start: usize = range
+        .as_deref()
+        .and_then(|r| r.strip_prefix("bytes="))
+        .and_then(|r| r.split('-').next())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    let socket = reader.get_mut();
+
+    match reply {
+        Reply::Status(code) => {
+            let head =
+                format!("HTTP/1.1 {code} X\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            socket.write_all(head.as_bytes()).await?;
+        }
+        Reply::IgnoresRange { body } => {
+            write_full(socket, &body, None).await?;
+        }
+        Reply::File { body, etag } => {
+            if start >= body.len() {
+                let head = format!(
+                    "HTTP/1.1 416 Range Not Satisfiable\r\nContent-Length: 0\r\n{}Connection: close\r\n\r\n",
+                    etag_header(etag.as_deref())
+                );
+                socket.write_all(head.as_bytes()).await?;
+            } else if start > 0 {
+                let slice = &body[start..];
+                let head = format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {}-{}/{}\r\n{}Connection: close\r\n\r\n",
+                    slice.len(),
+                    start,
+                    body.len() - 1,
+                    body.len(),
+                    etag_header(etag.as_deref())
+                );
+                socket.write_all(head.as_bytes()).await?;
+                socket.write_all(slice).await?;
+            } else {
+                write_full(socket, &body, etag.as_deref()).await?;
+            }
+        }
+        Reply::Truncated { body, limit } => {
+            // Advertise the full length, then send less and hang up. The client
+            // must treat what it got as a resumable partial.
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            socket.write_all(head.as_bytes()).await?;
+            socket.write_all(&body[..limit]).await?;
+        }
+    }
+
+    socket.flush().await?;
+    Ok(())
+}
+
+async fn write_full(
+    socket: &mut tokio::net::TcpStream,
+    body: &[u8],
+    etag: Option<&str>,
+) -> std::io::Result<()> {
+    let head = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n{}Connection: close\r\n\r\n",
+        body.len(),
+        etag_header(etag)
+    );
+    socket.write_all(head.as_bytes()).await?;
+    socket.write_all(body).await
+}
+
+fn etag_header(etag: Option<&str>) -> String {
+    etag.map_or_else(String::new, |e| format!("X-Linked-Etag: \"{e}\"\r\n"))
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+fn body_of(len: usize) -> Vec<u8> {
+    // A repeating non-power-of-two pattern, so a mis-sliced resume shows up as a
+    // content mismatch rather than lining up by accident.
+    (0..len)
+        .map(|i| u8::try_from(i % 251).unwrap_or_default())
+        .collect()
+}
+
+/// Every `(downloaded, total)` pair the downloader reported, in order.
+type ProgressLog = Arc<Mutex<Vec<(u64, u64)>>>;
+
+fn len_of(body: &[u8]) -> u64 {
+    body.len() as u64
+}
+
+fn sha256_of(bytes: &[u8]) -> String {
+    hex(&Sha256::digest(bytes))
+}
+
+/// Collects every `(downloaded, total)` the downloader reports.
+fn recording_progress() -> (ProgressCallback, ProgressLog) {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let cb: ProgressCallback = Arc::new(move |d, t| sink.lock().unwrap().push((d, t)));
+    (cb, seen)
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    dest: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let dest = dir.path().join("model.gguf");
+        Self { _dir: dir, dest }
+    }
+
+    fn part(&self) -> PathBuf {
+        part_path_for(&self.dest)
+    }
+}
+
+fn request<'a>(
+    url: &'a str,
+    dest: &'a Path,
+    expected_size: Option<u64>,
+    progress: Option<ProgressCallback>,
+) -> NativeDownload<'a> {
+    NativeDownload {
+        url,
+        dest,
+        token: None,
+        expected_size,
+        progress,
+        cancel: None,
+    }
+}
+
+// ============================================================================
+// Happy path and atomicity
+// ============================================================================
+
+#[tokio::test]
+async fn downloads_a_file_and_publishes_it_atomically() {
+    let body = body_of(4096);
+    let server = TestServer::start(vec![Reply::File {
+        body: body.clone(),
+        etag: Some(sha256_of(&body)),
+    }])
+    .await;
+    let fx = Fixture::new();
+    let (progress, seen) = recording_progress();
+
+    let url = server.url();
+    download_file(
+        &Client::new(),
+        &request(&url, &fx.dest, Some(len_of(&body)), Some(progress)),
+    )
+    .await
+    .expect("download succeeds");
+
+    assert_eq!(std::fs::read(&fx.dest).unwrap(), body);
+    assert!(
+        !fx.part().exists(),
+        "the .part file must be gone once the file is published"
+    );
+
+    let (last_downloaded, last_total) = {
+        let seen = seen.lock().unwrap();
+        *seen.last().expect("at least one progress report")
+    };
+    assert_eq!(last_downloaded, len_of(&body));
+    assert_eq!(last_total, len_of(&body));
+}
+
+#[tokio::test]
+async fn a_file_with_no_usable_etag_is_still_verified_by_size() {
+    let body = body_of(2048);
+    let server = TestServer::start(vec![Reply::File {
+        body: body.clone(),
+        // Opaque etag: not a digest, so it must be ignored rather than compared.
+        etag: Some("686897696a7c876b7e".to_string()),
+    }])
+    .await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    let err = download_file(&Client::new(), &request(&url, &fx.dest, Some(9999), None))
+        .await
+        .expect_err("a wrong expected size must fail");
+
+    assert!(
+        matches!(err, NativeError::SizeMismatch { .. }),
+        "got {err:?}"
+    );
+    assert!(!fx.dest.exists());
+}
+
+// ============================================================================
+// Resume after interrupt
+// ============================================================================
+
+#[tokio::test]
+async fn resumes_after_an_interrupted_transfer() {
+    let body = body_of(8192);
+    let cut = 3000;
+    let etag = sha256_of(&body);
+
+    let server = TestServer::start(vec![
+        Reply::Truncated {
+            body: body.clone(),
+            limit: cut,
+        },
+        Reply::File {
+            body: body.clone(),
+            etag: Some(etag),
+        },
+    ])
+    .await;
+    let fx = Fixture::new();
+    let url = server.url();
+    let size = Some(len_of(&body));
+
+    // First attempt: the server hangs up mid-body.
+    let err = download_file(&Client::new(), &request(&url, &fx.dest, size, None))
+        .await
+        .expect_err("a truncated body must not be accepted");
+    assert!(
+        matches!(
+            err,
+            NativeError::Network(_) | NativeError::SizeMismatch { .. }
+        ),
+        "got {err:?}"
+    );
+
+    // The bytes that did arrive are kept for the retry.
+    let partial = std::fs::metadata(fx.part())
+        .expect("a .part file survives the interruption")
+        .len();
+    let sent = len_of(&body[..cut]);
+    assert!(
+        partial > 0 && partial <= sent,
+        "kept {partial} of the {sent} bytes that arrived"
+    );
+    assert!(!fx.dest.exists(), "nothing is published yet");
+
+    // Second attempt: resumes rather than restarting.
+    let (progress, seen) = recording_progress();
+    download_file(
+        &Client::new(),
+        &request(&url, &fx.dest, size, Some(progress)),
+    )
+    .await
+    .expect("the retry completes");
+
+    assert_eq!(
+        std::fs::read(&fx.dest).unwrap(),
+        body,
+        "the resumed file must be byte-exact — proving the hasher was seeded \
+         with the bytes already on disk, since the etag check passed"
+    );
+    assert!(!fx.part().exists());
+
+    let ranges = server.ranges();
+    assert_eq!(ranges.len(), 2, "two requests: {ranges:?}");
+    assert_eq!(ranges[0], None, "the first attempt asks for the whole file");
+    assert_eq!(
+        ranges[1],
+        Some(format!("bytes={partial}-")),
+        "the retry asks only for what is missing"
+    );
+
+    let reports = seen.lock().unwrap().clone();
+    assert_eq!(
+        reports.first().map(|(d, _)| *d),
+        Some(partial),
+        "progress resumes from the bytes already on disk, it does not restart at 0"
+    );
+    assert!(
+        reports.windows(2).all(|w| w[1].0 >= w[0].0),
+        "progress must never go backwards: {reports:?}"
+    );
+}
+
+#[tokio::test]
+async fn restarts_when_the_server_ignores_the_range_request() {
+    let body = body_of(5000);
+    let fx = Fixture::new();
+
+    // Leave a stale partial behind that does NOT match the real file.
+    std::fs::write(fx.part(), vec![0xff_u8; 1000]).unwrap();
+
+    let server = TestServer::start(vec![Reply::IgnoresRange { body: body.clone() }]).await;
+    let url = server.url();
+
+    download_file(
+        &Client::new(),
+        &request(&url, &fx.dest, Some(len_of(&body)), None),
+    )
+    .await
+    .expect("download succeeds");
+
+    assert_eq!(
+        std::fs::read(&fx.dest).unwrap(),
+        body,
+        "a 200 answer to a ranged request means the stale partial must be discarded"
+    );
+}
+
+#[tokio::test]
+async fn a_complete_partial_file_is_published_without_refetching() {
+    let body = body_of(2048);
+    let fx = Fixture::new();
+    std::fs::write(fx.part(), &body).unwrap();
+
+    let server = TestServer::start(vec![Reply::File {
+        body: body.clone(),
+        etag: Some(sha256_of(&body)),
+    }])
+    .await;
+    let url = server.url();
+
+    download_file(
+        &Client::new(),
+        &request(&url, &fx.dest, Some(len_of(&body)), None),
+    )
+    .await
+    .expect("a 416 means the file is already complete");
+
+    assert_eq!(std::fs::read(&fx.dest).unwrap(), body);
+    assert!(!fx.part().exists());
+}
+
+// ============================================================================
+// Checksum mismatch
+// ============================================================================
+
+#[tokio::test]
+async fn a_checksum_mismatch_fails_and_clears_the_partial_file() {
+    let body = body_of(4096);
+    let server = TestServer::start(vec![Reply::File {
+        body,
+        // A valid-looking digest for entirely different content.
+        etag: Some(sha256_of(b"something else")),
+    }])
+    .await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+        .await
+        .expect_err("bytes that do not match the advertised digest must be rejected");
+
+    match err {
+        NativeError::ChecksumMismatch { expected, actual } => {
+            assert_ne!(expected, actual);
+        }
+        other => panic!("expected ChecksumMismatch, got {other:?}"),
+    }
+
+    assert!(!fx.dest.exists(), "corrupt bytes must never be published");
+    assert!(
+        !fx.part().exists(),
+        "the .part file must be cleared so a retry starts clean rather than \
+         resuming onto known-bad bytes forever"
+    );
+}
+
+// ============================================================================
+// Network failure
+// ============================================================================
+
+#[tokio::test]
+async fn a_404_is_reported_as_not_found() {
+    let server = TestServer::start(vec![Reply::Status(404)]).await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+        .await
+        .expect_err("404 must fail");
+
+    assert!(matches!(err, NativeError::NotFound(_)), "got {err:?}");
+    assert!(!fx.dest.exists());
+    assert!(!fx.part().exists(), "nothing should be created for a 404");
+}
+
+#[tokio::test]
+async fn a_server_error_preserves_its_status_code() {
+    let server = TestServer::start(vec![Reply::Status(503)]).await;
+    let fx = Fixture::new();
+
+    let url = server.url();
+    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+        .await
+        .expect_err("503 must fail");
+
+    match err {
+        NativeError::Http { status, .. } => assert_eq!(status, 503),
+        other => panic!("expected Http, got {other:?}"),
+    }
+    assert!(!fx.dest.exists());
+}
+
+#[tokio::test]
+async fn an_unreachable_host_is_a_network_error() {
+    // Bind and immediately drop, so the port is almost certainly refused.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let fx = Fixture::new();
+    let url = format!("http://{addr}/model.gguf");
+    let err = download_file(&Client::new(), &request(&url, &fx.dest, None, None))
+        .await
+        .expect_err("a refused connection must fail");
+
+    assert!(matches!(err, NativeError::Network(_)), "got {err:?}");
+    assert!(!fx.dest.exists());
+}
+
+#[tokio::test]
+async fn a_cancelled_download_keeps_its_partial_file() {
+    let body = body_of(8192);
+    let server = TestServer::start(vec![Reply::Truncated { body, limit: 2000 }]).await;
+    let fx = Fixture::new();
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let url = server.url();
+    let err = download_file(
+        &Client::new(),
+        &NativeDownload {
+            url: &url,
+            dest: &fx.dest,
+            token: None,
+            expected_size: None,
+            progress: None,
+            cancel: Some(cancel),
+        },
+    )
+    .await
+    .expect_err("a cancelled download must not report success");
+
+    assert!(matches!(err, NativeError::Cancelled), "got {err:?}");
+    assert!(!fx.dest.exists());
+    assert_eq!(server.request_count(), 1);
+}
+
+// ============================================================================
+// Header parsing
+// ============================================================================
+
+#[test]
+fn expected_digest_prefers_the_linked_etag() {
+    let digest = "a".repeat(64);
+    let other = "b".repeat(64);
+    let mut headers = HeaderMap::new();
+    headers.insert(ETAG, format!("\"{other}\"").parse().unwrap());
+    headers.insert(X_LINKED_ETAG, format!("\"{digest}\"").parse().unwrap());
+
+    assert_eq!(expected_digest(&headers), Some(digest));
+}
+
+#[test]
+fn expected_digest_falls_back_to_the_plain_etag() {
+    let digest = "c".repeat(64);
+    let mut headers = HeaderMap::new();
+    headers.insert(ETAG, format!("W/\"{digest}\"").parse().unwrap());
+
+    assert_eq!(expected_digest(&headers), Some(digest));
+}
+
+#[test]
+fn a_non_digest_etag_is_not_treated_as_a_checksum() {
+    // Real HuggingFace responses carry opaque etags for non-LFS files. Comparing
+    // a SHA-256 against one of those would fail every download.
+    for value in [
+        "\"686897696a7c876b7e\"",
+        "\"not-a-hash\"",
+        "\"\"",
+        "W/\"xyz\"",
+    ] {
+        let mut headers = HeaderMap::new();
+        headers.insert(ETAG, value.parse().unwrap());
+        assert_eq!(expected_digest(&headers), None, "for etag {value}");
+    }
+}
+
+#[test]
+fn an_absent_etag_yields_no_digest() {
+    assert_eq!(expected_digest(&HeaderMap::new()), None);
+}
+
+#[test]
+fn content_range_supplies_the_authoritative_total() {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_RANGE, "bytes 100-199/500".parse().unwrap());
+    headers.insert(reqwest::header::CONTENT_LENGTH, "100".parse().unwrap());
+
+    assert_eq!(total_size(&headers, 100), Some(500));
+}
+
+#[test]
+fn content_length_plus_the_resume_offset_is_the_fallback_total() {
+    let mut headers = HeaderMap::new();
+    headers.insert(reqwest::header::CONTENT_LENGTH, "400".parse().unwrap());
+
+    assert_eq!(total_size(&headers, 100), Some(500));
+}
+
+#[test]
+fn an_unknown_content_range_total_is_not_invented() {
+    assert_eq!(parse_content_range_total("bytes 0-99/*"), None);
+    assert_eq!(parse_content_range_total("bytes 0-99/500"), Some(500));
+}
+
+#[test]
+fn part_paths_sit_beside_their_destination() {
+    let dest = Path::new("/models/repo/model.gguf");
+    assert_eq!(
+        part_path_for(dest),
+        PathBuf::from("/models/repo/model.gguf.part")
+    );
+}

--- a/crates/gglib-download/src/manager/README.md
+++ b/crates/gglib-download/src/manager/README.md
@@ -14,9 +14,10 @@ between the worker (core download logic) and bridges (event emission).
 - **Worker**: Executes downloads, writes only to `watch::Sender` (no events) —
   with one narrow, deliberate exception: `WorkerDeps.event_emitter` lets
   `execute_download` emit `DownloadEvent::DownloadNotice` directly for
-  transient, cosmetic setup notes (e.g. building the fast downloader's
-  first-run Python venv) that aren't part of the progress or completion state
-  the manager sequences. See the doc comment on `WorkerDeps` in `worker.rs`.
+  transient, cosmetic notes (e.g. the optional `hf_xet` accelerator being
+  unavailable, so the transfer falls back to the native path) that aren't part
+  of the progress or completion state the manager sequences. See the doc
+  comment on `WorkerDeps` in `worker.rs`.
 - **Bridge tasks**: Subscribe to watch channels, emit events with rate-limiting
 
 # Concurrency Model

--- a/crates/gglib-download/src/manager/worker.rs
+++ b/crates/gglib-download/src/manager/worker.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 use gglib_core::download::{DownloadError, DownloadEvent, DownloadId, Quantization};
 use gglib_core::ports::{DownloadEventEmitterPort, DownloadManagerConfig};
 
-use crate::cli_exec::{FastDownloadRequest, PythonBridgeError, run_fast_download};
+use crate::executor::{DownloadPlan, download_files};
 
 use super::paths::DownloadDestination;
 
@@ -212,9 +212,10 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
             });
         });
 
-    // Notice callback: surfaces transient setup notes (e.g. first-run Python
-    // venv creation) on the bar instead of leaving it looking frozen for the
-    // tens of seconds that can take. See the doc comment on `WorkerDeps`.
+    // Notice callback: surfaces transient notes that carry no byte progress of
+    // their own — e.g. the accelerator being unavailable and the transfer
+    // falling back — instead of leaving the bar looking frozen. See the doc
+    // comment on `WorkerDeps`.
     let notice_id = job.id.to_string();
     let notice_emitter = Arc::clone(&deps.event_emitter);
     let notice_callback: crate::cli_exec::NoticeCallback = Arc::new(move |message: &str| {
@@ -224,11 +225,10 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
         });
     });
 
-    // Build download request
-    let request = FastDownloadRequest {
+    // Build download plan
+    let plan = DownloadPlan {
         repo_id: job.id.model_id(),
         revision: "main",
-        repo_type: "model",
         destination: &job.destination.model_dir,
         files: &job.destination.files,
         token: deps.config.hf_token.as_deref(),
@@ -236,7 +236,7 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
         progress: Some(Arc::clone(&progress_callback)),
         notice: Some(notice_callback),
         expected_total: job.expected_total,
-        cancel_token: Some(job.cancel.clone()),
+        cancel: Some(job.cancel.clone()),
     };
 
     // Execute with cancellation support via select
@@ -247,12 +247,7 @@ async fn execute_download(job: &DownloadJob, deps: &WorkerDeps) -> Result<(), Do
             Err(DownloadError::Cancelled)
         }
 
-        result = run_fast_download(&request) => {
-            result.map_err(|e| match e {
-                PythonBridgeError::Cancelled => DownloadError::Cancelled,
-                other => DownloadError::other(other.to_string()),
-            })
-        }
+        result = download_files(&plan) => result,
     }
 }
 

--- a/crates/gglib-hf/src/lib.rs
+++ b/crates/gglib-hf/src/lib.rs
@@ -24,6 +24,9 @@ pub use client::DefaultHfClient;
 // Configuration
 pub use config::HfClientConfig;
 
+// URL construction
+pub use url::build_file_url;
+
 // Silence unused dev-dependency warnings
 #[cfg(test)]
 use mockall as _;

--- a/crates/gglib-hf/src/url.rs
+++ b/crates/gglib-hf/src/url.rs
@@ -86,12 +86,22 @@ pub fn build_model_info_url(config: &HfConfig, repo: &HfRepoRef) -> Url {
 
 /// Build a URL for downloading a file from a repository.
 pub fn build_download_url(repo: &HfRepoRef, file_path: &str, revision: Option<&str>) -> Url {
+    Url::parse(&build_file_url(&repo.id(), file_path, revision))
+        .expect("download URL construction should not fail")
+}
+
+/// Build the URL that serves a file's bytes, from a bare `owner/name` repo ID.
+///
+/// This is the resolve endpoint: `HuggingFace` answers it with a redirect to the
+/// CDN for LFS objects, and the CDN honours `Range` requests. `revision` may be
+/// a branch, tag, or commit SHA; `None` means `main`.
+///
+/// Takes the repo ID as a string rather than an [`HfRepoRef`] so callers outside
+/// this crate — the native downloader in `gglib-download` — can reach it without
+/// the repo types becoming public API.
+pub fn build_file_url(repo_id: &str, file_path: &str, revision: Option<&str>) -> String {
     let rev = revision.unwrap_or("main");
-    Url::parse(&format!(
-        "https://huggingface.co/{}/resolve/{rev}/{file_path}",
-        repo.id(),
-    ))
-    .expect("download URL construction should not fail")
+    format!("https://huggingface.co/{repo_id}/resolve/{rev}/{file_path}")
 }
 
 #[cfg(test)]

--- a/crates/gglib-runtime/src/system/mod.rs
+++ b/crates/gglib-runtime/src/system/mod.rs
@@ -252,9 +252,12 @@ impl SystemProbePort for DefaultSystemProbe {
                 distro,
                 get_cmake_version(),
             ),
-            system_dep(
+            // Optional, not required: downloads run natively over HTTP. Python
+            // only enables the hf_xet accelerator, and only if the user opts in
+            // to provisioning it.
+            optional_dep(
                 "python3",
-                "Required for hf_xet fast download helper",
+                "Optional: enables the hf_xet download accelerator",
                 distro,
                 get_python3_version(),
             ),

--- a/crates/gglib-tauri/src/events.rs
+++ b/crates/gglib-tauri/src/events.rs
@@ -15,7 +15,12 @@ pub mod names {
     // Download events
     pub const DOWNLOAD_PROGRESS: &str = "download-progress";
 
-    // Download system initialization events (fast Python helper availability)
+    // Download system initialization.
+    //
+    // Downloads run natively over HTTP and need nothing provisioned, so startup
+    // always resolves to READY. ERROR is reserved for a subsystem that genuinely
+    // cannot download — the absence of the optional hf_xet accelerator is not
+    // that, and must not be reported here.
     pub const DOWNLOAD_SYSTEM_READY: &str = "download-system:ready";
     pub const DOWNLOAD_SYSTEM_ERROR: &str = "download-system:error";
 

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -115,9 +115,14 @@ get_version() {
     echo "$version_output" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]/) {print $i; exit}}'
 }
 
-# Dedicated Python 3 checker (accepts python3/python/py -3)
+# Dedicated Python 3 checker (accepts python3/python/py -3).
+#
+# Optional, not required: model downloads run natively over HTTP. Python only
+# enables the hf_xet accelerator, and only when the user opts in with
+# `gglib config check-deps --setup-fast-downloads`. A machine with no Python
+# must still pass this script.
 check_python() {
-    local description="Required for hf_xet fast download helper"
+    local description="Optional: enables the hf_xet download accelerator"
     local cmd=""
     local version=""
 
@@ -139,14 +144,13 @@ check_python() {
         local major=${version%%.*}
         if [ "$major" -ge 3 ] 2>/dev/null; then
             printf "%-20s ${GREEN}%-2s %-12s${RESET} %-50s\n" "python3" "✓" "$version" "$description"
-            PRESENT_REQUIRED+=("python3")
             return 0
         fi
     fi
 
-    printf "%-20s ${RED}%-2s %-12s${RESET} %-50s\n" "python3" "✗" "MISSING" "$description"
-    MISSING_REQUIRED+=("python3")
-    return 1
+    printf "%-20s ${YELLOW}%-2s %-12s${RESET} %-50s\n" "python3" "⚠" "optional" "$description"
+    MISSING_OPTIONAL+=("python3")
+    return 0
 }
 
 # Dedicated Node.js checker that validates version meets the project minimum:

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -113,30 +113,27 @@ fn main() {
 
             app.manage(app_state);
 
-            // Download system init: preflight the Python fast downloader helper.
-            // This runs on startup so the frontend can render a clear error state
-            // instead of waiting indefinitely if Python is broken/missing.
+            // Download system init: report the optional hf_xet accelerator.
+            //
+            // Downloads themselves need nothing here — they run natively over
+            // HTTP. So the subsystem is always ready, and a missing or broken
+            // Python is an unavailable accelerator, not an error state: it is
+            // logged, not surfaced as a failure the user has to act on.
             {
                 let app_handle_for_init = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     match preflight_fast_helper().await {
                         Ok(python_exe) => {
-                            info!(python = %python_exe, "Fast download helper preflight OK");
-                            emit_or_log(&app_handle_for_init, names::DOWNLOAD_SYSTEM_READY, true);
+                            info!(python = %python_exe, "hf_xet accelerator preflight OK");
                         }
                         Err(e) => {
-                            error!(error = %e, "Fast download helper preflight failed");
-                            let msg = format!(
-                                "Fast downloads are unavailable: {e}. Please install Python 3 (python3) or set {} to a working interpreter.",
-                                "GGLIB_PYTHON"
-                            );
-                            emit_or_log(
-                                &app_handle_for_init,
-                                names::DOWNLOAD_SYSTEM_ERROR,
-                                gglib_tauri::events::DownloadSystemErrorPayload { message: msg },
+                            info!(
+                                error = %e,
+                                "hf_xet accelerator unavailable; downloads will use the native HTTP path"
                             );
                         }
                     }
+                    emit_or_log(&app_handle_for_init, names::DOWNLOAD_SYSTEM_READY, true);
                 });
             }
 

--- a/src/components/SetupWizard/SetupWizard.tsx
+++ b/src/components/SetupWizard/SetupWizard.tsx
@@ -539,13 +539,13 @@ const PythonSetupStep: FC<{
         <div>
           <h2 className="text-xl font-semibold text-text mb-2">Fast Downloads</h2>
           <p className="text-text-secondary leading-relaxed">
-            The Python fast-download helper is ready. Large model downloads will
-            use optimized transfer for maximum speed.
+            The hf_xet accelerator is ready. Large model downloads will use
+            optimized transfer for maximum speed.
           </p>
         </div>
         <div className="bg-success/10 border border-success/30 rounded-lg p-4 flex items-center gap-3">
           <Icon icon={CheckCircle2} size={20} className="text-success shrink-0" />
-          <span className="text-sm text-text">Fast download helper is ready</span>
+          <span className="text-sm text-text">Download accelerator is ready</span>
         </div>
         <StepNavigation onBack={onBack} onNext={onNext} />
       </div>
@@ -557,9 +557,10 @@ const PythonSetupStep: FC<{
       <div>
         <h2 className="text-xl font-semibold text-text mb-2">Fast Downloads</h2>
         <p className="text-text-secondary leading-relaxed">
-          gglib can use a Python helper for{' '}
+          Downloads already work &mdash; gglib fetches models directly. If you have
+          Python 3, it can also install a helper for{' '}
           <span className="text-text font-medium">significantly faster</span>{' '}
-          model downloads from Hugging Face (via hf_xet). This is optional but recommended.
+          transfers from Hugging Face (via hf_xet). Entirely optional.
         </p>
       </div>
 
@@ -569,8 +570,9 @@ const PythonSetupStep: FC<{
           <div>
             <p className="text-sm font-medium text-warning mb-1">Python not found</p>
             <p className="text-xs text-text-secondary">
-              Python 3 is required for fast downloads. Install Python 3 and restart the wizard,
-              or skip this step to use standard downloads.
+              The accelerator needs Python 3. Skip this step and downloads will run
+              directly, which needs nothing installed. To use it later, install
+              Python 3 and re-run this wizard from Settings.
             </p>
           </div>
         </div>
@@ -601,7 +603,7 @@ const PythonSetupStep: FC<{
       {setting && (
         <div className="flex items-center gap-2 text-sm text-text-secondary">
           <Icon icon={Loader2} className="animate-spin" size={16} />
-          <span>Setting up Python environment... This may take a minute.</span>
+          <span>Installing the download accelerator... This may take a minute.</span>
         </div>
       )}
 
@@ -654,7 +656,9 @@ const CompleteStep: FC<{ status: SetupStatus; onFinish: () => void }> = ({ statu
     <div className="grid grid-cols-1 gap-2">
       <SummaryRow label="Models directory" ok={status.modelsDirectory.exists} value={status.modelsDirectory.path} />
       <SummaryRow label="llama.cpp" ok={status.llamaInstalled} value={status.llamaInstalled ? 'Installed' : 'Not installed'} />
-      <SummaryRow label="Fast downloads" ok={status.fastDownloadReady} value={status.fastDownloadReady ? 'Ready' : 'Not configured'} />
+      {/* Always ok: downloads work either way, so an absent accelerator is a
+          choice of transport, not a failure to flag. */}
+      <SummaryRow label="Downloads" ok value={status.fastDownloadReady ? 'Accelerated (hf_xet)' : 'Direct'} />
     </div>
 
     <div className="flex justify-center pt-4">

--- a/src/hooks/useDownloadSystemStatus.ts
+++ b/src/hooks/useDownloadSystemStatus.ts
@@ -14,10 +14,12 @@ type DownloadSystemErrorPayload = {
 };
 
 /**
- * Tracks whether the backend download subsystem (Python fast helper) is usable.
+ * Tracks whether the backend download subsystem is usable.
  *
- * On desktop (Tauri), the backend emits explicit init events on app startup.
- * On web, this is always ready (fast helper not applicable).
+ * On desktop (Tauri), the backend emits an init event on app startup. Downloads
+ * run natively over HTTP, so that resolves to ready regardless of whether the
+ * optional hf_xet accelerator is installed — a missing accelerator is not an
+ * error state. On web, this is always ready.
  */
 export function useDownloadSystemStatus(): DownloadSystemStatus {
   const [state, setState] = useState<DownloadSystemStatus>({


### PR DESCRIPTION
## Summary

Downloading a model required a provisioned Python/conda environment, with no fallback by design — the README said so outright. This makes native Rust HTTP (`reqwest`, ranged GETs, resumable `.part` files) the default download path and demotes the `hf_xet` Python accelerator to an explicit opt-in (`gglib config check-deps --setup-fast-downloads` or the GUI wizard's Fast Downloads step). Nothing provisions the venv implicitly anymore; it's only consulted if already on disk, and any failure there falls back to native rather than ending the download.

The tricky part was the integrity check. HuggingFace's redirect chain carries the file's real SHA-256 in `X-Linked-Etag` on the 302 — but the CDN's final `ETag` is a Xet block hash, also 64 hex characters, indistinguishable by shape from a real digest. The client follows redirects manually (`redirect::Policy::none()`) so the linked-etag header isn't discarded, the bearer token is sent only to the origin host (never forwarded to the pre-signed CDN URL), and plain `ETag` is never treated as a digest source — absent `X-Linked-Etag`, verification falls back to a size check. A short `.part` file is kept as a resumable valid prefix; a mismatched or over-long one is deleted, since wrong bytes would fail identically forever.

`DownloadEvent` is unchanged, so the CLI progress bar, Axum SSE stream, and Tauri event consumer all keep working with no edits. Axum's `/api/system/setup-python` route is untouched; Tauri startup no longer treats a missing Python as a broken subsystem.

**Known limitation:** Ctrl-C during a transfer isn't wired to SIGINT directly (unlike the old Python bridge) — interrupting mid-download may not respond immediately. Not a regression, but worth a follow-up.

## Test plan

- [x] End-to-end download with no `python3` on `PATH`: SHA-256 verified against `X-Linked-Etag`, atomically renamed, GGUF parsed and registered, nothing provisioned as a side effect
- [x] `fmt`, `clippy -D warnings`, doc tests, `check_boundaries.sh`, `check_readmes.sh`, `check-tauri-commands.sh`, `generate_module_tables.sh --check`, ESLint, `tsc`, 675 frontend tests, full Rust suite — all green
- [x] 28 new tests in `native_tests.rs` against a hand-rolled loopback server: HuggingFace redirect/decoy-etag shape, resume-after-interrupt with byte-exact resumed files, checksum mismatch cleanup, 404/500/refused-connection/redirect-loop handling, atomic publish, server-ignores-range, 416-already-complete, etag/Content-Range parsing
- [x] Confirmed the redirect-following guard actually bites: restoring automatic redirect following makes the decoy-etag test fail as expected