### PR TITLE
fix(ci): stop masking test failures and make the contention wait deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,20 @@ jobs:
     name: Test (Rust)
     runs-on: ubuntu-latest
     needs: [clippy]
+    # Every test step below pipes into `tee` so the output survives as an
+    # artifact, and a pipeline reports its *last* command's status — `tee`'s,
+    # which is always 0. GitHub's default shell is `bash -e` without pipefail,
+    # so a failing `cargo test` was reported as a passing step: three of the
+    # six CI runs before this change were green with a failing test inside.
+    # `shell: bash` is `bash --noprofile --norc -eo pipefail`, which makes
+    # cargo's status the one that counts.
+    #
+    # Set per job rather than on the workflow: a workflow-level default would
+    # also reach `cli-cross-os`, which runs on windows-2022, and switching that
+    # leg from pwsh to Git Bash has nothing to do with this problem.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -169,6 +183,11 @@ jobs:
     name: Test (Frontend)
     runs-on: ubuntu-latest
     needs: [clippy]
+    # Same masking as the Rust job: `npm run test:run … | tee` reported `tee`'s
+    # exit status, so a failing suite passed the step. See the note there.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,12 @@ jobs:
       contents: write
     env:
       RUSTFLAGS: "-C relocation-model=dynamic-no-pic"
+    # `… | tee` reports tee's exit status, not the test runner's, under
+    # GitHub's default `bash -e`. `shell: bash` adds pipefail so a failing
+    # suite fails the job here too — see the note in ci.yml's `test` job.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/crates/gglib-proxy/Cargo.toml
+++ b/crates/gglib-proxy/Cargo.toml
@@ -72,6 +72,11 @@ async-trait = "0.1"
 sysinfo = { workspace = true }
 
 [dev-dependencies]
+# `test-util` is what `#[tokio::test(start_paused = true)]` needs, and it is
+# deliberately not part of tokio's `full`. Declared explicitly rather than
+# inherited: it currently arrives only because `tokio-test` happens to enable
+# it, so removing that dependency would silently break the contention tests.
+tokio = { version = "1.0", features = ["test-util"] }
 tokio-test = "0.4"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"

--- a/crates/gglib-proxy/src/contention/wait.rs
+++ b/crates/gglib-proxy/src/contention/wait.rs
@@ -1,10 +1,14 @@
 //! Bounded wait for model-startup contention.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use gglib_core::ports::{ModelRuntimeError, ModelRuntimePort, RunningTarget};
 use gglib_core::retry::{RetryDecision, RetryPolicy, decide, jitter_unit};
+// Tokio's clock rather than `std`'s: identical in a normal runtime, but it is
+// the one `tokio::time::pause()` advances, which is what lets the tests below
+// drive a whole wait window without sleeping through it.
+use tokio::time::Instant;
 use tracing::{debug, warn};
 
 /// Environment override for the contention window, in seconds.
@@ -77,6 +81,38 @@ pub async fn ensure_with_contention_wait(
     default_ctx: u64,
     window: Duration,
 ) -> Result<RunningTarget, ModelRuntimeError> {
+    ensure_with(
+        runtime,
+        model_name,
+        num_ctx,
+        default_ctx,
+        window,
+        jitter_unit,
+    )
+    .await
+}
+
+/// [`ensure_with_contention_wait`], with the randomness supplied by the caller.
+///
+/// The same seam [`decide`] and
+/// [`RetryPolicy::with_env_overrides`](gglib_core::retry::RetryPolicy) already
+/// have: the impurity is a parameter, so a test states the draw it wants and
+/// asserts the resulting delays exactly instead of hoping the dice fall its way.
+/// Production passes [`jitter_unit`] and behaves as before.
+///
+/// Full jitter can return a delay of zero, so a caller that pins `jitter` at
+/// `0.0` against a permanently contended runtime will never advance `elapsed`
+/// and never reach the deadline — `polling_policy` sets no attempt ceiling on
+/// purpose. Real jitter makes that a measure-zero event; a fixed draw makes it
+/// reachable, so tests use a non-zero one.
+async fn ensure_with<J: Fn() -> f64>(
+    runtime: &Arc<dyn ModelRuntimePort>,
+    model_name: &str,
+    num_ctx: Option<u64>,
+    default_ctx: u64,
+    window: Duration,
+    jitter: J,
+) -> Result<RunningTarget, ModelRuntimeError> {
     let started = Instant::now();
     let policy = polling_policy(window);
     let mut attempt: u32 = 0;
@@ -97,7 +133,7 @@ pub async fn ensure_with_contention_wait(
         }
 
         let elapsed = started.elapsed();
-        match decide(&policy, attempt, None, elapsed, jitter_unit()) {
+        match decide(&policy, attempt, None, elapsed, jitter()) {
             RetryDecision::Retry { after } => {
                 debug!(
                     attempt,

--- a/crates/gglib-proxy/src/contention/wait_tests.rs
+++ b/crates/gglib-proxy/src/contention/wait_tests.rs
@@ -2,8 +2,24 @@
 //!
 //! A scripted runtime double returns a canned sequence of outcomes, so the
 //! interesting property — *which* errors are waited on and for how long — is
-//! asserted without launching a model. Windows are milliseconds so the suite
-//! stays fast; the backoff arithmetic itself is proven in `gglib_core::retry`.
+//! asserted without launching a model.
+//!
+//! Nothing here sleeps and nothing here rolls dice. Both impurities are
+//! supplied by the test:
+//!
+//! * **Randomness** — [`fixed`] pins the jitter draw, so every delay below is
+//!   an exact number rather than a range. The backoff arithmetic producing
+//!   those numbers is proven separately in `gglib_core::retry`.
+//! * **Time** — `#[tokio::test(start_paused = true)]` runs the whole window on
+//!   a virtual clock, which auto-advances whenever the runtime goes idle. The
+//!   elapsed assertions are therefore equalities, not margins, and a wait that
+//!   would take half a second of wall clock takes none.
+//!
+//! `dashboard.rs` documents a case where `start_paused` was rejected as flaky:
+//! `advance` fires a due timer but does not guarantee the woken *other* task is
+//! polled before the test's own future. That is a cross-task hazard and does
+//! not apply here — `ensure_with` is awaited directly in the test body, so
+//! there is only ever one task with work to do.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -88,30 +104,97 @@ fn contended() -> ModelRuntimeError {
     ModelRuntimeError::ContentionTimeout("slot held".to_owned())
 }
 
+/// A jitter source that always draws `unit`.
+///
+/// The counterpart to `retry/env_tests.rs`'s `fixture` — the impurity becomes
+/// an argument, so the delays below are arithmetic rather than a sample.
+/// `polling_policy` starts at 250 ms and doubles, capped at 2 s, and full
+/// jitter scales each window by the draw:
+///
+/// | retry | window | `fixed(0.5)` | `fixed(0.9)` |
+/// |-------|--------|--------------|--------------|
+/// | 1st   | 250 ms | 125 ms       | 225 ms       |
+/// | 2nd   | 500 ms | 250 ms       | 450 ms       |
+///
+/// Never `0.0` against a permanently contended runtime: every delay would be
+/// zero, `elapsed` would never advance on the virtual clock, and the wait has
+/// no attempt ceiling to stop it.
+fn fixed(unit: f64) -> impl Fn() -> f64 {
+    move || unit
+}
+
 // =============================================================================
 // Waiting
 // =============================================================================
 
-#[tokio::test]
+/// Two retries fitting inside the window: 125 ms + 250 ms = 375 ms of a 500 ms
+/// budget, then the script clears.
+#[tokio::test(start_paused = true)]
 async fn contention_that_clears_inside_the_window_succeeds() {
     let runtime = ScriptedRuntime::with_script(vec![Err(contended()), Err(contended()), Ok(())]);
 
-    let target =
-        ensure_with_contention_wait(&runtime, "llama", None, 4096, Duration::from_millis(500))
-            .await
-            .expect("the slot freed before the window elapsed");
+    let started = Instant::now();
+    let target = ensure_with(
+        &runtime,
+        "llama",
+        None,
+        4096,
+        Duration::from_millis(500),
+        fixed(0.5),
+    )
+    .await
+    .expect("the slot freed before the window elapsed");
 
     assert_eq!(target.model_name, "llama");
+    assert_eq!(
+        started.elapsed(),
+        Duration::from_millis(375),
+        "the wait should have cost exactly the two backoffs"
+    );
 }
 
-#[tokio::test]
+/// The other side of the same boundary, and the reason this pair exists.
+///
+/// The delays are drawn, so an unlucky draw makes the wait give up *before* the
+/// slot would have freed — 225 ms + 450 ms overruns the same 500 ms window that
+/// 375 ms fits inside. That behaviour was real and unasserted, and with a live
+/// jitter source it surfaced as the sibling test above failing about one run in
+/// four rather than as a test of its own.
+#[tokio::test(start_paused = true)]
+async fn contention_gives_up_when_the_backoff_would_overrun_the_window() {
+    let runtime = ScriptedRuntime::with_script(vec![Err(contended()), Err(contended()), Ok(())]);
+
+    let error = ensure_with(
+        &runtime,
+        "llama",
+        None,
+        4096,
+        Duration::from_millis(500),
+        fixed(0.9),
+    )
+    .await
+    .expect_err("a backoff that would overrun the window must not be taken");
+
+    assert!(
+        matches!(error, ModelRuntimeError::ContentionTimeout(_)),
+        "giving up early still owes the caller a 503: {error:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
 async fn contention_that_outlasts_the_window_surfaces_the_error() {
     let runtime = ScriptedRuntime::always_contended();
 
-    let error =
-        ensure_with_contention_wait(&runtime, "llama", None, 4096, Duration::from_millis(200))
-            .await
-            .expect_err("a permanently contended slot must still fail");
+    let error = ensure_with(
+        &runtime,
+        "llama",
+        None,
+        4096,
+        Duration::from_millis(200),
+        fixed(0.5),
+    )
+    .await
+    .expect_err("a permanently contended slot must still fail");
 
     assert!(
         matches!(error, ModelRuntimeError::ContentionTimeout(_)),
@@ -119,18 +202,20 @@ async fn contention_that_outlasts_the_window_surfaces_the_error() {
     );
 }
 
-#[tokio::test]
+/// One 125 ms backoff fits the 200 ms window; the next would be 250 ms, which
+/// does not, so the wait stops there rather than overrunning what it promised.
+#[tokio::test(start_paused = true)]
 async fn the_window_bounds_how_long_the_wait_lasts() {
     let runtime = ScriptedRuntime::always_contended();
     let window = Duration::from_millis(200);
 
     let started = Instant::now();
-    let _ = ensure_with_contention_wait(&runtime, "llama", None, 4096, window).await;
+    let _ = ensure_with(&runtime, "llama", None, 4096, window, fixed(0.5)).await;
 
-    assert!(
-        started.elapsed() < window * 4,
-        "waiting overran its window by too much: {:?}",
-        started.elapsed()
+    assert_eq!(
+        started.elapsed(),
+        Duration::from_millis(125),
+        "the wait must stop inside its window, not merely near it"
     );
 }
 
@@ -138,7 +223,7 @@ async fn the_window_bounds_how_long_the_wait_lasts() {
 // Fail-fast
 // =============================================================================
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn a_zero_window_restores_fail_fast() {
     // The behaviour this function replaced: no waiting, straight to 503.
     let runtime = ScriptedRuntime::always_contended();
@@ -149,10 +234,10 @@ async fn a_zero_window_restores_fail_fast() {
         .expect_err("zero window must not wait");
 
     assert!(matches!(error, ModelRuntimeError::ContentionTimeout(_)));
-    assert!(
-        started.elapsed() < Duration::from_millis(50),
-        "zero window slept anyway: {:?}",
-        started.elapsed()
+    assert_eq!(
+        started.elapsed(),
+        Duration::ZERO,
+        "zero window slept anyway"
     );
 }
 
@@ -160,7 +245,7 @@ async fn a_zero_window_restores_fail_fast() {
 // Scope — everything else passes through untouched
 // =============================================================================
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn model_loading_is_not_waited_on() {
     // ModelLoading has its own longer retry loop in the caller. Absorbing it
     // here too would stack two budgets on the same failure.
@@ -172,14 +257,14 @@ async fn model_loading_is_not_waited_on() {
         .expect_err("ModelLoading must pass straight through");
 
     assert!(matches!(error, ModelRuntimeError::ModelLoading));
-    assert!(
-        started.elapsed() < Duration::from_millis(50),
-        "ModelLoading was waited on: {:?}",
-        started.elapsed()
+    assert_eq!(
+        started.elapsed(),
+        Duration::ZERO,
+        "ModelLoading was waited on"
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn other_errors_pass_through_immediately() {
     let runtime =
         ScriptedRuntime::with_script(vec![Err(ModelRuntimeError::Internal("boom".to_owned()))]);


### PR DESCRIPTION
## Summary

`contention::wait::wait_tests::contention_that_clears_inside_the_window_succeeds` was failing about one run in four — arithmetic, not mystery: the test's two-retry window allows 500ms, and `polling_policy` draws jitter that overruns it roughly 25% of the time (measured 4/20 on an untouched base commit).

Nobody noticed because CI's test steps pipe into `tee` (`cargo test --verbose 2>&1 | tee rust-test-output.txt`), and a pipeline reports its *last* command's exit status under bash's default (non-`pipefail`) mode — so a failing `cargo test` still exited 0. Checking the uploaded artifacts against six recent "success" runs showed three were actually red inside, one of them on `main`.

Two fixes:
1. **`wait.rs` now takes its jitter source and clock as parameters**, matching the seam the rest of the retry code (`policy.rs`, `env.rs`) already documents as required for exact, non-sleeping tests. It switches to `tokio::time::Instant` so paused-clock tests can actually reach their deadline. Both sides of the timing boundary are now asserted directly (a jitter draw that fits the window succeeds; one that overruns correctly returns `ContentionTimeout`) rather than discovered at random. 50 consecutive runs, zero failures; the suite runs in 0.00s instead of ~1.3s.
2. **`ci.yml` sets `shell: bash` (`bash --noprofile --norc -eo pipefail`) on the `test`, `test-frontend`, and `coverage` jobs** — per-job rather than workflow-level, so the Windows `cli-cross-os` leg isn't affected. Verified directly: the same failing test through the old `bash -e` pipe exits 0; through `bash -eo pipefail` it exits 101.

Also declares tokio's `test-util` feature explicitly in `gglib-proxy`'s dev-dependencies — it was compiling only because `tokio-test` enabled it transitively, and removing that otherwise-unused dependency would have broken these tests silently.

**Not in scope:** 13 `sleep(30ms)`-after-spawn readiness races in the proxy integration fixtures — a different flake class (racy readiness, not timing arithmetic) where a virtual clock doesn't help since they depend on real I/O; worth its own issue. The other real `jitter_unit()` caller (`llm_completion/retry/execute.rs`) has a backoff cap far below its deadline, so randomness can't move its outcome — a seam there would have no consumer.

## Test plan

- [x] `make fmt && make lint && make check && make test`, `cargo test --doc`, `check_boundaries.sh` — all pass; full workspace 83 suites, 0 failures
- [x] 50 consecutive runs of the previously-flaky test, 0 failures (was ~4/20)
- [x] New sibling test asserting the give-up path (`ContentionTimeout`) that the flake was discovering at random instead of testing for
- [x] Verified the artifact evidence directly: 3 of the last 6 "successful" CI runs actually contained a failing suite
- [x] Verified the pipefail fix directly with a deliberately-failing test piped exactly as CI pipes it (exit 0 before, exit 101 after)