### PR TITLE
feat(benchmark): raw-vs-gglib A/B agentic eval with JSON export

### DIFF
--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -169,6 +169,7 @@ impl AgentLoop {
         messages: &mut Vec<AgentMessage>,
         content: String,
         iteration: usize,
+        total_completion_tokens: Option<u64>,
         tx: &mpsc::Sender<AgentEvent>,
     ) -> Result<AgentRunOutput, AgentError> {
         debug!("no tool calls; final answer reached");
@@ -187,6 +188,7 @@ impl AgentLoop {
             answer: content,
             history: std::mem::take(messages),
             total_iterations: iteration + 1,
+            total_completion_tokens,
         })
     }
 
@@ -266,10 +268,18 @@ impl AgentLoopPort for AgentLoop {
 
         messages = prune_for_budget(messages, &config);
 
+        // Summed across iterations; `None` until any upstream reports usage,
+        // so "not measured" stays distinct from "zero tokens".
+        let mut total_completion_tokens: Option<u64> = None;
+
         for iteration in 0..config.max_iterations {
             debug!(iteration, "agent loop iteration starting");
 
             let response = self.call_and_collect(&messages, &tools, &tx).await?;
+            if let Some(ct) = response.completion_tokens {
+                total_completion_tokens =
+                    Some(total_completion_tokens.unwrap_or(0) + u64::from(ct));
+            }
 
             if response.tool_calls.len() > config.max_parallel_tools {
                 // Soft recovery (was: hard `Err(ParallelToolLimitExceeded)`).
@@ -360,8 +370,14 @@ impl AgentLoopPort for AgentLoop {
                 .await?;
 
             if response.tool_calls.is_empty() {
-                return Self::finalize_answer(&mut messages, response.content, iteration, &tx)
-                    .await;
+                return Self::finalize_answer(
+                    &mut messages,
+                    response.content,
+                    iteration,
+                    total_completion_tokens,
+                    &tx,
+                )
+                .await;
             }
 
             self.execute_tool_iteration(&mut messages, response, &config, iteration, &tx, &tools)

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -76,6 +76,15 @@ pub struct CollectedResponse {
     pub tool_calls: Vec<ToolCall>,
     /// The `finish_reason` from the [`LlmStreamEvent::Done`] terminus event.
     pub finish_reason: String,
+    /// Completion-token count from the stream's trailing
+    /// [`LlmStreamEvent::Usage`] event.
+    ///
+    /// `None` when the upstream never reported usage — absent and zero are
+    /// distinct, exactly as on the event itself. Per the `OpenAI` streaming
+    /// convention the usage chunk arrives *after* `Done`, which is why the
+    /// collector drains the stream to its end instead of returning at the
+    /// `Done` event.
+    pub completion_tokens: Option<u32>,
 }
 
 // =============================================================================
@@ -138,6 +147,10 @@ pub async fn collect_stream(
     // Used to distinguish a hard connectivity failure (zero events) from a
     // mid-response truncation (some events, no Done frame).
     let mut got_any_event = false;
+    // Set at `Done`; the loop keeps draining afterwards because the OpenAI
+    // usage chunk legitimately trails `Done` (before the byte stream closes).
+    let mut finished: Option<(String, Vec<ToolCall>)> = None;
+    let mut completion_tokens: Option<u32> = None;
 
     while let Some(event) = stream.next().await {
         got_any_event = true;
@@ -176,64 +189,28 @@ pub async fn collect_stream(
                 id,
                 name,
                 arguments,
-            } => {
-                // Guard against a pathological index that would cause a huge allocation.
-                if index >= MAX_TOOL_CALL_INDEX {
-                    anyhow::bail!(
-                        "tool-call index {index} exceeds hard limit ({MAX_TOOL_CALL_INDEX})"
-                    );
-                }
-                // Ensure the partials vec has a slot at `index`.
-                if partials.len() <= index {
-                    partials.resize_with(index + 1, PartialToolCall::default);
-                }
-                let p = &mut partials[index];
-                if let Some(id) = id {
-                    if let Some(ref existing) = p.id {
-                        warn!(
-                            tool_index = index,
-                            existing = %existing,
-                            new = %id,
-                            "ToolCallDelta overwrote existing id"
-                        );
-                    }
-                    p.id = Some(id);
-                }
-                if let Some(name) = name {
-                    if let Some(ref existing) = p.name {
-                        warn!(
-                            tool_index = index,
-                            existing = %existing,
-                            new = %name,
-                            "ToolCallDelta overwrote existing name"
-                        );
-                    }
-                    p.name = Some(name);
-                }
-                if let Some(args) = arguments {
-                    p.arguments.push_str(&args);
-                }
-            }
+            } => upsert_tool_call_delta(&mut partials, index, id, name, arguments)?,
 
             LlmStreamEvent::Done { finish_reason } => {
-                let tool_calls = assemble_tool_calls(partials, tx).await?;
-
-                return Ok(CollectedResponse {
-                    content: text_buf,
-                    reasoning_content: reasoning_buf,
-                    tool_calls,
-                    finish_reason,
-                });
+                let tool_calls = assemble_tool_calls(std::mem::take(&mut partials), tx).await?;
+                finished = Some((finish_reason, tool_calls));
+                // Do not return yet: the trailing usage chunk arrives after
+                // Done. The decoder ends the stream right after the [DONE]
+                // sentinel, so this drains at most a few trailer events.
             }
 
             LlmStreamEvent::NormalizationError { kind, raw } => {
                 handle_normalization_error(tx, &kind, &raw).await;
             }
 
-            // Wire-facing telemetry (feeds e.g. a client's context-window
-            // UI widget) with no bearing on the agent loop's own internal
-            // state — nothing to accumulate or forward here.
-            LlmStreamEvent::Usage { .. } => {}
+            // Wire-facing telemetry; the completion count is kept so callers
+            // can compute generation throughput (the tune/eval speed axis).
+            LlmStreamEvent::Usage {
+                completion_tokens: ct,
+                ..
+            } => {
+                completion_tokens = Some(ct);
+            }
 
             LlmStreamEvent::UpstreamError {
                 message,
@@ -241,6 +218,16 @@ pub async fn collect_stream(
                 code,
             } => return Err(upstream_error(&message, &error_type, &code)),
         }
+    }
+
+    if let Some((finish_reason, tool_calls)) = finished {
+        return Ok(CollectedResponse {
+            content: text_buf,
+            reasoning_content: reasoning_buf,
+            tool_calls,
+            finish_reason,
+            completion_tokens,
+        });
     }
 
     // The stream ended without a Done event.  Distinguish two failure modes:
@@ -255,6 +242,54 @@ pub async fn collect_stream(
 // =============================================================================
 // Private helpers
 // =============================================================================
+
+/// Fold one `ToolCallDelta` into the partial-call accumulator at `index`.
+///
+/// Bounds the index against [`MAX_TOOL_CALL_INDEX`] (a malformed stream must
+/// not drive a huge allocation), grows the vec on demand, and logs when a
+/// delta overwrites an already-seen `id`/`name` — a should-never-happen the
+/// old inline code also surfaced.
+fn upsert_tool_call_delta(
+    partials: &mut Vec<PartialToolCall>,
+    index: usize,
+    id: Option<String>,
+    name: Option<String>,
+    arguments: Option<String>,
+) -> Result<()> {
+    if index >= MAX_TOOL_CALL_INDEX {
+        anyhow::bail!("tool-call index {index} exceeds hard limit ({MAX_TOOL_CALL_INDEX})");
+    }
+    if partials.len() <= index {
+        partials.resize_with(index + 1, PartialToolCall::default);
+    }
+    let p = &mut partials[index];
+    if let Some(id) = id {
+        if let Some(ref existing) = p.id {
+            warn!(
+                tool_index = index,
+                existing = %existing,
+                new = %id,
+                "ToolCallDelta overwrote existing id"
+            );
+        }
+        p.id = Some(id);
+    }
+    if let Some(name) = name {
+        if let Some(ref existing) = p.name {
+            warn!(
+                tool_index = index,
+                existing = %existing,
+                new = %name,
+                "ToolCallDelta overwrote existing name"
+            );
+        }
+        p.name = Some(name);
+    }
+    if let Some(args) = arguments {
+        p.arguments.push_str(&args);
+    }
+    Ok(())
+}
 
 /// Surface a non-fatal `NormalizationError` from the dialect parser.
 ///

--- a/crates/gglib-app-services/src/benchmark/agentic.rs
+++ b/crates/gglib-app-services/src/benchmark/agentic.rs
@@ -1,0 +1,266 @@
+//! Raw-vs-gglib A/B agentic evaluation.
+//!
+//! Runs the tune sweep's task suite twice against the same loaded model —
+//! once with the request pipeline bypassed (the *raw* arm: what a client
+//! pointed straight at llama-server gets) and once through the full gglib
+//! pipeline (the *gglib* arm) — and reports per-axis scores and their
+//! difference. See [`gglib_core::domain::benchmark::agentic`] for the
+//! report shape and the definition of each arm.
+//!
+//! One admission lease covers both arms, for the same reason the tune sweep
+//! holds one across candidates: an arm measured across a model swap would
+//! be measuring the swap. Tasks whose expected outcome demands a tool call
+//! send `tool_choice: "required"` in **both** arms — the same request an
+//! agentic client would make — which is what lets the gglib arm's
+//! decode-time grammar stage engage while the raw arm shows what that
+//! demand achieves without it.
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use gglib_core::domain::benchmark::BenchmarkEvent;
+use gglib_core::domain::benchmark::agentic::{
+    AgenticEvalConfig, AgenticEvalReport, AgenticTaskComparison, ArmScores, EvalArm,
+};
+use gglib_core::domain::benchmark::tune::result::TuneTaskResult;
+use gglib_core::domain::benchmark::tune::task::{ExpectedOutcome, TuneTask};
+use gglib_core::ports::LlmCompletionPort;
+use gglib_core::request_pipeline::ModelContext;
+use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
+use gglib_core::settings::DEFAULT_CONTEXT_SIZE;
+use gglib_runtime::LlmCompletionAdapter;
+use tokio::sync::mpsc::Sender;
+use tokio_util::sync::CancellationToken;
+
+use super::BenchmarkDeps;
+use super::tune::{axis_scores, run_task_with_llm, throughput_tps};
+
+/// Entry point called by [`super::BenchmarkOps::run_agentic`].
+pub async fn run_agentic_eval(
+    deps: &BenchmarkDeps,
+    config: AgenticEvalConfig,
+    tx: Sender<BenchmarkEvent>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let tasks = config
+        .task_suite
+        .resolve()
+        .context("failed to resolve agentic eval task suite")?;
+    anyhow::ensure!(!tasks.is_empty(), "agentic eval task suite must not be empty");
+
+    let model = deps
+        .model_repo
+        .get_by_id(config.model_id)
+        .await
+        .with_context(|| format!("model {} not found", config.model_id))?;
+
+    // Resolve the serving context exactly as the tune sweep does.
+    let settings = deps.settings_repo.load().await.ok();
+    let default_ctx = settings
+        .as_ref()
+        .and_then(|s| s.default_context_size)
+        .unwrap_or(DEFAULT_CONTEXT_SIZE);
+    let resolved_ctx = resolve_context_size(&ServerConfigOptions {
+        context_size: config.ctx_size,
+        model_server_ctx: model
+            .server_defaults
+            .as_ref()
+            .and_then(|s| s.context_length),
+        global_default_ctx: Some(default_ctx),
+        ..Default::default()
+    });
+
+    // One lease across both arms — an arm measured across a model swap would
+    // be measuring the swap.
+    let admission = match deps
+        .runtime
+        .admit(
+            &model.name,
+            Some(resolved_ctx),
+            resolved_ctx,
+            gglib_core::ports::LaunchOverrides::default(),
+        )
+        .await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            let msg = format!("failed to start model '{}': {e}", model.name);
+            let _ = tx.send(BenchmarkEvent::RunFailed { error: msg }).await;
+            return Ok(());
+        }
+    };
+    let base_url = admission.target.base_url.clone();
+
+    // The gglib arm's per-model facts, straight from the catalog row.
+    let model_context = ModelContext {
+        capabilities: model.capabilities,
+        tags: model.tags.clone(),
+        inference_defaults: model.inference_defaults.clone(),
+        defaults_origin: model.defaults_origin,
+        context_length: model.context_length,
+        catalog_resolved: true,
+    };
+
+    let mut arm_results: Vec<Vec<TuneTaskResult>> = Vec::with_capacity(2);
+    for arm in [EvalArm::Raw, EvalArm::Gglib] {
+        let _ = tx
+            .send(BenchmarkEvent::AgenticArmStarted {
+                arm,
+                total_tasks: tasks.len(),
+            })
+            .await;
+
+        let mut results = Vec::with_capacity(tasks.len());
+        for task in &tasks {
+            if cancel.is_cancelled() {
+                deps.runtime.stop_current().await.ok();
+                let _ = tx
+                    .send(BenchmarkEvent::RunFailed {
+                        error: "Aborted by user".into(),
+                    })
+                    .await;
+                return Ok(());
+            }
+
+            let llm = build_arm_llm(deps, &base_url, &model.name, arm, &model_context, task);
+            let result = run_task_with_llm(llm, task).await;
+            let _ = tx
+                .send(BenchmarkEvent::AgenticTaskComplete {
+                    arm,
+                    task_id: task.id.clone(),
+                    passed: result.passed,
+                })
+                .await;
+            results.push(result);
+        }
+        arm_results.push(results);
+    }
+
+    let gglib_results = arm_results.pop().unwrap_or_default();
+    let raw_results = arm_results.pop().unwrap_or_default();
+
+    let raw = arm_scores(&raw_results, &config);
+    let gglib = arm_scores(&gglib_results, &config);
+    let delta = AgenticEvalReport::delta_of(&raw, &gglib);
+
+    let tasks_cmp = raw_results
+        .into_iter()
+        .zip(gglib_results)
+        .map(|(raw, gglib)| AgenticTaskComparison {
+            task_id: raw.task_id.clone(),
+            category: raw.category,
+            raw,
+            gglib,
+        })
+        .collect();
+
+    let report = AgenticEvalReport {
+        model_name: model.name.clone(),
+        quantization: model.quantization.clone(),
+        param_count_b: model.param_count_b,
+        ctx_size: resolved_ctx,
+        raw,
+        gglib,
+        delta,
+        tasks: tasks_cmp,
+    };
+
+    let _ = tx
+        .send(BenchmarkEvent::AgenticEvalComplete { report })
+        .await;
+    Ok(())
+}
+
+/// Build the LLM port for one arm and one task.
+///
+/// The arm is the *entire* difference between the two runs:
+///
+/// - **Raw** bypasses the pipeline (`with_raw_passthrough`) and carries a
+///   passthrough model context, so no shaping, no per-model sampling, no
+///   dialect parsing and no grammar happen — llama-server's own defaults
+///   and wire format, verbatim.
+/// - **Gglib** carries the catalog-resolved [`ModelContext`], which switches
+///   on exactly what the proxy would do for this model.
+///
+/// Both arms send `tool_choice: "required"` when the task's expected outcome
+/// demands a call — identical requests, different machinery.
+fn build_arm_llm(
+    deps: &BenchmarkDeps,
+    base_url: &str,
+    model_name: &str,
+    arm: EvalArm,
+    model_context: &ModelContext,
+    task: &TuneTask,
+) -> Arc<dyn LlmCompletionPort> {
+    let tool_choice = demands_tool_call(task).then(|| "required".to_owned());
+
+    let adapter = LlmCompletionAdapter::with_client(
+        base_url.to_owned(),
+        deps.http_client.clone(),
+        Some(model_name.to_owned()),
+    )
+    .with_tool_choice(tool_choice);
+
+    let adapter = match arm {
+        EvalArm::Raw => adapter.with_raw_passthrough(true),
+        EvalArm::Gglib => adapter.with_model_context(model_context.clone()),
+    };
+    Arc::new(adapter)
+}
+
+/// Whether a task's expected outcome demands at least one tool call.
+fn demands_tool_call(task: &TuneTask) -> bool {
+    matches!(&task.expected, ExpectedOutcome::ToolCalls { calls } if !calls.is_empty())
+}
+
+/// Aggregate one arm's task results into [`ArmScores`].
+fn arm_scores(results: &[TuneTaskResult], config: &AgenticEvalConfig) -> ArmScores {
+    let axes = axis_scores(results);
+    let composite = super::tune::compute_composite_score(results, &config.weights);
+    let (tool_accuracy, loop_avoidance, task_completion) = axes.map_or((0.0, 0.0, 0.0), |a| {
+        (a.tool_accuracy, a.loop_avoidance, a.task_completion)
+    });
+    ArmScores {
+        tool_accuracy,
+        loop_avoidance,
+        task_completion,
+        composite,
+        tg_tps: throughput_tps(results),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gglib_core::domain::benchmark::tune::task::{ExpectedCall, TaskCategory};
+
+    fn call_task(expected: ExpectedOutcome) -> TuneTask {
+        TuneTask {
+            id: "t".into(),
+            category: TaskCategory::SingleCall,
+            system_prompt: None,
+            history: None,
+            user_prompt: "do it".into(),
+            tools: vec![],
+            expected,
+        }
+    }
+
+    /// A demanded call sends `tool_choice: "required"`; an irrelevance task
+    /// must not, or the model would be forced to call a tool the task
+    /// expects it to abstain from.
+    #[test]
+    fn tool_choice_follows_the_expected_outcome() {
+        let demanding = call_task(ExpectedOutcome::ToolCalls {
+            calls: vec![ExpectedCall {
+                name: "f".into(),
+                required_args: serde_json::Map::new(),
+                ordered: false,
+            }],
+        });
+        let abstaining = call_task(ExpectedOutcome::NoToolCall);
+
+        assert!(demands_tool_call(&demanding));
+        assert!(!demands_tool_call(&abstaining));
+    }
+}

--- a/crates/gglib-app-services/src/benchmark/agentic.rs
+++ b/crates/gglib-app-services/src/benchmark/agentic.rs
@@ -46,7 +46,10 @@ pub async fn run_agentic_eval(
         .task_suite
         .resolve()
         .context("failed to resolve agentic eval task suite")?;
-    anyhow::ensure!(!tasks.is_empty(), "agentic eval task suite must not be empty");
+    anyhow::ensure!(
+        !tasks.is_empty(),
+        "agentic eval task suite must not be empty"
+    );
 
     let model = deps
         .model_repo

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -6,12 +6,14 @@ use anyhow::Result;
 use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
 
+use gglib_core::domain::benchmark::AgenticEvalConfig;
 use gglib_core::domain::benchmark::tune::config::TuneConfig;
 use gglib_core::domain::benchmark::{BenchmarkEvent, CompareConfig, PerfConfig};
 use gglib_core::ports::{
     BenchmarkRepositoryPort, ModelRepository, ModelRuntimePort, SettingsRepository,
 };
 
+mod agentic;
 mod compare;
 pub mod guard;
 pub mod mapper;
@@ -132,5 +134,19 @@ impl BenchmarkOps {
         cancel: CancellationToken,
     ) -> Result<()> {
         tune::run_tune(&self.deps, config, tx, cancel).await
+    }
+
+    /// Run the raw-vs-gglib A/B agentic eval: the same task suite twice
+    /// against one loaded model — pipeline bypassed vs the full pipeline —
+    /// finishing with a [`BenchmarkEvent::AgenticEvalComplete`] report.
+    ///
+    /// Like `run_tune`, the model is loaded **once** for both arms.
+    pub async fn run_agentic(
+        &self,
+        config: AgenticEvalConfig,
+        tx: Sender<BenchmarkEvent>,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        agentic::run_agentic_eval(&self.deps, config, tx, cancel).await
     }
 }

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -196,13 +196,14 @@ pub async fn run_tune(
         }
 
         let composite_score = compute_composite_score(&task_results, &config.weights);
+        let tg_tps = throughput_tps(&task_results);
         let result = TuneCandidateResult {
             config: candidate_config,
             source,
             task_results,
             composite_score,
             pruned: !is_survivor,
-            tg_tps: None,
+            tg_tps,
         };
 
         if let Err(e) = deps
@@ -363,6 +364,28 @@ async fn run_task(
     candidate: &InferenceConfig,
     task: &TuneTask,
 ) -> TuneTaskResult {
+    let llm: Arc<dyn LlmCompletionPort> = Arc::new(
+        LlmCompletionAdapter::with_client(
+            target.base_url.clone(),
+            http_client.clone(),
+            Some(model.name.clone()),
+        )
+        .with_sampling(Some(candidate.clone())),
+    );
+    run_task_with_llm(llm, task).await
+}
+
+/// The task-execution core shared by the tune sweep and the raw-vs-gglib
+/// agentic eval: drive one task through the real `AgentLoop` against a
+/// caller-prepared [`LlmCompletionPort`], and score the recorded calls.
+///
+/// The adapter configuration is the caller's whole degree of freedom — tune
+/// varies sampling per candidate; the eval varies the entire pipeline per
+/// arm — so it arrives prebuilt rather than as parameters.
+pub(crate) async fn run_task_with_llm(
+    llm: Arc<dyn LlmCompletionPort>,
+    task: &TuneTask,
+) -> TuneTaskResult {
     let mut messages: Vec<AgentMessage> = task.history.clone().unwrap_or_default();
     if let Some(system_prompt) = &task.system_prompt {
         messages.insert(
@@ -376,14 +399,6 @@ async fn run_task(
         content: task.user_prompt.clone(),
     });
 
-    let llm: Arc<dyn LlmCompletionPort> = Arc::new(
-        LlmCompletionAdapter::with_client(
-            target.base_url.clone(),
-            http_client.clone(),
-            Some(model.name.clone()),
-        )
-        .with_sampling(Some(candidate.clone())),
-    );
     let executor = ScoringToolExecutorPort::new(task.tools.clone());
     let call_log = executor.call_log_handle();
     let tool_executor: Arc<dyn ToolExecutorPort> = Arc::new(executor);
@@ -408,6 +423,10 @@ async fn run_task(
     let recorded = call_log.lock().await.clone();
     let scoring = score_outcome(&task.expected, &recorded);
 
+    let completion_tokens = match &run_result {
+        Ok(Ok(output)) => output.total_completion_tokens,
+        _ => None,
+    };
     let (loop_detected, stagnation_detected, error_detail) = match &run_result {
         Ok(Ok(_)) => (false, false, None),
         Ok(Err(gglib_core::ports::AgentError::LoopDetected { .. })) => (true, false, None),
@@ -436,22 +455,71 @@ async fn run_task(
         stagnation_detected,
         iterations,
         latency_ms,
+        completion_tokens,
         detail,
     }
 }
 
+/// Completion-token throughput across a result set: total completion tokens
+/// over total wall time. `None` when no task reported usage. Wall time
+/// includes prompt pre-fill, so this is a consistent within-run comparison
+/// figure rather than a pure decode rate — see
+/// [`TuneCandidateResult::tg_tps`].
+pub(crate) fn throughput_tps(results: &[TuneTaskResult]) -> Option<f64> {
+    let tokens: u64 = results.iter().filter_map(|r| r.completion_tokens).sum();
+    let millis: u64 = results
+        .iter()
+        .filter(|r| r.completion_tokens.is_some())
+        .map(|r| r.latency_ms)
+        .sum();
+    if tokens == 0 || millis == 0 {
+        return None;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    Some(tokens as f64 / (millis as f64 / 1000.0))
+}
+
 /// Combine per-task results into one composite score using [`ScoreWeights`].
 ///
-/// The `speed` weight is currently excluded from the denominator (no
-/// per-candidate `tg_tps` measurement exists yet — see
-/// [`TuneCandidateResult::tg_tps`]) so the three measurable components
-/// (tool accuracy, loop avoidance, task completion) are renormalized to
-/// sum to `1.0` of the available weight.
-fn compute_composite_score(results: &[TuneTaskResult], weights: &ScoreWeights) -> f64 {
-    if results.is_empty() {
+/// The `speed` weight is still excluded from the denominator: `tg_tps` is
+/// now *measured* per candidate ([`TuneCandidateResult::tg_tps`]), but its
+/// scoring definition is relative-to-fastest-in-run, which cannot be
+/// computed while candidates stream out one at a time. The three
+/// self-contained components (tool accuracy, loop avoidance, task
+/// completion) are renormalized to sum to `1.0` of the available weight.
+pub(crate) fn compute_composite_score(results: &[TuneTaskResult], weights: &ScoreWeights) -> f64 {
+    let Some(axes) = axis_scores(results) else {
+        return 0.0;
+    };
+
+    let weight_sum = f64::from(weights.tool_accuracy)
+        + f64::from(weights.loop_avoidance)
+        + f64::from(weights.task_completion);
+    if weight_sum <= 0.0 {
         return 0.0;
     }
 
+    (axes.tool_accuracy * f64::from(weights.tool_accuracy)
+        + axes.loop_avoidance * f64::from(weights.loop_avoidance)
+        + axes.task_completion * f64::from(weights.task_completion))
+        / weight_sum
+}
+
+/// The three measured axes of a result set, each `0.0`–`1.0`.
+pub(crate) struct AxisScores {
+    /// Mean AST-style tool-call match score.
+    pub tool_accuracy: f64,
+    /// Fraction of tasks that triggered neither loop nor stagnation guards.
+    pub loop_avoidance: f64,
+    /// Fraction of tasks that passed outright.
+    pub task_completion: f64,
+}
+
+/// Compute the per-axis scores for a result set. `None` when empty.
+pub(crate) fn axis_scores(results: &[TuneTaskResult]) -> Option<AxisScores> {
+    if results.is_empty() {
+        return None;
+    }
     #[allow(clippy::cast_precision_loss)]
     let n = results.len() as f64;
     let tool_accuracy = results.iter().map(|r| r.tool_match_score).sum::<f64>() / n;
@@ -465,17 +533,11 @@ fn compute_composite_score(results: &[TuneTaskResult], weights: &ScoreWeights) -
     #[allow(clippy::cast_precision_loss)]
     let task_completion = passed as f64 / n;
 
-    let weight_sum = f64::from(weights.tool_accuracy)
-        + f64::from(weights.loop_avoidance)
-        + f64::from(weights.task_completion);
-    if weight_sum <= 0.0 {
-        return 0.0;
-    }
-
-    (tool_accuracy * f64::from(weights.tool_accuracy)
-        + loop_avoidance * f64::from(weights.loop_avoidance)
-        + task_completion * f64::from(weights.task_completion))
-        / weight_sum
+    Some(AxisScores {
+        tool_accuracy,
+        loop_avoidance,
+        task_completion,
+    })
 }
 
 #[cfg(test)]
@@ -492,6 +554,7 @@ mod tests {
             stagnation_detected: false,
             iterations: 1,
             latency_ms: 10,
+            completion_tokens: None,
             detail: None,
         }
     }
@@ -531,6 +594,22 @@ mod tests {
     #[test]
     fn composite_score_of_empty_results_is_zero() {
         assert_eq!(compute_composite_score(&[], &ScoreWeights::default()), 0.0);
+    }
+
+    /// Total tokens over total wall time — and tasks that reported no usage
+    /// contribute neither tokens nor time, so they cannot dilute the figure.
+    #[test]
+    fn throughput_is_tokens_over_wall_time() {
+        let mut measured = task_result(1.0, true, false);
+        measured.completion_tokens = Some(100);
+        measured.latency_ms = 2_000;
+        let mut unmeasured = task_result(1.0, true, false);
+        unmeasured.completion_tokens = None;
+        unmeasured.latency_ms = 5_000;
+
+        let tps = throughput_tps(&[measured, unmeasured]).unwrap();
+        assert!((tps - 50.0).abs() < 1e-9);
+        assert_eq!(throughput_tps(&[task_result(1.0, true, false)]), None);
     }
 
     #[test]

--- a/crates/gglib-axum/src/handlers/benchmark/agentic.rs
+++ b/crates/gglib-axum/src/handlers/benchmark/agentic.rs
@@ -1,0 +1,80 @@
+//! `POST /api/benchmark/agentic` — stream a raw-vs-gglib A/B agentic eval.
+//!
+//! Accepts an [`AgenticEvalConfig`] JSON body, spawns the eval in the
+//! background, and returns an SSE stream of [`BenchmarkEvent`]s ending in
+//! `agentic_eval_complete` with the full A/B report.
+//!
+//! Same [`BenchmarkTaskGuard`] `Drop`-cancels pattern and payload-limit
+//! considerations as `tune` — a custom `task_suite` can be large, so the
+//! route registration applies the same 5 MiB body limit.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::Json;
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures_core::Stream;
+use futures_util::StreamExt as _;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
+
+use gglib_app_services::benchmark::guard::BenchmarkTaskGuard;
+use gglib_core::domain::benchmark::{AgenticEvalConfig, BenchmarkEvent};
+
+use crate::error::HttpError;
+use crate::state::AppState;
+
+/// `POST /api/benchmark/agentic` — start an A/B eval and stream events.
+///
+/// # Request
+///
+/// ```json
+/// {
+///   "model_id": 1,
+///   "task_suite": { "source": "default" },
+///   "weights": { "tool_accuracy": 0.4, "loop_avoidance": 0.3, "task_completion": 0.2, "speed": 0.1 },
+///   "ctx_size": null
+/// }
+/// ```
+///
+/// # Response
+///
+/// `Content-Type: text/event-stream`. Frames carry [`BenchmarkEvent`]s
+/// (`agentic_arm_started`, `agentic_task_complete`,
+/// `agentic_eval_complete`, `run_failed`).
+pub async fn agentic_sse(
+    State(state): State<AppState>,
+    Json(config): Json<AgenticEvalConfig>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static>, HttpError> {
+    let cancel = CancellationToken::new();
+    let (tx, rx) = mpsc::channel::<BenchmarkEvent>(256);
+
+    let benchmark = state.benchmark.clone();
+    let cancel_task = cancel.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = benchmark.run_agentic(config, tx, cancel_task).await {
+            tracing::error!(error = %e, "benchmark/agentic: run failed");
+        }
+    });
+
+    let guard = BenchmarkTaskGuard::new(ReceiverStream::new(rx), cancel);
+
+    let sse_stream = guard.filter_map(|event| {
+        futures_util::future::ready(match serde_json::to_string(&event) {
+            Ok(json) => Some(Ok::<Event, Infallible>(Event::default().data(json))),
+            Err(e) => {
+                tracing::error!(error = %e, "benchmark/agentic: failed to serialise event");
+                None
+            }
+        })
+    });
+
+    Ok(Sse::new(sse_stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("ping"),
+    ))
+}

--- a/crates/gglib-axum/src/handlers/benchmark/mod.rs
+++ b/crates/gglib-axum/src/handlers/benchmark/mod.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("README.md")]
+pub mod agentic;
 pub mod compare;
 pub mod history;
 pub mod perf;

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -137,6 +137,13 @@ pub(crate) fn api_routes() -> Router<AppState> {
             "/benchmark/tune",
             post(handlers::benchmark::tune::tune_sse).layer(DefaultBodyLimit::max(5 * 1024 * 1024)),
         )
+        // Benchmark — raw-vs-gglib A/B agentic eval SSE stream. Same body
+        // limit as tune: a custom task_suite can embed long_context tasks.
+        .route(
+            "/benchmark/agentic",
+            post(handlers::benchmark::agentic::agentic_sse)
+                .layer(DefaultBodyLimit::max(5 * 1024 * 1024)),
+        )
         // Benchmark — run history
         .route(
             "/benchmark/runs",

--- a/crates/gglib-cli/src/benchmark_commands.rs
+++ b/crates/gglib-cli/src/benchmark_commands.rs
@@ -138,9 +138,11 @@ pub enum BenchmarkCommand {
         #[arg(long)]
         weight_task_completion: Option<f32>,
 
-        /// Composite-score weight for token-generation throughput
-        /// (currently a no-op — `tg_tps` is not yet measured per
-        /// candidate, see the tune service's module docs)
+        /// Composite-score weight for token-generation throughput.
+        /// `tg_tps` is measured and reported per candidate, but this weight
+        /// does not yet enter the composite (its definition is relative to
+        /// the fastest candidate, which is unknowable mid-stream — see the
+        /// tune service's module docs)
         #[arg(long)]
         weight_speed: Option<f32>,
 
@@ -154,5 +156,37 @@ pub enum BenchmarkCommand {
         /// applied automatically
         #[arg(long)]
         apply_best: bool,
+    },
+
+    /// Measure what the gglib pipeline buys: run the agentic task suite
+    /// twice against one model — once with the pipeline bypassed (bare
+    /// llama-server defaults) and once through it — and report the
+    /// before/after delta in tool-call accuracy, loop avoidance, and task
+    /// completion
+    #[command(display_order = 7)]
+    Agentic {
+        /// Model name or database ID to evaluate (exactly one)
+        #[arg(long = "model", short = 'm')]
+        model: String,
+
+        /// Task suite both arms run: `default` for the built-in BFCL-style
+        /// suite, or a path to a custom JSON task file (same schema as
+        /// `gglib benchmark tune --task-suite`)
+        #[arg(long = "task-suite", default_value = "default")]
+        task_suite: String,
+
+        /// Context size override (number of tokens)
+        #[arg(long)]
+        ctx_size: Option<u64>,
+
+        /// Print the full report as JSON to stdout (the leaderboard
+        /// interchange format: per-arm scores, deltas, per-task drill-down,
+        /// model/quant identity, hardware snapshot)
+        #[arg(long)]
+        json: bool,
+
+        /// Write the same JSON report to this file
+        #[arg(long, value_name = "FILE")]
+        output: Option<std::path::PathBuf>,
     },
 }

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -353,8 +353,11 @@ async fn cmd_agentic(
 
 /// Render the A/B table: one row per axis, columns raw / gglib / delta.
 fn render_agentic_report(report: &AgenticEvalReport) {
-    let fmt_tps =
-        |scores: &ArmScores| scores.tg_tps.map_or("     —".into(), |t| format!("{t:>6.1}"));
+    let fmt_tps = |scores: &ArmScores| {
+        scores
+            .tg_tps
+            .map_or("     —".into(), |t| format!("{t:>6.1}"))
+    };
 
     eprintln!();
     eprintln!(

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -13,8 +13,8 @@ use gglib_core::domain::benchmark::tune::config::{ScoreWeights, SweepSpec, TuneC
 use gglib_core::domain::benchmark::tune::result::TuneCandidateResult;
 use gglib_core::domain::benchmark::tune::task::{TaskSuite, TuneTask};
 use gglib_core::domain::benchmark::{
-    BenchmarkEvent, BenchmarkModelResult, CompareConfig, ModelCompareResult, ModelPerfResult,
-    PerfConfig,
+    AgenticEvalConfig, AgenticEvalReport, ArmScores, BenchmarkEvent, BenchmarkModelResult,
+    CompareConfig, ModelCompareResult, ModelPerfResult, PerfConfig,
 };
 
 use crate::benchmark_commands::BenchmarkCommand;
@@ -85,6 +85,14 @@ pub async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
             )
             .await
         }
+
+        BenchmarkCommand::Agentic {
+            model,
+            task_suite,
+            ctx_size,
+            json,
+            output,
+        } => cmd_agentic(ctx, model, task_suite, ctx_size, json, output).await,
 
         // Read-only commands: plain DB reads, no daemon involved.
         BenchmarkCommand::List { limit } => cmd_list(ctx, limit).await,
@@ -278,6 +286,153 @@ async fn cmd_tune(
     }
 
     Ok(())
+}
+
+/// Run the raw-vs-gglib A/B agentic eval on the daemon and render the delta.
+async fn cmd_agentic(
+    ctx: &CliContext,
+    model: String,
+    task_suite: String,
+    ctx_size: Option<u64>,
+    json: bool,
+    output: Option<std::path::PathBuf>,
+) -> Result<()> {
+    let model_id = resolve_model_ids(ctx, std::slice::from_ref(&model))
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("model not found: {model}"))?;
+
+    let config = AgenticEvalConfig {
+        model_id,
+        task_suite: load_task_suite(&task_suite)?,
+        weights: ScoreWeights::default(),
+        ctx_size,
+    };
+
+    style::print_info_banner("Agentic A/B Eval", "\u{2696}\u{fe0f}");
+    eprintln!("  Model : {model}");
+    eprintln!("  Suite : {task_suite}");
+    eprintln!("  Arms  : raw (pipeline bypassed) vs gglib (full pipeline)");
+    style::print_banner_close();
+
+    let mut report: Option<AgenticEvalReport> = None;
+    run_on_daemon("/api/benchmark/agentic", &config, |event| {
+        if let BenchmarkEvent::AgenticEvalComplete { report: r } = event {
+            report = Some(r.clone());
+        }
+        render_event(event);
+    })
+    .await?;
+
+    let report = report.ok_or_else(|| {
+        anyhow!("the eval ended without a report (run may have been aborted or failed)")
+    })?;
+
+    render_agentic_report(&report);
+
+    if json || output.is_some() {
+        let export = serde_json::json!({
+            "gglib_version": env!("CARGO_PKG_VERSION"),
+            "hardware": fetch_hardware_snapshot().await,
+            "report": report,
+        });
+        let pretty = serde_json::to_string_pretty(&export)?;
+        if let Some(path) = output {
+            std::fs::write(&path, &pretty)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("  report written to {}", path.display());
+        }
+        if json {
+            println!("{pretty}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Render the A/B table: one row per axis, columns raw / gglib / delta.
+fn render_agentic_report(report: &AgenticEvalReport) {
+    let fmt_tps =
+        |scores: &ArmScores| scores.tg_tps.map_or("     —".into(), |t| format!("{t:>6.1}"));
+
+    eprintln!();
+    eprintln!(
+        "  {BOLD}{model} ({params}B{quant}) @ {ctx} ctx{RESET}",
+        model = report.model_name,
+        params = report.param_count_b,
+        quant = report
+            .quantization
+            .as_deref()
+            .map_or(String::new(), |q| format!(", {q}")),
+        ctx = report.ctx_size,
+        BOLD = style::BOLD,
+        RESET = style::RESET,
+    );
+    eprintln!();
+    eprintln!("  axis              raw    gglib   delta");
+    eprintln!("  ─────────────── ────── ────── ───────");
+    for (name, raw, gglib, delta) in [
+        (
+            "tool accuracy  ",
+            report.raw.tool_accuracy,
+            report.gglib.tool_accuracy,
+            report.delta.tool_accuracy,
+        ),
+        (
+            "loop avoidance ",
+            report.raw.loop_avoidance,
+            report.gglib.loop_avoidance,
+            report.delta.loop_avoidance,
+        ),
+        (
+            "task completion",
+            report.raw.task_completion,
+            report.gglib.task_completion,
+            report.delta.task_completion,
+        ),
+        (
+            "composite      ",
+            report.raw.composite,
+            report.gglib.composite,
+            report.delta.composite,
+        ),
+    ] {
+        let colour = if delta > 0.0 {
+            style::SUCCESS
+        } else if delta < 0.0 {
+            style::DANGER
+        } else {
+            ""
+        };
+        eprintln!(
+            "  {name} {raw:>6.3} {gglib:>6.3} {colour}{delta:>+7.3}{RESET}",
+            RESET = style::RESET
+        );
+    }
+    eprintln!(
+        "  throughput tok/s {} {}",
+        fmt_tps(&report.raw),
+        fmt_tps(&report.gglib)
+    );
+    eprintln!();
+}
+
+/// Best-effort hardware snapshot for the JSON export, from the daemon's
+/// setup-status endpoint. `null` when unavailable — the report is still
+/// valid, just unpinned to a machine.
+async fn fetch_hardware_snapshot() -> serde_json::Value {
+    let url = format!(
+        "{}/api/config/system/setup-status",
+        daemon_client::base_url()
+    );
+    match reqwest::Client::new().get(&url).send().await {
+        Ok(resp) => resp
+            .json::<serde_json::Value>()
+            .await
+            .unwrap_or(serde_json::Value::Null),
+        Err(_) => serde_json::Value::Null,
+    }
 }
 
 /// Parse `--sweep DIM=V1,V2,...` arguments into a [`SweepSpec`].
@@ -608,6 +763,24 @@ fn render_event(event: &BenchmarkEvent) {
         BenchmarkEvent::TuneCandidateComplete { result } => {
             eprintln!("  composite score: {:.3}", result.composite_score);
         }
+
+        BenchmarkEvent::AgenticArmStarted { arm, total_tasks } => {
+            eprintln!(
+                "\n{BOLD}[{arm} arm]{RESET} {total_tasks} tasks",
+                BOLD = style::BOLD,
+                RESET = style::RESET
+            );
+        }
+
+        BenchmarkEvent::AgenticTaskComplete {
+            task_id, passed, ..
+        } => {
+            let mark = if *passed { "✓" } else { "✗" };
+            eprintln!("  {mark} {task_id}");
+        }
+
+        // Rendered by cmd_agentic as the final A/B table.
+        BenchmarkEvent::AgenticEvalComplete { .. } => {}
     }
 }
 

--- a/crates/gglib-core/src/domain/benchmark/agentic.rs
+++ b/crates/gglib-core/src/domain/benchmark/agentic.rs
@@ -1,0 +1,171 @@
+//! Raw-vs-gglib A/B agentic evaluation: config and report types.
+//!
+//! The eval answers one question with numbers: *what does routing a small
+//! model through the gglib pipeline actually buy in agentic behaviour?* It
+//! runs the same task suite the tune sweep uses — real `AgentLoop`, scripted
+//! BFCL-style tasks — twice against the same loaded model:
+//!
+//! - **raw**: the request pipeline bypassed entirely. No sampling
+//!   resolution (the server's own defaults apply), no capability shaping,
+//!   no dialect normalization, no grammar — what a client pointed straight
+//!   at llama-server experiences.
+//! - **gglib**: the full pipeline, exactly as the proxy runs it — per-model
+//!   sampling defaults, capability-aware shaping, dialect parsing, and
+//!   decode-time grammar enforcement where a task demands a tool call.
+//!
+//! The per-axis deltas in the [`AgenticEvalReport`] are the product: the
+//! measured difference in tool-call accuracy, loop avoidance, and task
+//! completion, on this model, on this machine.
+
+use serde::{Deserialize, Serialize};
+
+use super::tune::config::ScoreWeights;
+use super::tune::result::TuneTaskResult;
+use super::tune::task::{TaskCategory, TaskSuite};
+
+/// Configuration for one A/B agentic eval run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgenticEvalConfig {
+    /// Database ID of the model to evaluate.
+    pub model_id: i64,
+    /// Task suite both arms run — the same schema the tune sweep uses.
+    pub task_suite: TaskSuite,
+    /// Weights for each arm's composite score.
+    #[serde(default)]
+    pub weights: ScoreWeights,
+    /// Context size override (tokens). `None` resolves through the normal
+    /// chain (model server defaults → global setting → hardcoded default).
+    #[serde(default)]
+    pub ctx_size: Option<u64>,
+}
+
+/// Which arm a task ran under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalArm {
+    /// Pipeline bypassed — bare llama-server behaviour.
+    Raw,
+    /// The full gglib request/response pipeline.
+    Gglib,
+}
+
+impl std::fmt::Display for EvalArm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Raw => write!(f, "raw"),
+            Self::Gglib => write!(f, "gglib"),
+        }
+    }
+}
+
+/// One arm's aggregate scores across the task suite.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArmScores {
+    /// Mean AST-style tool-call match score, `0.0`–`1.0`.
+    pub tool_accuracy: f64,
+    /// Fraction of tasks that triggered neither loop nor stagnation guards.
+    pub loop_avoidance: f64,
+    /// Fraction of tasks passed outright.
+    pub task_completion: f64,
+    /// Weighted composite of the three axes above.
+    pub composite: f64,
+    /// Completion-token throughput (tokens per wall-clock second, pre-fill
+    /// included). `None` when the upstream reported no usage.
+    pub tg_tps: Option<f64>,
+}
+
+/// Per-axis difference, `gglib − raw`. Positive means gglib scored higher.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArmDelta {
+    /// Tool-accuracy difference.
+    pub tool_accuracy: f64,
+    /// Loop-avoidance difference.
+    pub loop_avoidance: f64,
+    /// Task-completion difference.
+    pub task_completion: f64,
+    /// Composite-score difference.
+    pub composite: f64,
+}
+
+/// One task's outcome under both arms, for drill-down.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgenticTaskComparison {
+    /// Task identifier from the suite.
+    pub task_id: String,
+    /// The task's BFCL-style category.
+    pub category: TaskCategory,
+    /// Result under the raw arm.
+    pub raw: TuneTaskResult,
+    /// Result under the gglib arm.
+    pub gglib: TuneTaskResult,
+}
+
+/// The complete A/B report — the leaderboard interchange format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgenticEvalReport {
+    /// Model name as stored in the catalog.
+    pub model_name: String,
+    /// Quantization label (e.g. `Q4_K_M`), when known.
+    pub quantization: Option<String>,
+    /// Parameter count in billions.
+    pub param_count_b: f64,
+    /// Context size both arms ran at, in tokens.
+    pub ctx_size: u64,
+    /// Aggregate scores under the raw arm.
+    pub raw: ArmScores,
+    /// Aggregate scores under the gglib arm.
+    pub gglib: ArmScores,
+    /// Per-axis `gglib − raw` differences.
+    pub delta: ArmDelta,
+    /// Per-task drill-down, one entry per suite task.
+    pub tasks: Vec<AgenticTaskComparison>,
+}
+
+impl AgenticEvalReport {
+    /// Compute the per-axis delta from the two arms' scores.
+    #[must_use]
+    pub fn delta_of(raw: &ArmScores, gglib: &ArmScores) -> ArmDelta {
+        ArmDelta {
+            tool_accuracy: gglib.tool_accuracy - raw.tool_accuracy,
+            loop_avoidance: gglib.loop_avoidance - raw.loop_avoidance,
+            task_completion: gglib.task_completion - raw.task_completion,
+            composite: gglib.composite - raw.composite,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delta_is_gglib_minus_raw() {
+        let raw = ArmScores {
+            tool_accuracy: 0.5,
+            loop_avoidance: 0.75,
+            task_completion: 0.25,
+            composite: 0.5,
+            tg_tps: Some(30.0),
+        };
+        let gglib = ArmScores {
+            tool_accuracy: 0.9,
+            loop_avoidance: 1.0,
+            task_completion: 0.75,
+            composite: 0.9,
+            tg_tps: Some(28.0),
+        };
+        let delta = AgenticEvalReport::delta_of(&raw, &gglib);
+        assert!((delta.tool_accuracy - 0.4).abs() < 1e-9);
+        assert!((delta.loop_avoidance - 0.25).abs() < 1e-9);
+        assert!((delta.task_completion - 0.5).abs() < 1e-9);
+        assert!((delta.composite - 0.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn config_round_trips_with_defaults() {
+        let json = r#"{"model_id": 3, "task_suite": {"source": "default"}}"#;
+        let config: AgenticEvalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.model_id, 3);
+        assert!(config.ctx_size.is_none());
+    }
+}

--- a/crates/gglib-core/src/domain/benchmark/events.rs
+++ b/crates/gglib-core/src/domain/benchmark/events.rs
@@ -58,6 +58,22 @@ pub enum BenchmarkEvent {
     },
     /// A tune candidate finished evaluating (pre-screen or full suite).
     TuneCandidateComplete { result: TuneCandidateResult },
+
+    /// An agentic-eval arm is about to run its task set.
+    AgenticArmStarted {
+        arm: crate::domain::benchmark::agentic::EvalArm,
+        total_tasks: usize,
+    },
+    /// One task finished under one agentic-eval arm.
+    AgenticTaskComplete {
+        arm: crate::domain::benchmark::agentic::EvalArm,
+        task_id: String,
+        passed: bool,
+    },
+    /// The agentic eval finished; the full A/B report.
+    AgenticEvalComplete {
+        report: crate::domain::benchmark::agentic::AgenticEvalReport,
+    },
 }
 
 /// Wraps either a compare or perf result for `BenchmarkEvent::ModelComplete`.

--- a/crates/gglib-core/src/domain/benchmark/mod.rs
+++ b/crates/gglib-core/src/domain/benchmark/mod.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("README.md")]
 
+pub mod agentic;
 pub mod compare;
 pub mod events;
 pub mod perf;
@@ -7,6 +8,9 @@ pub mod run;
 pub mod summary;
 pub mod tune;
 
+pub use agentic::{
+    AgenticEvalConfig, AgenticEvalReport, AgenticTaskComparison, ArmDelta, ArmScores, EvalArm,
+};
 pub use compare::{CompareConfig, ModelCompareResult};
 pub use events::{BenchmarkEvent, BenchmarkModelResult};
 pub use perf::{ModelPerfResult, PerfConfig};

--- a/crates/gglib-core/src/domain/benchmark/tune/result.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/result.rs
@@ -82,6 +82,11 @@ pub struct TuneTaskResult {
     pub iterations: usize,
     /// Wall-clock time spent on this task, in milliseconds.
     pub latency_ms: u64,
+    /// Completion tokens generated across the task's agent run, from the
+    /// upstream's usage reports. `None` when the run errored before any
+    /// response completed or the upstream reported no usage.
+    #[serde(default)]
+    pub completion_tokens: Option<u64>,
     /// Optional human-readable detail (e.g. which expected call was missed),
     /// surfaced in the leaderboard drill-down.
     #[serde(default)]
@@ -104,8 +109,11 @@ pub struct TuneCandidateResult {
     /// never ran the full suite (`task_results` only covers the pre-screen
     /// tasks in that case).
     pub pruned: bool,
-    /// Token-generation throughput observed for this candidate, if
-    /// measured (used to normalize the `speed` scoring component).
+    /// Completion-token throughput observed for this candidate, in tokens
+    /// per wall-clock second across its evaluated tasks (total completion
+    /// tokens ÷ total task wall time, which includes prompt pre-fill — a
+    /// consistent within-run comparison figure, not a pure decode rate).
+    /// `None` when no task reported usage.
     #[serde(default)]
     pub tg_tps: Option<f64>,
 }

--- a/crates/gglib-core/src/ports/agent.rs
+++ b/crates/gglib-core/src/ports/agent.rs
@@ -127,6 +127,13 @@ pub struct AgentRunOutput {
     /// Number of loop iterations consumed before the agent produced its final
     /// answer.  Always ≥ 1.  Useful for logging and telemetry.
     pub total_iterations: usize,
+    /// Total completion tokens generated across every iteration, summed from
+    /// each response's trailing usage report.
+    ///
+    /// `None` when no upstream response reported usage — distinct from zero,
+    /// which would be a real (if strange) measurement. Feeds the benchmark
+    /// speed axis (completion tokens over wall-clock time).
+    pub total_completion_tokens: Option<u64>,
 }
 
 // =============================================================================

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/body.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/body.rs
@@ -120,6 +120,10 @@ pub(super) fn build_chat_body(
         "messages": openai_messages,
         "stream": true,
         "return_progress": true,
+        // Ask for the trailing usage chunk (the proxy path injects the same
+        // override) so completion-token counts reach the stream collector —
+        // the input to the benchmark speed axis.
+        "stream_options": { "include_usage": true },
     });
     if !openai_tools.is_empty() {
         body["tools"] = json!(openai_tools);

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -88,6 +88,20 @@ pub struct LlmCompletionAdapter {
     /// the case for CLI `gglib chat`/`q`, which render the loop's events
     /// directly.
     retry_observer: Option<Arc<dyn RetryObserver>>,
+    /// Skip the request-shaping pipeline entirely and send the bare body.
+    ///
+    /// The control arm of an A/B evaluation: no sampling resolution (the
+    /// upstream's own defaults apply), no capability shaping, no truncation,
+    /// no grammar. Off everywhere else — this exists so "bare llama-server"
+    /// is measurable against "through the gglib pipeline" on identical
+    /// requests, not as a general escape hatch.
+    raw_passthrough: bool,
+    /// Optional `tool_choice` written into the request body.
+    ///
+    /// The agent path has no client to send one; benchmark harnesses set
+    /// `"required"` on tasks whose expected outcome demands a call, so the
+    /// request carries the same demand an agentic client would express.
+    tool_choice: Option<String>,
 }
 
 /// Build the completions endpoint URL from a base URL.
@@ -140,6 +154,8 @@ impl LlmCompletionAdapter {
             cache_metrics: None,
             retry_policy: RetryPolicy::from_env(),
             retry_observer: None,
+            raw_passthrough: false,
+            tool_choice: None,
         }
     }
 
@@ -214,6 +230,26 @@ impl LlmCompletionAdapter {
         self
     }
 
+    /// Bypass the request-shaping pipeline and send the bare body.
+    ///
+    /// The A/B evaluation's control arm — see the field docs on
+    /// [`Self`]. Leave off (the default) for every production path.
+    #[must_use]
+    pub fn with_raw_passthrough(mut self, raw: bool) -> Self {
+        self.raw_passthrough = raw;
+        self
+    }
+
+    /// Write a `tool_choice` value into each request body.
+    ///
+    /// Set before the pipeline runs, so the shaping stages (including the
+    /// dialect grammar stage) read it exactly as they would a client's.
+    #[must_use]
+    pub fn with_tool_choice(mut self, tool_choice: Option<String>) -> Self {
+        self.tool_choice = tool_choice;
+        self
+    }
+
     /// Build the request body and run the shared request-shaping pipeline over
     /// it — everything that happens before the bytes leave this process.
     ///
@@ -232,6 +268,18 @@ impl LlmCompletionAdapter {
         tools: &[ToolDefinition],
     ) -> Result<serde_json::Value> {
         let mut body = body::build_chat_body(&self.model, messages, tools, self.sampling.as_ref());
+
+        // Written before the pipeline runs so the shaping stages read it
+        // exactly as they would an external client's tool_choice.
+        if let Some(tool_choice) = &self.tool_choice {
+            body["tool_choice"] = serde_json::Value::String(tool_choice.clone());
+        }
+
+        // Control arm of an A/B evaluation: the bare body, upstream defaults,
+        // no shaping. See the `raw_passthrough` field docs.
+        if self.raw_passthrough {
+            return Ok(body);
+        }
 
         // The same pipeline, in the same order, that the proxy runs.
         // `build_chat_body` has already written the caller's sampling

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs
@@ -287,3 +287,36 @@ fn transport_fields_survive_the_pipeline() {
     assert_eq!(body["stream"], true);
     assert_eq!(body["return_progress"], true);
 }
+
+// ── A/B eval arms ─────────────────────────────────────────────────────────
+
+/// The eval's control arm: no pipeline at all. No sampling keys resolve in
+/// (the upstream's own defaults apply) and `cache_prompt` is never pinned.
+#[test]
+fn raw_passthrough_skips_the_pipeline_entirely() {
+    let adapter = LlmCompletionAdapter::new("http://127.0.0.1:0", Some("m".to_owned()))
+        .with_raw_passthrough(true);
+    let body = body_of(&adapter, &[user("hi")]);
+
+    assert!(body.get("temperature").is_none(), "no sampling floor");
+    assert!(body.get("cache_prompt").is_none(), "no pinning");
+    assert_eq!(body["stream"], true, "transport fields still present");
+}
+
+/// A caller-set tool_choice lands in the body where the pipeline (and the
+/// upstream) read it, overriding build_chat_body's `auto` default.
+#[test]
+fn tool_choice_is_written_into_the_body() {
+    let tools = vec![gglib_core::domain::agent::ToolDefinition {
+        name: "f".to_owned(),
+        description: None,
+        input_schema: Some(json!({"type": "object"})),
+        title: None,
+    }];
+    let adapter = LlmCompletionAdapter::new("http://127.0.0.1:0", Some("m".to_owned()))
+        .with_raw_passthrough(true)
+        .with_tool_choice(Some("required".to_owned()));
+    let body = adapter.shaped_body(&[user("hi")], &tools).unwrap();
+
+    assert_eq!(body["tool_choice"], "required");
+}

--- a/src/types/benchmark.ts
+++ b/src/types/benchmark.ts
@@ -225,6 +225,7 @@ export interface TuneTaskResult {
   stagnation_detected: boolean;
   iterations: number;
   latency_ms: number;
+  completion_tokens?: number | null;
   detail?: string | null;
 }
 
@@ -263,7 +264,52 @@ export type BenchmarkEvent =
   | { type: 'tune_candidate_started'; candidate_index: number; total: number }
   | { type: 'tune_task_complete'; candidate_index: number; task_id: string; passed: boolean }
   | { type: 'tune_pruned'; candidate_index: number; reason: string }
-  | { type: 'tune_candidate_complete'; result: TuneCandidateResult };
+  | { type: 'tune_candidate_complete'; result: TuneCandidateResult }
+  | { type: 'agentic_arm_started'; arm: EvalArm; total_tasks: number }
+  | { type: 'agentic_task_complete'; arm: EvalArm; task_id: string; passed: boolean }
+  | { type: 'agentic_eval_complete'; report: AgenticEvalReport };
+
+// ─── Agentic A/B Eval (raw vs gglib) ─────────────────────────────────────────
+
+/** Which arm of the A/B eval a task ran under. */
+export type EvalArm = 'raw' | 'gglib';
+
+/** One arm's aggregate scores. Mirrors `gglib_core::domain::benchmark::agentic::ArmScores`. */
+export interface ArmScores {
+  tool_accuracy: number;
+  loop_avoidance: number;
+  task_completion: number;
+  composite: number;
+  tg_tps?: number | null;
+}
+
+/** Per-axis `gglib − raw` difference. */
+export interface ArmDelta {
+  tool_accuracy: number;
+  loop_avoidance: number;
+  task_completion: number;
+  composite: number;
+}
+
+/** One task's outcome under both arms. */
+export interface AgenticTaskComparison {
+  task_id: string;
+  category: TaskCategory;
+  raw: TuneTaskResult;
+  gglib: TuneTaskResult;
+}
+
+/** The complete raw-vs-gglib report. Mirrors `AgenticEvalReport`. */
+export interface AgenticEvalReport {
+  model_name: string;
+  quantization?: string | null;
+  param_count_b: number;
+  ctx_size: number;
+  raw: ArmScores;
+  gglib: ArmScores;
+  delta: ArmDelta;
+  tasks: AgenticTaskComparison[];
+}
 
 // ─── API Response Shapes ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Stacked on #716 — and built to prove it. `gglib benchmark agentic -m <model>` answers the series' central question with numbers: **what does routing a small model through the gglib pipeline actually buy in agentic behaviour?**

## What it does

Runs the tune sweep's BFCL-style task suite (real `AgentLoop`, scripted single-call / parallel / multi-turn / irrelevance / long-context tasks) **twice against the same loaded model**:

- **raw arm** — request pipeline bypassed entirely: no sampling resolution (llama-server's own defaults), no capability shaping, no dialect normalization, no grammar. What a client pointed straight at llama-server experiences.
- **gglib arm** — the full pipeline exactly as the proxy runs it: per-model sampling defaults, capability-aware shaping, dialect parsing, and #716's decode-time grammar enforcement where a task demands a call.

One admission lease covers both arms (same principle as tune: an arm measured across a model swap is measuring the swap). Tasks whose expected outcome demands a tool call send `tool_choice: "required"` in **both** arms — identical requests, different machinery — which is what lets the grammar stage engage in the gglib arm while the raw arm shows the same demand without it. Irrelevance tasks send no `tool_choice`, so abstention is tested fairly.

Output: a per-axis table (tool accuracy, loop avoidance, task completion, composite, throughput) with the `gglib − raw` delta, plus `--json` / `--output <file>` exporting the leaderboard interchange format — per-arm scores, deltas, per-task drill-down, model/quant identity, gglib version, and a best-effort hardware snapshot from the daemon.

## Plumbing (shared with tune)

- **`tg_tps` is finally live.** The stream collector no longer returns at `Done` — it drains the trailing OpenAI usage chunk (which legitimately arrives *after* `Done`), so completion-token counts flow `CollectedResponse` → `AgentRunOutput` → `TuneTaskResult.completion_tokens` → `TuneCandidateResult.tg_tps` (total tokens over total wall time, pre-fill included, documented as a within-run comparison figure). The agent path now requests `stream_options.include_usage` as the proxy path always has. The speed *weight* still stays out of the tune composite — its definition is relative-to-fastest-in-run, unknowable while candidates stream — and both doc comments now say exactly that.
- The task-execution core is extracted (`run_task_with_llm`) and shared between tune and the eval; per-axis scoring (`axis_scores`) likewise.
- `LlmCompletionAdapter` gains `with_raw_passthrough` (the control arm, documented as eval-only) and `with_tool_choice`.
- Runs on the daemon like every mutating benchmark: `POST /api/benchmark/agentic` (SSE, 5 MiB body limit for custom suites), new `BenchmarkEvent` variants (`agentic_arm_started` / `agentic_task_complete` / `agentic_eval_complete`) mirrored in the frontend types.

No DB schema changes — the report is delivered over the stream and exported; run-history persistence can follow if wanted.

## Tests

New units: trailing-usage throughput math (unmeasured tasks can't dilute the figure), delta computation, config defaults round-trip, `tool_choice`-follows-expected-outcome, adapter raw-passthrough (no sampling floor, no `cache_prompt` pinning) and `tool_choice` body wiring. Full workspace tests, clippy (0 warnings), tsc, and vitest are green.

## How to produce the headline number (real hardware)

```bash
gglib benchmark agentic -m qwen2.5-coder-7b --json --output eval.json
```

The `delta.tool_accuracy` on a `format:qwen-xml` model is the before/after for #716; `delta.loop_avoidance` and `delta.task_completion` capture the rest of the pipeline's contribution.