### PR TITLE
docs: sweep the stale docs left behind by the M8–M10 refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,13 +64,20 @@ The workspace is organized into layers. Dependencies flow strictly inward.
 
 **`gglib-runtime`** orchestrates processes (llama.cpp, llama-server). It owns the build and install pipelines.
 
-**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) adapt the shared backend to their output medium. They contain no business logic. Any feature added to one surface must be achievable on all three — see the [GUI Parity Principle](#gui-parity-principle).
+**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) adapt the shared backend to their output medium. They contain no business logic. Any feature added to one surface must be achievable on all three; how quickly the other surfaces must follow depends on the capability's tier — see the [GUI Parity Principle](#gui-parity-principle).
 
 ---
 
 ## GUI Parity Principle
 
-Every capability offered through one interface must be reachable through all three. Downloads, builds, agent loops, and model management all follow the same pattern:
+Parity is tiered. Every capability must remain *achievable* on all three surfaces (the shared backend guarantees that), but when the other surfaces ship depends on what kind of capability it is:
+
+- **Tier 1 — runtime behaviour.** Anything that changes what the proxy or runtime *does*: request handling, model lifecycle, launch flags, admission, security posture. A Tier 1 capability must be reachable through all three surfaces, and all three ship in the same PR.
+- **Tier 2 — management and inspection.** Operator conveniences for looking at or arranging things (e.g. `gglib model explain`, `gglib up`, documentation). These may land CLI-first, provided the PR says so and links a tracked issue for the surface gap — parity debt must be explicit, never silent.
+
+State the tier in the PR description (recent PRs also carry it in the commit message). When in doubt, treat it as Tier 1.
+
+The event-channel pattern below is what makes Tier 1 parity cheap — use it for any long-running operation regardless of tier. Downloads, builds, agent loops, and model management all follow the same pattern:
 
 1. **Core logic in a runtime or domain crate** — emits typed events over a `tokio::sync::mpsc::Sender<T>` channel. It has no knowledge of the terminal, HTTP, or Tauri.
 2. **Surface adapters consume the channel** — the CLI renders events as an `indicatif` progress bar; the Axum layer streams them as SSE; the Tauri layer emits them as Tauri events to the WebView.
@@ -88,7 +95,7 @@ When adding a new long-running operation:
 - Define the event enum in the relevant runtime or domain crate.
 - The function signature takes `tx: tokio::sync::mpsc::Sender<YourEvent>` as a parameter.
 - Wire the CLI adapter in its own function. Wire the Axum handler. Wire the Tauri command.
-- All three ship in the same PR.
+- Tier 1: all three ship in the same PR. Tier 2: the CLI ships now and the remaining surfaces are tracked in a linked issue.
 
 **Tauri commands are OS integration only.** Product features are served over HTTP (Axum). The CI enforces that `#[tauri::command]` functions live only in a small set of approved files (`util.rs`, `llama.rs`, `app_logs.rs`). A new product feature does not get a Tauri command — it gets an Axum route that the WebView calls over HTTP, just like the browser-based UI does.
 
@@ -656,6 +663,6 @@ Before requesting review, confirm each item:
 - [ ] Subprocess I/O is captured with `Stdio::piped()` and read on an OS thread, not a Tokio task.
 - [ ] Environment variable merging uses read-then-append, not a bare `.env()` that overwrites.
 - [ ] Any feature gated behind `#[cfg(feature = "...")]` is declared correctly in all consuming `Cargo.toml` files.
-- [ ] If the change adds a new long-running operation, all three surfaces (CLI, Axum, Tauri) are wired up.
+- [ ] If the change adds a new long-running operation: for Tier 1 (runtime behaviour), all three surfaces (CLI, Axum, Tauri) are wired up in this PR; for Tier 2 (management/inspection), the CLI is wired and the surface gap is tracked in a linked issue.
 - [ ] `Cargo.lock` is up to date and committed.
 - [ ] No new dependency has been introduced from a higher layer to a lower layer.

--- a/crates/gglib-app-services/src/benchmark/README.md
+++ b/crates/gglib-app-services/src/benchmark/README.md
@@ -23,9 +23,10 @@ benchmark/
 
 `BenchmarkDeps::runtime` is the **same** [`ModelRuntimePort`] instance
 shared with `ProxyOps` at the composition root (created once in
-`bootstrap.rs`).  Both operations go through the same `SingleSwap`
-[`ProcessManager`], which guarantees only one llama-server runs at a time
-system-wide.  `run_perf()` additionally calls `stop_current()` before
+`bootstrap.rs`).  Both operations go through the same
+[`ProcessManager`] and its admission queue, which guarantees every
+llama-server on the machine lives in the same bounded resident set.
+`run_perf()` additionally calls `stop_current()` before
 spawning `llama-bench` so that the GPU is free when the binary loads the
 model directly.
 

--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -2,8 +2,9 @@
 //!
 //! Runs the same prompt through N models **sequentially** (one at a time) and
 //! emits [`BenchmarkEvent`]s on `tx`.  Sequential execution is intentional:
-//! a single GPU cannot run two models in VRAM simultaneously, and the shared
-//! [`ModelRuntimePort`] (`SingleSwap`) enforces this at the process level.
+//! a single GPU cannot fit two large models in VRAM simultaneously, and the
+//! shared [`ModelRuntimePort`]'s admission queue enforces this at the process
+//! level — each model waits for the slot its predecessor holds.
 //!
 //! # Cancellation
 //!

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -41,8 +41,8 @@ pub struct BenchmarkDeps {
     pub model_repo: Arc<dyn ModelRepository>,
     /// Shared [`ModelRuntimePort`] — same instance used by `ProxyOps`.
     ///
-    /// Sharing this ensures SingleSwap semantics: only one llama-server can
-    /// run at any time system-wide.
+    /// Sharing this ensures every launch goes through the same admission
+    /// queue, so the benchmark can never fight the proxy for VRAM.
     pub runtime: Arc<dyn ModelRuntimePort>,
     /// Benchmark persistence (runs, results, summaries).
     pub bench_repo: Arc<dyn BenchmarkRepositoryPort>,

--- a/crates/gglib-app-services/src/benchmark/perf.rs
+++ b/crates/gglib-app-services/src/benchmark/perf.rs
@@ -9,8 +9,8 @@
 //! to stop any currently-running llama-server via `stop_current()`.  Without
 //! this drain, the llama-server and `llama-bench` would compete for GPU
 //! memory, likely causing an OOM or silent performance degradation.  Because
-//! the [`ModelRuntimePort`] is the same `SingleSwap` instance shared with
-//! `ProxyOps`, stopping the proxy server here is both safe and intentional.
+//! the [`ModelRuntimePort`] is the same shared instance `ProxyOps` uses,
+//! stopping the proxy's server here is both safe and intentional.
 //!
 //! # Process Spawning
 //!

--- a/crates/gglib-app-services/src/proxy.rs
+++ b/crates/gglib-app-services/src/proxy.rs
@@ -3,10 +3,11 @@
 //! Wraps the ProxySupervisor to provide start/stop/status operations
 //! for the OpenAI-compatible proxy.
 //!
-//! The `ModelRuntimePort` (wrapping a shared `SingleSwap` `ProcessManager`) is
-//! injected at construction time from the composition root, ensuring that the
-//! proxy and any other service that drives llama-server (e.g. benchmarking)
-//! share a single manager — preventing VRAM contention.
+//! The `ModelRuntimePort` (wrapping the shared `ProcessManager`) is injected
+//! at construction time from the composition root, ensuring that the proxy and
+//! any other service that drives llama-server (e.g. benchmarking) share a
+//! single manager — one admission queue over one resident set — preventing
+//! VRAM contention.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -65,8 +66,8 @@ pub struct ProxyDeps {
     pub mcp: Arc<McpService>,
     pub core: Arc<AppCore>,
     /// Shared runtime port — injected from the composition root so proxy and
-    /// benchmark share the same `SingleSwap` `ProcessManager`, enforcing the
-    /// invariant that only one llama-server runs at a time system-wide.
+    /// benchmark share the same `ProcessManager`, enforcing the invariant
+    /// that every llama-server on this machine lives in the same resident set.
     pub runtime: Arc<dyn ModelRuntimePort>,
 }
 
@@ -74,7 +75,8 @@ pub struct ProxyDeps {
 ///
 /// Provides GUI-friendly interface to proxy lifecycle management.
 /// The `ModelRuntimePort` is shared with other services (e.g. benchmarking)
-/// via the composition root, so only one llama-server can run system-wide.
+/// via the composition root, so every llama-server runs inside the same
+/// admission-controlled resident set.
 pub struct ProxyOps {
     supervisor: Arc<ProxySupervisor>,
     model_repo: Arc<dyn ModelRepository>,

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -107,8 +107,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **CLI Chat** — Direct terminal chat via llama-cli
 - **`OpenAI` Proxy** — Transparent proxy that routes to appropriate model instances
 - **Auto Model Swap** — Proxy automatically loads/unloads models based on requests
-- **Pinned Mode** — `ProcessManager::new_pinned` serves exactly one model and refuses all others, backing `gglib serve`
-- **Concurrent Startup Coordination** — SingleSwap strategy uses watch channels so concurrent requests during model startup wait for the result rather than failing immediately.
+- **Pinned Mode** — `ProcessManager::set_pin` restricts the resident set to exactly one model and refuses all others, backing `gglib serve`
+- **Admission & Startup Coordination** — concurrent requests during a model's launch wait in the admission queue and are served when the launch completes, rather than failing immediately.
 - **Health Monitoring** — Polls server health endpoints for readiness
 - **GPU Detection** — Detects available GPUs and VRAM for context sizing
 - **Reasoning Model Support** — Streaming of thinking/reasoning phases

--- a/crates/gglib-runtime/src/ports_impl/model_runtime.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_runtime.rs
@@ -1,7 +1,7 @@
 //! ModelRuntimePort implementation using ProcessManager.
 //!
-//! This adapter wraps the ProcessManager (SingleSwap strategy) to implement
-//! the ModelRuntimePort interface from gglib-core.
+//! This adapter wraps the ProcessManager — an admission queue over a bounded
+//! resident set — to implement the ModelRuntimePort interface from gglib-core.
 
 use async_trait::async_trait;
 use gglib_core::cache_config::CacheRamSetting;

--- a/crates/gglib-runtime/src/process/README.md
+++ b/crates/gglib-runtime/src/process/README.md
@@ -11,32 +11,37 @@ with integrated log streaming and event broadcasting for GUI use cases.
 
 - `GuiProcessCore` - Low-level process spawning with log streaming (u32 model IDs)
 - `ProcessManager` - High-level orchestration; dispatch only
-- `SwapState` - Single-model-at-a-time state and the startup driver itself
+- `ResidentSet` (`residency/`) - The VRAM slots and the launch driver that fills them
+- `AdmissionQueue` (`admission/`) - Decides who gets the GPU next, and for how long
 - `ServerEvent` / `ServerEventBroadcaster` - Lifecycle event broadcasting
 - `ServerLogManager` - Log streaming infrastructure
 - Health check utilities
 
-# Strategies
+# Residency and admission
 
-`ProcessStrategy` has one shape today:
+`ProcessManager` routes; [`ResidentSet`] (`residency/`) owns the state. M9
+replaced the old single-swap strategy with a bounded resident set — a small
+number of VRAM slots filled by an `AdmissionQueue` (`admission/`) that decides,
+per request: serve from a resident model, launch into a free or evictable
+slot, wait, or give up.
 
-- **SingleSwap** — one model at a time, holding a [`SwapState`]. Optionally
-  *pinned*: `ProcessManager::new_pinned` serves exactly one model and returns
-  `PinnedModelMismatch` for any other, rather than swapping. Pinning changes
-  only which models are admitted — startup coordination, cache handling and
-  launch options are identical either way.
+A set may be *pinned*: `ProcessManager::set_pin` restricts admission to
+exactly one model (backing `gglib serve`) and returns `PinnedModelMismatch`
+for any other, rather than swapping. Pinning changes only which models are
+admitted — startup coordination, cache handling and launch options are
+identical either way.
 
-Every launch surface — the CLI, the proxy, both GUIs — shares one
-`SingleSwap` manager built by `build_service_graph`, which is what makes
-"only one llama-server runs at a time system-wide" an invariant. A
-`Concurrent` strategy existed here for the GUI's earlier direct-spawn path;
-epic #630 routed the GUI through the proxy's manager instead, so it was
-deleted along with the rest of that path.
+Every launch surface — the CLI, the proxy, both GUIs — shares one manager
+built by `build_service_graph` inside the daemon, which is what makes "gglib
+owns every llama-server on this machine" an invariant. A `Concurrent`
+strategy existed here for the GUI's earlier direct-spawn path; epic #630
+routed the GUI through the proxy's manager instead, so it was deleted along
+with the rest of that path.
 
 # Launch options
 
-`SwapState` carries a standing `ServerConfigOptions` template rather than a
-hand-picked list of fields. Each launch resolves to
+The `ResidentSet` carries a standing `ServerConfigOptions` template rather
+than a hand-picked list of fields. Each launch resolves to
 
 ```text
 template  ⊕  per-call overrides  ⊕  this request's context chain

--- a/src/commands/download/README.md
+++ b/src/commands/download/README.md
@@ -32,11 +32,11 @@ The download module handles interactions with the HuggingFace Hub, including sea
 
 When a GGUF file is downloaded and added to the database, `model_ops.rs` automatically analyzes the model's metadata to detect reasoning/thinking capabilities. Models with chat templates containing `<think>`, `<reasoning>`, or similar tags (e.g., DeepSeek R1, Qwen3, QwQ) receive a `reasoning` tag automatically. This enables optimal configuration when serving via `llama-server --reasoning-format`.
 
-### Fast-path helper overview
+### Download backends
 
-The download flow always invokes `scripts/hf_xet_downloader.py` inside the managed Miniconda environment (`<data_root>/.conda/gglib-hf-xet`). `gglib config check-deps`/`make setup` ensure that environment exists with `huggingface_hub>=1.1.5` and `hf_xet>=0.6`. The helper pulls GGUF blobs via Xet storage and emits newline-delimited JSON progress that ties back into the existing `ProgressCallback` plumbing.
+Downloads run natively over HTTP by default: a `reqwest`-based streaming downloader with resumable `.part` transfers, SHA-256 verification against `X-Linked-Etag`, and atomic rename on completion. No Python is required for a download to succeed.
 
-Fast mode is now mandatory: if the helper is missing or fails, the command returns an error with remediation steps and does not fall back to the legacy Rust HTTP downloader.
+The `hf_xet` accelerator is opt-in. When its environment has already been provisioned (`gglib config check-deps --setup-fast-downloads`), the flow invokes `hf_xet_downloader.py` inside the managed environment (`<data_root>/.conda/gglib-hf-xet`, with `huggingface_hub>=1.1.5` and `hf_xet>=0.6`), which pulls GGUF blobs via Xet storage and emits newline-delimited JSON progress that ties back into the existing `ProgressCallback` plumbing. The environment is never provisioned implicitly, and if the accelerator is present but fails, the download falls back to the native path rather than erroring.
 
 ## Deep Dive: Quantization Filter
 

--- a/src/pages/README.md
+++ b/src/pages/README.md
@@ -9,37 +9,37 @@ Top-level page components for the gglib GUI application.
 
 ## Architecture
 
+Two entry points build two windows from this directory:
+
 ```text
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                     App.tsx                                         │
-│                                        │                                            │
-│                     ┌──────────────────┼──────────────────┐                         │
-│                     ▼                  ▼                  ▼                         │
-│   ┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐         │
-│   │  ModelControlCenter │  │      ChatPage       │  │    (future pages)   │         │
-│   │       Page          │  │                     │  │                     │         │
-│   └──────────┬──────────┘  └──────────┬──────────┘  └─────────────────────┘         │
-│              │                        │                                             │
-│              ▼                        ▼                                             │
-│   ┌─────────────────────────────────────────────────────────────────────────────┐   │
-│   │                              components/                                    │   │
-│   │                        (Shared UI Components)                               │   │
-│   └─────────────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────────────┘
+main.tsx ──► App.tsx                        tray-main.tsx ──► TrayPanel.tsx
+                │                           (separate "tray" Tauri window:
+                ▼                            proxy status, endpoint, metrics)
+  ┌────────────────────────┐
+  │ ModelControlCenterPage │──swaps to──► ChatPage / BenchmarkPage
+  └───────────┬────────────┘
+              ▼
+        components/
+   (Shared UI Components)
 ```
 
 ## Pages
 
 | Page | Description |
 |------|-------------|
-| [`ModelControlCenterPage.tsx`](ModelControlCenterPage.tsx) | Main dashboard for model management, server control, and downloads |
+| [`ModelControlCenterPage.tsx`](ModelControlCenterPage.tsx) | Model catalog and control: library, server control, and downloads — the main window's landing page |
 | [`ChatPage.tsx`](ChatPage.tsx) | Chat interface for interacting with running models |
+| [`BenchmarkPage.tsx`](BenchmarkPage.tsx) | Benchmark workflows: compare, perf, and sampling-parameter tune |
+| [`TrayPanel.tsx`](TrayPanel.tsx) | Proxy tray window — is the endpoint up, and what is it doing (status, endpoint copy bar, connections, slots) |
+
+`ChatPageSkeleton.tsx` and `chatTabs.tsx` are supporting pieces of `ChatPage`,
+not routed pages.
 
 ### Model Control Center
 
-The primary page containing:
+The main window's landing page containing:
 - Model list with metadata display
-- Server start/stop controls
+- Server start/stop controls and proxy control (with the Proxy Dashboard modal)
 - Download queue management
 - MCP server configuration
 - Settings management
@@ -57,12 +57,6 @@ Interactive chat interface featuring:
 | Directory | Description |
 |-----------|-------------|
 | [`modelControlCenter/`](modelControlCenter/) | Components specific to the Model Control Center page |
-
-## Styling
-
-Each page has a corresponding CSS file:
-- `ModelControlCenterPage.css` — Control center layout and styling
-- `ChatPage.css` — Chat interface styling
 
 ## Design Principles
 


### PR DESCRIPTION
Tier 2 — documentation only; no code paths change.

The M-series PRs (#695–#709) changed what the runtime, downloader, and daemon actually do, but several docs still describe the pre-refactor world. This PR makes the repo stop contradicting its own code, in five independent commits:

- **`src/commands/download/README.md`** still claimed the conda/hf_xet helper was *mandatory* with "no fallback". Since #697 the native Rust HTTP downloader is the default and the accelerator is opt-in with automatic fallback. The section now describes the real mechanism (mirroring `crates/gglib-download/src/executor/README.md`).
- **`gglib-runtime` docs** still described `ProcessStrategy::SingleSwap`, `SwapState`, `ProcessManager::new_pinned`, and watch-channel startup coordination — none of which exist since #709. `process/README.md` (module docs via `include_str!`), `ports_impl/model_runtime.rs`, and the crate README now describe the admission queue + bounded resident set, `set_pin`, and queue-based startup coordination.
- **`gglib-app-services` comments** promised "only one llama-server runs at a time system-wide" via a shared `SingleSwap` manager. The real invariant since #709 is that every llama-server lives in the same admission-controlled resident set; the proxy and benchmark comments now say that.
- **`src/pages/README.md`** listed only two pages, called the catalog the "main dashboard", and documented CSS files that no longer exist. `TrayPanel.tsx` (with its separate `tray-main.tsx` entry point) and `BenchmarkPage.tsx` are now in the inventory.
- **`CONTRIBUTING.md`** still mandated all-three-surfaces-in-one-PR parity, while #697–#709 already practiced an undocumented Tier 1/Tier 2 split in their commit messages. The tier rule is now written down: Tier 1 (runtime behaviour) keeps the all-three requirement; Tier 2 (management/inspection) may land CLI-first with the surface gap tracked in a linked issue. The PR checklist matches.

Verification: `grep -ri singleswap crates/ src/` returns nothing; `cargo check -p gglib-runtime -p gglib-app-services` passes (the intra-doc links in the injected READMEs resolve — `ResidentSet` and `AdmissionQueue` are both `pub use`d in `process::mod`).

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4z91CBLkwDdbLMifNuZn)_