### PR TITLE
fix(core): stop overriding llama.cpp's native min_p default

### DIFF
--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -108,8 +108,13 @@ pub struct InferenceConfig {
     /// Minimum-probability sampling threshold (0.0 - 1.0).
     ///
     /// Removes tokens whose probability is below `min_p × P(top token)`.
-    /// - 0.0: Disabled (explicit off; recommended by Qwen3.6)
-    /// - 0.05: llama.cpp built-in default when the flag is omitted
+    /// - 0.0: Disabled (explicit off; recommended by Qwen3.6, and the floor
+    ///   for `reasoning`-tagged models — see [`reasoning_floor`])
+    /// - 0.05: llama.cpp's own default, and the neutral floor here — see
+    ///   [`with_hardcoded_defaults`]
+    ///
+    /// [`reasoning_floor`]: Self::reasoning_floor
+    /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     pub min_p: Option<f32>,
 }
 
@@ -428,7 +433,21 @@ impl InferenceConfig {
     /// Explicit per-request, per-profile, and per-model values are unaffected —
     /// [`reasoning_profile`] still sets its own ceiling.
     ///
+    /// # `min_p` matches llama.cpp rather than disabling itself
+    ///
+    /// `0.05` is llama.cpp's own default for the flag, restated here rather
+    /// than left to the upstream. It used to be `0.0`, which reads like an
+    /// absence but is not one: [`to_openai_json_patch`] drops only `None`, and
+    /// resolution force-writes what survives, so the floor was *explicitly
+    /// disabling* min-p on every request that did not set its own. At this
+    /// floor's own `temperature: 0.7` that removes the tail cut entirely.
+    ///
+    /// Stated rather than omitted so llama-server keeps receiving fully
+    /// specified parameters, and so the value stays visible as `min_p=floor`
+    /// in sampling provenance instead of reporting as unset.
+    ///
     /// [`reasoning_profile`]: Self::reasoning_profile
+    /// [`to_openai_json_patch`]: Self::to_openai_json_patch
     #[must_use]
     pub const fn with_hardcoded_defaults() -> Self {
         Self {
@@ -438,7 +457,7 @@ impl InferenceConfig {
             max_tokens: None,
             repeat_penalty: Some(1.0),
             presence_penalty: Some(0.0),
-            min_p: Some(0.0),
+            min_p: Some(0.05),
         }
     }
 
@@ -454,6 +473,13 @@ impl InferenceConfig {
     /// prevent this). `1.0` keeps a real guard in place at the floor without
     /// asserting the full recipe tuned for a different temperature.
     ///
+    /// `min_p` is pinned to `0.0` for the same class-specific reason, and
+    /// deliberately does *not* inherit the neutral floor's `0.05`: Qwen3.6's
+    /// published guidance is to disable min-p on these models, which
+    /// [`reasoning_profile`] already encodes. Spelling it out here keeps that
+    /// carve-out from silently disappearing the next time the neutral floor
+    /// moves.
+    ///
     /// [`resolve_layers`]: Self::resolve_layers
     /// [`with_hardcoded_defaults`]: Self::with_hardcoded_defaults
     /// [`reasoning_profile`]: Self::reasoning_profile
@@ -461,6 +487,7 @@ impl InferenceConfig {
     pub const fn reasoning_floor() -> Self {
         Self {
             presence_penalty: Some(1.0),
+            min_p: Some(0.0),
             ..Self::with_hardcoded_defaults()
         }
     }
@@ -824,25 +851,32 @@ mod tests {
         assert_eq!(config.max_tokens, None);
         assert_eq!(config.repeat_penalty, Some(1.0));
         assert_eq!(config.presence_penalty, Some(0.0));
-        assert_eq!(config.min_p, Some(0.0));
+        // llama.cpp's own default, restated. `Some(0.0)` here would not read
+        // as "unset" — it would be force-written, explicitly disabling the
+        // tail cut on every request. See `with_hardcoded_defaults`.
+        assert_eq!(config.min_p, Some(0.05));
     }
 
-    /// The reasoning floor differs from the hardcoded floor in exactly one
-    /// field — a real anti-repetition guard where the neutral floor has none.
+    /// The reasoning floor differs from the hardcoded floor in exactly two
+    /// fields, both class-specific: a real anti-repetition guard where the
+    /// neutral floor has none, and min-p disabled per Qwen3.6's guidance
+    /// where the neutral floor matches llama.cpp.
     #[test]
-    fn test_reasoning_floor_differs_only_in_presence_penalty() {
+    fn test_reasoning_floor_differs_only_in_presence_penalty_and_min_p() {
         let neutral = InferenceConfig::with_hardcoded_defaults();
         let reasoning = InferenceConfig::reasoning_floor();
 
         assert_eq!(reasoning.presence_penalty, Some(1.0));
         assert_ne!(reasoning.presence_penalty, neutral.presence_penalty);
 
+        assert_eq!(reasoning.min_p, Some(0.0));
+        assert_ne!(reasoning.min_p, neutral.min_p);
+
         assert_eq!(reasoning.temperature, neutral.temperature);
         assert_eq!(reasoning.top_p, neutral.top_p);
         assert_eq!(reasoning.top_k, neutral.top_k);
         assert_eq!(reasoning.max_tokens, neutral.max_tokens);
         assert_eq!(reasoning.repeat_penalty, neutral.repeat_penalty);
-        assert_eq!(reasoning.min_p, neutral.min_p);
     }
 
     /// If nothing in the stack ever declares a temperature, nothing has been

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -350,11 +350,15 @@ request params  →  profile  →  model defaults  →  global settings  →  ha
 4. **Global settings** — `Settings::inference_defaults`, read from the
    per-request settings snapshot (`settings_cache`).
 5. **Hardcoded fallback** — `temperature=0.7`, `top_p=0.95`, `top_k=40`,
-   `repeat_penalty=1.0`, `presence_penalty=0.0`, `min_p=0.0`. **`max_tokens`
+   `repeat_penalty=1.0`, `presence_penalty=0.0`, `min_p=0.05`. **`max_tokens`
    has no fallback**: because resolution force-writes every set parameter, one
    here would cap every request that did not name its own. Left unset, no
    `max_tokens` key is sent and llama-server generates until a stop token or the
-   context limit.
+   context limit. `min_p=0.05` restates llama.cpp's own default for the same
+   force-write reason, in reverse: a `0.0` here would not read as "unset", it
+   would be written, explicitly disabling the tail cut on every request.
+   A `reasoning`-tagged model floors at `presence_penalty=1.0` and `min_p=0.0`
+   instead — the two parameters whose floor is model-dependent.
 
 Resolution runs through `InferenceConfig::resolve_with_profile`, the single
 source of truth for the merge order.  The resolved values are aggressively

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -33,7 +33,7 @@ The full set of configurable parameters:
 | `max_tokens` | `--max-tokens` | int | *(none)* | Deliberately unset — see below |
 | `repeat_penalty` | `--repeat-penalty` | > 0.0 | 1.0 | |
 | `presence_penalty` | `--presence-penalty` | 0.0 – 2.0 | 0.0, or 1.0 on a `reasoning`-tagged model | See below |
-| `min_p` | `--min-p` | 0.0 – 1.0 | 0.0 (disabled) | 0.05 is llama.cpp built-in default when omitted |
+| `min_p` | `--min-p` | 0.0 – 1.0 | 0.05, or 0.0 on a `reasoning`-tagged model | Matches llama.cpp's own default — see below |
 
 ## Temperature coupling
 
@@ -59,6 +59,16 @@ that did not name its own — silently truncating long answers. Left unset, no
 `max_tokens` key is sent and llama-server applies its own `n_predict` default of
 `-1`, generating until a stop token or the context limit. Explicit per-request,
 per-profile and per-model values are unaffected.
+
+**`min_p` restates llama.cpp's default rather than disabling itself.** The floor
+is `0.05`, the same value llama.cpp applies when the flag is omitted. It is
+stated here rather than left out because resolution force-writes every set
+parameter, so llama-server receives a fully specified request and the value
+stays visible as `min_p=floor` in provenance. A `0.0` floor would not read as
+"unset" — it would be written too, explicitly turning off the tail cut on every
+request that did not set its own. `reasoning`-tagged models floor at `0.0`
+instead, matching Qwen3.6's guidance to disable min-p; that is the only other
+parameter besides `presence_penalty` whose floor depends on the model.
 
 ## Reasoning model auto-defaults
 

--- a/src/constants/inferenceDefaults.ts
+++ b/src/constants/inferenceDefaults.ts
@@ -71,10 +71,17 @@ export const INFERENCE_PARAMS: Record<SamplingParamKey, InferenceParamSpec> = {
    * Rust: `with_hardcoded_defaults().presence_penalty`, range `0.0..=2.0`.
    *
    * `reasoning`-tagged models use `reasoning_floor()` instead, which overrides
-   * this one field to `1.0` — the only parameter whose floor is model-dependent.
+   * this to `1.0` — one of the two parameters whose floor is model-dependent
+   * (see `minP` for the other).
    */
   presencePenalty: { default: 0.0, min: 0, max: 2, step: 0.05 },
 
-  /** Rust: `with_hardcoded_defaults().min_p`, range `0.0..=1.0`. */
-  minP: { default: 0.0, min: 0, max: 1, step: 0.01 },
+  /**
+   * Rust: `with_hardcoded_defaults().min_p`, range `0.0..=1.0`.
+   *
+   * `0.05` matches llama.cpp's own default. `reasoning`-tagged models use
+   * `reasoning_floor()` instead, which overrides this to `0.0` per Qwen3.6's
+   * guidance to disable min-p.
+   */
+  minP: { default: 0.05, min: 0, max: 1, step: 0.01 },
 };

--- a/tests/ts/contracts/settingsBounds.test.ts
+++ b/tests/ts/contracts/settingsBounds.test.ts
@@ -241,12 +241,13 @@ describe('sampling parameters vs validate_inference_config', () => {
     );
   });
 
-  it('only presence_penalty differs in the reasoning floor', () => {
-    // inferenceDefaults.ts annotates presencePenalty as the one model-dependent
-    // floor. If reasoning_floor() ever overrides a second field, that comment —
-    // and the settings-surface caption built on it — goes stale.
+  it('only presence_penalty and min_p differ in the reasoning floor', () => {
+    // inferenceDefaults.ts annotates presencePenalty and minP as the two
+    // model-dependent floors. If reasoning_floor() ever overrides a third
+    // field, those comments — and the settings-surface captions built on
+    // them — go stale.
     const overrides = [...structLiteral(INFERENCE_RS, 'reasoning_floor').keys()];
 
-    expect(overrides).toEqual(['presence_penalty']);
+    expect(overrides).toEqual(['presence_penalty', 'min_p']);
   });
 });


### PR DESCRIPTION
Closes #737

## What was wrong

`InferenceConfig::with_hardcoded_defaults()` set `min_p: Some(0.0)`. That reads like an
absence but is not one — it was force-written into every forwarded request, explicitly
disabling min-p rather than letting llama.cpp apply its own `0.05`.

Three mechanisms combine, each individually correct:

1. `to_openai_json_patch()` filters on `!v.is_null()`, so only `None` is dropped — `Some(0.0)`
   is a real value and reaches the wire.
2. `resolve_sampling` force-inserts the resolved patch (deliberately — it is what makes the
   hierarchy authoritative), so nothing downstream can defeat the floor.
3. `min_p` is part of the coupled trio bound to `temperature` in `resolve_layers`, so when a
   layer claims a temperature and leaves `min_p` unset, resolution falls straight through to
   the floor.

That last point is what makes the reach wide rather than marginal. No builtin profile supplies
a `min_p` (`builtin_templates_are_sparse` pins this), and `trust_client_sampling` defaults to
`false`, so the floor decided `min_p` for most traffic. At the floor's own `temperature: 0.7`,
that removed the tail cut entirely.

## What changed

The neutral floor now pins `min_p: Some(0.05)` — llama.cpp's own default, restated here rather
than left to the upstream.

Pinned rather than omitted (`min_p: None`, letting the key drop out of the patch) so that
llama-server keeps receiving fully specified parameters, per the contract stated in
`crates/gglib-proxy/README.md`, and so the value stays visible as `min_p=floor` in sampling
provenance instead of reporting as unset. Omitting would also have newly exposed a null-floor
path in surfaces that have never seen one — `renderSlider`'s `.toFixed(2)`, `fallbackCaption`'s
`NO_LIMIT` copy (wrong wording for a min-p threshold), and `chat_api.rs`'s `json!` body, which
would have emitted a literal `"min_p": null`.

### Reasoning models are deliberately unaffected

`reasoning_floor()` now pins `min_p: Some(0.0)` explicitly instead of inheriting the new value
through its `..with_hardcoded_defaults()` spread. Qwen3.6's guidance is to disable min-p on
these models, which `reasoning_profile()` already encodes. Spelling it out also stops the
carve-out from disappearing silently the next time the neutral floor moves.

`reasoning_profile()` itself is untouched: `resolve_defaults_origin` classifies legacy rows by
comparing stored defaults against it verbatim, so changing it would reclassify existing
auto-detected rows as user-set and move them up a resolution rung.

## Commits

| Commit | Scope |
|---|---|
| `fix(core): stop overriding llama.cpp's native min_p default` | the floor, the reasoning carve-out, rustdoc, and the two affected tests |
| `fix(frontend): sync the min_p floor constant with the Rust default` | `inferenceDefaults.ts` mirror + the contract tests that parse the Rust literal |
| `docs: correct the documented min_p floor` | `docs/sampling.md` and the proxy README |

## Verification

- `cargo clippy --all-targets -- -D warnings` clean on `gglib-core`, `gglib-proxy`,
  `gglib-runtime`, `gglib-app-services`, `gglib-db`, `gglib-cli`.
- `cargo fmt --check` clean; `cargo test --doc` passes.
- Full test suite green across those crates — 0 failures. Notably
  `test_sources_always_account_for_the_resolved_values` (sweeps both floors across six
  resolution ladders) and the `sampling_*` body-emission contracts in `gglib-runtime` both pass
  unchanged.
- `settingsBounds.test.ts` could not be executed locally (this checkout's `node_modules` is a
  symlink to a path outside the build environment), so its two assertions were verified by
  running the test's own `structLiteral` parser against the updated Rust source: the floor
  parses as `min_p: 0.05`, matching the TS constant, and `reasoning_floor`'s override set parses
  as `['presence_penalty', 'min_p']`, matching the updated expectation. CI will run it for real.

### Not verified here

The end-to-end check — confirming a live request logs `min_p=0.05` with provenance `min_p=floor`
on an untagged model and `0.0` on a `reasoning`-tagged one — needs a machine with models and a
GPU, so it is left for local confirmation before merge.

## Out of scope

The dynamic date/time line placement found alongside this is **not** addressed here; it is
tracked in #738. Moving those lines earlier in the message array would break llama.cpp's
common-prefix match and collapse `derive_fallback_session_id` into a fresh session ID per
request — a real TTFT regression traded for a speculative attention gain. It needs the redesign
described in that issue, not a quick fix.
