### PR TITLE
docs(readme): remove phantom voice endpoint documentation

### DIFF
--- a/crates/gglib-axum/README.md
+++ b/crates/gglib-axum/README.md
@@ -52,11 +52,11 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 │  │             │     │  & wiring   │     │  mounting   │                            │
 │  └─────────────┘     └─────────────┘     └─────────────┘                            │
 │                                                                                     │
-│  ┌───────────┐     ┌───────────┐     ┌───────────┐                            │
-│  │    dto/     │     │  error.rs   │     │ ws_audio.rs │                            │
-│  │  Request &  │     │  HTTP error │     │ WS audio    │                            │
-│  │  Response   │     │  handling   │     │ source/sink │                            │
-│  └───────────┘     └───────────┘     └───────────┘                            │
+│  ┌─────────────┐     ┌─────────────┐                                                │
+│  │    dto/     │     │  error.rs   │                                                │
+│  │  Request &  │     │  HTTP error │                                                │
+│  │  Response   │     │  handling   │                                                │
+│  └─────────────┘     └─────────────┘                                                │
 │                                                                                     │
 └─────────────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -86,12 +86,9 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **`error.rs`** — HTTP error types and JSON error responses
 - **`routes.rs`** — Route definitions and handler mounting
 - **`sse.rs`** — Server-Sent Events utilities for streaming
-- **`ws_audio.rs`** — `WebSocketAudioSource` and `WebSocketAudioSink`: mpsc-backed `AudioSource`/`AudioSink` implementations that bridge browser PCM16 LE audio over a WebSocket binary channel
 - **`dto/`** — Request/response DTOs for API endpoints
 - **`handlers/model/`** — Model CRUD, verification, downloads, HuggingFace discovery handlers
 - **`handlers/config/`** — Settings and system setup handlers
-- **`handlers/voice.rs`** — 19 thin Axum handlers for voice data/config operations and audio control endpoints
-- **`handlers/voice_ws.rs`** — WebSocket upgrade handler (`GET /api/voice/audio`): registers `WebSocketAudioSource`/`WebSocketAudioSink` with `VoiceService`, spawns ingest/egress tasks
 
 ## Endpoints
 
@@ -112,26 +109,6 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `POST` | `/api/models/:id/verify` | Verify model integrity (streams progress via SSE) |
 | `GET` | `/api/models/:id/updates` | Check for HuggingFace updates |
 | `POST` | `/api/models/:id/repair` | Re-download corrupt shards |
-| `GET` | `/api/voice/status` | Voice pipeline state and loaded models |
-| `GET` | `/api/voice/models` | Voice model catalog with download status |
-| `GET` | `/api/voice/devices` | OS audio input devices |
-| `POST` | `/api/voice/models/stt/{id}/download` | Download STT model |
-| `POST` | `/api/voice/models/tts/download` | Download TTS bundle |
-| `POST` | `/api/voice/models/vad/download` | Download Silero VAD |
-| `POST` | `/api/voice/stt/load` | Load STT model into pipeline |
-| `POST` | `/api/voice/tts/load` | Load TTS model into pipeline |
-| `PUT` | `/api/voice/mode` | Set PTT / VAD interaction mode |
-| `PUT` | `/api/voice/voice` | Set active TTS voice |
-| `PUT` | `/api/voice/speed` | Set TTS playback speed |
-| `PUT` | `/api/voice/auto-speak` | Enable/disable auto-TTS on LLM responses |
-| `POST` | `/api/voice/unload` | Stop audio I/O and release model memory |
-| `POST` | `/api/voice/start` | Start voice pipeline (PTT or VAD mode) |
-| `POST` | `/api/voice/stop` | Stop voice pipeline |
-| `POST` | `/api/voice/ptt-start` | Begin push-to-talk recording |
-| `POST` | `/api/voice/ptt-stop` | Stop PTT recording and transcribe |
-| `POST` | `/api/voice/speak` | Synthesize and play TTS (202 fire-and-forget) |
-| `POST` | `/api/voice/stop-speaking` | Interrupt TTS playback |
-| `GET` | `/api/voice/audio` | WebSocket upgrade — binary PCM16 LE audio data plane |
 
 ## Usage
 

--- a/crates/gglib-core/README.md
+++ b/crates/gglib-core/README.md
@@ -86,7 +86,7 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 
 **Module Descriptions:**
 - **`domain/`** — Pure domain types: `Model`, `ModelFile`, `McpServer`, `Conversation`; agent loop primitives: `AgentConfig`, `AgentMessage`, `AgentEvent`, `ToolDefinition`, `ToolCall`, `ToolResult`; and server configuration: `ServerConfig` (per-model launch defaults with `context_length`, used in the 4-level fallback chain: runtime request → model `server_defaults` → global settings → hardcoded `DEFAULT_CONTEXT_SIZE`)
-- **`ports/`** — Trait definitions (repository ports, HF client port, event emitter, `VoicePipelinePort` for voice, `AgentLoopPort` / `ToolExecutorPort` / `AgentError` for the backend agentic loop)
+- **`ports/`** — Trait definitions (repository ports, HF client port, event emitter, `AgentLoopPort` / `ToolExecutorPort` / `AgentError` for the backend agentic loop)
 - **`services/`** — Application use cases and business logic orchestration (model management, server lifecycle, chat history, settings, model verification & repair)
 - **`events/`** — Strongly-typed application events for UI/adapter notification
 - **`paths/`** — Path configuration and platform-specific directory handling

--- a/crates/gglib-runtime/src/system/mod.rs
+++ b/crates/gglib-runtime/src/system/mod.rs
@@ -391,7 +391,7 @@ impl SystemProbePort for DefaultSystemProbe {
                 ),
                 system_dep(
                     "libasound2-dev",
-                    "Required for voice/audio support",
+                    "Required for audio support (ALSA)",
                     distro,
                     check_libasound(),
                 ),

--- a/crates/gglib-tauri/README.md
+++ b/crates/gglib-tauri/README.md
@@ -74,7 +74,7 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 </details>
 
 **Module Descriptions:**
-- **`bootstrap.rs`** — Dependency injection and service wiring (includes `ModelVerificationService` and `VoiceService` initialization)
+- **`bootstrap.rs`** — Dependency injection and service wiring (includes `ModelVerificationService` initialization)
 - **`error.rs`** — IPC-compatible error types
 - **`event_emitter.rs`** — `TauriEmitter` implementation of `AppEventEmitter`
 - **`events.rs`** — Event type definitions and serialization
@@ -113,7 +113,6 @@ Real-time events are delivered via SSE (`/api/events`) with Bearer auth, not Tau
 | `server:*` | Server lifecycle (start, ready, stop, error) |
 | `download:*` | Download progress and completion |
 | `log:*` | Server console output |
-| `voice:*` | Voice pipeline state, transcripts, audio levels |
 
 ## Usage
 

--- a/crates/gglib-tauri/README.md
+++ b/crates/gglib-tauri/README.md
@@ -102,7 +102,9 @@ The desktop app uses an **HTTP-first architecture** — model operations, chat, 
 | `set_proxy_state` | util | Update proxy menu toggle |
 | `check_llama_status` | llama | Check llama.cpp installation |
 | `install_llama` | llama | Install/build llama.cpp |
-| `log_from_frontend` | app_logs | Forward frontend logs to Rust logger |\n\nSee [src-tauri/README.md](../../src-tauri/README.md) for the full architecture explanation.
+| `log_from_frontend` | app_logs | Forward frontend logs to Rust logger |
+
+See [src-tauri/README.md](../../src-tauri/README.md) for the full architecture explanation.
 
 ## Events
 

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
 	<key>com.apple.security.device.audio-output</key>
 	<true/>
 </dict>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -7,7 +7,5 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>gglib needs microphone access for voice mode — local speech-to-text input via Whisper. Audio is processed entirely on-device and never leaves your machine.</string>
 </dict>
 </plist>

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -31,7 +31,6 @@ The Tauri application uses an **HTTP-first architecture** with minimal OS integr
    - `/api/proxy` - Proxy management
    - `/api/downloads` - Download queue management
    - `/api/mcp` - MCP server configuration
-   - `/api/voice/*` - Voice pipeline: models, devices, audio control, WebSocket audio data plane
    - `/api/events` - Server-Sent Events for real-time updates
 
 4. **System Tray**: The tray icon, its menu and the popover panel live in `src/tray/`. The panel is a second window loading its own Vite entry (`tray.html`), and uses **no Tauri IPC at all** — it reaches the embedded API through the same HTTP transport as every other surface. Window-level actions (open, preferences, quit) are on the native tray menu, handled in Rust, which is what keeps the command list below unchanged.
@@ -46,12 +45,6 @@ The Tauri application uses an **HTTP-first architecture** with minimal OS integr
    - `server:*` events - Server lifecycle updates
    - `download:*` events - Download progress
    - `log:*` events - Server console output
-   - `voice:state-changed` - Pipeline state transitions
-   - `voice:transcript` - STT transcription results
-   - `voice:speaking-started` / `voice:speaking-finished` - TTS playback lifecycle
-   - `voice:audio-level` - Microphone input level for UI indicators
-   - `voice:error` - Pipeline error notifications
-   - `voice:model-download-progress` - Voice model download progress
 
 This architecture means:
 - **Security**: All API access requires Bearer token, no unauthorized access to embedded server

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -82,7 +82,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
   const abortControllerRef = useRef<AbortController | null>(null);
   const [isRunning, setIsRunning] = useState(false);
 
-  // Extra metadata to merge into the next user message (e.g. isVoice)
+  // Extra metadata to merge into the next user message
   const nextMessageMetaRef = useRef<Partial<import('../../types/messages').GglibMessageCustom>>({});
   const setNextMessageMeta = useCallback((meta: Partial<import('../../types/messages').GglibMessageCustom>) => {
     nextMessageMetaRef.current = meta;
@@ -191,7 +191,7 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
 
     // User sends a new message
     onNew: async (msg: AppendMessage) => {
-      // Drain any one-shot metadata (e.g. isVoice) queued for this message
+      // Drain any one-shot metadata queued for this message
       const extraMeta = nextMessageMetaRef.current;
       nextMessageMetaRef.current = {};
 


### PR DESCRIPTION
## Summary

The voice feature (STT/TTS/VAD) was removed from every layer on 2026-04-25 in 58b4f94a — *"chore(voice): Remove voice feature (STT/TTS/VAD) across all layers"* (#450), a four-phase removal spanning 93 files and ~12,138 deletions. It deleted the `gglib-voice` crate, `handlers/voice.rs`, `handlers/voice_ws.rs`, `ws_audio.rs`, `ports/voice.rs`, `commands/voice.rs`, and all `src/**/voice.ts`.

That commit updated the architecture diagrams and badge tables but **missed the endpoint documentation**. Four READMEs have since advertised a complete voice API that 404s on every call — misleading for contributors, client generators, and onboarding agents alike.

This branch finishes that cleanup. **No routes, handlers, or types change.**

**Tier 2** (documentation) per the [GUI Parity Principle](../blob/main/CONTRIBUTING.md#gui-parity-principle).

## Files cleaned

| File | Removed |
|---|---|
| `crates/gglib-axum/README.md` | The 20-row `/api/voice/*` endpoint table; the `ws_audio.rs`, `handlers/voice.rs` and `handlers/voice_ws.rs` module descriptions; the `ws_audio.rs` box in the internal-structure diagram |
| `src-tauri/README.md` | The `/api/voice/*` frontend route bullet and six `voice:*` SSE event descriptions |
| `crates/gglib-tauri/README.md` | The `voice:*` events table row and the `VoiceService` mention in `bootstrap.rs` |
| `crates/gglib-core/README.md` | The `VoicePipelinePort` mention in the `ports/` description |

## Commits

1. **`docs(readme): remove phantom voice endpoint documentation`** — the removal above, kept as a pure deletion.
2. **`docs(readme): repair the broken IPC table render`** — `crates/gglib-tauri/README.md` had a *literal* `\n\n` on the last row of the IPC command table, gluing the "See src-tauri/README.md" sentence into the table cell. Pre-existing; fixed while in the file.
3. **`chore(voice): drop the last traces of the removed voice feature`** — leftovers outside the READMEs. No behaviour changes:
   - `src-tauri/Info.plist` — drop `NSMicrophoneUsageDescription`. The app has not captured audio since April 2026, but the key still triggered a macOS privacy prompt and invited App Store review questions about a capability that no longer exists.
   - `src-tauri/Entitlements.plist` — drop `com.apple.security.device.audio-input` to match. `audio-output` is kept deliberately.
   - `crates/gglib-runtime/src/system/mod.rs` — the `libasound2-dev` entry described itself as "Required for voice/audio support". ALSA is still a genuine system dependency, so only the description changes, to the wording `scripts/check-deps.sh:793` already uses. #450 updated the shell script but not this Rust mirror.
   - `src/hooks/useGglibRuntime/useGglibRuntime.ts` — two comments cited `isVoice` as the example payload for the one-shot message-metadata channel. That field went with the feature; the channel is generic and still in use, so only the stale example is removed.

## Note on the diagram

The `ws_audio.rs` row of the gglib-axum internal-structure diagram was **already broken** — lines 55 and 59 measured 81 columns against 87 for every other line in the box. Removing the box forced a rebuild, so the row is now correctly aligned at 87.

## Verification

- `bash scripts/check_boundaries.sh` (includes `check_readmes.sh --strict`) — pass
- `cargo clippy -p gglib-axum -p gglib-tauri -p gglib-core -p gglib-runtime --all-targets` — pass
- `cargo doc -p gglib-axum -p gglib-tauri -p gglib-core --no-deps` — pass, **9 warnings before and after** (all pre-existing, unrelated to voice)
- `cargo test --doc` on all four crates — pass
- `cargo fmt --check`, `npx tsc --noEmit`, `npx eslint` — pass
- Both plists re-parsed with `plistlib` to confirm valid XML
- `grep -ri voice` across project markdown — zero hits

Crate READMEs are compiled as rustdoc via `include_str!` in `lib.rs`, so the `cargo doc` / clippy `doc_markdown` checks above matter here rather than being incidental.

## Deliberately out of scope

- `crates/gglib-runtime/src/proxy/mod.rs:3` and `proxy/banner.rs:4` use "voice" metaphorically ("the proxy's output voice") — not the feature.
- `src/utils/messages/README.md` mentions "audio" as an OpenAI message *content part* — unrelated.

## Pre-existing drift found but not fixed here

Worth follow-up issues; all unrelated to voice, so left out to keep this branch clean:

1. **`crates/gglib-axum/README.md` still documents `POST`/`DELETE /api/serve/:id`, which do not exist.** The real routes are `POST /api/servers/{id}/start` and `POST /api/servers/{id}/stop`. The endpoint table also uses axum 0.7 `:id` syntax throughout while `routes.rs` is on 0.8 `{id}`. Removing the voice rows does **not** make this table fully accurate.
2. **`src-tauri/README.md:39`** claims IPC is "limited to 6 OS integration functions" while `src-tauri/src/main.rs` registers 9.
