### PR TITLE
security(daemon): Host guard and bearer auth for the management API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 # PID files (runtime state)
 /pids
 
+# Daemon singleton lock (runtime state)
+daemon.lock
+
 # KV cache slot files (--cache/--slot-dir runtime state)
 /slots
 

--- a/crates/gglib-axum/src/access.rs
+++ b/crates/gglib-axum/src/access.rs
@@ -1,0 +1,219 @@
+//! Access control for the daemon's management API.
+//!
+//! The management API can start and stop inference, change settings, and
+//! queue downloads, so it gets the same two gates the OpenAI proxy received
+//! in the `--api-key`/`--allowed-host` work: a Host-header allowlist (the
+//! DNS-rebinding guard, always on) and an optional bearer token. The pure
+//! policy — normalization, loopback detection, the allowlist itself — is
+//! [`gglib_core::ProxyAccessConfig`], shared with the proxy; this module
+//! only adapts it to the daemon's router and error shape.
+//!
+//! One deliberate divergence from the proxy: when the daemon is bound off
+//! loopback (`--share-lan`), a `Host` header that is an IP literal is
+//! accepted without being listed. DNS rebinding is a hostname attack — a
+//! rebound page always presents the attacker's domain, never a bare IP —
+//! so refusing `192.168.1.5:9887` would break "reachable by IP" LAN use
+//! while stopping nobody. Loopback binds keep the strict policy.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Request, State},
+    http::{StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use gglib_core::access::{is_loopback_host, normalize_host};
+use gglib_core::{CorsConfig, ProxyAccessConfig};
+use serde_json::json;
+use tracing::warn;
+
+/// Who may reach the daemon's management API, and how they prove it.
+#[derive(Debug, Clone)]
+pub struct DaemonAccess {
+    /// The shared host-allowlist + bearer policy from `gglib-core`. Its CORS
+    /// field is unused here — the daemon router builds CORS separately.
+    policy: ProxyAccessConfig,
+    /// Accept IP-literal `Host` values that are not on the allowlist. Set
+    /// only for non-loopback binds; see the module docs for why this is
+    /// safe against rebinding.
+    allow_ip_literal_hosts: bool,
+}
+
+impl DaemonAccess {
+    /// Build the access policy for a daemon about to bind `bind_host`.
+    ///
+    /// `api_key = None` leaves `/api/*` unauthenticated — the right default
+    /// for loopback, where the socket itself is the boundary. Callers that
+    /// bind anything else are expected to resolve or mint a key first.
+    #[must_use]
+    pub fn new(api_key: Option<String>, bind_host: &str, extra_hosts: Vec<String>) -> Self {
+        Self {
+            policy: ProxyAccessConfig::new(CorsConfig::default(), api_key, bind_host, extra_hosts),
+            allow_ip_literal_hosts: !is_loopback_host(bind_host),
+        }
+    }
+
+    /// The policy for a plain loopback daemon: loopback hosts only, no token.
+    #[must_use]
+    pub fn loopback() -> Self {
+        Self::new(None, "127.0.0.1", Vec::new())
+    }
+
+    /// Whether a request carrying this `Host` header may proceed.
+    #[must_use]
+    pub fn host_allowed(&self, host_header: &str) -> bool {
+        if self.policy.host_allowed(host_header) {
+            return true;
+        }
+        self.allow_ip_literal_hosts
+            && normalize_host(host_header)
+                .is_some_and(|host| host.parse::<std::net::IpAddr>().is_ok())
+    }
+
+    /// The `"Bearer <token>"` string a request must present verbatim, or
+    /// `None` when authentication is off.
+    #[must_use]
+    pub fn expected_authorization(&self) -> Option<String> {
+        self.policy.expected_authorization()
+    }
+}
+
+/// Reject any request whose `Host` header is not one this daemon answers to.
+///
+/// Applied as the outermost layer so it covers every route — `/health`, the
+/// SPA assets, and paths that match nothing. A check this cheap has no
+/// reason to have holes in it.
+pub(crate) async fn host_guard(
+    State(access): State<Arc<DaemonAccess>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    if access.host_allowed(host) {
+        return next.run(req).await;
+    }
+
+    warn!(
+        host,
+        path = %req.uri().path(),
+        "rejected request with a Host header this daemon does not answer to"
+    );
+    let remedy = match normalize_host(host) {
+        Some(name) => format!(" Add --allowed-host {name} if that is how you reach it."),
+        None => String::new(),
+    };
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({
+            "error": format!(
+                "Host '{host}' is not allowed. The daemon answers to loopback and to hosts \
+                 named with --allowed-host.{remedy}"
+            ),
+            "status": StatusCode::FORBIDDEN.as_u16(),
+            "type": "HOST_NOT_ALLOWED",
+        })),
+    )
+        .into_response()
+}
+
+/// Require `Authorization: Bearer <token>` before a request reaches `/api/*`.
+///
+/// Installed only when a token is configured, so the unauthenticated
+/// loopback default costs nothing per request. `expected` holds the whole
+/// `"Bearer <token>"` string so the check is one comparison.
+pub(crate) async fn bearer_guard(
+    State(expected): State<Arc<str>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let presented = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    if constant_time_eq(presented.as_bytes(), expected.as_bytes()) {
+        return next.run(req).await;
+    }
+
+    warn!(
+        path = %req.uri().path(),
+        "rejected management API request with a missing or invalid bearer token"
+    );
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, "Bearer")],
+        Json(json!({
+            "error": "Missing or invalid API key. Send it as 'Authorization: Bearer <key>'.",
+            "status": StatusCode::UNAUTHORIZED.as_u16(),
+            "type": "INVALID_API_KEY",
+        })),
+    )
+        .into_response()
+}
+
+/// Compare two byte strings without an early exit on the first difference,
+/// so response timing does not leak how many leading bytes of the token a
+/// caller guessed right. The length check leaks only the token's length,
+/// which is not the secret.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_agrees_with_equality() {
+        assert!(constant_time_eq(b"Bearer abc", b"Bearer abc"));
+        assert!(constant_time_eq(b"", b""));
+        assert!(!constant_time_eq(b"Bearer abc", b"Bearer abd"));
+        assert!(!constant_time_eq(b"Bearer abc", b"Bearer ab"));
+    }
+
+    /// Loopback binds keep the proxy's strict policy: no IP-literal
+    /// exemption, no foreign hostnames.
+    #[test]
+    fn loopback_policy_is_strict() {
+        let access = DaemonAccess::loopback();
+        assert!(access.host_allowed("127.0.0.1:9887"));
+        assert!(access.host_allowed("localhost"));
+        assert!(!access.host_allowed("192.168.1.5:9887"));
+        assert!(!access.host_allowed("evil.com"));
+        assert!(!access.host_allowed(""));
+    }
+
+    /// A shared daemon must stay reachable by raw IP without ceremony —
+    /// that is not a rebinding vector, because a rebound page presents the
+    /// attacker's hostname, not an IP.
+    #[test]
+    fn non_loopback_bind_accepts_ip_literals_but_not_hostnames() {
+        let access = DaemonAccess::new(None, "0.0.0.0", vec!["gglib.local".into()]);
+        assert!(access.host_allowed("192.168.1.5:9887"));
+        assert!(access.host_allowed("[fe80::1]:9887"));
+        assert!(access.host_allowed("gglib.local:9887"));
+        assert!(access.host_allowed("127.0.0.1:9887"));
+        assert!(!access.host_allowed("evil.com:9887"));
+    }
+
+    #[test]
+    fn expected_authorization_is_preformatted() {
+        let access = DaemonAccess::new(Some("secret".into()), "0.0.0.0", Vec::new());
+        assert_eq!(
+            access.expected_authorization().as_deref(),
+            Some("Bearer secret")
+        );
+        assert_eq!(DaemonAccess::loopback().expected_authorization(), None);
+    }
+}

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -317,7 +317,11 @@ pub async fn start_server(config: ServerConfig) -> Result<()> {
     // Host-guarded, tokenless: this entry point has no key resolution of its
     // own, so a non-loopback bind here relies on the allowlist alone. The
     // daemon path (`run_daemon`) is the one that resolves and mints keys.
-    let access = Arc::new(crate::access::DaemonAccess::new(None, &config.host, Vec::new()));
+    let access = Arc::new(crate::access::DaemonAccess::new(
+        None,
+        &config.host,
+        Vec::new(),
+    ));
 
     // Choose router based on whether static serving is configured
     let app = if let Some(ref static_dir) = config.static_dir {

--- a/crates/gglib-axum/src/bootstrap.rs
+++ b/crates/gglib-axum/src/bootstrap.rs
@@ -314,12 +314,17 @@ pub async fn start_server(config: ServerConfig) -> Result<()> {
     let ctx = bootstrap(config.clone()).await?;
     let state: crate::state::AppState = Arc::new(ctx);
 
+    // Host-guarded, tokenless: this entry point has no key resolution of its
+    // own, so a non-loopback bind here relies on the allowlist alone. The
+    // daemon path (`run_daemon`) is the one that resolves and mints keys.
+    let access = Arc::new(crate::access::DaemonAccess::new(None, &config.host, Vec::new()));
+
     // Choose router based on whether static serving is configured
     let app = if let Some(ref static_dir) = config.static_dir {
         info!("Serving static assets from: {}", static_dir.display());
-        crate::routes::create_spa_router(state, static_dir, &config.cors)
+        crate::routes::create_spa_router(state, static_dir, &config.cors, access)
     } else {
-        crate::routes::create_router(state, &config.cors)
+        crate::routes::create_router(state, &config.cors, access)
     };
 
     let addr = format!("{}:{}", config.host, config.port);

--- a/crates/gglib-axum/src/daemon/README.md
+++ b/crates/gglib-axum/src/daemon/README.md
@@ -21,6 +21,10 @@ reported, not fought.
 This module is responsible for:
 
 - the singleton lock and the "already running (pid N)" refusal,
+- resolving the management API's access policy
+  ([`access`](crate::access)): the Host-header allowlist is always on, and
+  a non-loopback bind (`--share-lan`) requires the stored API key, minting
+  one if none exists,
 - sweeping orphaned llama-server pidfiles at startup (moved here from the
   desktop app, which used to kill a concurrent CLI's servers),
 - SIGINT/SIGTERM handling and the `POST /api/daemon/shutdown` route's

--- a/crates/gglib-axum/src/daemon/mod.rs
+++ b/crates/gglib-axum/src/daemon/mod.rs
@@ -43,6 +43,10 @@ pub struct DaemonOptions {
     /// Directory with a built frontend to serve as an SPA. `None` means
     /// auto-discover; `Some` is an explicit location.
     pub static_dir: Option<PathBuf>,
+    /// `Host` header values accepted in addition to loopback (and, on a
+    /// non-loopback bind, IP literals). The mDNS name and `--allowed-host`
+    /// entries arrive here.
+    pub allowed_hosts: Vec<String>,
 }
 
 impl Default for DaemonOptions {
@@ -51,6 +55,7 @@ impl Default for DaemonOptions {
             host: "127.0.0.1".into(),
             cors: CorsConfig::AllowOrigins(daemon_cors_origins()),
             static_dir: None,
+            allowed_hosts: Vec::new(),
         }
     }
 }
@@ -78,8 +83,9 @@ pub fn discover_static_dir() -> Option<PathBuf> {
 /// 2. Sweep orphaned llama-server pidfiles left by a crashed daemon.
 /// 3. [`bootstrap`](crate::bootstrap::bootstrap) the one `AxumContext` —
 ///    and with it the one `ProcessManager` on this machine.
-/// 4. Bind `{host}:{DAEMON_PORT}` and serve the management API (+ SPA when a
-///    frontend build is found).
+/// 4. Resolve the access policy — Host allowlist always, bearer token for
+///    non-loopback binds — then bind `{host}:{DAEMON_PORT}` and serve the
+///    management API (+ SPA when a frontend build is found).
 /// 5. Honour `proxy_autostart` so the OpenAI endpoint comes up with the
 ///    daemon rather than with the desktop app.
 /// 6. On SIGINT/SIGTERM/shutdown-route: drain the proxy, stop every child,
@@ -114,14 +120,24 @@ pub async fn run_daemon(opts: DaemonOptions) -> Result<()> {
     ctx.daemon_shutdown = Some(shutdown_token.clone());
     let state: AppState = Arc::new(ctx);
 
-    // 4. Router — SPA when a frontend build exists, API-only otherwise.
+    // 4. Access policy, then the router. The Host guard is always on; the
+    //    bearer token exists only for non-loopback binds, where the socket
+    //    stops being the boundary.
+    let api_key = resolve_daemon_api_key(&opts.host, &state).await;
+    let access = Arc::new(crate::access::DaemonAccess::new(
+        api_key,
+        &opts.host,
+        opts.allowed_hosts.clone(),
+    ));
+
+    // Router — SPA when a frontend build exists, API-only otherwise.
     let static_dir = opts.static_dir.clone().or_else(discover_static_dir);
     let app = match &static_dir {
         Some(dir) => {
             info!("serving dashboard from {}", dir.display());
-            crate::routes::create_spa_router(Arc::clone(&state), dir, &opts.cors)
+            crate::routes::create_spa_router(Arc::clone(&state), dir, &opts.cors, access)
         }
-        None => crate::routes::create_router(Arc::clone(&state), &opts.cors),
+        None => crate::routes::create_router(Arc::clone(&state), &opts.cors, access),
     };
 
     let addr = format!("{}:{}", opts.host, DAEMON_PORT);
@@ -169,4 +185,62 @@ pub async fn run_daemon(opts: DaemonOptions) -> Result<()> {
     shutdown::perform_shutdown(&state).await;
 
     Ok(())
+}
+
+/// Settle the bearer token for a daemon about to bind `bind_host`.
+///
+/// Same policy as the proxy supervisor's key resolution: loopback binds get
+/// no token (the socket is the boundary, and demanding one would break every
+/// existing local client for no gain); anything else uses the stored
+/// `proxy_api_key` — one machine key across both surfaces — minting and
+/// persisting a fresh one when the setting is empty. The key is printed so a
+/// `--share-lan` operator can copy it; the eprintln lands in `daemon.log`
+/// for detached daemons, which cannot bind non-loopback today anyway.
+async fn resolve_daemon_api_key(bind_host: &str, state: &AppState) -> Option<String> {
+    if gglib_core::access::is_loopback_host(bind_host) {
+        return None;
+    }
+
+    let settings = state.core.settings();
+    let stored = match settings.get().await {
+        Ok(s) => s,
+        Err(e) => {
+            // Fail closed with an unsaved key: an unauthenticated management
+            // API on a network is strictly worse than a token that changes
+            // next run.
+            warn!("could not read settings while resolving the daemon API key: {e}");
+            let key = gglib_core::access::generate_api_key();
+            announce_api_key(&key, "generated, not saved");
+            return Some(key);
+        }
+    };
+
+    if let Some(key) = stored
+        .proxy_api_key
+        .clone()
+        .filter(|key| !key.trim().is_empty())
+    {
+        announce_api_key(&key, "from settings");
+        return Some(key);
+    }
+
+    let key = gglib_core::access::generate_api_key();
+    let mut updated = stored;
+    updated.proxy_api_key = Some(key.clone());
+    match settings.save(&updated).await {
+        Ok(()) => announce_api_key(&key, "generated"),
+        Err(e) => {
+            warn!("generated a daemon API key but could not save it: {e}");
+            announce_api_key(&key, "generated, not saved");
+        }
+    }
+    Some(key)
+}
+
+/// Print the management-API key at startup, once, where the operator who
+/// chose a non-loopback bind will see it.
+fn announce_api_key(key: &str, source: &str) {
+    info!("management API requires a bearer token ({source})");
+    eprintln!("  \u{1f511} Management API key ({source}): {key}");
+    eprintln!("     Clients on the network must send: Authorization: Bearer {key}");
 }

--- a/crates/gglib-axum/src/lib.rs
+++ b/crates/gglib-axum/src/lib.rs
@@ -28,6 +28,7 @@ use tokio_stream as _;
 use tracing as _;
 use tracing_subscriber as _; // Used by main.rs binary
 
+pub mod access;
 pub mod bootstrap;
 pub mod chat_api;
 pub mod daemon;
@@ -39,6 +40,7 @@ pub mod sse;
 pub mod state;
 
 // Re-export primary types
+pub use access::DaemonAccess;
 pub use bootstrap::{AxumContext, ServerConfig, bootstrap, start_server};
 pub use error::HttpError;
 pub use gglib_core::CorsConfig;

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -6,12 +6,15 @@
 use axum::Json;
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
+use axum::middleware;
 use axum::routing::{delete, get, post, put};
 use serde_json::{Value, json};
 use std::path::Path;
+use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 
+use crate::access::{DaemonAccess, bearer_guard, host_guard};
 use crate::chat_api::chat_routes_no_prefix;
 use crate::handlers;
 use crate::state::AppState;
@@ -291,16 +294,28 @@ fn config_routes() -> Router<AppState> {
         )
 }
 
-/// Create the main Axum router with all API routes.
+/// The router core shared by [`create_router`] and [`create_spa_router`]:
+/// `/health` plus `/api/*`, with CORS and (when a key is configured) the
+/// bearer guard scoped to `/api/*`.
 ///
-/// This creates the API routes only. For serving static assets,
-/// use [`create_spa_router`] which includes both API routes and
-/// static file serving with SPA fallback.
-///
-/// # Path Parameter Syntax
-/// Axum 0.8 uses brace syntax for path parameters: `{id}`, `{tag}`
-pub fn create_router(state: AppState, cors_config: &CorsConfig) -> Router {
+/// The Host guard is *not* applied here — each public constructor layers it
+/// last, after any fallback service, so it wraps everything the router will
+/// ever serve.
+fn base_router(state: AppState, cors_config: &CorsConfig, access: &Arc<DaemonAccess>) -> Router {
     let cors = build_cors_layer(cors_config);
+
+    let mut api = api_routes().with_state(state);
+    // The bearer layer exists only when a token is configured, so the
+    // unauthenticated loopback default costs nothing per request. /health
+    // stays outside the group: probes must not need credentials. CORS is
+    // layered *after* (outside) the bearer guard so preflight OPTIONS
+    // requests — which never carry Authorization — are answered by the CORS
+    // layer instead of dying on a 401.
+    if let Some(expected) = access.expected_authorization() {
+        let expected: Arc<str> = expected.into();
+        api = api.layer(middleware::from_fn_with_state(expected, bearer_guard));
+    }
+    let api = api.layer(cors);
 
     Router::new()
         // Intentionally placed outside the CORS layer — /health is a
@@ -309,7 +324,23 @@ pub fn create_router(state: AppState, cors_config: &CorsConfig) -> Router {
         // The proxy server applies CORS globally (including /health) via a
         // router-level .layer(), but this Axum router scopes CORS to /api/* only.
         .route("/health", get(health_check))
-        .nest("/api", api_routes().with_state(state).layer(cors))
+        .nest("/api", api)
+}
+
+/// Create the main Axum router with all API routes.
+///
+/// This creates the API routes only. For serving static assets,
+/// use [`create_spa_router`] which includes both API routes and
+/// static file serving with SPA fallback.
+///
+/// `access` carries the Host allowlist (always enforced, on every route)
+/// and the optional bearer token (enforced on `/api/*` when set).
+///
+/// # Path Parameter Syntax
+/// Axum 0.8 uses brace syntax for path parameters: `{id}`, `{tag}`
+pub fn create_router(state: AppState, cors_config: &CorsConfig, access: Arc<DaemonAccess>) -> Router {
+    base_router(state, cors_config, &access)
+        .layer(middleware::from_fn_with_state(access, host_guard))
 }
 
 /// Create a router with API routes and static asset serving.
@@ -326,15 +357,18 @@ pub fn create_router(state: AppState, cors_config: &CorsConfig) -> Router {
 ///
 /// # Example
 /// ```no_run
-/// # use gglib_axum::{CorsConfig, state::AppState};
+/// # use std::sync::Arc;
+/// # use gglib_axum::{CorsConfig, DaemonAccess, state::AppState};
 /// # async fn example(state: AppState) {
-/// let router = gglib_axum::routes::create_spa_router(state, "./dist", &CorsConfig::AllowAll);
+/// let access = Arc::new(DaemonAccess::loopback());
+/// let router = gglib_axum::routes::create_spa_router(state, "./dist", &CorsConfig::AllowAll, access);
 /// # }
 /// ```
 pub fn create_spa_router<P: AsRef<Path>>(
     state: AppState,
     static_dir: P,
     cors_config: &CorsConfig,
+    access: Arc<DaemonAccess>,
 ) -> Router {
     let static_path = static_dir.as_ref();
     let index_path = static_path.join("index.html");
@@ -343,12 +377,12 @@ pub fn create_spa_router<P: AsRef<Path>>(
     // Using .fallback() on ServeDir makes it return index.html for missing files
     let serve_dir = ServeDir::new(static_path).fallback(ServeFile::new(&index_path));
 
-    // API routes (without fallback - they should 404 on unknown API paths)
-    let api = create_router(state, cors_config);
-
-    // Merge API routes with static serving as fallback
-    // API routes take priority, then fallback to static/SPA serving
-    api.fallback_service(serve_dir)
+    // Merge API routes with static serving as fallback, then wrap the whole
+    // thing — SPA assets included — in the Host guard. The layer must come
+    // after the fallback so a rebound page cannot even load the dashboard.
+    base_router(state, cors_config, &access)
+        .fallback_service(serve_dir)
+        .layer(middleware::from_fn_with_state(access, host_guard))
 }
 
 /// Health check endpoint.

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -338,7 +338,11 @@ fn base_router(state: AppState, cors_config: &CorsConfig, access: &Arc<DaemonAcc
 ///
 /// # Path Parameter Syntax
 /// Axum 0.8 uses brace syntax for path parameters: `{id}`, `{tag}`
-pub fn create_router(state: AppState, cors_config: &CorsConfig, access: Arc<DaemonAccess>) -> Router {
+pub fn create_router(
+    state: AppState,
+    cors_config: &CorsConfig,
+    access: Arc<DaemonAccess>,
+) -> Router {
     base_router(state, cors_config, &access)
         .layer(middleware::from_fn_with_state(access, host_guard))
 }

--- a/crates/gglib-axum/tests/cors_local_only.rs
+++ b/crates/gglib-axum/tests/cors_local_only.rs
@@ -10,8 +10,8 @@ use axum::http::Request;
 use tower::ServiceExt;
 
 use common::ports::TEST_BASE_PORT;
-use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::DaemonAccess;
+use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::routes::create_router;
 use gglib_core::CorsConfig;
 
@@ -46,7 +46,7 @@ async fn local_only_rejects_remote_origin() {
                 .method("OPTIONS")
                 .uri("/api/models")
                 .header("Host", "127.0.0.1:9887")
-                .header("Origin","http://evil.example.com")
+                .header("Origin", "http://evil.example.com")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -81,7 +81,7 @@ async fn local_only_allows_localhost_origin() {
                 .method("OPTIONS")
                 .uri("/api/models")
                 .header("Host", "127.0.0.1:9887")
-                .header("Origin","http://localhost:9887")
+                .header("Origin", "http://localhost:9887")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -117,7 +117,7 @@ async fn local_only_allows_127_0_0_1_origin() {
                 .method("OPTIONS")
                 .uri("/api/models")
                 .header("Host", "127.0.0.1:9887")
-                .header("Origin","http://127.0.0.1:3000")
+                .header("Origin", "http://127.0.0.1:3000")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -148,7 +148,7 @@ async fn local_only_allows_ipv6_localhost() {
                 .method("OPTIONS")
                 .uri("/api/models")
                 .header("Host", "127.0.0.1:9887")
-                .header("Origin","http://[::1]:8080")
+                .header("Origin", "http://[::1]:8080")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -187,7 +187,7 @@ async fn local_only_allows_tauri_localhost_origin() {
                 .method("OPTIONS")
                 .uri("/api/models")
                 .header("Host", "127.0.0.1:9887")
-                .header("Origin","http://tauri.localhost")
+                .header("Origin", "http://tauri.localhost")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),

--- a/crates/gglib-axum/tests/cors_local_only.rs
+++ b/crates/gglib-axum/tests/cors_local_only.rs
@@ -11,6 +11,7 @@ use tower::ServiceExt;
 
 use common::ports::TEST_BASE_PORT;
 use gglib_axum::bootstrap::{ServerConfig, bootstrap};
+use gglib_axum::DaemonAccess;
 use gglib_axum::routes::create_router;
 use gglib_core::CorsConfig;
 
@@ -33,14 +34,19 @@ async fn local_only_rejects_remote_origin() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::LocalOnly);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::LocalOnly,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
                 .uri("/api/models")
-                .header("Origin", "http://evil.example.com")
+                .header("Host", "127.0.0.1:9887")
+                .header("Origin","http://evil.example.com")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -63,14 +69,19 @@ async fn local_only_allows_localhost_origin() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::LocalOnly);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::LocalOnly,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
                 .uri("/api/models")
-                .header("Origin", "http://localhost:9887")
+                .header("Host", "127.0.0.1:9887")
+                .header("Origin","http://localhost:9887")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -94,14 +105,19 @@ async fn local_only_allows_127_0_0_1_origin() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::LocalOnly);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::LocalOnly,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
                 .uri("/api/models")
-                .header("Origin", "http://127.0.0.1:3000")
+                .header("Host", "127.0.0.1:9887")
+                .header("Origin","http://127.0.0.1:3000")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -120,14 +136,19 @@ async fn local_only_allows_ipv6_localhost() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::LocalOnly);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::LocalOnly,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
                 .uri("/api/models")
-                .header("Origin", "http://[::1]:8080")
+                .header("Host", "127.0.0.1:9887")
+                .header("Origin","http://[::1]:8080")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -154,14 +175,19 @@ async fn local_only_allows_tauri_localhost_origin() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::LocalOnly);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::LocalOnly,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .method("OPTIONS")
                 .uri("/api/models")
-                .header("Origin", "http://tauri.localhost")
+                .header("Host", "127.0.0.1:9887")
+                .header("Origin","http://tauri.localhost")
                 .header("Access-Control-Request-Method", "GET")
                 .body(Body::empty())
                 .unwrap(),

--- a/crates/gglib-axum/tests/daemon_access.rs
+++ b/crates/gglib-axum/tests/daemon_access.rs
@@ -73,7 +73,12 @@ async fn missing_host_is_rejected() {
     };
 
     let response = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -92,7 +97,10 @@ async fn loopback_stays_open_by_default() {
         assert_eq!(response.status(), StatusCode::OK, "{host} must be allowed");
     }
 
-    let response = app.oneshot(get("/api/servers", "127.0.0.1:9887")).await.unwrap();
+    let response = app
+        .oneshot(get("/api/servers", "127.0.0.1:9887"))
+        .await
+        .unwrap();
     assert_eq!(
         response.status(),
         StatusCode::OK,
@@ -104,8 +112,12 @@ async fn loopback_stays_open_by_default() {
 /// probes and health checks keep working.
 #[tokio::test]
 async fn configured_token_gates_api_but_not_health() {
-    let Some(app) =
-        build_app(DaemonAccess::new(Some("s3cret".into()), "0.0.0.0", Vec::new())).await
+    let Some(app) = build_app(DaemonAccess::new(
+        Some("s3cret".into()),
+        "0.0.0.0",
+        Vec::new(),
+    ))
+    .await
     else {
         return;
     };
@@ -115,14 +127,22 @@ async fn configured_token_gates_api_but_not_health() {
         .oneshot(get("/api/servers", "127.0.0.1:9887"))
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "no token → 401");
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "no token → 401"
+    );
 
     let mut wrong = get("/api/servers", "127.0.0.1:9887");
     wrong
         .headers_mut()
         .insert("authorization", "Bearer wrong".parse().unwrap());
     let response = app.clone().oneshot(wrong).await.unwrap();
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "wrong token → 401");
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "wrong token → 401"
+    );
 
     let mut right = get("/api/servers", "127.0.0.1:9887");
     right
@@ -139,8 +159,12 @@ async fn configured_token_gates_api_but_not_health() {
 /// mDNS name, while still refusing foreign hostnames.
 #[tokio::test]
 async fn share_lan_policy_accepts_ip_literals_and_named_hosts() {
-    let Some(app) =
-        build_app(DaemonAccess::new(None, "0.0.0.0", vec!["gglib.local".into()])).await
+    let Some(app) = build_app(DaemonAccess::new(
+        None,
+        "0.0.0.0",
+        vec!["gglib.local".into()],
+    ))
+    .await
     else {
         return;
     };
@@ -150,6 +174,9 @@ async fn share_lan_policy_accepts_ip_literals_and_named_hosts() {
         assert_eq!(response.status(), StatusCode::OK, "{host} must be allowed");
     }
 
-    let response = app.oneshot(get("/health", "evil.example.com")).await.unwrap();
+    let response = app
+        .oneshot(get("/health", "evil.example.com"))
+        .await
+        .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }

--- a/crates/gglib-axum/tests/daemon_access.rs
+++ b/crates/gglib-axum/tests/daemon_access.rs
@@ -1,0 +1,155 @@
+//! Integration tests for the daemon management API's access control:
+//! the Host-header allowlist (DNS-rebinding guard) and the optional
+//! bearer token, as applied by `create_router`.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use common::ports::TEST_BASE_PORT;
+use gglib_axum::DaemonAccess;
+use gglib_axum::bootstrap::{ServerConfig, bootstrap};
+use gglib_axum::routes::create_router;
+use gglib_core::CorsConfig;
+
+fn test_config() -> ServerConfig {
+    ServerConfig {
+        host: "127.0.0.1".into(),
+        port: 0,
+        base_port: TEST_BASE_PORT,
+        llama_server_path: "/nonexistent/llama-server".into(),
+        max_concurrent_agent_loops: 1,
+        static_dir: None,
+        cors: CorsConfig::AllowAll,
+    }
+}
+
+async fn build_app(access: DaemonAccess) -> Option<axum::Router> {
+    let ctx = bootstrap(test_config()).await.ok()?;
+    Some(create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        std::sync::Arc::new(access),
+    ))
+}
+
+fn get(uri: &str, host: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header("Host", host)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// The rebinding case the guard exists for: the request reached the socket,
+/// but the Host names a hostname this daemon never agreed to answer to.
+#[tokio::test]
+async fn foreign_host_is_rejected_on_every_route() {
+    let Some(app) = build_app(DaemonAccess::loopback()).await else {
+        return;
+    };
+
+    for uri in ["/api/servers", "/health", "/no/such/path"] {
+        let response = app
+            .clone()
+            .oneshot(get(uri, "evil.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{uri} must be Host-guarded"
+        );
+    }
+}
+
+/// A request that omits Host entirely has no claim to check.
+#[tokio::test]
+async fn missing_host_is_rejected() {
+    let Some(app) = build_app(DaemonAccess::loopback()).await else {
+        return;
+    };
+
+    let response = app
+        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+/// The unchanged default: loopback clients keep working with no token and
+/// no configuration.
+#[tokio::test]
+async fn loopback_stays_open_by_default() {
+    let Some(app) = build_app(DaemonAccess::loopback()).await else {
+        return;
+    };
+
+    for host in ["127.0.0.1:9887", "localhost:9887", "[::1]:9887"] {
+        let response = app.clone().oneshot(get("/health", host)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{host} must be allowed");
+    }
+
+    let response = app.oneshot(get("/api/servers", "127.0.0.1:9887")).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "/api must not require a token when none is configured"
+    );
+}
+
+/// With a token configured, /api/* requires it — and /health does not, so
+/// probes and health checks keep working.
+#[tokio::test]
+async fn configured_token_gates_api_but_not_health() {
+    let Some(app) =
+        build_app(DaemonAccess::new(Some("s3cret".into()), "0.0.0.0", Vec::new())).await
+    else {
+        return;
+    };
+
+    let response = app
+        .clone()
+        .oneshot(get("/api/servers", "127.0.0.1:9887"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "no token → 401");
+
+    let mut wrong = get("/api/servers", "127.0.0.1:9887");
+    wrong
+        .headers_mut()
+        .insert("authorization", "Bearer wrong".parse().unwrap());
+    let response = app.clone().oneshot(wrong).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "wrong token → 401");
+
+    let mut right = get("/api/servers", "127.0.0.1:9887");
+    right
+        .headers_mut()
+        .insert("authorization", "Bearer s3cret".parse().unwrap());
+    let response = app.clone().oneshot(right).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "right token → 200");
+
+    let response = app.oneshot(get("/health", "127.0.0.1:9887")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "/health stays open");
+}
+
+/// A LAN-shared daemon must be reachable by raw IP and by its advertised
+/// mDNS name, while still refusing foreign hostnames.
+#[tokio::test]
+async fn share_lan_policy_accepts_ip_literals_and_named_hosts() {
+    let Some(app) =
+        build_app(DaemonAccess::new(None, "0.0.0.0", vec!["gglib.local".into()])).await
+    else {
+        return;
+    };
+
+    for host in ["192.168.1.7:9887", "gglib.local:9887", "127.0.0.1:9887"] {
+        let response = app.clone().oneshot(get("/health", host)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{host} must be allowed");
+    }
+
+    let response = app.oneshot(get("/health", "evil.example.com")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/crates/gglib-axum/tests/daemon_contract.rs
+++ b/crates/gglib-axum/tests/daemon_contract.rs
@@ -13,6 +13,7 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 use common::ports::TEST_BASE_PORT;
+use gglib_axum::DaemonAccess;
 use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::routes::create_router;
 use gglib_core::CorsConfig;
@@ -44,7 +45,11 @@ async fn pinned_start_pins_the_runtime_and_stop_clears_it() {
         Err(_) => return, // Skip if the environment has no DB path
     };
     let state = std::sync::Arc::new(ctx);
-    let app = create_router(std::sync::Arc::clone(&state), &CorsConfig::AllowAll);
+    let app = create_router(
+        std::sync::Arc::clone(&state),
+        &CorsConfig::AllowAll,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     // Start pinned, on an ephemeral port so nothing on the machine is hit.
     let response = app
@@ -53,6 +58,7 @@ async fn pinned_start_pins_the_runtime_and_stop_clears_it() {
             Request::builder()
                 .method("POST")
                 .uri("/api/proxy/start")
+                .header("Host", "127.0.0.1:9887")
                 .header("content-type", "application/json")
                 .body(Body::from(r#"{"port":0,"pinned":{"name":"pinned-model"}}"#))
                 .unwrap(),
@@ -94,6 +100,7 @@ async fn pinned_start_pins_the_runtime_and_stop_clears_it() {
             Request::builder()
                 .method("POST")
                 .uri("/api/proxy/start")
+                .header("Host", "127.0.0.1:9887")
                 .header("content-type", "application/json")
                 .body(Body::from(r#"{"port":0,"pinned":{"name":"another"}}"#))
                 .unwrap(),
@@ -109,6 +116,7 @@ async fn pinned_start_pins_the_runtime_and_stop_clears_it() {
             Request::builder()
                 .method("POST")
                 .uri("/api/proxy/stop")
+                .header("Host", "127.0.0.1:9887")
                 .header("content-type", "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -134,13 +142,18 @@ async fn shutdown_route_refuses_when_not_a_daemon() {
         Ok(ctx) => ctx,
         Err(_) => return,
     };
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        std::sync::Arc::new(DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .method("POST")
                 .uri("/api/daemon/shutdown")
+                .header("Host", "127.0.0.1:9887")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -10,9 +10,15 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 use common::ports::{TEST_BASE_PORT, TEST_MODEL_PORT};
+use gglib_axum::DaemonAccess;
 use gglib_axum::bootstrap::{ServerConfig, bootstrap};
 use gglib_axum::routes::create_router;
 use gglib_core::CorsConfig;
+
+/// Access policy for tests: loopback, no token — the daemon's default.
+fn test_access() -> std::sync::Arc<DaemonAccess> {
+    std::sync::Arc::new(DaemonAccess::loopback())
+}
 
 /// Helper to create a test config that doesn't require llama-server.
 fn test_config() -> ServerConfig {
@@ -35,11 +41,12 @@ async fn health_endpoint_returns_ok() {
         Err(_) => return, // Skip test if bootstrap fails
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/health")
                 .body(Body::empty())
                 .unwrap(),
@@ -63,11 +70,12 @@ async fn models_endpoint_returns_json() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/models")
                 .body(Body::empty())
                 .unwrap(),
@@ -94,11 +102,12 @@ async fn servers_endpoint_returns_json_array() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/servers")
                 .body(Body::empty())
                 .unwrap(),
@@ -119,11 +128,12 @@ async fn downloads_endpoint_returns_queue_snapshot() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/models/downloads")
                 .body(Body::empty())
                 .unwrap(),
@@ -147,11 +157,12 @@ async fn events_endpoint_returns_sse_stream() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/events")
                 .body(Body::empty())
                 .unwrap(),
@@ -194,11 +205,13 @@ async fn events_endpoint_not_intercepted_by_spa_fallback() {
         std::sync::Arc::new(ctx),
         temp_dir.path(),
         &CorsConfig::AllowAll,
+        test_access(),
     );
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/events")
                 .body(Body::empty())
                 .unwrap(),
@@ -235,11 +248,12 @@ async fn nonexistent_route_returns_not_found() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/nonexistent")
                 .body(Body::empty())
                 .unwrap(),
@@ -271,12 +285,14 @@ async fn spa_fallback_returns_index_html() {
         std::sync::Arc::new(ctx),
         temp_dir.path(),
         &CorsConfig::AllowAll,
+        test_access(),
     );
 
     // Request a non-existent client-side route (not under /api/)
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/some/client/route")
                 .body(Body::empty())
                 .unwrap(),
@@ -306,7 +322,7 @@ async fn hf_search_endpoint_accepts_post_and_returns_valid_response() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Minimal valid request body for HF search
     let request_body = r#"{"query": "test", "page": 1}"#;
@@ -314,6 +330,7 @@ async fn hf_search_endpoint_accepts_post_and_returns_valid_response() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri(gglib_core::contracts::http::hf::SEARCH_PATH)
                 .header("content-type", "application/json")
@@ -348,11 +365,12 @@ async fn settings_endpoint_accepts_get() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/config/settings")
                 .body(Body::empty())
                 .unwrap(),
@@ -371,7 +389,7 @@ async fn settings_endpoint_accepts_put() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Empty update request (no changes)
     let request_body = r#"{}"#;
@@ -379,6 +397,7 @@ async fn settings_endpoint_accepts_put() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("PUT")
                 .uri("/api/config/settings")
                 .header("content-type", "application/json")
@@ -403,7 +422,7 @@ async fn settings_endpoint_accepts_patch() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Empty update request (no changes)
     let request_body = r#"{}"#;
@@ -411,6 +430,7 @@ async fn settings_endpoint_accepts_patch() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("PATCH")
                 .uri("/api/config/settings")
                 .header("content-type", "application/json")
@@ -439,7 +459,7 @@ async fn servers_start_collection_route_accepts_post() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Request with model_id in body (matches frontend transport contract)
     let request_body = format!(r#"{{"model_id": 999, "port": {}}}"#, TEST_MODEL_PORT);
@@ -447,6 +467,7 @@ async fn servers_start_collection_route_accepts_post() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/servers/start")
                 .header("content-type", "application/json")
@@ -481,7 +502,7 @@ async fn servers_stop_collection_route_accepts_post() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Request with model_id in body (matches frontend transport contract)
     let request_body = r#"{"model_id": 999}"#;
@@ -489,6 +510,7 @@ async fn servers_stop_collection_route_accepts_post() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/servers/stop")
                 .header("content-type", "application/json")
@@ -527,11 +549,12 @@ async fn proxy_status_returns_stopped_when_not_running() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/proxy/status")
                 .body(Body::empty())
                 .unwrap(),
@@ -567,13 +590,14 @@ async fn proxy_start_accepts_json_config() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let request_body = r#"null"#;
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/proxy/start")
                 .header("content-type", "application/json")
@@ -602,11 +626,12 @@ async fn proxy_stop_is_idempotent() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/proxy/stop")
                 .body(Body::empty())
@@ -638,11 +663,12 @@ async fn downloads_queue_accepts_get() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/models/downloads/queue")
                 .body(Body::empty())
                 .unwrap(),
@@ -688,11 +714,13 @@ async fn model_get_by_id_returns_json_not_html() {
         std::sync::Arc::new(ctx),
         temp_dir.path(),
         &CorsConfig::AllowAll,
+        test_access(),
     );
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/models/test-model-id")
                 .body(Body::empty())
                 .unwrap(),
@@ -734,11 +762,13 @@ async fn model_tags_by_id_returns_json_not_html() {
         std::sync::Arc::new(ctx),
         temp_dir.path(),
         &CorsConfig::AllowAll,
+        test_access(),
     );
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/models/test-model-id/tags")
                 .body(Body::empty())
                 .unwrap(),
@@ -779,11 +809,13 @@ async fn mcp_server_tools_by_id_returns_json_not_html() {
         std::sync::Arc::new(ctx),
         temp_dir.path(),
         &CorsConfig::AllowAll,
+        test_access(),
     );
 
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .uri("/api/mcp/servers/test-mcp-id/tools")
                 .body(Body::empty())
                 .unwrap(),
@@ -815,12 +847,13 @@ async fn model_tags_accepts_post_with_body() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Frontend POSTs to /api/models/{id}/tags with { tag: "..." } in body
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/models/1/tags")
                 .header("content-type", "application/json")
@@ -847,13 +880,14 @@ async fn proxy_start_uses_settings_default_context_when_not_overridden() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // First, set a non-default context size in settings (8192 instead of 4096)
     let settings_response = app
         .clone()
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("PUT")
                 .uri("/api/config/settings")
                 .header("content-type", "application/json")
@@ -873,6 +907,7 @@ async fn proxy_start_uses_settings_default_context_when_not_overridden() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/proxy/start")
                 .header("content-type", "application/json")
@@ -899,13 +934,14 @@ async fn proxy_start_fallback_to_hardcoded_default_when_no_settings() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
 
     // Clear any settings default by explicitly setting null
     let settings_response = app
         .clone()
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("PUT")
                 .uri("/api/config/settings")
                 .header("content-type", "application/json")
@@ -925,6 +961,7 @@ async fn proxy_start_fallback_to_hardcoded_default_when_no_settings() {
     let response = app
         .oneshot(
             Request::builder()
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .uri("/api/proxy/start")
                 .header("content-type", "application/json")

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -41,7 +41,11 @@ async fn health_endpoint_returns_ok() {
         Err(_) => return, // Skip test if bootstrap fails
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -70,7 +74,11 @@ async fn models_endpoint_returns_json() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -102,7 +110,11 @@ async fn servers_endpoint_returns_json_array() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -128,7 +140,11 @@ async fn downloads_endpoint_returns_queue_snapshot() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -157,7 +173,11 @@ async fn events_endpoint_returns_sse_stream() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -248,7 +268,11 @@ async fn nonexistent_route_returns_not_found() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -322,7 +346,11 @@ async fn hf_search_endpoint_accepts_post_and_returns_valid_response() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Minimal valid request body for HF search
     let request_body = r#"{"query": "test", "page": 1}"#;
@@ -365,7 +393,11 @@ async fn settings_endpoint_accepts_get() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -389,7 +421,11 @@ async fn settings_endpoint_accepts_put() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Empty update request (no changes)
     let request_body = r#"{}"#;
@@ -422,7 +458,11 @@ async fn settings_endpoint_accepts_patch() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Empty update request (no changes)
     let request_body = r#"{}"#;
@@ -459,7 +499,11 @@ async fn servers_start_collection_route_accepts_post() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Request with model_id in body (matches frontend transport contract)
     let request_body = format!(r#"{{"model_id": 999, "port": {}}}"#, TEST_MODEL_PORT);
@@ -502,7 +546,11 @@ async fn servers_stop_collection_route_accepts_post() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Request with model_id in body (matches frontend transport contract)
     let request_body = r#"{"model_id": 999}"#;
@@ -549,7 +597,11 @@ async fn proxy_status_returns_stopped_when_not_running() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -590,7 +642,11 @@ async fn proxy_start_accepts_json_config() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let request_body = r#"null"#;
 
@@ -626,7 +682,11 @@ async fn proxy_stop_is_idempotent() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -663,7 +723,11 @@ async fn downloads_queue_accepts_get() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     let response = app
         .oneshot(
@@ -847,7 +911,11 @@ async fn model_tags_accepts_post_with_body() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Frontend POSTs to /api/models/{id}/tags with { tag: "..." } in body
     let response = app
@@ -880,7 +948,11 @@ async fn proxy_start_uses_settings_default_context_when_not_overridden() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // First, set a non-default context size in settings (8192 instead of 4096)
     let settings_response = app
@@ -934,7 +1006,11 @@ async fn proxy_start_fallback_to_hardcoded_default_when_no_settings() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll, test_access());
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
 
     // Clear any settings default by explicitly setting null
     let settings_response = app

--- a/crates/gglib-axum/tests/mcp_contract_test.rs
+++ b/crates/gglib-axum/tests/mcp_contract_test.rs
@@ -36,12 +36,17 @@ async fn test_list_mcp_servers_json_structure() {
         Err(_) => return, // Skip if bootstrap fails
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        std::sync::Arc::new(gglib_axum::DaemonAccess::loopback()),
+    );
 
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/api/mcp/servers")
+                .header("Host", "127.0.0.1:9887")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -117,7 +122,11 @@ async fn test_add_mcp_server_returns_nested_structure() {
         Err(_) => return,
     };
 
-    let app = create_router(std::sync::Arc::new(ctx), &CorsConfig::AllowAll);
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        std::sync::Arc::new(gglib_axum::DaemonAccess::loopback()),
+    );
 
     let request_body = json!({
         "name": "Test Server",
@@ -132,6 +141,7 @@ async fn test_add_mcp_server_returns_nested_structure() {
         .oneshot(
             Request::builder()
                 .uri("/api/mcp/servers")
+                .header("Host", "127.0.0.1:9887")
                 .method("POST")
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))

--- a/crates/gglib-cli/src/commands.rs
+++ b/crates/gglib-cli/src/commands.rs
@@ -89,11 +89,21 @@ pub enum DaemonCommand {
         /// Expose the daemon on all LAN interfaces (0.0.0.0) and advertise
         /// it over mDNS
         ///
-        /// WARNING: the management API has no authentication — every device
-        /// on the network can control this machine's models. Only use on
+        /// The management API then requires a bearer token (the stored
+        /// API key, minted and printed at startup if none exists). It can
+        /// still start and stop inference on this machine — only use on
         /// networks you trust.
         #[arg(long)]
         share_lan: bool,
+
+        /// Accept this Host header value in addition to loopback and IP
+        /// literals (repeatable)
+        ///
+        /// The daemon refuses requests whose Host names a hostname it was
+        /// never told about — the DNS-rebinding guard. Name your DNS alias
+        /// here if you reach a shared daemon through one.
+        #[arg(long = "allowed-host", value_name = "HOST")]
+        allowed_host: Vec<String>,
     },
     /// Show whether the daemon is running, and what it is doing
     Status,

--- a/crates/gglib-cli/src/dispatch.rs
+++ b/crates/gglib-cli/src/dispatch.rs
@@ -156,8 +156,11 @@ pub async fn dispatch(ctx: &CliContext, command: Commands, verbose: bool) -> Res
             handlers::web::execute(share_lan).await?;
         }
         Commands::Daemon { command } => match command {
-            crate::commands::DaemonCommand::Run { share_lan } => {
-                handlers::daemon::run(share_lan).await?;
+            crate::commands::DaemonCommand::Run {
+                share_lan,
+                allowed_host,
+            } => {
+                handlers::daemon::run(share_lan, allowed_host).await?;
             }
             crate::commands::DaemonCommand::Status => {
                 handlers::daemon::status().await?;

--- a/crates/gglib-cli/src/handlers/daemon/mdns.rs
+++ b/crates/gglib-cli/src/handlers/daemon/mdns.rs
@@ -34,6 +34,11 @@ const INSTANCE_NAME: &str = "gglib";
 /// Hostname the address record is published under → resolves as `gglib.local`.
 const HOSTNAME: &str = "gglib.local.";
 
+/// The name LAN clients actually type — [`HOSTNAME`] without the trailing
+/// dot. Exposed so `daemon run` can add it to the Host allowlist: a name the
+/// daemon advertises is plainly one it answers to.
+pub(crate) const LAN_HOSTNAME: &str = "gglib.local";
+
 /// An active mDNS registration, unregistered on [`shutdown`](Self::shutdown).
 pub struct MdnsAdvertiser {
     daemon: ServiceDaemon,

--- a/crates/gglib-cli/src/handlers/daemon/mod.rs
+++ b/crates/gglib-cli/src/handlers/daemon/mod.rs
@@ -10,16 +10,24 @@ use gglib_axum::daemon::{DaemonLock, DaemonOptions, run_daemon};
 use gglib_core::{CorsConfig, DAEMON_PORT};
 
 /// Execute `gglib daemon run`: host the daemon in the foreground.
-pub async fn run(share_lan: bool) -> Result<()> {
+pub async fn run(share_lan: bool, allowed_hosts: Vec<String>) -> Result<()> {
     let opts = if share_lan {
         print_share_lan_warning();
+        // The mDNS name is advertised below, so it is plainly a name this
+        // daemon answers to — nobody should have to repeat it as a flag.
+        let mut allowed_hosts = allowed_hosts;
+        allowed_hosts.push(mdns::LAN_HOSTNAME.into());
         DaemonOptions {
             host: "0.0.0.0".into(),
             cors: CorsConfig::AllowAll,
+            allowed_hosts,
             ..DaemonOptions::default()
         }
     } else {
-        DaemonOptions::default()
+        DaemonOptions {
+            allowed_hosts,
+            ..DaemonOptions::default()
+        }
     };
 
     // Registered just before the daemon binds; every mDNS failure is
@@ -127,8 +135,8 @@ fn print_share_lan_warning() {
     eprintln!();
     eprintln!("  \u{26a0}\u{fe0f}  LAN SHARING ENABLED (--share-lan)");
     eprintln!("     The daemon is reachable by every device on your network.");
-    eprintln!("     Its management API has NO authentication: anyone on the network");
-    eprintln!("     can download models and start or stop inference on this machine.");
-    eprintln!("     Only use this on networks you trust.");
+    eprintln!("     Its management API requires the API key printed below \u{2014} anyone");
+    eprintln!("     holding it can download models and start or stop inference on");
+    eprintln!("     this machine. Only use this on networks you trust.");
     eprintln!();
 }

--- a/crates/gglib-cli/src/handlers/web.rs
+++ b/crates/gglib-cli/src/handlers/web.rs
@@ -15,7 +15,7 @@ use crate::presentation::style;
 pub async fn execute(share_lan: bool) -> Result<()> {
     if share_lan {
         // Foreground, eyes-open LAN mode — identical to `daemon run --share-lan`.
-        return super::daemon::run(true).await;
+        return super::daemon::run(true, Vec::new()).await;
     }
 
     daemon_client::ensure_daemon().await?;

--- a/src/services/transport/api/client.ts
+++ b/src/services/transport/api/client.ts
@@ -115,6 +115,45 @@ async function discoverEmbeddedApi(): Promise<EmbeddedApiInfo> {
 }
 
 /**
+ * localStorage key holding the API key for web mode.
+ *
+ * Only relevant when the daemon is shared over the LAN (`--share-lan`), where
+ * /api/* requires a bearer token. Same-origin loopback needs no key and never
+ * touches this.
+ */
+const WEB_API_KEY_STORAGE = 'gglib_api_key';
+
+function readStoredWebApiKey(): string | undefined {
+  try {
+    return localStorage.getItem(WEB_API_KEY_STORAGE) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Ask the user for the daemon's API key after a 401 in web mode.
+ * Returns true if a key was provided and stored (so the request can retry).
+ */
+function promptForWebApiKey(): boolean {
+  const entered = window.prompt(
+    'This gglib daemon requires an API key (it was printed when the daemon started).\n' +
+      'Enter it to continue:'
+  );
+  if (!entered || !entered.trim()) {
+    return false;
+  }
+  try {
+    localStorage.setItem(WEB_API_KEY_STORAGE, entered.trim());
+  } catch {
+    // Storage unavailable (private mode) — the retry still works this session
+    // because the client cache rebuild re-reads via the in-memory session.
+  }
+  setApiSession('', entered.trim());
+  return true;
+}
+
+/**
  * Cached client promise for lazy initialization.
  */
 let cachedClientPromise: Promise<HttpClient> | null = null;
@@ -179,11 +218,20 @@ function buildClient(config: HttpClientConfig): HttpClient {
       });
       
       // If 401 and not already retrying, clear cache and retry once
-      if (response.status === 401 && !isRetry && isTauri()) {
-        appLogger.warn('transport.api', '[ApiClient] 401 Unauthorized - clearing cache and retrying');
-        resetClientCache();
-        const newClient = await getClient();
-        return newClient.request<T>(path, options, true);
+      if (response.status === 401 && !isRetry) {
+        if (isTauri()) {
+          appLogger.warn('transport.api', '[ApiClient] 401 Unauthorized - clearing cache and retrying');
+          resetClientCache();
+          const newClient = await getClient();
+          return newClient.request<T>(path, options, true);
+        }
+        // Web mode: a LAN-shared daemon requires its API key — ask for it.
+        if (promptForWebApiKey()) {
+          appLogger.warn('transport.api', '[ApiClient] 401 Unauthorized - retrying with entered API key');
+          resetClientCache();
+          const newClient = await getClient();
+          return newClient.request<T>(path, options, true);
+        }
       }
       
       return await readData<T>(response);
@@ -228,9 +276,11 @@ export async function getClient(): Promise<HttpClient> {
         setApiSession(config.baseUrl, config.token);
         return buildClient(config);
       } else {
-        // Web mode: same-origin, no token
-        setApiSession('', undefined);
-        return buildClient({ baseUrl: '' });
+        // Web mode: same-origin. A token is only needed against a LAN-shared
+        // daemon; use one previously stored (or entered this session).
+        const token = readStoredWebApiKey() ?? apiAuthToken;
+        setApiSession('', token);
+        return buildClient({ baseUrl: '', token });
       }
     } catch (error) {
       // Clear cache on discovery failure to allow retry


### PR DESCRIPTION
## What

Closes the access-control gap on the daemon's management API (`/api/*`, port 9887) deferred during the daemon consolidation (#708). The API can start/stop inference, change settings, and queue downloads; until now it carried only CORS and a body limit.

## How

Two gates, mirroring what #701 gave the proxy — the pure policy (`ProxyAccessConfig`: host normalization, loopback detection, allowlist, bearer formatting) is reused from `gglib-core`; `gglib-axum` adds only a thin adapter (`crates/gglib-axum/src/access.rs`) matching its own error shape.

**Host-header allowlist (DNS-rebinding guard) — always on.** Outermost layer, wrapping every route including `/health`, unknown paths, and the SPA assets. Loopback names pass with zero configuration. One deliberate divergence from the proxy: a non-loopback bind also accepts IP-literal `Host` values — a rebound page always presents the attacker's *hostname*, never a bare IP, so this keeps `--share-lan` reachable by raw IP while stopping the actual attack.

**Bearer token on `/api/*` — non-loopback binds only.** Loopback stays open: the socket is the boundary, and the CLI, desktop app, and same-origin web UI keep working untouched. A `--share-lan` daemon resolves the stored `proxy_api_key` (one machine key across both surfaces), minting, persisting, and printing one when absent. `/health` stays open for probes. CORS is layered outside the bearer guard so browser preflights aren't killed by a 401.

## Surface changes

- `gglib daemon run` gains `--allowed-host <HOST>` (repeatable) and auto-allows the advertised mDNS name `gglib.local` under `--share-lan`; the LAN warning now describes the token instead of claiming no authentication exists.
- Web UI: on a 401 in web mode the client prompts for the key once and stores it (`localStorage`); Tauri and loopback flows are unchanged.
- `.gitignore`: `daemon.lock` (runtime state the daemon drops in the cwd).

## Tests

New `crates/gglib-axum/tests/daemon_access.rs`: foreign `Host` → 403 on every route class, missing `Host` → 403, loopback stays open with no token, configured token gates `/api/*` but not `/health` (wrong/missing token → 401, correct → 200), share-LAN policy accepts IP literals + named hosts and still refuses foreign hostnames. Existing daemon/CORS/MCP/route contract tests updated for the new router signature and pass; full workspace check, clippy, tsc, and the 580-test vitest suite are green.