### PR TITLE
feat(gui): show sampling provenance in the model inspector

### DIFF
--- a/crates/gglib-app-services/src/lib.rs
+++ b/crates/gglib-app-services/src/lib.rs
@@ -22,6 +22,7 @@ mod downloads;
 mod mcp;
 mod models;
 mod proxy;
+mod sampling_explain;
 mod servers;
 mod service_graph;
 mod settings;
@@ -37,6 +38,9 @@ pub use downloads::{DownloadDeps, DownloadOps};
 pub use mcp::{McpDeps, McpOps};
 pub use models::{ModelDeps, ModelOps};
 pub use proxy::{ProxyDeps, ProxyOps};
+pub use sampling_explain::{
+    ParamProvenanceDto, ProvenanceKindDto, SamplingExplanationDto, SamplingLayerDto,
+};
 pub use servers::{ServerDeps, ServerOps};
 pub use service_graph::{AppServices, ServiceGraphParams, build_service_graph};
 pub use settings::{SettingsDeps, SettingsOps};

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -11,6 +11,7 @@ use gglib_core::{
 };
 
 use crate::error::GuiError;
+use crate::sampling_explain::{self, SamplingExplanationDto};
 use crate::types::{
     AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, SetCapabilitiesRequest,
     UpdateModelRequest,
@@ -108,6 +109,39 @@ impl ModelOps {
         let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
         let (is_serving, port) = self.get_server_status(id).await;
         Ok(ModelDetailDto::from_model(model, is_serving, port))
+    }
+
+    /// Resolve a model's sampling parameters and report which layer supplied
+    /// each one.
+    ///
+    /// The shared data source for the CLI `model explain` command and the
+    /// `GET /api/models/:id/explain` route. `profile` names a configured
+    /// [`InferenceProfile`] to apply on top of the model's own defaults;
+    /// an unknown name is a [`GuiError::ValidationFailed`] rather than a
+    /// silent fall back to the unprofiled resolution.
+    ///
+    /// [`InferenceProfile`]: gglib_core::domain::InferenceProfile
+    pub async fn explain_sampling(
+        &self,
+        id: i64,
+        profile: Option<&str>,
+    ) -> Result<SamplingExplanationDto, GuiError> {
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
+        let settings = self
+            .deps
+            .core
+            .settings()
+            .get()
+            .await
+            .map_err(|e| GuiError::Internal(format!("Failed to load settings: {e}")))?;
+
+        let selected = profile
+            .map(|name| {
+                sampling_explain::find_profile(name, settings.inference_profiles.as_deref())
+            })
+            .transpose()?;
+
+        Ok(sampling_explain::explain(&model, &settings, selected))
     }
 
     pub async fn add(&self, request: AddModelRequest) -> Result<GuiModel, GuiError> {
@@ -324,6 +358,7 @@ mod tests {
 
     use super::*;
     use crate::error::GuiError;
+    use crate::sampling_explain::ProvenanceKindDto;
     use crate::test_support::test_core;
     use gglib_core::ports::{NoopGgufParser, NoopModelRuntime};
 
@@ -622,5 +657,141 @@ mod tests {
             cleared.server_defaults.is_none(),
             "explicit JSON null must clear server_defaults"
         );
+    }
+
+    // ── explain_sampling ──────────────────────────────────────────────────
+    //
+    // The resolution itself is covered in `sampling_explain`; these cover the
+    // wiring — model lookup, settings load, and profile selection.
+
+    /// Import a placeholder model and return its id.
+    async fn seed_model(ops: &ModelOps, dir: &tempfile::TempDir) -> i64 {
+        let gguf_path = dir.path().join("model.gguf");
+        fs::write(&gguf_path, b"placeholder").await.unwrap();
+        ops.add(AddModelRequest {
+            file_path: gguf_path.to_str().unwrap().to_string(),
+        })
+        .await
+        .expect("add should succeed")
+        .id
+    }
+
+    fn profile(name: &str, temperature: f32) -> gglib_core::domain::InferenceProfile {
+        gglib_core::domain::InferenceProfile {
+            name: name.to_owned(),
+            description: None,
+            config: gglib_core::domain::InferenceConfig {
+                temperature: Some(temperature),
+                ..Default::default()
+            },
+            list_in_models: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn explain_sampling_falls_back_to_the_floor_when_nothing_is_stored() {
+        let core = test_core().await;
+        let ops = make_ops(Arc::clone(&core));
+        let dir = tempdir().unwrap();
+        let id = seed_model(&ops, &dir).await;
+
+        let dto = ops.explain_sampling(id, None).await.expect("explain");
+
+        assert_eq!(dto.resolved.temperature, Some(0.7));
+        assert!(dto.profile.is_none());
+        assert!(!dto.is_reasoning);
+        assert!(
+            dto.sources
+                .iter()
+                .all(|entry| entry.layer.is_none() && entry.kind != ProvenanceKindDto::Layer),
+            "no layer should have supplied anything: {:?}",
+            dto.sources
+        );
+    }
+
+    #[tokio::test]
+    async fn explain_sampling_unknown_id_returns_not_found() {
+        let core = test_core().await;
+        let ops = make_ops(core);
+        let result = ops.explain_sampling(999, None).await;
+        assert!(
+            matches!(
+                result,
+                Err(GuiError::NotFound {
+                    entity: "model",
+                    ..
+                })
+            ),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    /// A named profile that does not exist is a caller error, not a reason to
+    /// answer a different question.
+    #[tokio::test]
+    async fn explain_sampling_unknown_profile_names_the_configured_ones() {
+        let core = test_core().await;
+        let ops = make_ops(Arc::clone(&core));
+        let dir = tempdir().unwrap();
+        let id = seed_model(&ops, &dir).await;
+
+        core.settings()
+            .update(gglib_core::SettingsUpdate {
+                inference_profiles: Some(Some(vec![profile("coding", 0.2)])),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let result = ops.explain_sampling(id, Some("codign")).await;
+        let Err(GuiError::ValidationFailed(message)) = result else {
+            panic!("expected ValidationFailed, got {result:?}");
+        };
+        assert!(message.contains("codign"), "{message}");
+        assert!(message.contains("coding"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn explain_sampling_applies_a_named_profile_over_global_settings() {
+        let core = test_core().await;
+        let ops = make_ops(Arc::clone(&core));
+        let dir = tempdir().unwrap();
+        let id = seed_model(&ops, &dir).await;
+
+        core.settings()
+            .update(gglib_core::SettingsUpdate {
+                inference_defaults: Some(Some(gglib_core::domain::InferenceConfig {
+                    temperature: Some(0.4),
+                    ..Default::default()
+                })),
+                inference_profiles: Some(Some(vec![profile("coding", 0.2)])),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let unprofiled = ops.explain_sampling(id, None).await.expect("explain");
+        assert_eq!(unprofiled.resolved.temperature, Some(0.4));
+
+        let profiled = ops
+            .explain_sampling(id, Some("coding"))
+            .await
+            .expect("explain");
+        assert_eq!(profiled.profile.as_deref(), Some("coding"));
+        assert_eq!(profiled.resolved.temperature, Some(0.2));
+    }
+
+    #[tokio::test]
+    async fn explain_sampling_reads_the_reasoning_tag_from_the_stored_model() {
+        let core = test_core().await;
+        let ops = make_ops(Arc::clone(&core));
+        let dir = tempdir().unwrap();
+        let id = seed_model(&ops, &dir).await;
+
+        ops.add_tag(id, "reasoning".to_owned()).await.unwrap();
+
+        let dto = ops.explain_sampling(id, None).await.expect("explain");
+        assert!(dto.is_reasoning);
+        assert_eq!(dto.resolved.presence_penalty, Some(1.0));
     }
 }

--- a/crates/gglib-app-services/src/sampling_explain.rs
+++ b/crates/gglib-app-services/src/sampling_explain.rs
@@ -1,0 +1,546 @@
+//! Resolved sampling parameters plus the layer that supplied each one.
+//!
+//! The wire form of [`FieldSources`](gglib_core::domain::FieldSources), which the surfaces cannot serialize
+//! directly: [`ParamSource::Layer`] carries a ladder index rather than a name,
+//! and the core provenance types predate the camelCase convention the rest of
+//! the HTTP API follows. Translating once here keeps a single description of
+//! the shape instead of one per surface.
+//!
+//! Nothing in this module re-derives the ladder. The values and their
+//! provenance both come from
+//! [`InferenceConfig::resolve_with_profile_explained`] — the same call the
+//! plain resolution makes — so an explanation cannot describe a hierarchy that
+//! differs from the one that runs.
+
+use gglib_core::domain::{
+    InferenceConfig, InferenceProfile, Model, ModelSamplingContext, ParamSource, SamplingLayer,
+};
+use gglib_core::settings::Settings;
+use serde::{Deserialize, Serialize};
+
+use crate::error::GuiError;
+
+/// A model's resolved sampling parameters and where each value came from.
+///
+/// Consumers:
+/// - Axum: `GET /api/models/:id/explain`
+/// - GUI frontend: the inspector's Sampling section
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SamplingExplanationDto {
+    /// The fully resolved configuration, after floors.
+    ///
+    /// Carried whole rather than copied field-by-field into
+    /// [`ParamProvenanceDto`], so each value keeps the width it was declared
+    /// at and `serde_json` emits the shortest representation that round-trips
+    /// — `0.95`, not the `0.949999988079071` a detour through `f64` produces.
+    pub resolved: InferenceConfig,
+    /// Per-parameter provenance, in [`FieldSources::iter`](gglib_core::domain::FieldSources::iter)'s display order.
+    pub sources: Vec<ParamProvenanceDto>,
+    /// The profile applied, if the caller named one.
+    pub profile: Option<String>,
+    /// Whether the model carries the `reasoning` tag, which selects the floor.
+    pub is_reasoning: bool,
+    /// Whether client-supplied sampling is trusted, which the table cannot
+    /// show: that rung is never stored on the model.
+    pub trust_client_sampling: bool,
+}
+
+/// Where one resolved parameter's value came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParamProvenanceDto {
+    /// The camelCase key this entry describes in
+    /// [`SamplingExplanationDto::resolved`], e.g. `topP`.
+    pub param: String,
+    /// Which class of source supplied the value.
+    pub kind: ProvenanceKindDto,
+    /// The ladder rung, present only when `kind` is
+    /// [`Layer`](ProvenanceKindDto::Layer).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layer: Option<SamplingLayerDto>,
+}
+
+/// The wire form of [`ParamSource`], with the ladder index resolved to a name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProvenanceKindDto {
+    /// A ladder rung named the value; see [`ParamProvenanceDto::layer`].
+    Layer,
+    /// The class floor, because no rung named a value at all.
+    Floor,
+    /// The class floor, because a rung claimed `temperature` and this
+    /// parameter is tuned against it.
+    FloorCoupled,
+    /// Nothing named it and the floor carries none either.
+    Unset,
+}
+
+/// The wire form of [`SamplingLayer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SamplingLayerDto {
+    /// Caller-supplied overrides — request parameters or CLI flags.
+    Request,
+    /// The named profile the caller selected.
+    Profile,
+    /// Per-model defaults a person tuned deliberately.
+    ModelUserSet,
+    /// Global settings defaults.
+    Global,
+    /// Per-model defaults written automatically from the `reasoning` tag.
+    ModelAutoDetected,
+}
+
+impl From<SamplingLayer> for SamplingLayerDto {
+    fn from(layer: SamplingLayer) -> Self {
+        match layer {
+            SamplingLayer::Request => Self::Request,
+            SamplingLayer::Profile => Self::Profile,
+            SamplingLayer::ModelUserSet => Self::ModelUserSet,
+            SamplingLayer::Global => Self::Global,
+            SamplingLayer::ModelAutoDetected => Self::ModelAutoDetected,
+        }
+    }
+}
+
+/// The camelCase key one [`FieldSources`](gglib_core::domain::FieldSources) field occupies in a serialized
+/// [`InferenceConfig`].
+///
+/// A field this does not know is returned unchanged, which produces a `param`
+/// that indexes nothing rather than a panic in a read-only view. The pairing
+/// is pinned by `every_param_is_a_key_of_the_resolved_config` below, so a new
+/// field on `FieldSources` fails a test rather than reaching a client.
+fn wire_key(field: &'static str) -> &'static str {
+    match field {
+        "top_p" => "topP",
+        "top_k" => "topK",
+        "presence_penalty" => "presencePenalty",
+        "repeat_penalty" => "repeatPenalty",
+        "min_p" => "minP",
+        "max_tokens" => "maxTokens",
+        other => other,
+    }
+}
+
+/// Translate one `(field, source)` pair into its wire form.
+fn provenance(field: &'static str, source: ParamSource) -> ParamProvenanceDto {
+    let (kind, layer) = match source {
+        // `from_index` returns `None` only for a ladder longer than the five
+        // rungs `resolve_with_profile_explained` builds, which this module
+        // never resolves. Surface it as a nameless layer rather than guessing.
+        ParamSource::Layer(index) => (
+            ProvenanceKindDto::Layer,
+            SamplingLayer::from_index(index).map(SamplingLayerDto::from),
+        ),
+        ParamSource::Floor => (ProvenanceKindDto::Floor, None),
+        ParamSource::FloorCoupled => (ProvenanceKindDto::FloorCoupled, None),
+        ParamSource::Unset => (ProvenanceKindDto::Unset, None),
+    };
+
+    ParamProvenanceDto {
+        param: wire_key(field).to_owned(),
+        kind,
+        layer,
+    }
+}
+
+/// Look up a configured profile by name.
+///
+/// Errors rather than falling back to no profile: someone who named a profile
+/// wants to see that profile's effect, and silently showing them the
+/// unprofiled resolution would answer a question they did not ask. The message
+/// names what does exist, so a typo is self-correcting.
+pub(crate) fn find_profile<'a>(
+    name: &str,
+    profiles: Option<&'a [InferenceProfile]>,
+) -> Result<&'a InferenceProfile, GuiError> {
+    let profiles = profiles.unwrap_or_default();
+    profiles
+        .iter()
+        .find(|profile| profile.name == name)
+        .ok_or_else(|| {
+            let names = profiles
+                .iter()
+                .map(|profile| profile.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            GuiError::ValidationFailed(if names.is_empty() {
+                format!("no profile named '{name}'; none are configured")
+            } else {
+                format!("no profile named '{name}'; configured profiles are: {names}")
+            })
+        })
+}
+
+/// Resolve a model's sampling parameters and describe where each came from.
+pub(crate) fn explain(
+    model: &Model,
+    settings: &Settings,
+    profile: Option<&InferenceProfile>,
+) -> SamplingExplanationDto {
+    // The two facts about the model that change how resolution behaves.
+    let model_ctx = ModelSamplingContext {
+        is_reasoning: is_reasoning(&model.tags),
+        defaults_origin: model.defaults_origin,
+    };
+
+    // An empty request layer: this explains the stored configuration, so there
+    // are no per-request parameters to occupy the top rung.
+    let (resolved, sources) = InferenceConfig::default().resolve_with_profile_explained(
+        profile.map(|selected| &selected.config),
+        model.inference_defaults.as_ref(),
+        settings.inference_defaults.as_ref(),
+        model_ctx,
+    );
+
+    SamplingExplanationDto {
+        resolved,
+        sources: sources
+            .iter()
+            .map(|(field, source)| provenance(field, source))
+            .collect(),
+        profile: profile.map(|selected| selected.name.clone()),
+        is_reasoning: model_ctx.is_reasoning,
+        trust_client_sampling: settings.trust_client_sampling.unwrap_or(false),
+    }
+}
+
+/// Whether the model carries the `reasoning` tag, which selects the floor.
+fn is_reasoning(tags: &[String]) -> bool {
+    tags.iter().any(|tag| tag.eq_ignore_ascii_case("reasoning"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use chrono::Utc;
+    use gglib_core::ModelCapabilities;
+    use gglib_core::domain::DefaultsOrigin;
+    use serde_json::json;
+
+    use super::*;
+
+    /// A model with nothing sampling-relevant set. `Model` has no `Default`,
+    /// so the variants below build on this with struct-update syntax.
+    fn model() -> Model {
+        Model {
+            id: 1,
+            name: "test-model".to_owned(),
+            model_key: String::new(),
+            file_path: PathBuf::from("/models/test.gguf"),
+            param_count_b: 7.0,
+            architecture: None,
+            quantization: None,
+            context_length: None,
+            expert_count: None,
+            expert_used_count: None,
+            expert_shared_count: None,
+            metadata: HashMap::new(),
+            added_at: Utc::now(),
+            hf_repo_id: None,
+            hf_commit_sha: None,
+            hf_filename: None,
+            download_date: None,
+            last_update_check: None,
+            tags: Vec::new(),
+            capabilities: ModelCapabilities::default(),
+            inference_defaults: None,
+            defaults_origin: None,
+            server_defaults: None,
+            benchmark_summary: None,
+        }
+    }
+
+    fn profile(name: &str, config: InferenceConfig) -> InferenceProfile {
+        InferenceProfile {
+            name: name.to_owned(),
+            description: None,
+            config,
+            list_in_models: false,
+        }
+    }
+
+    fn source_for<'a>(dto: &'a SamplingExplanationDto, param: &str) -> &'a ParamProvenanceDto {
+        dto.sources
+            .iter()
+            .find(|entry| entry.param == param)
+            .unwrap_or_else(|| panic!("no provenance entry for {param}"))
+    }
+
+    #[test]
+    fn finds_a_configured_profile_by_name() {
+        let profiles = vec![profile("coding", InferenceConfig::default())];
+        assert_eq!(
+            find_profile("coding", Some(&profiles)).unwrap().name,
+            "coding"
+        );
+    }
+
+    #[test]
+    fn an_unknown_profile_errors_and_lists_the_configured_ones() {
+        let profiles = vec![profile("coding", InferenceConfig::default())];
+        let err = find_profile("codign", Some(&profiles))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("codign"), "{err}");
+        assert!(err.contains("coding"), "{err}");
+    }
+
+    /// An empty list is a different situation from a typo, and saying so saves
+    /// the reader from hunting for a profile that was never there.
+    #[test]
+    fn an_unset_profile_list_is_not_an_empty_list() {
+        let err = find_profile("coding", None).unwrap_err().to_string();
+        assert!(err.contains("none are configured"), "{err}");
+    }
+
+    #[test]
+    fn a_layer_index_resolves_to_its_rung_name() {
+        let entry = provenance("temperature", ParamSource::Layer(2));
+        assert_eq!(entry.kind, ProvenanceKindDto::Layer);
+        assert_eq!(entry.layer, Some(SamplingLayerDto::ModelUserSet));
+    }
+
+    #[test]
+    fn the_floor_variants_stay_distinguishable_and_carry_no_layer() {
+        let floor = provenance("top_p", ParamSource::Floor);
+        assert_eq!(floor.kind, ProvenanceKindDto::Floor);
+        assert_eq!(floor.layer, None);
+
+        let coupled = provenance("min_p", ParamSource::FloorCoupled);
+        assert_eq!(coupled.kind, ProvenanceKindDto::FloorCoupled);
+        assert_eq!(coupled.layer, None);
+
+        let unset = provenance("max_tokens", ParamSource::Unset);
+        assert_eq!(unset.kind, ProvenanceKindDto::Unset);
+        assert_eq!(unset.layer, None);
+    }
+
+    /// A ladder longer than the five rungs this module resolves cannot happen
+    /// today; render it as a nameless layer rather than panicking in a
+    /// read-only view.
+    #[test]
+    fn an_index_past_the_ladder_is_a_layer_without_a_name() {
+        let entry = provenance("temperature", ParamSource::Layer(9));
+        assert_eq!(entry.kind, ProvenanceKindDto::Layer);
+        assert_eq!(entry.layer, None);
+    }
+
+    /// The client zips `sources[i].param` against `resolved`. If a field on
+    /// `FieldSources` ever stops matching a key of the serialized config, that
+    /// lookup silently yields nothing — so pin the pairing here.
+    #[test]
+    fn every_param_is_a_key_of_the_resolved_config() {
+        let populated = InferenceConfig {
+            temperature: Some(0.7),
+            top_p: Some(0.95),
+            top_k: Some(40),
+            max_tokens: Some(512),
+            repeat_penalty: Some(1.0),
+            presence_penalty: Some(0.0),
+            min_p: Some(0.0),
+        };
+        let keys = serde_json::to_value(&populated).unwrap();
+        let keys = keys.as_object().expect("config serializes as an object");
+
+        let dto = explain(&model(), &Settings::with_defaults(), None);
+        assert_eq!(dto.sources.len(), keys.len());
+        for entry in &dto.sources {
+            assert!(
+                keys.contains_key(&entry.param),
+                "'{}' is not a key of the resolved config",
+                entry.param
+            );
+        }
+    }
+
+    /// The wire contract the frontend is written against.
+    ///
+    /// Asserted against the serialized *string*, which is what `axum::Json`
+    /// writes, rather than `to_value`: the `Value` serializer widens `f32` to
+    /// `f64` and would report a `topP` of `0.949999988079071` that no client
+    /// ever receives.
+    #[test]
+    fn serializes_camel_case_with_the_layer_omitted_for_floors() {
+        let dto = explain(&model(), &Settings::with_defaults(), None);
+        let wire = serde_json::to_string(&dto).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&wire).unwrap();
+
+        assert_eq!(value["resolved"]["topP"], json!(0.95), "{wire}");
+        assert_eq!(value["isReasoning"], json!(false));
+        assert_eq!(value["trustClientSampling"], json!(false));
+        assert_eq!(value["profile"], json!(null));
+        assert_eq!(
+            value["sources"][0],
+            json!({ "param": "temperature", "kind": "floor" })
+        );
+        assert_eq!(
+            value["sources"][6],
+            json!({ "param": "maxTokens", "kind": "unset" })
+        );
+    }
+
+    /// Order is the contract: the client renders `sources` as it arrives.
+    #[test]
+    fn sources_arrive_in_the_canonical_display_order() {
+        let dto = explain(&model(), &Settings::with_defaults(), None);
+        let params: Vec<&str> = dto.sources.iter().map(|e| e.param.as_str()).collect();
+        assert_eq!(
+            params,
+            [
+                "temperature",
+                "topP",
+                "topK",
+                "presencePenalty",
+                "repeatPenalty",
+                "minP",
+                "maxTokens",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_model_with_nothing_stored_resolves_entirely_from_the_floor() {
+        let dto = explain(&model(), &Settings::with_defaults(), None);
+
+        assert_eq!(dto.resolved.temperature, Some(0.7));
+        assert_eq!(
+            source_for(&dto, "temperature").kind,
+            ProvenanceKindDto::Floor
+        );
+        assert_eq!(source_for(&dto, "maxTokens").kind, ProvenanceKindDto::Unset);
+        assert!(!dto.is_reasoning);
+    }
+
+    #[test]
+    fn a_profile_outranks_global_settings_and_is_echoed_back() {
+        let settings = Settings {
+            inference_defaults: Some(InferenceConfig {
+                temperature: Some(0.4),
+                top_k: Some(15),
+                ..Default::default()
+            }),
+            ..Settings::with_defaults()
+        };
+        let coding = profile(
+            "coding",
+            InferenceConfig {
+                temperature: Some(0.2),
+                ..Default::default()
+            },
+        );
+
+        let dto = explain(&model(), &settings, Some(&coding));
+
+        assert_eq!(dto.profile.as_deref(), Some("coding"));
+        assert_eq!(dto.resolved.temperature, Some(0.2));
+        assert_eq!(
+            source_for(&dto, "temperature").layer,
+            Some(SamplingLayerDto::Profile)
+        );
+        // Untouched by the profile, so the lower rung still fills it.
+        assert_eq!(dto.resolved.top_k, Some(15));
+        assert_eq!(
+            source_for(&dto, "topK").layer,
+            Some(SamplingLayerDto::Global)
+        );
+    }
+
+    /// The distinction #688 introduced, which is the whole reason a per-field
+    /// view beats the stored-defaults view it replaces.
+    #[test]
+    fn auto_detected_model_defaults_rank_below_global_settings() {
+        let settings = Settings {
+            inference_defaults: Some(InferenceConfig {
+                temperature: Some(0.4),
+                ..Default::default()
+            }),
+            ..Settings::with_defaults()
+        };
+        let auto = Model {
+            inference_defaults: Some(InferenceConfig {
+                temperature: Some(1.0),
+                ..Default::default()
+            }),
+            defaults_origin: Some(DefaultsOrigin::AutoDetected),
+            ..model()
+        };
+
+        let dto = explain(&auto, &settings, None);
+
+        assert_eq!(dto.resolved.temperature, Some(0.4));
+        assert_eq!(
+            source_for(&dto, "temperature").layer,
+            Some(SamplingLayerDto::Global)
+        );
+
+        let user = Model {
+            defaults_origin: Some(DefaultsOrigin::User),
+            ..auto
+        };
+        let dto = explain(&user, &settings, None);
+
+        assert_eq!(dto.resolved.temperature, Some(1.0));
+        assert_eq!(
+            source_for(&dto, "temperature").layer,
+            Some(SamplingLayerDto::ModelUserSet)
+        );
+    }
+
+    /// The tag changes both the flag the client renders and the floor the
+    /// coupled trio falls back to.
+    #[test]
+    fn the_reasoning_tag_selects_the_reasoning_floor() {
+        let reasoning = Model {
+            tags: vec!["Reasoning".to_owned()],
+            ..model()
+        };
+
+        let dto = explain(&reasoning, &Settings::with_defaults(), None);
+
+        assert!(dto.is_reasoning);
+        assert_eq!(dto.resolved.presence_penalty, Some(1.0));
+    }
+
+    /// A layer that claims `temperature` passes over lower rungs for the trio
+    /// tuned against it — the case a bare value cannot explain.
+    #[test]
+    fn a_claimed_temperature_couples_the_trio_to_the_floor() {
+        let coding = profile(
+            "coding",
+            InferenceConfig {
+                temperature: Some(0.2),
+                ..Default::default()
+            },
+        );
+        let tuned = Model {
+            inference_defaults: Some(InferenceConfig {
+                presence_penalty: Some(1.5),
+                ..Default::default()
+            }),
+            defaults_origin: Some(DefaultsOrigin::User),
+            ..model()
+        };
+
+        let dto = explain(&tuned, &Settings::with_defaults(), Some(&coding));
+
+        assert_eq!(dto.resolved.presence_penalty, Some(0.0));
+        assert_eq!(
+            source_for(&dto, "presencePenalty").kind,
+            ProvenanceKindDto::FloorCoupled
+        );
+    }
+
+    #[test]
+    fn trust_client_sampling_is_echoed_from_settings() {
+        let settings = Settings {
+            trust_client_sampling: Some(true),
+            ..Settings::with_defaults()
+        };
+        assert!(explain(&model(), &settings, None).trust_client_sampling);
+    }
+}

--- a/crates/gglib-axum/src/handlers/model/models.rs
+++ b/crates/gglib-axum/src/handlers/model/models.rs
@@ -5,6 +5,7 @@ use axum::extract::{Path, Query, State};
 
 use crate::error::HttpError;
 use crate::state::AppState;
+use gglib_app_services::SamplingExplanationDto;
 use gglib_app_services::types::{
     AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, SetCapabilitiesRequest,
     UpdateModelRequest,
@@ -199,4 +200,31 @@ pub async fn detail(
     Path(id): Path<i64>,
 ) -> Result<Json<ModelDetailDto>, HttpError> {
     Ok(Json(state.models.get_detail(id).await?))
+}
+
+/// Query parameters for `GET /api/models/{id}/explain`.
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct ExplainQueryParams {
+    /// Name of a configured inference profile to apply on top of the model's
+    /// own defaults. An unknown name is a 400 listing the configured ones,
+    /// not a silent fall back to the unprofiled resolution.
+    pub profile: Option<String>,
+}
+
+/// Resolved sampling parameters for a model, and which layer supplied each.
+///
+/// The HTTP equivalent of `gglib model explain`. Both surfaces call
+/// `ModelOps::explain_sampling`, so neither can describe a hierarchy that
+/// differs from the one the proxy actually resolves.
+pub async fn explain(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Query(params): Query<ExplainQueryParams>,
+) -> Result<Json<SamplingExplanationDto>, HttpError> {
+    Ok(Json(
+        state
+            .models
+            .explain_sampling(id, params.profile.as_deref())
+            .await?,
+    ))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -185,6 +185,10 @@ fn model_routes() -> Router<AppState> {
         // Returns ModelDetailDto — superset of GuiModel with raw GGUF metadata,
         // MoE topology, HuggingFace provenance, inference defaults, and timestamps.
         .route("/{id}/detail", get(handlers::model::models::detail))
+        // Sampling provenance: GET /api/models/{id}/explain[?profile=NAME]
+        // The resolved sampling parameters plus the layer that supplied each —
+        // the HTTP form of `gglib model explain`.
+        .route("/{id}/explain", get(handlers::model::models::explain))
         // Benchmark history for this model
         .route(
             "/{id}/benchmark",

--- a/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
+++ b/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
@@ -213,7 +213,11 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
               onServerDefaultsChange={editMode.setEditedServerDefaults}
             />
           ) : (
-            <ModelMetadataGrid model={model} detail={detail.modelDetail ?? undefined} />
+            <ModelMetadataGrid
+              model={model}
+              detail={detail.modelDetail ?? undefined}
+              profiles={settings?.inferenceProfiles ?? []}
+            />
           )}
 
           <InspectorTags

--- a/src/components/ModelInspectorPanel/README.md
+++ b/src/components/ModelInspectorPanel/README.md
@@ -12,6 +12,7 @@ Right-hand detail panel for viewing, editing, and serving a selected GGUF model.
 ```
 ModelInspectorPanel
     ├── ModelMetadataGrid      ← read-only metadata display
+    │     └── SamplingProvenanceSection ← resolved sampling + which layer won
     ├── TagChips + TagAddInput ← tag management
     ├── InferenceParametersForm ← per-model inference defaults
     ├── InspectorActions       ← serve / edit / delete / benchmark
@@ -19,11 +20,15 @@ ModelInspectorPanel
     └── DeleteModal            ← confirmation dialog
 ```
 
+Read mode shows what a model's sampling parameters *resolve to* and which
+layer supplied each; edit mode shows the model's own stored defaults, which
+are one rung of that resolution.
+
 ## Sub-directories
 
 | Directory | Contents |
 |-----------|----------|
-| `components/` | `ModelMetadataGrid`, `ModelEditForm`, `TagChips`, `TagAddInput`, `ServeModal`, `DeleteModal`, `InspectorActions` |
-| `hooks/` | `useEditMode`, `useModelDetail`, `useServeModal`, `useDeleteModal`, `useServerActions` |
+| `components/` | `ModelMetadataGrid`, `SamplingProvenanceSection`, `ModelEditForm`, `TagChips`, `TagAddInput`, `ServeModal`, `DeleteModal`, `InspectorActions` |
+| `hooks/` | `useEditMode`, `useModelDetail`, `useSamplingExplanation`, `useServeModal`, `useDeleteModal`, `useServerActions` |
 
 <!-- module-docs:end -->

--- a/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
+++ b/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
@@ -1,17 +1,20 @@
 import { FC } from 'react';
 import { ChevronRight, Copy, ExternalLink } from 'lucide-react';
-import type { GgufModel, ModelDetail } from '../../../types';
+import type { GgufModel, InferenceProfile, ModelDetail } from '../../../types';
 import { formatParamCount, getHuggingFaceUrl } from '../../../utils/format';
 import { openUrl } from '../../../services/platform';
 import { Icon } from '../../ui/Icon';
 import { Button } from '../../ui/Button';
 import { InfoRow } from './InfoRow';
 import { MetadataSection } from './MetadataSection';
+import { SamplingProvenanceSection } from './SamplingProvenanceSection';
 
 interface ModelMetadataGridProps {
   model: GgufModel;
   /** Full model detail from GET /api/models/:id/detail. Enables HF provenance rows and GGUF metadata. */
   detail?: ModelDetail;
+  /** Configured inference profiles, for the sampling section's selector. */
+  profiles?: InferenceProfile[];
 }
 
 /** Context length, preferring an explicit server override over GGUF metadata. */
@@ -29,10 +32,11 @@ function formatContextLength(model: GgufModel): string {
  * Read-only metadata display for the model inspector.
  * Shows size, architecture, quantization, context length, path, and HuggingFace link.
  */
-export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model, detail }) => {
-  const inferenceDefaults = model.inferenceDefaults;
-  const hasInferenceDefaults =
-    inferenceDefaults != null && Object.values(inferenceDefaults).some((v) => v != null);
+export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({
+  model,
+  detail,
+  profiles = [],
+}) => {
   const metadataEntries = detail ? Object.entries(detail.metadata) : [];
 
   return (
@@ -112,33 +116,15 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({ model, detail })
         )}
       </MetadataSection>
 
-      {hasInferenceDefaults && (
-        <MetadataSection title="Inference Defaults">
-          {model.defaultsOrigin != null && (
-            <InfoRow label="Source">
-              {model.defaultsOrigin === 'auto_detected'
-                ? 'Auto-detected (ranks below global settings)'
-                : 'User-set'}
-            </InfoRow>
-          )}
-          {inferenceDefaults.temperature != null && (
-            <InfoRow label="Temperature">{inferenceDefaults.temperature}</InfoRow>
-          )}
-          {inferenceDefaults.topP != null && <InfoRow label="Top P">{inferenceDefaults.topP}</InfoRow>}
-          {inferenceDefaults.topK != null && <InfoRow label="Top K">{inferenceDefaults.topK}</InfoRow>}
-          {inferenceDefaults.maxTokens != null && (
-            <InfoRow label="Max Tokens">{inferenceDefaults.maxTokens.toLocaleString()}</InfoRow>
-          )}
-          {inferenceDefaults.repeatPenalty != null && (
-            <InfoRow label="Repeat Penalty">{inferenceDefaults.repeatPenalty}</InfoRow>
-          )}
-          {inferenceDefaults.presencePenalty != null && (
-            <InfoRow label="Presence Penalty">{inferenceDefaults.presencePenalty}</InfoRow>
-          )}
-          {inferenceDefaults.minP != null && (
-            <InfoRow label="Min P">{inferenceDefaults.minP}</InfoRow>
-          )}
-        </MetadataSection>
+      {/* Resolved sampling, not the stored defaults: a stored value that wins
+          shows as `per-model defaults (user-set)`, and one that loses is
+          finally visible as having lost. */}
+      {model.id != null && (
+        <SamplingProvenanceSection
+          modelId={model.id}
+          profiles={profiles}
+          refreshKey={model.inferenceDefaults}
+        />
       )}
 
       {/* Raw GGUF Metadata — stateless collapsible via native <details>.

--- a/src/components/ModelInspectorPanel/components/SamplingProvenanceSection.tsx
+++ b/src/components/ModelInspectorPanel/components/SamplingProvenanceSection.tsx
@@ -1,0 +1,118 @@
+import { FC, useEffect, useState } from 'react';
+import type { InferenceProfile } from '../../../types';
+import { Skeleton } from '../../primitives';
+import { Select } from '../../ui/Select';
+import { useSamplingExplanation } from '../hooks/useSamplingExplanation';
+import { InfoRow } from './InfoRow';
+import { MetadataSection } from './MetadataSection';
+import {
+  PARAM_LABELS,
+  caveats,
+  describeSource,
+  formatParamValue,
+  resolvedValue,
+} from './samplingProvenance';
+
+interface SamplingProvenanceSectionProps {
+  modelId: number;
+  /** Configured profiles, from AppSettings. An empty list hides the selector. */
+  profiles: InferenceProfile[];
+  /** Invalidation signal — pass the model's stored defaults. */
+  refreshKey?: unknown;
+}
+
+/**
+ * What the model's sampling parameters actually resolve to, and which layer
+ * supplied each one.
+ *
+ * Supersedes the stored-defaults view this replaced: a stored value that wins
+ * appears here as `per-model defaults (user-set)`, and a stored value that
+ * loses is finally visible as having lost. Every model gets a section, since
+ * a model with nothing stored still resolves to something.
+ *
+ * Provenance is a fact about the model, not a state, so it borrows no state
+ * colour — the same call the CLI's table makes.
+ */
+export const SamplingProvenanceSection: FC<SamplingProvenanceSectionProps> = ({
+  modelId,
+  profiles,
+  refreshKey,
+}) => {
+  const [profileName, setProfileName] = useState<string | null>(null);
+
+  // A profile selected for one model should not silently carry to the next.
+  useEffect(() => setProfileName(null), [modelId]);
+
+  const { explanation, isLoading, hasError } = useSamplingExplanation(
+    modelId,
+    profileName,
+    refreshKey,
+  );
+
+  const selector = profiles.length > 0 && (
+    <InfoRow label="Profile">
+      <Select
+        size="sm"
+        aria-label="Inference profile"
+        value={profileName ?? ''}
+        onChange={(e) => setProfileName(e.target.value || null)}
+        className="max-w-[12rem]"
+      >
+        <option value="">None</option>
+        {profiles.map((profile) => (
+          <option key={profile.name} value={profile.name}>
+            {profile.name}
+          </option>
+        ))}
+      </Select>
+    </InfoRow>
+  );
+
+  if (hasError) {
+    return (
+      <MetadataSection title="Sampling">
+        {selector}
+        <InfoRow label="Status">
+          <span className="text-text-muted">Sampling provenance unavailable.</span>
+        </InfoRow>
+      </MetadataSection>
+    );
+  }
+
+  if (!explanation) {
+    return (
+      <MetadataSection title="Sampling">
+        {selector}
+        {/* Deliberately unlabelled: a placeholder carrying real parameter
+            names would claim to show a resolution that has not arrived. */}
+        <div className="col-span-2">
+          <Skeleton variant="text" count={4} />
+        </div>
+      </MetadataSection>
+    );
+  }
+
+  const ctx = { profile: explanation.profile, isReasoning: explanation.isReasoning };
+
+  return (
+    <>
+      <MetadataSection title="Sampling" className={isLoading ? 'opacity-60' : undefined}>
+        {selector}
+        {explanation.sources.map((entry) => (
+          <InfoRow key={entry.param} label={PARAM_LABELS[entry.param] ?? entry.param}>
+            <span className="tabular-nums">
+              {formatParamValue(entry.param, resolvedValue(explanation.resolved, entry.param))}
+            </span>
+            <span className="text-text-muted"> {describeSource(entry, ctx)}</span>
+          </InfoRow>
+        ))}
+      </MetadataSection>
+
+      <div className="mt-md flex flex-col gap-xs text-xs text-text-muted">
+        {caveats(explanation.trustClientSampling).map((note) => (
+          <span key={note}>{note}</span>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/src/components/ModelInspectorPanel/components/index.ts
+++ b/src/components/ModelInspectorPanel/components/index.ts
@@ -2,6 +2,7 @@
 export { ModelMetadataGrid } from './ModelMetadataGrid';
 export { InfoRow } from './InfoRow';
 export { MetadataSection } from './MetadataSection';
+export { SamplingProvenanceSection } from './SamplingProvenanceSection';
 export { ModelEditForm } from './ModelEditForm';
 export { TagChips } from './TagChips';
 export { TagAddInput } from './TagAddInput';

--- a/src/components/ModelInspectorPanel/components/samplingProvenance.ts
+++ b/src/components/ModelInspectorPanel/components/samplingProvenance.ts
@@ -1,0 +1,106 @@
+/**
+ * Display helpers for the resolved-sampling section.
+ *
+ * The wording mirrors `gglib model explain`
+ * (`crates/gglib-cli/src/presentation/explain_display.rs`) so the two surfaces
+ * describe the same fact the same way. Kept apart from the component so each
+ * mapping is directly testable.
+ */
+
+import type { InferenceConfig, ParamProvenance, SamplingParamKey } from '../../../types';
+import { UNKNOWN } from '../../../utils/format';
+
+/** Human-readable label per parameter, in the order the server sends them. */
+export const PARAM_LABELS: Record<SamplingParamKey, string> = {
+  temperature: 'Temperature',
+  topP: 'Top P',
+  topK: 'Top K',
+  presencePenalty: 'Presence Penalty',
+  repeatPenalty: 'Repeat Penalty',
+  minP: 'Min P',
+  maxTokens: 'Max Tokens',
+};
+
+/** The facts about the model that change how a source reads. */
+export interface SourceContext {
+  /** The profile applied, if one was selected. */
+  profile?: string | null;
+  /** Selects which floor the coupled trio falls back to. */
+  isReasoning: boolean;
+}
+
+/**
+ * Describe where one resolved value came from.
+ *
+ * A layer index the server could not name renders as `unknown layer` rather
+ * than being dropped — an unexplained value is worse than an oddly labelled
+ * one in a view whose whole purpose is explanation.
+ */
+export function describeSource(entry: ParamProvenance, ctx: SourceContext): string {
+  const floor = ctx.isReasoning ? 'reasoning floor' : 'default floor';
+
+  switch (entry.kind) {
+    case 'layer':
+      switch (entry.layer) {
+        case 'request':
+          return 'request parameters';
+        case 'profile':
+          return ctx.profile ? `profile '${ctx.profile}'` : 'profile';
+        case 'modelUserSet':
+          return 'per-model defaults (user-set)';
+        case 'global':
+          return 'global settings';
+        case 'modelAutoDetected':
+          return 'per-model defaults (auto-detected: reasoning tag)';
+        default:
+          return 'unknown layer';
+      }
+    case 'floor':
+      return floor;
+    case 'floorCoupled':
+      return `${floor} (coupled to temperature layer)`;
+    case 'unset':
+      return 'unset by design';
+    default:
+      return UNKNOWN;
+  }
+}
+
+/**
+ * Format one resolved value for display.
+ *
+ * Whole floats keep a decimal place, as they do on the CLI: `1.0` reads as a
+ * sampling parameter where a bare `1` reads as a count.
+ */
+export function formatParamValue(
+  param: SamplingParamKey,
+  value: number | null | undefined,
+): string {
+  if (value == null) return UNKNOWN;
+  if (param === 'topK') return String(value);
+  if (param === 'maxTokens') return value.toLocaleString();
+  return Number.isInteger(value) ? value.toFixed(1) : String(value);
+}
+
+/** Read the value for one provenance entry out of the resolved config. */
+export function resolvedValue(
+  resolved: InferenceConfig,
+  param: SamplingParamKey,
+): number | undefined {
+  return resolved[param];
+}
+
+/**
+ * The two rungs the table cannot show, because neither is stored on the model.
+ *
+ * Without these the view looks complete while omitting the layers that
+ * actually outrank everything in it.
+ */
+export function caveats(trustClientSampling: boolean): [string, string] {
+  return [
+    'Operator flags (gglib proxy --temperature, ...) outrank every layer above.',
+    trustClientSampling
+      ? 'Client-supplied sampling is trusted and outranks all but those flags.'
+      : 'Client-supplied sampling is ignored, except max_tokens.',
+  ];
+}

--- a/src/components/ModelInspectorPanel/hooks/index.ts
+++ b/src/components/ModelInspectorPanel/hooks/index.ts
@@ -5,6 +5,9 @@ export type { EditModeState } from './useEditMode';
 export { useModelDetail } from './useModelDetail';
 export type { ModelDetailState } from './useModelDetail';
 
+export { useSamplingExplanation } from './useSamplingExplanation';
+export type { SamplingExplanationState } from './useSamplingExplanation';
+
 export { useServeModal } from './useServeModal';
 export type { ServeModalState } from './useServeModal';
 

--- a/src/components/ModelInspectorPanel/hooks/useSamplingExplanation.ts
+++ b/src/components/ModelInspectorPanel/hooks/useSamplingExplanation.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { SamplingExplanation } from '../../../types';
+import { explainModelSampling } from '../../../services/transport/api/models/local';
+import { appLogger } from '../../../services/platform';
+
+export interface SamplingExplanationState {
+  explanation: SamplingExplanation | null;
+  isLoading: boolean;
+  /** The fetch failed; render a fallback rather than stale rows. */
+  hasError: boolean;
+  reload: () => Promise<void>;
+}
+
+/**
+ * Fetch a model's resolved sampling parameters and their provenance.
+ *
+ * Refetches when the selected model or profile changes, and when `refreshKey`
+ * does — pass the model's stored defaults so saving an edit re-resolves rather
+ * than leaving the panel describing the previous configuration.
+ */
+export function useSamplingExplanation(
+  modelId: number | undefined,
+  profileName: string | null,
+  refreshKey?: unknown,
+): SamplingExplanationState {
+  const [explanation, setExplanation] = useState<SamplingExplanation | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const reload = useCallback(async () => {
+    if (!modelId) return;
+    setIsLoading(true);
+    setHasError(false);
+    try {
+      setExplanation(await explainModelSampling(modelId, profileName ?? undefined));
+    } catch (error) {
+      appLogger.error('hook.ui', 'Failed to load sampling explanation', {
+        error,
+        modelId,
+        profileName,
+      });
+      setExplanation(null);
+      setHasError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [modelId, profileName]);
+
+  useEffect(() => {
+    if (modelId) {
+      reload();
+    } else {
+      setExplanation(null);
+    }
+    // `refreshKey` is a caller-supplied invalidation signal, not a value this
+    // hook reads.
+  }, [modelId, reload, refreshKey]);
+
+  return { explanation, isLoading, hasError, reload };
+}

--- a/src/services/transport/api/models/local.ts
+++ b/src/services/transport/api/models/local.ts
@@ -16,6 +16,7 @@ import type {
   SystemMemoryInfo,
   ModelsDirectoryInfo,
 } from '../../types/models';
+import type { SamplingExplanation } from '../../../../types';
 
 /**
  * List all local models.
@@ -47,6 +48,30 @@ export async function getModel(id: ModelId): Promise<GgufModel | null> {
 export async function getModelDetail(id: ModelId): Promise<ModelDetail | null> {
   try {
     return await get<ModelDetail>(`/api/models/${id}/detail`);
+  } catch (error) {
+    if (TransportError.hasCode(error, 'NOT_FOUND')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get a model's resolved sampling parameters and the layer that supplied each.
+ *
+ * `profile` names a configured inference profile to apply on top of the
+ * model's own defaults; an unknown name is a 400 from the server rather than a
+ * silent fall back to the unprofiled resolution.
+ *
+ * Returns null if the model is not found (instead of throwing).
+ */
+export async function explainModelSampling(
+  id: ModelId,
+  profile?: string,
+): Promise<SamplingExplanation | null> {
+  const query = profile ? `?profile=${encodeURIComponent(profile)}` : '';
+  try {
+    return await get<SamplingExplanation>(`/api/models/${id}/explain${query}`);
   } catch (error) {
     if (TransportError.hasCode(error, 'NOT_FOUND')) {
       return null;

--- a/src/services/transport/types/models.ts
+++ b/src/services/transport/types/models.ts
@@ -80,6 +80,10 @@ export interface ModelsTransport {
   listModels(): Promise<GgufModel[]>;
   getModel(id: ModelId): Promise<GgufModel | null>;
   getModelDetail(id: ModelId): Promise<ModelDetail | null>;
+  explainModelSampling(
+    id: ModelId,
+    profile?: string,
+  ): Promise<import('../../../types').SamplingExplanation | null>;
   addModel(params: AddModelParams): Promise<GgufModel>;
   removeModel(id: ModelId): Promise<void>;
   updateModel(params: UpdateModelParams): Promise<GgufModel>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,78 @@ export interface InferenceProfile {
 }
 
 // ============================================================================
+// Sampling provenance
+// ============================================================================
+
+/**
+ * A rung of the resolution ladder, in priority order.
+ *
+ * Mirrors the backend `SamplingLayerDto`
+ * (`gglib-app-services/src/sampling_explain.rs`), which is the wire form of
+ * `gglib_core::domain::SamplingLayer`.
+ */
+export type SamplingLayerName =
+  | 'request'
+  | 'profile'
+  | 'modelUserSet'
+  | 'global'
+  | 'modelAutoDetected';
+
+/**
+ * What class of source supplied a resolved value.
+ *
+ * Mirrors the backend `ProvenanceKindDto`. `floorCoupled` is distinct from
+ * `floor`: it means a layer claimed `temperature` and this parameter is tuned
+ * against it, so lower layers were deliberately passed over rather than simply
+ * having nothing to say.
+ */
+export type ProvenanceKind = 'layer' | 'floor' | 'floorCoupled' | 'unset';
+
+/** The parameters that carry provenance — the keys of {@link InferenceConfig}. */
+export type SamplingParamKey =
+  | 'temperature'
+  | 'topP'
+  | 'topK'
+  | 'presencePenalty'
+  | 'repeatPenalty'
+  | 'minP'
+  | 'maxTokens';
+
+/**
+ * Where one resolved parameter's value came from.
+ *
+ * Mirrors the backend `ParamProvenanceDto`. `layer` is present only when
+ * `kind` is `'layer'`.
+ */
+export interface ParamProvenance {
+  /** The key this entry describes in {@link SamplingExplanation.resolved}. */
+  param: SamplingParamKey;
+  kind: ProvenanceKind;
+  layer?: SamplingLayerName;
+}
+
+/**
+ * A model's resolved sampling parameters and where each value came from —
+ * `GET /api/models/:id/explain`.
+ *
+ * Mirrors the backend `SamplingExplanationDto`. The values live in `resolved`
+ * rather than beside each provenance entry, so `sources[i].param` is a key
+ * into `resolved`.
+ */
+export interface SamplingExplanation {
+  /** The fully resolved configuration, after floors. */
+  resolved: InferenceConfig;
+  /** Per-parameter provenance, already in display order. */
+  sources: ParamProvenance[];
+  /** The profile applied, if one was named. */
+  profile?: string | null;
+  /** Whether the model carries the `reasoning` tag, which selects the floor. */
+  isReasoning: boolean;
+  /** Whether client-supplied sampling is trusted — a rung the table cannot show. */
+  trustClientSampling: boolean;
+}
+
+// ============================================================================
 // Server Configuration
 // ============================================================================
 

--- a/tests/ts/components/SamplingProvenanceSection.test.tsx
+++ b/tests/ts/components/SamplingProvenanceSection.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { SamplingProvenanceSection } from '../../../src/components/ModelInspectorPanel/components/SamplingProvenanceSection';
+import {
+  caveats,
+  describeSource,
+  formatParamValue,
+} from '../../../src/components/ModelInspectorPanel/components/samplingProvenance';
+import type {
+  InferenceProfile,
+  ParamProvenance,
+  SamplingExplanation,
+} from '../../../src/types';
+
+const explainModelSampling = vi.fn();
+
+vi.mock('../../../src/services/transport/api/models/local', () => ({
+  explainModelSampling: (...args: unknown[]) => explainModelSampling(...args),
+}));
+
+/** The seven entries the server always sends, in its display order. */
+function sources(overrides: Partial<Record<string, ParamProvenance>> = {}): ParamProvenance[] {
+  const base: ParamProvenance[] = [
+    { param: 'temperature', kind: 'layer', layer: 'profile' },
+    { param: 'topP', kind: 'floor' },
+    { param: 'topK', kind: 'layer', layer: 'global' },
+    { param: 'presencePenalty', kind: 'floorCoupled' },
+    { param: 'repeatPenalty', kind: 'floor' },
+    { param: 'minP', kind: 'layer', layer: 'modelAutoDetected' },
+    { param: 'maxTokens', kind: 'unset' },
+  ];
+  return base.map((entry) => overrides[entry.param] ?? entry);
+}
+
+function explanation(overrides: Partial<SamplingExplanation> = {}): SamplingExplanation {
+  return {
+    resolved: {
+      temperature: 0.2,
+      topP: 0.95,
+      topK: 40,
+      presencePenalty: 0,
+      repeatPenalty: 1,
+      minP: 0.05,
+    },
+    sources: sources(),
+    profile: 'coding',
+    isReasoning: false,
+    trustClientSampling: false,
+    ...overrides,
+  };
+}
+
+function profile(name: string): InferenceProfile {
+  return { name, description: null, config: {}, listInModels: false };
+}
+
+beforeEach(() => {
+  explainModelSampling.mockReset();
+  explainModelSampling.mockResolvedValue(explanation());
+});
+
+describe('SamplingProvenanceSection', () => {
+  it('renders every parameter with its value and the layer that supplied it', async () => {
+    render(<SamplingProvenanceSection modelId={1} profiles={[]} />);
+
+    expect(await screen.findByText('Temperature')).toBeInTheDocument();
+    expect(screen.getByText('0.2')).toBeInTheDocument();
+    expect(screen.getByText("profile 'coding'")).toBeInTheDocument();
+    expect(screen.getByText('global settings')).toBeInTheDocument();
+    expect(
+      screen.getByText('per-model defaults (auto-detected: reasoning tag)'),
+    ).toBeInTheDocument();
+  });
+
+  /// A whole float keeps its decimal so it reads as a sampling parameter.
+  it('formats whole floats with a decimal place and absent values as a dash', async () => {
+    render(<SamplingProvenanceSection modelId={1} profiles={[]} />);
+
+    expect(await screen.findByText('1.0')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.getByText('unset by design')).toBeInTheDocument();
+  });
+
+  it('names the reasoning floor and the coupling that reached it', async () => {
+    explainModelSampling.mockResolvedValue(explanation({ isReasoning: true }));
+    render(<SamplingProvenanceSection modelId={1} profiles={[]} />);
+
+    expect(
+      await screen.findByText('reasoning floor (coupled to temperature layer)'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('reasoning floor').length).toBeGreaterThan(0);
+  });
+
+  it('states that operator flags outrank the table, and whether clients are trusted', async () => {
+    render(<SamplingProvenanceSection modelId={1} profiles={[]} />);
+
+    expect(await screen.findByText(/Operator flags/)).toBeInTheDocument();
+    expect(screen.getByText(/Client-supplied sampling is ignored/)).toBeInTheDocument();
+
+    explainModelSampling.mockResolvedValue(explanation({ trustClientSampling: true }));
+    render(<SamplingProvenanceSection modelId={2} profiles={[]} />);
+
+    expect(await screen.findByText(/Client-supplied sampling is trusted/)).toBeInTheDocument();
+  });
+
+  it('offers no profile selector when none are configured', async () => {
+    render(<SamplingProvenanceSection modelId={1} profiles={[]} />);
+
+    await screen.findByText('Temperature');
+    expect(screen.queryByLabelText('Inference profile')).not.toBeInTheDocument();
+  });
+
+  it('re-resolves against the selected profile', async () => {
+    render(<SamplingProvenanceSection modelId={1} profiles={[profile('coding')]} />);
+
+    const select = await screen.findByLabelText('Inference profile');
+    expect(explainModelSampling).toHaveBeenCalledWith(1, undefined);
+
+    await userEvent.selectOptions(select, 'coding');
+
+    await waitFor(() => expect(explainModelSampling).toHaveBeenCalledWith(1, 'coding'));
+  });
+
+  it('falls back to a notice rather than stale rows when the fetch fails', async () => {
+    explainModelSampling.mockRejectedValue(new Error('boom'));
+    render(<SamplingProvenanceSection modelId={1} profiles={[]} />);
+
+    expect(await screen.findByText('Sampling provenance unavailable.')).toBeInTheDocument();
+    expect(screen.queryByText('Temperature')).not.toBeInTheDocument();
+  });
+});
+
+describe('describeSource', () => {
+  const ctx = { profile: 'coding', isReasoning: false };
+
+  it('matches the wording gglib model explain prints', () => {
+    expect(describeSource({ param: 'temperature', kind: 'layer', layer: 'request' }, ctx)).toBe(
+      'request parameters',
+    );
+    expect(describeSource({ param: 'temperature', kind: 'layer', layer: 'profile' }, ctx)).toBe(
+      "profile 'coding'",
+    );
+    expect(
+      describeSource({ param: 'temperature', kind: 'layer', layer: 'modelUserSet' }, ctx),
+    ).toBe('per-model defaults (user-set)');
+    expect(describeSource({ param: 'temperature', kind: 'layer', layer: 'global' }, ctx)).toBe(
+      'global settings',
+    );
+    expect(describeSource({ param: 'temperature', kind: 'unset' }, ctx)).toBe('unset by design');
+  });
+
+  it('names the profile rung without a name when none was selected', () => {
+    expect(
+      describeSource({ param: 'temperature', kind: 'layer', layer: 'profile' }, {
+        profile: null,
+        isReasoning: false,
+      }),
+    ).toBe('profile');
+  });
+
+  it('switches the floor name on the reasoning tag', () => {
+    expect(describeSource({ param: 'topP', kind: 'floor' }, ctx)).toBe('default floor');
+    expect(
+      describeSource({ param: 'topP', kind: 'floor' }, { profile: null, isReasoning: true }),
+    ).toBe('reasoning floor');
+  });
+
+  /// A layer the server could not name is still worth showing.
+  it('renders an unnamed layer visibly rather than dropping it', () => {
+    expect(describeSource({ param: 'temperature', kind: 'layer' }, ctx)).toBe('unknown layer');
+  });
+});
+
+describe('formatParamValue', () => {
+  it('keeps a decimal on whole floats but not on counts', () => {
+    expect(formatParamValue('temperature', 1)).toBe('1.0');
+    expect(formatParamValue('temperature', 0.65)).toBe('0.65');
+    expect(formatParamValue('topK', 40)).toBe('40');
+    expect(formatParamValue('maxTokens', 32768)).toBe('32,768');
+  });
+
+  it('renders an absent value as the shared unknown placeholder', () => {
+    expect(formatParamValue('maxTokens', undefined)).toBe('—');
+    expect(formatParamValue('minP', null)).toBe('—');
+  });
+});
+
+describe('caveats', () => {
+  it('always leads with the operator flags that outrank every stored layer', () => {
+    expect(caveats(false)[0]).toMatch(/Operator flags/);
+    expect(caveats(true)[0]).toMatch(/Operator flags/);
+  });
+
+  it('reports the client-sampling posture from settings', () => {
+    expect(caveats(false)[1]).toMatch(/ignored, except max_tokens/);
+    expect(caveats(true)[1]).toMatch(/trusted/);
+  });
+});


### PR DESCRIPTION
Closes #705.

## Problem

The inspector showed a model's stored `inferenceDefaults` and, when it had any, a single `Source` row reading `Auto-detected` or `User-set`. That is one fact about the whole set, and the ranking is decided **per parameter** — so the panel could not show that an auto-detected recipe lost `temperature` to global settings while still supplying `top_k`, or that the temperature-coupling rule suppressed a value the user set. A model with nothing stored showed no section at all, despite still resolving to something.

`gglib model explain` (#704) answers this on the CLI. This is the same answer over HTTP and in the GUI.

## Changes

Three commits, in dependency order.

**1. `feat(app-services)`** — `sampling_explain`, the wire form of `FieldSources`, plus `ModelOps::explain_sampling` as the shared data source. `FieldSources` cannot be serialized as-is: `ParamSource::Layer` carries a ladder index rather than a name, and the core provenance types predate the camelCase convention the rest of the HTTP API follows. Nothing re-derives the ladder — values and provenance both come from `resolve_with_profile_explained`, the same call the plain resolution makes.

**2. `feat(axum)`** — `GET /api/models/{id}/explain[?profile=NAME]`. 404 on an unknown id, 400 listing the configured profiles on an unknown name.

**3. `feat(frontend)`** — a `Sampling` section replacing the stored-defaults one, for **every** model. A stored value that wins now reads `per-model defaults (user-set)`; one that loses is finally visible as having lost.

## Two design calls worth stating

**The DTO carries the resolved `InferenceConfig` whole rather than copying each value beside its provenance entry.** Copying means choosing a width, and `f32` → `f64` is not free — a resolved `top_p` of `0.95` comes back as `0.949999988079071`. Keeping the config intact keeps serde on its `f32` path, which emits the shortest representation that round-trips. The serde test asserts against the serialized *string* for the same reason: `to_value` widens, `axum::Json` does not, and only the latter is what a client sees. (The first draft of that test asserted against `to_value` and failed, which is how the distinction surfaced.)

**The caveat footnotes are not decoration.** Operator flags and client-supplied sampling are rungs no table can show, because neither is stored on the model. A panel that omits them looks *more* complete than the one it replaces while being less honest. Wording matches `explain_display.rs` so the two surfaces describe the same fact the same way — but the CLI's `<-` arrow is a terminal affordance and is not ported, and provenance is a fact rather than a state, so it borrows no state colour.

## Profiles get their first consumer in the GUI

They have been CRUD-able in Settings with nothing reading them. The section shows a selector when any are configured, which answers "what would `model:coding` actually run with". Profile names come from the settings context the panel already loads, so the wire contract stays provenance-only.

## Parity tier

**Tier 2** (management and inspection). This *closes* the surface gap #704 opened rather than creating one. No Tauri work: product features are served over HTTP and the WebView calls the same route.

## Tests

20 Rust tests (mapping, profile lookup, resolution behaviour, service wiring) and 15 TypeScript tests. Two are worth calling out:

- **A contract test** asserts every `param` the DTO emits is a key of the serialized `InferenceConfig`. The client zips `sources[i].param` against `resolved`, so a `FieldSources` field that stops matching would silently yield nothing; this fails a test instead.
- The **loading placeholder is deliberately unlabelled**. Naming real parameters in it made the skeleton indistinguishable from a resolved row — a test matched the placeholder and then failed on the element React had already replaced. That was a real defect in the component, not just the test.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --workspace`, `cargo test --doc`, `npm run test:run` (595 passed), `npm run lint`, `check_boundaries.sh`, `check_readmes.sh --strict` all pass.

Two things I could not verify here, stated plainly:

- **The route was not exercised at runtime.** `DAEMON_PORT` is a hard constant (9887) and that port is held by an unrelated process on this machine, so no daemon could start. The compile proves the handler and route type-check against `AppState`; the path string itself is review-only. The repo has no HTTP-level test harness — building the first one needs an 18-field `AxumContext` and belongs in its own PR, not bolted onto this one.
- `gglib-runtime`'s `free_gpu_memory_is_answerable_on_any_machine` fails on this machine. Confirmed pre-existing on a clean `main` checkout — unrelated to this change.
