### PR TITLE
docs: make the README proxy-first, split deep reference into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 ![Version](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/version.json)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 
-<!-- crate-docs:start -->
+**The local model runtime that makes llama.cpp behave like an API provider.**
 
-Manage your local GGUF models without remembering file paths or llama.cpp commands.
-
-GGLib keeps a catalog of your GGUFs, handles downloading from HuggingFace, and starts llama-server for you. Use it from the terminal, a desktop app, a web UI, or as an OpenAI-compatible API — they all share the same database and model directory.
+Point your agentic coding client — Cline, Roo Code, Continue, Aider, Zed,
+Copilot BYOK — at one OpenAI-compatible endpoint backed by your own GPU. GGLib
+downloads GGUFs from HuggingFace, launches and swaps llama-server for you, and
+runs an intelligent proxy between your client and the model that fixes the
+problems raw llama-server (and Ollama) leave you with: tool calls arriving as
+raw XML, context ballooning until the model loops, clients hardcoding sampling
+you never chose.
 
 ## Start here
 
@@ -20,1171 +24,156 @@ gglib up
 
 One command from a clean machine to a working OpenAI-compatible endpoint. It
 reads your hardware, installs llama.cpp if it is missing, recommends a model
-that actually fits your VRAM (and says why, and asks before downloading
-anything), starts the proxy, sends a real request through it to prove the
-endpoint answers, and prints the settings to paste into Cline, Continue,
-Open WebUI or Copilot.
+that actually fits your VRAM (asking before downloading anything), starts the
+proxy, sends a real request through it to prove the endpoint answers, and
+prints the settings to paste into your client. Re-running it is safe; `--yes`
+skips the confirmation, `--model <name>` loads a different installed model,
+`--port` moves it off 8080. Everything beyond that is `gglib proxy`.
 
-Re-running it is safe: whatever is already in place is skipped, so a second run
-just starts the proxy. Add `--yes` to accept the recommendation without being
-asked, `--model <name>` to load a different installed model, `--port` to bind
-somewhere other than 8080. Anything beyond that — a non-loopback host, sampling
-overrides, KV cache tuning — is what `gglib proxy` is for.
+## Point your client at it
 
-## Quick look
+The endpoint is `http://127.0.0.1:8080/v1`. No API key is required on
+loopback — enter any placeholder if your client insists. Use a model name from
+`gglib model list` (shown below as `qwen3.6`).
 
-```bash
-# Download a model from HuggingFace (interactive queue — press [a] to add more, [q] to cancel)
-gglib model download bartowski/Qwen2.5-7B-Instruct-GGUF
+**Cline / Roo Code** — Settings → API Provider: *OpenAI Compatible*, Base URL
+`http://127.0.0.1:8080/v1`, API Key `gglib`, Model ID `qwen3.6`.
 
-# List what you have
-gglib model list
+**Continue** — `config.yaml`:
 
-# Start chatting (launches llama-server automatically)
-gglib chat qwen2.5
-
-# Pin one model to an OpenAI-compatible endpoint (same proxy stack, one model)
-gglib serve qwen2.5
-# API:       http://127.0.0.1:8080/v1/chat/completions
-# Dashboard: http://127.0.0.1:8080/v1/proxy/status
-
-# Pipe anything into a question
-cat error.log | gglib question "what went wrong?"
-
-# Or skip the CLI — open the desktop app or web UI
-gglib gui
-gglib web
+```yaml
+models:
+  - name: qwen3.6 (local)
+    provider: openai
+    model: qwen3.6
+    apiBase: http://127.0.0.1:8080/v1
+    apiKey: gglib
 ```
 
-## Pipe anything, ask anything
-
-GGLib treats your local model like a Unix tool. Pipe in any text and ask a question — no API keys, no cloud, no context window gymnastics. Use `gglib question` (or `gglib q` for short).
+**Aider**:
 
 ```bash
-# Code review a PR diff
-git diff main | gglib q "review this for bugs and suggest improvements"
-
-# Understand an error log
-journalctl -u myapp --since "1 hour ago" | gglib q "what caused this crash?"
-
-# Summarize a man page
-man rsync | gglib q "how do I sync only .rs files, excluding target/?"
-
-# Explain unfamiliar config
-cat nginx.conf | gglib q "explain the proxy_pass rules"
-
-# Quick code explanation
-cat src/main.rs | gglib q "what does this program do?"
-
-# Get a commit message from staged changes
-git diff --cached | gglib q "write a concise commit message for these changes"
-
-# Translate a file
-cat README_ja.md | gglib q "translate this to English"
-
-# Use {} as a placeholder to control where input goes
-echo "segfault at 0x0" | gglib q "I got this error: {}. What does it mean?"
-
-# Read context from a file instead of stdin
-gglib q --file Cargo.toml "what dependencies does this project use?"
-
-# Agentic mode: let the model explore the codebase with filesystem tools
-gglib q --agent "How is error handling structured in this project?"
+OPENAI_API_BASE=http://127.0.0.1:8080/v1 OPENAI_API_KEY=gglib aider --model openai/qwen3.6
 ```
 
-Works with any command that produces text. If you can `cat` it, you can ask a local model about it.
+**Zed** — `settings.json`:
 
-## Benchmarking & inference tuning
-
-`gglib benchmark` answers three questions about a model, from the same CLI/API/GUI surface:
-
-```bash
-# How fast is it? (llama-bench throughput)
-gglib benchmark perf --model qwen2.5
-
-# Side-by-side response quality across models
-gglib benchmark compare --model qwen2.5 --model llama3 --prompt "Explain gradient descent"
-
-# What sampling settings make it a good tool-calling agent?
-gglib benchmark tune --model qwen2.5 --sweep temperature=0.2,0.5,0.8 --apply-best
-```
-
-`tune` sweeps sampling parameters (temperature, top-p, top-k, min-p, repeat-penalty)
-against an agentic tool-calling task suite, scoring each candidate on tool-call
-accuracy (AST-style structural matching, not string diffing) and resistance to
-the agent loop's loop/stagnation guards — the failure mode that matters most
-when a local model is powering an agentic coding IDE via `gglib proxy`, where
-losing attention over a long session can send it into an infinite tool-call
-loop. `--apply-best` writes the winning settings straight to the model's
-`inference_defaults`, the same effect as `gglib model update --temperature ...`.
-
-The built-in task suite covers five categories (modeled on the Berkeley
-Function Calling Leaderboard, plus one gglib-specific category):
-
-| Category | Tests |
-|----------|-------|
-| `single_call` | Exactly one tool call is expected |
-| `parallel_call` | Multiple independent tool calls in the same turn |
-| `multi_turn` | Sequential tool calls that build on prior results |
-| `irrelevance` | Correctly abstaining from a tool call when none applies |
-| `long_context` | Loop/stagnation resistance after a long simulated prior session |
-
-**Custom task suites** — write your own scenarios (e.g. targeting your real MCP
-tools) as a plain JSON array and pass it with `--task-suite path.json`. The CLI
-and the GUI (file upload, parsed client-side) accept the identical schema —
-see [`gglib-core/assets/tune_default_suite.json`](crates/gglib-core/assets/tune_default_suite.json)
-for a full worked example. Each element is:
-
-```jsonc
+```json
 {
-  "id": "single_call_weather",          // stable identifier
-  "category": "single_call",            // single_call | parallel_call | multi_turn | irrelevance | long_context
-  "system_prompt": null,                // optional
-  "history": null,                      // optional: simulated prior turns (long_context only),
-                                         // an array of ChatMessage-shaped objects, e.g.
-                                         // [{"role":"user","content":"..."},
-                                         //  {"role":"assistant","tool_calls":[...]}]
-  "user_prompt": "What's the weather in Boston, MA?",
-  "tools": [
-    { "name": "get_weather", "description": "...", "input_schema": { "type": "object", "properties": { "location": { "type": "string" } }, "required": ["location"] } }
-  ],
-  "expected": {
-    "kind": "tool_calls",                // "tool_calls" | "no_tool_call"
-    "calls": [
-      { "name": "get_weather", "required_args": { "location": "Boston, MA" }, "ordered": false }
-    ]
+  "language_models": {
+    "openai_compatible": {
+      "gglib": {
+        "api_url": "http://127.0.0.1:8080/v1",
+        "available_models": [{ "name": "qwen3.6", "max_tokens": 32768 }]
+      }
+    }
   }
 }
 ```
 
-Scoring is partial-credit: extra arguments the model supplies are never
-penalized, missing required arguments reduce the score proportionally
-(`matching / total`), and values are compared structurally (a JSON `1` matches
-`1.0` — never a string diff).
-
-## Architecture
-
-Cargo workspace with compile-time enforced boundaries. Adapters → infrastructure → core — never the reverse.
-
-### Model capability detection
-
-When you add a GGUF model, gglib reads its `tokenizer.chat_template` and `general.architecture` fields to automatically detect capability flags: whether the model requires strict user/assistant turn alternation, supports a system role, can handle tool calls, and so on. These flags are stored in the database and used by the OpenAI-compatible proxy to preprocess requests before they reach llama-server.
-
-For models whose quantized builds ship without a chat template, the architecture name (`general.architecture`) acts as a backstop — for example, `"mistral"` architecture always implies `REQUIRES_STRICT_TURNS`.
-
-You can inspect or override any model's flags at any time:
-
-```bash
-# Show current capabilities
-gglib model capabilities 3
-
-# Force strict-turn coalescing on
-gglib model capabilities 3 --set requires-strict-turns
-
-# Or via the REST API
-curl -X PATCH http://localhost:9887/api/models/3/capabilities \
-     -H 'Content-Type: application/json' \
-     -d '{"requiresStrictTurns": true}'
-```
-
-For details on how to add support for a new architecture, see [`CONTRIBUTING.md`](CONTRIBUTING.md#model-architecture-registry).
-
-### History Truncation & Proxy Status
-
-When gglib acts as an OpenAI-compatible proxy (e.g. `gglib web --api-only`), it
-defends against a problem with some AI clients: client-side context compaction
-can be broken for custom endpoints, causing tool call responses to be permanently
-embedded in chat history. After several tool-heavy turns the prompt balloons past
-the local model's context window and the model falls into logic loops.
-
-**The proxy intercepts and compacts history automatically.** Before every request
-is forwarded to llama-server, a stateless truncation pass runs:
-
-- Any unprotected `role: "tool"` or `role: "assistant"` message whose content
-  exceeds **2,000 characters** has its content replaced with a short placeholder.
-- The last **4 messages** and all `role: "system"` messages are always preserved.
-- If the total payload still exceeds **240,000 characters** (≈ 60,000 tokens)
-  after truncation, the request is rejected with HTTP 400
-  (`context_length_exceeded`) rather than forwarding a prompt that would cause
-  the model to fail.
-
-**Proxy dashboard** — a unified `DashboardSnapshot` of active connections,
-per-slot context usage, and recent request history — is available at
-`GET /v1/proxy/status` (JSON) and `GET /v1/proxy/status/stream` (live SSE
-updates), on `gglib serve` as well as `gglib proxy`: `serve` runs the same
-stack pinned to one model, so it gets the same endpoints. It's consumed by
-both `gglib proxy dashboard` (a live terminal view) and the web GUI's Proxy
-Dashboard modal. See
-[`gglib-proxy`'s docs](crates/gglib-proxy/README.md#proxy-dashboard) for the
-full data contract.
-
-```bash
-curl http://localhost:9887/v1/proxy/status | jq .
-gglib proxy dashboard --port 9887
-```
-
-### KV Cache Session Persistence
-
-Available on `gglib serve` and `gglib proxy` alike, and opt-in on both. For
-sequential multi-agent workflows, enable `--cache --slot-dir <path>` to persist
-KV cache state between requests. The proxy automatically saves and restores per-session
-slot files (saved atomically via a temp-then-rename), gated by a semaphore to prevent
-concurrent access. Stale caches are detected via mtime comparison and skipped
-(fail-open). A background sweep evicts the least-recently-used slot files once the
-on-disk cache exceeds a byte budget — by default auto-sized from free disk space,
-override with `--cache-disk-gb`. Use `gglib proxy cache-clear` to manually clear
-cached state.
-
-Disk persistence is skipped automatically for models whose attention keeps only
-part of the token history — sliding-window, hybrid (e.g. a GGUF declaring
-`full_attention_interval`), and recurrent/SSM architectures. llama-server's slot
-files carry KV state and tokens but not the context checkpoints those models need
-to resume, so a restore cannot pick up where it left off and instead re-prefills
-the whole prompt, while also crowding out the host-RAM prompt cache that *would*
-have resumed cheaply. Such models rely on the RAM cache alone; the proxy logs the
-decision at startup. Set `GGLIB_FORCE_HYBRID_DISK_CACHE=1` to re-enable the disk
-layer anyway (intended for testing an upstream llama.cpp fix).
-
-Independently of disk persistence, every launch auto-sizes llama-server's own
-host-RAM prompt cache (`--cache-ram`) from system RAM, the model's weights, and its
-KV footprint — override with `--cache-ram-mb`. The KV cache itself defaults to
-`q8_0` quantization on both K and V (`--cache-type-k`/`--cache-type-v`), roughly
-halving KV memory versus llama-server's own `f16` default; override per-axis or set
-`GGLIB_DISABLE_KV_QUANT=1` to fall back to `f16`.
-
-The proxy dashboard reports how the cache resolved and how much it is actually
-doing: the RAM budget, whether either tier is degraded, and measured reuse
-(prompt tokens served from cache vs. re-processed, per request and in total).
-These are raw counts taken from the upstream's own `usage` reporting — there is
-no estimated "time saved", since reuse is measured exactly but what it saved
-depends on a prefill that never ran.
-
-![Rust Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/tests.json)
-![Rust Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/coverage.json)
-![TS Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-tests.json)
-![TS Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-coverage.json)
-![Boundaries](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/boundary.json)
-
-```text
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                    Core Layer                                       │
-│                                                                                     │
-│   ┌─────────────────────────────────────────────────────────────────────────────┐   │
-│   │                              gglib-core                                     │   │
-│   │              Pure domain types, ports & traits (no infra deps)              │   │
-│   └─────────────────────────────────────────────────────────────────────────────┘   │
-│                                                                                     │
-└─────────────────────────────────────────────────────────────────────────────────────┘
-                                          │
-        ┌─────────────┬─────────────┬─────┴─────┬─────────────┬─────────────┐
-        ▼             ▼             ▼           ▼             ▼             ▼
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                              Infrastructure Layer                                   │
-│                                                                                     │
-│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐                      │
-│  │  gglib-db  │ │ gglib-gguf │ │ gglib-mcp  │ │ gglib-proxy│                      │
-│  │   SQLite   │ │ GGUF file  │ │    MCP     │ │  OpenAI-   │                      │
-│  │   repos    │ │   parser   │ │  servers   │ │  compat    │                      │
-│  └────────────┘ └────────────┘ └────────────┘ └────────────┘                      │
-│                                                                                     │
-│  ╔═══════════════════════════════════════════════════════════════════════════════╗  │
-│  ║                          External Gateways                                    ║  │
-│  ║                                                                               ║  │
-│  ║  ┌────────────────────────────────────┐  ┌────────────────────────────────┐   ║  │
-│  ║  │      gglib-runtime                 │  │      gglib-download            │   ║  │
-│  ║  │  Process lifecycle manager         │  │  Download orchestrator         │   ║  │
-│  ║  │  ONLY component that spawns        │  │  ONLY component that contacts  │   ║  │
-│  ║  │  & manages llama-server            │  │  HuggingFace Hub               │   ║  │
-│  ║  │                                    │  │  (via gglib-hf + optional      │   ║  │
-│  ║  │                                    │  │   hf_xet subprocess)           │   ║  │
-│  ║  └────────────────────────────────────┘  └────────────────────────────────┘   ║  │
-│  ╚═══════════════════════════════════════════════════════════════════════════════╝  │
-│                                                                                     │
-└─────────────────────────────────────────────────────────────────────────────────────┘
-                                          │
-                                          ▼
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                   Facade Layer                                      │
-│                                                                                     │
-│   ┌─────────────────────────────────────────────────────────────────────────────┐   │
-│   │                              gglib-app-services                             │   │
-│   │         Shared service ops (ensures feature parity across adapters)         │   │
-│   └─────────────────────────────────────────────────────────────────────────────┘   │
-│   ┌─────────────────────────────────────────────────────────────────────────────┐   │
-│   │                              gglib-bootstrap                                │   │
-│   │         Shared composition root (infra wiring for all adapters)             │   │
-│   └─────────────────────────────────────────────────────────────────────────────┘   │
-│                                                                                     │
-└─────────────────────────────────────────────────────────────────────────────────────┘
-                                          │
-                      ┌───────────────────┼───────────────────┐
-                      ▼                   ▼                   ▼
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                   Adapter Layer                                     │
-│                                                                                     │
-│   ┌─────────────────────┐  ┌──────────────────────┐  ┌──────────────────────────┐   │
-│   │    gglib-cli        │  │    gglib-axum        │  │     gglib-tauri          │   │
-│   │  CLI interface      │  │  HTTP server         │  │  Desktop application     │   │
-│   │  (terminal UI)      │  │  ┌────────────────┐  │  │  ┌────────────────────┐  │   │
-│   │                     │  │  │ Serves React   │  │  │  │ Embeds React UI    │  │   │
-│   │                     │  │  │ UI (static)    │  │  │  │ (WebView assets)   │  │   │
-│   │                     │  │  └────────────────┘  │  │  ├────────────────────┤  │   │
-│   │                     │  │                      │  │  │ Embedded Axum      │  │   │
-│   │                     │  │                      │  │  │ (HTTP endpoints)   │  │   │
-│   │                     │  │                      │  │  └────────────────────┘  │   │
-│   └─────────┬───────────┘  └──────────┬───────────┘  └───────────┬──────────────┘   │
-│             │                         │                          │                  │
-│             └─────────────────────────┼──────────────────────────┘                  │
-│                                       │                                             │
-│                  All adapters call infrastructure layer via:                        │
-│                  • External Gateways (runtime, download)                            │
-│                  • Other infrastructure services (db, gguf, mcp, proxy)             │
-│                                       │                                             │
-└───────────────────────────────────────┼─────────────────────────────────────────────┘
-                                        │
-                                        ▼
-                            ╔═══════════════════════╗
-                            ║  External Gateways    ║
-                            ║  (from infra layer)   ║
-                            ╚═══════════════════════╝
-                                        │
-                    ┌───────────────────┴────────────────────┐
-                    ▼                                        ▼
-          ┌──────────────────────┐              ┌──────────────────────┐
-          │   gglib-runtime      │              │   gglib-download     │
-          │   spawns/manages     │              │   calls HF Hub API   │
-          └──────────┬───────────┘              └──────────┬───────────┘
-                     │                                     │
-                     ▼                                     ▼
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                  External Systems                                   │
-│                                                                                     │
-│               ┌──────────────────────────────┐                                      │
-│               │   llama-server instances     │                                      │
-│               │   (child processes)          │                                      │
-│               └──────────────────────────────┘                                      │
-│                                                                                     │
-│               ┌──────────────────────────────┐                                      │
-│               │   HuggingFace Hub API        │                                      │
-│               │   (HTTPS endpoints)          │                                      │
-│               └──────────────────────────────┘                                      │
-│                                                                                     │
-└─────────────────────────────────────────────────────────────────────────────────────┘
-```
-
-Only `gglib-runtime` spawns llama-server processes; only `gglib-download` talks to HuggingFace. Everything else goes through the infrastructure layer.
-
-### Universal Consistency Layer
-
-`gglib` exposes a **strict OpenAI-compatible** chat-completions surface from every entry point — the `gglib-proxy` HTTP server, the `gglib-axum` web API, the `gglib-cli` agent loop, and the `gglib-tauri` desktop app (which routes through the same axum handlers) — regardless of which dialect the upstream `llama-server` happens to emit (Qwen XML tool calls, bare `<think>` reasoning tags, etc.). External clients — OpenWebUI, the OpenAI SDKs, custom scripts — only ever see canonical `chat.completion.chunk` events.
-
-This is achieved by a three-stage pipeline that runs on every streaming request, wired identically into every surface by `gglib-runtime::compose`:
-
-```text
-upstream bytes ─► SseStreamDecoder ─► NormalizingStream ─► SseEncoder ─► wire bytes
-                  (gglib-core::sse)   (gglib-core::normalize)   (gglib-core::sse)
-                       parse              dialect rewrite             re-emit
-```
-
-1. **Parse** — `SseStreamDecoder` reassembles SSE frames across arbitrary TCP chunk boundaries and produces typed `LlmStreamEvent`s.
-2. **Normalize** — A per-request `ToolCallParser` is selected by model tags via `normalize::registry::get_parser`. Dialect parsers (`QwenXmlParser`) rewrite model-specific markup into strict tool-call / reasoning events. Models without a dialect tag use the identity `StandardJsonParser`. Recoverable parser issues become `NormalizationError` events that are logged and suppressed from the wire; unrecoverable upstream errors surface as a structured `error` data frame followed by `data: [DONE]`.
-3. **Re-encode** — `SseEncoder` wraps every event in the canonical envelope (`id: "chatcmpl-…"`, `object: "chat.completion.chunk"`, stable `model` / `created`) so clients see identical framing on every request.
-
-#### `format:*` tag taxonomy
-
-Dialect selection is driven entirely by **system tags** in the `format:*` namespace, persisted on each model row:
-
-| Tag | Parser | When auto-applied |
-|-----|--------|-------------------|
-| `format:qwen-xml` | `QwenXmlParser` | Model name contains `qwen` and the chat template emits `<tool_call>` markup |
-| `format:hermes` | `StandardJsonParser` | Hermes/ChatML-style tool-calling templates |
-
-In addition to `format:*` tags, gglib detects the following **capability tags** at import
-time from GGUF metadata, which drive automatic flag selection at serve time:
-
-| Tag | Detection trigger | Effect |
-|-----|-------------------|--------|
-| `agent` | Chat template contains tool-calling syntax | `--jinja` auto-enabled |
-| `reasoning` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled |
-| `mtp` | `{arch}.nextn_predict_layers > 0` in GGUF metadata | `--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75` auto-enabled |
-
-Override MTP from the CLI:
-```bash
-# Disable MTP on a tagged model
-gglib serve <id> --mtp-draft-n-max 0
-
-# Explicit settings (4 draft tokens, 80% p-min)
-gglib serve <id> --mtp-draft-n-max 4 --mtp-draft-p-min 0.8
-```
-
-Disable MTP globally on **every** launch path (including proxy auto-start,
-where no per-model flag is reachable) with an environment variable — useful
-for A/B testing speculative decoding as a suspect for long-context issues:
-```bash
-# Truthy values: 1, true, yes, on (case-insensitive)
-GGLIB_DISABLE_MTP=1 gglib proxy
-```
-
-These tags are **auto-detected at import time** by `gglib-gguf::capabilities::detect_all` and persisted by `ModelService::import_from_file`. They are protected as system tags: `gglib model remove-tag` will reject any attempt to remove a `format:*` tag (use the `_force` service path for admin operations).
-
-#### Inference parameter defaults
-
-Sampling parameters are resolved through a **5-level merge hierarchy** on every request. Each level fills in only the fields left unset by the previous level:
-
-```
-Request override  →  Inference profile  →  Per-model defaults  →  Global settings  →  Floor
-```
-
-The "Request override" level is gated by `trust_client_sampling` (see below) — untrusted by
-default, it drops out of the hierarchy entirely except for `max_tokens`.
-
-"Per-model defaults" isn't always one rung: it sits *above* global settings when a person set
-it, and *below* global settings when gglib auto-detected it — see "Reasoning model
-auto-defaults" and "Where a model's defaults came from" further down.
-
-The full set of configurable parameters:
-
-| Parameter | CLI flag | Range | Floor | Notes |
-|-----------|----------|-------|-------|-------|
-| `temperature` | `--temperature` | 0.0 – 2.0 | 0.7 | |
-| `top_p` | `--top-p` | 0.0 – 1.0 | 0.95 | |
-| `top_k` | `--top-k` | int | 40 | |
-| `max_tokens` | `--max-tokens` | int | *(none)* | Deliberately unset — see below |
-| `repeat_penalty` | `--repeat-penalty` | > 0.0 | 1.0 | |
-| `presence_penalty` | `--presence-penalty` | 0.0 – 2.0 | 0.0, or 1.0 on a `reasoning`-tagged model | See below |
-| `min_p` | `--min-p` | 0.0 – 1.0 | 0.0 (disabled) | 0.05 is llama.cpp built-in default when omitted |
-
-**`temperature`, `presence_penalty`, `repeat_penalty` and `min_p` are coupled.**
-The last three are only meaningful relative to how sharp `temperature` makes the
-sampling distribution, so they always come from whichever layer supplied the
-`temperature` — never a lower layer, which would apply a penalty tuned for a
-distribution nothing above it asked for. If that layer left one of the three
-unset (or if no layer names a temperature at all, in which case the pair-up
-doesn't apply), it falls to the floor rather than to a lower layer's value.
-
-The floor itself is class-aware for exactly one field: a plain `0.0`
-`presence_penalty` is fine for most models, but a `reasoning`-tagged model
-(Qwen3.6, DeepSeek-R1, QwQ, …) degrades into repetitive reasoning loops under
-greedy or near-greedy decoding, so its floor is `1.0` — a real guard, without
-asserting the model's full tuned recipe onto a temperature it wasn't chosen
-for. `top_p`, `top_k` and `max_tokens` are uncoupled and fill from any layer
-independently regardless of temperature.
-
-**`max_tokens` has no fallback, by design.** Resolution force-writes every set
-parameter into the outgoing request, so a fallback here would cap *every* request
-that did not name its own — silently truncating long answers. Left unset, no
-`max_tokens` key is sent and llama-server applies its own `n_predict` default of
-`-1`, generating until a stop token or the context limit. Explicit per-request,
-per-profile and per-model values are unaffected.
-
-**Reasoning model auto-defaults.** Models tagged `reasoning` at import time (Qwen3.6,
-DeepSeek R1, QwQ, etc.) automatically receive a pre-tuned `InferenceConfig` profile as
-their per-model defaults:
-
-```
-temperature=1.0  top_p=0.95  top_k=20  max_tokens=8192
-presence_penalty=1.5  min_p=0.0  repeat_penalty=1.0
-```
-
-These are baked into the database at download time and are fully user-overridable:
-
-```bash
-# Inspect all stored details for a model (arch, quant, capabilities, inference defaults)
-gglib model inspect <id>
-
-# Show every resolved parameter and which layer supplied it
-gglib model explain <id>
-
-# Override individual params
-gglib model update <id> --presence-penalty 0.8 --max-tokens 32768
-
-# Clear all inference defaults (revert to global/hardcoded chain)
-gglib model update <id> --clear-inference-defaults
-```
-
-All the same flags are available on `gglib serve`, `gglib chat`, and `gglib q` as
-per-invocation overrides that sit at the top of the hierarchy.
-
-**Where a model's defaults came from.** gglib tracks whether a model's stored
-`inference_defaults` were set by a person or written automatically by the auto-default
-behaviour above, and the two rank differently:
-
-```
-Request override → Inference profile → Per-model defaults (user-set) → Global settings
-  → Per-model defaults (auto-detected) → Floor
-```
-
-A deliberate per-model choice (`gglib model update --presence-penalty …`, or an edit in
-the WebUI) keeps outranking global settings — that's what "per-model" is supposed to
-mean. An unreviewed guess from the `reasoning` tag does not: it ranks *below* global
-settings instead of silently shadowing them. Without this, a model tagged `reasoning`
-would always resolve its full auto-written recipe over anything configured globally, with
-no way to tell the two apart in the resolved output.
-
-```bash
-# Shows whether the current defaults are user-set or auto-detected
-gglib model inspect <id>
-
-# Shows the rung each parameter actually resolved from, for this model
-gglib model explain <id>
-
-# ...and how selecting a profile changes that resolution
-gglib model explain <id> --profile coding
-
-# Any explicit edit marks the defaults user-set from then on, even if the
-# values happen to match what gglib would have guessed
-gglib model update <id> --presence-penalty 0.8
-```
-
-`gglib model explain` is the direct answer to "why is this parameter this
-value?". It resolves through the same code the proxy does and labels each
-result with the layer it came from — including the cases that surprise people:
-a parameter sitting on the floor because a higher layer claimed the
-temperature, and a `reasoning` model's auto-written recipe losing to global
-settings.
-
-```
-temperature      0.2     ← profile 'coding'
-top_k            20      ← global settings
-presence_penalty 1.0     ← reasoning floor (coupled to temperature layer)
-max_tokens       —       ← unset by design
-```
-
-Rows written before this distinction existed have nothing stored for it — there's no
-migration that goes back and stamps every existing row, since the two backend service
-processes (`gglib-axum`, standalone `gglib`) don't share a single startup hook to run one
-in. Instead, every read derives the answer on the spot: a stored value that matches the
-reasoning recipe byte-for-byte is treated as auto-detected, and anything else as user-set.
-
-#### Client sampling authority
-
-By default, an external client's own sampling parameters (`temperature`, `top_p`,
-`top_k`, `presence_penalty`, `repeat_penalty`, `min_p`) are **not honoured** — they
-are read off the incoming request and then dropped, so the request resolves exactly
-as if the client had sent none of them. `max_tokens` is the one exception: it is a
-budget, not a taste, and ignoring it would silently truncate the client's own turns,
-so it is always forwarded regardless of this setting.
-
-This is the default because many OpenAI-compatible clients send fixed sampling
-values with no user-facing control behind them. VS Code Copilot's LLM Gateway, for
-one, hardcodes `temperature: 0` on every agent request — that is boilerplate the
-extension always sends, not a deliberate choice by whoever is using it. Trusting it
-by default would let that boilerplate silently outrank a model's own tuned defaults
-and this server's global settings, defeating the point of configuring either.
-
-```bash
-# Inspect the current setting
-gglib config settings show
-
-# Trust clients that expose real sampling controls to their user (e.g. OpenWebUI)
-gglib config settings set --trust-client-sampling true
-
-# Back to the default
-gglib config settings set --trust-client-sampling false
-```
-
-`{model}:{profile}` selection is unaffected either way — that is not a client
-sampling parameter, it is part of the requested model name, and profiles remain the
-sanctioned way for a client to express a sampling preference without needing to be
-trusted (see below). In-process callers (`gglib chat`, `gglib q`) are also
-unaffected: their sampling parameters are gglib's own typed configuration, not an
-external client's request body, so they are always honoured.
-
-#### Inference profiles (`<model>:<profile>`)
-
-One proxy often serves clients that want incompatible sampling: a coding agent
-wants low-variance output while a chat UI wants something warmer. Both hit the
-same model name, so per-model defaults alone cannot tell them apart.
-
-**Inference profiles** are named sampling overrides selected per request by
-suffixing the model:
-
-```bash
-# Install the starter profiles (coding, chat, creative), then edit to taste
-gglib config profile install-templates
-gglib config profile list
-
-# Create or adjust one — only the flags you pass are set
-gglib config profile set coding --temperature 0.15 --top-p 0.9
-gglib config profile set coding --unset top-p        # back to the model default
-gglib config profile show coding
-```
-
-A client then selects it as part of the model name:
-
-```jsonc
-{ "model": "qwen3.6:coding", "messages": [...] }
-```
-
-Profiles are **global** — one `coding` profile applies to every model — and
-deliberately **sparse**: only the parameters you set override anything, and the
-rest fall through to that model's own defaults. That is what makes a single
-profile safe across models with different architectures; a `coding` profile
-setting only `top_k` still lets a thinking model contribute its own `top_p`
-and `max_tokens`.
-
-One exception: a `coding` profile that sets `temperature` does **not** also
-inherit the model's `presence_penalty` — see the coupling rule above. A
-profile is presumed to be choosing its own distribution sharpness, so it gets
-the floor for the coupled parameters it doesn't name, not the model's recipe
-tuned for a different temperature. Set `presence_penalty` explicitly on the
-profile if it needs one.
-
-Key behaviours:
-
-- **Bare model names are unchanged.** `qwen3.6` resolves exactly as it always
-  did. Nothing is applied unless a profile is named.
-- **A real model always wins.** If a model is literally named `qwen3.6:27b`, it
-  resolves as that model — adding a profile can never shadow an existing one.
-- **An unknown profile is a 404, not a fallback.** If `coding` is renamed or
-  deleted, requests naming it fail loudly rather than quietly sampling at the
-  wrong temperature.
-- **No model reload.** A profile changes only the request body, so switching
-  between `qwen3.6:coding` and `qwen3.6` does not restart llama-server or
-  invalidate the KV cache.
-
-Set `--list-in-models` on a profile to advertise `<model>:<profile>` in
-`/v1/models`, which makes it directly selectable in clients like OpenWebUI:
-
-```bash
-gglib config profile set chat --list-in-models
-```
-
-Listing is opt-in per profile because the full cross product of models and
-profiles would swamp a client's model picker. Unlisted profiles remain fully
-usable by name. Profiles can also be managed from the GUI under
-**Settings → Inference Profiles**.
-
-#### Server launch defaults
-
-In addition to inference parameters, each model can store per-model **server launch
-defaults** (e.g., `context_length`) in the `server_defaults` DB column. These are
-resolved through a 4-level fallback chain:
-
-```
-Runtime request / CLI flag  →  Per-model server_defaults  →  Global settings  →  Hardcoded default (4096)
-```
-
-Per-model server defaults can be set via the GUI or API (`PATCH /api/models/:id` with
-`serverDefaults: { contextLength: 8192 }`), cleared with `serverDefaults: null`, or
-left unchanged by omitting the field. The CLI `serve`, `chat`, and `q` commands
-automatically consume these defaults, so models with large context windows don't need
-manual `--ctx-size` flags on every invocation.
-
-#### Backfilling tags on existing catalogs
-
-Models imported before format-tag detection landed can be retagged in place from their persisted GGUF metadata — no re-download required:
-
-```bash
-# Additive: only append missing format:* tags, never remove anything
-gglib model retag --all
-
-# Full rebuild: drop and re-derive every auto-generated tag, preserving user tags
-gglib model retag --all --full
-
-# Single model
-gglib model retag qwen3-30b
-```
-
-End-to-end round-trip coverage lives in [`crates/gglib-proxy/tests/integration_proxy_pipeline.rs`](crates/gglib-proxy/tests/integration_proxy_pipeline.rs).
-
-### Crate Metrics
-
-#### Core Layer
-| Crate | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [gglib-core](crates/gglib-core) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-complexity.json) |
-
-#### Application Layer
-| Crate | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [gglib-agent](crates/gglib-agent) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-agent-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-agent-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-agent-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-agent-complexity.json) |
-
-#### Infrastructure Layer
-| Crate | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [gglib-db](crates/gglib-db) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-db-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-db-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-db-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-db-complexity.json) |
-| [gglib-gguf](crates/gglib-gguf) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-gguf-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-gguf-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-gguf-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-gguf-complexity.json) |
-| [gglib-hf](crates/gglib-hf) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-hf-complexity.json) |
-| [gglib-download](crates/gglib-download) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-download-complexity.json) |
-| [gglib-mcp](crates/gglib-mcp) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-mcp-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-mcp-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-mcp-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-mcp-complexity.json) |
-| [gglib-proxy](crates/gglib-proxy) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-complexity.json) |
-| [gglib-runtime](crates/gglib-runtime) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-runtime-complexity.json) |
-
-#### Facade Layer
-| Crate | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [gglib-app-services](crates/gglib-app-services) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-app-services-complexity.json) |
-| [gglib-bootstrap](crates/gglib-bootstrap) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-bootstrap-complexity.json) |
-
-#### Adapter Layer
-| Crate | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [gglib-cli](crates/gglib-cli) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-cli-complexity.json) |
-| [gglib-axum](crates/gglib-axum) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-axum-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-axum-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-axum-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-axum-complexity.json) |
-| [gglib-tauri](crates/gglib-tauri) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-tauri-tests.json) | ![N/A](https://img.shields.io/badge/coverage-N%2FA-lightgrey) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-tauri-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-tauri-complexity.json) |
-
-#### Frontend Layer
-| Component | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [Web UI](src/) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-tests.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-coverage.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-complexity.json) |
-
-#### Utility Crates
-| Crate | Tests | Coverage | LOC | Complexity |
-|-------|-------|----------|-----|------------|
-| [gglib-build-info](crates/gglib-build-info) | ![N/A](https://img.shields.io/badge/tests-N%2FA-lightgrey) | ![N/A](https://img.shields.io/badge/coverage-N%2FA-lightgrey) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-build-info-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-build-info-complexity.json) |
-
-### Crate Documentation
-
-Each crate has its own README with architecture diagrams, module breakdowns, and design decisions:
-
-| Layer | Crate | Description |
-|-------|-------|-------------|
-| **Core** | [gglib-core](crates/gglib-core/README.md) | Pure domain types, ports & traits |
-| **App** | [gglib-agent](crates/gglib-agent/README.md) | Pure-domain agentic loop (LLM→tool→LLM, port-injected) |
-| **Infra** | [gglib-db](crates/gglib-db/README.md) | SQLite repository implementations |
-| **Infra** | [gglib-gguf](crates/gglib-gguf/README.md) | GGUF file format parser |
-| **Infra** | [gglib-hf](crates/gglib-hf/README.md) | HuggingFace Hub client |
-| **Infra** | [gglib-download](crates/gglib-download/README.md) | Download queue & manager |
-| **Infra** | [gglib-mcp](crates/gglib-mcp/README.md) | MCP server management |
-| **Infra** | [gglib-proxy](crates/gglib-proxy/README.md) | OpenAI-compatible proxy server |
-| **Infra** | [gglib-runtime](crates/gglib-runtime/README.md) | Process manager & system probes |
-| **Facade** | [gglib-app-services](crates/gglib-app-services/README.md) | Shared application service ops (feature parity) |
-| **Facade** | [gglib-bootstrap](crates/gglib-bootstrap/README.md) | Shared composition root (infra wiring) |
-| **Adapter** | [gglib-cli](crates/gglib-cli/README.md) | CLI interface |
-| **Adapter** | [gglib-axum](crates/gglib-axum/README.md) | HTTP API server |
-| **Adapter** | [gglib-tauri](crates/gglib-tauri/README.md) | Desktop GUI (Tauri + React) |
-| **Utility** | [gglib-build-info](crates/gglib-build-info/README.md) | Compile-time version & git metadata |
-
-### Module Reference
-
-#### TypeScript Frontend
-- **[`components`](src/components/README.md)** – React UI components
-- **[`contexts`](src/contexts/README.md)** – React Context providers
-- **[`hooks`](src/hooks/README.md)** – Custom React hooks
-- **[`pages`](src/pages/README.md)** – Top-level page components
-- **[`types`](src/types/README.md)** – Shared TypeScript type definitions
-- **[`utils`](src/utils/README.md)** – Shared helpers (formatting, SSE, platform detection)
-- **[`services`](src/services/README.md)** – API client layer (HTTP and Tauri IPC)
-- **[`commands`](src/commands/README.md)** – CLI command reference (download, llama management)
-
-<!-- crate-docs:end -->
+Requests naming `qwen3.6:coding` select a sampling profile on top of the same
+model — see [Sampling resolution](docs/sampling.md#inference-profiles-modelprofile).
+
+## What the proxy does to every request
+
+Everything between the OpenAI request and llama-server is the product:
+
+- **Dialect normalization** — a parse → normalize → re-encode pipeline turns
+  model-specific markup (Qwen XML tool calls, bare `<think>` tags) into strict
+  `chat.completion.chunk` events, selected per model by
+  [`format:*` tags](docs/tags.md#format-dialect-tags).
+- **Context defense** — oversized tool/assistant messages are compacted before
+  forwarding, and prompts that would still blow the context window are rejected
+  with a clean 400 instead of a looping model — see
+  [History Truncation](crates/gglib-proxy/README.md#history-truncation).
+- **Sampling authority** — a 5-level resolution hierarchy decides every
+  parameter; clients that hardcode `temperature: 0` don't silently win — see
+  [Sampling resolution](docs/sampling.md).
+- **KV cache tiering** — `q8_0` KV quantization, auto-sized host-RAM prompt
+  cache, and opt-in disk slot persistence — see
+  [KV cache tiering](docs/cache.md).
+- **Capability detection** — GGUF metadata drives launch flags (`--jinja`,
+  reasoning format, MTP speculative decoding, embeddings) with no per-model
+  setup — see [Tags & capability detection](docs/tags.md).
+- **Contention absorption** — model-swap collisions are waited out server-side
+  instead of surfacing as a `503` that clients treat as terminal — see
+  [contention](crates/gglib-proxy/src/contention/README.md).
+
+## Dashboard
+
+The proxy reports what it is doing: active connections, per-slot context
+usage, cache reuse, and recent request history, at `GET /v1/proxy/status`
+(JSON) and `/v1/proxy/status/stream` (SSE). `gglib proxy dashboard` renders it
+live in the terminal; the web and desktop GUIs render the same snapshot as the
+Proxy Dashboard modal.
+
+<!-- placeholder: docs/assets/proxy-dashboard.png — GUI dashboard screenshot -->
 
 ## Interfaces
 
-All interfaces share the same database and model directory. Pick whichever fits your workflow — or use several.
+All interfaces share the same database and model directory.
 
 | Interface | Launch | Details |
 |-----------|--------|---------|
-| **CLI** | `gglib <command>` | [gglib-cli](crates/gglib-cli/README.md) |
-| **Desktop GUI** | `gglib gui` | [gglib-tauri](crates/gglib-tauri/README.md), [src-tauri](src-tauri/README.md) |
+| **OpenAI proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — all models, hot-swapped on demand |
+| **Pinned endpoint** | `gglib serve <id>` | Same proxy stack locked to one model |
+| **Always-on proxy** | Desktop GUI tray | `--proxy-autostart`, `--close-to-tray`, `--start-at-login` |
+| **CLI** | `gglib <command>` | [gglib-cli](crates/gglib-cli/README.md) — download, chat, `cat log \| gglib q "…"`, benchmark/tune |
+| **Desktop GUI** | `gglib gui` | [gglib-tauri](crates/gglib-tauri/README.md) |
 | **Web UI** | `gglib web` | [gglib-axum](crates/gglib-axum/README.md) — default `127.0.0.1:9887` |
-| **OpenAI Proxy** | `gglib proxy` | [gglib-proxy](crates/gglib-proxy/README.md) — works with OpenWebUI, any OpenAI SDK |
-| **Pinned endpoint** | `gglib serve <id>` | The same proxy locked to one model — `/v1/models` advertises only that model, for clients that cannot switch |
-| **Always-on proxy** | Desktop GUI, in the tray | The proxy as a background service — see below |
-
-**Always-on proxy** — the desktop app can keep the endpoint up without a terminal
-or a visible window, which is the usual way to feed a client like VS Code Copilot.
-Three settings, in the GUI's Settings dialog, the Web UI, or `gglib config settings set`:
-
-| Setting | Effect |
-|---------|--------|
-| `--proxy-autostart` | Start the proxy as soon as the app launches |
-| `--close-to-tray` | Closing the window hides it, leaving the proxy serving |
-| `--start-at-login` | Register the app with your OS autostart |
-
-With all three on, the endpoint is there from the moment you log in — gglib comes up
-in the menu bar with no window at all. The tray icon shows whether the **proxy** is
-running — not merely whether gglib is open — and its panel gives you the endpoint URL,
-live connections and context usage, and start/stop. Right-click the icon for the full
-menu.
-
-On macOS, `--close-to-tray` also drops gglib out of the Dock while it is hidden. That
-necessarily takes it out of the Cmd+Tab switcher too, so the menu bar icon is the way
-back — click it, or use its Open gglib item. Windows and Linux need no equivalent: a
-taskbar button belongs to a window, so hiding the window already removes it.
-
-If the tray icon fails to appear, gglib shows its window rather than starting hidden —
-on Linux that failure usually means `libayatana-appindicator3` is missing, or a bar
-without StatusNotifierItem support under Wayland.
-
-`gglib proxy` and `gglib serve` are unaffected: they stay explicit foreground
-commands. If one of them already holds the port, the desktop app leaves it alone
-rather than fighting it for the bind.
-
-**Shell completions** — enable tab completion for your shell:
-
-| Shell | Setup |
-|-------|-------|
-| fish | `gglib completions fish > ~/.config/fish/completions/gglib.fish` |
-| bash | `gglib completions bash > ~/.bash_completion` |
-| zsh | `gglib completions zsh > ~/.zsh/_gglib` |
-| elvish | `gglib completions elvish > ~/.config/elvish/lib/gglib.elv` |
-| powershell | `gglib completions powershell >> $PROFILE` |
 
 ## Security
 
-The proxy endpoint has an MCP gateway attached to it (`POST /mcp`) whose
-`invoke_tool` executes filesystem tools and whatever external MCP servers you
-have configured. Everything below is about who is allowed to reach that port.
+Everything binds `127.0.0.1` by default. A bearer API key is optional on
+loopback (`GGLIB_API_KEY`, `--api-key`, or settings) and minted automatically
+the first time you bind anything else. A Host-header allowlist (DNS-rebinding
+guard) and local-only CORS are always on. There is no multi-tenancy or rate
+limiting — keep it off the public internet. Details:
+[gglib-proxy](crates/gglib-proxy/README.md).
 
-### Binding
+## Architecture
 
-`gglib proxy`, `gglib serve`, `gglib up` and `gglib web` all bind `127.0.0.1`
-by default. Binding anywhere else is opt-in and never inherited.
-
-### API key
-
-Optional, and off by default for a loopback bind — an endpoint only your own
-machine can reach does not need a password, and requiring one would break every
-existing local setup for nothing.
-
-| Source | How |
-|---|---|
-| Flag | `gglib proxy --api-key <key>` |
-| Environment | `GGLIB_API_KEY` (e.g. in `<data-dir>/.env`) |
-| Setting | `gglib config settings set --proxy-api-key <key>`, or the GUI's Settings dialog |
-
-Highest wins. Prefer the environment variable or the setting over the flag: a
-key on the command line is visible to every process on the machine through the
-process list, and lands in your shell history.
-
-When set, `Authorization: Bearer <key>` is required on `/v1/*` and `/mcp`.
-`/health` stays open so a supervisor or container healthcheck can poll it
-without credentials.
-
-```bash
-curl -H "Authorization: Bearer $GGLIB_API_KEY" http://127.0.0.1:8080/v1/models
-```
-
-**Binding off loopback generates a key automatically.** The first time the proxy
-binds anything other than a loopback address without a key configured, it mints
-one, saves it to settings, and prints it in the startup banner — so an endpoint
-that reaches a network is never left open because someone forgot. It is reused
-on subsequent starts; recover it with `gglib config settings show`.
-
-### Host allowlist (DNS-rebinding guard)
-
-Always on, independent of the API key. The proxy rejects any request whose
-`Host` header is not one it answers to, with `403 host_not_allowed`.
-
-| Bind | Accepted `Host` |
-|---|---|
-| `127.0.0.1` / `localhost` / `::1` | any loopback name or address |
-| `192.168.1.5` | loopback, plus `192.168.1.5` |
-| `0.0.0.0` / `::` | loopback only |
-
-A wildcard bind names no reachable address, so it grants nothing on its own —
-add `--allowed-host` for each name clients will actually use:
-
-```bash
-gglib proxy --host 0.0.0.0 --allowed-host 192.168.1.5 --allowed-host gglib.lan
-```
-
-**Why this exists, precisely.** DNS rebinding does not change the attacker's
-`Origin` — it changes which IP a hostname resolves to. The `Origin` header stays
-`https://evil.com`, so `CorsConfig::LocalOnly` does reject it. What CORS does
-not do is stop the request from being *sent*; it governs whether the response
-may be *read*. Preflighted requests (anything sending `Content-Type:
-application/json`, which is every `/v1/chat/completions` and `/mcp` call) are
-genuinely blocked, but a simple `GET` is sent and runs to completion with only
-its response withheld. The `Host` header is the part rebinding cannot forge.
-Checking it closes that gap, covers any route that is not preflighted, and stops
-the endpoint depending on CORS being configured correctly.
-
-### CORS
-
-`gglib web`, `gglib proxy` and `gglib serve` use `CorsConfig::LocalOnly` by
-default — only `localhost`, `127.0.0.1`, `::1`, and Tauri custom schemes
-(`tauri://localhost`, `http://tauri.localhost`) are accepted as origins.
-
-### What is still not covered
-
-There is no multi-tenancy, no per-client authorization, no rate limiting, and
-no audit log. One key is one key. Use firewall rules, private subnets, or a VPN;
-do not expose this to the public internet.
+A Cargo workspace (~17 crates, Rust + a React front end) with CI-enforced
+dependency direction: adapters (`gglib-cli`, `gglib-axum`, `gglib-tauri`) →
+facades (`gglib-app-services`, `gglib-bootstrap`) → infrastructure (`gglib-db`,
+`gglib-gguf`, `gglib-mcp`, `gglib-proxy`) → core (`gglib-core`, pure domain).
+Only [`gglib-runtime`](crates/gglib-runtime/README.md) spawns llama-server;
+only [`gglib-download`](crates/gglib-download/README.md) talks to HuggingFace.
+Every crate's README carries its architecture diagram and module breakdown —
+start at [`crates/`](crates/) or the
+[generated API docs](https://mmogr.github.io/gglib), and see
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions.
 
 ## Installation
 
-Download from the [Releases page](https://github.com/mmogr/gglib/releases):
-
-| Platform | Archive | Post-install |
-|----------|---------|--------------|
-| **macOS (Apple Silicon)** | `gglib-gui-*-aarch64-apple-darwin.tar.gz` | Run `macos-install.command` to remove quarantine |
-| **macOS (Intel)** | `gglib-gui-*-x86_64-apple-darwin.tar.gz` | Same as above |
-| **Linux** | `gglib-gui-*-x86_64-unknown-linux-gnu.tar.gz` | Run `gglib-gui` |
-| **Windows** | `gglib-gui-*-x86_64-pc-windows-msvc.zip` | Run `gglib-gui.exe` |
-
-### From Source
+Grab a build from the [Releases page](https://github.com/mmogr/gglib/releases)
+(macOS Apple Silicon/Intel, Linux, Windows — on macOS run
+`macos-install.command` to remove quarantine), or build from source:
 
 ```bash
 git clone https://github.com/mmogr/gglib.git && cd gglib
 make setup   # check deps → build frontend → install CLI → offer llama.cpp install
 ```
 
-`make setup` checks for Rust, Node.js, and build tools; builds the web UI; and installs the CLI to `~/.cargo/bin/`. It needs no Python — model downloads are native Rust HTTP.
-
-> **Developer Mode:** When installed via `make setup`, the database (`gglib.db`), config (`.env`), and llama.cpp binaries live inside your repo folder. Downloaded models default to `~/.local/share/llama_models`.
-
-### Prerequisites
-
-- **Rust** 1.70+ (MSRV). Tooling/CI currently pins Rust **1.97.1** via `rust-toolchain.toml` — using that version is recommended. — [rustup.rs](https://rustup.rs/)
-- **Node.js** 20.19+ (matches the `package.json` `engines` field) — [nodejs.org](https://nodejs.org/) (for web UI)
-- **SQLite** 3.x
-- **Build tools**: macOS `xcode-select --install` + `brew install cmake` · Ubuntu `build-essential cmake git` · Windows VS 2022 C++ + CMake
-- **Linux desktop app**: WebKit2GTK 4.1 and libayatana-appindicator (the system tray). Package names differ by distribution — `libwebkit2gtk-4.1-dev` and `libayatana-appindicator3-dev` on Debian/Ubuntu, `webkit2gtk-4.1` and `libayatana-appindicator` on Arch. Run `gglib config check-deps`, which detects your distribution and prints the exact command.
-
-llama.cpp is managed by GGLib — no separate install needed.
-
-<details>
-<summary><strong>Makefile targets</strong></summary>
-
-**Installation & Setup:**
-- `make setup` — Full setup (dependencies + build + install + llama.cpp)
-- `make install` — Build and install CLI to `~/.cargo/bin/`
-- `make uninstall` — Full cleanup (removes binary, system data, database; preserves models)
-
-**Building:**
-- `make build` / `make build-dev` — Release / debug binary
-- `make build-gui` — Web UI frontend
-- `make build-tauri` — Desktop GUI
-- `make build-all` — Everything (CLI + web UI)
-
-**Development:**
-- `make test` / `make check` / `make fmt` / `make lint` / `make doc`
-
-**llama.cpp:**
-- `make llama-install-auto` / `make llama-status` / `make llama-update`
-
-**Running:**
-- `make run-gui` / `make run-web` / `make run-serve` / `make run-proxy`
-
-**Cleaning:**
-- `make clean` / `make clean-gui` / `make clean-llama` / `make clean-db`
-
-</details>
-
-<details>
-<summary><strong>Manual installation (Cargo)</strong></summary>
-
-```bash
-cargo install --path .
-```
-
-</details>
-
-<details>
-<summary><strong>Configuring the models directory</strong></summary>
-
-Default: `~/.local/share/llama_models`. Change via any of:
-
-- `make setup` prompt
-- `.env` file: `GGLIB_MODELS_DIR=/absolute/path`
-- CLI: `gglib config models-dir set <path>` or `gglib --models-dir <path> download …`
-- GUI/Web: Settings modal (gear icon)
-
-Precedence: CLI flag → env var → default. Changing the directory does **not** move existing files.
-
-</details>
-
-## Development
-
-Start the backend and frontend in separate terminals:
-
-```bash
-# Backend API server
-cargo run --package gglib-cli -- web --api-only --port 9887 --base-port 9000
-
-# Frontend dev server (proxies /api/* to backend)
-npm run dev
-# → http://localhost:5173
-```
-
-Or use the VS Code task **🚀 Run Dev (Frontend + Backend)** to launch both in parallel.
-
-<details>
-<summary><strong>Port configuration</strong></summary>
-
-Set `VITE_GGLIB_WEB_PORT` in `.env` to change the API port (default `9887`). Both the Rust backend (via clap env) and Vite proxy read this value. The `VITE_` prefix is required for Vite. Port config only affects dev mode — production uses same-origin relative paths. Tauri uses dynamic port discovery.
-
-</details>
-
-<details>
-<summary><strong>Production builds</strong></summary>
-
-```bash
-npm run build                                                      # → ./web_ui/
-cargo run --package gglib-cli -- web --port 9887 --static-dir ./web_ui  # single-port serving
-```
-
-</details>
-
-<details>
-<summary><strong>Accelerated downloads (hf_xet)</strong></summary>
-
-Downloads run natively in Rust by default: a resumable ranged GET straight to the Hugging Face CDN, verified against the object's SHA-256 and renamed into place only once it checks out. This needs nothing installed beyond gglib itself.
-
-[hf_xet](https://github.com/huggingface/hf-xet) is available as an **optional** accelerator on top of that. It is never provisioned implicitly — you opt in explicitly:
-
-```bash
-gglib config check-deps --setup-fast-downloads   # CLI
-```
-
-or the **Fast Downloads** step of the setup wizard in the GUI. Either builds a Python environment under `<data_root>/.conda/gglib-hf-xet` with `huggingface_hub>=1.1.5` + `hf_xet>=0.6`, and needs Python 3 on `PATH`.
-
-Once that environment exists, downloads use it automatically. If it is absent — or present but failing — downloads fall back to the native path rather than erroring.
-
-</details>
-
-<details>
-<summary><strong>VS Code tasks</strong></summary>
-
-- **🚀 Run Dev (Frontend + Backend)** — parallel launch
-- **🧠 Run Backend Dev (API-only)** — backend only
-- **🎨 Run Frontend Dev** — Vite dev server
-- **🖥️ Run GUI (Dev)** — Tauri desktop in dev mode
-- **🧪 Run All Tests** / **📎 Clippy** / **🎨 Format Code**
-
-</details>
-
-## Troubleshooting & Debugging
-
-<details>
-<summary><strong>Verbose logging</strong></summary>
-
-Use `-v` / `--verbose` on any command to enable debug-level logging with file output:
-
-```bash
-gglib proxy -v
-```
-
-- **Log level:** `debug` (all targets). Override with `RUST_LOG=trace gglib proxy -v` for finer control.
-- **Log files:** Written to logs in development builds, or `<data_root>/logs/` in release builds (e.g., `~/.local/share/gglib/logs/`). Files rotate daily.
-- The `-v` flag is global — it works with any subcommand (`proxy`, `serve`, `question`, etc.).
-
-</details>
-
-<details>
-<summary><strong>Model contention & retry budgets</strong></summary>
-
-When a request arrives for one model while another is still starting, the two
-collide over the same startup slot. If the collision does not clear, the loser
-gets a `503`. This only happens with concurrent traffic for *different* models —
-a single client working with one model will never see it.
-
-Two layers absorb that, and they compose:
-
-| Layer | Budget | Tuning |
-|---|---|---|
-| Proxy waits out the collision | ≤ 30 s | `GGLIB_CONTENTION_WAIT_SECS` |
-| Client retries the resulting `503` | ≤ 60 s, 4 attempts | `GGLIB_LLM_RETRY_DEADLINE_SECS`, `GGLIB_LLM_RETRY_MAX_ATTEMPTS` |
-
-So a request that never succeeds fails after roughly **90 seconds**. The layers
-are deliberately independent — neither reads the other's state — so each can be
-tuned or switched off without disturbing the other.
-
-**Why the server waits at all.** OpenAI-compatible clients such as the VS Code
-LLM Gateway and Copilot treat `503` as terminal and abandon the request rather
-than backing off. For them a slow `200` is strictly better than a fast `503`, and
-no amount of client-side retry on our side helps, because the retry would have to
-happen in their code. Setting `GGLIB_CONTENTION_WAIT_SECS=0` restores immediate
-fail-fast.
-
-**Tuning.** Raise `GGLIB_CONTENTION_WAIT_SECS` if you routinely run several large
-models and would rather wait than fail. Lower it — or zero it — if you would
-rather see failures immediately, for instance when scripting. Shortening
-`GGLIB_LLM_RETRY_DEADLINE_SECS` pulls the client's backoff ceiling down with it,
-so a tightened budget still gets at least one retry rather than silently getting
-none. `gglib chat --no-retry` disables client-side retry for a single run.
-
-**Diagnosing.** A `503` caused by contention carries
-`x-gglib-retry-reason: contention`, distinguishing it from ordinary model
-loading — the two are otherwise identical on the wire, since both report
-`service_unavailable`. While a retry is in flight the CLI and GUI both show a
-non-fatal notice ("Model unavailable — retrying in Ns"); the full upstream reason
-is in the logs at `warn` level.
-
-</details>
+Requires Rust (pinned via `rust-toolchain.toml`), Node.js 20.19+, and a C++
+toolchain with CMake; `gglib config check-deps` prints your platform's exact
+install commands. llama.cpp itself is managed by GGLib — no separate install.
 
 ## Documentation
 
-**[View Full API Documentation →](https://mmogr.github.io/gglib)**
-
-Auto-generated from source and updated with every release.
-
-## Acknowledgments
-
-### Core & CLI
-![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white)
-![Clap](https://img.shields.io/badge/Clap-CLI-orange?style=flat-square)
-![Tokio](https://img.shields.io/badge/Tokio-Async-blue?style=flat-square)
-![SQLx](https://img.shields.io/badge/SQLx-Database-green?style=flat-square)
-![Axum](https://img.shields.io/badge/Axum-Web_Server-darkred?style=flat-square)
-
-### GUI & Frontend
-![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=white)
-![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)
-![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)
-![Tailwind CSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)
-![Assistant UI](https://img.shields.io/badge/Assistant_UI-Chat_Interface-purple?style=flat-square)
-
-### Integrations
-![HuggingFace](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Hub-yellow?style=flat-square)
-![Llama.cpp](https://img.shields.io/badge/Llama.cpp-Inference-lightgrey?style=flat-square)
-
-## LLM Optimization / Progressive Disclosure
-
-When gglib is connected to an external MCP client (VS Code Copilot, OpenWebUI,
-etc.), the proxy exposes a **Progressive Disclosure** interface instead of
-dumping every tool schema up-front. This reduces context-window consumption by
-90 %+ and eliminates timeout failures caused by 100 k-token schema payloads.
-
-### How it works
-
-`tools/list` always returns exactly **three meta-tools** regardless of how many
-internal MCP servers are running:
-
-| Meta-tool         | Purpose                                                        |
-|-------------------|----------------------------------------------------------------|
-| `search_tools`    | Keyword search over tool IDs and descriptions (≤ 30 results)  |
-| `get_tool_schema` | Lazily fetch the full JSON input schema for one specific tool  |
-| `invoke_tool`     | Execute a tool by its qualified ID with the given arguments    |
-
-### Typical client flow
-
-```
-1. tools/list         → receives 3 meta-tool specs (~300 tokens)
-2. search_tools       → discovers relevant tool IDs by keyword
-3. get_tool_schema    → fetches only the schema it actually needs
-4. invoke_tool        → executes with known arguments
-```
-
-### Qualified tool IDs
-
-Internal tools are addressed with a double-underscore namespaced format:
-`"<server_name>__<tool_name>"` (e.g. `"filesystem__read_file"`). This ID is
-returned by `search_tools` and accepted by both `get_tool_schema` and
-`invoke_tool`.
-
-### Hard break — no legacy passthrough
-
-Direct calls to raw tool names via `tools/call` return `METHOD_NOT_FOUND`.
-All tool invocations must go through `invoke_tool`. There is no compatibility
-shim for the pre-disclosure interface.
-
-### Implementation
-
-| Location | Role |
-|---|---|
-| [`gglib-core/src/domain/mcp/tool_index.rs`](crates/gglib-core/src/domain/mcp/tool_index.rs) | `ToolIndex` + `ToolSummary` pure-data types; `SEARCH_RESULTS_CAP = 30` |
-| [`gglib-proxy/src/mcp/meta_tools.rs`](crates/gglib-proxy/src/mcp/meta_tools.rs) | Index construction from `McpService`; 3 static `McpToolSpec` definitions |
-| [`gglib-proxy/src/mcp/handlers.rs`](crates/gglib-proxy/src/mcp/handlers.rs) | `handle_meta_tools_list` + `handle_meta_tools_call` dispatch |
+- [Sampling resolution](docs/sampling.md) — the 5-level hierarchy,
+  temperature coupling, profiles, and `gglib model explain`
+- [Tags & capability detection](docs/tags.md) — GGUF auto-detection taxonomy
+  and retagging
+- [KV cache tiering](docs/cache.md) — quantization, RAM auto-sizing, disk
+  slot offloading
+- [Full API documentation](https://mmogr.github.io/gglib) — generated from
+  source on every release
 
 ## License
 
-GGLib is open source under the [GNU Affero General Public License v3.0](LICENSE) (AGPL-3.0).
-
-- **Personal and open source use** is free.
-- **Commercial use** — building a product, running a SaaS, or embedding GGLib in paid software — requires a commercial license.
-
-For commercial licensing enquiries, contact [@mmogr](https://github.com/mmogr) on GitHub.
+GGLib is open source under the
+[GNU Affero General Public License v3.0](LICENSE) (AGPL-3.0). Personal and
+open source use is free; commercial use — building a product, running a SaaS,
+or embedding GGLib in paid software — requires a commercial license. Contact
+[@mmogr](https://github.com/mmogr) on GitHub.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,59 @@
+# KV cache tiering
+
+gglib manages llama-server's cache stack across three tiers, each sized
+automatically and each overridable:
+
+1. **KV cache quantization** — the in-VRAM KV cache itself, quantized to
+   halve its footprint.
+2. **Host-RAM prompt cache** — llama-server's `--cache-ram`, auto-sized on
+   every launch.
+3. **Disk slot persistence** — opt-in per-session slot files that survive
+   model swaps and restarts.
+
+## KV cache quantization
+
+Every launch defaults the KV cache to `q8_0` quantization on both K and V
+(`--cache-type-k`/`--cache-type-v`), roughly halving KV memory versus
+llama-server's own `f16` default — which directly buys context headroom on a
+16–24 GB card. Override per-axis with the same flags, or set
+`GGLIB_DISABLE_KV_QUANT=1` to fall back to `f16`.
+
+## Host-RAM prompt cache auto-sizing
+
+Independently of disk persistence, every launch auto-sizes llama-server's own
+host-RAM prompt cache (`--cache-ram`) from system RAM, the model's weights, and
+its KV footprint — override with `--cache-ram-mb`.
+
+## Disk slot persistence
+
+Available on `gglib serve` and `gglib proxy` alike, and opt-in on both. For
+sequential multi-agent workflows, enable `--cache --slot-dir <path>` to persist
+KV cache state between requests. The proxy automatically saves and restores per-session
+slot files (saved atomically via a temp-then-rename), gated by a semaphore to prevent
+concurrent access. Stale caches are detected via mtime comparison and skipped
+(fail-open). A background sweep evicts the least-recently-used slot files once the
+on-disk cache exceeds a byte budget — by default auto-sized from free disk space,
+override with `--cache-disk-gb`. Use `gglib proxy cache-clear` to manually clear
+cached state.
+
+### Models where disk persistence is skipped
+
+Disk persistence is skipped automatically for models whose attention keeps only
+part of the token history — sliding-window, hybrid (e.g. a GGUF declaring
+`full_attention_interval`), and recurrent/SSM architectures. llama-server's slot
+files carry KV state and tokens but not the context checkpoints those models need
+to resume, so a restore cannot pick up where it left off and instead re-prefills
+the whole prompt, while also crowding out the host-RAM prompt cache that *would*
+have resumed cheaply. Such models rely on the RAM cache alone; the proxy logs the
+decision at startup. Set `GGLIB_FORCE_HYBRID_DISK_CACHE=1` to re-enable the disk
+layer anyway (intended for testing an upstream llama.cpp fix).
+
+## Observability
+
+The [proxy dashboard](../crates/gglib-proxy/README.md#proxy-dashboard) reports
+how the cache resolved and how much it is actually doing: the RAM budget,
+whether either tier is degraded, and measured reuse (prompt tokens served from
+cache vs. re-processed, per request and in total). These are raw counts taken
+from the upstream's own `usage` reporting — there is no estimated "time saved",
+since reuse is measured exactly but what it saved depends on a prefill that
+never ran.

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -1,0 +1,261 @@
+# Sampling resolution
+
+gglib treats sampling as server-side configuration, not something every client
+gets to improvise. Every request that reaches llama-server — from the proxy,
+`gglib serve`, `gglib chat`, or `gglib q` — resolves its sampling parameters
+through the same hierarchy, and `gglib model explain` shows exactly how any
+given model resolves.
+
+## The 5-level merge hierarchy
+
+Each level fills in only the fields left unset by the previous level:
+
+```
+Request override  →  Inference profile  →  Per-model defaults  →  Global settings  →  Floor
+```
+
+The "Request override" level is gated by `trust_client_sampling` (see
+[Client sampling authority](#client-sampling-authority)) — untrusted by
+default, it drops out of the hierarchy entirely except for `max_tokens`.
+
+"Per-model defaults" isn't always one rung: it sits *above* global settings when a person set
+it, and *below* global settings when gglib auto-detected it — see [Reasoning model
+auto-defaults](#reasoning-model-auto-defaults) and [Where a model's defaults came
+from](#where-a-models-defaults-came-from) below.
+
+The full set of configurable parameters:
+
+| Parameter | CLI flag | Range | Floor | Notes |
+|-----------|----------|-------|-------|-------|
+| `temperature` | `--temperature` | 0.0 – 2.0 | 0.7 | |
+| `top_p` | `--top-p` | 0.0 – 1.0 | 0.95 | |
+| `top_k` | `--top-k` | int | 40 | |
+| `max_tokens` | `--max-tokens` | int | *(none)* | Deliberately unset — see below |
+| `repeat_penalty` | `--repeat-penalty` | > 0.0 | 1.0 | |
+| `presence_penalty` | `--presence-penalty` | 0.0 – 2.0 | 0.0, or 1.0 on a `reasoning`-tagged model | See below |
+| `min_p` | `--min-p` | 0.0 – 1.0 | 0.0 (disabled) | 0.05 is llama.cpp built-in default when omitted |
+
+## Temperature coupling
+
+**`temperature`, `presence_penalty`, `repeat_penalty` and `min_p` are coupled.**
+The last three are only meaningful relative to how sharp `temperature` makes the
+sampling distribution, so they always come from whichever layer supplied the
+`temperature` — never a lower layer, which would apply a penalty tuned for a
+distribution nothing above it asked for. If that layer left one of the three
+unset (or if no layer names a temperature at all, in which case the pair-up
+doesn't apply), it falls to the floor rather than to a lower layer's value.
+
+The floor itself is class-aware for exactly one field: a plain `0.0`
+`presence_penalty` is fine for most models, but a `reasoning`-tagged model
+(Qwen3.6, DeepSeek-R1, QwQ, …) degrades into repetitive reasoning loops under
+greedy or near-greedy decoding, so its floor is `1.0` — a real guard, without
+asserting the model's full tuned recipe onto a temperature it wasn't chosen
+for. `top_p`, `top_k` and `max_tokens` are uncoupled and fill from any layer
+independently regardless of temperature.
+
+**`max_tokens` has no fallback, by design.** Resolution force-writes every set
+parameter into the outgoing request, so a fallback here would cap *every* request
+that did not name its own — silently truncating long answers. Left unset, no
+`max_tokens` key is sent and llama-server applies its own `n_predict` default of
+`-1`, generating until a stop token or the context limit. Explicit per-request,
+per-profile and per-model values are unaffected.
+
+## Reasoning model auto-defaults
+
+Models tagged `reasoning` at import time (Qwen3.6, DeepSeek R1, QwQ, etc. — see
+[docs/tags.md](tags.md)) automatically receive a pre-tuned `InferenceConfig`
+profile as their per-model defaults:
+
+```
+temperature=1.0  top_p=0.95  top_k=20  max_tokens=8192
+presence_penalty=1.5  min_p=0.0  repeat_penalty=1.0
+```
+
+These are baked into the database at download time and are fully user-overridable:
+
+```bash
+# Inspect all stored details for a model (arch, quant, capabilities, inference defaults)
+gglib model inspect <id>
+
+# Show every resolved parameter and which layer supplied it
+gglib model explain <id>
+
+# Override individual params
+gglib model update <id> --presence-penalty 0.8 --max-tokens 32768
+
+# Clear all inference defaults (revert to global/hardcoded chain)
+gglib model update <id> --clear-inference-defaults
+```
+
+All the same flags are available on `gglib serve`, `gglib chat`, and `gglib q` as
+per-invocation overrides that sit at the top of the hierarchy.
+
+## Where a model's defaults came from
+
+gglib tracks whether a model's stored `inference_defaults` were set by a person
+or written automatically by the auto-default behaviour above, and the two rank
+differently:
+
+```
+Request override → Inference profile → Per-model defaults (user-set) → Global settings
+  → Per-model defaults (auto-detected) → Floor
+```
+
+A deliberate per-model choice (`gglib model update --presence-penalty …`, or an edit in
+the WebUI) keeps outranking global settings — that's what "per-model" is supposed to
+mean. An unreviewed guess from the `reasoning` tag does not: it ranks *below* global
+settings instead of silently shadowing them. Without this, a model tagged `reasoning`
+would always resolve its full auto-written recipe over anything configured globally, with
+no way to tell the two apart in the resolved output.
+
+```bash
+# Shows whether the current defaults are user-set or auto-detected
+gglib model inspect <id>
+
+# Shows the rung each parameter actually resolved from, for this model
+gglib model explain <id>
+
+# ...and how selecting a profile changes that resolution
+gglib model explain <id> --profile coding
+
+# Any explicit edit marks the defaults user-set from then on, even if the
+# values happen to match what gglib would have guessed
+gglib model update <id> --presence-penalty 0.8
+```
+
+Rows written before this distinction existed have nothing stored for it — there's no
+migration that goes back and stamps every existing row, since the two backend service
+processes (`gglib-axum`, standalone `gglib`) don't share a single startup hook to run one
+in. Instead, every read derives the answer on the spot: a stored value that matches the
+reasoning recipe byte-for-byte is treated as auto-detected, and anything else as user-set.
+
+## `gglib model explain`
+
+`gglib model explain` is the direct answer to "why is this parameter this
+value?". It resolves through the same code the proxy does and labels each
+result with the layer it came from — including the cases that surprise people:
+a parameter sitting on the floor because a higher layer claimed the
+temperature, and a `reasoning` model's auto-written recipe losing to global
+settings.
+
+```
+temperature      0.2     ← profile 'coding'
+top_k            20      ← global settings
+presence_penalty 1.0     ← reasoning floor (coupled to temperature layer)
+max_tokens       —       ← unset by design
+```
+
+## Client sampling authority
+
+By default, an external client's own sampling parameters (`temperature`, `top_p`,
+`top_k`, `presence_penalty`, `repeat_penalty`, `min_p`) are **not honoured** — they
+are read off the incoming request and then dropped, so the request resolves exactly
+as if the client had sent none of them. `max_tokens` is the one exception: it is a
+budget, not a taste, and ignoring it would silently truncate the client's own turns,
+so it is always forwarded regardless of this setting.
+
+This is the default because many OpenAI-compatible clients send fixed sampling
+values with no user-facing control behind them. VS Code Copilot's LLM Gateway, for
+one, hardcodes `temperature: 0` on every agent request — that is boilerplate the
+extension always sends, not a deliberate choice by whoever is using it. Trusting it
+by default would let that boilerplate silently outrank a model's own tuned defaults
+and this server's global settings, defeating the point of configuring either.
+
+```bash
+# Inspect the current setting
+gglib config settings show
+
+# Trust clients that expose real sampling controls to their user (e.g. OpenWebUI)
+gglib config settings set --trust-client-sampling true
+
+# Back to the default
+gglib config settings set --trust-client-sampling false
+```
+
+`{model}:{profile}` selection is unaffected either way — that is not a client
+sampling parameter, it is part of the requested model name, and profiles remain the
+sanctioned way for a client to express a sampling preference without needing to be
+trusted (see below). In-process callers (`gglib chat`, `gglib q`) are also
+unaffected: their sampling parameters are gglib's own typed configuration, not an
+external client's request body, so they are always honoured.
+
+## Inference profiles (`<model>:<profile>`)
+
+One proxy often serves clients that want incompatible sampling: a coding agent
+wants low-variance output while a chat UI wants something warmer. Both hit the
+same model name, so per-model defaults alone cannot tell them apart.
+
+**Inference profiles** are named sampling overrides selected per request by
+suffixing the model:
+
+```bash
+# Install the starter profiles (coding, chat, creative), then edit to taste
+gglib config profile install-templates
+gglib config profile list
+
+# Create or adjust one — only the flags you pass are set
+gglib config profile set coding --temperature 0.15 --top-p 0.9
+gglib config profile set coding --unset top-p        # back to the model default
+gglib config profile show coding
+```
+
+A client then selects it as part of the model name:
+
+```jsonc
+{ "model": "qwen3.6:coding", "messages": [...] }
+```
+
+Profiles are **global** — one `coding` profile applies to every model — and
+deliberately **sparse**: only the parameters you set override anything, and the
+rest fall through to that model's own defaults. That is what makes a single
+profile safe across models with different architectures; a `coding` profile
+setting only `top_k` still lets a thinking model contribute its own `top_p`
+and `max_tokens`.
+
+One exception: a `coding` profile that sets `temperature` does **not** also
+inherit the model's `presence_penalty` — see the coupling rule above. A
+profile is presumed to be choosing its own distribution sharpness, so it gets
+the floor for the coupled parameters it doesn't name, not the model's recipe
+tuned for a different temperature. Set `presence_penalty` explicitly on the
+profile if it needs one.
+
+Key behaviours:
+
+- **Bare model names are unchanged.** `qwen3.6` resolves exactly as it always
+  did. Nothing is applied unless a profile is named.
+- **A real model always wins.** If a model is literally named `qwen3.6:27b`, it
+  resolves as that model — adding a profile can never shadow an existing one.
+- **An unknown profile is a 404, not a fallback.** If `coding` is renamed or
+  deleted, requests naming it fail loudly rather than quietly sampling at the
+  wrong temperature.
+- **No model reload.** A profile changes only the request body, so switching
+  between `qwen3.6:coding` and `qwen3.6` does not restart llama-server or
+  invalidate the KV cache.
+
+Set `--list-in-models` on a profile to advertise `<model>:<profile>` in
+`/v1/models`, which makes it directly selectable in clients like OpenWebUI:
+
+```bash
+gglib config profile set chat --list-in-models
+```
+
+Listing is opt-in per profile because the full cross product of models and
+profiles would swamp a client's model picker. Unlisted profiles remain fully
+usable by name. Profiles can also be managed from the GUI under
+**Settings → Inference Profiles**.
+
+## Server launch defaults
+
+In addition to inference parameters, each model can store per-model **server launch
+defaults** (e.g., `context_length`) in the `server_defaults` DB column. These are
+resolved through a 4-level fallback chain:
+
+```
+Runtime request / CLI flag  →  Per-model server_defaults  →  Global settings  →  Hardcoded default (4096)
+```
+
+Per-model server defaults can be set via the GUI or API (`PATCH /api/models/:id` with
+`serverDefaults: { contextLength: 8192 }`), cleared with `serverDefaults: null`, or
+left unchanged by omitting the field. The CLI `serve`, `chat`, and `q` commands
+automatically consume these defaults, so models with large context windows don't need
+manual `--ctx-size` flags on every invocation.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,121 @@
+# Tags & capability detection
+
+When you add a GGUF model, gglib reads its metadata — `tokenizer.chat_template`,
+`general.architecture`, and architecture-specific keys — and derives two kinds
+of information automatically:
+
+- **Capability flags** stored on the model row and used by the proxy to
+  preprocess requests (strict turn alternation, system-role support, …).
+- **Tags** in a protected auto-generated namespace (`reasoning`, `agent`,
+  `mtp`, `embedding`, `format:*`, …) that drive parser selection and
+  llama-server launch flags.
+
+Detection happens at import time in `gglib-gguf::capabilities::detect_all` and
+is persisted by `ModelService::import_from_file`. Nothing needs re-downloading
+to re-derive it — see [Retagging](#retagging-an-existing-catalog).
+
+## Capability flags
+
+The proxy uses per-model capability flags to preprocess requests before they
+reach llama-server: whether the model requires strict user/assistant turn
+alternation, supports a system role, can handle tool calls, and so on.
+
+For models whose quantized builds ship without a chat template, the
+architecture name (`general.architecture`) acts as a backstop — for example,
+`"mistral"` architecture always implies `REQUIRES_STRICT_TURNS`.
+
+You can inspect or override any model's flags at any time:
+
+```bash
+# Show current capabilities
+gglib model capabilities 3
+
+# Force strict-turn coalescing on
+gglib model capabilities 3 --set requires-strict-turns
+
+# Or via the REST API
+curl -X PATCH http://localhost:9887/api/models/3/capabilities \
+     -H 'Content-Type: application/json' \
+     -d '{"requiresStrictTurns": true}'
+```
+
+For details on how to add support for a new architecture, see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#model-architecture-registry).
+
+## `format:*` dialect tags
+
+The proxy normalizes every stream into strict OpenAI-compatible events
+regardless of the dialect llama-server emits (Qwen XML tool calls, bare
+`<think>` tags, …). Which dialect parser runs is driven entirely by **system
+tags** in the `format:*` namespace, persisted on each model row:
+
+| Tag | Parser | When auto-applied |
+|-----|--------|-------------------|
+| `format:qwen-xml` | `QwenXmlParser` | Model name contains `qwen` and the chat template emits `<tool_call>` markup |
+| `format:hermes` | `StandardJsonParser` | Hermes/ChatML-style tool-calling templates |
+
+Models without a dialect tag use the identity `StandardJsonParser`. A
+`format:*` tag is only emitted when tool calling is actually detected — a stray
+format hint on a non-tool-calling model would wire a parser with nothing to
+parse.
+
+## Capability tags
+
+Alongside `format:*` tags, gglib detects **capability tags** at import time
+from GGUF metadata, which drive automatic flag selection at serve time:
+
+| Tag | Detection trigger | Effect |
+|-----|-------------------|--------|
+| `agent` | Chat template contains tool-calling syntax | `--jinja` auto-enabled |
+| `reasoning` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled; pre-tuned sampling defaults written (see [docs/sampling.md](sampling.md#reasoning-model-auto-defaults)) |
+| `mtp` | `{arch}.nextn_predict_layers > 0` in GGUF metadata | `--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75` auto-enabled |
+| `embedding` | Non-none `{arch}.pooling_type`, or an encoder-only `general.architecture` | `--embeddings` auto-enabled; the server refuses chat completions and serves `/v1/embeddings` |
+
+The taxonomy also reserves `vision`, `code`, and `moe` as recognized capability
+tags in the same auto-generated namespace; they carry no launch-flag effect
+today.
+
+### Overriding MTP
+
+```bash
+# Disable MTP on a tagged model
+gglib serve <id> --mtp-draft-n-max 0
+
+# Explicit settings (4 draft tokens, 80% p-min)
+gglib serve <id> --mtp-draft-n-max 4 --mtp-draft-p-min 0.8
+```
+
+Disable MTP globally on **every** launch path (including proxy auto-start,
+where no per-model flag is reachable) with an environment variable — useful
+for A/B testing speculative decoding as a suspect for long-context issues:
+
+```bash
+# Truthy values: 1, true, yes, on (case-insensitive)
+GGLIB_DISABLE_MTP=1 gglib proxy
+```
+
+## System-tag protection
+
+Auto-detected tags are protected as system tags: `gglib model remove-tag` will
+reject any attempt to remove a `format:*` tag (use the `_force` service path
+for admin operations). User-curated tags outside the auto-generated namespace
+are never touched by detection or retagging.
+
+## Retagging an existing catalog
+
+Models imported before format-tag detection landed can be retagged in place
+from their persisted GGUF metadata — no re-download required:
+
+```bash
+# Additive: only append missing format:* tags, never remove anything
+gglib model retag --all
+
+# Full rebuild: drop and re-derive every auto-generated tag, preserving user tags
+gglib model retag --all --full
+
+# Single model
+gglib model retag qwen3-30b
+```
+
+End-to-end round-trip coverage lives in
+[`crates/gglib-proxy/tests/integration_proxy_pipeline.rs`](../crates/gglib-proxy/tests/integration_proxy_pipeline.rs).


### PR DESCRIPTION
## Summary

The root README was ~1,190 lines and led with a retired "GGUF model manager" framing, burying the actual product — a zero-config local OpenAI-compatible provider for agentic coding clients, with the intelligent proxy as the differentiator. Cut to ~180 lines: leads with the positioning statement and `gglib up`, gives copy-pasteable client configs for Cline/Roo Code, Continue, Aider, and Zed, and names the six proxy behaviors between an OpenAI request and llama-server (dialect normalization, context defense, sampling authority, KV cache tiering, capability detection, contention absorption), each linked to its reference doc or crate README. The `#architecture`/`#interfaces` anchors that crate READMEs link into are preserved.

Deep reference material moved to `docs/`: `docs/sampling.md` (merge hierarchy, temperature coupling, reasoning auto-defaults, client sampling authority, profiles, `gglib model explain`), `docs/tags.md` (capability flags, dialect tags, MTP overrides, retagging), `docs/cache.md` (KV quantization, cache auto-sizing, disk slot persistence, dashboard metrics). Dropped entirely from the root, verified unused by any script/workflow/build.rs first: crate metrics/badge tables (each crate README carries its own), benchmark walkthroughs, the mid-file ASCII architecture diagram, and unused `crate-docs` markers.

## Test plan

- [x] `./scripts/check_readmes.sh --strict` — all checks pass
- [x] All relative links and anchor fragments in `README.md` and `docs/*.md` validated programmatically
- [x] `cargo doc --workspace --no-deps` — clean (two pre-existing `//!` link warnings in `gglib-cli`, untouched here)
- [x] `make fmt && make lint && make check && make test` — all pass