### PR TITLE
docs: carry the proxy-first narrative below the root README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,13 +64,20 @@ The workspace is organized into layers. Dependencies flow strictly inward.
 
 **`gglib-runtime`** orchestrates processes (llama.cpp, llama-server). It owns the build and install pipelines.
 
-**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) adapt the shared backend to their output medium. They contain no business logic. Any feature added to one surface must be achievable on all three — see the [GUI Parity Principle](#gui-parity-principle).
+**Surface crates** (`gglib-cli`, `gglib-axum`, `gglib-tauri`) adapt the shared backend to their output medium. They contain no business logic. Any feature added to one surface must be achievable on all three; how quickly the other surfaces must follow depends on the capability's tier — see the [GUI Parity Principle](#gui-parity-principle).
 
 ---
 
 ## GUI Parity Principle
 
-Every capability offered through one interface must be reachable through all three. Downloads, builds, agent loops, and model management all follow the same pattern:
+Parity is tiered. Every capability must remain *achievable* on all three surfaces (the shared backend guarantees that), but when the other surfaces ship depends on what kind of capability it is:
+
+- **Tier 1 — runtime behaviour.** Anything that changes what the proxy or runtime *does*: request handling, model lifecycle, launch flags, admission, security posture. A Tier 1 capability must be reachable through all three surfaces, and all three ship in the same PR.
+- **Tier 2 — management and inspection.** Operator conveniences for looking at or arranging things (e.g. `gglib model explain`, `gglib up`, documentation). These may land CLI-first, provided the PR says so and links a tracked issue for the surface gap — parity debt must be explicit, never silent.
+
+State the tier in the PR description (recent PRs also carry it in the commit message). When in doubt, treat it as Tier 1.
+
+The event-channel pattern below is what makes Tier 1 parity cheap — use it for any long-running operation regardless of tier. Downloads, builds, agent loops, and model management all follow the same pattern:
 
 1. **Core logic in a runtime or domain crate** — emits typed events over a `tokio::sync::mpsc::Sender<T>` channel. It has no knowledge of the terminal, HTTP, or Tauri.
 2. **Surface adapters consume the channel** — the CLI renders events as an `indicatif` progress bar; the Axum layer streams them as SSE; the Tauri layer emits them as Tauri events to the WebView.
@@ -88,7 +95,7 @@ When adding a new long-running operation:
 - Define the event enum in the relevant runtime or domain crate.
 - The function signature takes `tx: tokio::sync::mpsc::Sender<YourEvent>` as a parameter.
 - Wire the CLI adapter in its own function. Wire the Axum handler. Wire the Tauri command.
-- All three ship in the same PR.
+- Tier 1: all three ship in the same PR. Tier 2: the CLI ships now and the remaining surfaces are tracked in a linked issue.
 
 **Tauri commands are OS integration only.** Product features are served over HTTP (Axum). The CI enforces that `#[tauri::command]` functions live only in a small set of approved files (`util.rs`, `llama.rs`, `app_logs.rs`). A new product feature does not get a Tauri command — it gets an Axum route that the WebView calls over HTTP, just like the browser-based UI does.
 
@@ -656,6 +663,6 @@ Before requesting review, confirm each item:
 - [ ] Subprocess I/O is captured with `Stdio::piped()` and read on an OS thread, not a Tokio task.
 - [ ] Environment variable merging uses read-then-append, not a bare `.env()` that overwrites.
 - [ ] Any feature gated behind `#[cfg(feature = "...")]` is declared correctly in all consuming `Cargo.toml` files.
-- [ ] If the change adds a new long-running operation, all three surfaces (CLI, Axum, Tauri) are wired up.
+- [ ] If the change adds a new long-running operation: for Tier 1 (runtime behaviour), all three surfaces (CLI, Axum, Tauri) are wired up in this PR; for Tier 2 (management/inspection), the CLI is wired and the surface gap is tracked in a linked issue.
 - [ ] `Cargo.lock` is up to date and committed.
 - [ ] No new dependency has been introduced from a higher layer to a lower layer.

--- a/crates/gglib-agent/README.md
+++ b/crates/gglib-agent/README.md
@@ -7,6 +7,10 @@
 
 Pure-domain agentic loop implementation for gglib.
 
+Backs `gglib chat` and `gglib q`, and carries the defences a local model needs
+to finish a tool-calling task: loop detection, stagnation detection, and context
+pruning.
+
 ## Architecture
 
 This crate is in the **Application Layer** — it orchestrates the LLM→tool→LLM

--- a/crates/gglib-app-services/README.md
+++ b/crates/gglib-app-services/README.md
@@ -7,6 +7,10 @@
 
 Shared GUI backend facade for gglib adapters (Tauri desktop, Axum web).
 
+One implementation behind both GUIs, so the desktop app and the web UI cannot
+drift apart: a capability added here appears on both at once, and both drive the
+same shared runtime rather than competing for the GPU.
+
 ## Architecture
 
 This crate is a **Shared Facade** — sitting between adapters and infrastructure, providing a unified orchestration layer.

--- a/crates/gglib-app-services/src/benchmark/README.md
+++ b/crates/gglib-app-services/src/benchmark/README.md
@@ -23,9 +23,10 @@ benchmark/
 
 `BenchmarkDeps::runtime` is the **same** [`ModelRuntimePort`] instance
 shared with `ProxyOps` at the composition root (created once in
-`bootstrap.rs`).  Both operations go through the same `SingleSwap`
-[`ProcessManager`], which guarantees only one llama-server runs at a time
-system-wide.  `run_perf()` additionally calls `stop_current()` before
+`bootstrap.rs`).  Both operations go through the same
+[`ProcessManager`] and its admission queue, which guarantees every
+llama-server on the machine lives in the same bounded resident set.
+`run_perf()` additionally calls `stop_current()` before
 spawning `llama-bench` so that the GPU is free when the binary loads the
 model directly.
 

--- a/crates/gglib-app-services/src/benchmark/compare.rs
+++ b/crates/gglib-app-services/src/benchmark/compare.rs
@@ -2,8 +2,9 @@
 //!
 //! Runs the same prompt through N models **sequentially** (one at a time) and
 //! emits [`BenchmarkEvent`]s on `tx`.  Sequential execution is intentional:
-//! a single GPU cannot run two models in VRAM simultaneously, and the shared
-//! [`ModelRuntimePort`] (`SingleSwap`) enforces this at the process level.
+//! a single GPU cannot fit two large models in VRAM simultaneously, and the
+//! shared [`ModelRuntimePort`]'s admission queue enforces this at the process
+//! level — each model waits for the slot its predecessor holds.
 //!
 //! # Cancellation
 //!

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -41,8 +41,8 @@ pub struct BenchmarkDeps {
     pub model_repo: Arc<dyn ModelRepository>,
     /// Shared [`ModelRuntimePort`] — same instance used by `ProxyOps`.
     ///
-    /// Sharing this ensures SingleSwap semantics: only one llama-server can
-    /// run at any time system-wide.
+    /// Sharing this ensures every launch goes through the same admission
+    /// queue, so the benchmark can never fight the proxy for VRAM.
     pub runtime: Arc<dyn ModelRuntimePort>,
     /// Benchmark persistence (runs, results, summaries).
     pub bench_repo: Arc<dyn BenchmarkRepositoryPort>,

--- a/crates/gglib-app-services/src/benchmark/perf.rs
+++ b/crates/gglib-app-services/src/benchmark/perf.rs
@@ -9,8 +9,8 @@
 //! to stop any currently-running llama-server via `stop_current()`.  Without
 //! this drain, the llama-server and `llama-bench` would compete for GPU
 //! memory, likely causing an OOM or silent performance degradation.  Because
-//! the [`ModelRuntimePort`] is the same `SingleSwap` instance shared with
-//! `ProxyOps`, stopping the proxy server here is both safe and intentional.
+//! the [`ModelRuntimePort`] is the same shared instance `ProxyOps` uses,
+//! stopping the proxy's server here is both safe and intentional.
 //!
 //! # Process Spawning
 //!

--- a/crates/gglib-app-services/src/proxy.rs
+++ b/crates/gglib-app-services/src/proxy.rs
@@ -3,10 +3,11 @@
 //! Wraps the ProxySupervisor to provide start/stop/status operations
 //! for the OpenAI-compatible proxy.
 //!
-//! The `ModelRuntimePort` (wrapping a shared `SingleSwap` `ProcessManager`) is
-//! injected at construction time from the composition root, ensuring that the
-//! proxy and any other service that drives llama-server (e.g. benchmarking)
-//! share a single manager — preventing VRAM contention.
+//! The `ModelRuntimePort` (wrapping the shared `ProcessManager`) is injected
+//! at construction time from the composition root, ensuring that the proxy and
+//! any other service that drives llama-server (e.g. benchmarking) share a
+//! single manager — one admission queue over one resident set — preventing
+//! VRAM contention.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -65,8 +66,8 @@ pub struct ProxyDeps {
     pub mcp: Arc<McpService>,
     pub core: Arc<AppCore>,
     /// Shared runtime port — injected from the composition root so proxy and
-    /// benchmark share the same `SingleSwap` `ProcessManager`, enforcing the
-    /// invariant that only one llama-server runs at a time system-wide.
+    /// benchmark share the same `ProcessManager`, enforcing the invariant
+    /// that every llama-server on this machine lives in the same resident set.
     pub runtime: Arc<dyn ModelRuntimePort>,
 }
 
@@ -74,7 +75,8 @@ pub struct ProxyDeps {
 ///
 /// Provides GUI-friendly interface to proxy lifecycle management.
 /// The `ModelRuntimePort` is shared with other services (e.g. benchmarking)
-/// via the composition root, so only one llama-server can run system-wide.
+/// via the composition root, so every llama-server runs inside the same
+/// admission-controlled resident set.
 pub struct ProxyOps {
     supervisor: Arc<ProxySupervisor>,
     model_repo: Arc<dyn ModelRepository>,

--- a/crates/gglib-app-services/src/proxy.rs
+++ b/crates/gglib-app-services/src/proxy.rs
@@ -208,8 +208,9 @@ impl ProxyOps {
     ///
     /// # Errors
     ///
-    /// Returns `GuiError::Internal` if settings cannot be loaded, and
-    /// whatever [`Self::map_start_error`] produces if the proxy cannot start.
+    /// Returns `GuiError::Internal` if settings cannot be loaded, and whatever
+    /// `map_start_error` produces if the proxy cannot start — a bind failure or
+    /// an already-running supervisor both surface as `GuiError::Conflict`.
     pub async fn ensure_running(&self) -> Result<SocketAddr, GuiError> {
         if let ProxyStatus::Running { address } = self.supervisor.status().await {
             return Ok(address);

--- a/crates/gglib-axum/README.md
+++ b/crates/gglib-axum/README.md
@@ -7,6 +7,10 @@
 
 HTTP API server for gglib — provides REST endpoints for the web UI and external integrations.
 
+It also hosts the daemon: the single process that owns llama-server and holds
+the exclusive lock every other surface connects through. When the CLI, the
+desktop app, or the web UI needs the runtime, this is what they talk to.
+
 ## Architecture
 
 This crate is in the **Adapter Layer** — it exposes gglib functionality via HTTP using the Axum framework.

--- a/crates/gglib-bootstrap/README.md
+++ b/crates/gglib-bootstrap/README.md
@@ -7,6 +7,10 @@
 
 Shared composition root for gglib adapters.
 
+Wiring happens once, here, so every surface gets the same runtime, the same
+database, and the same shared process manager — the structural reason a model
+launched from one interface is the same model another sees.
+
 This crate consolidates the infrastructure-wiring steps that were previously duplicated
 across the CLI, Axum, and Tauri bootstrap modules into a single
 `CoreBootstrap::build(config, emitter) → BuiltCore` call.

--- a/crates/gglib-build-info/README.md
+++ b/crates/gglib-build-info/README.md
@@ -5,6 +5,9 @@
 
 Shared build/version metadata for gglib frontends.
 
+Every surface reports the same version and commit, so a bug report names a build
+that can actually be checked out.
+
 ## Overview
 
 This crate provides compile-time constants for version information and git metadata, populated by its `build.rs` script using [vergen-gix](https://crates.io/crates/vergen-gix).

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -9,6 +9,10 @@
 
 Command-line interface for gglib — the primary user-facing CLI application.
 
+`gglib up` lives here: one command from a clean machine to a working endpoint.
+Every command is a thin client of the daemon that owns the runtime — this crate
+renders and asks, it never spawns llama-server itself.
+
 ## Architecture
 
 This crate is in the **Adapter Layer** — it wires together all infrastructure crates and exposes them via CLI commands.

--- a/crates/gglib-core/README.md
+++ b/crates/gglib-core/README.md
@@ -7,6 +7,10 @@
 
 Pure domain types, ports, and traits for gglib — the foundation of the hexagonal architecture.
 
+The product's judgment lives here as pure logic: sampling resolution, dialect
+normalization, GGUF capability detection, and residency policy — all decidable
+without a GPU, a network, or a running llama-server, and therefore testable.
+
 ## Architecture
 
 This crate is the **Core Layer** — the innermost ring of the architecture. All other crates depend on it; it depends on none.

--- a/crates/gglib-db/README.md
+++ b/crates/gglib-db/README.md
@@ -7,6 +7,10 @@
 
 `SQLite` repository implementations for gglib domain types.
 
+One database behind every surface, which is why a model tagged in the GUI is
+tagged for the proxy too, and why per-model inference defaults survive a
+restart.
+
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it implements the repository ports defined in `gglib-core`.

--- a/crates/gglib-download/README.md
+++ b/crates/gglib-download/README.md
@@ -7,6 +7,10 @@
 
 Download queue and manager for `HuggingFace` model files.
 
+Transfers run natively over HTTP — resumable and checksum-verified — so a new
+user's first download needs no Python toolchain. The `hf_xet` accelerator is an
+opt-in upgrade that falls back to the native path rather than failing.
+
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it orchestrates downloads using `gglib-hf` for file resolution.

--- a/crates/gglib-gguf/README.md
+++ b/crates/gglib-gguf/README.md
@@ -7,6 +7,10 @@
 
 GGUF file format parser for gglib — extracts metadata from GGUF model files.
 
+What this crate reads out of a file is what lets the runtime configure it
+without asking: architecture, chat template, and layer counts become capability
+tags, and those tags become llama-server flags. No per-model setup.
+
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it implements the `GgufParser` port from `gglib-core`.

--- a/crates/gglib-hf/README.md
+++ b/crates/gglib-hf/README.md
@@ -7,6 +7,10 @@
 
 `HuggingFace` Hub client for gglib — searching, browsing, and resolving GGUF models on the Hub. Implements `HfClientPort` from `gglib-core`.
 
+Resolving a repository to the right quantization is the step that turns "I want
+this model" into a concrete file to fetch — including the sizing judgement
+behind `gglib up`'s recommendation.
+
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it implements the `HfClientPort` trait from `gglib-core`.

--- a/crates/gglib-mcp/README.md
+++ b/crates/gglib-mcp/README.md
@@ -7,6 +7,10 @@
 
 MCP (Model Context Protocol) server management for gglib.
 
+Tools are what make a local model useful for real work rather than just chat.
+This crate manages the MCP servers that provide them, and backs the gateway the
+proxy exposes at `/mcp`.
+
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it manages MCP server lifecycle and protocol handling.

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -5,7 +5,11 @@
 ![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-loc.json)
 ![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-proxy-complexity.json)
 
-**Single Active Backend Proxy** - OpenAI-compatible proxy server for gglib with an integrated MCP Streamable HTTP gateway.
+**OpenAI-compatible proxy** — the front door to your local models, with an integrated MCP Streamable HTTP gateway.
+
+Everything between the OpenAI request and llama-server happens here: dialect
+normalization, context defense, sampling authority, and admission. This is the
+crate that makes a local model behave like an API provider.
 
 ## Architecture
 

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -107,8 +107,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **CLI Chat** — Direct terminal chat via llama-cli
 - **`OpenAI` Proxy** — Transparent proxy that routes to appropriate model instances
 - **Auto Model Swap** — Proxy automatically loads/unloads models based on requests
-- **Pinned Mode** — `ProcessManager::new_pinned` serves exactly one model and refuses all others, backing `gglib serve`
-- **Concurrent Startup Coordination** — SingleSwap strategy uses watch channels so concurrent requests during model startup wait for the result rather than failing immediately.
+- **Pinned Mode** — `ProcessManager::set_pin` restricts the resident set to exactly one model and refuses all others, backing `gglib serve`
+- **Admission & Startup Coordination** — concurrent requests during a model's launch wait in the admission queue and are served when the launch completes, rather than failing immediately.
 - **Health Monitoring** — Polls server health endpoints for readiness
 - **GPU Detection** — Detects available GPUs and VRAM for context sizing
 - **Reasoning Model Support** — Streaming of thinking/reasoning phases

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -7,6 +7,11 @@
 
 Process management and system probes for gglib — manages llama.cpp server instances and proxy routing.
 
+Every llama-server on the machine is owned here. This crate decides what gets
+loaded and when (admission over a bounded resident set), what flags each model
+launches with, and narrates those decisions at startup — the work that makes
+the runtime feel smarter than llama.cpp on its own.
+
 ## Architecture
 
 This crate is in the **Infrastructure Layer** — it manages external processes and provides system information.

--- a/crates/gglib-runtime/src/ports_impl/model_runtime.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_runtime.rs
@@ -1,7 +1,7 @@
 //! ModelRuntimePort implementation using ProcessManager.
 //!
-//! This adapter wraps the ProcessManager (SingleSwap strategy) to implement
-//! the ModelRuntimePort interface from gglib-core.
+//! This adapter wraps the ProcessManager — an admission queue over a bounded
+//! resident set — to implement the ModelRuntimePort interface from gglib-core.
 
 use async_trait::async_trait;
 use gglib_core::cache_config::CacheRamSetting;

--- a/crates/gglib-runtime/src/process/README.md
+++ b/crates/gglib-runtime/src/process/README.md
@@ -11,32 +11,37 @@ with integrated log streaming and event broadcasting for GUI use cases.
 
 - `GuiProcessCore` - Low-level process spawning with log streaming (u32 model IDs)
 - `ProcessManager` - High-level orchestration; dispatch only
-- `SwapState` - Single-model-at-a-time state and the startup driver itself
+- `ResidentSet` (`residency/`) - The VRAM slots and the launch driver that fills them
+- `AdmissionQueue` (`admission/`) - Decides who gets the GPU next, and for how long
 - `ServerEvent` / `ServerEventBroadcaster` - Lifecycle event broadcasting
 - `ServerLogManager` - Log streaming infrastructure
 - Health check utilities
 
-# Strategies
+# Residency and admission
 
-`ProcessStrategy` has one shape today:
+`ProcessManager` routes; [`ResidentSet`] (`residency/`) owns the state. M9
+replaced the old single-swap strategy with a bounded resident set — a small
+number of VRAM slots filled by an `AdmissionQueue` (`admission/`) that decides,
+per request: serve from a resident model, launch into a free or evictable
+slot, wait, or give up.
 
-- **SingleSwap** — one model at a time, holding a [`SwapState`]. Optionally
-  *pinned*: `ProcessManager::new_pinned` serves exactly one model and returns
-  `PinnedModelMismatch` for any other, rather than swapping. Pinning changes
-  only which models are admitted — startup coordination, cache handling and
-  launch options are identical either way.
+A set may be *pinned*: `ProcessManager::set_pin` restricts admission to
+exactly one model (backing `gglib serve`) and returns `PinnedModelMismatch`
+for any other, rather than swapping. Pinning changes only which models are
+admitted — startup coordination, cache handling and launch options are
+identical either way.
 
-Every launch surface — the CLI, the proxy, both GUIs — shares one
-`SingleSwap` manager built by `build_service_graph`, which is what makes
-"only one llama-server runs at a time system-wide" an invariant. A
-`Concurrent` strategy existed here for the GUI's earlier direct-spawn path;
-epic #630 routed the GUI through the proxy's manager instead, so it was
-deleted along with the rest of that path.
+Every launch surface — the CLI, the proxy, both GUIs — shares one manager
+built by `build_service_graph` inside the daemon, which is what makes "gglib
+owns every llama-server on this machine" an invariant. A `Concurrent`
+strategy existed here for the GUI's earlier direct-spawn path; epic #630
+routed the GUI through the proxy's manager instead, so it was deleted along
+with the rest of that path.
 
 # Launch options
 
-`SwapState` carries a standing `ServerConfigOptions` template rather than a
-hand-picked list of fields. Each launch resolves to
+The `ResidentSet` carries a standing `ServerConfigOptions` template rather
+than a hand-picked list of fields. Each launch resolves to
 
 ```text
 template  ⊕  per-call overrides  ⊕  this request's context chain

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -58,8 +58,11 @@ impl ProcessManager {
     /// * `cache_ram` — how to size llama-server's own host-RAM prompt cache
     ///   (`--cache-ram`). Not part of `launch_overrides` because it is resolved
     ///   at spawn rather than passed through.
-    ///   [`CacheRamSetting::LlamaDefault`] emits no flag — the right choice for
-    ///   benchmark launches, where a large prompt cache would perturb results.
+    ///   [`CacheRamSetting::ExplicitMb`]`(0)` disables the cache outright — the
+    ///   right choice for benchmark launches, where a prompt cache would
+    ///   perturb prefill timings. (Omitting the flag entirely, so llama-server's
+    ///   own default applies, is what [`CacheRamSetting::Auto`] does when
+    ///   autosizing is suppressed by env.)
     ///
     /// Use [`Self::set_pin`] afterwards when the manager must refuse every
     /// model but one (`gglib serve`).

--- a/crates/gglib-runtime/src/server_config.rs
+++ b/crates/gglib-runtime/src/server_config.rs
@@ -96,7 +96,7 @@ pub struct ResolvedCapabilities {
 /// * `model_name` — Human-readable model name forwarded to the process manager.
 /// * `model_path` — Absolute path to the GGUF model file.
 /// * `base_port` — Base port for llama-server port allocation.  Pass `0` when
-///   the underlying [`GuiProcessCore`] allocates the port itself.
+///   the underlying [`crate::process::GuiProcessCore`] allocates the port itself.
 /// * `tags` — Model capability tags (e.g. `["mtp", "agent", "reasoning"]`).
 ///   Used for all tag-based auto-detection when the corresponding option field
 ///   is `None`.

--- a/crates/gglib-sse/README.md
+++ b/crates/gglib-sse/README.md
@@ -7,6 +7,10 @@
 
 Generic Server-Sent Events broadcast utility shared by `gglib-axum` and `gglib-proxy`.
 
+Streaming is the default shape of everything users watch here — tokens, download
+progress, dashboard updates — so the fan-out lives in one dependency-free place
+rather than being reimplemented per surface.
+
 ## Architecture
 
 This crate is a pure, dependency-free **leaf** utility - it depends on nothing but `axum`'s SSE

--- a/crates/gglib-tauri/README.md
+++ b/crates/gglib-tauri/README.md
@@ -7,6 +7,11 @@
 
 Desktop GUI backend for gglib — Tauri application with React frontend.
 
+The desktop app is a client of the daemon, not an owner of the runtime: it
+launches or connects to one, then watches. That is what lets the proxy keep
+serving after the window closes, and why the tray can run it as a background
+service.
+
 > **Note:** Coverage metrics are not tracked for this crate due to GTK system library dependencies required by Tauri.
 
 ## Architecture

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GGLib - GGUF Model Manager</title>
+    <title>GGLib — Local Model Runtime</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gglib-gui",
   "version": "0.11.0",
-  "description": "Modern GUI for GGLib GGUF Model Manager",
+  "description": "Dashboard and control surface for the GGLib local model runtime",
   "author": "mmogr",
   "license": "AGPL-3.0",
   "repository": {

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -4,7 +4,7 @@ This directory contains the Tauri-based desktop application for GGLib.
 
 ## Overview
 
-The GGLib Desktop GUI is one of three complementary interfaces for managing GGUF models (along with the CLI and Web UI). All interfaces share the same backend architecture, ensuring consistent functionality and behavior.
+The GGLib Desktop GUI is a client of the daemon that owns the runtime — a place to watch the proxy and manage the model library, not the thing serving requests. It launches or connects to a daemon and can run it as a background service from the tray, so the endpoint keeps serving after the window closes. The CLI and Web UI are clients of the same daemon, sharing one backend and one database.
 
 For a complete overview of all interfaces and the shared architecture, see the main [README.md](../README.md#interfaces).
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "GGLib - GGUF Model Manager",
+        "title": "GGLib — Local Model Runtime",
         "width": 1200,
         "height": 800,
         "minWidth": 800,

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -5,442 +5,237 @@
 ![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-commands-loc.json)
 ![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-commands-complexity.json)
 
-This document provides a detailed reference for all available CLI commands.
+What each command is for, and how they fit together. For the exhaustive flag
+list on any command, run `gglib <command> --help` — clap generates that from the
+same source the binary parses, so it cannot drift. This document covers what
+`--help` cannot: why a command exists, how the shared flag groups compose, and
+which resolution layer wins.
 
-For an overview of all interfaces (CLI, Desktop GUI, Web UI), see the main [README](../README.md#interfaces).
+Start at [`gglib up`](#getting-started). Everything beyond it is
+[`gglib proxy`](#serving-an-endpoint).
 
-## Global Options
+## Everything goes through the daemon
 
-- `--help`: Show help information
-- `--version`: Show version information
-- `--models-dir <PATH>`: Override the models directory for the current invocation (CLI flag takes precedence over `.env`/defaults)
-
-## Command Flow
+One process owns llama-server: the **gglib daemon**. It holds an exclusive lock
+on the data directory, and every other surface — this CLI, the desktop GUI, the
+web UI — is a client of it. No CLI command spawns llama-server itself.
 
 ```text
-┌─────────────┐      ┌────────────────┐      ┌───────────────────┐
-│  CLI Input  │ ───► │ Command Parser │ ───► │  Command Handler  │
-│ (clap args) │      │ (main.rs)      │      │ (commands/*.rs)   │
-└─────────────┘      └────────────────┘      └─────────┬─────────┘
-                                                       │
-                                                       ▼
-                                             ┌───────────────────┐
-                                             │  Shared Services  │
-                                             │ (Database, Proxy) │
-                                             └───────────────────┘
+  gglib up ─┐
+  gglib q  ─┤                    ┌──────────────────┐
+  gglib    ─┼──► gglib daemon ──►│   llama-server   │
+  chat      │    (owns the       │  (1–2 resident)  │
+  Desktop  ─┤     runtime,       └──────────────────┘
+  GUI       │     holds the lock)          ▲
+  Web UI   ─┘           │                  │
+                        └── admission queue ┘
 ```
 
-## Sub-modules
+That is why a model started from the GUI is the same model the proxy serves, why
+the endpoint keeps running after you close the desktop window, and why commands
+that used to configure a per-run process (`--llama-port`, the `--cache-*` flags)
+now warn that the daemon does not apply them per run.
 
-- **[Download Module](download/README.md)**: HuggingFace Hub integration and file operations.
-- **[Llama Management](llama/README.md)**: Installation and building of llama.cpp.
+Commands that need the runtime start a daemon automatically if one is not
+already up. A *foreign* process on the daemon port is never fought — it is
+reported as an error.
 
-## Internal Modules
+## Global options
 
-- **llama_invocation**: Shared builder for constructing llama-cli/llama-server commands. Eliminates duplication between `chat` and `serve` commands by centralizing model resolution, context size handling, and flag construction.
+| Option | Effect |
+|---|---|
+| `--models-dir <PATH>` | Override the models directory for this invocation (wins over `.env` and defaults) |
+| `-v`, `--verbose` | Debug-level logging plus file output to `logs/` |
+| `--help`, `--version` | Standard |
 
-## Commands
+## Command map
 
-### Model Management
+| Command | For |
+|---|---|
+| [`up`](#getting-started) | Nothing → working endpoint, in one command |
+| [`proxy`](#serving-an-endpoint) | OpenAI-compatible endpoint, all models, swapped on demand |
+| [`serve <id>`](#serving-an-endpoint) | Same stack pinned to one model |
+| [`daemon`](#serving-an-endpoint) | Inspect or stop the process that owns the runtime |
+| [`model`](#models) | Add, list, download, verify, retag, inspect, explain |
+| [`chat`](#chat-and-ask) | Interactive tool-calling session |
+| [`q`](#chat-and-ask) | One-shot question, pipe-friendly (alias of `question`) |
+| [`benchmark`](#benchmark) | Compare outputs, measure throughput, tune sampling |
+| [`mcp`](#mcp-tool-servers) | Manage MCP tool servers |
+| [`config`](#configuration) | Settings, profiles, llama.cpp, dependencies, paths |
+| [`gui`](#interfaces) / [`web`](#interfaces) | Desktop app / web dashboard |
+| `completions <shell>` | Print a completion script for bash, zsh, fish, elvish, or powershell |
 
-#### `model add <file_path>`
-Add a GGUF model to the database.
+## Getting started
 
-**Example:**
+### `up`
+
+Detects your hardware, installs llama.cpp if missing, recommends and downloads a
+model that fits your VRAM (asking first), starts the proxy, sends a real request
+through it to prove the endpoint answers, and prints the settings to paste into
+your client.
+
+Safe to re-run — anything already present is skipped, so a second run is just
+"start the proxy". Deliberately unconfigurable beyond `--yes`, `--model` and
+`--port`: it binds loopback with gglib's defaults. Reach for `gglib proxy` when
+you want to choose the host, the upstream port, or sampling and cache behaviour.
+
 ```bash
-gglib model add /path/to/model.gguf
+gglib up                      # ask before downloading
+gglib up --yes                # take the recommendation
+gglib up --model qwen3.6 --port 8081
 ```
 
-#### `model list`
-List all models in the database.
+## Serving an endpoint
 
-**Example:**
+### `proxy`
+
+Serves `/v1` chat completions, `/v1/embeddings`, `/v1/models` and `/mcp` (MCP
+Streamable HTTP) from one port. When a request names a model that is not
+resident, the proxy queues it, launches that model, and applies flags derived
+from its capability tags — `mtp` → speculative decoding, `reasoning` →
+`--reasoning-format`, `agent` → `--jinja`. Every surface uses the same config
+builder, so a model behaves identically however it was started.
+
+Sampling flags here act as proxy-wide defaults: per-request and per-model values
+still win. Subcommands: `dashboard` (live terminal view), `cache-clear`, `stop`.
+
+### `serve <id>`
+
+The same proxy stack pinned to one model — requests naming any other are refused
+rather than swapped. That is what clients which cannot switch models via
+`/v1/models` need, VS Code Copilot's BYOK endpoint among them. `--port` is the
+endpoint; `--llama-port` is the upstream behind it.
+
+### `daemon`
+
+`run` (foreground, `--share-lan` to expose on the network), `status`, `stop`.
+Stopping the daemon stops every llama-server it owns.
+
+## Shared flag groups
+
+Several commands flatten the same argument groups. Learning them once covers
+`up`, `proxy`, `serve`, `chat` and `q`.
+
+| Group | Flags cover | Notes |
+|---|---|---|
+| **Context** | `--ctx-size` / `-c` | A number, or `max` to take the model's own metadata. Falls back to the global default. |
+| **Sampling** | temperature, top-p, penalties, … | One layer of a five-level hierarchy — see [Sampling resolution](../../docs/sampling.md). Use [`model explain`](#models) to see which layer won. |
+| **Cache** | `--cache-ram`, `--cache-reuse`, KV cache types | KV quantization and host-RAM prompt cache — see [KV cache tiering](../../docs/cache.md). |
+| **Access** | `--host`, `--api-key`, `--allowed-host` | Loopback needs no key. Binding elsewhere mints one and prints it, and every host a client will reach the endpoint by must be named with `--allowed-host` (DNS-rebinding guard). |
+| **MTP** | `--mtp-draft-n-max`, `--mtp-draft-p-min` | Auto-enabled for `mtp`-tagged models; set `n-max` to `0` to force it off. |
+| **Retry** | retry budget, `--no-retry` | Transient upstream failures on the completion path. |
+
+## Models
+
+`gglib model <subcommand>`:
+
+**Library** — `add`, `list`, `remove`, `update`. `list` sorts by added, name,
+params, or benchmark speed.
+
+**HuggingFace** — `download`, `search`, `browse`, `check-updates`, `upgrade`.
+
+Downloads route through the shared queue the GUI uses. In a TTY the terminal
+becomes a live monitor: **[a]** adds another model while one is in flight;
+**[q]** / `Esc` / `Ctrl-C` drains once, then force-quits on a second press. The
+bar shows the lifecycle phase — `Downloading` → `Finalizing` → `Registering` →
+`Completed` / `Failed` / `Cancelled`. Non-TTY environments fall back to a plain
+monitor automatically. Set `HF_TOKEN` in the environment for private repos.
+
+Transfers run natively over HTTP, resumable and checksum-verified; no Python is
+required. See the [Download Module](download/README.md).
+
+**Integrity** — `verify` (SHA-256), `repair` (re-download failed shards).
+
+**Metadata and capability** — `capabilities`, `inspect`, `retag`, `explain`.
+
+`retag` re-derives auto-tags from persisted GGUF metadata; run it after
+upgrading gglib to backfill newly-introduced tags such as the `format:*` dialect
+family. It is additive by default and never touches user-curated tags; `--full`
+rebuilds the auto namespace only. See [Tags & capability
+detection](../../docs/tags.md).
+
+`explain` prints every resolved sampling parameter alongside the layer that
+supplied it, using the same resolver the live path uses — so it cannot describe
+a hierarchy different from the one that runs.
+
+## Chat and ask
+
+### `chat <identifier>`
+
+Interactive session with tool access (filesystem plus any configured MCP
+servers). `--no-tools` for plain chat. Conversations persist: `--continue <id>`
+resumes one, and `gglib chat history` lists them.
+
+Local models need guardrails to finish a tool-calling task, so the loop carries
+iteration limits (`--max-iterations`), a tool allowlist (`--tools`, evaluated
+once at session start), parallelism and timeout caps, and a dual-threshold loop
+guard — `--observation-tool` / `--max-observation-steps` let read-only tools
+repeat more often than mutating ones before loop detection fires.
+
+### `q` / `question`
+
+One-shot, built for pipes. `{}` in the question is replaced by piped or `--file`
+input. `-Q` / `--quiet` strips tool progress and reasoning tokens for scripting.
+
 ```bash
-gglib model list
+gglib q "What is Rust?"
+cat file.rs | gglib q "Explain this code"
+gglib q --file README.md "Summarize this project"
 ```
 
-#### `model remove <identifier> [--force]`
-Remove a model by name or ID.
-
-**Options:**
-- `--force`: Skip confirmation prompt
-
-**Example:**
-```bash
-gglib model remove 1 --force
-```
-
-#### `model update <id> [OPTIONS]`
-Update model metadata.
-
-**Options:**
-- `--name <NAME>`: Update model name
-- `--param-count <COUNT>`: Update parameter count (in billions)
-- `--architecture <ARCH>`: Update architecture
-- `--quantization <QUANT>`: Update quantization type
-- `--context-length <LENGTH>`: Update context length
-- `--metadata <KEY=VALUE>`: Add or update metadata (can be used multiple times)
-- `--remove-metadata <KEYS>`: Remove metadata keys (comma-separated)
-- `--replace-metadata`: Replace all metadata instead of merging
-- `--dry-run`: Preview changes without applying
-- `--force`: Skip confirmation prompts
-
-**Example:**
-```bash
-gglib model update 1 --name "Llama 2 7B" --metadata "use-case=chat"
-```
-
-### Model Operations
-
-#### `serve <id> [OPTIONS]`
-Serve a model with llama-server.
-
-**Options:**
-- `--ctx-size <SIZE>`, `-c`: Context size override (number or "max" for model metadata). Falls back to the global default from `gglib config settings`.
-- `--mlock`: Enable memory lock
-- `--jinja`: Force-enable Jinja template parsing for llama-server chat templates
-- `--port <PORT>`, `-p`: Port to serve on (default: 8080)
-- `--mtp-draft-n-max <N>`: MTP speculative decoding draft token count.
-  Auto-enabled with `n=2` when the model has the `mtp` tag.
-  Set to `0` to explicitly disable MTP even on a tagged model.
-- `--mtp-draft-p-min <P>`: Minimum acceptance probability for MTP draft tokens (default: `0.75`).
-  Lower values improve throughput at the cost of quality. Recommended range: `0.5`–`0.95`.
-
-**Example:**
-```bash
-gglib serve 1 --ctx-size max --mlock
-
-# Explicitly enable MTP with custom settings (even without tag)
-gglib serve 1 --mtp-draft-n-max 4 --mtp-draft-p-min 0.8
-
-# Disable MTP even though the model has the mtp tag
-gglib serve 1 --mtp-draft-n-max 0
-```
-
-#### `chat <identifier> [OPTIONS]`
-Start an interactive chat session with `llama-cli` using any stored model.
-
-**Options:**
-- `--ctx-size <SIZE>`: Context size override (number or `max` for model metadata). Falls back to the global default from `gglib config settings`.
-- `--mlock`: Enable memory locking
-- `--chat-template <NAME>`: Override the template name baked into llama-cli
-- `--chat-template-file <PATH>`: Provide a custom Jinja template path
-- `--jinja`: Force-enable Jinja parsing for custom templates
-- `--system-prompt <TEXT>` / `-s`: Supply a system prompt passed as `-sys`
-- `--multiline-input`: Allow multi-line prompts without trailing `\`
-- `--simple-io`: Switch to simplified IO for restricted terminals
-
-**Example:**
-```bash
-gglib chat llama-3.1 --ctx-size max --system-prompt "You are a helpful assistant"
-```
-
-#### `proxy [OPTIONS]`
-Start OpenAI-compatible proxy for automatic model swapping.
-
-**Options:**
-- `--host <HOST>`: Host to bind to (default: 127.0.0.1)
-- `--port <PORT>`: Port to bind the proxy to (default: 8080)
-- `--llama-port <PORT>`: Starting port for llama-server instances (default: 5500)
-- `--default-context <SIZE>`: Default context size when not specified by client (default: 4096)
-
-**Example:**
-```bash
-# Local access only
-gglib proxy --port 8080
-
-# LAN access (see LAN Server Mode documentation)
-gglib proxy --host 0.0.0.0 --port 8080 --llama-port 5500
-```
-
-### HuggingFace Hub Integration
-
-#### `model download <repo_id> [OPTIONS]`
-Download a model from HuggingFace Hub with interactive queue support.
-
-**Options:**
-- `--quantization <QUANT>`, `-q`: Specific quantization to download (e.g., "Q4_K_M", "F16")
-- `--list-quants`: List available quantizations for the model
-- `--token <TOKEN>`: HuggingFace token (for `--list-quants` only; use `HF_TOKEN` env var for downloads)
-- `--force`, `-f`: Skip confirmation prompt
-
-**Interactive mode (TTY):**
-- After queuing a download, the terminal enters a live progress monitor
-- **[a]** — add another model to the queue while the current one is downloading
-- **[q]** / Ctrl-C — cancel all pending downloads and exit
-- Non-TTY environments (CI, pipes) automatically fall back to a plain monitor
-
-**Authentication:**
-For downloading private models, set the `HF_TOKEN` environment variable. It is read at startup and wired into the download manager, mirroring how the GUI handles authentication.
-
-**Example:**
-```bash
-# List available quantizations
-gglib model download microsoft/DialoGPT-medium --list-quants
-
-# Download specific quantization (auto-registered in database)
-gglib model download microsoft/DialoGPT-medium --quantization Q4_K_M
-
-# Download a private model using HF_TOKEN
-HF_TOKEN=hf_... gglib model download my-org/private-model -q Q4_K_M
-```
-
-#### `model search <query> [OPTIONS]`
-Search for GGUF models on HuggingFace Hub.
-
-**Options:**
-- `--limit <N>`: Maximum number of results (default: 10)
-- `--sort <FIELD>`: Sort by "downloads", "created", "likes", or "updated" (default: downloads)
-- `--gguf-only`: Only show models with GGUF files
-
-**Example:**
-```bash
-gglib model search "llama 7b gguf" --limit 5 --sort downloads
-```
-
-#### `model browse <category> [OPTIONS]`
-Browse popular GGUF models on HuggingFace Hub.
-
-**Options:**
-- `--limit <N>`: Maximum number of results (default: 20)
-- `--size <SIZE>`: Filter by model size (e.g., "7B", "13B", "70B")
-
-**Categories:**
-- `popular`: Most popular models
-- `recent`: Recently updated models
-- `trending`: Trending models
-
-**Example:**
-```bash
-gglib model browse popular --limit 10
-gglib model browse recent --size 7B
-```
-
-#### `model check-updates [OPTIONS]`
-Check for updates to downloaded models.
-
-**Options:**
-- `--model-id <ID>`: Check specific model by ID
-- `--all`: Check all models
-
-**Example:**
-```bash
-gglib model check-updates --all
-```
-
-#### `model upgrade <model_id> [--force]`
-Update a model to the latest version from HuggingFace Hub.
-
-**Options:**
-- `--force`: Skip confirmation prompt
-
-**Example:**
-```bash
-gglib model upgrade 1
-```
-
-### User Interfaces
-
-#### `gui [OPTIONS]`
-Launch the Tauri desktop GUI.
-
-**Options:**
-- `--dev`: Run in development mode with hot-reload (requires Node.js and npm)
-
-**Example:**
-```bash
-# Launch desktop GUI
-gglib gui
-
-# Development mode (for contributors)
-gglib gui --dev
-```
-
-For more details, see the [Desktop GUI documentation](../src-tauri/README.md).
-
-#### `web [OPTIONS]`
-Start the web-based GUI server.
-
-**Options:**
-- `--port <PORT>`: Port to serve the web GUI on (default: 9887)
-- `--base-port <PORT>`: Base port for llama-server instances (default: 9000)
-- `--api-only`: Serve API endpoints only (do not serve static UI assets)
-
-**Example:**
-```bash
-# Start web server (accessible from LAN by default)
-gglib web --port 9887
-
-# API-only mode (useful when running the React dev server separately)
-gglib web --api-only --port 9887
-
-# Use different base port for model servers
-gglib web --port 9887 --base-port 9000
-```
-
-The web server binds to `127.0.0.1` by default (local only). Use `--host 0.0.0.0` for LAN access. See [Interfaces](../README.md#interfaces) for details.
-
-### llama.cpp Management
-
-#### `llama install`
-Install and build llama.cpp with automatic hardware detection.
-
-**Example:**
-```bash
-gglib config llama install
-```
-
-#### `llama status`
-Show llama.cpp installation status and build information.
-
-**Example:**
-```bash
-gglib config llama status
-```
-
-#### `llama check-updates`
-Check if a newer version of llama.cpp is available.
-
-**Example:**
-```bash
-gglib config llama check-updates
-```
-
-#### `llama update`
-Update llama.cpp to the latest version and rebuild.
-
-**Example:**
-```bash
-gglib config llama update
-```
-
-#### `llama rebuild [OPTIONS]`
-Rebuild llama.cpp with different acceleration options.
-
-**Options:**
-- `--cuda`: Force CUDA acceleration (NVIDIA GPUs)
-- `--metal`: Force Metal acceleration (Apple Silicon)
-- `--cpu-only`: Force CPU-only build
-
-**Example:**
-```bash
-gglib config llama rebuild --cuda
-```
-
-#### `llama uninstall`
-Remove llama.cpp installation.
-
-**Example:**
-```bash
-gglib config llama uninstall
-```
-
-### assistant-ui Management
-
-#### `assistant-ui install`
-Install assistant-ui npm dependencies.
-
-**Example:**
-```bash
-gglib config assistant-ui install
-```
-
-#### `assistant-ui status`
-Show assistant-ui installation status.
-
-**Example:**
-```bash
-gglib config assistant-ui status
-```
-
-#### `assistant-ui update`
-Update assistant-ui dependencies.
-
-**Example:**
-```bash
-gglib config assistant-ui update
-```
-
-### System
-
-#### `paths`
-Show resolved paths for all gglib directories (models, database, config, etc.).
-
-**Example:**
-```bash
-gglib config paths
-```
-
-#### `check-deps`
-Check system dependencies required for gglib.
-
-**Example:**
-```bash
-gglib config check-deps
-```
-
-#### `config models-dir <action>`
-Inspect or update the persistent models directory configuration used by downloads and serving commands.
-
-**Actions:**
-- `show` – print the resolved path along with its source (CLI flag/env/default)
-- `prompt` – interactively ask for a new path, creating it if necessary and saving to `.env`
-- `set <PATH>` – non-interactively persist a new path to `.env`
-
-**Examples:**
-```bash
-# Review the current directory
-gglib config models-dir show
-
-# Walk through the interactive prompt (Enter keeps existing value)
-gglib config models-dir prompt
-
-# Force a specific path
-gglib config models-dir set /fast-ssd/llama_models
-```
-
-#### `config settings <action>`
-Manage application settings including download queue configuration, agent loop parameters, and display preferences.
-
-**Actions:**
-- `show` – display current settings
-- `set` – update settings (see flags below)
-- `reset` – reset all settings to defaults
-
-**`set` flags:**
-- `--default-context-size <N>` – default context size (512-1000000)
-- `--proxy-port <PORT>` – OpenAI-compatible proxy port (≥ 1024)
-- `--llama-base-port <PORT>` – llama-server base port (≥ 1024)
-- `--max-download-queue-size <N>` – max download queue size (1-50)
-- `--default-download-path <PATH>` – default model download directory
-- `--max-tool-iterations <N>` – max agent loop iterations (1-50)
-- `--max-stagnation-steps <N>` – max stagnation steps before abort
-- `--show-memory-fit-indicators <BOOL>` – show memory fit in HF browser
-
-**Examples:**
-```bash
-# View current settings
-gglib config settings show
-
-# Set max agent iterations to 40
-gglib config settings set --max-tool-iterations 40
-
-# Set max download queue size
-gglib config settings set --max-download-queue-size 20
-
-# Reset to defaults
-gglib config settings reset
-```
-
-> Changing settings only affects application behavior; it does **not** affect existing downloads or models.
-
+## Benchmark
+
+`compare` runs one prompt through N models sequentially and shows outputs
+side-by-side. `perf` measures prompt-processing and generation throughput via
+llama-bench. `list`, `show` and `model` read past runs.
+
+`tune` sweeps sampling parameters against an agentic tool-calling suite, scoring
+both tool-call accuracy and resistance to loops and stagnation, and can write the
+winning settings straight back to the model's inference defaults.
+
+## MCP tool servers
+
+`list`, `add`, `remove`, `start`, `stop`, `enable`, `disable`, `tools`, `test`.
+
+Servers are `stdio` (a process) or `sse` (HTTP). The `lifecycle` policy decides
+when gglib spawns one: `eager` at host init, `lazy` on first tool use (default),
+`manual` never.
+
+## Configuration
+
+`gglib config <subcommand>`:
+
+- **`settings`** — context size, ports, download queue size, agent loop limits,
+  display preferences. `show` / `set` / `reset`.
+- **`profile`** — named sampling profiles, selectable per request as
+  `<model>:<profile>`. Only the flags you pass are set; the rest fall through to
+  the model's own defaults.
+- **`default`** — view or set the default model.
+- **`models-dir`** — `show` (with its source), `prompt` (interactive), or
+  `set <PATH>`.
+- **`llama`** — install, status, check-updates, update, rebuild, uninstall.
+  gglib manages llama.cpp itself; see [Llama Management](llama/README.md).
+- **`assistant-ui`** — install, status, update.
+- **`check-deps`** — report what is missing and print your platform's exact
+  install commands. `--setup-fast-downloads` additionally provisions the
+  optional `hf_xet` accelerator; downloads work without it.
+- **`paths`** — resolved locations for models, database, config and logs.
+
+Changing settings affects future behaviour only — it does not alter existing
+downloads or models.
+
+## Interfaces
+
+`gui` launches the desktop app (`--dev` for hot-reload, contributors only).
+`web` ensures the daemon is up and prints the dashboard URL; the daemon serves
+UI and API from one loopback port. To expose it on the network, run
+`gglib daemon run --share-lan` in the foreground.
 
 ## See Also
 
-- [Main README](../README.md) — Overview and getting started
-- [Interfaces](../README.md#interfaces) — CLI, Desktop GUI, Web UI, and Proxy
-- [Architecture](../README.md#architecture) — How GGLib is structured
-- [gglib-cli crate](../../crates/gglib-cli/README.md) — Rust source for the CLI
-- [Desktop GUI](../src-tauri/README.md) — Tauri app details
+- [Main README](../../README.md) — what GGLib is and how to point a client at it
+- [Sampling resolution](../../docs/sampling.md) · [Tags](../../docs/tags.md) · [KV cache](../../docs/cache.md)
+- [gglib-cli crate](../../crates/gglib-cli/README.md) — the Rust source behind these commands
+- [Desktop GUI](../../src-tauri/README.md)
 
 <!-- module-docs:end -->

--- a/src/commands/download/README.md
+++ b/src/commands/download/README.md
@@ -32,11 +32,11 @@ The download module handles interactions with the HuggingFace Hub, including sea
 
 When a GGUF file is downloaded and added to the database, `model_ops.rs` automatically analyzes the model's metadata to detect reasoning/thinking capabilities. Models with chat templates containing `<think>`, `<reasoning>`, or similar tags (e.g., DeepSeek R1, Qwen3, QwQ) receive a `reasoning` tag automatically. This enables optimal configuration when serving via `llama-server --reasoning-format`.
 
-### Fast-path helper overview
+### Download backends
 
-The download flow always invokes `scripts/hf_xet_downloader.py` inside the managed Miniconda environment (`<data_root>/.conda/gglib-hf-xet`). `gglib config check-deps`/`make setup` ensure that environment exists with `huggingface_hub>=1.1.5` and `hf_xet>=0.6`. The helper pulls GGUF blobs via Xet storage and emits newline-delimited JSON progress that ties back into the existing `ProgressCallback` plumbing.
+Downloads run natively over HTTP by default: a `reqwest`-based streaming downloader with resumable `.part` transfers, SHA-256 verification against `X-Linked-Etag`, and atomic rename on completion. No Python is required for a download to succeed.
 
-Fast mode is now mandatory: if the helper is missing or fails, the command returns an error with remediation steps and does not fall back to the legacy Rust HTTP downloader.
+The `hf_xet` accelerator is opt-in. When its environment has already been provisioned (`gglib config check-deps --setup-fast-downloads`), the flow invokes `hf_xet_downloader.py` inside the managed environment (`<data_root>/.conda/gglib-hf-xet`, with `huggingface_hub>=1.1.5` and `hf_xet>=0.6`), which pulls GGUF blobs via Xet storage and emits newline-delimited JSON progress that ties back into the existing `ProgressCallback` plumbing. The environment is never provisioned implicitly, and if the accelerator is present but fails, the download falls back to the native path rather than erroring.
 
 ## Deep Dive: Quantization Filter
 

--- a/src/pages/README.md
+++ b/src/pages/README.md
@@ -9,37 +9,37 @@ Top-level page components for the gglib GUI application.
 
 ## Architecture
 
+Two entry points build two windows from this directory:
+
 ```text
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                     App.tsx                                         │
-│                                        │                                            │
-│                     ┌──────────────────┼──────────────────┐                         │
-│                     ▼                  ▼                  ▼                         │
-│   ┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐         │
-│   │  ModelControlCenter │  │      ChatPage       │  │    (future pages)   │         │
-│   │       Page          │  │                     │  │                     │         │
-│   └──────────┬──────────┘  └──────────┬──────────┘  └─────────────────────┘         │
-│              │                        │                                             │
-│              ▼                        ▼                                             │
-│   ┌─────────────────────────────────────────────────────────────────────────────┐   │
-│   │                              components/                                    │   │
-│   │                        (Shared UI Components)                               │   │
-│   └─────────────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────────────┘
+main.tsx ──► App.tsx                        tray-main.tsx ──► TrayPanel.tsx
+                │                           (separate "tray" Tauri window:
+                ▼                            proxy status, endpoint, metrics)
+  ┌────────────────────────┐
+  │ ModelControlCenterPage │──swaps to──► ChatPage / BenchmarkPage
+  └───────────┬────────────┘
+              ▼
+        components/
+   (Shared UI Components)
 ```
 
 ## Pages
 
 | Page | Description |
 |------|-------------|
-| [`ModelControlCenterPage.tsx`](ModelControlCenterPage.tsx) | Main dashboard for model management, server control, and downloads |
+| [`ModelControlCenterPage.tsx`](ModelControlCenterPage.tsx) | Model catalog and control: library, server control, and downloads — the main window's landing page |
 | [`ChatPage.tsx`](ChatPage.tsx) | Chat interface for interacting with running models |
+| [`BenchmarkPage.tsx`](BenchmarkPage.tsx) | Benchmark workflows: compare, perf, and sampling-parameter tune |
+| [`TrayPanel.tsx`](TrayPanel.tsx) | Proxy tray window — is the endpoint up, and what is it doing (status, endpoint copy bar, connections, slots) |
+
+`ChatPageSkeleton.tsx` and `chatTabs.tsx` are supporting pieces of `ChatPage`,
+not routed pages.
 
 ### Model Control Center
 
-The primary page containing:
+The main window's landing page containing:
 - Model list with metadata display
-- Server start/stop controls
+- Server start/stop controls and proxy control (with the Proxy Dashboard modal)
 - Download queue management
 - MCP server configuration
 - Settings management
@@ -57,12 +57,6 @@ Interactive chat interface featuring:
 | Directory | Description |
 |-----------|-------------|
 | [`modelControlCenter/`](modelControlCenter/) | Components specific to the Model Control Center page |
-
-## Styling
-
-Each page has a corresponding CSS file:
-- `ModelControlCenterPage.css` — Control center layout and styling
-- `ChatPage.css` — Chat interface styling
 
 ## Design Principles
 


### PR DESCRIPTION
> **Stacked on #710 — merge that first.** This branch builds on it (both touch `gglib-runtime/README.md` and `gglib-app-services/src/proxy.rs`), so until #710 lands this PR shows its five commits too. Once #710 is merged I'll rebase and this will show only its own four.

#707 rewrote the root README around the proxy. Below that one file, the old identity was still fully intact — the narrative was exactly one page deep. This carries it down.

**Four commits:**

1. **`docs(runtime)`: fix doc links that break the README-to-rustdoc build.** Three hand-written intra-doc links didn't resolve, so the published API docs carried dead references. The substantive one: `manager.rs` documented `CacheRamSetting::LlamaDefault`, a variant that doesn't exist, and described it as emitting no flag. Benchmarks actually pass `ExplicitMb(0)` → `--cache-ram 0`; *omitting* the flag is what `Auto` does under env suppression. Both the name and the mechanism were wrong. `cargo doc` now reports no unresolved links for either crate.

2. **`feat(gui)`: retitle the app off "GGUF Model Manager".** The main window's title bar, the web UI's document title, and the npm description all still announced a GGUF model manager. The tray already said "gglib Proxy"; the main window never caught up. Now "GGLib — Local Model Runtime", matching the README's opening line. `productName` deliberately untouched — it names the release bundle.

3. **`docs`: lead each crate README with what it does for the product.** All 16 crate READMEs plus `src-tauri` opened with their architectural layer ("This crate is in the Infrastructure Layer"), which says where it sits but not why it exists — and since these files are each crate's rustdoc landing page, that was the first thing an API-docs reader saw. Each now carries one short paragraph above the layer description. Two were wrong rather than merely abstract: `gglib-proxy` still called itself a **"Single Active Backend Proxy"** (M9 replaced single-swap with a bounded resident set), and `src-tauri` still framed the desktop app as "one of three complementary interfaces for managing GGUF models".

4. **`docs(cli)`: rewrite the command reference.** `src/commands/README.md` had drifted badly — no `up`, `daemon`, `benchmark`, `mcp`, `q`, `model explain`/`retag`/`verify`, or proxy subcommands; a command-flow diagram predating the daemon; and five links to `../README.md`, which doesn't exist. It rotted because it hand-transcribed every flag, so the rewrite doesn't: `--help` owns the flag list, generated from the same source the binary parses. What's here instead is what `--help` can't say — that one daemon owns llama-server and every command is a client of it, how the six shared arg groups compose across `up`/`proxy`/`serve`/`chat`/`q`, which resolution layer wins, and the non-obvious behaviour around downloads, tagging, and the agent loop's guardrails. 373 lines removed, 168 added.

**Diagrams are untouched.** The ASCII-in-```text choice is deliberate — these READMEs are injected into rustdoc via `build_common.rs` → `include_str!`, and Mermaid doesn't render there without `aquamarine` or an `--html-in-header` hack, while ASCII renders identically in both. The one diagram that changed is the command-flow one in commit 4, corrected to show the daemon rather than removed.

**Verification:** `cargo doc -p gglib-runtime -p gglib-app-services` reports no unresolved links; both edited JSON files parse; all eight relative links in the new command reference resolve (checked individually — that's how the dead `../README.md` ones were found).

**Known and deliberately not fixed here:** ten remaining `public documentation for X links to private item Y` rustdoc warnings. Most come from the *generated* module tables enumerating private modules, so hand-patching the READMEs would be overwritten by `generate_module_tables.sh` — the fix belongs in the generator, which is outside this PR's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4z91CBLkwDdbLMifNuZn)_