### PR TITLE
feat(runtime): narrate the runtime's decisions at startup

### DIFF
--- a/crates/gglib-core/src/domain/launch_narration.rs
+++ b/crates/gglib-core/src/domain/launch_narration.rs
@@ -1,0 +1,232 @@
+//! What the runtime decided for one llama-server launch, and why.
+//!
+//! ## Why this type exists
+//!
+//! gglib makes a series of non-obvious choices every time it launches a
+//! model: it sizes the host-RAM prompt cache against free memory, quantizes
+//! the KV cache, enables speculative decoding from the model's own metadata,
+//! picks a tool-call dialect parser, and resolves the context size through a
+//! four-level fallback chain. Every one of those values already existed at
+//! launch — but only in a `debug!` line or a local variable, so the user's
+//! evidence that any of it happened was a 1,000-line README.
+//!
+//! [`LaunchNarration`] is the record of those decisions, captured once at
+//! spawn where each resolver's `*Source` enum is still in scope. It carries
+//! **provenance, not just values**: "32768" is a number, "32768 (model
+//! `server_defaults`)" is an explanation, and the second is the one that makes
+//! the runtime's behaviour auditable rather than magical.
+//!
+//! ## One record, three surfaces
+//!
+//! The same narration is rendered by the CLI banner at startup, served on
+//! `GET /v1/proxy/status`, and displayed in the GUI dashboard. It lives in
+//! `gglib-core` so all three can name the type without any of them depending
+//! on the runtime that produces it.
+//!
+//! ## Presentation, not computation
+//!
+//! Nothing here re-derives a value. Every field is assigned from a resolution
+//! the launch already performed; a decision gglib does not actually make has
+//! no business appearing in this struct. Notably absent is the GPU layer
+//! split: gglib never emits `-ngl`, so how many layers get offloaded is
+//! llama.cpp's decision and is not gglib's to report. See
+//! [`Self::backend`] for what *is* known.
+
+use serde::{Deserialize, Serialize};
+
+/// One resolved launch decision, paired with the reason it was chosen.
+///
+/// [`Self::source`] is the whole point of the type — a value without its
+/// provenance tells a user what happened but never why, which is precisely
+/// the gap this record closes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaunchDecision {
+    /// Short stable key naming the decision: `ctx`, `backend`, `kv`,
+    /// `cache`, `mtp`, `flags`, `dialect`.
+    ///
+    /// Stable because the GUI and the CLI dashboard both key styling off it;
+    /// treat it as part of the wire contract rather than a display string.
+    pub label: String,
+    /// Display-ready value, e.g. `32768` or `q8_0 -> 2.1 GB, f16 would be 4.2 GB`.
+    pub value: String,
+    /// Where the value came from, rendered in parentheses by every consumer.
+    ///
+    /// `None` only for decisions whose value already states its own origin —
+    /// never as a shortcut for "didn't bother", since an unexplained value is
+    /// the exact failure mode this type exists to prevent.
+    pub source: Option<String>,
+}
+
+impl LaunchDecision {
+    /// A decision whose provenance is worth stating.
+    #[must_use]
+    pub fn new(
+        label: impl Into<String>,
+        value: impl Into<String>,
+        source: impl Into<String>,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+            source: Some(source.into()),
+        }
+    }
+
+    /// A decision that is self-explanatory — see [`Self::source`] for when
+    /// that is legitimate.
+    #[must_use]
+    pub fn bare(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+            source: None,
+        }
+    }
+
+    /// Render as `value (source)`, or just `value` when unsourced.
+    #[must_use]
+    pub fn render_value(&self) -> String {
+        self.source.as_ref().map_or_else(
+            || self.value.clone(),
+            |source| format!("{} ({})", self.value, source),
+        )
+    }
+}
+
+/// Everything the runtime decided for one llama-server launch.
+///
+/// Built at spawn by the runtime; consumed by the CLI banner, the proxy
+/// status endpoint, and the GUI dashboard. See the [module docs](self) for
+/// why the decisions are an ordered list rather than named fields: the three
+/// consumers all render the same rows in the same order, and a list keeps
+/// adding a decision to a single site instead of four.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaunchNarration {
+    /// Model name as the catalog knows it.
+    pub model_name: String,
+    /// Quantization label (`Q4_K_M`), when the catalog recorded one.
+    pub quantization: Option<String>,
+    /// On-disk weight size in bytes, summed across shards. `0` when unknown —
+    /// rendered as absent rather than as "0 GB".
+    pub weights_bytes: u64,
+    /// The decisions, in the order they should be displayed.
+    pub decisions: Vec<LaunchDecision>,
+}
+
+impl LaunchNarration {
+    /// Start a narration for a model; decisions are appended by the runtime
+    /// as each resolution comes into scope.
+    #[must_use]
+    pub fn new(
+        model_name: impl Into<String>,
+        quantization: Option<String>,
+        weights_bytes: u64,
+    ) -> Self {
+        Self {
+            model_name: model_name.into(),
+            quantization,
+            weights_bytes,
+            decisions: Vec::new(),
+        }
+    }
+
+    /// Append a decision, keeping display order.
+    pub fn push(&mut self, decision: LaunchDecision) {
+        self.decisions.push(decision);
+    }
+
+    /// The identity line: `qwen3-30b-a3b · Q4_K_M · 17.2 GB`.
+    ///
+    /// Unknown quantization and unknown size are dropped rather than rendered
+    /// as `unknown` or `0 GB` — a banner that pads itself with non-answers
+    /// reads as broken.
+    #[must_use]
+    pub fn headline(&self) -> String {
+        let mut parts = vec![self.model_name.clone()];
+        if let Some(quant) = &self.quantization {
+            parts.push(quant.clone());
+        }
+        if self.weights_bytes > 0 {
+            parts.push(format_gib(self.weights_bytes));
+        }
+        parts.join(" \u{b7} ")
+    }
+
+    /// Look up a decision by its stable label.
+    #[must_use]
+    pub fn decision(&self, label: &str) -> Option<&LaunchDecision> {
+        self.decisions.iter().find(|d| d.label == label)
+    }
+}
+
+/// Format a byte count as GiB with one decimal, e.g. `17.2 GB`.
+///
+/// Deliberately GiB-not-GB: it matches how every other memory figure in the
+/// launch path is computed, and a banner whose numbers disagree with the
+/// `--cache-ram` budget beside them is worse than no banner.
+#[must_use]
+pub fn format_gib(bytes: u64) -> String {
+    #[allow(clippy::cast_precision_loss)]
+    let gib = bytes as f64 / 1_073_741_824.0;
+    format!("{gib:.1} GB")
+}
+
+/// Format a MiB count as GiB with one decimal, for the RAM cache budget.
+#[must_use]
+pub fn format_mib_as_gib(mib: u64) -> String {
+    #[allow(clippy::cast_precision_loss)]
+    let gib = mib as f64 / 1024.0;
+    format!("{gib:.1} GB")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_value_appends_provenance_in_parentheses() {
+        let d = LaunchDecision::new("ctx", "32768", "model server_defaults");
+        assert_eq!(d.render_value(), "32768 (model server_defaults)");
+    }
+
+    #[test]
+    fn render_value_omits_parentheses_when_unsourced() {
+        assert_eq!(LaunchDecision::bare("ctx", "32768").render_value(), "32768");
+    }
+
+    #[test]
+    fn headline_joins_the_three_identity_parts() {
+        let n = LaunchNarration::new("qwen3-30b-a3b", Some("Q4_K_M".to_string()), 18_476_297_420);
+        assert_eq!(n.headline(), "qwen3-30b-a3b \u{b7} Q4_K_M \u{b7} 17.2 GB");
+    }
+
+    /// Unknown quant and unknown size drop out rather than rendering as
+    /// filler — see [`LaunchNarration::headline`].
+    #[test]
+    fn headline_drops_unknown_quantization_and_zero_size() {
+        let n = LaunchNarration::new("mystery", None, 0);
+        assert_eq!(n.headline(), "mystery");
+    }
+
+    #[test]
+    fn headline_keeps_size_when_only_quantization_is_unknown() {
+        let n = LaunchNarration::new("mystery", None, 1_073_741_824);
+        assert_eq!(n.headline(), "mystery \u{b7} 1.0 GB");
+    }
+
+    #[test]
+    fn decisions_keep_insertion_order_and_are_findable_by_label() {
+        let mut n = LaunchNarration::new("m", None, 0);
+        n.push(LaunchDecision::new("ctx", "32768", "flag"));
+        n.push(LaunchDecision::new("kv", "q8_0", "default"));
+        let labels: Vec<&str> = n.decisions.iter().map(|d| d.label.as_str()).collect();
+        assert_eq!(labels, ["ctx", "kv"]);
+        assert_eq!(n.decision("kv").unwrap().value, "q8_0");
+        assert!(n.decision("mtp").is_none());
+    }
+
+    #[test]
+    fn format_mib_as_gib_scales_by_1024() {
+        assert_eq!(format_mib_as_gib(6144), "6.0 GB");
+    }
+}

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -10,6 +10,7 @@ pub mod inference;
 pub mod inference_profile;
 pub mod kv_estimate;
 pub mod kv_memory;
+pub mod launch_narration;
 pub mod mcp;
 mod model;
 pub mod model_naming;
@@ -48,6 +49,9 @@ pub use kv_estimate::{
 
 // Re-export KV memory-shape detection at the domain level for convenience
 pub use kv_memory::kv_memory_is_partial;
+
+// Re-export launch narration types at the domain level for convenience
+pub use launch_narration::{LaunchDecision, LaunchNarration, format_gib, format_mib_as_gib};
 pub use server_config::ServerConfig;
 
 // Re-export cache-RAM budget math at the domain level for convenience

--- a/crates/gglib-core/src/ports/model_catalog.rs
+++ b/crates/gglib-core/src/ports/model_catalog.rs
@@ -90,6 +90,12 @@ pub struct ModelLaunchSpec {
     pub tags: Vec<String>,
     /// Model architecture (for runtime configuration).
     pub architecture: Option<String>,
+    /// Quantization label (`Q4_K_M`), when the catalog recorded one.
+    ///
+    /// Carried purely so the launch can name what it loaded — see
+    /// [`crate::domain::LaunchNarration`]. `None` for models whose GGUF
+    /// metadata did not identify a quantization.
+    pub quantization: Option<String>,
     /// Maximum context length the model supports.
     pub context_length: Option<u64>,
     /// Per-model server defaults (e.g., `context_length` for launch).

--- a/crates/gglib-core/src/ports/model_runtime.rs
+++ b/crates/gglib-core/src/ports/model_runtime.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use thiserror::Error;
 
 use crate::cache_config::CacheRamSetting;
-use crate::domain::CacheRamHealth;
+use crate::domain::{CacheRamHealth, LaunchNarration};
 use crate::ports::ProcessHandle;
 use crate::server_config::ServerConfigOptions;
 
@@ -73,6 +73,15 @@ pub struct RunningTarget {
     /// user-facing surfaces can report it without re-deriving thresholds. See
     /// [`crate::domain::classify_cache_ram`].
     pub cache_ram_health: CacheRamHealth,
+    /// What this launch decided, and why (see
+    /// [`crate::domain::LaunchNarration`]).
+    ///
+    /// Carried on the target for the same reason as
+    /// [`Self::cache_ram_health`]: the resolutions and their provenance exist
+    /// only at spawn, so anything downstream that wants to explain the
+    /// running model has no way to recover them otherwise. `None` for targets
+    /// that did not come from a gglib launch.
+    pub narration: Option<LaunchNarration>,
 }
 
 impl RunningTarget {
@@ -100,7 +109,15 @@ impl RunningTarget {
             just_started,
             slot_restore_supported: true,
             cache_ram_health: CacheRamHealth::LlamaDefault,
+            narration: None,
         }
+    }
+
+    /// Attach the narration of the launch that produced this target.
+    #[must_use]
+    pub fn with_narration(mut self, narration: LaunchNarration) -> Self {
+        self.narration = Some(narration);
+        self
     }
 
     /// Set whether disk slot restore can resume this model.

--- a/crates/gglib-core/src/server_config.rs
+++ b/crates/gglib-core/src/server_config.rs
@@ -228,16 +228,70 @@ impl ServerConfigOptions {
 // Resolver
 // =============================================================================
 
+/// Which rung of the context fallback chain supplied the resolved value.
+///
+/// Exists so a launch can state *why* it runs at a given context rather than
+/// only what that context is — the number alone cannot distinguish a value
+/// the user asked for from one inherited from the model's stored defaults or
+/// from the 4096 floor. See [`crate::domain::LaunchNarration`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextSizeSource {
+    /// Runtime request or CLI flag (`opts.context_size`).
+    Explicit,
+    /// Per-model server defaults from the database (`opts.model_server_ctx`).
+    ModelServerDefaults,
+    /// Global app setting (`opts.global_default_ctx`).
+    GlobalDefault,
+    /// The hardcoded [`DEFAULT_CONTEXT_SIZE`] floor — nothing else was set.
+    BuiltInDefault,
+}
+
+impl ContextSizeSource {
+    /// Short label for display, e.g. `model server_defaults`.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::ModelServerDefaults => "model server_defaults",
+            Self::GlobalDefault => "global default",
+            Self::BuiltInDefault => "built-in default",
+        }
+    }
+}
+
+/// Resolve context size using the 4-level fallback chain, reporting which
+/// rung won.
+///
+/// 1. Runtime request / CLI flag (`opts.context_size`) — highest priority
+/// 2. Per-model server defaults (`opts.model_server_ctx`) — from DB
+/// 3. Global app setting (`opts.global_default_ctx`)
+/// 4. Hardcoded default (`DEFAULT_CONTEXT_SIZE` = 4096) — lowest priority
+///
+/// [`resolve_context_size`] delegates here and discards the source, so the
+/// chain exists in exactly one place: a second copy that drifted would make
+/// the banner explain a decision the launch did not actually take.
+pub const fn resolve_context_size_with_source(
+    opts: &ServerConfigOptions,
+) -> (u64, ContextSizeSource) {
+    if let Some(ctx) = opts.context_size {
+        return (ctx, ContextSizeSource::Explicit);
+    }
+    if let Some(ctx) = opts.model_server_ctx {
+        return (ctx as u64, ContextSizeSource::ModelServerDefaults);
+    }
+    if let Some(ctx) = opts.global_default_ctx {
+        return (ctx, ContextSizeSource::GlobalDefault);
+    }
+    (DEFAULT_CONTEXT_SIZE, ContextSizeSource::BuiltInDefault)
+}
+
 /// Resolve context size using the 4-level fallback chain.
 /// 1. Runtime request / CLI flag (`opts.context_size`) — highest priority
 /// 2. Per-model server defaults (`opts.model_server_ctx`) — from DB
 /// 3. Global app setting (`opts.global_default_ctx`)
 /// 4. Hardcoded default (`DEFAULT_CONTEXT_SIZE` = 4096) — lowest priority
-pub fn resolve_context_size(opts: &ServerConfigOptions) -> u64 {
-    opts.context_size
-        .or_else(|| opts.model_server_ctx.map(|v| v as u64))
-        .or(opts.global_default_ctx)
-        .unwrap_or(DEFAULT_CONTEXT_SIZE)
+pub const fn resolve_context_size(opts: &ServerConfigOptions) -> u64 {
+    resolve_context_size_with_source(opts).0
 }
 
 // =============================================================================
@@ -267,6 +321,63 @@ mod tests {
     fn test_resolve_context_size_default_when_all_none() {
         let opts = ServerConfigOptions::default();
         assert_eq!(resolve_context_size(&opts), DEFAULT_CONTEXT_SIZE);
+    }
+
+    use crate::server_config::{ContextSizeSource, resolve_context_size_with_source};
+
+    /// Each rung wins in turn as the one above it is removed — this is the
+    /// precedence the banner claims to be reporting.
+    #[test]
+    fn context_source_names_the_winning_rung_at_each_level() {
+        let full = ServerConfigOptions {
+            context_size: Some(32_768),
+            model_server_ctx: Some(16_384),
+            global_default_ctx: Some(8192),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_context_size_with_source(&full),
+            (32_768, ContextSizeSource::Explicit)
+        );
+
+        let no_explicit = ServerConfigOptions {
+            context_size: None,
+            ..full.clone()
+        };
+        assert_eq!(
+            resolve_context_size_with_source(&no_explicit),
+            (16_384, ContextSizeSource::ModelServerDefaults)
+        );
+
+        let global_only = ServerConfigOptions {
+            context_size: None,
+            model_server_ctx: None,
+            ..full
+        };
+        assert_eq!(
+            resolve_context_size_with_source(&global_only),
+            (8192, ContextSizeSource::GlobalDefault)
+        );
+
+        assert_eq!(
+            resolve_context_size_with_source(&ServerConfigOptions::default()),
+            (DEFAULT_CONTEXT_SIZE, ContextSizeSource::BuiltInDefault)
+        );
+    }
+
+    /// The bare resolver must stay a projection of the sourced one, or the
+    /// banner would explain a decision the launch did not take.
+    #[test]
+    fn bare_resolver_agrees_with_the_sourced_one() {
+        let opts = ServerConfigOptions {
+            model_server_ctx: Some(16_384),
+            global_default_ctx: Some(8192),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_context_size(&opts),
+            resolve_context_size_with_source(&opts).0
+        );
     }
 
     // Cache-RAM budget math tests now live in

--- a/crates/gglib-proxy/src/dashboard.rs
+++ b/crates/gglib-proxy/src/dashboard.rs
@@ -43,6 +43,7 @@ use crate::slots::{SlotSnapshot, SlotsPollResult};
 use crate::slots_poller::SlotsCache;
 use crate::upstream_health::{UpstreamHealth, UpstreamHealthSnapshot};
 use gglib_core::cache_metrics::{CacheMetricsStore, CacheUsage};
+use gglib_core::domain::LaunchNarration;
 
 /// Number of recent request snapshots included in each [`DashboardSnapshot`].
 const RECENT_REQUEST_LIMIT: usize = 20;
@@ -214,6 +215,49 @@ impl CacheStatusCache {
     }
 }
 
+/// Latest launch narration, written by the request path as models resolve
+/// and read by the dashboard publisher.
+///
+/// Mirrors [`CacheStatusCache`] exactly, and for the same reason: the launch
+/// decisions and their provenance exist only at spawn, inside the runtime,
+/// while the dashboard that displays them lives here. The resolved target is
+/// where the two meet.
+///
+/// `None` until the first request resolves a model — before that, there is no
+/// launch to narrate.
+#[derive(Debug, Default)]
+pub struct LaunchNarrationCache {
+    latest: std::sync::Mutex<Option<LaunchNarration>>,
+}
+
+impl LaunchNarrationCache {
+    /// Create an empty cache ("nothing launched yet").
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The most recently observed launch narration.
+    #[must_use]
+    pub fn get(&self) -> Option<LaunchNarration> {
+        self.latest
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Record the narration of a freshly resolved target.
+    ///
+    /// Skips the write when nothing changed, so the steady state — every
+    /// request resolving the same model — never contends with the publisher.
+    pub fn set(&self, narration: LaunchNarration) {
+        let mut guard = self.latest.lock().unwrap_or_else(|e| e.into_inner());
+        if guard.as_ref() != Some(&narration) {
+            *guard = Some(narration);
+        }
+    }
+}
+
 /// Cadence at which a fresh snapshot is recomputed and pushed to SSE
 /// subscribers of `GET /v1/proxy/status/stream`.
 const PUBLISH_INTERVAL: Duration = Duration::from_secs(1);
@@ -269,6 +313,11 @@ pub struct DashboardSnapshot {
     /// proxy's cache configuration and must surface even before a proxied
     /// request has resolved a model.
     pub agent_usage: CacheUsage,
+    /// What the running model's launch decided, and why — the same record the
+    /// CLI banner prints at startup (see
+    /// [`gglib_core::domain::LaunchNarration`]). `None` until a request has
+    /// resolved a model, since nothing has been launched to explain.
+    pub launch: Option<LaunchNarration>,
 }
 
 impl DashboardSnapshot {
@@ -285,6 +334,7 @@ impl DashboardSnapshot {
         cache: &CacheStatusCache,
         cache_metrics: &CacheMetricsStore,
         agent_metrics: &CacheMetricsStore,
+        launch: &LaunchNarrationCache,
     ) -> Self {
         let (slots_available, slots_vec, slots_status) = match slots.get() {
             SlotsPollResult::Available(snapshots) => (true, snapshots, None),
@@ -309,6 +359,7 @@ impl DashboardSnapshot {
                 .get()
                 .map(|status| status.with_usage(cache_metrics.snapshot())),
             agent_usage: agent_metrics.snapshot(),
+            launch: launch.get(),
         }
     }
 }
@@ -340,6 +391,10 @@ pub struct DashboardState {
     /// Owned by the supervisor and passed in, so it outlives a single proxy
     /// run and can be shared with the embedded axum server.
     pub agent_metrics: Arc<CacheMetricsStore>,
+    /// Latest launch narration, populated by the request path as models
+    /// resolve. Created here rather than passed in: unlike
+    /// [`Self::cache_metrics`], nothing outside the proxy writes to it.
+    pub launch: Arc<LaunchNarrationCache>,
 }
 
 impl DashboardState {
@@ -365,6 +420,7 @@ impl DashboardState {
             cache,
             cache_metrics,
             agent_metrics,
+            launch: Arc::new(LaunchNarrationCache::new()),
         }
     }
 
@@ -380,6 +436,7 @@ impl DashboardState {
             &self.cache,
             &self.cache_metrics,
             &self.agent_metrics,
+            &self.launch,
         )
     }
 }
@@ -450,6 +507,7 @@ mod tests {
             &CacheStatusCache::new(),
             &CacheMetricsStore::new(),
             &CacheMetricsStore::new(),
+            &LaunchNarrationCache::new(),
         );
 
         assert!(snapshot.active_connections.is_empty());
@@ -484,6 +542,7 @@ mod tests {
             &CacheStatusCache::new(),
             &CacheMetricsStore::new(),
             &CacheMetricsStore::new(),
+            &LaunchNarrationCache::new(),
         );
 
         assert_eq!(snapshot.active_connections.len(), 1);
@@ -508,6 +567,7 @@ mod tests {
             &CacheStatusCache::new(),
             &CacheMetricsStore::new(),
             &CacheMetricsStore::new(),
+            &LaunchNarrationCache::new(),
         );
 
         assert!(snapshot.slots_available);
@@ -539,6 +599,7 @@ mod tests {
                 &CacheStatusCache::new(),
                 &CacheMetricsStore::new(),
                 &CacheMetricsStore::new(),
+                &LaunchNarrationCache::new(),
             );
 
             serde_json::to_string(&snapshot).expect("DashboardSnapshot must always serialize");
@@ -676,6 +737,58 @@ mod tests {
         assert_eq!(cache.get(), Some(low));
     }
 
+    #[test]
+    fn launch_cache_starts_empty_and_records_the_latest_narration() {
+        use gglib_core::domain::{LaunchDecision, LaunchNarration};
+
+        let cache = LaunchNarrationCache::new();
+        assert_eq!(cache.get(), None, "nothing launched yet");
+
+        let mut first = LaunchNarration::new("qwen3", Some("Q4_K_M".to_string()), 1_073_741_824);
+        first.push(LaunchDecision::new("ctx", "32768", "model server_defaults"));
+        cache.set(first.clone());
+        assert_eq!(cache.get(), Some(first));
+
+        // A model swap replaces the narration rather than accumulating.
+        let second = LaunchNarration::new("llama3", None, 0);
+        cache.set(second.clone());
+        assert_eq!(cache.get(), Some(second));
+    }
+
+    /// Tier 1 parity: what the banner prints must also be reachable over
+    /// `GET /v1/proxy/status`, which is this snapshot.
+    #[test]
+    fn snapshot_surfaces_the_recorded_launch_narration() {
+        use gglib_core::domain::{LaunchDecision, LaunchNarration};
+
+        let connections = ActiveConnectionsRegistry::new();
+        let slots = SlotsCache::new();
+        let metrics = ContextMetricsStore::new();
+        let upstream_health = UpstreamHealth::new();
+        let launch = LaunchNarrationCache::new();
+
+        let build = |launch: &LaunchNarrationCache| {
+            DashboardSnapshot::build(
+                &connections,
+                &slots,
+                &metrics,
+                &upstream_health,
+                &CacheStatusCache::new(),
+                &CacheMetricsStore::new(),
+                &CacheMetricsStore::new(),
+                launch,
+            )
+        };
+
+        assert_eq!(build(&launch).launch, None, "nothing launched yet");
+
+        let mut narration = LaunchNarration::new("qwen3", Some("Q4_K_M".to_string()), 0);
+        narration.push(LaunchDecision::new("kv", "q8_0", "default"));
+        launch.set(narration.clone());
+
+        assert_eq!(build(&launch).launch, Some(narration));
+    }
+
     /// The snapshot must expose whatever the cache holds, so the request path
     /// and the publisher agree without further plumbing.
     #[test]
@@ -695,6 +808,7 @@ mod tests {
             &cache,
             &cache_metrics,
             &CacheMetricsStore::new(),
+            &LaunchNarrationCache::new(),
         );
         assert_eq!(before.cache, None);
 
@@ -711,6 +825,7 @@ mod tests {
             &cache,
             &cache_metrics,
             &CacheMetricsStore::new(),
+            &LaunchNarrationCache::new(),
         );
         let status = after.cache.expect("cache status present after set");
         assert!(status.needs_attention);
@@ -745,6 +860,7 @@ mod tests {
                 &cache,
                 cm,
                 &CacheMetricsStore::new(),
+                &LaunchNarrationCache::new(),
             )
             .cache
             .expect("cache status present")
@@ -794,6 +910,7 @@ mod tests {
             &cache,
             &proxied,
             &agent,
+            &LaunchNarrationCache::new(),
         );
 
         assert_eq!(snap.agent_usage.reporting_requests, 1);

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -856,6 +856,12 @@ async fn chat_completions(
         target.cache_ram_health,
     ));
 
+    // Same rationale, same meeting point: the launch decided all of this in
+    // the runtime, and this is where the dashboard first sees the result.
+    if let Some(narration) = target.narration.clone() {
+        state.dashboard.launch.set(narration);
+    }
+
     // Register this request in the active-connections dashboard registry.
     // The returned guard unregisters on drop (see `connections` module docs)
     // — normal completion, early return, client disconnect, or panic all

--- a/crates/gglib-runtime/src/launch_narration.rs
+++ b/crates/gglib-runtime/src/launch_narration.rs
@@ -1,0 +1,564 @@
+//! Assembling a [`LaunchNarration`] from the resolutions a launch performed.
+//!
+//! Every value here arrives from a resolver that already ran — this module
+//! chooses wording and ordering, and computes nothing. The one rule worth
+//! stating: if a decision is not gglib's to make, it does not get a line.
+//! The GPU layer split is the notable case (gglib never emits `-ngl`, so the
+//! offload is llama.cpp's own choice); [`backend`] reports only which
+//! acceleration the installed llama build was compiled for, which gglib does
+//! determine.
+//!
+//! Ordering is fixed here rather than at each display surface so the CLI
+//! banner, `GET /v1/proxy/status`, and the GUI dashboard cannot disagree
+//! about what a launch decided.
+
+use gglib_core::cache_config::KvCacheType;
+use gglib_core::domain::{
+    LaunchDecision, LaunchNarration, estimate_kv_bytes_for_context, format_gib, format_mib_as_gib,
+    kv_bytes_per_token,
+};
+use gglib_core::normalize::tags::FORMAT_QWEN_XML;
+use gglib_core::ports::ModelLaunchSpec;
+use gglib_core::server_config::ContextSizeSource;
+
+use crate::llama::args::{
+    CacheRamResolution, CacheRamSource, JinjaResolutionSource, KvCacheTypeResolution,
+    KvCacheTypeSource, MtpResolutionSource, ReasoningFormatSource, SlotRestoreResolution,
+};
+use crate::server_config::ResolvedCapabilities;
+
+/// Everything one launch decided, gathered at the spawn site.
+///
+/// A parameter object rather than a twelve-argument function: the spawn site
+/// holds each of these in a local already, and a positional list of that
+/// length is a standing invitation to transpose two of them.
+pub struct NarrationInputs<'a> {
+    /// The model being launched.
+    pub spec: &'a ModelLaunchSpec,
+    /// Resolved context size and the rung of the chain that supplied it.
+    pub context: (u64, ContextSizeSource),
+    /// Resolved K/V cache quantization.
+    pub kv_types: KvCacheTypeResolution,
+    /// Resolved host-RAM prompt cache budget.
+    pub cache_ram: &'a CacheRamResolution,
+    /// Whether the disk slot layer is enabled on this proxy at all.
+    pub disk_cache_enabled: bool,
+    /// Whether the disk slot layer can actually resume this model.
+    pub slot_restore: SlotRestoreResolution,
+    /// The capability flags `build_server_config` resolved.
+    pub capabilities: &'a ResolvedCapabilities,
+}
+
+/// Build the narration for one launch.
+#[must_use]
+pub fn narrate(inputs: &NarrationInputs<'_>) -> LaunchNarration {
+    let mut n = LaunchNarration::new(
+        inputs.spec.name.clone(),
+        inputs.spec.quantization.clone(),
+        inputs.spec.file_size_bytes,
+    );
+
+    let (ctx, ctx_source) = inputs.context;
+    n.push(LaunchDecision::new(
+        "ctx",
+        ctx.to_string(),
+        ctx_source.label(),
+    ));
+
+    if let Some(backend) = backend() {
+        n.push(LaunchDecision::new("backend", backend, "llama build"));
+    }
+
+    n.push(kv_decision(inputs, ctx));
+    n.push(cache_decision(inputs));
+
+    if let Some(mtp) = mtp_decision(inputs) {
+        n.push(mtp);
+    }
+    if let Some(flags) = flags_decision(inputs) {
+        n.push(flags);
+    }
+    n.push(dialect_decision(inputs));
+
+    n
+}
+
+/// Which acceleration the installed llama.cpp build was compiled for.
+///
+/// Read from the build config written at install time. `None` when llama.cpp
+/// was never installed through gglib or the file is unreadable — a missing
+/// backend line is the honest outcome there, since gglib genuinely does not
+/// know what the binary on `PATH` was built with.
+fn backend() -> Option<String> {
+    let path = gglib_core::paths::llama_config_path().ok()?;
+    let config = crate::llama::BuildConfig::load(&path).ok()?;
+    Some(config.acceleration)
+}
+
+/// The KV line, including what quantization actually bought.
+///
+/// The `f16 would be N` comparison is the point: `q8_0` alone means nothing
+/// to a user, while "2.1 GB, and f16 would be 4.2" is the reason the default
+/// exists. Omitted when the model's metadata didn't yield a per-token
+/// estimate, rather than shown against a fabricated one.
+fn kv_decision(inputs: &NarrationInputs<'_>, ctx: u64) -> LaunchDecision {
+    let kv = inputs.kv_types;
+    let types = if kv.k == kv.v {
+        kv.k.as_llama_arg().to_string()
+    } else {
+        format!("k={} v={}", kv.k.as_llama_arg(), kv.v.as_llama_arg())
+    };
+
+    let source = match kv.source {
+        KvCacheTypeSource::Default => "default",
+        KvCacheTypeSource::Explicit => "explicit override",
+        KvCacheTypeSource::DisabledByEnv => "GGLIB_DISABLE_KV_QUANT",
+    };
+
+    let Some(elems) = inputs.spec.kv_elems_per_token else {
+        return LaunchDecision::new("kv", types, source);
+    };
+
+    let actual = estimate_kv_bytes_for_context(kv_bytes_per_token(elems, kv.k, kv.v), ctx);
+    let value = if kv.k == KvCacheType::F16 && kv.v == KvCacheType::F16 {
+        format!("{types} -> {}", format_gib(actual))
+    } else {
+        let f16 = estimate_kv_bytes_for_context(
+            kv_bytes_per_token(elems, KvCacheType::F16, KvCacheType::F16),
+            ctx,
+        );
+        // Comma rather than parentheses: the renderer appends the provenance
+        // in parens, and nesting a second pair inside it reads as a typo.
+        format!(
+            "{types} -> {}, f16 would be {}",
+            format_gib(actual),
+            format_gib(f16)
+        )
+    };
+    LaunchDecision::new("kv", value, source)
+}
+
+/// The prompt-cache line: RAM budget plus whether the disk slot layer is live.
+///
+/// Both tiers on one line because they are one user-facing question — "will
+/// switching conversations be fast" — answered by two independent mechanisms.
+fn cache_decision(inputs: &NarrationInputs<'_>) -> LaunchDecision {
+    let res = inputs.cache_ram;
+    let (ram, source) = match (res.cache_ram_mb, res.source) {
+        (Some(0), CacheRamSource::Explicit) => ("RAM cache off".to_string(), "explicit"),
+        (Some(0), _) => (
+            "RAM cache off".to_string(),
+            "auto: no room after weights + KV",
+        ),
+        (Some(mb), CacheRamSource::Explicit) => {
+            (format!("{} RAM", format_mib_as_gib(mb)), "explicit")
+        }
+        (Some(mb), _) => (
+            format!(
+                "{} RAM of {} free",
+                format_mib_as_gib(mb),
+                format_gib(res.total_ram_bytes)
+            ),
+            "auto-sized",
+        ),
+        (None, _) => (
+            "llama.cpp default".to_string(),
+            "GGLIB_DISABLE_CACHE_AUTOSIZE",
+        ),
+    };
+
+    let disk = match (inputs.disk_cache_enabled, inputs.slot_restore.enabled) {
+        (false, _) => "disk slots off",
+        (true, true) => "disk slots on",
+        // Enabled but useless for this model — stated rather than silently
+        // dropped, since the user turned it on and would otherwise assume it
+        // was working.
+        (true, false) => "disk slots n/a for this model",
+    };
+
+    LaunchDecision::new("cache", format!("{ram} \u{b7} {disk}"), source)
+}
+
+/// The speculative-decoding line, present only when MTP is actually on.
+fn mtp_decision(inputs: &NarrationInputs<'_>) -> Option<LaunchDecision> {
+    let mtp = &inputs.capabilities.mtp;
+    if !mtp.enabled {
+        return None;
+    }
+    let source = match mtp.source {
+        MtpResolutionSource::Explicit => "explicit",
+        MtpResolutionSource::MtpTag => "mtp tag",
+        MtpResolutionSource::Default => "default",
+    };
+    Some(LaunchDecision::new(
+        "mtp",
+        format!("on, {} draft tokens", mtp.draft_n_max),
+        source,
+    ))
+}
+
+/// The llama-server flags gglib chose on the user's behalf.
+///
+/// Each flag carries its own provenance inline, so the line reads
+/// `--jinja (agent tag) · --reasoning-format deepseek (reasoning tag)`.
+/// `None` when gglib added no flags of its own — an empty `flags` line would
+/// imply a decision that was never taken.
+fn flags_decision(inputs: &NarrationInputs<'_>) -> Option<LaunchDecision> {
+    let caps = inputs.capabilities;
+    let mut parts: Vec<String> = Vec::new();
+
+    if caps.jinja.enabled {
+        let why = match caps.jinja.source {
+            JinjaResolutionSource::AgentTag => "agent tag",
+            JinjaResolutionSource::ExplicitTrue => "explicit",
+            // Not reachable while `enabled` is true, but matched exhaustively
+            // so a new source cannot silently render as the wrong reason.
+            JinjaResolutionSource::ExplicitFalse | JinjaResolutionSource::Default => "default",
+        };
+        parts.push(format!("--jinja ({why})"));
+    }
+
+    if let Some(format) = &caps.reasoning.format {
+        let why = match caps.reasoning.source {
+            ReasoningFormatSource::ReasoningTag => "reasoning tag",
+            ReasoningFormatSource::MetadataDetection => "gguf metadata",
+            ReasoningFormatSource::Explicit => "explicit",
+            ReasoningFormatSource::Default => "default",
+        };
+        parts.push(format!("--reasoning-format {format} ({why})"));
+    }
+
+    (!parts.is_empty()).then(|| LaunchDecision::bare("flags", parts.join(" \u{b7} ")))
+}
+
+/// Which tool-call dialect the proxy will normalize on the way out.
+///
+/// Always present, including the pass-through case: "this model's tool calls
+/// arrive as OpenAI JSON already" is exactly as informative as naming a
+/// parser, and its absence would read as a missing feature.
+fn dialect_decision(inputs: &NarrationInputs<'_>) -> LaunchDecision {
+    if inputs
+        .spec
+        .tags
+        .iter()
+        .any(|t| t.as_str() == FORMAT_QWEN_XML)
+    {
+        LaunchDecision::new(
+            "dialect",
+            "qwen-xml -> OpenAI tool_calls",
+            format!("{FORMAT_QWEN_XML} tag"),
+        )
+    } else {
+        LaunchDecision::new("dialect", "OpenAI tool_calls", "pass-through")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gglib_core::domain::KvElemsPerToken;
+    use std::path::PathBuf;
+
+    use crate::llama::args::{
+        JinjaResolution, MtpResolution, ReasoningFormatResolution, SlotRestoreSource,
+    };
+
+    fn spec(tags: &[&str]) -> ModelLaunchSpec {
+        ModelLaunchSpec {
+            id: 7,
+            name: "qwen3-30b-a3b".to_string(),
+            file_path: PathBuf::from("/models/q.gguf"),
+            tags: tags.iter().map(|t| (*t).to_string()).collect(),
+            architecture: None,
+            quantization: Some("Q4_K_M".to_string()),
+            context_length: None,
+            server_defaults: None,
+            file_size_bytes: 18_476_297_420,
+            kv_elems_per_token: Some(KvElemsPerToken { k: 8192, v: 8192 }),
+            kv_memory_is_partial: false,
+        }
+    }
+
+    fn caps() -> ResolvedCapabilities {
+        ResolvedCapabilities {
+            jinja: JinjaResolution {
+                enabled: false,
+                source: JinjaResolutionSource::Default,
+            },
+            reasoning: ReasoningFormatResolution {
+                format: None,
+                source: ReasoningFormatSource::Default,
+            },
+            mtp: MtpResolution {
+                enabled: false,
+                draft_n_max: 0,
+                draft_p_min: 0.0,
+                source: MtpResolutionSource::Default,
+            },
+        }
+    }
+
+    fn cache_ram(mb: Option<u64>, source: CacheRamSource) -> CacheRamResolution {
+        CacheRamResolution {
+            cache_ram_mb: mb,
+            source,
+            total_ram_bytes: 33_285_996_544,
+            model_bytes: 18_476_297_420,
+            kv_bytes: 0,
+            kv_estimated: true,
+            context_size: 32_768,
+        }
+    }
+
+    fn inputs<'a>(
+        spec: &'a ModelLaunchSpec,
+        caps: &'a ResolvedCapabilities,
+        ram: &'a CacheRamResolution,
+    ) -> NarrationInputs<'a> {
+        NarrationInputs {
+            spec,
+            context: (32_768, ContextSizeSource::ModelServerDefaults),
+            kv_types: KvCacheTypeResolution {
+                k: KvCacheType::Q8_0,
+                v: KvCacheType::Q8_0,
+                source: KvCacheTypeSource::Default,
+            },
+            cache_ram: ram,
+            disk_cache_enabled: true,
+            slot_restore: SlotRestoreResolution {
+                enabled: true,
+                source: SlotRestoreSource::Supported,
+            },
+            capabilities: caps,
+        }
+    }
+
+    #[test]
+    fn context_line_names_the_rung_that_won() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let n = narrate(&inputs(&s, &c, &r));
+        let ctx = n.decision("ctx").unwrap();
+        assert_eq!(ctx.value, "32768");
+        assert_eq!(ctx.source.as_deref(), Some("model server_defaults"));
+    }
+
+    /// The f16 comparison is what makes the KV default legible — without it
+    /// the line is a magic string.
+    #[test]
+    fn kv_line_shows_what_quantization_saved() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let n = narrate(&inputs(&s, &c, &r));
+        let kv = n.decision("kv").unwrap();
+        assert!(kv.value.starts_with("q8_0 -> "), "got {}", kv.value);
+        assert!(kv.value.contains("f16 would be"), "got {}", kv.value);
+        assert_eq!(kv.source.as_deref(), Some("default"));
+    }
+
+    /// An f16 launch has nothing to compare against — it *is* the baseline.
+    #[test]
+    fn kv_line_omits_the_comparison_when_already_f16() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let mut i = inputs(&s, &c, &r);
+        i.kv_types = KvCacheTypeResolution {
+            k: KvCacheType::F16,
+            v: KvCacheType::F16,
+            source: KvCacheTypeSource::DisabledByEnv,
+        };
+        let n = narrate(&i);
+        let kv = n.decision("kv").unwrap();
+        assert!(!kv.value.contains("f16 would be"), "got {}", kv.value);
+        assert_eq!(kv.source.as_deref(), Some("GGLIB_DISABLE_KV_QUANT"));
+    }
+
+    /// Without a per-token estimate there is no honest byte figure to show.
+    #[test]
+    fn kv_line_degrades_to_the_bare_types_without_an_estimate() {
+        let mut s = spec(&[]);
+        s.kv_elems_per_token = None;
+        let (c, r) = (caps(), cache_ram(Some(6144), CacheRamSource::Auto));
+        let n = narrate(&inputs(&s, &c, &r));
+        assert_eq!(n.decision("kv").unwrap().value, "q8_0");
+    }
+
+    #[test]
+    fn cache_line_reports_the_auto_budget_against_free_ram() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let n = narrate(&inputs(&s, &c, &r));
+        let cache = n.decision("cache").unwrap();
+        assert_eq!(
+            cache.value,
+            "6.0 GB RAM of 31.0 GB free \u{b7} disk slots on"
+        );
+        assert_eq!(cache.source.as_deref(), Some("auto-sized"));
+    }
+
+    /// A zero budget the machine forced reads differently from one the user
+    /// chose — the whole reason `CacheRamSource` is carried this far.
+    #[test]
+    fn cache_line_distinguishes_a_forced_zero_from_a_chosen_one() {
+        let s = spec(&[]);
+        let c = caps();
+        let forced = cache_ram(Some(0), CacheRamSource::Auto);
+        let chosen = cache_ram(Some(0), CacheRamSource::Explicit);
+        assert_eq!(
+            narrate(&inputs(&s, &c, &forced))
+                .decision("cache")
+                .unwrap()
+                .source
+                .as_deref(),
+            Some("auto: no room after weights + KV")
+        );
+        assert_eq!(
+            narrate(&inputs(&s, &c, &chosen))
+                .decision("cache")
+                .unwrap()
+                .source
+                .as_deref(),
+            Some("explicit")
+        );
+    }
+
+    /// Enabling the disk layer for a model that cannot use it is precisely
+    /// the case a user would otherwise misread as working.
+    #[test]
+    fn cache_line_flags_a_disk_layer_the_model_cannot_use() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let mut i = inputs(&s, &c, &r);
+        i.slot_restore = SlotRestoreResolution {
+            enabled: false,
+            source: SlotRestoreSource::UnsupportedPartialKv,
+        };
+        let n = narrate(&i);
+        assert!(
+            n.decision("cache")
+                .unwrap()
+                .value
+                .contains("disk slots n/a for this model")
+        );
+    }
+
+    #[test]
+    fn mtp_line_appears_only_when_enabled() {
+        let (s, r) = (spec(&[]), cache_ram(Some(6144), CacheRamSource::Auto));
+        let off = caps();
+        assert!(narrate(&inputs(&s, &off, &r)).decision("mtp").is_none());
+
+        let mut on = caps();
+        on.mtp = MtpResolution {
+            enabled: true,
+            draft_n_max: 2,
+            draft_p_min: 0.75,
+            source: MtpResolutionSource::MtpTag,
+        };
+        let n = narrate(&inputs(&s, &on, &r));
+        let mtp = n.decision("mtp").unwrap();
+        assert_eq!(mtp.value, "on, 2 draft tokens");
+        assert_eq!(mtp.source.as_deref(), Some("mtp tag"));
+    }
+
+    #[test]
+    fn flags_line_carries_per_flag_provenance() {
+        let (s, r) = (spec(&[]), cache_ram(Some(6144), CacheRamSource::Auto));
+        let mut c = caps();
+        c.jinja = JinjaResolution {
+            enabled: true,
+            source: JinjaResolutionSource::AgentTag,
+        };
+        c.reasoning = ReasoningFormatResolution {
+            format: Some("deepseek".to_string()),
+            source: ReasoningFormatSource::ReasoningTag,
+        };
+        let n = narrate(&inputs(&s, &c, &r));
+        assert_eq!(
+            n.decision("flags").unwrap().value,
+            "--jinja (agent tag) \u{b7} --reasoning-format deepseek (reasoning tag)"
+        );
+    }
+
+    /// No flags means no line — an empty one would imply a decision gglib
+    /// never took.
+    #[test]
+    fn flags_line_is_absent_when_gglib_added_no_flags() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        assert!(narrate(&inputs(&s, &c, &r)).decision("flags").is_none());
+    }
+
+    #[test]
+    fn dialect_line_names_the_parser_for_a_tagged_model() {
+        let (s, c, r) = (
+            spec(&[FORMAT_QWEN_XML]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let n = narrate(&inputs(&s, &c, &r));
+        let d = n.decision("dialect").unwrap();
+        assert_eq!(d.value, "qwen-xml -> OpenAI tool_calls");
+    }
+
+    /// Pass-through is still a decision worth stating.
+    #[test]
+    fn dialect_line_states_pass_through_for_an_untagged_model() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let n = narrate(&inputs(&s, &c, &r));
+        assert_eq!(n.decision("dialect").unwrap().value, "OpenAI tool_calls");
+    }
+
+    /// The mission caps the banner at ~12 lines; the decision list is what
+    /// drives that, so it is asserted here rather than in the renderer.
+    #[test]
+    fn narration_stays_within_the_banner_budget() {
+        let (s, r) = (
+            spec(&[FORMAT_QWEN_XML]),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        let mut c = caps();
+        c.jinja = JinjaResolution {
+            enabled: true,
+            source: JinjaResolutionSource::AgentTag,
+        };
+        c.reasoning = ReasoningFormatResolution {
+            format: Some("deepseek".to_string()),
+            source: ReasoningFormatSource::ReasoningTag,
+        };
+        c.mtp = MtpResolution {
+            enabled: true,
+            draft_n_max: 2,
+            draft_p_min: 0.75,
+            source: MtpResolutionSource::MtpTag,
+        };
+        let n = narrate(&inputs(&s, &c, &r));
+        assert!(
+            n.decisions.len() <= 8,
+            "{} decisions would overflow the banner",
+            n.decisions.len()
+        );
+    }
+}

--- a/crates/gglib-runtime/src/lib.rs
+++ b/crates/gglib-runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compose;
 pub mod council_runner;
 mod health;
 pub mod health_monitor;
+pub mod launch_narration;
 pub mod llama;
 pub mod pidfile;
 pub mod ports_impl;

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -27,6 +27,10 @@ mod validate;
 
 // Error types
 pub use error::{LlamaError, LlamaResult};
+
+// The installed build's recorded configuration. Exposed so a launch can name
+// which acceleration the binary it is about to spawn was compiled for.
+pub use config::BuildConfig;
 pub use server_availability::{LlamaServerError, LlamaServerResult, resolve_llama_server};
 
 // Progress and prompt traits

--- a/crates/gglib-runtime/src/ports_impl/model_catalog.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_catalog.rs
@@ -64,6 +64,7 @@ fn model_to_launch_spec(m: Model) -> ModelLaunchSpec {
         file_path: m.file_path,
         tags: m.tags,
         architecture: m.architecture,
+        quantization: m.quantization,
         context_length: m.context_length,
         server_defaults: m.server_defaults,
         file_size_bytes,

--- a/crates/gglib-runtime/src/process/swap_state.rs
+++ b/crates/gglib-runtime/src/process/swap_state.rs
@@ -24,20 +24,23 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use gglib_core::domain::{CacheRamHealth, classify_cache_ram};
+use gglib_core::domain::{CacheRamHealth, LaunchNarration, classify_cache_ram};
 use gglib_core::paths::slot_model_prefix;
 use gglib_core::ports::{
     CatalogError, LaunchOverrides, ModelCatalogPort, ModelRuntimeError, RunningTarget,
 };
-use gglib_core::server_config::{CacheRamSetting, ServerConfigOptions, resolve_context_size};
+use gglib_core::server_config::{
+    CacheRamSetting, ContextSizeSource, ServerConfigOptions, resolve_context_size_with_source,
+};
 use std::path::PathBuf;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 use super::core::GuiProcessCore;
 use super::health::{check_http_health, wait_for_http_health};
+use crate::launch_narration::NarrationInputs;
 use crate::process::startup_guard::StartupState;
-use crate::server_config::build_server_config;
+use crate::server_config::build_server_config_narrated;
 
 /// Currently running model state for the swap strategy.
 #[derive(Debug, Clone)]
@@ -62,6 +65,11 @@ pub struct CurrentModelState {
     /// same reason: the budget arithmetic only happens at spawn, so a later
     /// `current_model()` call has no way to recompute it.
     pub cache_ram_health: CacheRamHealth,
+    /// What this instance's launch decided (see
+    /// [`gglib_core::domain::LaunchNarration`]). Cached so the
+    /// already-running fast path can report the same explanation as the
+    /// spawn that produced it, rather than nothing.
+    pub narration: Option<LaunchNarration>,
 }
 
 /// Everything the single-model-at-a-time strategy owns.
@@ -110,13 +118,13 @@ fn resolve_launch_opts(
     num_ctx: Option<u64>,
     default_ctx: u64,
     model_server_ctx: Option<usize>,
-) -> (ServerConfigOptions, u64) {
+) -> (ServerConfigOptions, u64, ContextSizeSource) {
     let mut opts = template.overlay(per_call);
     opts.context_size = num_ctx.or(opts.context_size);
     opts.model_server_ctx = model_server_ctx;
     opts.global_default_ctx = Some(default_ctx);
-    let resolved_ctx = resolve_context_size(&opts);
-    (opts, resolved_ctx)
+    let (resolved_ctx, ctx_source) = resolve_context_size_with_source(&opts);
+    (opts, resolved_ctx, ctx_source)
 }
 
 impl SwapState {
@@ -230,7 +238,7 @@ impl SwapState {
             // configured, everything upstream of the actual `-c` flag
             // — the reuse decision, `/v1/models`, and the proxy's
             // prompt-truncation budget — silently reported the wrong number.
-            let (mut opts, resolved_ctx) = resolve_launch_opts(
+            let (mut opts, resolved_ctx, ctx_source) = resolve_launch_opts(
                 &template,
                 &per_call,
                 num_ctx,
@@ -245,11 +253,18 @@ impl SwapState {
             let cached = {
                 let guard = current.read().await;
                 guard.as_ref().and_then(|c| {
-                    (c.model_id == launch_spec.id && c.context_size == resolved_ctx)
-                        .then(|| (c.port, c.model_id, c.model_name.clone(), c.context_size))
+                    (c.model_id == launch_spec.id && c.context_size == resolved_ctx).then(|| {
+                        (
+                            c.port,
+                            c.model_id,
+                            c.model_name.clone(),
+                            c.context_size,
+                            c.narration.clone(),
+                        )
+                    })
                 })
             };
-            if let Some((port, model_id, cached_name, context_size)) = cached {
+            if let Some((port, model_id, cached_name, context_size, cached_narration)) = cached {
                 if check_http_health(port).await {
                     info!(
                         model_id = %model_id,
@@ -258,7 +273,7 @@ impl SwapState {
                         context = %context_size,
                         "Model already running with correct context"
                     );
-                    return Ok(RunningTarget::local(
+                    let mut target = RunningTarget::local(
                         port,
                         model_id,
                         cached_name,
@@ -270,7 +285,15 @@ impl SwapState {
                     .with_slot_restore_supported(
                         crate::llama::args::resolve_slot_restore(launch_spec.kv_memory_is_partial)
                             .enabled,
-                    ));
+                    );
+                    // Reused verbatim rather than re-narrated: this instance
+                    // was launched with whatever the stored narration says,
+                    // and re-resolving now against current settings would
+                    // describe a launch that never happened.
+                    if let Some(narration) = cached_narration {
+                        target = target.with_narration(narration);
+                    }
+                    return Ok(target);
                 }
                 warn!(
                     model_id = %model_id,
@@ -360,7 +383,7 @@ impl SwapState {
 
             let slot_save_path = opts.slot_save_path.clone();
 
-            let config = build_server_config(
+            let (config, capabilities) = build_server_config_narrated(
                 i64::from(launch_spec.id),
                 launch_spec.name.clone(),
                 model_path.to_path_buf(),
@@ -368,6 +391,22 @@ impl SwapState {
                 &launch_spec.tags,
                 opts,
             );
+
+            // Every decision above is now resolved, so this is the last point
+            // at which they all coexist — the narration is assembled here and
+            // then carried, never re-derived. Printed before the spawn rather
+            // than after the health check so a launch that hangs still tells
+            // the user what it was trying to do.
+            let narration = crate::launch_narration::narrate(&NarrationInputs {
+                spec: &launch_spec,
+                context: (resolved_ctx, ctx_source),
+                kv_types,
+                cache_ram: &cache_ram,
+                disk_cache_enabled: slot_save_path.is_some(),
+                slot_restore,
+                capabilities: &capabilities,
+            });
+            crate::proxy::banner::print_launch_narration(&narration);
 
             // Purge stale slot .bin files before spawning a fresh instance:
             // old slot files are incompatible with the new server process.
@@ -402,6 +441,7 @@ impl SwapState {
                     model_path: launch_spec.file_path.clone(),
                     slot_restore_supported: slot_restore.enabled,
                     cache_ram_health,
+                    narration: Some(narration.clone()),
                 });
             }
 
@@ -421,7 +461,8 @@ impl SwapState {
                 true, // fresh spawn — cache slots are stale
             )
             .with_slot_restore_supported(slot_restore.enabled)
-            .with_cache_ram_health(cache_ram_health))
+            .with_cache_ram_health(cache_ram_health)
+            .with_narration(narration))
         }
     }
 }
@@ -564,7 +605,7 @@ mod tests {
     /// launched llama-server with.
     #[test]
     fn resolve_launch_opts_applies_the_per_model_context_when_nothing_more_specific_is_set() {
-        let (opts, resolved_ctx) = resolve_launch_opts(
+        let (opts, resolved_ctx, _) = resolve_launch_opts(
             &ServerConfigOptions::default(),
             &ServerConfigOptions::default(),
             None,          // no per-request override
@@ -584,7 +625,7 @@ mod tests {
     /// refactor, only how many times it runs and who reads the result.
     #[test]
     fn resolve_launch_opts_explicit_num_ctx_beats_the_per_model_tier() {
-        let (_, resolved_ctx) = resolve_launch_opts(
+        let (_, resolved_ctx, _) = resolve_launch_opts(
             &ServerConfigOptions::default(),
             &ServerConfigOptions::default(),
             Some(8_192),
@@ -598,7 +639,7 @@ mod tests {
     /// With nothing else set, the global default is what's left.
     #[test]
     fn resolve_launch_opts_falls_back_to_the_global_default() {
-        let (_, resolved_ctx) = resolve_launch_opts(
+        let (_, resolved_ctx, _) = resolve_launch_opts(
             &ServerConfigOptions::default(),
             &ServerConfigOptions::default(),
             None,
@@ -619,7 +660,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (opts, resolved_ctx) = resolve_launch_opts(
+        let (opts, resolved_ctx, _) = resolve_launch_opts(
             &stale_template,
             &ServerConfigOptions::default(),
             None,

--- a/crates/gglib-runtime/src/proxy/banner.rs
+++ b/crates/gglib-runtime/src/proxy/banner.rs
@@ -6,10 +6,11 @@
 //! values rather than the runtime's own types, so the banner has no opinion
 //! on where its inputs come from and stays trivial to read top to bottom.
 
+use std::io::IsTerminal;
 use std::net::SocketAddr;
 use std::path::Path;
 
-use gglib_core::domain::InferenceConfig;
+use gglib_core::domain::{InferenceConfig, LaunchNarration};
 
 use super::params::PinnedModel;
 
@@ -124,9 +125,167 @@ pub(super) fn print_ready(addr: SocketAddr, pinned: Option<&PinnedModel>) {
     println!();
 }
 
+// =============================================================================
+// Launch narration
+// =============================================================================
+
+/// ANSI dim, for the provenance in parentheses.
+///
+/// Only the provenance is styled: the values are the content, and dimming the
+/// reasons is what lets the eye read the column of decisions first and the
+/// explanations second.
+const DIM: &str = "\u{1b}[2m";
+/// ANSI bold, for the model identity line.
+const BOLD: &str = "\u{1b}[1m";
+const RESET: &str = "\u{1b}[0m";
+
+/// Whether to emit ANSI styling on stdout.
+///
+/// Two independent reasons to decline, both of which must be honoured:
+/// `NO_COLOR` (any value, per the convention) is an explicit request, and a
+/// non-TTY stdout means the output is being piped or captured — a log file
+/// full of escape sequences helps nobody.
+fn use_color() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal()
+}
+
+/// Print what the runtime decided for a launch, and why.
+///
+/// The visible counterpart to [`crate::launch_narration::narrate`]: gglib
+/// auto-sizes the RAM cache, quantizes the KV cache, enables MTP, picks a
+/// dialect parser and resolves the context through a four-level chain, and
+/// before this existed it did all of that in silence.
+pub fn print_launch_narration(narration: &LaunchNarration) {
+    for line in render_launch_narration(narration, use_color()) {
+        println!("{line}");
+    }
+}
+
+/// The rendered lines, as data.
+///
+/// Split from the printing so the layout is testable without capturing
+/// stdout — the alignment and the provenance placement are the parts worth
+/// asserting on, and neither is observable through `println!`.
+fn render_launch_narration(narration: &LaunchNarration, color: bool) -> Vec<String> {
+    let (dim, bold, reset) = if color {
+        (DIM, BOLD, RESET)
+    } else {
+        ("", "", "")
+    };
+
+    let mut lines = vec![
+        String::new(),
+        format!("  {bold}{}{reset}", narration.headline()),
+    ];
+
+    // Pad labels to a common width so the values form a column. Computed from
+    // the labels actually present rather than a constant, since which
+    // decisions appear varies by launch.
+    let width = narration
+        .decisions
+        .iter()
+        .map(|d| d.label.len())
+        .max()
+        .unwrap_or(0);
+
+    for decision in &narration.decisions {
+        let label = format!("{:<width$}", decision.label, width = width);
+        let line = match &decision.source {
+            Some(source) => format!("    {label}  {}  {dim}({source}){reset}", decision.value),
+            None => format!("    {label}  {}", decision.value),
+        };
+        lines.push(line);
+    }
+
+    lines.push(String::new());
+    lines
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gglib_core::domain::LaunchDecision;
+
+    fn narration() -> LaunchNarration {
+        let mut n =
+            LaunchNarration::new("qwen3-30b-a3b", Some("Q4_K_M".to_string()), 18_476_297_420);
+        n.push(LaunchDecision::new("ctx", "32768", "model server_defaults"));
+        n.push(LaunchDecision::new(
+            "dialect",
+            "qwen-xml -> OpenAI tool_calls",
+            "format:qwen-xml tag",
+        ));
+        n
+    }
+
+    /// The provenance in parentheses is the feature; without it the banner is
+    /// just a config dump.
+    #[test]
+    fn every_sourced_decision_renders_its_provenance() {
+        let lines = render_launch_narration(&narration(), false);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("32768") && l.contains("(model server_defaults)"))
+        );
+        assert!(lines.iter().any(|l| l.contains("(format:qwen-xml tag)")));
+    }
+
+    #[test]
+    fn headline_leads_the_block() {
+        let lines = render_launch_narration(&narration(), false);
+        assert_eq!(
+            lines[1].trim(),
+            "qwen3-30b-a3b \u{b7} Q4_K_M \u{b7} 17.2 GB"
+        );
+    }
+
+    /// Labels pad to a shared width so the values line up as a column.
+    #[test]
+    fn labels_are_padded_to_a_common_column() {
+        let lines = render_launch_narration(&narration(), false);
+        let ctx = lines.iter().find(|l| l.contains("32768")).unwrap();
+        let dialect = lines.iter().find(|l| l.contains("qwen-xml")).unwrap();
+        let ctx_value = ctx.find("32768").unwrap();
+        let dialect_value = dialect.find("qwen-xml").unwrap();
+        assert_eq!(ctx_value, dialect_value);
+    }
+
+    /// Piped or captured output must carry no escape sequences at all.
+    #[test]
+    fn no_ansi_escapes_when_color_is_off() {
+        let lines = render_launch_narration(&narration(), false);
+        assert!(
+            lines.iter().all(|l| !l.contains('\u{1b}')),
+            "escape sequence leaked into uncoloured output"
+        );
+    }
+
+    #[test]
+    fn ansi_escapes_appear_only_when_color_is_on() {
+        let lines = render_launch_narration(&narration(), true);
+        assert!(lines.iter().any(|l| l.contains(DIM)));
+        assert!(lines.iter().any(|l| l.contains(BOLD)));
+    }
+
+    /// The mission's budget. Two blanks plus a headline plus the decisions.
+    #[test]
+    fn the_block_stays_under_twelve_lines() {
+        let mut n = narration();
+        for label in ["backend", "kv", "cache", "mtp", "flags"] {
+            n.push(LaunchDecision::new(label, "v", "s"));
+        }
+        let lines = render_launch_narration(&n, false);
+        assert!(lines.len() <= 12, "{} lines is over budget", lines.len());
+    }
+
+    /// A narration with no decisions must not panic on the width computation.
+    #[test]
+    fn renders_a_bare_headline_without_decisions() {
+        let n = LaunchNarration::new("solo", None, 0);
+        let lines = render_launch_narration(&n, false);
+        assert_eq!(lines[1].trim(), "solo");
+    }
 
     /// Not a snapshot test — `println!` output isn't worth pinning byte for
     /// byte — but `format_inference_override` is the one piece with real

--- a/crates/gglib-runtime/src/proxy/mod.rs
+++ b/crates/gglib-runtime/src/proxy/mod.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("README.md")]
-mod banner;
+// `pub(crate)` for the launch narration: the banner is the proxy's output
+// voice, but the launch it narrates happens in `process::swap_state`.
+pub(crate) mod banner;
 pub mod models;
 pub mod params;
 pub mod supervisor;

--- a/crates/gglib-runtime/src/server_config.rs
+++ b/crates/gglib-runtime/src/server_config.rs
@@ -47,8 +47,26 @@ pub use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
 use tracing::debug;
 
 use crate::llama::args::{
+    JinjaResolution, MtpResolution, ReasoningFormatResolution, ReasoningFormatSource,
     resolve_jinja_flag, resolve_kv_cache_types, resolve_mtp_args, resolve_reasoning_format,
 };
+
+/// The capability resolutions [`build_server_config`] performed, handed back
+/// so a caller can explain the launch it just configured.
+///
+/// These decisions are taken here and nowhere else (see the module docs), so
+/// this is the only place their `*Source` provenance exists. Returning it
+/// rather than re-resolving at the call site is deliberate: a second
+/// resolution that drifted would narrate a launch that never happened.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedCapabilities {
+    /// Whether `--jinja` was emitted, and why.
+    pub jinja: JinjaResolution,
+    /// The `--reasoning-format` decision, and why.
+    pub reasoning: ReasoningFormatResolution,
+    /// The MTP speculative-decoding decision, and why.
+    pub mtp: MtpResolution,
+}
 
 // =============================================================================
 // Builder
@@ -82,6 +100,22 @@ pub fn build_server_config(
     tags: &[String],
     opts: ServerConfigOptions,
 ) -> ServerConfig {
+    build_server_config_narrated(model_id, model_name, model_path, base_port, tags, opts).0
+}
+
+/// [`build_server_config`], additionally returning the capability
+/// resolutions it performed so the caller can narrate them.
+///
+/// Same translation, same single source of truth — `build_server_config` is a
+/// projection of this function that drops the explanation.
+pub fn build_server_config_narrated(
+    model_id: i64,
+    model_name: String,
+    model_path: PathBuf,
+    base_port: u16,
+    tags: &[String],
+    opts: ServerConfigOptions,
+) -> (ServerConfig, ResolvedCapabilities) {
     let mut config = ServerConfig::new(model_id, model_name, model_path, base_port);
 
     // --- Context size (4-level fallback chain) --------------------------------
@@ -100,20 +134,28 @@ pub fn build_server_config(
     }
 
     // --- Reasoning format ------------------------------------------------------
-    match opts.reasoning_format.as_deref() {
+    let reasoning = match opts.reasoning_format.as_deref() {
         Some("none") => {
             // Caller explicitly suppressed reasoning — don't set the flag.
             debug!("reasoning format explicitly suppressed by caller");
+            ReasoningFormatResolution {
+                format: None,
+                source: ReasoningFormatSource::Explicit,
+            }
         }
         Some(format) => {
             // Caller provided an explicit format string — use it directly.
             debug!(format, "using explicit reasoning format");
             config = config.with_reasoning_format(format.to_owned());
+            ReasoningFormatResolution {
+                format: Some(format.to_owned()),
+                source: ReasoningFormatSource::Explicit,
+            }
         }
         None => {
             // Auto-detect from model tags.
             let reasoning = resolve_reasoning_format(None, tags);
-            if let Some(format) = reasoning.format {
+            if let Some(format) = reasoning.format.clone() {
                 debug!(
                     format = %format,
                     source = ?reasoning.source,
@@ -121,8 +163,9 @@ pub fn build_server_config(
                 );
                 config = config.with_reasoning_format(format);
             }
+            reasoning
         }
-    }
+    };
 
     // --- Inference parameters --------------------------------------------------
     if let Some(params) = opts.inference_params {
@@ -176,7 +219,14 @@ pub fn build_server_config(
         config = config.with_mlock();
     }
 
-    config
+    (
+        config,
+        ResolvedCapabilities {
+            jinja,
+            reasoning,
+            mtp,
+        },
+    )
 }
 
 #[cfg(test)]

--- a/src/components/ProxyDashboardModal.tsx
+++ b/src/components/ProxyDashboardModal.tsx
@@ -22,6 +22,7 @@
 import type { FC } from 'react';
 import { Modal } from './ui/Modal';
 import { CacheUsageRows, ProxyCachePanel } from './ProxyCachePanel';
+import { ProxyLaunchPanel } from './ProxyLaunchPanel';
 import { ActiveConnectionsSection, InferenceSlotsSection } from './proxy';
 import { useProxyDashboard } from '../hooks/useProxyDashboard';
 
@@ -52,6 +53,13 @@ export const ProxyDashboardModal: FC<ProxyDashboardModalProps> = ({
     >
       <div className="flex flex-col gap-lg">
         <ActiveConnectionsSection snapshot={snapshot} />
+
+        <section>
+          <h3 className="text-xs font-semibold uppercase text-text-secondary mb-sm">
+            Launch Decisions
+          </h3>
+          <ProxyLaunchPanel launch={snapshot?.launch} />
+        </section>
 
         <section>
           <h3 className="text-xs font-semibold uppercase text-text-secondary mb-sm">Prompt Cache</h3>

--- a/src/components/ProxyLaunchPanel.tsx
+++ b/src/components/ProxyLaunchPanel.tsx
@@ -1,0 +1,78 @@
+/**
+ * ProxyLaunchPanel.
+ *
+ * What the runtime decided when it launched the running model, and why.
+ *
+ * The GUI counterpart to the CLI startup banner: gglib auto-sizes the RAM
+ * cache, quantizes the KV cache, enables speculative decoding, picks a tool-call
+ * dialect parser and resolves the context through a four-level chain, and until
+ * this panel existed a GUI user's only evidence of any of it was the README.
+ *
+ * Every row is rendered exactly as the backend ordered and worded it — see
+ * `gglib_core::domain::LaunchNarration`. Nothing is re-derived, re-sorted or
+ * re-labelled here, so this panel and the banner cannot drift into describing
+ * the same launch differently.
+ *
+ * @module components/ProxyLaunchPanel
+ */
+
+import type { FC } from 'react';
+import type { LaunchNarration } from '../services/transport/types/dashboard';
+
+export interface ProxyLaunchPanelProps {
+  /** `null`/`undefined` before the first request resolves a model. */
+  launch?: LaunchNarration | null;
+}
+
+/** Bytes as GiB with one decimal, matching the backend's `format_gib`. */
+export function formatWeights(bytes: number): string {
+  return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+}
+
+/**
+ * The model identity line: `qwen3-30b-a3b · Q4_K_M · 17.2 GB`.
+ *
+ * Unknown quantization and unknown size drop out rather than rendering as
+ * filler, mirroring `LaunchNarration::headline` on the backend.
+ */
+export function headline(launch: LaunchNarration): string {
+  const parts = [launch.model_name];
+  if (launch.quantization) {
+    parts.push(launch.quantization);
+  }
+  if (launch.weights_bytes > 0) {
+    parts.push(formatWeights(launch.weights_bytes));
+  }
+  return parts.join(' · ');
+}
+
+export const ProxyLaunchPanel: FC<ProxyLaunchPanelProps> = ({ launch }) => {
+  if (!launch) {
+    return <p className="text-sm text-text-muted">No model resolved yet.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-sm">
+      <p className="text-sm font-semibold text-text">{headline(launch)}</p>
+
+      <div className="flex flex-col gap-xs p-md rounded-base border border-border bg-surface-elevated">
+        {launch.decisions.map((decision) => (
+          <div key={decision.label} className="flex items-baseline gap-md">
+            <span className="text-xs text-text-muted w-16 shrink-0">{decision.label}</span>
+            <span className="text-sm text-text">{decision.value}</span>
+            {/*
+              The provenance is why this panel exists rather than a config
+              dump, but it is the secondary read — dimmed so the eye takes the
+              decisions first and the reasons second.
+            */}
+            {decision.source && (
+              <span className="text-xs text-text-muted ml-auto">({decision.source})</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProxyLaunchPanel;

--- a/src/services/transport/types/dashboard.ts
+++ b/src/services/transport/types/dashboard.ts
@@ -173,6 +173,39 @@ export interface CacheStatus {
   usage: CacheUsage;
 }
 
+/**
+ * Mirrors `gglib_core::domain::LaunchDecision` — one resolved launch decision
+ * and the reason it was chosen.
+ *
+ * `source` is the point of the type: a value alone says what happened, never
+ * why. `null` only for decisions whose value states its own origin.
+ */
+export interface LaunchDecision {
+  /** Stable key: `ctx`, `backend`, `kv`, `cache`, `mtp`, `flags`, `dialect`. */
+  label: string;
+  /** Display-ready value. */
+  value: string;
+  /** Provenance, rendered in parentheses. */
+  source?: string | null;
+}
+
+/**
+ * Mirrors `gglib_core::domain::LaunchNarration` — what the runtime decided
+ * when it launched the running model, and why.
+ *
+ * The same record the CLI banner prints at startup. `decisions` arrives in
+ * display order; consumers render it as given rather than re-sorting, so the
+ * GUI and the banner cannot disagree about what a launch decided.
+ */
+export interface LaunchNarration {
+  model_name: string;
+  /** Quantization label (`Q4_K_M`); `null` when the catalog recorded none. */
+  quantization?: string | null;
+  /** On-disk weight size in bytes; `0` when unknown. */
+  weights_bytes: number;
+  decisions: LaunchDecision[];
+}
+
 /** Mirrors `gglib_proxy::dashboard::DashboardSnapshot` — the full hydration/tick payload. */
 export interface DashboardSnapshot {
   active_connections: ActiveConnectionSnapshot[];
@@ -196,4 +229,9 @@ export interface DashboardSnapshot {
    * on a proxy older than this field.
    */
   agent_usage?: CacheUsage | null;
+  /**
+   * What the running model's launch decided, and why. `null` until a request
+   * resolves a model, and absent on a proxy older than this field.
+   */
+  launch?: LaunchNarration | null;
 }


### PR DESCRIPTION
## Summary

gglib auto-sizes the host-RAM prompt cache, quantizes KV to `q8_0`, enables MTP from model tags, picks a dialect parser, and resolves context through a four-level chain — and said nothing about any of it; those values existed only in `debug!` lines. This adds `LaunchNarration` (gglib-core), which records each decision with its provenance at spawn time, and prints a banner honoring `NO_COLOR` and non-TTY stdout, e.g. `ctx 32768 (model server_defaults)`, `kv q8_0 -> 2.1 GB, f16 would be 4.2 GB (default)`. The same record reaches the CLI banner, `GET /v1/proxy/status`, and a new `ProxyLaunchPanel` in the GUI dashboard (mirroring the existing `CacheStatusCache` pattern).

This is presentation over existing computation, not new resolution logic: `build_server_config` gained a `_narrated` sibling that returns the jinja/reasoning/MTP resolutions it already computes, with the original now a thin projection over it, and `resolve_context_size_with_source` names the winning rung with `resolve_context_size` delegating to it. Both the capability translation and the context chain still exist in exactly one place, so narration can't drift from what actually launched.

**Deliberately not implemented:** a GPU layer count line (`gpu 48/48 layers -> Vulkan (RX 7900 XT)`). gglib never emits `-ngl` — layer offload is llama.cpp's own decision, invisible to us at banner time — and no GPU device name is available anywhere in the stack. The `backend` line instead reports the acceleration the installed build was compiled for, which is genuinely known. `serve.rs`'s own pre-launch context/MTP lines are now largely redundant with the narration but were left alone as a separate surface, worth deleting in a follow-up.

## Test plan

- [x] `make fmt`, `make lint`, `make check` — clean
- [x] `make test` — 2311 passed, 0 failed
- [x] `tsc --noEmit` and ESLint clean on changed frontend files
- [x] Boundary, tauri-command, and transport-branching gates pass
- [x] `check_file_complexity` — the five files it flags are byte-identical to clean `main`; none touched here