### PR TITLE
fix(axum,proxy,core): privacy dump removal, non-streaming normalization, tool stripping

### DIFF
--- a/crates/gglib-axum/src/chat_api.rs
+++ b/crates/gglib-axum/src/chat_api.rs
@@ -580,27 +580,6 @@ pub async fn proxy_chat(
         capabilities,
     );
 
-    // DEBUG: Log the exact payload sent to llama-server
-    let log_path = std::env::var("HOME")
-        .map(|h| format!("{}/llama-request-debug.json", h))
-        .unwrap_or_else(|_| "/tmp/llama-request-debug.json".to_string());
-
-    if let Ok(json_str) = serde_json::to_string_pretty(&forward_body) {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let log_entry = format!(
-            "\n=== REQUEST {} ===\npath: /api/chat (chat_api::proxy_chat)\n{}\n====================================\n",
-            timestamp, json_str
-        );
-        let _ = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)
-            .and_then(|mut f| std::io::Write::write_all(&mut f, log_entry.as_bytes()));
-    }
-
     // Forward the request
     let client = Client::new();
     let response = client

--- a/crates/gglib-core/src/normalize/mod.rs
+++ b/crates/gglib-core/src/normalize/mod.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("README.md")]
 pub mod error;
 pub mod history;
+pub mod oneshot;
 pub mod parser;
 pub mod parsers;
 pub mod registry;
@@ -9,6 +10,7 @@ pub mod tags;
 
 pub use error::{NormalizationError, NormalizationErrorKind};
 pub use history::strip_thinking_debt;
+pub use oneshot::normalize_chat_completion_body;
 pub use parser::{ParserOutput, ToolCallParser};
 pub use registry::get_parser;
 pub use stream::NormalizingStream;

--- a/crates/gglib-core/src/normalize/oneshot.rs
+++ b/crates/gglib-core/src/normalize/oneshot.rs
@@ -163,8 +163,9 @@ mod tests {
     /// body becomes structured `tool_calls`, not raw text.
     #[test]
     fn qwen_tool_call_markup_becomes_structured_tool_calls() {
-        let mut body =
-            body_with_content(r#"<tool_call>{"name":"read_file","arguments":{"path":"a.rs"}}</tool_call>"#);
+        let mut body = body_with_content(
+            r#"<tool_call>{"name":"read_file","arguments":{"path":"a.rs"}}</tool_call>"#,
+        );
         let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
 
         assert!(errors.is_empty(), "{errors:?}");
@@ -182,9 +183,8 @@ mod tests {
     /// Text around the markup survives as content alongside the calls.
     #[test]
     fn surrounding_text_is_preserved() {
-        let mut body = body_with_content(
-            r#"On it. <tool_call>{"name":"ls","arguments":{}}</tool_call>"#,
-        );
+        let mut body =
+            body_with_content(r#"On it. <tool_call>{"name":"ls","arguments":{}}</tool_call>"#);
         let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
 
         assert!(errors.is_empty());

--- a/crates/gglib-core/src/normalize/oneshot.rs
+++ b/crates/gglib-core/src/normalize/oneshot.rs
@@ -1,0 +1,246 @@
+//! One-shot dialect normalization for non-streaming responses.
+//!
+//! The streaming path runs every response through a [`ToolCallParser`] via
+//! [`super::stream::NormalizingStream`]; a `stream: false` request gets the
+//! same model, the same dialect, and — until this module — none of the
+//! normalization. A Qwen-XML tool call in a non-streaming reply reached the
+//! client as raw `<tool_call>` text.
+//!
+//! [`normalize_chat_completion_body`] closes that gap: it drives the exact
+//! same parser (one full-content push, then [`ToolCallParser::finish`]) over
+//! each choice's `message.content` and rewrites the body in place — content
+//! stripped of markup, extracted calls appended to `message.tool_calls` in
+//! the `OpenAI` non-streaming shape, reasoning routed to `reasoning_content`.
+//! Chunk-safety is trivially satisfied (the whole body is one chunk), so
+//! streaming and non-streaming responses cannot drift: there is one parser
+//! per dialect, chosen by the same [`super::registry::get_parser`].
+
+use serde_json::{Value, json};
+
+use super::error::NormalizationError;
+use super::parser::ParserOutput;
+use super::registry::get_parser;
+
+/// Normalize a complete (non-streaming) `chat.completion` response body in
+/// place, using the dialect parser selected by `model_tags`.
+///
+/// Only `message.content` strings are processed; a null, absent, or
+/// non-string content is left untouched, as is everything else in the body.
+/// For models with no recognised `format:*` tag the parser is the identity
+/// passthrough and the body comes back byte-identical.
+///
+/// When markup is extracted:
+/// - `message.content` becomes the remaining text, or `null` when a tool
+///   call consumed all of it (the `OpenAI` shape for tool-call turns);
+/// - extracted calls are appended to `message.tool_calls`, `arguments`
+///   serialized to a compact JSON string exactly as the streaming encoder
+///   does;
+/// - reasoning captured by the parser is appended to
+///   `message.reasoning_content`;
+/// - a `finish_reason` of `stop`/null is upgraded to `"tool_calls"`.
+///
+/// Returns every [`NormalizationError`] the parser surfaced; the caller
+/// decides whether to log them or surface the raw bytes to the client, as
+/// the streaming path does.
+pub fn normalize_chat_completion_body(
+    body: &mut Value,
+    model_tags: &[String],
+) -> Vec<NormalizationError> {
+    let mut all_errors = Vec::new();
+
+    let Some(choices) = body.get_mut("choices").and_then(Value::as_array_mut) else {
+        return all_errors;
+    };
+
+    for choice in choices {
+        let Some(message) = choice.get_mut("message") else {
+            continue;
+        };
+        let Some(content) = message.get("content").and_then(Value::as_str) else {
+            continue;
+        };
+        if content.is_empty() {
+            continue;
+        }
+
+        // Parsers are stream-stateful: one fresh parser per choice, fed the
+        // whole content as a single chunk, then flushed.
+        let mut parser = get_parser(model_tags);
+        let mut out = parser.push_text(content);
+        let fin = parser.finish();
+        merge(&mut out, fin);
+
+        // Identity fast-path: nothing extracted, nothing failed, text
+        // unchanged — leave the message untouched rather than rebuilding it.
+        if out.tool_calls.is_empty()
+            && out.errors.is_empty()
+            && out.forward_reasoning.is_empty()
+            && out.forward_text == content
+        {
+            continue;
+        }
+
+        let extracted_calls = !out.tool_calls.is_empty();
+
+        message["content"] = if out.forward_text.is_empty() && extracted_calls {
+            Value::Null
+        } else {
+            Value::String(out.forward_text)
+        };
+
+        if !out.forward_reasoning.is_empty() {
+            let merged = match message.get("reasoning_content").and_then(Value::as_str) {
+                Some(existing) => format!("{existing}{}", out.forward_reasoning),
+                None => out.forward_reasoning,
+            };
+            message["reasoning_content"] = Value::String(merged);
+        }
+
+        if extracted_calls {
+            let rendered = out.tool_calls.into_iter().map(|tc| {
+                json!({
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        // Compact JSON string, matching the streaming
+                        // encoder's `arguments.to_string()`.
+                        "arguments": tc.arguments.to_string(),
+                    },
+                })
+            });
+            match message.get_mut("tool_calls").and_then(Value::as_array_mut) {
+                Some(existing) => existing.extend(rendered),
+                None => message["tool_calls"] = Value::Array(rendered.collect()),
+            }
+
+            // llama-server reported how the *raw* text ended; with the markup
+            // rewritten into structured calls, `stop` misdescribes the turn
+            // and breaks clients that dispatch on finish_reason.
+            let finish = choice.get("finish_reason").and_then(Value::as_str);
+            if matches!(finish, None | Some("stop")) {
+                choice["finish_reason"] = Value::String("tool_calls".into());
+            }
+        }
+
+        all_errors.extend(out.errors);
+    }
+
+    all_errors
+}
+
+/// Fold a second [`ParserOutput`] (from `finish`) into the first.
+fn merge(into: &mut ParserOutput, from: ParserOutput) {
+    into.forward_text.push_str(&from.forward_text);
+    into.forward_reasoning.push_str(&from.forward_reasoning);
+    into.tool_calls.extend(from.tool_calls);
+    into.errors.extend(from.errors);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::normalize::tags::FORMAT_QWEN_XML;
+
+    fn qwen_tags() -> Vec<String> {
+        vec![FORMAT_QWEN_XML.to_owned()]
+    }
+
+    fn body_with_content(content: &str) -> Value {
+        json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": content },
+                "finish_reason": "stop",
+            }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1 },
+        })
+    }
+
+    /// The gap this module closes: a qwen-xml tool call in a non-streaming
+    /// body becomes structured `tool_calls`, not raw text.
+    #[test]
+    fn qwen_tool_call_markup_becomes_structured_tool_calls() {
+        let mut body =
+            body_with_content(r#"<tool_call>{"name":"read_file","arguments":{"path":"a.rs"}}</tool_call>"#);
+        let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
+
+        assert!(errors.is_empty(), "{errors:?}");
+        let message = &body["choices"][0]["message"];
+        assert_eq!(message["content"], Value::Null);
+        assert_eq!(message["tool_calls"][0]["type"], "function");
+        assert_eq!(message["tool_calls"][0]["function"]["name"], "read_file");
+        assert_eq!(
+            message["tool_calls"][0]["function"]["arguments"],
+            r#"{"path":"a.rs"}"#
+        );
+        assert_eq!(body["choices"][0]["finish_reason"], "tool_calls");
+    }
+
+    /// Text around the markup survives as content alongside the calls.
+    #[test]
+    fn surrounding_text_is_preserved() {
+        let mut body = body_with_content(
+            r#"On it. <tool_call>{"name":"ls","arguments":{}}</tool_call>"#,
+        );
+        let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
+
+        assert!(errors.is_empty());
+        let message = &body["choices"][0]["message"];
+        assert_eq!(message["content"], "On it. ");
+        assert_eq!(message["tool_calls"][0]["function"]["name"], "ls");
+    }
+
+    /// No recognised tag → identity: the body must come back untouched.
+    #[test]
+    fn untagged_model_is_passthrough() {
+        let original = body_with_content("<tool_call>not for us</tool_call>");
+        let mut body = original.clone();
+        let errors = normalize_chat_completion_body(&mut body, &[]);
+
+        assert!(errors.is_empty());
+        assert_eq!(body, original);
+    }
+
+    /// A tagged model whose reply has no markup is also untouched —
+    /// including its original `finish_reason`.
+    #[test]
+    fn plain_text_reply_is_untouched() {
+        let original = body_with_content("Just an answer.");
+        let mut body = original.clone();
+        let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
+
+        assert!(errors.is_empty());
+        assert_eq!(body, original);
+    }
+
+    /// Malformed markup surfaces as an error for the caller to handle, and
+    /// never silently vanishes.
+    #[test]
+    fn malformed_markup_surfaces_an_error() {
+        let mut body = body_with_content("<tool_call>{not json}</tool_call>");
+        let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
+
+        assert_eq!(errors.len(), 1);
+    }
+
+    /// Null content (already-structured tool-call responses from a --jinja
+    /// server) is left alone.
+    #[test]
+    fn null_content_is_skipped() {
+        let mut body = json!({
+            "choices": [{
+                "message": { "role": "assistant", "content": Value::Null,
+                             "tool_calls": [{"id": "x"}] },
+                "finish_reason": "tool_calls",
+            }],
+        });
+        let original = body.clone();
+        let errors = normalize_chat_completion_body(&mut body, &qwen_tags());
+
+        assert!(errors.is_empty());
+        assert_eq!(body, original);
+    }
+}

--- a/crates/gglib-core/src/request_pipeline/apply.rs
+++ b/crates/gglib-core/src/request_pipeline/apply.rs
@@ -6,6 +6,7 @@
 //! |---|---|---|---|
 //! | 1 | Strip prior reasoning | [`super::messages`] | `messages` |
 //! | 2 | Coalesce for capabilities | [`super::messages`] | `messages` |
+//! | 2b | Strip unsupported tools | [`super::tools`] | `tools`, capabilities |
 //! | 3 | Truncate stale history | [`super::truncation`] | `messages`, payload size |
 //! | 4 | Resolve the sampling hierarchy | [`super::sampling`] | top-level keys |
 //! | 5 | Pin `cache_prompt` | [`super::sampling`] | top-level keys |
@@ -19,6 +20,8 @@
 //! **2 before 3.** Both stages 1 and 2 only ever shrink the body, and stage 3
 //! measures it. Truncating first would size its budget against bytes that were
 //! about to be discarded anyway, and trim history that did not need trimming.
+//! The same goes for stage 2b: a stripped tools array must not count against
+//! the truncation budget.
 //!
 //! **3 before 4.** Stage 3 measures the payload; stage 4 inserts up to seven
 //! sampling keys. Resolving sampling first would have truncation size its
@@ -53,7 +56,7 @@
 use serde_json::Value;
 
 use super::truncation::{TruncationError, TruncationReport};
-use super::{ModelContext, SamplingLayers, messages, sampling, truncation};
+use super::{ModelContext, SamplingLayers, messages, sampling, tools, truncation};
 
 /// Apply every request-shaping transform, in order, in place.
 ///
@@ -81,6 +84,7 @@ pub fn apply(
     budget_chars: Option<usize>,
 ) -> Result<TruncationReport, TruncationError> {
     messages::shape_messages(body, ctx);
+    tools::strip_unsupported_tools(body, ctx);
 
     let report = match budget_chars {
         Some(limit) => truncation::truncate_history(body, limit)?,

--- a/crates/gglib-core/src/request_pipeline/mod.rs
+++ b/crates/gglib-core/src/request_pipeline/mod.rs
@@ -4,6 +4,7 @@ pub mod messages;
 pub mod model_context;
 pub mod resolve;
 pub mod sampling;
+pub mod tools;
 pub mod truncation;
 
 pub use apply::apply;
@@ -11,6 +12,7 @@ pub use messages::shape_messages;
 pub use model_context::ModelContext;
 pub use resolve::resolve;
 pub use sampling::{SamplingLayers, resolve_sampling};
+pub use tools::strip_unsupported_tools;
 pub use truncation::{CHARS_PER_TOKEN_APPROX, TruncationError, TruncationReport, truncate_history};
 
 #[cfg(test)]

--- a/crates/gglib-core/src/request_pipeline/model_context.rs
+++ b/crates/gglib-core/src/request_pipeline/model_context.rs
@@ -38,6 +38,13 @@ pub struct ModelContext {
     /// Maximum context the model supports, in tokens — the history-truncation
     /// budget for every surface that cannot measure a live serving context.
     pub context_length: Option<u64>,
+    /// Whether this context came from an actual catalog row.
+    ///
+    /// `false` for [`passthrough`](Self::passthrough) — the fallback for
+    /// unknown or unresolvable models. Transforms that act on the *absence*
+    /// of a capability (tool stripping) must check this: an empty bitfield on
+    /// a passthrough context means "nobody knows", not "the model can't".
+    pub catalog_resolved: bool,
 }
 
 impl ModelContext {
@@ -82,6 +89,7 @@ impl From<&ModelSummary> for ModelContext {
             inference_defaults: summary.inference_defaults.clone(),
             defaults_origin: summary.defaults_origin,
             context_length: summary.context_length,
+            catalog_resolved: true,
         }
     }
 }

--- a/crates/gglib-core/src/request_pipeline/tools.rs
+++ b/crates/gglib-core/src/request_pipeline/tools.rs
@@ -1,0 +1,106 @@
+//! Stage: strip `tools` from requests to models that cannot call them.
+//!
+//! A client that always advertises its tools (most agentic harnesses do)
+//! will send them to whatever model is selected. For a model without
+//! [`ModelCapabilities::SUPPORTS_TOOL_CALLS`], forwarding the array is worse
+//! than useless: llama-server either rejects the request outright or renders
+//! dozens of schemas into the prompt of a model that will only parrot them
+//! back as text. The `WebUI`'s chat path has stripped tools this way since it
+//! existed; this stage gives every `apply` caller — the proxy above all —
+//! the same behaviour.
+//!
+//! The check is deliberately conservative: it acts only on a
+//! [`catalog_resolved`](super::ModelContext::catalog_resolved) context. A
+//! passthrough context has an empty capability bitfield because *nobody
+//! knows* what the model supports, and stripping tools from an unknown model
+//! would silently break a working agent. Unknown models keep their tools.
+//!
+//! [`ModelCapabilities::SUPPORTS_TOOL_CALLS`]: crate::domain::ModelCapabilities::SUPPORTS_TOOL_CALLS
+
+use serde_json::Value;
+use tracing::debug;
+
+use super::ModelContext;
+
+/// Remove `tools` and `tool_choice` when the resolved model cannot use them.
+///
+/// No-op for tool-capable models, for unresolved (passthrough) contexts, and
+/// for requests that carry no tools.
+pub fn strip_unsupported_tools(body: &mut Value, ctx: &ModelContext) {
+    if !ctx.catalog_resolved || ctx.capabilities.supports_tool_calls() {
+        return;
+    }
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    if obj.remove("tools").is_some() {
+        obj.remove("tool_choice");
+        debug!("stripped tools from request: model does not support tool calls");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::ModelCapabilities;
+    use serde_json::json;
+
+    fn body_with_tools() -> Value {
+        json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "f"}}],
+            "tool_choice": "auto",
+        })
+    }
+
+    fn resolved(capabilities: ModelCapabilities) -> ModelContext {
+        ModelContext {
+            capabilities,
+            catalog_resolved: true,
+            ..ModelContext::passthrough()
+        }
+    }
+
+    /// The case this stage exists for: a resolved model without the
+    /// capability loses the tools array and its `tool_choice`.
+    #[test]
+    fn a_resolved_non_tool_model_loses_its_tools() {
+        let mut body = body_with_tools();
+        strip_unsupported_tools(&mut body, &resolved(ModelCapabilities::empty()));
+
+        assert!(body.get("tools").is_none());
+        assert!(body.get("tool_choice").is_none());
+        assert_eq!(body["model"], "m", "everything else is untouched");
+    }
+
+    #[test]
+    fn a_tool_capable_model_keeps_its_tools() {
+        let mut body = body_with_tools();
+        strip_unsupported_tools(&mut body, &resolved(ModelCapabilities::SUPPORTS_TOOL_CALLS));
+
+        assert!(body.get("tools").is_some());
+        assert!(body.get("tool_choice").is_some());
+    }
+
+    /// An unknown model must not be second-guessed — empty capabilities on a
+    /// passthrough context mean "unknown", not "unsupported".
+    #[test]
+    fn an_unresolved_model_keeps_its_tools() {
+        let mut body = body_with_tools();
+        strip_unsupported_tools(&mut body, &ModelContext::passthrough());
+
+        assert!(body.get("tools").is_some());
+    }
+
+    /// `tool_choice` alone is left in place: it is inert without `tools`,
+    /// and inventing removals the `WebUI` path never did would be a behaviour
+    /// change smuggled into a refactor.
+    #[test]
+    fn tool_choice_without_tools_is_left_alone() {
+        let mut body = json!({"model": "m", "tool_choice": "auto"});
+        strip_unsupported_tools(&mut body, &resolved(ModelCapabilities::empty()));
+
+        assert!(body.get("tool_choice").is_some());
+    }
+}

--- a/crates/gglib-proxy/src/embeddings.rs
+++ b/crates/gglib-proxy/src/embeddings.rs
@@ -212,5 +212,7 @@ pub(crate) async fn embeddings(
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
 
-    forward_non_streaming_response(response, &state.dashboard.cache_metrics).await
+    // No tags: an embeddings body has no `choices`, so normalization is a
+    // no-op — this just satisfies the shared forwarding signature.
+    forward_non_streaming_response(response, &state.dashboard.cache_metrics, &[]).await
 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -54,9 +54,10 @@
 //! `NormalizationError` events surfaced by the parsers are logged via
 //! `tracing::warn` and never forwarded to the wire.
 //!
-//! Non-streaming responses are forwarded verbatim for now — the dialects
-//! we currently rewrite (Qwen XML tool calls, bare `<think>` tags) only
-//! manifest in streaming clients today.
+//! Non-streaming responses run through the same parser in one shot
+//! ([`gglib_core::normalize::normalize_chat_completion_body`]), so a
+//! `stream: false` client gets the same structured `tool_calls` a streaming
+//! client would.
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -625,11 +626,9 @@ pub(crate) async fn forward_chat_completion(
         "upstream llama-server accepted request"
     );
 
-    // Non-streaming: read full response. Dialect normalization for
-    // non-streaming responses is intentionally deferred — the wire
-    // formats we currently rewrite (Qwen XML tool calls, bare <think>
-    // tags) only manifest in streaming clients today.
-    Ok(forward_non_streaming_response(response, &cache_metrics).await)
+    // Non-streaming: read the full response and run it through the same
+    // dialect normalization the streaming path applies.
+    Ok(forward_non_streaming_response(response, &cache_metrics, &context.tags).await)
 }
 
 /// Extract the `host:port` authority from an HTTP/HTTPS URL string.
@@ -890,10 +889,12 @@ fn usage_from_response_body(body: &[u8]) -> Option<(u32, Option<u32>)> {
     Some((prompt_tokens, cached_tokens))
 }
 
-/// Forward a non-streaming JSON response from llama-server.
+/// Forward a non-streaming JSON response from llama-server, running the same
+/// dialect normalization the streaming path applies.
 pub(crate) async fn forward_non_streaming_response(
     response: reqwest::Response,
     cache_metrics: &CacheMetricsStore,
+    model_tags: &[String],
 ) -> Response {
     // Collect upstream headers we want to preserve
     let content_type = response
@@ -912,6 +913,7 @@ pub(crate) async fn forward_non_streaming_response(
             if let Some((prompt_tokens, cached_tokens)) = usage_from_response_body(&body_bytes) {
                 cache_metrics.record(prompt_tokens, cached_tokens);
             }
+            let body_bytes = normalize_non_streaming_body(body_bytes, model_tags);
             Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", content_type)
@@ -927,6 +929,44 @@ pub(crate) async fn forward_non_streaming_response(
                 .into_response()
         }
     }
+}
+
+/// Run dialect normalization over a buffered non-streaming body.
+///
+/// The same parser the streaming path uses, driven once over the complete
+/// content (`gglib_core::normalize::normalize_chat_completion_body`), so a
+/// `stream: false` client gets structured `tool_calls` instead of raw
+/// dialect markup. Parse failures forward the original bytes verbatim — a
+/// body we cannot read is a body we must not rewrite. Normalization errors
+/// get the same treatment as on the streaming path: logged, and the raw
+/// markup surfaced as visibly-flagged assistant text rather than silently
+/// dropped.
+fn normalize_non_streaming_body(body_bytes: Bytes, model_tags: &[String]) -> Bytes {
+    let Ok(mut parsed) = serde_json::from_slice::<serde_json::Value>(&body_bytes) else {
+        return body_bytes;
+    };
+
+    let errors = gglib_core::normalize::normalize_chat_completion_body(&mut parsed, model_tags);
+
+    for err in &errors {
+        warn!(?err, "normalization error in non-streaming response");
+    }
+    if !errors.is_empty()
+        && let Some(content) = parsed
+            .get_mut("choices")
+            .and_then(|c| c.get_mut(0))
+            .and_then(|c| c.get_mut("message"))
+            .and_then(|m| m.get_mut("content"))
+    {
+        let mut text = content.as_str().unwrap_or_default().to_owned();
+        for err in &errors {
+            text.push_str(NORMALIZATION_NOTICE_PREFIX);
+            text.push_str(&err.raw);
+        }
+        *content = serde_json::Value::String(text);
+    }
+
+    serde_json::to_vec(&parsed).map_or(body_bytes, Bytes::from)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Stacked on #714. Three defects found during the post-v0.12.0 audit.

## 1. Privacy: delete the WebUI chat debug dump

`crates/gglib-axum/src/chat_api.rs` appended every `/api/chat` request body — the full conversation — to `~/llama-request-debug.json` (falling back to `/tmp`), unconditionally, with unbounded growth. Gone.

## 2. Non-streaming responses now get dialect normalization

The streaming path parses Qwen-XML markup into structured `tool_calls`; `stream: false` responses were forwarded verbatim, so the same model's tool call reached clients as raw `<tool_call>` text.

New `gglib_core::normalize::normalize_chat_completion_body` drives the **same parser** the streaming path uses (one full-content push, then `finish`) over each choice and rewrites the body in place: content stripped of markup, calls appended to `message.tool_calls` in the OpenAI non-streaming shape (`arguments` compact-serialized exactly like the streaming encoder), reasoning routed to `reasoning_content`, and a `stop` finish_reason upgraded to `tool_calls`. Parser choice goes through the same `get_parser` registry, so the two paths cannot drift. The proxy surfaces parse failures the same way the streaming path does: logged, and the raw markup appended as visibly-flagged assistant text instead of silently dropped. Untagged models are byte-identical passthrough; embeddings bodies (no `choices`) are untouched.

## 3. Tool stripping for non-tool models, in the shared pipeline

The WebUI chat path has always stripped `tools`/`tool_choice` for models without `SUPPORTS_TOOL_CALLS`; the proxy forwarded them into llama-server anyway. The pipeline gains a stage (`request_pipeline/tools.rs`, ordered before truncation so a stripped array never counts against the budget).

Deliberately conservative: `ModelContext` now records `catalog_resolved`, and the stage acts **only** on resolved contexts — an empty capability bitfield on a passthrough context means *unknown*, not *unsupported*, and stripping tools from an unknown model would silently break a working agent.

## Tests

10 new unit tests (6 one-shot normalization: structured extraction, surrounding text, identity passthrough, malformed-markup errors, null-content skip; 4 tool stripping: strip/keep/unresolved-keeps/tool_choice-alone). Full workspace test run and clippy are green.