### PR TITLE
feat(pipeline): low-watermark hysteresis for KV-cache-stable history truncation

### DIFF
--- a/crates/gglib-core/src/request_pipeline/truncation.rs
+++ b/crates/gglib-core/src/request_pipeline/truncation.rs
@@ -169,17 +169,18 @@ pub fn truncate_history(
 
     // ── Oldest-first trim ────────────────────────────────────────────────────
     // Walk from the oldest message toward the newest, eliding eligible
-    // oversized content only until the running payload estimate drops back
-    // under budget. `running` tracks the approximate payload size as each
-    // replacement shrinks it, so we stop at the minimum necessary and leave the
-    // freshest tool outputs intact.
+    // oversized content only until the cumulative estimated savings reach the
+    // target, so the freshest tool outputs are the last to be sacrificed. The
+    // budget gate above guarantees the target is positive, so the loop never
+    // stops before considering the first eligible message.
     let total = messages.len();
     let placeholder_len = TRUNCATION_PLACEHOLDER.len();
+    let target_savings = payload_chars_before - limit_chars;
     let mut messages_truncated = 0usize;
-    let mut running = payload_chars_before;
+    let mut saved = 0usize;
 
     for (i, msg) in messages.iter_mut().enumerate() {
-        if running <= limit_chars {
+        if saved >= target_savings {
             break;
         }
         // Tail-protected messages and non-candidate roles (system, user) are
@@ -202,11 +203,11 @@ pub fn truncate_history(
         msg["content"] = Value::String(TRUNCATION_PLACEHOLDER.to_owned());
         messages_truncated += 1;
         // Each replacement reclaims (content_len - placeholder_len) chars.
-        running = running.saturating_sub(content_len.saturating_sub(placeholder_len));
+        saved = saved.saturating_add(content_len.saturating_sub(placeholder_len));
     }
 
     // ── Budget check ─────────────────────────────────────────────────────────
-    // Re-measure only when something actually changed; `running` is an estimate
+    // Re-measure only when something actually changed; `saved` is an estimate
     // and the hard abort deserves the real number.
     let payload_chars_after = if messages_truncated == 0 {
         payload_chars_before

--- a/crates/gglib-core/src/request_pipeline/truncation.rs
+++ b/crates/gglib-core/src/request_pipeline/truncation.rs
@@ -16,14 +16,14 @@
 //!    elided while there is room, so the model keeps maximum context on every
 //!    turn that does not actually need trimming.
 //!
-//! 2. **Oldest-first trim** — only when the payload exceeds the budget are
-//!    messages elided, and then only as many as necessary: unprotected
-//!    `role: "tool"` / `role: "assistant"` messages whose `content` string
-//!    exceeds [`TOOL_CONTENT_THRESHOLD_CHARS`] are replaced with
-//!    [`TRUNCATION_PLACEHOLDER`] **from oldest to newest**, stopping as soon as
-//!    the running payload estimate drops back under budget. The freshest tool
-//!    outputs — the ones the model most likely still needs — are the last to be
-//!    sacrificed.
+//! 2. **Oldest-first trim to a low watermark** — only when the payload exceeds
+//!    the budget are messages elided: unprotected `role: "tool"` /
+//!    `role: "assistant"` messages whose `content` string exceeds
+//!    [`TOOL_CONTENT_THRESHOLD_CHARS`] are replaced with
+//!    [`TRUNCATION_PLACEHOLDER`] **from oldest to newest**, until the estimated
+//!    savings reach a quantized target aimed at [`LOW_WATERMARK_PCT`] of the
+//!    budget. The freshest tool outputs — the ones the model most likely still
+//!    needs — are the last to be sacrificed.
 //!
 //! 3. **Hard abort** — if the payload still exceeds the budget after every
 //!    eligible message has been trimmed (an enormous protected system prompt,
@@ -34,6 +34,28 @@
 //!    [`PROTECTED_TAIL_COUNT`] messages by index (the immediate conversational
 //!    context, spanning several recent tool-call/result pairs) are never
 //!    modified. Neither is `tool_calls`, at any role.
+//!
+//! ## Why trim past the budget, and why the target is quantized
+//!
+//! This stage is stateless and clients resend the full raw history every turn,
+//! so an elision never persists: each request re-derives the elision set from
+//! scratch. Trimming to just under the budget therefore moves the elision
+//! frontier forward by ~one message on every turn of a long agentic session —
+//! and every move shifts the first byte at which the forwarded prompt differs
+//! from the previous turn's, breaking llama.cpp's common-prefix KV-cache match
+//! and forcing a near-full prompt re-prefill each turn.
+//!
+//! Aiming lower (a classic low watermark) is not enough by itself: a minimal
+//! elision set computed against *any* fixed threshold still grows at the same
+//! per-turn cadence. Instead the savings target is quantized to whole
+//! multiples of the watermark margin (budget − watermark, 25% of budget).
+//! Within one margin's worth of payload growth the target — and therefore the
+//! elision set — is identical across turns, so consecutive requests share
+//! their prompt prefix and llama-server only prefills the new tail. When
+//! growth crosses a margin boundary, several messages are elided at once and
+//! the cycle restarts: the post-trim payload lands at or below the watermark,
+//! sawtoothing within (50%, 75%] of budget, and prefix breaks happen once per
+//! ~25%-of-budget of growth instead of once per turn.
 //!
 //! ## The budget is the model's, and only the model's
 //!
@@ -76,6 +98,15 @@ pub const CHARS_PER_TOKEN_APPROX: usize = 4;
 /// coherently — sized to span several recent tool-call/result pairs so a live
 /// tool exchange is never half-elided.
 pub const PROTECTED_TAIL_COUNT: usize = 8;
+
+/// Low watermark the trim aims for, as a percentage of the request budget.
+///
+/// Once truncation is triggered (payload over `limit_chars`), the stage trims
+/// past the budget down toward this fraction of it, buying several turns of
+/// headroom in which follow-up requests need no new elisions — the property
+/// that keeps the forwarded prompt prefix stable for llama.cpp's KV cache.
+/// See the module docs for why the savings target is also quantized.
+pub const LOW_WATERMARK_PCT: usize = 75;
 
 /// Replacement string inserted in place of truncated message content.
 pub const TRUNCATION_PLACEHOLDER: &str = "[Raw tool output truncated by proxy to maintain context window. \
@@ -137,7 +168,9 @@ pub enum TruncationError {
 // The stage
 // =============================================================================
 
-/// Trim stale history in place so the request fits within `limit_chars`.
+/// Trim stale history in place so the request fits within `limit_chars`,
+/// aiming past the budget for the [`LOW_WATERMARK_PCT`] watermark once
+/// triggered.
 ///
 /// `limit_chars` is the total payload character budget for this request. See
 /// the [module documentation](self) for the full algorithm.
@@ -169,13 +202,16 @@ pub fn truncate_history(
 
     // ── Oldest-first trim ────────────────────────────────────────────────────
     // Walk from the oldest message toward the newest, eliding eligible
-    // oversized content only until the cumulative estimated savings reach the
-    // target, so the freshest tool outputs are the last to be sacrificed. The
-    // budget gate above guarantees the target is positive, so the loop never
-    // stops before considering the first eligible message.
+    // oversized content until the cumulative estimated savings reach the
+    // quantized watermark target, so the freshest tool outputs are the last to
+    // be sacrificed. The budget gate above guarantees the target is positive,
+    // so the loop never stops before considering the first eligible message.
+    // Exhausting the eligible messages short of the target is fine: the hard
+    // abort below fires only when the payload still exceeds the budget itself,
+    // not the watermark.
     let total = messages.len();
     let placeholder_len = TRUNCATION_PLACEHOLDER.len();
-    let target_savings = payload_chars_before - limit_chars;
+    let target_savings = target_savings_chars(payload_chars_before, limit_chars);
     let mut messages_truncated = 0usize;
     let mut saved = 0usize;
 
@@ -232,6 +268,32 @@ pub fn truncate_history(
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/// The number of estimated characters truncation must reclaim from a payload
+/// of `payload_chars` under a budget of `limit_chars`.
+///
+/// The naive answer — `payload_chars - limit_chars`, just enough to fit —
+/// re-elides one more message on almost every turn of a growing conversation,
+/// because this stage is stateless and the client resends the full raw history
+/// each time. The target is therefore anchored at the [`LOW_WATERMARK_PCT`]
+/// watermark and rounded **up** to a whole multiple of the margin between
+/// watermark and budget: the result depends on the payload size only through
+/// that coarse bracket, so the elision set it induces stays identical across
+/// every turn within one margin (~25% of budget) of payload growth. See the
+/// module docs for the full KV-cache rationale.
+///
+/// Returns `0` when the payload is already at or below the watermark. The
+/// margin is clamped to at least one character so a degenerate `limit_chars`
+/// of `0` still yields a finite target (the whole payload).
+const fn target_savings_chars(payload_chars: usize, limit_chars: usize) -> usize {
+    let watermark = limit_chars.saturating_mul(LOW_WATERMARK_PCT) / 100;
+    let margin = match limit_chars - watermark {
+        0 => 1,
+        margin => margin,
+    };
+    let needed = payload_chars.saturating_sub(watermark);
+    needed.div_ceil(margin).saturating_mul(margin)
+}
 
 /// Byte length of `body` once serialized, without allocating a copy of it.
 ///

--- a/crates/gglib-core/src/request_pipeline/truncation_tests.rs
+++ b/crates/gglib-core/src/request_pipeline/truncation_tests.rs
@@ -141,9 +141,10 @@ fn system_messages_are_never_truncated() {
 /// recent turns, however tight the budget.
 #[test]
 fn the_protected_tail_is_never_trimmed() {
-    // One huge unprotected tool at index 0, then two oversized tools that sit
-    // inside the protected tail. Trimming index 0 alone drops the payload under
-    // budget, and the tail must be untouched regardless.
+    // One huge tool at index 0, then two oversized tools at indices 1-2. With
+    // eleven messages the protected window is indices 3..=10, so all three are
+    // eligible — but index 0 alone covers the savings target, and everything
+    // behind it survives, protected tail included.
     let mut b = body(&with_tail(vec![
         msg("tool", &big(300_000)),
         msg("tool", &big(30_000)),
@@ -292,4 +293,151 @@ fn a_large_budget_admits_a_payload_the_old_floor_would_have_allowed_anyway() {
     ]);
 
     assert!(truncate_history(&mut b, 131_072 * CHARS_PER_TOKEN_APPROX).is_ok());
+}
+
+// ── Low-watermark hysteresis ─────────────────────────────────────────────────
+
+#[test]
+fn a_payload_in_the_dead_zone_is_left_untouched() {
+    // Two 100k tool messages land the payload (~200k) between the 180k
+    // watermark and the 240k budget. Over the watermark is not a trigger —
+    // only over the budget is — so nothing moves and the prompt prefix
+    // survives verbatim.
+    let mut b = body(&with_tail(vec![
+        msg("tool", &big(100_000)),
+        msg("tool", &big(100_000)),
+    ]));
+    let before = b.clone();
+
+    let report = truncate_history(&mut b, ROOMY).unwrap();
+
+    assert_eq!(b, before, "no trimming inside the dead zone");
+    assert_eq!(report.messages_truncated, 0);
+    assert_eq!(report.payload_chars_before, report.payload_chars_after);
+    // The fixture really is inside the zone, not merely under the budget.
+    assert!(report.payload_chars_before > ROOMY * LOW_WATERMARK_PCT / 100);
+    assert!(report.payload_chars_before <= ROOMY);
+}
+
+#[test]
+fn a_triggered_trim_lands_at_the_watermark_not_barely_under_budget() {
+    // Same fixture as `over_budget_trims_oldest_first_and_stops_early`:
+    // minimal-fit trimming would stop after two messages, just under the 240k
+    // budget, and then move the elision frontier again on the very next turn.
+    // The watermark target takes a third, parking the payload under 75% of
+    // budget so following turns need no new elisions.
+    let mut b = body(&with_tail(vec![
+        msg("tool", &big(100_000)),
+        msg("tool", &big(100_000)),
+        msg("tool", &big(100_000)),
+        msg("tool", &big(100_000)),
+    ]));
+
+    let report = truncate_history(&mut b, ROOMY).unwrap();
+
+    assert_eq!(report.messages_truncated, 3, "one more than minimal fit");
+    assert!(report.payload_chars_after <= ROOMY * LOW_WATERMARK_PCT / 100);
+}
+
+#[test]
+fn the_savings_target_is_quantized_to_watermark_margins() {
+    // limit 1,000 → watermark 750, margin 250.
+    assert_eq!(target_savings_chars(1_000, 1_000), 250, "bracket floor");
+    assert_eq!(target_savings_chars(1_001, 1_000), 500, "first crossing");
+    assert_eq!(target_savings_chars(1_250, 1_000), 500, "bracket edge");
+    assert_eq!(
+        target_savings_chars(1_251, 1_000),
+        750,
+        "just past the edge"
+    );
+}
+
+#[test]
+fn a_payload_at_or_below_the_watermark_needs_no_savings() {
+    assert_eq!(target_savings_chars(750, 1_000), 0);
+    assert_eq!(target_savings_chars(0, 1_000), 0);
+}
+
+#[test]
+fn a_degenerate_budget_clamps_the_margin_rather_than_dividing_by_zero() {
+    // limit 0 → watermark 0, margin clamps to 1: the whole payload is owed.
+    assert_eq!(target_savings_chars(42, 0), 42);
+    // limit 1 → watermark 1 * 75 / 100 = 0, margin 1.
+    assert_eq!(target_savings_chars(10, 1), 10);
+}
+
+/// The property this whole feature exists for: as a conversation grows past
+/// the budget turn after turn, the elision set — and therefore the forwarded
+/// prompt prefix llama.cpp matches its KV cache against — stays identical
+/// until growth crosses a whole watermark margin, instead of shifting on
+/// every turn.
+#[test]
+fn the_elision_set_is_stable_while_the_conversation_grows_within_a_bracket() {
+    fn elided_indices(b: &Value) -> Vec<usize> {
+        b["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| m["content"] == TRUNCATION_PLACEHOLDER)
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    // Budget 200,000 → watermark 150,000, margin 50,000. Turn `t` resends the
+    // full raw history as `t` identical 10k tool messages (the stage is
+    // stateless), so the serialized payload is 35 + 10,029·t and each elision
+    // saves 9,900. Growth per turn (10,029) exceeds savings per message
+    // (9,900): the pre-watermark minimal-fit rule would have moved the elision
+    // frontier on *every* triggered turn of this schedule.
+    const LIMIT: usize = 200_000;
+
+    let mut previous: Option<(Vec<usize>, Vec<Value>)> = None;
+    let mut transitions = 0usize;
+
+    for t in 1..=30 {
+        let mut b = body(&vec![msg("tool", &big(10_000)); t]);
+        let report = truncate_history(&mut b, LIMIT).unwrap();
+
+        // Hand-computed: t ≤ 19 fits (190,586 ≤ 200,000 at t = 19); the
+        // savings target is then 100,000 (turns 20-24, 11 elisions), 150,000
+        // (turns 25-29, 16 elisions), and 200,000 (turn 30, 21 elisions).
+        let expected: Vec<usize> = match t {
+            ..=19 => vec![],
+            20..=24 => (0..=10).collect(),
+            25..=29 => (0..=15).collect(),
+            _ => (0..=20).collect(),
+        };
+        let actual = elided_indices(&b);
+        assert_eq!(actual, expected, "elision set at turn {t}");
+
+        if report.messages_truncated > 0 {
+            assert!(
+                report.payload_chars_after <= LIMIT * LOW_WATERMARK_PCT / 100,
+                "turn {t} must land at or below the watermark"
+            );
+        }
+
+        let messages = b["messages"].as_array().unwrap().clone();
+        if let Some((previous_set, previous_messages)) = previous {
+            if actual == previous_set {
+                // The KV-cache property: while the elision set holds, the
+                // previous turn's entire forwarded message array is a literal
+                // prefix of this turn's.
+                assert_eq!(
+                    &messages[..previous_messages.len()],
+                    &previous_messages[..],
+                    "prefix must be stable into turn {t}"
+                );
+            } else {
+                transitions += 1;
+            }
+        }
+        previous = Some((actual, messages));
+    }
+
+    // One initial truncation event (turn 20) plus two bracket crossings
+    // (turns 25 and 30). Minimal-fit trimming would have made ~11 of the 30
+    // turns move the frontier — one per triggered turn.
+    assert_eq!(transitions, 3, "prefix breaks across the whole session");
 }

--- a/crates/gglib-core/src/request_pipeline/truncation_tests.rs
+++ b/crates/gglib-core/src/request_pipeline/truncation_tests.rs
@@ -79,8 +79,8 @@ fn missing_messages_field_passes_through_unchanged() {
 #[test]
 fn over_budget_trims_oldest_first_and_stops_early() {
     // Four 100k tool messages outside the protected tail. The payload (~400k)
-    // exceeds the 240k budget; trimming the two oldest brings it back under, so
-    // the two newer ones must survive.
+    // exceeds the 240k budget; the quantized watermark target (240,000 saved
+    // chars here) takes the three oldest, so the newest must survive.
     let mut b = body(&with_tail(vec![
         msg("tool", &big(100_000)),
         msg("tool", &big(100_000)),
@@ -91,18 +91,18 @@ fn over_budget_trims_oldest_first_and_stops_early() {
     let report = truncate_history(&mut b, ROOMY).unwrap();
 
     assert_eq!(
-        report.messages_truncated, 2,
-        "only as many oldest messages as needed to get under budget"
+        report.messages_truncated, 3,
+        "as many oldest messages as the watermark target needs"
     );
     assert_eq!(b["messages"][0]["content"], TRUNCATION_PLACEHOLDER);
     assert_eq!(b["messages"][1]["content"], TRUNCATION_PLACEHOLDER);
+    assert_eq!(b["messages"][2]["content"], TRUNCATION_PLACEHOLDER);
     assert_eq!(
-        b["messages"][2]["content"].as_str().unwrap().len(),
+        b["messages"][3]["content"].as_str().unwrap().len(),
         100_000,
-        "newer big message preserved once under budget"
+        "newest big message preserved once the target is met"
     );
-    assert_eq!(b["messages"][3]["content"].as_str().unwrap().len(), 100_000);
-    assert!(report.payload_chars_after <= ROOMY);
+    assert!(report.payload_chars_after <= ROOMY * LOW_WATERMARK_PCT / 100);
     assert!(report.payload_chars_after < report.payload_chars_before);
 }
 


### PR DESCRIPTION
## Problem

Once a long agentic session crosses the context budget, stage-3 truncation elides one more message on almost every turn. The stage is stateless — clients resend the full raw history each request — so each turn re-derives a *minimal-fit* elision set, and the elision frontier keeps advancing. Every advance shifts the first byte at which the forwarded prompt differs from the previous turn's, breaking llama.cpp's common-prefix KV-cache match and forcing a near-full prompt re-prefill on **every** request. For a session pinned near a 128k context that is tens of seconds of prefill latency per turn, every turn.

## Mechanism

Trigger and hard-abort semantics are unchanged: nothing is touched at or under the budget, and an error still means the payload could not fit the budget itself. But once triggered, the trim now reclaims a savings target anchored at a **75% low watermark** (`LOW_WATERMARK_PCT`) and rounded up to a whole multiple of the watermark margin (25% of budget).

The quantization is the load-bearing part. A classic low watermark alone does not survive statelessness: a minimal elision set computed against *any* fixed threshold still grows at the same per-turn cadence — only the threshold moves. Rounding the savings target up to whole margin brackets makes the elision set depend on payload size only through the bracket index, i.e. **piecewise-constant** as the conversation grows.

## Properties

- After a truncation event, subsequent turns re-derive the *identical* elision set until raw growth crosses a margin boundary (~25% of budget) — the forwarded prefix is byte-for-byte stable and llama-server only prefills the new tail.
- Prefix breaks drop from ~once per turn to once per ~25%-of-budget of growth. The 30-turn adversarial simulation in the test suite counts **3** prefix breaks where minimal-fit trimming would have caused **11**.
- Post-trim payload lands at or below the watermark, sawtoothing within (50%, 75%] of budget.
- Best-effort between watermark and budget when eligible savings run out; the error path is untouched.

Implemented entirely inside the shared pipeline stage (`truncate_history` signature unchanged, zero caller edits), so the proxy, CLI agent, and GUI surfaces all inherit it. This is the output-side complement to the session-frozen chars-per-token calibration in `forward.rs`, which stabilised the budget *input* for exactly this prefix-cache reason.

## Commits

1. `refactor(pipeline)` — NFC: restructure the trim loop around a savings target (provably equivalent to the old running-estimate stop).
2. `feat(pipeline)` — the watermark + quantized target, rustdoc, and the single existing-test expectation that changes workspace-wide.
3. `test(pipeline)` — dead-zone, watermark-landing, target-arithmetic, and 30-turn prefix-stability coverage.

## Notes

- `make pre-commit` (fmt, clippy `-D warnings`, check, full test suite) passes; `gglib-proxy` and `gglib-runtime` suites need zero changes.
- `crates/gglib-proxy/README.md`'s truncation algorithm blurb ("stopping as soon as the payload drops back under budget") is now stale; left untouched here deliberately — docs sweep as follow-up.