### PR TITLE
fix(frontend): restore default-value placeholders on numeric settings fields

### DIFF
--- a/src/components/SettingsModal/fields/AdvancedSettings.tsx
+++ b/src/components/SettingsModal/fields/AdvancedSettings.tsx
@@ -2,12 +2,12 @@ import { FC } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Icon } from '../../ui/Icon';
 import { Button } from '../../ui/Button';
-import { Input } from '../../ui/Input';
 import { Textarea } from '../../ui/Textarea';
 import { InferenceParametersForm } from '../../InferenceParametersForm';
 import type { InferenceConfig } from '../../../types';
 import { Label } from '../../primitives';
 import { MAX_TOOL_ITERATIONS } from '../../../constants/settingsDefaults';
+import { NumberSettingField } from './NumberSettingField';
 import { SettingField } from './SettingField';
 import { ToggleField } from './ToggleField';
 import { DEFAULT_TITLE_GENERATION_PROMPT } from '../../../services/transport';
@@ -62,23 +62,15 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
 
     {isOpen && (
       <div className="flex flex-col gap-md pl-md border-l-2 border-l-border mt-sm animate-slide-down">
-        <SettingField
+        <NumberSettingField
           id="max-tool-iterations-input"
           label="Max Tool Iterations"
-          controlWidth="xs"
-          defaultHint={MAX_TOOL_ITERATIONS.default}
+          spec={MAX_TOOL_ITERATIONS}
+          value={maxToolIterationsInput}
+          onChange={setMaxToolIterationsInput}
           description="Maximum iterations for tool calling in agentic loop"
-        >
-          <Input
-            id="max-tool-iterations-input"
-            type="number"
-            value={maxToolIterationsInput}
-            onChange={(event) => setMaxToolIterationsInput(event.target.value)}
-            min={MAX_TOOL_ITERATIONS.min}
-            max={MAX_TOOL_ITERATIONS.max}
-            disabled={saving}
-          />
-        </SettingField>
+          disabled={saving}
+        />
 
         <SettingField
           id="title-prompt-input"

--- a/src/components/SettingsModal/fields/AdvancedSettings.tsx
+++ b/src/components/SettingsModal/fields/AdvancedSettings.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '../../ui/Textarea';
 import { InferenceParametersForm } from '../../InferenceParametersForm';
 import type { InferenceConfig } from '../../../types';
 import { Label } from '../../primitives';
+import { MAX_TOOL_ITERATIONS } from '../../../constants/settingsDefaults';
 import { SettingField } from './SettingField';
 import { ToggleField } from './ToggleField';
 import { DEFAULT_TITLE_GENERATION_PROMPT } from '../../../services/transport';
@@ -65,7 +66,7 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
           id="max-tool-iterations-input"
           label="Max Tool Iterations"
           controlWidth="xs"
-          defaultHint="25"
+          defaultHint={MAX_TOOL_ITERATIONS.default}
           description="Maximum iterations for tool calling in agentic loop"
         >
           <Input
@@ -73,8 +74,8 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
             type="number"
             value={maxToolIterationsInput}
             onChange={(event) => setMaxToolIterationsInput(event.target.value)}
-            min="1"
-            max="50"
+            min={MAX_TOOL_ITERATIONS.min}
+            max={MAX_TOOL_ITERATIONS.max}
             disabled={saving}
           />
         </SettingField>

--- a/src/components/SettingsModal/fields/ModelDefaults.tsx
+++ b/src/components/SettingsModal/fields/ModelDefaults.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { Input } from '../../ui/Input';
 import { Select } from '../../ui/Select';
 import type { GgufModel } from '../../../types';
+import { CONTEXT_SIZE } from '../../../constants/settingsDefaults';
 import { SettingField } from './SettingField';
 
 interface ModelDefaultsProps {
@@ -31,7 +32,7 @@ export const ModelDefaults: FC<ModelDefaultsProps> = ({
       id="context-size-input"
       label="Default Context Size"
       controlWidth="xs"
-      defaultHint="4096"
+      defaultHint={CONTEXT_SIZE.default}
       description="Default context size for models (e.g., 4096, 8192, 16384)"
     >
       <Input
@@ -39,8 +40,8 @@ export const ModelDefaults: FC<ModelDefaultsProps> = ({
         type="number"
         value={contextSizeInput}
         onChange={(event) => setContextSizeInput(event.target.value)}
-        min="512"
-        max="1000000"
+        min={CONTEXT_SIZE.min}
+        max={CONTEXT_SIZE.max}
         disabled={saving}
       />
     </SettingField>

--- a/src/components/SettingsModal/fields/ModelDefaults.tsx
+++ b/src/components/SettingsModal/fields/ModelDefaults.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react';
-import { Input } from '../../ui/Input';
 import { Select } from '../../ui/Select';
 import type { GgufModel } from '../../../types';
 import { CONTEXT_SIZE } from '../../../constants/settingsDefaults';
+import { NumberSettingField } from './NumberSettingField';
 import { SettingField } from './SettingField';
 
 interface ModelDefaultsProps {
@@ -28,23 +28,15 @@ export const ModelDefaults: FC<ModelDefaultsProps> = ({
   saving,
 }) => (
   <>
-    <SettingField
+    <NumberSettingField
       id="context-size-input"
       label="Default Context Size"
-      controlWidth="xs"
-      defaultHint={CONTEXT_SIZE.default}
+      spec={CONTEXT_SIZE}
+      value={contextSizeInput}
+      onChange={setContextSizeInput}
       description="Default context size for models (e.g., 4096, 8192, 16384)"
-    >
-      <Input
-        id="context-size-input"
-        type="number"
-        value={contextSizeInput}
-        onChange={(event) => setContextSizeInput(event.target.value)}
-        min={CONTEXT_SIZE.min}
-        max={CONTEXT_SIZE.max}
-        disabled={saving}
-      />
-    </SettingField>
+      disabled={saving}
+    />
 
     <SettingField
       id="default-model-select"

--- a/src/components/SettingsModal/fields/NumberSettingField.tsx
+++ b/src/components/SettingsModal/fields/NumberSettingField.tsx
@@ -51,6 +51,7 @@ export const NumberSettingField: FC<NumberSettingFieldProps> = ({
       type="number"
       value={value}
       onChange={(event) => onChange(event.target.value)}
+      placeholder={spec.default}
       min={spec.min}
       max={spec.max}
       disabled={disabled}

--- a/src/components/SettingsModal/fields/NumberSettingField.tsx
+++ b/src/components/SettingsModal/fields/NumberSettingField.tsx
@@ -1,0 +1,59 @@
+import { FC, ReactNode } from 'react';
+import { Input } from '../../ui/Input';
+import type { NumericSettingSpec } from '../../../constants/settingsDefaults';
+import { SettingField } from './SettingField';
+
+interface NumberSettingFieldProps {
+  /** Field id, wired to the label via htmlFor and forwarded to the input. */
+  id: string;
+  label: string;
+  /**
+   * Default value and accepted range for this field, from
+   * `src/constants/settingsDefaults.ts`. Taking the whole spec rather than
+   * three loose props keeps a field's bounds and its fallback from being
+   * sourced independently.
+   */
+  spec: NumericSettingSpec;
+  value: string;
+  onChange: (value: string) => void;
+  description?: ReactNode;
+  disabled?: boolean;
+}
+
+/**
+ * A numeric settings input with its label, description, and default hint.
+ *
+ * Ports, sizes, and caps all want the same shape — a narrow number input,
+ * min/max bounds, and a visible statement of what the backend falls back to
+ * when the field is left empty — and were repeating it call site by call
+ * site. Owning the `Input` here (rather than leaving it to each caller, as
+ * plain `SettingField` does) is what lets the default reach the control as
+ * well as the hint, without `SettingField` having to clone its children.
+ */
+export const NumberSettingField: FC<NumberSettingFieldProps> = ({
+  id,
+  label,
+  spec,
+  value,
+  onChange,
+  description,
+  disabled,
+}) => (
+  <SettingField
+    id={id}
+    label={label}
+    controlWidth="xs"
+    defaultHint={spec.default}
+    description={description}
+  >
+    <Input
+      id={id}
+      type="number"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      min={spec.min}
+      max={spec.max}
+      disabled={disabled}
+    />
+  </SettingField>
+);

--- a/src/components/SettingsModal/fields/NumberSettingField.tsx
+++ b/src/components/SettingsModal/fields/NumberSettingField.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode } from 'react';
 import { Input } from '../../ui/Input';
 import type { NumericSettingSpec } from '../../../constants/settingsDefaults';
-import { SettingField } from './SettingField';
+import { SettingField, settingDescriptionId } from './SettingField';
 
 interface NumberSettingFieldProps {
   /** Field id, wired to the label via htmlFor and forwarded to the input. */
@@ -28,7 +28,9 @@ interface NumberSettingFieldProps {
  * when the field is left empty — and were repeating it call site by call
  * site. Owning the `Input` here (rather than leaving it to each caller, as
  * plain `SettingField` does) is what lets the default reach the control as
- * well as the hint, without `SettingField` having to clone its children.
+ * well as the hint, without `SettingField` having to clone its children —
+ * both as the placeholder and, via `aria-describedby`, as something a
+ * screen reader will actually read out.
  */
 export const NumberSettingField: FC<NumberSettingFieldProps> = ({
   id,
@@ -55,6 +57,7 @@ export const NumberSettingField: FC<NumberSettingFieldProps> = ({
       min={spec.min}
       max={spec.max}
       disabled={disabled}
+      aria-describedby={settingDescriptionId(id)}
     />
   </SettingField>
 );

--- a/src/components/SettingsModal/fields/PortSettings.tsx
+++ b/src/components/SettingsModal/fields/PortSettings.tsx
@@ -1,5 +1,10 @@
 import { FC } from 'react';
 import { Input } from '../../ui/Input';
+import {
+  LLAMA_BASE_PORT,
+  MAX_DOWNLOAD_QUEUE_SIZE,
+  PROXY_PORT,
+} from '../../../constants/settingsDefaults';
 import { SettingField } from './SettingField';
 
 interface PortSettingsProps {
@@ -29,7 +34,7 @@ export const PortSettings: FC<PortSettingsProps> = ({
       id="proxy-port-input"
       label="Proxy Server Port"
       controlWidth="xs"
-      defaultHint="8080"
+      defaultHint={PROXY_PORT.default}
       description="Port for the OpenAI-compatible proxy server"
     >
       <Input
@@ -37,8 +42,8 @@ export const PortSettings: FC<PortSettingsProps> = ({
         type="number"
         value={proxyPortInput}
         onChange={(event) => setProxyPortInput(event.target.value)}
-        min="1024"
-        max="65535"
+        min={PROXY_PORT.min}
+        max={PROXY_PORT.max}
         disabled={saving}
       />
     </SettingField>
@@ -47,7 +52,7 @@ export const PortSettings: FC<PortSettingsProps> = ({
       id="server-port-input"
       label="Base Server Port"
       controlWidth="xs"
-      defaultHint="9000"
+      defaultHint={LLAMA_BASE_PORT.default}
       description="Starting port for llama-server instances"
     >
       <Input
@@ -55,8 +60,8 @@ export const PortSettings: FC<PortSettingsProps> = ({
         type="number"
         value={serverPortInput}
         onChange={(event) => setServerPortInput(event.target.value)}
-        min="1024"
-        max="65535"
+        min={LLAMA_BASE_PORT.min}
+        max={LLAMA_BASE_PORT.max}
         disabled={saving}
       />
     </SettingField>
@@ -65,16 +70,16 @@ export const PortSettings: FC<PortSettingsProps> = ({
       id="max-queue-size-input"
       label="Max Download Queue Size"
       controlWidth="xs"
-      defaultHint="10"
-      description="Maximum number of models that can be queued for download (1-50)"
+      defaultHint={MAX_DOWNLOAD_QUEUE_SIZE.default}
+      description={`Maximum number of models that can be queued for download (${MAX_DOWNLOAD_QUEUE_SIZE.min}-${MAX_DOWNLOAD_QUEUE_SIZE.max})`}
     >
       <Input
         id="max-queue-size-input"
         type="number"
         value={maxQueueSizeInput}
         onChange={(event) => setMaxQueueSizeInput(event.target.value)}
-        min="1"
-        max="50"
+        min={MAX_DOWNLOAD_QUEUE_SIZE.min}
+        max={MAX_DOWNLOAD_QUEUE_SIZE.max}
         disabled={saving}
       />
     </SettingField>

--- a/src/components/SettingsModal/fields/PortSettings.tsx
+++ b/src/components/SettingsModal/fields/PortSettings.tsx
@@ -1,11 +1,10 @@
 import { FC } from 'react';
-import { Input } from '../../ui/Input';
 import {
   LLAMA_BASE_PORT,
   MAX_DOWNLOAD_QUEUE_SIZE,
   PROXY_PORT,
 } from '../../../constants/settingsDefaults';
-import { SettingField } from './SettingField';
+import { NumberSettingField } from './NumberSettingField';
 
 interface PortSettingsProps {
   proxyPortInput: string;
@@ -30,58 +29,34 @@ export const PortSettings: FC<PortSettingsProps> = ({
   saving,
 }) => (
   <>
-    <SettingField
+    <NumberSettingField
       id="proxy-port-input"
       label="Proxy Server Port"
-      controlWidth="xs"
-      defaultHint={PROXY_PORT.default}
+      spec={PROXY_PORT}
+      value={proxyPortInput}
+      onChange={setProxyPortInput}
       description="Port for the OpenAI-compatible proxy server"
-    >
-      <Input
-        id="proxy-port-input"
-        type="number"
-        value={proxyPortInput}
-        onChange={(event) => setProxyPortInput(event.target.value)}
-        min={PROXY_PORT.min}
-        max={PROXY_PORT.max}
-        disabled={saving}
-      />
-    </SettingField>
+      disabled={saving}
+    />
 
-    <SettingField
+    <NumberSettingField
       id="server-port-input"
       label="Base Server Port"
-      controlWidth="xs"
-      defaultHint={LLAMA_BASE_PORT.default}
+      spec={LLAMA_BASE_PORT}
+      value={serverPortInput}
+      onChange={setServerPortInput}
       description="Starting port for llama-server instances"
-    >
-      <Input
-        id="server-port-input"
-        type="number"
-        value={serverPortInput}
-        onChange={(event) => setServerPortInput(event.target.value)}
-        min={LLAMA_BASE_PORT.min}
-        max={LLAMA_BASE_PORT.max}
-        disabled={saving}
-      />
-    </SettingField>
+      disabled={saving}
+    />
 
-    <SettingField
+    <NumberSettingField
       id="max-queue-size-input"
       label="Max Download Queue Size"
-      controlWidth="xs"
-      defaultHint={MAX_DOWNLOAD_QUEUE_SIZE.default}
+      spec={MAX_DOWNLOAD_QUEUE_SIZE}
+      value={maxQueueSizeInput}
+      onChange={setMaxQueueSizeInput}
       description={`Maximum number of models that can be queued for download (${MAX_DOWNLOAD_QUEUE_SIZE.min}-${MAX_DOWNLOAD_QUEUE_SIZE.max})`}
-    >
-      <Input
-        id="max-queue-size-input"
-        type="number"
-        value={maxQueueSizeInput}
-        onChange={(event) => setMaxQueueSizeInput(event.target.value)}
-        min={MAX_DOWNLOAD_QUEUE_SIZE.min}
-        max={MAX_DOWNLOAD_QUEUE_SIZE.max}
-        disabled={saving}
-      />
-    </SettingField>
+      disabled={saving}
+    />
   </>
 );

--- a/src/components/SettingsModal/fields/README.md
+++ b/src/components/SettingsModal/fields/README.md
@@ -4,7 +4,7 @@
 
 Single-responsibility field groups for the General Settings form, plus the `SettingField` primitive they're built on.
 
-`SettingField` renders one label / control / hint group and is where the placeholder-as-default problem is fixed once: settings inputs start empty and only backfill from the server when a value has been explicitly set, so an unset field previously showed nothing but its HTML placeholder — indistinguishable from a field the user hasn't typed in yet. `SettingField` accepts an explicit `defaultHint` and renders it as an always-visible "Default: 4096" line instead.
+`SettingField` renders one label / control / hint group. Settings inputs start empty and only backfill from the server when a value has been explicitly set, so a field's default has to be stated rather than inferred, and it is stated twice on purpose: `SettingField`'s `defaultHint` renders an always-visible "Default: 4096" line, and the control carries the same value as its placeholder. The hint survives focus and survives a value being entered; the placeholder sits in the box where it can be typed over. Numeric fields get both from a single `{default, min, max}` spec through `NumberSettingField` — a field that supplies its own control (the models directory, the title prompt) owns its placeholder itself.
 
 ## Key Files
 

--- a/src/components/SettingsModal/fields/README.md
+++ b/src/components/SettingsModal/fields/README.md
@@ -11,6 +11,7 @@ Single-responsibility field groups for the General Settings form, plus the `Sett
 | File | Role |
 |------|------|
 | `SettingField.tsx` | Label + control + hint/default/action row |
+| `NumberSettingField.tsx` | `SettingField` plus the number input itself, wired to a `{default, min, max}` spec from `src/constants/settingsDefaults.ts`; every numeric setting renders through it |
 | `ToggleField.tsx` | Checkbox + bold label + explanatory paragraph; every boolean setting renders through it |
 | `PathSettings.tsx` | Models directory field and its exists/writable status pills |
 | `ModelDefaults.tsx` | Default context size and default model selector |

--- a/src/components/SettingsModal/fields/SettingField.tsx
+++ b/src/components/SettingsModal/fields/SettingField.tsx
@@ -44,6 +44,16 @@ const controlWidthClasses = {
   full: 'w-full',
 } as const;
 
+/**
+ * Id of the element holding a field's description and default hint.
+ *
+ * A control passes this to `aria-describedby` so the hint is announced with
+ * the field. `SettingField` cannot attach it itself — `children` is an opaque
+ * ReactNode, and reaching into it would mean cloneElement — so the id is
+ * derived from the field id and both sides compute it from here.
+ */
+export const settingDescriptionId = (id: string): string => `${id}-description`;
+
 export const SettingField: FC<SettingFieldProps> = ({
   id,
   label,
@@ -60,7 +70,7 @@ export const SettingField: FC<SettingFieldProps> = ({
     <div className={controlWidthClasses[controlWidth]}>{children}</div>
     {(description || defaultHint || action) && (
       <Row justify="between" gap="sm" className="text-text-secondary text-sm">
-        <span>
+        <span id={id ? settingDescriptionId(id) : undefined}>
           {description}
           {description && defaultHint && ' '}
           {defaultHint && <span className="text-text-muted">Default: {defaultHint}</span>}

--- a/src/components/SettingsModal/fields/SettingField.tsx
+++ b/src/components/SettingsModal/fields/SettingField.tsx
@@ -15,12 +15,13 @@ interface SettingFieldProps {
    * The value this field falls back to when left empty, e.g. "4096".
    * Rendered as an explicit "Default: 4096" hint below the control.
    *
-   * Settings inputs start empty and only backfill from the server value
-   * when one has been explicitly set (see SettingsModal.tsx), so an unset
-   * field previously showed nothing but its HTML placeholder — visually
-   * identical to a field the user just hasn't typed in yet. This makes
-   * the fallback an explicit, always-visible fact instead of a value
-   * that vanishes the instant the field gains focus.
+   * This is the half of the story that survives: it stays put when the
+   * field takes focus, and it stays put once a value has been entered, so
+   * the fallback is still legible to someone deciding whether to clear the
+   * field. The control's own placeholder is the other half — it shows the
+   * same value in the box, where it can be typed over. Numeric fields get
+   * both, from one source, via NumberSettingField; a caller supplying its
+   * own control is responsible for its own placeholder.
    */
   defaultHint?: string;
   /** Additional description text, shown alongside the default hint. */
@@ -34,8 +35,8 @@ interface SettingFieldProps {
  *
  * GeneralSettings.tsx used to repeat this structure by hand for every
  * field with slightly different markup each time. Centralising it here
- * is also where the placeholder-as-default defect gets fixed once,
- * instead of once per field.
+ * gives every field the same label placement, control width, and
+ * hint row.
  */
 const controlWidthClasses = {
   xs: 'w-28',

--- a/src/components/SettingsModal/fields/index.ts
+++ b/src/components/SettingsModal/fields/index.ts
@@ -1,4 +1,5 @@
 export { SettingField } from './SettingField';
+export { NumberSettingField } from './NumberSettingField';
 export { ToggleField } from './ToggleField';
 export { DesktopSettings } from './DesktopSettings';
 export { PathSettings } from './PathSettings';

--- a/src/constants/README.md
+++ b/src/constants/README.md
@@ -12,6 +12,7 @@ Application-wide shared constant values: fixed, non-environment-specific values 
 | File | Role |
 |------|------|
 | `prompts.ts` | `DEFAULT_SYSTEM_PROMPT = 'You are a helpful assistant.'` — default chat system prompt; keeps runtime hooks free of UI-level defaults |
+| `settingsDefaults.ts` | Default value and accepted range for each numeric settings-modal field, mirroring `Settings::with_defaults()` and `validate_settings()` in `crates/gglib-core/src/settings.rs` |
 
 Adding constants here prevents duplication and ensures consistent defaults across tests, the backend API, and the UI.
 

--- a/src/constants/settingsDefaults.ts
+++ b/src/constants/settingsDefaults.ts
@@ -1,0 +1,81 @@
+/**
+ * Default values and accepted ranges for the numeric fields in the settings modal.
+ *
+ * The authoritative values live in Rust — `Settings::with_defaults()` and
+ * `validate_settings()` in `crates/gglib-core/src/settings.rs`. These entries
+ * mirror them so the GUI can show the user what the backend will fall back to
+ * and reject out-of-range input before a round trip.
+ *
+ * Mirroring is not enforcement: nothing here fails if the Rust side changes.
+ * What this module buys is that a Rust-side change is a one-file fix instead of
+ * a hunt through five JSX literals, and that each value is written exactly once
+ * (the ranges used to be spelled out twice per field — as `min`/`max` props and
+ * again in prose).
+ *
+ * Values are strings because they feed `<input type="number">` attributes.
+ */
+
+/** Default value plus the range accepted by a numeric settings input. */
+export interface NumericSettingSpec {
+  /** Value the backend falls back to when the field is left empty. */
+  readonly default: string;
+  readonly min: string;
+  readonly max: string;
+}
+
+/**
+ * OpenAI-compatible proxy listener.
+ *
+ * Rust: `DEFAULT_PROXY_PORT`; ports below 1024 are rejected by
+ * `validate_settings`, and the field is a `u16`.
+ */
+export const PROXY_PORT: NumericSettingSpec = {
+  default: '8080',
+  min: '1024',
+  max: '65535',
+};
+
+/**
+ * First port handed out to llama-server instances.
+ *
+ * Rust: `DEFAULT_LLAMA_BASE_PORT`; same bounds as the proxy port.
+ */
+export const LLAMA_BASE_PORT: NumericSettingSpec = {
+  default: '9000',
+  min: '1024',
+  max: '65535',
+};
+
+/**
+ * How many model downloads may be queued at once.
+ *
+ * Rust: literal `10` in `with_defaults()`, range `1..=50` in `validate_settings`.
+ */
+export const MAX_DOWNLOAD_QUEUE_SIZE: NumericSettingSpec = {
+  default: '10',
+  min: '1',
+  max: '50',
+};
+
+/**
+ * Context window applied to a model with no per-model override.
+ *
+ * Rust: `DEFAULT_CONTEXT_SIZE`, range `512..=1_000_000` in `validate_settings`.
+ */
+export const CONTEXT_SIZE: NumericSettingSpec = {
+  default: '4096',
+  min: '512',
+  max: '1000000',
+};
+
+/**
+ * Tool-call rounds the agentic loop will run before giving up.
+ *
+ * Rust: `domain::agent::DEFAULT_MAX_ITERATIONS`. Note the range is a UI-side
+ * guard rail only — `validate_settings` does not bound this field.
+ */
+export const MAX_TOOL_ITERATIONS: NumericSettingSpec = {
+  default: '25',
+  min: '1',
+  max: '50',
+};

--- a/tests/ts/components/SettingsFields.test.tsx
+++ b/tests/ts/components/SettingsFields.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { PortSettings } from '../../../src/components/SettingsModal/fields/PortSettings';
+import { ModelDefaults } from '../../../src/components/SettingsModal/fields/ModelDefaults';
+import { AdvancedSettings } from '../../../src/components/SettingsModal/fields/AdvancedSettings';
+
+const noop = () => {};
+
+type Setter = (value: string) => void;
+
+/** Renders the section owning a field, with that one field's value and setter. */
+type RenderField = (value: string, onChange: Setter) => void;
+
+const renderPortSettings =
+  (field: 'proxy' | 'server' | 'queue'): RenderField =>
+  (value, onChange) =>
+    render(
+      <PortSettings
+        proxyPortInput={field === 'proxy' ? value : ''}
+        setProxyPortInput={field === 'proxy' ? onChange : noop}
+        serverPortInput={field === 'server' ? value : ''}
+        setServerPortInput={field === 'server' ? onChange : noop}
+        maxQueueSizeInput={field === 'queue' ? value : ''}
+        setMaxQueueSizeInput={field === 'queue' ? onChange : noop}
+        saving={false}
+      />,
+    );
+
+const renderModelDefaults: RenderField = (value, onChange) =>
+  render(
+    <ModelDefaults
+      contextSizeInput={value}
+      setContextSizeInput={onChange}
+      defaultModelInput=""
+      setDefaultModelInput={noop}
+      models={[]}
+      loadingModels={false}
+      saving={false}
+    />,
+  );
+
+const renderAdvancedSettings: RenderField = (value, onChange) =>
+  render(
+    <AdvancedSettings
+      isOpen
+      onToggle={noop}
+      maxToolIterationsInput={value}
+      setMaxToolIterationsInput={onChange}
+      titlePromptInput=""
+      setTitlePromptInput={noop}
+      inferenceDefaultsInput={undefined}
+      setInferenceDefaultsInput={noop}
+      trustClientSampling={false}
+      setTrustClientSampling={noop}
+      proxyLoopDetection
+      setProxyLoopDetection={noop}
+      saving={false}
+    />,
+  );
+
+/**
+ * Every numeric field in the settings modal, with the values a user should
+ * see.
+ *
+ * The expectations are literals rather than imports from
+ * `src/constants/settingsDefaults.ts` on purpose: a test that reads the same
+ * constant it is checking would pass whatever that constant happened to say,
+ * including a typo. These are transcribed from
+ * `crates/gglib-core/src/settings.rs`, which is what the GUI is promising the
+ * user the backend will do.
+ */
+const FIELDS: {
+  label: string;
+  fallback: string;
+  min: string;
+  max: string;
+  renderField: RenderField;
+}[] = [
+  {
+    label: 'Proxy Server Port',
+    fallback: '8080',
+    min: '1024',
+    max: '65535',
+    renderField: renderPortSettings('proxy'),
+  },
+  {
+    label: 'Base Server Port',
+    fallback: '9000',
+    min: '1024',
+    max: '65535',
+    renderField: renderPortSettings('server'),
+  },
+  {
+    label: 'Max Download Queue Size',
+    fallback: '10',
+    min: '1',
+    max: '50',
+    renderField: renderPortSettings('queue'),
+  },
+  {
+    label: 'Default Context Size',
+    fallback: '4096',
+    min: '512',
+    max: '1000000',
+    renderField: renderModelDefaults,
+  },
+  {
+    label: 'Max Tool Iterations',
+    fallback: '25',
+    min: '1',
+    max: '50',
+    renderField: renderAdvancedSettings,
+  },
+];
+
+describe.each(FIELDS)('$label', ({ label, fallback, min, max, renderField }) => {
+  it('offers the default as a placeholder to type over while empty', () => {
+    renderField('', noop);
+
+    // The regression from #730: the hint below the field was left in place
+    // but the in-box affordance went away.
+    expect(screen.getByLabelText(label)).toHaveAttribute('placeholder', fallback);
+  });
+
+  it('states the default below the field', () => {
+    renderField('', noop);
+
+    expect(screen.getByText(`Default: ${fallback}`)).toBeInTheDocument();
+  });
+
+  it('keeps the default legible once a value is set', async () => {
+    renderField('7', noop);
+
+    // The placeholder is gone at this point — the hint is the only thing
+    // still telling the user what clearing the field would fall back to.
+    expect(screen.getByLabelText(label)).toHaveValue(7);
+    expect(screen.getByText(`Default: ${fallback}`)).toBeInTheDocument();
+  });
+
+  it('announces the default to assistive technology', () => {
+    renderField('', noop);
+
+    expect(screen.getByLabelText(label)).toHaveAccessibleDescription(
+      new RegExp(`Default: ${fallback}`),
+    );
+  });
+
+  it('constrains input to the range the backend accepts', () => {
+    renderField('', noop);
+
+    const input = screen.getByLabelText(label);
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveAttribute('min', min);
+    expect(input).toHaveAttribute('max', max);
+  });
+
+  it('reports edits to its own setter', async () => {
+    const onChange = vi.fn();
+    renderField('', onChange);
+
+    await userEvent.type(screen.getByLabelText(label), '7');
+
+    expect(onChange).toHaveBeenCalledWith('7');
+  });
+});


### PR DESCRIPTION
Closes #733.

## What regressed

Five numeric inputs in the settings modal stopped showing the faint, type-over-able default inside the box: Proxy Server Port (8080), Base Server Port (9000), Max Download Queue Size (10), Default Context Size (4096), and Max Tool Iterations (25).

This was deliberate. #730's commit message says those fields "lose their placeholder props, so a configured value renders as a value and the visible `Default: N` hint is the only fallback affordance", and the reasoning was written into `SettingField.tsx`'s docstring and the fields README.

## Why it goes back

The two affordances aren't substitutes — they cover different moments:

- The **placeholder** says the field is editable and the number can be typed straight over, with the number where the caret already is. Visible only while the field is empty, which is exactly when that's useful.
- The **hint** survives focus and survives a value being entered, so it still answers "what happens if I clear this?" when the placeholder is necessarily gone.

Both now read from one `{default, min, max}` spec per field, so they can't disagree. Top K and Max Tokens already worked this way (`InferenceParametersForm` was never touched by #730) — this brings the settings fields to the same place and improves on the hint: theirs disappears once a value is set, this one doesn't.

## Commits

| | |
|---|---|
| `9db5433` | **refactor** — `src/constants/settingsDefaults.ts`: one `{default, min, max}` per field, each naming the Rust symbol it mirrors in `crates/gglib-core/src/settings.rs`. Removes the JSX literals and the ranges that were written twice (`min`/`max` props *and* the "(1-50)" prose, which now interpolates). |
| `eb6911a` | **refactor** — `NumberSettingField`: the same 17 lines were repeated at five call sites. Owning the `Input` (which `SettingField` can't, since `children` is an opaque `ReactNode`) is what lets the default reach the control without `cloneElement`. |
| `e61c2b1` | **fix** — `placeholder={spec.default}`, plus a rewrite of the rationale in `SettingField`'s docstring and the fields README, both of which documented placeholder-as-default as the *defect*. |
| `231b740` | **fix** — `aria-describedby` on the hint row. The default was visible but unreachable: focusing Proxy Server Port announced the label and stopped. Same defect as above, audio channel. Follows the existing `InferenceProfileEditor` / `ui/Modal` pattern. |
| `9d57085` | **test** — `tests/ts/components/SettingsFields.test.tsx`, table-driven over all five. |

The two refactors are behaviour-neutral; the two fixes are one line each.

## Testing

- 634/634 frontend tests pass (30 new).
- Verified the new tests actually guard: reverting the `placeholder` and `aria-describedby` lines fails exactly 10 of them, two per field.
- `tsc --noEmit` and `eslint src/` clean.
- `check_file_complexity.sh` reports 20 violations, all pre-existing on `main` and none in the files touched here.
- Manually: each field shows the faint default when unset with `Default: N` below, typing replaces it, a saved value renders solid with the hint still below, and values round-trip through save/reopen.

Expected values in the test are literals rather than imports from `settingsDefaults.ts` — a test reading the same constant it asserts on would pass whatever that constant said.

## Not included

Filed separately as #735 rather than smuggled in here: `InferenceParametersForm`'s `Using default (40)` is a second phrasing for the same idea in the same modal and vanishes once a value is set, and its label elements have no `htmlFor`. That component also renders in `ModelEditForm` and `ServeModal`, and "should the caption stay visible?" is a design call, not a cleanup.