### PR TITLE
feat(proxy): decode-time grammar enforcement for demanded dialect tool calls

### DIFF
--- a/crates/gglib-core/src/request_pipeline/apply.rs
+++ b/crates/gglib-core/src/request_pipeline/apply.rs
@@ -10,6 +10,7 @@
 //! | 3 | Truncate stale history | [`super::truncation`] | `messages`, payload size |
 //! | 4 | Resolve the sampling hierarchy | [`super::sampling`] | top-level keys |
 //! | 5 | Pin `cache_prompt` | [`super::sampling`] | top-level keys |
+//! | 6 | Constrain dialect tool calls | [`super::constrain`] | `tools`, `tool_choice`, tags |
 //!
 //! # The order is load-bearing
 //!
@@ -31,6 +32,10 @@
 //!
 //! **4 before 5.** `cache_prompt` is not an [`InferenceConfig`] field, so
 //! pinning it last means the resolved sampling patch can never overwrite it.
+//!
+//! **6 after 3.** The grammar stage 6 *adds* a top-level key, so it runs
+//! after the measurement for the same reason sampling does: the truncation
+//! budget measures the client's conversation, not our own additions to it.
 //!
 //! [`InferenceConfig`]: crate::domain::InferenceConfig
 //!
@@ -56,7 +61,7 @@
 use serde_json::Value;
 
 use super::truncation::{TruncationError, TruncationReport};
-use super::{ModelContext, SamplingLayers, messages, sampling, tools, truncation};
+use super::{ModelContext, SamplingLayers, constrain, messages, sampling, tools, truncation};
 
 /// Apply every request-shaping transform, in order, in place.
 ///
@@ -92,6 +97,7 @@ pub fn apply(
     };
 
     sampling::resolve_sampling(body, ctx, layers);
+    constrain::constrain_tool_calls(body, ctx);
     Ok(report)
 }
 

--- a/crates/gglib-core/src/request_pipeline/constrain.rs
+++ b/crates/gglib-core/src/request_pipeline/constrain.rs
@@ -243,7 +243,10 @@ mod tests {
         assert!(grammar.contains(r#""\"read_file\"" | "\"ls\"""#));
         assert!(grammar.contains(r#""<tool_call>""#));
         assert_eq!(b["tool_choice"], "none");
-        assert!(b.get("tools").is_some(), "tools stay for template rendering");
+        assert!(
+            b.get("tools").is_some(),
+            "tools stay for template rendering"
+        );
     }
 
     /// A named function narrows the grammar to that one tool.
@@ -339,8 +342,7 @@ mod tests {
         use crate::normalize::get_parser;
 
         // A string the grammar admits (call rule, JSON dialect, newlines).
-        let emission =
-            "<tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"a.rs\"}}\n</tool_call>";
+        let emission = "<tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"a.rs\"}}\n</tool_call>";
 
         let mut parser = get_parser(&[FORMAT_QWEN_XML.to_owned()]);
         let mut out = parser.push_text(emission);

--- a/crates/gglib-core/src/request_pipeline/constrain.rs
+++ b/crates/gglib-core/src/request_pipeline/constrain.rs
@@ -1,0 +1,356 @@
+//! Stage 6: decode-time enforcement of dialect tool calls.
+//!
+//! For models tagged [`FORMAT_QWEN_XML`], tool calls are free text — the
+//! model *chooses* to emit `<tool_call>{json}</tool_call>` and the proxy
+//! parses it after the fact. Post-hoc parsing can rescue a well-formed call,
+//! but it cannot stop a small model from producing a malformed one. This
+//! stage can: when the client *demands* a tool call (`tool_choice:
+//! "required"` or a named function), it originates a GBNF `grammar` that
+//! llama-server enforces at decode time, making an invalid envelope,
+//! invalid JSON, or an invented tool name unrepresentable.
+//!
+//! # Why only the qwen-xml dialect
+//!
+//! Models whose chat template does native tool handling are already
+//! constrained: llama.cpp builds its own grammar from the template (eager
+//! under `required`, lazily-triggered under `auto`) — and its `OpenAI`
+//! endpoint *rejects* a request that combines a custom `grammar` with
+//! `tools` ("Cannot use custom grammar constraints with tools") unless
+//! `tool_choice` is `"none"`. Dialect models are exactly the ones that
+//! machinery does not cover, so they are exactly where the proxy steps in.
+//!
+//! # Why `tool_choice` is rewritten to `"none"`
+//!
+//! That same upstream rejection is the reason the stage rewrites
+//! `tool_choice` to `"none"` when it installs a grammar: it is the one
+//! escape hatch llama-server leaves open for grammar + tools. The template
+//! still renders the tool schemas into the prompt (templates never see
+//! `tool_choice`), and the requirement the client expressed now lives in
+//! the grammar itself — which is *stronger* than what `tool_choice` could
+//! ask for on a model llama-server has no tool handling for anyway.
+//!
+//! # Why `auto` is left alone
+//!
+//! A grammar constrains from the first token, so under `tool_choice:
+//! "auto"` it would forbid the plain-text answers `auto` exists to permit.
+//! llama.cpp solves this internally with lazily-triggered grammars, but
+//! does not expose lazy triggers as request fields — so `auto` keeps
+//! today's behaviour: unconstrained decode, post-hoc parsing.
+//!
+//! [`FORMAT_QWEN_XML`]: crate::normalize::tags::FORMAT_QWEN_XML
+
+use serde_json::Value;
+use tracing::{debug, info};
+
+use super::ModelContext;
+use crate::normalize::tags::FORMAT_QWEN_XML;
+
+/// Environment kill switch. Truthy values (case-insensitive `1`, `true`,
+/// `yes`, `on`) disable grammar origination entirely — the same contract as
+/// `GGLIB_DISABLE_MTP` and `GGLIB_DISABLE_CACHE_REUSE`.
+pub const DISABLE_GRAMMAR_ENV: &str = "GGLIB_DISABLE_GRAMMAR";
+
+/// Whether [`DISABLE_GRAMMAR_ENV`] is set to a truthy value.
+fn grammar_disabled_via_env() -> bool {
+    std::env::var(DISABLE_GRAMMAR_ENV).ok().is_some_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Originate a decode-time grammar for a demanded dialect tool call.
+///
+/// Engages only when *all* of the following hold, and is a no-op otherwise:
+///
+/// - `GGLIB_DISABLE_GRAMMAR` is not set to a truthy value;
+/// - the model resolved from the catalog and carries the qwen-xml format
+///   tag (see module docs for why the native path is excluded);
+/// - the request carries a non-empty `tools` array whose function names are
+///   expressible in a GBNF literal;
+/// - the client sent none of `grammar` / `json_schema` / `response_format`
+///   — a client that constrains its own decode is always respected;
+/// - `tool_choice` demands a call: `"required"`, or a named function.
+///
+/// Returns `true` when a grammar was installed.
+pub fn constrain_tool_calls(body: &mut Value, ctx: &ModelContext) -> bool {
+    if grammar_disabled_via_env() {
+        return false;
+    }
+    constrain_tool_calls_inner(body, ctx)
+}
+
+/// [`constrain_tool_calls`] without the environment check, for tests.
+fn constrain_tool_calls_inner(body: &mut Value, ctx: &ModelContext) -> bool {
+    if !ctx.catalog_resolved || !ctx.tags.iter().any(|t| t == FORMAT_QWEN_XML) {
+        return false;
+    }
+    if body.get("grammar").is_some()
+        || body.get("json_schema").is_some()
+        || body.get("response_format").is_some()
+    {
+        debug!("client sent its own decode constraint; not originating a grammar");
+        return false;
+    }
+
+    let Some(all_names) = tool_names(body) else {
+        return false;
+    };
+
+    let allowed: Vec<String> = match demanded_names(body.get("tool_choice"), &all_names) {
+        Some(names) => names,
+        None => return false,
+    };
+    if allowed.is_empty() || !allowed.iter().all(|n| gbnf_literal_safe(n)) {
+        debug!("tool names not expressible in a GBNF literal; not constraining");
+        return false;
+    }
+
+    let grammar = qwen_tool_call_grammar(&allowed);
+    body["grammar"] = Value::String(grammar);
+    // The one combination llama-server accepts alongside a custom grammar —
+    // see the module docs. The demand now lives in the grammar.
+    body["tool_choice"] = Value::String("none".into());
+
+    info!(
+        tools = allowed.len(),
+        "originated decode-time grammar for a demanded qwen-xml tool call"
+    );
+    true
+}
+
+/// The advertised function names, or `None` when `tools` is absent, empty,
+/// or not in the `OpenAI` function-tool shape.
+fn tool_names(body: &Value) -> Option<Vec<String>> {
+    let tools = body.get("tools")?.as_array()?;
+    if tools.is_empty() {
+        return None;
+    }
+    let names: Vec<String> = tools
+        .iter()
+        .filter_map(|t| t.get("function")?.get("name")?.as_str())
+        .map(str::to_owned)
+        .collect();
+    (names.len() == tools.len()).then_some(names)
+}
+
+/// Which names the client's `tool_choice` demands a call from.
+///
+/// `Some(names)` means "a call is demanded, constrain to these"; `None`
+/// means "no demand" (`auto`, absent, `"none"`, or an unrecognized shape)
+/// and the stage stays out of the way.
+fn demanded_names(tool_choice: Option<&Value>, all_names: &[String]) -> Option<Vec<String>> {
+    match tool_choice {
+        Some(Value::String(s)) if s == "required" => Some(all_names.to_vec()),
+        Some(Value::Object(_)) => {
+            let named = tool_choice?
+                .get("function")?
+                .get("name")?
+                .as_str()?
+                .to_owned();
+            // A demand for a tool that is not advertised is the client's
+            // inconsistency to surface, not ours to paper over with a
+            // grammar for a name the model has never seen.
+            all_names.contains(&named).then(|| vec![named])
+        }
+        _ => None,
+    }
+}
+
+/// Whether `name` can be embedded in a GBNF double-quoted literal verbatim.
+///
+/// Function names are identifier-like in practice; anything that would need
+/// escaping (quotes, backslashes, control bytes, non-ASCII) makes the whole
+/// request fall back to unconstrained decode rather than risk emitting a
+/// grammar llama-server cannot compile.
+fn gbnf_literal_safe(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_graphic() && c != '"' && c != '\\')
+}
+
+/// Build the GBNF grammar for one or more Qwen-dialect tool calls.
+///
+/// The envelope is exactly what [`QwenXmlParser`] prefers to parse — the
+/// JSON body dialect, `{"name": …, "arguments": {…}}` in that key order
+/// (the order the models were trained on) — wrapped in
+/// `<tool_call>`/`</tool_call>` with the newlines Qwen emits. `name` is an
+/// enum of the demanded tools; `arguments` is constrained to well-formed
+/// JSON. Malformed envelopes, truncated JSON, and invented tool names all
+/// become unrepresentable at decode time.
+///
+/// [`QwenXmlParser`]: crate::normalize::parsers::qwen_xml::QwenXmlParser
+fn qwen_tool_call_grammar(names: &[String]) -> String {
+    let name_alternatives = names
+        .iter()
+        .map(|n| format!("\"\\\"{n}\\\"\""))
+        .collect::<Vec<_>>()
+        .join(" | ");
+
+    format!(
+        r#"root ::= sp call (sp call)* sp
+call ::= "<tool_call>" nl "{{" sp "\"name\"" sp ":" sp name sp "," sp "\"arguments\"" sp ":" sp object sp "}}" nl "</tool_call>"
+name ::= {name_alternatives}
+object ::= "{{" sp ( member ( sp "," sp member )* )? sp "}}"
+member ::= string sp ":" sp value
+value ::= object | array | string | number | "true" | "false" | "null"
+array ::= "[" sp ( value ( sp "," sp value )* )? sp "]"
+string ::= "\"" char* "\""
+char ::= [^"\\\x7F\x00-\x1F] | "\\" (["\\bfnrt/] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+sp ::= [ \t\r\n]*
+nl ::= "\n"
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn qwen_ctx() -> ModelContext {
+        ModelContext {
+            tags: vec![FORMAT_QWEN_XML.to_owned()],
+            catalog_resolved: true,
+            ..ModelContext::passthrough()
+        }
+    }
+
+    fn body(tool_choice: &Value) -> Value {
+        json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {"type": "function", "function": {"name": "read_file", "parameters": {}}},
+                {"type": "function", "function": {"name": "ls", "parameters": {}}},
+            ],
+            "tool_choice": tool_choice,
+        })
+    }
+
+    /// The case the stage exists for: a demanded call on a dialect model
+    /// gets a grammar, and `tool_choice` is rewritten to the one value
+    /// llama-server accepts alongside it.
+    #[test]
+    fn required_installs_a_grammar_and_rewrites_tool_choice() {
+        let mut b = body(&json!("required"));
+        assert!(constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+
+        let grammar = b["grammar"].as_str().unwrap();
+        assert!(grammar.contains(r#""\"read_file\"" | "\"ls\"""#));
+        assert!(grammar.contains(r#""<tool_call>""#));
+        assert_eq!(b["tool_choice"], "none");
+        assert!(b.get("tools").is_some(), "tools stay for template rendering");
+    }
+
+    /// A named function narrows the grammar to that one tool.
+    #[test]
+    fn a_named_function_constrains_to_that_name() {
+        let mut b = body(&json!({"type": "function", "function": {"name": "ls"}}));
+        assert!(constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+
+        let grammar = b["grammar"].as_str().unwrap();
+        assert!(grammar.contains(r#"name ::= "\"ls\"""#));
+        assert!(!grammar.contains("read_file"));
+    }
+
+    /// `auto` (and absent) must stay unconstrained — a start-anchored
+    /// grammar would forbid the plain-text answers `auto` permits.
+    #[test]
+    fn auto_and_absent_are_left_alone() {
+        for tc in [json!("auto"), Value::Null] {
+            let mut b = body(&tc);
+            if b["tool_choice"].is_null() {
+                b.as_object_mut().unwrap().remove("tool_choice");
+            }
+            assert!(!constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+            assert!(b.get("grammar").is_none());
+        }
+    }
+
+    /// A client that constrains its own decode is always respected.
+    #[test]
+    fn client_constraints_are_never_overwritten() {
+        for (key, value) in [
+            ("grammar", json!("root ::= \"x\"")),
+            ("json_schema", json!({"type": "object"})),
+            ("response_format", json!({"type": "json_object"})),
+        ] {
+            let mut b = body(&json!("required"));
+            b[key] = value.clone();
+            assert!(!constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+            assert_eq!(b[key], value, "{key} must be untouched");
+            assert_eq!(b["tool_choice"], "required");
+        }
+    }
+
+    /// Only the dialect the proxy parses is constrained; native-path models
+    /// belong to llama-server's own tool machinery.
+    #[test]
+    fn non_dialect_and_unresolved_models_are_skipped() {
+        let untagged = ModelContext {
+            catalog_resolved: true,
+            ..ModelContext::passthrough()
+        };
+        let unresolved = ModelContext {
+            tags: vec![FORMAT_QWEN_XML.to_owned()],
+            ..ModelContext::passthrough()
+        };
+        for ctx in [untagged, unresolved] {
+            let mut b = body(&json!("required"));
+            assert!(!constrain_tool_calls_inner(&mut b, &ctx));
+            assert!(b.get("grammar").is_none());
+        }
+    }
+
+    /// A demand for a tool that was never advertised is forwarded as-is for
+    /// llama-server (or the model) to answer, not constrained to a name the
+    /// prompt does not contain.
+    #[test]
+    fn a_named_function_not_in_tools_is_not_constrained() {
+        let mut b = body(&json!({"type": "function", "function": {"name": "ghost"}}));
+        assert!(!constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+    }
+
+    /// Names that would need escaping inside a GBNF literal abort the whole
+    /// constraint rather than risk an uncompilable grammar.
+    #[test]
+    fn unsafe_tool_names_abort_constraint() {
+        let mut b = body(&json!("required"));
+        b["tools"][0]["function"]["name"] = json!("evil\"name");
+        assert!(!constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+        assert!(b.get("grammar").is_none());
+    }
+
+    /// `tool_choice: "none"` is an explicit opt-out, not a demand.
+    #[test]
+    fn tool_choice_none_is_untouched() {
+        let mut b = body(&json!("none"));
+        assert!(!constrain_tool_calls_inner(&mut b, &qwen_ctx()));
+    }
+
+    /// The generated grammar parses back through the `QwenXmlParser`: what
+    /// the grammar admits, the proxy's own parser must extract.
+    #[test]
+    fn grammar_shape_round_trips_through_the_parser() {
+        use crate::normalize::get_parser;
+
+        // A string the grammar admits (call rule, JSON dialect, newlines).
+        let emission =
+            "<tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"a.rs\"}}\n</tool_call>";
+
+        let mut parser = get_parser(&[FORMAT_QWEN_XML.to_owned()]);
+        let mut out = parser.push_text(emission);
+        let fin = parser.finish();
+        out.tool_calls.extend(fin.tool_calls);
+        out.errors.extend(fin.errors);
+
+        assert!(out.errors.is_empty(), "{:?}", out.errors);
+        assert_eq!(out.tool_calls.len(), 1);
+        assert_eq!(out.tool_calls[0].name, "read_file");
+        assert_eq!(out.tool_calls[0].arguments["path"], "a.rs");
+    }
+}

--- a/crates/gglib-core/src/request_pipeline/mod.rs
+++ b/crates/gglib-core/src/request_pipeline/mod.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("README.md")]
 pub mod apply;
+pub mod constrain;
 pub mod messages;
 pub mod model_context;
 pub mod resolve;
@@ -8,6 +9,7 @@ pub mod tools;
 pub mod truncation;
 
 pub use apply::apply;
+pub use constrain::{DISABLE_GRAMMAR_ENV, constrain_tool_calls};
 pub use messages::shape_messages;
 pub use model_context::ModelContext;
 pub use resolve::resolve;

--- a/crates/gglib-proxy/src/dashboard.rs
+++ b/crates/gglib-proxy/src/dashboard.rs
@@ -559,6 +559,7 @@ mod tests {
             payload_chars_after: 100,
             messages_truncated: 0,
             was_clamped: false,
+            grammar_enforced: false,
             recorded_at_secs: 0,
         });
 

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -281,18 +281,22 @@ fn shape_request_body(
     ctx: &ModelContext,
     layers: &SamplingLayers,
     budget_chars: Option<usize>,
-) -> Result<(Bytes, TruncationReport), TruncationError> {
+) -> Result<(Bytes, TruncationReport, bool), TruncationError> {
     let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
-        return Ok((body, TruncationReport::default()));
+        return Ok((body, TruncationReport::default(), false));
     };
 
+    // The constrain stage never engages over a client-sent grammar, so
+    // before-absent + after-present is exactly "the pipeline originated one".
+    let grammar_before = value.get("grammar").is_some();
     let report = request_pipeline::apply(&mut value, ctx, layers, budget_chars)?;
+    let grammar_enforced = !grammar_before && value.get("grammar").is_some();
 
     match serde_json::to_vec(&value) {
-        Ok(v) => Ok((Bytes::from(v), report)),
+        Ok(v) => Ok((Bytes::from(v), report, grammar_enforced)),
         Err(e) => {
             warn!(error = %e, "failed to re-serialize request body after shaping; forwarding original");
-            Ok((body, TruncationReport::default()))
+            Ok((body, TruncationReport::default(), false))
         }
     }
 }
@@ -443,28 +447,30 @@ pub(crate) async fn forward_chat_completion(
     );
     let budget_chars = Some((effective_ctx as f64 * chars_per_token) as usize);
 
-    let (body, report) = match shape_request_body(body, &context, &sampling, budget_chars) {
-        Ok(shaped) => shaped,
-        Err(e) => {
-            // Hard abort: the conversation cannot be trimmed to fit. Record a
-            // clamped snapshot — the zeroed char counts are how the dashboard
-            // tells a clamped request from a measured one — then reject with
-            // the wire contract clients already handle.
-            debug!(error = %e, "rejecting request that exceeds the context budget");
-            metrics.record(ContextSnapshot {
-                model_name: model_name.to_owned(),
-                payload_chars_before: 0,
-                payload_chars_after: 0,
-                messages_truncated: 0,
-                was_clamped: true,
-                recorded_at_secs: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-            });
-            return Ok(context_length_exceeded_response());
-        }
-    };
+    let (body, report, grammar_enforced) =
+        match shape_request_body(body, &context, &sampling, budget_chars) {
+            Ok(shaped) => shaped,
+            Err(e) => {
+                // Hard abort: the conversation cannot be trimmed to fit. Record a
+                // clamped snapshot — the zeroed char counts are how the dashboard
+                // tells a clamped request from a measured one — then reject with
+                // the wire contract clients already handle.
+                debug!(error = %e, "rejecting request that exceeds the context budget");
+                metrics.record(ContextSnapshot {
+                    model_name: model_name.to_owned(),
+                    payload_chars_before: 0,
+                    payload_chars_after: 0,
+                    messages_truncated: 0,
+                    was_clamped: true,
+                    grammar_enforced: false,
+                    recorded_at_secs: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs(),
+                });
+                return Ok(context_length_exceeded_response());
+            }
+        };
 
     // Deliberate noise control: history truncation is routine enough that
     // logging every no-op would drown the interesting case.
@@ -476,12 +482,19 @@ pub(crate) async fn forward_chat_completion(
             "history truncated: reduced payload before upstream forwarding"
         );
     }
+    if grammar_enforced {
+        info!(
+            model = model_name,
+            "tool-call grammar enforced for this request (decode-time constraint)"
+        );
+    }
     metrics.record(ContextSnapshot {
         model_name: model_name.to_owned(),
         payload_chars_before: report.payload_chars_before,
         payload_chars_after: report.payload_chars_after,
         messages_truncated: report.messages_truncated,
         was_clamped: false,
+        grammar_enforced,
         recorded_at_secs: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -1089,13 +1102,14 @@ mod tests {
     #[test]
     fn shaping_runs_the_pipeline_and_preserves_unknown_fields() {
         let body = Bytes::from(r#"{"model":"m","messages":[],"totally_made_up":{"a":1}}"#);
-        let (out, report) = shape_request_body(
+        let (out, report, grammar_enforced) = shape_request_body(
             body,
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             None,
         )
         .expect("no budget, so nothing to reject");
+        assert!(!grammar_enforced, "passthrough context never constrains");
 
         let parsed: serde_json::Value = serde_json::from_slice(&out).expect("valid json");
         assert_eq!(parsed["cache_prompt"], true, "the pipeline ran");
@@ -1104,10 +1118,36 @@ mod tests {
         assert_eq!(report, TruncationReport::default(), "unmeasured, no budget");
     }
 
+    /// The end-to-end proxy view of the constrain stage: a demanded tool
+    /// call on a qwen-xml model reports `grammar_enforced` so the log line
+    /// and dashboard snapshot can say so.
+    #[test]
+    fn shaping_reports_grammar_enforcement_for_a_demanded_dialect_call() {
+        let ctx = ModelContext {
+            tags: vec![gglib_core::normalize::tags::FORMAT_QWEN_XML.to_owned()],
+            // Tool-capable, or stage 2b strips the tools before stage 6 sees
+            // them — the correct interplay for a model that cannot call tools.
+            capabilities: gglib_core::domain::ModelCapabilities::SUPPORTS_TOOL_CALLS,
+            catalog_resolved: true,
+            ..ModelContext::passthrough()
+        };
+        let body = Bytes::from(
+            r#"{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"f"}}],"tool_choice":"required"}"#,
+        );
+        let (out, _, grammar_enforced) =
+            shape_request_body(body, &ctx, &SamplingLayers::default(), None)
+                .expect("nothing to reject");
+
+        assert!(grammar_enforced);
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(parsed["grammar"].is_string());
+        assert_eq!(parsed["tool_choice"], "none");
+    }
+
     #[test]
     fn shaping_leaves_non_json_bodies_alone() {
         let body = Bytes::from_static(b"not json at all");
-        let (out, report) = shape_request_body(
+        let (out, report, _) = shape_request_body(
             body.clone(),
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
@@ -1121,7 +1161,7 @@ mod tests {
 
     #[test]
     fn shaping_truncates_when_the_budget_binds() {
-        let (out, report) = shape_request_body(
+        let (out, report, _) = shape_request_body(
             oversized_body(),
             &ModelContext::passthrough(),
             &SamplingLayers::default(),

--- a/crates/gglib-proxy/src/metrics.rs
+++ b/crates/gglib-proxy/src/metrics.rs
@@ -47,6 +47,9 @@ pub struct ContextSnapshot {
     /// `true` when the hard-abort budget check triggered and an HTTP 400 was
     /// returned to the client instead of forwarding the request.
     pub was_clamped: bool,
+    /// `true` when the request pipeline originated a decode-time tool-call
+    /// grammar for this request (see `request_pipeline::constrain`).
+    pub grammar_enforced: bool,
     /// Unix timestamp (seconds since epoch) at which this snapshot was recorded.
     pub recorded_at_secs: u64,
 }
@@ -142,6 +145,7 @@ mod tests {
             payload_chars_after: 800,
             messages_truncated: 1,
             was_clamped: false,
+            grammar_enforced: false,
             recorded_at_secs: 0,
         }
     }

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -59,6 +59,22 @@ Models without a dialect tag use the identity `StandardJsonParser`. A
 format hint on a non-tool-calling model would wire a parser with nothing to
 parse.
 
+### Decode-time enforcement for `format:qwen-xml`
+
+Parsing is the rescue path; enforcement is stronger. When a client *demands*
+a tool call from a `format:qwen-xml` model — `tool_choice: "required"` or a
+named function — the proxy also originates a GBNF grammar that llama-server
+applies at decode time, so a malformed `<tool_call>` envelope, truncated
+JSON, or invented tool name cannot be generated at all. `tool_choice:
+"auto"` stays unconstrained (a grammar would forbid plain-text answers), a
+client-supplied `grammar`/`json_schema`/`response_format` is always
+respected, and requests where enforcement engaged are flagged in the proxy
+log and the dashboard's recent-request list. Kill switch:
+
+```bash
+GGLIB_DISABLE_GRAMMAR=1 gglib proxy
+```
+
 ## Capability tags
 
 Alongside `format:*` tags, gglib detects **capability tags** at import time

--- a/src/services/transport/types/dashboard.ts
+++ b/src/services/transport/types/dashboard.ts
@@ -117,6 +117,8 @@ export interface ContextSnapshot {
   payload_chars_after: number;
   messages_truncated: number;
   was_clamped: boolean;
+  /** True when the proxy originated a decode-time tool-call grammar. */
+  grammar_enforced: boolean;
   recorded_at_secs: number;
 }
 


### PR DESCRIPTION
Stacked on #715. The lead innovation of this series: for dialect models, malformed tool calls stop being something the proxy *parses around* and become something the model *cannot generate*.

## What

A new request-pipeline stage (stage 6, after sampling resolution, in `crates/gglib-core/src/request_pipeline/constrain.rs`) originates a GBNF `grammar` when a client **demands** a tool call from a `format:qwen-xml` model — `tool_choice: "required"` or a named function. llama-server applies the grammar at decode time, so the three failure modes the tune suite scores hardest (malformed `<tool_call>` envelope, invalid/truncated JSON, invented tool name) are unrepresentable. The grammar constrains `name` to the advertised tool set (or the one named tool), `arguments` to well-formed JSON, and the envelope to exactly the shape `QwenXmlParser` parses — proven by a round-trip test (what the grammar admits, the parser extracts).

## Why the scope is shaped this way (llama-server's actual contract, verified upstream)

- **Native-template models are untouched.** llama.cpp builds its own grammar from the chat template when tools are present (eager under `required`, lazily-triggered under `auto`), and its OpenAI endpoint **rejects** a custom `grammar` combined with `tools` — `"Cannot use custom grammar constraints with tools."` — unless `tool_choice` is `"none"`. Dialect models are precisely the ones that machinery doesn't cover, so they're precisely where the proxy steps in.
- **`tool_choice` is rewritten to `"none"`** when a grammar is installed — the one combination llama-server accepts. Templates never see `tool_choice`, so the tool schemas still render into the prompt; the client's demand now lives in the grammar, which is stronger.
- **`auto` stays unconstrained.** A grammar binds from the first token and would forbid the plain-text answers `auto` exists to permit; llama-server exposes no per-request lazy triggers. Post-hoc parsing (and PR #715's non-streaming normalization) remains the rescue path there.
- **Client constraints always win**: a request carrying its own `grammar`/`json_schema`/`response_format` is never touched. Tool names that would need escaping inside a GBNF literal abort the constraint entirely rather than risk an uncompilable grammar.

## Kill switch & visibility

- `GGLIB_DISABLE_GRAMMAR` (truthy: `1`/`true`/`yes`/`on`), matching the `GGLIB_DISABLE_MTP`/`GGLIB_DISABLE_CACHE_REUSE` pattern. Documented in `docs/tags.md`.
- Each enforced request logs an info line and sets a new `grammar_enforced` flag on the dashboard's recent-request snapshots (`/v1/proxy/status` → GUI `ContextSnapshot` type).

## Tests

9 unit tests on the stage (required/named-function enforcement, auto/absent/none untouched, client constraints respected, non-dialect and unresolved models skipped, unadvertised named tool skipped, unsafe names abort, grammar→parser round-trip) plus a proxy-level test that `shape_request_body` reports enforcement end-to-end. Full workspace tests, clippy, tsc, and vitest are green.

## Validation note

No local model is installed on this machine, so live llama-server behaviour (grammar acceptance and the measured tool-accuracy delta) is exercised by the next PR in the stack — the A/B eval ruler — which is built to demonstrate exactly this change on real hardware.