### PR TITLE
fix(runtime): AdmissionQueue re-entrant deadlock, plus wedge hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,6 +2241,7 @@ version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "futures-util",
  "gglib-core",

--- a/crates/gglib-axum/src/daemon/mod.rs
+++ b/crates/gglib-axum/src/daemon/mod.rs
@@ -2,6 +2,7 @@
 
 mod lock;
 mod shutdown;
+mod watchdog;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -150,6 +151,14 @@ pub async fn run_daemon(opts: DaemonOptions) -> Result<()> {
             )
         })?;
     info!("gglib daemon listening on http://{addr}");
+
+    // From here the daemon can wedge in the worst way — listening but not
+    // serving — so from here it watches itself. See the module docs for why
+    // this must be a plain thread probing over TCP.
+    match listener.local_addr() {
+        Ok(bound) => watchdog::spawn(bound),
+        Err(e) => warn!("no local addr for the liveness watchdog: {e}"),
+    }
 
     // 5. The proxy belongs to the daemon now: honour autostart here, not in
     //    the desktop app.

--- a/crates/gglib-axum/src/daemon/shutdown.rs
+++ b/crates/gglib-axum/src/daemon/shutdown.rs
@@ -58,13 +58,28 @@ pub async fn shutdown_signal() {
 /// still runs, because each protects a different resource (proxy clients,
 /// llama-server children, download partials, pidfiles).
 pub async fn perform_shutdown(state: &AppState) {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     info!("daemon shutting down");
 
     // If teardown wedges — typically a llama-server stuck in an
     // uninterruptible CUDA ioctl — exit anyway. Children the watchdog
     // abandons are caught by the next daemon start's orphan sweep.
-    let watchdog = tokio::spawn(async {
-        tokio::time::sleep(SHUTDOWN_WATCHDOG).await;
+    //
+    // An OS thread, not a tokio task, and non-negotiably so: the wedge being
+    // guarded against can be the runtime itself (every worker blocked, as in
+    // the #721 admission deadlock), and a watchdog that needs a free worker
+    // to fire is starved by exactly the condition it exists to escape. The
+    // thread cannot be aborted, so completion is signalled through a flag it
+    // checks on waking; a disarmed watchdog simply returns.
+    let completed = Arc::new(AtomicBool::new(false));
+    let disarm = Arc::clone(&completed);
+    std::thread::spawn(move || {
+        std::thread::sleep(SHUTDOWN_WATCHDOG);
+        if disarm.load(Ordering::Acquire) {
+            return;
+        }
         warn!("shutdown watchdog fired — forcing exit");
         std::process::exit(1);
     });
@@ -90,6 +105,6 @@ pub async fn perform_shutdown(state: &AppState) {
         warn!("final orphan audit failed: {e}");
     }
 
-    watchdog.abort();
+    completed.store(true, Ordering::Release);
     info!("daemon shutdown complete");
 }

--- a/crates/gglib-axum/src/daemon/watchdog.rs
+++ b/crates/gglib-axum/src/daemon/watchdog.rs
@@ -1,0 +1,248 @@
+//! Liveness watchdog: a thread that exits a daemon that has stopped answering.
+//!
+//! The failure this guards against is the worst one the daemon has: wedged but
+//! still listening. A deadlocked runtime (issue #721) keeps its LISTEN sockets
+//! — TCP connects succeed, so nothing looks dead from outside — while no
+//! request is ever serviced. That state blocks graceful `daemon stop` (the
+//! stop endpoint is HTTP), blocks a replacement daemon (the port is held), and
+//! defeats `ensure_daemon` (a connect is its health signal). The only way out
+//! was a manual `kill -9`.
+//!
+//! The watchdog turns that terminal state into a restart: it probes the
+//! daemon's own `/health` from outside the runtime, and after
+//! [`FAILURE_THRESHOLD`] consecutive failures it exits the process. Exiting
+//! frees the ports and the lock, so the next CLI call's `ensure_daemon` starts
+//! a fresh daemon; llama-server children left behind are caught by that
+//! start's orphan sweep.
+//!
+//! Everything here is deliberately runtime-free: a plain OS thread, a blocking
+//! `TcpStream`, a hand-written HTTP/1.1 request. The condition being detected
+//! is "the async runtime no longer runs anything", so no part of the detector
+//! may depend on the runtime — a tokio task or a reqwest client would be
+//! starved by exactly the wedge it exists to notice.
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::time::Duration;
+
+use tracing::{error, info, warn};
+
+/// How long the daemon must sit between probes.
+///
+/// Long enough that the watchdog is invisible in the logs and the load, short
+/// enough that a wedged daemon self-clears in under a minute.
+const PROBE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Budget for one probe: connect, write, and read the status line.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Consecutive failed probes before the daemon is declared wedged.
+///
+/// Three, so one slow moment — a paging storm while a model loads, a laptop
+/// waking from sleep mid-probe — never kills a healthy daemon. Tripping
+/// requires ~45s of continuous unresponsiveness, and a healthy daemon answers
+/// `/health` in microseconds no matter how busy the models are.
+const FAILURE_THRESHOLD: u32 = 3;
+
+/// Exit code for a self-detected wedge: `EX_SOFTWARE`, and distinct from the
+/// shutdown watchdog's `1`, so `daemon.log` and a supervisor can tell "hung
+/// and gave up" from "teardown overran".
+const WEDGED_EXIT_CODE: i32 = 70;
+
+/// Start the watchdog thread for a daemon bound to `bound`.
+///
+/// `GGLIB_DAEMON_WATCHDOG=off` disables it, for debugging sessions where a
+/// stopped-in-a-debugger daemon must not be shot for failing probes.
+pub(super) fn spawn(bound: SocketAddr) {
+    if std::env::var("GGLIB_DAEMON_WATCHDOG").is_ok_and(|v| v.eq_ignore_ascii_case("off")) {
+        info!("liveness watchdog disabled by GGLIB_DAEMON_WATCHDOG=off");
+        return;
+    }
+
+    let target = probe_target(bound);
+    let spawned = std::thread::Builder::new()
+        .name("gglib-liveness".into())
+        .spawn(move || watch(target));
+    if let Err(e) = spawned {
+        // Degraded but not fatal: the daemon merely loses self-defence.
+        warn!("could not start the liveness watchdog thread: {e}");
+    }
+}
+
+/// The address a probe should dial.
+///
+/// A daemon bound to the unspecified address (`0.0.0.0`) is reachable on
+/// loopback but not *at* `0.0.0.0`; any other bind — loopback or a LAN IP —
+/// is dialled exactly where it listens.
+fn probe_target(bound: SocketAddr) -> SocketAddr {
+    if bound.ip().is_unspecified() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), bound.port())
+    } else {
+        bound
+    }
+}
+
+/// Probe forever; exit the process when the failure streak crosses the line.
+fn watch(target: SocketAddr) -> ! {
+    let mut streak = FailureStreak::new(FAILURE_THRESHOLD);
+    loop {
+        std::thread::sleep(PROBE_INTERVAL);
+        let healthy = probe(target, PROBE_TIMEOUT);
+        if healthy {
+            streak.record_success();
+            continue;
+        }
+        warn!(
+            failures = streak.failures + 1,
+            threshold = FAILURE_THRESHOLD,
+            "daemon liveness probe got no answer from /health"
+        );
+        if streak.record_failure() {
+            error!(
+                "daemon unresponsive for {FAILURE_THRESHOLD} consecutive probes — exiting \
+                 (code {WEDGED_EXIT_CODE}) so the ports free and the next gglib command can \
+                 start a fresh daemon; llama-server children are caught by its orphan sweep"
+            );
+            std::process::exit(WEDGED_EXIT_CODE);
+        }
+    }
+}
+
+/// Consecutive-failure accounting, separated so the tripwire is testable
+/// without a clock or a socket.
+struct FailureStreak {
+    failures: u32,
+    threshold: u32,
+}
+
+impl FailureStreak {
+    const fn new(threshold: u32) -> Self {
+        Self {
+            failures: 0,
+            threshold,
+        }
+    }
+
+    fn record_success(&mut self) {
+        self.failures = 0;
+    }
+
+    /// Record one failed probe; `true` means the threshold is reached.
+    fn record_failure(&mut self) -> bool {
+        self.failures += 1;
+        self.failures >= self.threshold
+    }
+}
+
+/// One round trip: `GET /health`, expect a 200 status line within `timeout`.
+///
+/// A refused connect counts as a failure just like a hung read: a daemon whose
+/// listener is gone but whose process survives is the zombie variant of the
+/// same wedge. Anything that answers 200 is alive — the body is not read.
+fn probe(target: SocketAddr, timeout: Duration) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(&target, timeout) else {
+        return false;
+    };
+    if stream.set_read_timeout(Some(timeout)).is_err()
+        || stream.set_write_timeout(Some(timeout)).is_err()
+    {
+        return false;
+    }
+
+    // `Host` must name where we dialled or the daemon's Host guard rejects the
+    // probe — loopback is always allowed, and a LAN bind allows its own IP.
+    let request = format!("GET /health HTTP/1.1\r\nHost: {target}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+
+    read_status_line_is_200(&mut stream)
+}
+
+/// Read just enough of the response to judge the status line.
+fn read_status_line_is_200(stream: &mut impl Read) -> bool {
+    const EXPECTED: &[u8] = b"HTTP/1.1 200";
+    let mut buf = [0u8; EXPECTED.len()];
+    let mut filled = 0;
+    while filled < buf.len() {
+        match stream.read(&mut buf[filled..]) {
+            Ok(0) | Err(_) => return false,
+            Ok(n) => filled += n,
+        }
+    }
+    buf == EXPECTED
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    /// A scratch server that answers one connection with `response`.
+    fn one_shot_server(response: &'static [u8]) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral port");
+        let addr = listener.local_addr().expect("bound addr");
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut discard = [0u8; 512];
+                let _ = stream.read(&mut discard);
+                let _ = stream.write_all(response);
+            }
+        });
+        addr
+    }
+
+    #[test]
+    fn a_healthy_daemon_passes_the_probe() {
+        let addr = one_shot_server(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok");
+        assert!(probe(addr, Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn a_non_200_answer_fails_the_probe() {
+        let addr = one_shot_server(b"HTTP/1.1 403 Forbidden\r\n\r\n");
+        assert!(!probe(addr, Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn a_dead_port_fails_the_probe() {
+        // Bind-then-drop yields a port that is closed at probe time.
+        let addr = TcpListener::bind("127.0.0.1:0")
+            .expect("ephemeral port")
+            .local_addr()
+            .expect("bound addr");
+        assert!(!probe(addr, Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn a_wedged_daemon_accepts_but_never_answers_and_fails_the_probe() {
+        // The #721 signature: the listener accepts, nothing ever responds.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral port");
+        let addr = listener.local_addr().expect("bound addr");
+        std::thread::spawn(move || {
+            let held = listener.accept();
+            std::thread::sleep(Duration::from_secs(2));
+            drop(held);
+        });
+        assert!(!probe(addr, Duration::from_millis(300)));
+    }
+
+    #[test]
+    fn the_streak_trips_only_on_consecutive_failures() {
+        let mut streak = FailureStreak::new(3);
+        assert!(!streak.record_failure());
+        assert!(!streak.record_failure());
+        streak.record_success(); // a good probe resets the count
+        assert!(!streak.record_failure());
+        assert!(!streak.record_failure());
+        assert!(streak.record_failure(), "third consecutive failure trips");
+    }
+
+    #[test]
+    fn an_unspecified_bind_is_probed_on_loopback() {
+        let target = probe_target("0.0.0.0:9887".parse().expect("addr"));
+        assert_eq!(target, "127.0.0.1:9887".parse().expect("addr"));
+        let lan = probe_target("192.168.1.5:9887".parse().expect("addr"));
+        assert_eq!(lan, "192.168.1.5:9887".parse().expect("addr"));
+    }
+}

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -398,9 +398,14 @@ pub fn create_spa_router<P: AsRef<Path>>(
 
 /// Health check endpoint.
 ///
-/// Returns `{"service":"gglib-daemon","status":"ok"}` so the CLI daemon
-/// detection logic (Phase 3b) can confirm it is talking to a live gglib
-/// daemon rather than an unrelated HTTP server on the same port.
+/// Returns `{"service":"gglib-daemon","status":"ok","version":...}` so the
+/// CLI daemon detection logic (Phase 3b) can confirm it is talking to a live
+/// gglib daemon rather than an unrelated HTTP server on the same port. The
+/// version lets clients detect a daemon left running from an older install.
 pub(crate) async fn health_check() -> Json<Value> {
-    Json(json!({ "service": "gglib-daemon", "status": "ok" }))
+    Json(json!({
+        "service": "gglib-daemon",
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
 }

--- a/crates/gglib-cli/src/handlers/model/download/remote.rs
+++ b/crates/gglib-cli/src/handlers/model/download/remote.rs
@@ -12,13 +12,15 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
-use gglib_core::download::{DownloadStatus, QueueSnapshot};
+use gglib_core::download::{DownloadStatus, QueueSnapshot, QueuedDownload};
+use gglib_download::{rate_suffix, total_bytes_key};
 
 use crate::daemon_client::DaemonHandle;
 
-/// Poll interval for queue snapshots. Half a second keeps the bars lively
-/// without hammering the loopback API.
-const POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Poll interval for queue snapshots. Matches the daemon's own progress
+/// sampling tick (250ms), so the bars are at most one tick behind without
+/// hammering the loopback API.
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Queue a download on the daemon.
 pub async fn queue(handle: &DaemonHandle, model_id: &str, quant: Option<String>) -> Result<()> {
@@ -64,11 +66,15 @@ pub async fn monitor(handle: &DaemonHandle) -> Result<()> {
 async fn watch_queue(handle: &DaemonHandle) -> Result<()> {
     let url = format!("{}/api/models/downloads", crate::daemon_client::base_url());
     let multi = MultiProgress::new();
-    let style = ProgressStyle::with_template(
-        "  {msg:32!} [{bar:30}] {bytes}/{total_bytes} ({bytes_per_sec})",
-    )
-    .unwrap_or_else(|_| ProgressStyle::default_bar())
-    .progress_chars("=> ");
+    // No `{bytes_per_sec}`: that's indicatif's own estimate, derived from our
+    // `set_position` calls, and it disagrees with the rate the daemon's
+    // estimator computed for the same transfer (see the BAR_TEMPLATE comment
+    // in gglib_download::cli_emitter). The daemon's rate arrives on the
+    // snapshot and is rendered into the message instead.
+    let style = ProgressStyle::with_template("  {msg:48!} [{bar:30}] {bytes}/{total_bytes}")
+        .unwrap_or_else(|_| ProgressStyle::default_bar())
+        .progress_chars("=> ")
+        .with_key("total_bytes", total_bytes_key);
 
     let mut bars: HashMap<String, ProgressBar> = HashMap::new();
     let mut seen_items = false;
@@ -92,20 +98,19 @@ async fn watch_queue(handle: &DaemonHandle) -> Result<()> {
                 observed.push(item.id.clone());
             }
             let bar = bars.entry(item.id.clone()).or_insert_with(|| {
-                let bar = multi.add(ProgressBar::new(item.total_bytes.max(1)));
+                // `no_length()`, never `new(0)`: indicatif renders an explicit
+                // length of 0 as 100% full. Unknown totals draw an empty bar
+                // and `—` (via `total_bytes_key`) until the first snapshot
+                // carries a real total.
+                let bar = multi.add(ProgressBar::no_length());
                 bar.set_style(style.clone());
-                bar.set_message(item.display_name.clone());
                 bar
             });
-            if item.total_bytes > 0 {
+            if item.total_bytes > 0 && bar.length() != Some(item.total_bytes) {
                 bar.set_length(item.total_bytes);
             }
             bar.set_position(item.downloaded_bytes);
-            if matches!(item.status, DownloadStatus::Queued) {
-                bar.set_message(format!("{} (queued)", item.display_name));
-            } else {
-                bar.set_message(item.display_name.clone());
-            }
+            bar.set_message(item_message(item));
         }
 
         // Items that left the queue are finished (or failed — checked below).
@@ -141,5 +146,65 @@ async fn watch_queue(handle: &DaemonHandle) -> Result<()> {
         }
 
         tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Label for a queue item: name, shard position, and — while downloading —
+/// the rate and ETA the daemon's estimator computed.
+fn item_message(item: &QueuedDownload) -> String {
+    if matches!(item.status, DownloadStatus::Queued) {
+        return format!("{} (queued)", item.display_name);
+    }
+
+    let shard = item.shard_info.as_ref().map_or_else(String::new, |shard| {
+        format!(" [shard {}/{}]", shard.shard_index + 1, shard.total_shards)
+    });
+
+    format!(
+        "{}{} {}",
+        item.display_name,
+        shard,
+        rate_suffix(item.speed_bps, item.eta_seconds)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gglib_core::download::ShardInfo;
+
+    fn item(status: DownloadStatus) -> QueuedDownload {
+        QueuedDownload::new("owner/repo:Q8_0", "owner/repo", "owner/repo:Q8_0", 1, 0)
+            .with_status(status)
+    }
+
+    #[test]
+    fn queued_items_are_labeled_queued() {
+        let msg = item_message(&item(DownloadStatus::Queued));
+        assert_eq!(msg, "owner/repo:Q8_0 (queued)");
+    }
+
+    #[test]
+    fn downloading_items_render_placeholder_rate_during_warmup() {
+        // speed/eta are None until the daemon's estimator warms up — the
+        // message must show a placeholder, not 0 B/s (reads as stalled).
+        let msg = item_message(&item(DownloadStatus::Downloading));
+        assert!(msg.starts_with("owner/repo:Q8_0 "));
+        assert!(
+            !msg.contains("0 B/s"),
+            "warmup must not render a zero rate: {msg}"
+        );
+    }
+
+    #[test]
+    fn downloading_items_render_manager_rate_and_shard() {
+        let mut item = item(DownloadStatus::Downloading)
+            .with_shard_info("group".into(), ShardInfo::new(0, 3, "shard-0.gguf"));
+        item.update_progress(500, 1_000, Some(1_048_576.0), Some(90.0));
+
+        let msg = item_message(&item);
+        assert!(msg.contains("[shard 1/3]"), "{msg}");
+        assert!(msg.contains("MB/s") || msg.contains("MiB/s"), "{msg}");
+        assert!(msg.contains("ETA"), "{msg}");
     }
 }

--- a/crates/gglib-download/Cargo.toml
+++ b/crates/gglib-download/Cargo.toml
@@ -43,6 +43,8 @@ hf-hub.workspace = true
 # HTTP client (for API calls and the native download path)
 reqwest = { workspace = true }
 futures-util.workspace = true
+# Body chunk type handed over by reqwest's byte stream (native download sink)
+bytes = "1"
 
 # Checksum verification for downloaded files
 sha2.workspace = true

--- a/crates/gglib-download/src/cli_emitter.rs
+++ b/crates/gglib-download/src/cli_emitter.rs
@@ -226,11 +226,14 @@ impl CliDownloadEventEmitter {
     }
 }
 
-/// Custom `{total_bytes}` renderer: `—` while the length is unknown, the
-/// human-readable size once `set_length` has been called with a real total.
-/// Registered via `ProgressStyle::with_key` — see the module-level comment on
-/// `BAR_TEMPLATE`.
-fn total_bytes_key(state: &ProgressState, w: &mut dyn std::fmt::Write) {
+/// Custom `{total_bytes}` renderer: `—` while the length is unknown.
+///
+/// Renders the human-readable size once `set_length` has been called with a
+/// real total. Registered via `ProgressStyle::with_key` — see the module-level
+/// comment on `BAR_TEMPLATE`. Public so the daemon-polling monitor
+/// (`gglib model download`) renders unknown totals the same way this emitter
+/// does.
+pub fn total_bytes_key(state: &ProgressState, w: &mut dyn std::fmt::Write) {
     match state.len() {
         Some(len) => {
             let _ = write!(w, "{}", HumanBytes(len));
@@ -245,7 +248,10 @@ fn total_bytes_key(state: &ProgressState, w: &mut dyn std::fmt::Write) {
 ///
 /// Both are `None` until the estimator warms up, and render as a placeholder
 /// rather than `0`, which would read as a stalled transfer.
-fn rate_suffix(speed_bps: Option<f64>, eta_seconds: Option<f64>) -> String {
+///
+/// Public so the daemon-polling monitor renders the manager's rate the same
+/// way this emitter does, instead of falling back to indicatif's own estimate.
+pub fn rate_suffix(speed_bps: Option<f64>, eta_seconds: Option<f64>) -> String {
     format!(
         "{} · ETA {}",
         format_rate(speed_bps),

--- a/crates/gglib-download/src/executor/mod.rs
+++ b/crates/gglib-download/src/executor/mod.rs
@@ -80,9 +80,28 @@ pub async fn download_files(plan: &DownloadPlan<'_>) -> Result<(), DownloadError
                 );
             }
         }
+    } else {
+        suggest_accelerator_once(plan);
     }
 
     run_native(plan).await
+}
+
+/// One-time (per process) hint that the parallel accelerator exists.
+///
+/// Once per process, not per plan: a sharded model runs one plan per shard,
+/// and repeating the hint on every shard would read as nagging.
+fn suggest_accelerator_once(plan: &DownloadPlan<'_>) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static SUGGESTED: AtomicBool = AtomicBool::new(false);
+    if SUGGESTED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    let hint = "using the built-in downloader — `gglib config check-deps \
+                --setup-fast-downloads` enables the parallel accelerator";
+    tracing::info!("{hint}");
+    notify(plan, hint);
 }
 
 /// Drive the pre-existing `hf_xet` helper.

--- a/crates/gglib-download/src/executor/native.rs
+++ b/crates/gglib-download/src/executor/native.rs
@@ -331,6 +331,13 @@ async fn join_sink(
 pub(super) fn build_client() -> Client {
     Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        // Bound connection establishment, but no overall request timeout:
+        // multi-GB bodies legitimately stream for hours.
+        .connect_timeout(std::time::Duration::from_secs(30))
+        // Sharded models fetch one file after another from the same hosts;
+        // keeping a few connections warm skips a TLS handshake per shard.
+        .pool_max_idle_per_host(4)
+        .pool_idle_timeout(std::time::Duration::from_secs(90))
         .build()
         .expect("default reqwest client builds")
 }

--- a/crates/gglib-download/src/executor/native.rs
+++ b/crates/gglib-download/src/executor/native.rs
@@ -17,6 +17,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::cli_exec::ProgressCallback;
+use crate::progress::ProgressThrottle;
 
 /// Suffix for the in-progress file that sits beside the final destination.
 const PART_SUFFIX: &str = ".part";
@@ -220,7 +221,14 @@ async fn stream_to_part(
     let mut sink = spawn_sink(file, hasher, rx);
 
     let mut downloaded = start_at;
+    // The initial report is unconditional: downstream relies on seq moving off
+    // 0 to know a transfer has started (see emit_synthetic_progress_if_cached).
     report(req.progress.as_ref(), downloaded, total);
+
+    // Per-chunk reporting hammered the watch channel thousands of times a
+    // second; consumers sample every 250ms anyway. 100ms keeps the final
+    // display one tick fresh while shedding ~99% of the sends.
+    let mut throttle = ProgressThrottle::default_interval();
 
     let mut stream = response.bytes_stream();
     loop {
@@ -255,11 +263,17 @@ async fn stream_to_part(
         }
 
         downloaded += len;
-        report(req.progress.as_ref(), downloaded, total);
+        if throttle.should_emit() {
+            report(req.progress.as_ref(), downloaded, total);
+        }
     }
 
     drop(tx);
     let hasher = join_sink(&mut sink).await?;
+
+    // Unconditional final report so the last sample lands on the exact final
+    // byte count instead of wherever the throttle last let one through.
+    report(req.progress.as_ref(), downloaded, total);
 
     Ok(TransferOutcome {
         digest: hasher.map(|h| Digested {

--- a/crates/gglib-download/src/executor/native.rs
+++ b/crates/gglib-download/src/executor/native.rs
@@ -5,7 +5,7 @@
 //! bytes have been verified. This is the default download path — it needs
 //! nothing on the machine beyond the gglib binary itself.
 
-use std::io::{Read, Write};
+use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use futures_util::StreamExt;
@@ -13,12 +13,27 @@ use reqwest::header::{AUTHORIZATION, CONTENT_RANGE, HeaderMap, LOCATION, RANGE};
 use reqwest::{Client, Response, StatusCode, Url};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::cli_exec::ProgressCallback;
 
 /// Suffix for the in-progress file that sits beside the final destination.
 const PART_SUFFIX: &str = ".part";
+
+/// Write buffer in front of the `.part` file.
+///
+/// Hyper hands the body over in ~8-16 KB chunks; writing each one straight to
+/// the file costs a syscall per chunk. Batching them into 4 MB writes keeps
+/// the sink thread almost always idle in `blocking_recv`, waiting.
+const SINK_BUF_BYTES: usize = 4 * 1024 * 1024;
+
+/// Chunks buffered between the network loop and the sink thread.
+///
+/// Deep enough to ride out a disk-latency spike without stalling the socket,
+/// shallow enough that cancellation never waits on more than a few MB of
+/// backlog draining.
+const SINK_QUEUE_CHUNKS: usize = 32;
 
 /// The only header that carries the file's true SHA-256.
 ///
@@ -184,7 +199,7 @@ async fn stream_to_part(
 
     let total = total_size(response.headers(), start_at).or(req.expected_size);
 
-    let mut file = open_part(part_path, appending)?;
+    let file = open_part(part_path, appending)?;
     let mut hasher = expected.is_some().then(Sha256::new);
 
     // Resuming: the bytes already on disk are part of the digest, so replay them
@@ -195,6 +210,15 @@ async fn stream_to_part(
         }
     }
 
+    // Writes and hashing happen on a dedicated blocking thread, fed through a
+    // bounded channel, so network reads overlap disk I/O instead of
+    // serializing with it — and no async worker thread ever blocks on a
+    // syscall. Every exit path below drops `tx` and joins the sink, which
+    // flushes whatever arrived; on errors and cancellation that keeps the
+    // `.part` file resumable.
+    let (tx, rx) = mpsc::channel::<bytes::Bytes>(SINK_QUEUE_CHUNKS);
+    let mut sink = spawn_sink(file, hasher, rx);
+
     let mut downloaded = start_at;
     report(req.progress.as_ref(), downloaded, total);
 
@@ -204,7 +228,8 @@ async fn stream_to_part(
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
-                    let _ = file.flush();
+                    drop(tx);
+                    let _ = sink.await;
                     return Err(NativeError::Cancelled);
                 }
                 chunk = stream.next() => chunk,
@@ -214,19 +239,27 @@ async fn stream_to_part(
         };
 
         let Some(chunk) = chunk else { break };
-        let chunk = chunk.map_err(|e| NativeError::Network(e.to_string()))?;
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(e) => {
+                drop(tx);
+                let _ = sink.await;
+                return Err(NativeError::Network(e.to_string()));
+            }
+        };
 
-        file.write_all(&chunk)
-            .map_err(|e| NativeError::io("write", &e))?;
-        if let Some(h) = hasher.as_mut() {
-            h.update(&chunk);
+        let len = chunk.len() as u64;
+        if tx.send(chunk).await.is_err() {
+            // The sink died; its join result carries the real I/O error.
+            break;
         }
 
-        downloaded += chunk.len() as u64;
+        downloaded += len;
         report(req.progress.as_ref(), downloaded, total);
     }
 
-    file.flush().map_err(|e| NativeError::io("flush", &e))?;
+    drop(tx);
+    let hasher = join_sink(&mut sink).await?;
 
     Ok(TransferOutcome {
         digest: hasher.map(|h| Digested {
@@ -234,6 +267,42 @@ async fn stream_to_part(
             actual: hex(&h.finalize()),
         }),
     })
+}
+
+/// The sink half of the transfer: a blocking thread that owns the `.part`
+/// file and the hasher, draining chunks the network loop sends it.
+///
+/// Returns the hasher once the channel closes and the buffer is flushed.
+fn spawn_sink(
+    file: std::fs::File,
+    mut hasher: Option<Sha256>,
+    mut rx: mpsc::Receiver<bytes::Bytes>,
+) -> tokio::task::JoinHandle<std::io::Result<Option<Sha256>>> {
+    tokio::task::spawn_blocking(move || {
+        let mut writer = BufWriter::with_capacity(SINK_BUF_BYTES, file);
+        while let Some(chunk) = rx.blocking_recv() {
+            writer.write_all(&chunk)?;
+            if let Some(h) = hasher.as_mut() {
+                h.update(&chunk);
+            }
+        }
+        writer.flush()?;
+        Ok(hasher)
+    })
+}
+
+/// Join the sink thread, mapping its two failure layers onto [`NativeError`].
+async fn join_sink(
+    sink: &mut tokio::task::JoinHandle<std::io::Result<Option<Sha256>>>,
+) -> Result<Option<Sha256>, NativeError> {
+    match sink.await {
+        Ok(Ok(hasher)) => Ok(hasher),
+        Ok(Err(e)) => Err(NativeError::io("write", &e)),
+        Err(e) => Err(NativeError::Io {
+            operation: "write".to_string(),
+            message: format!("sink thread panicked: {e}"),
+        }),
+    }
 }
 
 /// Build the HTTP client this module requires.

--- a/crates/gglib-download/src/executor/native_tests.rs
+++ b/crates/gglib-download/src/executor/native_tests.rs
@@ -376,6 +376,47 @@ async fn a_file_with_no_usable_etag_is_still_verified_by_size() {
 }
 
 // ============================================================================
+// Progress throttling
+// ============================================================================
+
+#[tokio::test]
+async fn progress_reports_are_throttled_but_land_on_the_final_count() {
+    // 4 MB arrives as hundreds of network chunks; per-chunk reporting would
+    // log hundreds of samples. A loopback transfer completes in well under a
+    // second, so the 100ms throttle admits only a handful.
+    let body = body_of(4 << 20);
+    let server = TestServer::start(vec![Reply::File {
+        body: body.clone(),
+        etag: Some(sha256_of(&body)),
+    }])
+    .await;
+    let fx = Fixture::new();
+    let (progress, seen) = recording_progress();
+
+    let url = server.url();
+    download_file(
+        &build_client(),
+        &request(&url, &fx.dest, Some(len_of(&body)), Some(progress)),
+    )
+    .await
+    .expect("download succeeds");
+
+    let (count, last) = {
+        let seen = seen.lock().unwrap();
+        (seen.len(), *seen.last().expect("at least one report"))
+    };
+    assert!(
+        count < 30,
+        "throttle should shed nearly all per-chunk reports, got {count}"
+    );
+    assert_eq!(
+        last,
+        (len_of(&body), len_of(&body)),
+        "the final report must land on the exact final byte count"
+    );
+}
+
+// ============================================================================
 // Resume after interrupt
 // ============================================================================
 

--- a/crates/gglib-download/src/lib.rs
+++ b/crates/gglib-download/src/lib.rs
@@ -37,7 +37,7 @@ pub mod cli_exec;
 
 // CLI terminal progress emitter
 mod cli_emitter;
-pub use cli_emitter::CliDownloadEventEmitter;
+pub use cli_emitter::{CliDownloadEventEmitter, rate_suffix, total_bytes_key};
 
 // Public API - modular download manager
 mod manager;

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -1368,6 +1368,47 @@ fn aggregate_progress(shard: &ShardInfo, downloaded: u64, shard_total: u64) -> (
     )
 }
 
+/// Build the queue-snapshot DTO for the active download from a live progress
+/// sample.
+///
+/// Bytes go through [`aggregate_progress`] for sharded downloads so the REST
+/// snapshot agrees with the SSE bridge. Before the first chunk lands
+/// (`progress.total == 0`) the shard's known file size stands in for the
+/// per-shard total, so consumers can size a bar immediately.
+fn build_active_dto(
+    id: &DownloadId,
+    progress: &ProgressUpdate,
+    shard_info: Option<&ShardInfo>,
+    group_id: Option<&str>,
+    speed_bps: Option<f64>,
+    eta_seconds: Option<f64>,
+) -> gglib_core::download::QueuedDownload {
+    let (downloaded, total) = shard_info.map_or((progress.downloaded, progress.total), |shard| {
+        let shard_total = if progress.total == 0 {
+            shard.file_size.unwrap_or(0)
+        } else {
+            progress.total
+        };
+        aggregate_progress(shard, progress.downloaded, shard_total)
+    });
+
+    let mut dto = gglib_core::download::QueuedDownload::new(
+        id.to_string(),
+        id.model_id(),
+        id.to_string(),
+        1,
+        0,
+    )
+    .with_status(gglib_core::download::DownloadStatus::Downloading);
+
+    if let (Some(shard), Some(group)) = (shard_info, group_id) {
+        dto = dto.with_shard_info(group.to_string(), shard.clone());
+    }
+
+    dto.update_progress(downloaded, total, speed_bps, eta_seconds);
+    dto
+}
+
 /// Emit a progress event.
 ///
 /// Emits `ShardProgress` if `shard_info` is present, otherwise `DownloadProgress`.
@@ -1535,28 +1576,44 @@ impl DownloadManagerPort for DownloadManagerImpl {
     }
 
     async fn get_queue_snapshot(&self) -> Result<QueueSnapshot, DownloadError> {
-        // Build current item DTO if there's an active download (short lock scope)
-        let current_dto = {
+        // Sample the active job under its lock (short scope), then read the
+        // estimator afterwards — never nested, preserving the queue → active
+        // lock order.
+        let active_sample = {
             let active = self.active.lock().await;
             active.iter().next().map(|(id, job)| {
-                let mut dto = gglib_core::download::QueuedDownload::new(
-                    id.to_string(),
-                    id.model_id(),
-                    id.to_string(),
-                    1,
-                    0,
+                (
+                    id.clone(),
+                    job.progress_tx.borrow().clone(),
+                    job.shard_info.clone(),
+                    job.group_id.clone(),
                 )
-                .with_status(gglib_core::download::DownloadStatus::Downloading);
-
-                // Preserve shard info if this is a sharded download
-                if let Some(shard) = &job.shard_info {
-                    if let Some(group) = &job.group_id {
-                        dto = dto.with_shard_info(group.clone(), shard.clone());
-                    }
-                }
-
-                dto
             })
+        };
+
+        let current_dto = match active_sample {
+            Some((id, progress, shard_info, group_id)) => {
+                let key = group_id.clone().unwrap_or_else(|| id.to_string());
+                let estimator = self.rate_estimators.lock().await.get(&key).map(Arc::clone);
+                // Read-only: `record()` here would let snapshot polling perturb
+                // the decayed average every consumer sees.
+                let (speed_bps, eta_seconds) = match estimator {
+                    Some(estimator) => {
+                        let estimator = estimator.lock().await;
+                        (estimator.rate_bps(), estimator.eta_seconds())
+                    }
+                    None => (None, None),
+                };
+                Some(build_active_dto(
+                    &id,
+                    &progress,
+                    shard_info.as_ref(),
+                    group_id.as_deref(),
+                    speed_bps,
+                    eta_seconds,
+                ))
+            }
+            None => None,
         };
 
         let queue = self.queue.read().await;
@@ -1899,6 +1956,68 @@ mod tests {
     fn falls_back_to_shard_progress_when_no_size_is_known() {
         let shard = ShardInfo::new(1, 3, "shard-1.gguf");
         assert_eq!(aggregate_progress(&shard, 2_000, 4_000), (2_000, 12_000));
+    }
+
+    #[test]
+    fn active_dto_carries_live_progress() {
+        let id = DownloadId::new("owner/repo", Some("Q4_K_M"));
+        let progress = ProgressUpdate::new(2_500, 10_000, 7);
+
+        let dto = build_active_dto(&id, &progress, None, None, Some(1_000.0), Some(7.5));
+
+        assert_eq!(dto.downloaded_bytes, 2_500);
+        assert_eq!(dto.total_bytes, 10_000);
+        assert_eq!(dto.speed_bps, Some(1_000.0));
+        assert_eq!(dto.eta_seconds, Some(7.5));
+        assert!((dto.progress_percent - 25.0).abs() < f64::EPSILON);
+        assert_eq!(
+            dto.status,
+            gglib_core::download::DownloadStatus::Downloading
+        );
+    }
+
+    #[test]
+    fn active_dto_aggregates_sharded_progress() {
+        let id = DownloadId::new("owner/repo", Some("Q4_K_M"));
+        let (a, b, c) = (4_000, 4_000, 1_500);
+        let shard = shard_with_offsets(1, a, a + b + c, b);
+        let progress = ProgressUpdate::new(2_000, b, 3);
+
+        let dto = build_active_dto(&id, &progress, Some(&shard), Some("group-1"), None, None);
+
+        // Same numbers the SSE bridge derives via aggregate_progress.
+        assert_eq!(dto.downloaded_bytes, 6_000);
+        assert_eq!(dto.total_bytes, 9_500);
+        assert_eq!(dto.group_id.as_deref(), Some("group-1"));
+        assert!(dto.shard_info.is_some());
+    }
+
+    #[test]
+    fn active_dto_uses_shard_file_size_before_first_chunk() {
+        let id = DownloadId::new("owner/repo", Some("Q4_K_M"));
+        let shard = shard_with_offsets(0, 0, 9_500, 4_000);
+        let progress = ProgressUpdate::default();
+
+        let dto = build_active_dto(&id, &progress, Some(&shard), Some("group-1"), None, None);
+
+        assert_eq!(dto.downloaded_bytes, 0);
+        assert_eq!(
+            dto.total_bytes, 9_500,
+            "known shard sizes should size the bar immediately"
+        );
+    }
+
+    #[test]
+    fn active_dto_passes_through_unknowns_during_warmup() {
+        let id = DownloadId::new("owner/repo", None::<String>);
+        let progress = ProgressUpdate::default();
+
+        let dto = build_active_dto(&id, &progress, None, None, None, None);
+
+        assert_eq!(dto.total_bytes, 0);
+        assert_eq!(dto.speed_bps, None);
+        assert_eq!(dto.eta_seconds, None);
+        assert!(dto.progress_percent.abs() < f64::EPSILON);
     }
 
     fn test_bridge(cancel: CancellationToken, finished: CancellationToken) -> ProgressBridge {

--- a/crates/gglib-proxy/src/lib.rs
+++ b/crates/gglib-proxy/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/README_GENERATED.md"))]
 #![deny(unsafe_code)]
+// A std MutexGuard held across an .await starves the whole runtime the moment
+// two tasks contend — the #721 daemon wedge was this bug class. Denied here
+// because neither crate inherits the workspace clippy lints yet.
+#![deny(clippy::await_holding_lock, clippy::await_holding_refcell_ref)]
 
 mod access;
 pub mod cache_lifecycle;

--- a/crates/gglib-runtime/src/lib.rs
+++ b/crates/gglib-runtime/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/README_GENERATED.md"))]
 #![deny(unsafe_code)]
+// A std MutexGuard held across an .await starves the whole runtime the moment
+// two tasks contend — the #721 daemon wedge was this bug class. Denied here
+// because neither crate inherits the workspace clippy lints yet.
+#![deny(clippy::await_holding_lock, clippy::await_holding_refcell_ref)]
 
 pub mod assistant_ui;
 mod command;

--- a/crates/gglib-runtime/src/process/admission/lease.rs
+++ b/crates/gglib-runtime/src/process/admission/lease.rs
@@ -11,11 +11,20 @@
 //! impossible at the type level to hold the lock across an await point. The one
 //! genuinely async part of admission — waiting for a wakeup — happens with the
 //! lock released.
+//!
+//! Just as load-bearing: **no caller-supplied code runs while the lock is
+//! held**. Every method takes plain data in and hands plain data out. This is
+//! not an aesthetic preference — [`AdmissionQueue::poll`] originally took a
+//! `secondary_fits` callback and invoked it inside the critical section, and
+//! the production callback called back into the queue, re-locking this
+//! non-reentrant mutex and wedging the whole daemon (issue #721). A method
+//! that wants a caller's judgement must receive it as a value computed before
+//! the lock is taken.
 
 use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::time::Instant;
 
-use gglib_core::domain::{AdmissionSnapshot, SecondarySlotStatus};
+use gglib_core::domain::{AdmissionSnapshot, SecondarySlotDecision};
 use gglib_core::ports::{AdmissionLease, AdmissionRelease};
 use tokio::sync::Notify;
 
@@ -77,17 +86,18 @@ impl AdmissionQueue {
 
     /// Ask what this request should do now.
     ///
-    /// `secondary_fits` is consulted only when the second slot is empty and a
-    /// co-load is the alternative to a swap. It is a callback rather than a
-    /// precomputed flag because free VRAM is a property of the moment: asking
-    /// once at enqueue time and acting on it thirty seconds later would be
-    /// acting on a reading the primary model has since invalidated.
-    pub fn poll(
-        &self,
-        ticket: &Ticket,
-        secondary_fits: &dyn Fn(&str) -> bool,
-    ) -> AdmissionDecision {
-        self.lock().poll(ticket, Instant::now(), secondary_fits)
+    /// `secondary` is the caller's verdict on whether this request's model may
+    /// co-reside in the second slot, computed against a free-VRAM reading taken
+    /// just before this call. A value rather than a callback, deliberately: an
+    /// earlier callback version ran caller code inside the critical section,
+    /// and that code re-entered the queue and deadlocked the daemon (#721).
+    /// The price is a verdict up to one poll tick stale, which is well inside
+    /// the staleness the probe's own cache already allows. It is consulted only
+    /// when a secondary slot is empty or evictable and a co-load is the
+    /// alternative to a swap; callers re-poll on every tick, so the reading
+    /// never outlives the wait the way an enqueue-time reading would.
+    pub fn poll(&self, ticket: &Ticket, secondary: SecondarySlotDecision) -> AdmissionDecision {
+        self.lock().poll(ticket, Instant::now(), secondary)
     }
 
     /// A future that resolves the next time the state changes.
@@ -197,18 +207,6 @@ impl AdmissionQueue {
     /// Whether any slot is mid-launch.
     pub fn is_loading(&self) -> bool {
         self.lock().is_loading()
-    }
-
-    /// Record the most recent second-slot verdict, so an idle secondary can
-    /// explain itself on the dashboard.
-    ///
-    /// Skips the write when nothing changed, keeping the steady state — every
-    /// request reaching the same verdict — off the publisher's back.
-    pub fn record_secondary_status(&self, status: SecondarySlotStatus) {
-        let mut state = self.lock();
-        if state.secondary_slot != status {
-            state.secondary_slot = status;
-        }
     }
 
     /// Project the queue for the dashboard.

--- a/crates/gglib-runtime/src/process/admission/queue_tests.rs
+++ b/crates/gglib-runtime/src/process/admission/queue_tests.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::time::Instant;
 
-use gglib_core::domain::CacheRamHealth;
+use gglib_core::domain::{CacheRamHealth, SecondarySlotDecision};
 
 use super::*;
 
@@ -38,20 +38,22 @@ fn resident(model_id: u32, name: &str) -> Resident {
 
 /// The common case for these tests: nothing may co-reside, so every model
 /// change is a swap and the fairness rules are what decide it.
-fn never_fits(_: &str) -> bool {
-    false
-}
+const NEVER_FITS: SecondarySlotDecision = SecondarySlotDecision::RefuseTooLarge {
+    footprint_bytes: 9 * 1024 * 1024 * 1024,
+    ceiling_bytes: 2 * 1024 * 1024 * 1024,
+};
 
 /// The co-residency case: anything fits, so the second slot is always offered.
-fn always_fits(_: &str) -> bool {
-    true
-}
+const ALWAYS_FITS: SecondarySlotDecision = SecondarySlotDecision::Grant {
+    footprint_bytes: 256 * 1024 * 1024,
+    headroom_bytes: 8 * 1024 * 1024 * 1024,
+};
 
 /// Enqueue and immediately poll, the shape every requester's first iteration
 /// takes. Returns the ticket so the caller can keep polling it.
 fn request(q: &Arc<AdmissionQueue>, model: &str) -> (Ticket, AdmissionDecision) {
     let ticket = q.enqueue(model);
-    let decision = q.poll(&ticket, &never_fits);
+    let decision = q.poll(&ticket, NEVER_FITS);
     (ticket, decision)
 }
 
@@ -133,7 +135,7 @@ async fn a_waiter_is_served_by_the_launch_it_waited_for() {
     let _lease = q.install(PRIMARY_SLOT, resident(1, "qwen-coder"));
 
     assert_eq!(
-        q.poll(&second, &never_fits),
+        q.poll(&second, NEVER_FITS),
         AdmissionDecision::Serve { slot: PRIMARY_SLOT }
     );
     assert_eq!(q.snapshot().total_swaps, 0, "a cold start is not a swap");
@@ -159,12 +161,12 @@ async fn a_slot_with_a_request_in_flight_is_never_evicted() {
     // Even once every fairness bound has been blown through.
     tokio::time::pause();
     tokio::time::advance(DRAIN_QUANTUM * 4).await;
-    assert_eq!(q.poll(&rival, &never_fits), AdmissionDecision::Wait);
+    assert_eq!(q.poll(&rival, NEVER_FITS), AdmissionDecision::Wait);
 
     // The instant the lease drops, the swap is legal.
     drop(lease);
     assert_eq!(
-        q.poll(&rival, &never_fits),
+        q.poll(&rival, NEVER_FITS),
         AdmissionDecision::Launch {
             slot: PRIMARY_SLOT,
             evict: Some(1),
@@ -183,14 +185,14 @@ async fn a_slot_frees_only_when_the_last_lease_drops() {
     let (rival, _) = request(&q, "nomic-embed");
     drop(first);
     assert_eq!(
-        q.poll(&rival, &never_fits),
+        q.poll(&rival, NEVER_FITS),
         AdmissionDecision::Wait,
         "one lease still outstanding"
     );
 
     drop(second);
     assert!(matches!(
-        q.poll(&rival, &never_fits),
+        q.poll(&rival, NEVER_FITS),
         AdmissionDecision::Launch { .. }
     ));
 }
@@ -208,13 +210,13 @@ async fn a_burst_of_queued_requests_costs_a_single_swap() {
     let tickets: Vec<Ticket> = (0..10).map(|_| q.enqueue("nomic-embed")).collect();
 
     // The first one through drives the launch; the rest wait behind it.
-    let first = q.poll(&tickets[0], &never_fits);
+    let first = q.poll(&tickets[0], NEVER_FITS);
     let AdmissionDecision::Launch { slot, evict } = first else {
         panic!("expected a launch, got {first:?}");
     };
     assert_eq!(evict, Some(1));
     for ticket in &tickets[1..] {
-        assert_eq!(q.poll(ticket, &never_fits), AdmissionDecision::Wait);
+        assert_eq!(q.poll(ticket, NEVER_FITS), AdmissionDecision::Wait);
     }
 
     let _lease = q.install(slot, resident(2, "nomic-embed"));
@@ -224,7 +226,7 @@ async fn a_burst_of_queued_requests_costs_a_single_swap() {
         .iter()
         .map(|ticket| {
             assert_eq!(
-                q.poll(ticket, &never_fits),
+                q.poll(ticket, NEVER_FITS),
                 AdmissionDecision::Serve { slot }
             );
             q.claim(slot)
@@ -257,7 +259,7 @@ async fn alternating_traffic_does_not_swap_per_request() {
         guard += 1;
         let mut remaining = Vec::new();
         for ticket in tickets {
-            match q.poll(&ticket, &never_fits) {
+            match q.poll(&ticket, NEVER_FITS) {
                 // `Serve` has already counted this request against the slot, so
                 // the lease must be claimed — exactly as a real requester does.
                 // Leaving it unclaimed would pin the model resident forever.
@@ -304,7 +306,7 @@ async fn the_turn_holder_yields_once_its_quantum_elapses() {
     drop(lease);
 
     assert_eq!(
-        q.poll(&rival, &never_fits),
+        q.poll(&rival, NEVER_FITS),
         AdmissionDecision::Wait,
         "the turn is still young"
     );
@@ -312,10 +314,7 @@ async fn the_turn_holder_yields_once_its_quantum_elapses() {
     tokio::time::advance(DRAIN_QUANTUM + std::time::Duration::from_secs(1)).await;
 
     assert!(
-        matches!(
-            q.poll(&rival, &never_fits),
-            AdmissionDecision::Launch { .. }
-        ),
+        matches!(q.poll(&rival, NEVER_FITS), AdmissionDecision::Launch { .. }),
         "the quantum must end the turn"
     );
 }
@@ -338,7 +337,7 @@ async fn a_deep_queue_does_not_outrank_a_single_older_request() {
 
     assert!(
         matches!(
-            q.poll(&lonely, &never_fits),
+            q.poll(&lonely, NEVER_FITS),
             AdmissionDecision::Launch { .. }
         ),
         "fifty newer requests must not bury one older one"
@@ -358,13 +357,13 @@ async fn a_permanently_busy_slot_expires_the_rival_rather_than_stalling_it() {
     let (rival, _) = request(&q, "nomic-embed");
     tokio::time::advance(DRAIN_QUANTUM * 4).await;
     assert_eq!(
-        q.poll(&rival, &never_fits),
+        q.poll(&rival, NEVER_FITS),
         AdmissionDecision::Wait,
         "still blocked, because preemption is never an option"
     );
 
     tokio::time::advance(ADMISSION_DEADLINE).await;
-    assert_eq!(q.poll(&rival, &never_fits), AdmissionDecision::Expired);
+    assert_eq!(q.poll(&rival, NEVER_FITS), AdmissionDecision::Expired);
 }
 
 /// A turn holder that has run out of work does not get to keep the slot warm
@@ -395,12 +394,12 @@ async fn the_globally_oldest_waiter_decides_which_model_is_next() {
     let newer = q.enqueue("model-b");
 
     assert_eq!(
-        q.poll(&newer, &never_fits),
+        q.poll(&newer, NEVER_FITS),
         AdmissionDecision::Wait,
         "a later arrival must not overtake"
     );
     assert!(matches!(
-        q.poll(&older, &never_fits),
+        q.poll(&older, NEVER_FITS),
         AdmissionDecision::Launch { .. }
     ));
 }
@@ -415,7 +414,7 @@ async fn a_model_that_fits_co_loads_rather_than_swapping() {
     let _lease = make_resident(&q, "qwen-coder", 1);
 
     let ticket = q.enqueue("nomic-embed");
-    let decision = q.poll(&ticket, &always_fits);
+    let decision = q.poll(&ticket, ALWAYS_FITS);
 
     assert_eq!(
         decision,
@@ -435,7 +434,7 @@ async fn co_resident_models_never_contend() {
     let chat = make_resident(&q, "qwen-coder", 1);
 
     let ticket = q.enqueue("nomic-embed");
-    let AdmissionDecision::Launch { slot, .. } = q.poll(&ticket, &always_fits) else {
+    let AdmissionDecision::Launch { slot, .. } = q.poll(&ticket, ALWAYS_FITS) else {
         panic!("expected a co-load");
     };
     drop(ticket);
@@ -463,7 +462,7 @@ async fn a_model_that_does_not_fit_falls_back_to_swapping() {
     drop(lease);
 
     let ticket = q.enqueue("llama-70b");
-    let decision = q.poll(&ticket, &never_fits);
+    let decision = q.poll(&ticket, NEVER_FITS);
 
     assert_eq!(
         decision,
@@ -483,7 +482,7 @@ async fn a_third_model_evicts_the_secondary_not_the_primary() {
     let q = queue();
     let chat = make_resident(&q, "qwen-coder", 1);
     let embed_ticket = q.enqueue("nomic-embed");
-    let AdmissionDecision::Launch { slot, .. } = q.poll(&embed_ticket, &always_fits) else {
+    let AdmissionDecision::Launch { slot, .. } = q.poll(&embed_ticket, ALWAYS_FITS) else {
         panic!("expected a co-load");
     };
     drop(embed_ticket);
@@ -492,7 +491,7 @@ async fn a_third_model_evicts_the_secondary_not_the_primary() {
 
     let third = q.enqueue("reranker");
     assert_eq!(
-        q.poll(&third, &always_fits),
+        q.poll(&third, ALWAYS_FITS),
         AdmissionDecision::Launch {
             slot: PRIMARY_SLOT + 1,
             evict: Some(2),
@@ -513,7 +512,7 @@ async fn a_request_expires_once_its_deadline_passes() {
     let (rival, _) = request(&q, "nomic-embed");
     tokio::time::advance(ADMISSION_DEADLINE + std::time::Duration::from_secs(1)).await;
 
-    assert_eq!(q.poll(&rival, &never_fits), AdmissionDecision::Expired);
+    assert_eq!(q.poll(&rival, NEVER_FITS), AdmissionDecision::Expired);
 }
 
 /// An expired or abandoned request must stop holding the front of the queue,
@@ -580,7 +579,7 @@ async fn the_snapshot_names_a_co_resident_secondary() {
     let q = queue();
     let _chat = make_resident(&q, "qwen-coder", 1);
     let ticket = q.enqueue("nomic-embed");
-    let AdmissionDecision::Launch { slot, .. } = q.poll(&ticket, &always_fits) else {
+    let AdmissionDecision::Launch { slot, .. } = q.poll(&ticket, ALWAYS_FITS) else {
         panic!("expected a co-load");
     };
     drop(ticket);
@@ -591,6 +590,61 @@ async fn the_snapshot_names_a_co_resident_secondary() {
     assert!(snapshot.secondary_slot.detail.contains("nomic-embed"));
     assert_eq!(snapshot.slots.len(), 2);
     assert!(!snapshot.slots[1].is_primary);
+}
+
+/// The verdict handed to `poll` lands in the snapshot whenever a secondary
+/// slot could have used it, so an idle second slot can explain itself on the
+/// dashboard. (The verdict is a value computed by the caller before the queue
+/// locks — the regression guarded here is #721, where a callback ran under the
+/// lock and re-entered the queue.)
+#[tokio::test]
+async fn a_consulted_refusal_is_recorded_for_the_dashboard() {
+    let q = queue();
+    let _lease = make_resident(&q, "qwen-coder", 1);
+
+    // Secondary slot is empty, so the refusal is consulted — and recorded.
+    let (_rival, _) = request(&q, "llama-70b");
+
+    assert_eq!(q.snapshot().secondary_slot.state, "too_large");
+}
+
+/// A grant that has not finished loading holds nothing, so it reports the slot
+/// as available rather than resident.
+#[tokio::test]
+async fn a_consulted_grant_reports_the_slot_as_available() {
+    let q = queue();
+    let _lease = make_resident(&q, "qwen-coder", 1);
+
+    let ticket = q.enqueue("nomic-embed");
+    let AdmissionDecision::Launch { .. } = q.poll(&ticket, ALWAYS_FITS) else {
+        panic!("expected a co-load");
+    };
+
+    assert_eq!(q.snapshot().secondary_slot.state, "available");
+}
+
+/// A verdict for a moment when no secondary slot was on offer never mattered,
+/// so it must not overwrite the last one that did.
+#[tokio::test]
+async fn an_unconsulted_verdict_does_not_overwrite_the_recorded_one() {
+    let q = queue();
+    let _chat = make_resident(&q, "qwen-coder", 1);
+
+    // A granted co-load leaves the secondary slot `Loading` — neither empty
+    // nor evictable, so nothing consults a verdict while it stays that way.
+    let embed = q.enqueue("nomic-embed");
+    let AdmissionDecision::Launch { .. } = q.poll(&embed, ALWAYS_FITS) else {
+        panic!("expected a co-load");
+    };
+    drop(embed);
+
+    let (_rival, _) = request(&q, "llama-70b"); // NEVER_FITS, unconsulted
+
+    assert_eq!(
+        q.snapshot().secondary_slot.state,
+        "available",
+        "the refusal was never consulted and must not be recorded"
+    );
 }
 
 /// Every request that passes through is counted, so the ratio against

--- a/crates/gglib-runtime/src/process/admission/state.rs
+++ b/crates/gglib-runtime/src/process/admission/state.rs
@@ -17,7 +17,7 @@ use tokio::time::Instant;
 
 use gglib_core::domain::{
     AdmissionSnapshot, CacheRamHealth, LaunchNarration, QueuedModelSnapshot, ResidentSlotSnapshot,
-    SecondarySlotStatus,
+    SecondarySlotDecision, SecondarySlotStatus,
 };
 
 /// How many models may be resident in VRAM at once.
@@ -281,7 +281,7 @@ impl QueueState {
         &mut self,
         ticket: &Ticket,
         now: Instant,
-        secondary_fits: &dyn Fn(&str) -> bool,
+        secondary: SecondarySlotDecision,
     ) -> AdmissionDecision {
         // The fast path, and the payoff of a second slot: a co-resident model
         // serves without ever consulting the scheduler's fairness rules,
@@ -311,7 +311,22 @@ impl QueueState {
             return AdmissionDecision::Wait;
         }
 
-        let Some(slot) = self.choose_slot(&ticket.model, now, secondary_fits) else {
+        // The co-residence verdict was computed by the caller *before* the
+        // queue's lock was taken — no caller code runs inside this critical
+        // section (see the locking notes in `lease.rs`; a callback here once
+        // re-entered the queue and deadlocked the daemon). Recorded only when
+        // a secondary slot could actually have used it, so the dashboard shows
+        // the last verdict that mattered rather than one for a moment when no
+        // slot was on offer.
+        let secondary_available = self.secondary_slots().any(|slot| {
+            matches!(self.slots[slot], SlotState::Empty) || self.slots[slot].is_evictable()
+        });
+        if secondary_available {
+            self.secondary_slot = SecondarySlotStatus::from_decision(secondary);
+        }
+        let may_co_reside = secondary_available && secondary.is_grant();
+
+        let Some(slot) = self.choose_slot(&ticket.model, now, may_co_reside) else {
             return AdmissionDecision::Wait;
         };
 
@@ -339,18 +354,7 @@ impl QueueState {
     /// 1. An empty slot — nothing is displaced, so nothing has to be justified.
     /// 2. The secondary slot, when the candidate is small enough to co-reside.
     /// 3. An evictable slot, once the fairness rules permit the swap.
-    fn choose_slot(
-        &self,
-        model: &str,
-        now: Instant,
-        secondary_fits: &dyn Fn(&str) -> bool,
-    ) -> Option<usize> {
-        // Asked once. The answer involves a live free-VRAM reading, and asking
-        // twice inside one decision could give two different answers.
-        let may_co_reside = self.secondary_slots().any(|slot| {
-            matches!(self.slots[slot], SlotState::Empty) || self.slots[slot].is_evictable()
-        }) && secondary_fits(model);
-
+    fn choose_slot(&self, model: &str, now: Instant, may_co_reside: bool) -> Option<usize> {
         // 1. A free slot displaces nothing, so it needs no justification.
         if matches!(self.slots[PRIMARY_SLOT], SlotState::Empty) {
             return Some(PRIMARY_SLOT);

--- a/crates/gglib-runtime/src/process/residency/mod.rs
+++ b/crates/gglib-runtime/src/process/residency/mod.rs
@@ -5,7 +5,7 @@ mod vram;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gglib_core::domain::SecondarySlotStatus;
+use gglib_core::domain::SecondarySlotDecision;
 use gglib_core::ports::{
     Admission, CatalogError, LaunchOverrides, ModelCatalogPort, ModelLaunchSpec, ModelRuntimeError,
     PinnedSpec, RunningTarget,
@@ -261,7 +261,7 @@ impl ResidentSet {
 
             match self
                 .queue
-                .poll(&queued.ticket, &|name| self.secondary_fits(name, &request))
+                .poll(&queued.ticket, self.secondary_verdict(&request))
             {
                 AdmissionDecision::Serve { slot } => {
                     if let Some(admission) = self.serve(slot, resolved_ctx, core).await {
@@ -292,29 +292,34 @@ impl ResidentSet {
         }
     }
 
-    /// Whether `name` may co-reside, recording the verdict for the dashboard.
+    /// Whether this request's model may co-reside in the second slot.
     ///
-    /// Only ever asked about the model this request is for; the closure takes a
-    /// name purely so the queue does not have to know what a launch request is.
-    fn secondary_fits(&self, name: &str, request: &LaunchRequest) -> bool {
-        if name != request.spec.name {
-            return false;
-        }
+    /// Judged against a free-VRAM reading taken now rather than at enqueue
+    /// time: the primary model may have finished loading since the request
+    /// queued, and a decision made against the earlier figure would be about a
+    /// machine that no longer exists. Re-computed on every poll tick, so the
+    /// verdict the queue acts on is at most one [`POLL_TICK`] old — on top of
+    /// the probe's own short-lived cache.
+    ///
+    /// Computed *before* [`AdmissionQueue::poll`] takes the queue's lock,
+    /// necessarily: the probe can block (it may fork `nvidia-smi`), and no
+    /// caller code may run inside the queue's critical section — a callback
+    /// version of this once re-entered the queue from under its own lock and
+    /// deadlocked the daemon (#721).
+    fn secondary_verdict(&self, request: &LaunchRequest) -> SecondarySlotDecision {
         let kv_types = crate::llama::args::resolve_kv_cache_types(
             request.opts.cache_type_k,
             request.opts.cache_type_v,
         );
         let decision = vram::secondary_slot_decision(&request.spec, kv_types, request.context.0);
-        self.queue
-            .record_secondary_status(SecondarySlotStatus::from_decision(decision));
         if !decision.is_grant() {
             debug!(
-                model = %name,
+                model = %request.spec.name,
                 verdict = decision.label(),
                 "second resident slot refused"
             );
         }
-        decision.is_grant()
+        decision
     }
 
     /// Serve from a model already resident in `slot`.


### PR DESCRIPTION
Closes #721.

## Root cause — a correction to the issue

The issue hypothesised a MutexGuard held across an `.await`. The stack sample says otherwise: it was a **re-entrant self-deadlock** on `AdmissionQueue`'s non-reentrant `std::sync::Mutex`:

```
ResidentSet::wait_for_slot
  → AdmissionQueue::poll                       takes self.lock(), holds it
    → QueueState::choose_slot                  invokes secondary_fits UNDER the guard
      → ResidentSet::secondary_fits
        → AdmissionQueue::record_secondary_status   self.lock() again → blocks forever
```

The polling thread deadlocks on itself; every other admission user (dashboard publisher, slots poller, status stream) piles up behind it — the four blocked workers in the sample, one of which *is* the holder. Deterministic on any **launch decision** made while a secondary slot is empty or evictable, including cold start; requests for an already-resident model take the fast path and never hit it, which is why the daemon looked healthy until a launch was needed. Introduced in M9 (#709). `queue_tests.rs` never caught it because every test passes a pure closure — only the production closure re-entered the queue.

A full audit found **no** guard-across-await anywhere in the subsystem, and no lock nesting with the admission mutex. It did find the same callback running the free-VRAM probe — potentially a blocking `nvidia-smi` fork/exec — inside the critical section.

## Commits

1. **fix(runtime): pass the secondary-slot verdict into admission poll by value** — `poll` now takes a `SecondarySlotDecision` the caller computes before the lock; `QueueState` records the verdict itself (only when a secondary slot could have used it); `record_secondary_status` is deleted. No caller-supplied code can run under the queue's lock at all, and the VRAM probe moves outside the critical section in the same stroke. Verdict staleness: at most one 250ms poll tick, inside the probe's own 2s cache. New tests cover verdict recording (consulted refusal, consulted grant, unconsulted verdict not overwriting).
2. **fix(axum): run the shutdown force-exit watchdog on an OS thread** — the 10s teardown watchdog was a tokio task, so a starved runtime (exactly this wedge) starved the watchdog too; that's how a daemon survived its own "Proxy stop timed out" path as a zombie. Now a plain thread disarmed by a completion flag.
3. **feat(axum): liveness watchdog exits a wedged daemon** — an OS thread probes the daemon's own `/health` over a raw `TcpStream` every 10s; 3 consecutive failures (~45s unresponsive) → log + exit(70), freeing the ports and the lock so the next `ensure_daemon` starts fresh. Runtime-free by construction; `GGLIB_DAEMON_WATCHDOG=off` opts out.
4. **chore(runtime,proxy): deny await_holding_lock** — crate-level `#![deny(clippy::await_holding_lock, clippy::await_holding_refcell_ref)]` in the two async-heavy crates, which currently don't inherit the workspace lints.

## Verification

- `cargo test --workspace`: 78 suites, 0 failures. `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean.
- Live on the affected machine: a cold-start chat completion — the exact request that wedged the daemon permanently on main — completes in ~11s (launch + inference); daemon stays healthy; `/v1/proxy/status` shows the consulted secondary-slot verdict; `daemon stop` exits cleanly with ports freed and no zombie or orphaned llama-server.

## Follow-up (not in this PR)

- `gglib-runtime` declares `[lints.rust]` without `workspace = true` and `gglib-proxy` has no `[lints]` section, so neither inherits the workspace clippy config; fixing that will surface a pile of pedantic/nursery warnings and deserves its own pass.