### PR TITLE
fix(runtime): cap admission at the parallelism llama-server can start

### DIFF
--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -203,11 +203,16 @@ const EMPTY_STREAM_NOTICE: &str = "⚠️ [proxy] The model produced no output f
 /// would otherwise keep the client hanging on keepalive comments indefinitely
 /// — not to cap normal prefill latency.
 ///
-/// This is a *per-cycle* bound, not an absolute cap: with `--parallel 1` a
-/// second request legitimately queues behind an in-flight one, so when the
-/// deadline fires and another connection is still active the wait is extended
-/// for another cycle rather than failed (see the keepalive loop). Only an
-/// expiry with no other active request counts as degradation.
+/// This is a *per-cycle* bound, not an absolute cap: another connection can
+/// legitimately be occupying the upstream — a co-resident model serving from
+/// the second slot, or a request the admission queue admitted just before this
+/// one — so when the deadline fires and another connection is still active the
+/// wait is extended for another cycle rather than failed (see the keepalive
+/// loop). Only an expiry with no other active request counts as degradation.
+///
+/// Requests for the *same* model no longer stack up behind each other here:
+/// admission caps them at what llama-server was launched to serve at once, so
+/// that queue forms in the runtime rather than inside the upstream.
 pub(crate) const FIRST_BYTE_DEADLINE_SECS: u64 = 300;
 
 /// Force-insert the streaming-only overrides every forwarded chat-completion

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -13,6 +13,17 @@ use std::sync::Arc;
 use tokio::process::Child;
 use tracing::{debug, info, warn};
 
+/// How many requests one llama-server instance serves at once.
+///
+/// Forced to one for the KV-cache reason given at its emission in
+/// [`build_command`], and read by the admission queue so it never grants more
+/// concurrent leases than the process behind them can start. The two must
+/// agree: anything admitted beyond this would queue *inside* llama-server,
+/// where the scheduler cannot see it and where it holds the slot's in-flight
+/// count off zero for as long as it sits there — which is exactly what stops a
+/// model under overlapping load from ever being swapped out.
+pub const SERVER_PARALLEL: u32 = 1;
+
 /// Whether the `GGLIB_DISABLE_MTP` environment variable requests that MTP
 /// speculative-decoding flags be suppressed.
 ///
@@ -180,10 +191,12 @@ fn build_command(validated_path: &Path, config: &ServerConfig, port: u16) -> std
     // "Context size has been exceeded", surfacing as an empty response.
     //
     // Forcing a single slot gives every request the full `-c` context
-    // exclusively; a second concurrent request queues inside llama-server
-    // until the slot frees, which the proxy's streaming keepalive path is
-    // built to wait out.
-    cmd.arg("--parallel").arg("1");
+    // exclusively. A second concurrent request therefore has to wait, and the
+    // admission queue is what makes it wait *here* rather than inside
+    // llama-server: it caps in-flight requests per resident model at
+    // `SERVER_PARALLEL`, so the backlog stays visible, ordered, and out of the
+    // way of a model swap.
+    cmd.arg("--parallel").arg(SERVER_PARALLEL.to_string());
 
     // Add context size if specified
     if let Some(ctx) = config.context_size {
@@ -372,6 +385,24 @@ mod tests {
         cmd.get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect()
+    }
+
+    /// The admission queue caps in-flight requests per model at
+    /// [`SERVER_PARALLEL`], so the flag llama-server is actually launched with
+    /// has to be that same number. If these two ever drift apart the queue
+    /// either starves a slot llama-server could have kept busy, or admits work
+    /// that piles up invisibly inside it.
+    #[test]
+    fn parallelism_emitted_matches_what_admission_caps_at() {
+        let config = minimal_config();
+        let cmd = build_command(Path::new("/fake/llama-server"), &config, 5500);
+        let args = args_of(&cmd);
+
+        let idx = args
+            .iter()
+            .position(|a| a == "--parallel")
+            .expect("--parallel is always emitted");
+        assert_eq!(args[idx + 1], SERVER_PARALLEL.to_string());
     }
 
     #[test]

--- a/crates/gglib-runtime/src/process/admission/README.md
+++ b/crates/gglib-runtime/src/process/admission/README.md
@@ -28,23 +28,45 @@ gets a look in. N alternating requests cost two swaps instead of N.
 
 # Fairness
 
-Two rules, and they compose to bound the wait:
+Three rules, and they compose to bound the wait:
 
 | Rule | Effect |
 |---|---|
 | Global FIFO | The oldest waiting request decides which model is up next, so a model with a hundred requests behind it cannot bury one with a single older request |
 | [`DRAIN_QUANTUM`] | A turn ends once it has run this long with a rival waiting — or immediately, if nothing is left queued for the turn holder |
+| `SERVER_PARALLEL` | A resident model is admitted at most this many requests at once, matching what its llama-server can actually start |
 
-Together those cap an ordinary wait at roughly one quantum. They are not
-unconditional, though, and it is worth being exact about why:
+The first two decide *whose* turn it is. The third is what makes a turn able to
+end at all, and it is worth being exact about why.
 
 **A swap never preempts a request in flight.** A slot with outstanding leases is
 not evictable, full stop — no bound in this module can override that, because
-the alternative is killing a live generation mid-stream. A model under
-continuous overlapping load therefore holds its slot for as long as the load
-lasts. [`ADMISSION_DEADLINE`] is the backstop for exactly that case: the request
-gives up and gets a 503 with `Retry-After`, and the caller controls its own
-backoff from there.
+the alternative is killing a live generation mid-stream. So a turn can only
+change hands in a moment when the outgoing model has nothing in flight.
+
+llama-server is launched with `--parallel 1`. If the queue admits four
+concurrent requests for a resident model anyway, all four are forwarded, three
+of them queue up *inside* llama-server, and the slot stays pinned for the whole
+serialised run — invisibly, since those three are not in this queue and do not
+appear in its depth. A client that keeps one request outstanding at all times
+never lets the count reach zero, and the quantum expires against a slot that can
+never actually be handed over. Capping admission at what the instance can start
+is what keeps the backlog here, where it is visible and ordered, and where the
+count between requests genuinely returns to zero.
+
+The cap has to be exactly `SERVER_PARALLEL` rather than a little above it to
+keep the pipeline fed: a slot becomes evictable only at *zero* in flight, so any
+standing surplus would reintroduce the stall.
+
+One more rule follows from the same reasoning: a resident model **stands aside**
+once a rival is entitled to its slot under the two rules above, rather than
+renewing its lease. Without that the cap would only create an instant at zero
+in flight, and which of the woken requesters claims that instant is a race.
+
+What none of this covers is a single generation that simply runs for a very long
+time — it is indivisible, so the rival behind it waits. [`ADMISSION_DEADLINE`]
+is the backstop there: the request gives up and gets a 503 with `Retry-After`,
+and the caller controls its own backoff from there.
 
 This is why admission returns a lease rather than just a target — see
 [`AdmissionLease`](gglib_core::ports::AdmissionLease).

--- a/crates/gglib-runtime/src/process/admission/queue_tests.rs
+++ b/crates/gglib-runtime/src/process/admission/queue_tests.rs
@@ -241,6 +241,91 @@ async fn a_slot_frees_only_when_the_last_lease_drops() {
     ));
 }
 
+// ── capacity: what llama-server can actually start ────────────────────────
+
+/// llama-server is launched with `--parallel 1`, so admitting a second
+/// concurrent request would not serve it any sooner — it would only move the
+/// wait inside llama-server, out of the queue's sight.
+#[tokio::test]
+async fn a_resident_slot_admits_only_what_llama_server_can_serve() {
+    let q = queue();
+    let serving = make_resident(&q, "qwen-coder", 1);
+
+    let (ticket, decision) = request(&q, "qwen-coder");
+    assert_eq!(
+        decision,
+        AdmissionDecision::Wait,
+        "the instance is already serving all it can"
+    );
+
+    drop(serving);
+    assert_eq!(
+        q.poll(&ticket, NEVER_FITS),
+        AdmissionDecision::Serve { slot: PRIMARY_SLOT },
+        "and is admitted the moment that finishes"
+    );
+}
+
+/// The regression this whole exercise is about.
+///
+/// An agentic client issues its next request the instant the previous one
+/// returns, so the model never goes idle for longer than it takes to hand over.
+/// That used to pin the slot outright: every one of those requests was admitted
+/// on arrival, `inflight` never reached zero, and the rival waited out
+/// [`ADMISSION_DEADLINE`] for a 503 while the GPU sat there serving one request
+/// at a time.
+///
+/// The incumbent must now stand aside once the rival is entitled to the slot,
+/// rather than renewing its lease ahead of it.
+#[tokio::test]
+async fn a_pipelined_client_cannot_pin_a_model_forever() {
+    tokio::time::pause();
+    let q = queue();
+    let in_flight = make_resident(&q, "qwen-coder", 1);
+
+    // The rival arrives and waits out the incumbent's turn.
+    let (rival, _) = request(&q, "nomic-embed");
+    tokio::time::advance(DRAIN_QUANTUM + std::time::Duration::from_secs(1)).await;
+
+    // The pipelined client has its next request queued before the current one
+    // returns, which is exactly how it kept the slot pinned.
+    let (pipelined, _) = request(&q, "qwen-coder");
+    drop(in_flight);
+
+    assert_eq!(
+        q.poll(&pipelined, NEVER_FITS),
+        AdmissionDecision::Wait,
+        "the incumbent must not renew its lease over a rival's turn"
+    );
+    assert!(
+        matches!(
+            q.poll(&rival, NEVER_FITS),
+            AdmissionDecision::Launch {
+                slot: PRIMARY_SLOT,
+                evict: Some(1)
+            }
+        ),
+        "the rival must get the slot the quantum promised it"
+    );
+}
+
+/// A request held back by the cap is waiting like any other, so the deadline
+/// has to reach it. The capacity test sits above the deadline check in `poll`,
+/// and an early return there would leave it waiting forever with nothing to
+/// surface a 503.
+#[tokio::test]
+async fn a_capped_request_still_expires() {
+    tokio::time::pause();
+    let q = queue();
+    let _never_released = make_resident(&q, "qwen-coder", 1);
+
+    let (capped, decision) = request(&q, "qwen-coder");
+    assert_eq!(decision, AdmissionDecision::Wait);
+
+    tokio::time::advance(ADMISSION_DEADLINE).await;
+    assert_eq!(q.poll(&capped, NEVER_FITS), AdmissionDecision::Expired);
+}
+
 // ── batching: the point of the exercise ───────────────────────────────────
 
 /// The headline behaviour. Ten queued requests for a model that is not loaded

--- a/crates/gglib-runtime/src/process/admission/queue_tests.rs
+++ b/crates/gglib-runtime/src/process/admission/queue_tests.rs
@@ -89,27 +89,56 @@ async fn the_first_request_launches_into_the_primary_slot() {
     );
 }
 
-/// The steady state: once a model is resident, its requests are served without
-/// ever consulting the scheduler.
+/// The steady state: once a model is resident and its slot is free, requests
+/// are served without ever consulting the scheduler.
 #[tokio::test]
 async fn a_resident_model_serves_immediately() {
     let q = queue();
-    let _lease = make_resident(&q, "qwen-coder", 1);
+    // The launching request finishes, leaving the slot free for the next one.
+    drop(make_resident(&q, "qwen-coder", 1));
 
     let (_ticket, decision) = request(&q, "qwen-coder");
     assert_eq!(decision, AdmissionDecision::Serve { slot: PRIMARY_SLOT });
 }
 
-/// Nothing is queued while a model is resident and serving, or the dashboard
-/// would report every in-flight request as waiting.
+/// A resident model with no rival waiting is limited only by its own capacity,
+/// never by the fairness rules — those exist to arbitrate between models, and
+/// there is only one here.
 #[tokio::test]
-async fn serving_a_resident_model_leaves_nothing_queued() {
+async fn a_resident_model_is_not_throttled_without_a_rival() {
+    tokio::time::pause();
     let q = queue();
-    let _lease = make_resident(&q, "qwen-coder", 1);
-    let (_t1, _) = request(&q, "qwen-coder");
-    let (_t2, _) = request(&q, "qwen-coder");
+    drop(make_resident(&q, "qwen-coder", 1));
 
-    assert_eq!(q.snapshot().waiting(), 0);
+    // Well past every fairness bound, with nothing to be fair to.
+    tokio::time::advance(DRAIN_QUANTUM * 4).await;
+
+    for _ in 0..5 {
+        let (ticket, decision) = request(&q, "qwen-coder");
+        let AdmissionDecision::Serve { slot } = decision else {
+            panic!("a lone resident model must keep serving, got {decision:?}");
+        };
+        drop((ticket, q.claim(slot)));
+    }
+}
+
+/// The excess above what llama-server can start waits *here*, where the
+/// dashboard can see it. Before the cap it was forwarded anyway and queued
+/// inside llama-server instead, so a real backlog reported a depth of zero.
+#[tokio::test]
+async fn the_backlog_is_visible_while_it_waits() {
+    let q = queue();
+    let _serving = make_resident(&q, "qwen-coder", 1);
+    let (_t1, first) = request(&q, "qwen-coder");
+    let (_t2, second) = request(&q, "qwen-coder");
+
+    assert_eq!(first, AdmissionDecision::Wait, "the slot is already busy");
+    assert_eq!(second, AdmissionDecision::Wait);
+    assert_eq!(
+        q.snapshot().waiting(),
+        2,
+        "a backlog the scheduler cannot see is one it cannot drain"
+    );
 }
 
 /// Two requesters must not both be told to launch the same model — that would
@@ -124,7 +153,9 @@ async fn only_one_requester_drives_a_given_launch() {
     assert_eq!(second_decision, AdmissionDecision::Wait);
 }
 
-/// The waiter behind a launch is served by it, rather than launching again.
+/// The waiter behind a launch is served by it, rather than launching again —
+/// but it takes its turn rather than piling in alongside the request that drove
+/// the launch, since the fresh instance can only serve one of them at a time.
 #[tokio::test]
 async fn a_waiter_is_served_by_the_launch_it_waited_for() {
     let q = queue();
@@ -132,11 +163,19 @@ async fn a_waiter_is_served_by_the_launch_it_waited_for() {
     let (second, _) = request(&q, "qwen-coder");
     drop(first);
 
-    let _lease = q.install(PRIMARY_SLOT, resident(1, "qwen-coder"));
+    let launcher = q.install(PRIMARY_SLOT, resident(1, "qwen-coder"));
 
     assert_eq!(
         q.poll(&second, NEVER_FITS),
-        AdmissionDecision::Serve { slot: PRIMARY_SLOT }
+        AdmissionDecision::Wait,
+        "the launching request still holds the only slot"
+    );
+
+    drop(launcher);
+    assert_eq!(
+        q.poll(&second, NEVER_FITS),
+        AdmissionDecision::Serve { slot: PRIMARY_SLOT },
+        "and is served by that launch rather than driving a second one"
     );
     assert_eq!(q.snapshot().total_swaps, 0, "a cold start is not a swap");
 }
@@ -176,6 +215,11 @@ async fn a_slot_with_a_request_in_flight_is_never_evicted() {
 
 /// Leases are counted, not latched: two concurrent requests both have to
 /// finish before the slot frees.
+///
+/// Takes the second lease through `lease()` rather than through admission,
+/// which deliberately sidesteps the `SERVER_PARALLEL` cap — the release
+/// accounting has to be right whatever the count reached, and the cap is not
+/// what this test is about.
 #[tokio::test]
 async fn a_slot_frees_only_when_the_last_lease_drops() {
     let q = queue();
@@ -219,19 +263,19 @@ async fn a_burst_of_queued_requests_costs_a_single_swap() {
         assert_eq!(q.poll(ticket, NEVER_FITS), AdmissionDecision::Wait);
     }
 
-    let _lease = q.install(slot, resident(2, "nomic-embed"));
+    // The launching request is served by its own launch, then finishes.
+    drop(q.install(slot, resident(2, "nomic-embed")));
 
-    // Every remaining request is now served by that one launch.
-    let _leases: Vec<_> = tickets[1..]
-        .iter()
-        .map(|ticket| {
-            assert_eq!(
-                q.poll(ticket, NEVER_FITS),
-                AdmissionDecision::Serve { slot }
-            );
-            q.claim(slot)
-        })
-        .collect();
+    // Every remaining request is served by that same launch, one at a time —
+    // the instance serves one at a time, so they take turns rather than
+    // overlapping, but not one of them pays for another swap.
+    for ticket in &tickets[1..] {
+        assert_eq!(
+            q.poll(ticket, NEVER_FITS),
+            AdmissionDecision::Serve { slot }
+        );
+        drop(q.claim(slot));
+    }
 
     assert_eq!(
         q.snapshot().total_swaps,
@@ -253,30 +297,35 @@ async fn alternating_traffic_does_not_swap_per_request() {
     }
 
     // Drive the queue to completion, serving whatever it grants.
-    let mut leases = Vec::new();
     let mut guard = 0;
     while !tickets.is_empty() && guard < 500 {
         guard += 1;
         let mut remaining = Vec::new();
+        let mut progressed = false;
         for ticket in tickets {
             match q.poll(&ticket, NEVER_FITS) {
                 // `Serve` has already counted this request against the slot, so
                 // the lease must be claimed — exactly as a real requester does.
                 // Leaving it unclaimed would pin the model resident forever.
-                AdmissionDecision::Serve { slot } => leases.push(q.claim(slot)),
+                // Dropping it straight away stands in for the request finishing.
+                AdmissionDecision::Serve { slot } => {
+                    drop(q.claim(slot));
+                    progressed = true;
+                }
                 AdmissionDecision::Launch { slot, .. } => {
-                    leases.push(
-                        q.install(slot, resident(if slot == 0 { 1 } else { 2 }, &ticket.model)),
-                    );
+                    drop(q.install(slot, resident(if slot == 0 { 1 } else { 2 }, &ticket.model)));
+                    progressed = true;
                 }
                 AdmissionDecision::Wait => remaining.push(ticket),
                 AdmissionDecision::Expired => panic!("nothing should expire here"),
             }
         }
-        // Requests complete promptly, freeing the slot for the next turn.
-        leases.clear();
         tickets = remaining;
-        if !tickets.is_empty() {
+        // Let the clock run only when a round achieved nothing. Advancing it
+        // unconditionally would end the turn holder's quantum after every
+        // single request, which is precisely the per-request swapping this
+        // test exists to rule out.
+        if !tickets.is_empty() && !progressed {
             tokio::time::advance(DRAIN_QUANTUM + std::time::Duration::from_secs(1)).await;
         }
     }
@@ -284,8 +333,9 @@ async fn alternating_traffic_does_not_swap_per_request() {
     assert!(tickets.is_empty(), "the queue must drain");
     let swaps = q.snapshot().total_swaps;
     assert!(
-        swaps < 20,
-        "twenty alternating requests cost {swaps} swaps — no batching happened"
+        swaps <= 2,
+        "twenty alternating requests cost {swaps} swaps — each model should \
+         drain its whole batch within one turn"
     );
 }
 
@@ -440,7 +490,12 @@ async fn co_resident_models_never_contend() {
     drop(ticket);
     let embed = q.install(slot, resident(2, "nomic-embed"));
 
-    // Both busy at once, neither waiting on the other.
+    // The co-load happened while the primary was mid-generation, which is the
+    // whole point of the second slot. Both launching requests now finish.
+    drop((chat, embed));
+
+    // Each slot has its own capacity, so both models serve at the same time —
+    // neither one's cap has anything to say about the other's.
     let (chat_again, chat_decision) = request(&q, "qwen-coder");
     let (embed_again, embed_decision) = request(&q, "nomic-embed");
     assert_eq!(
@@ -450,7 +505,7 @@ async fn co_resident_models_never_contend() {
     assert_eq!(embed_decision, AdmissionDecision::Serve { slot });
     assert_eq!(q.snapshot().total_swaps, 0);
 
-    drop((chat, embed, chat_again, embed_again));
+    drop((chat_again, embed_again));
 }
 
 /// VRAM overflow is not a failure — it falls back to the swap path, which is

--- a/crates/gglib-runtime/src/process/admission/state.rs
+++ b/crates/gglib-runtime/src/process/admission/state.rs
@@ -20,6 +20,8 @@ use gglib_core::domain::{
     SecondarySlotDecision, SecondarySlotStatus,
 };
 
+use crate::command::SERVER_PARALLEL;
+
 /// How many models may be resident in VRAM at once.
 ///
 /// Two: one primary, plus room for a small auxiliary model that would otherwise
@@ -54,9 +56,17 @@ pub const LAUNCH_TIMEOUT: Duration = Duration::from_secs(150);
 /// The hard cap on waiting, and the only bound that holds unconditionally.
 /// [`DRAIN_QUANTUM`] bounds how long a *turn* lasts, but a turn cannot end
 /// while the outgoing model still has requests in flight — no swap may preempt
-/// a live generation — so a model under continuous overlapping load can hold
-/// its slot indefinitely. This is what stops a request waiting on that from
-/// waiting forever.
+/// a live generation. What that leaves uncovered is one request that runs for a
+/// very long time: a single generation is indivisible, so the rival behind it
+/// has no bound but this one.
+///
+/// It used to cover a great deal more. A model under *overlapping* load could
+/// hold its slot indefinitely, because nothing capped how many requests were in
+/// flight at once and a client that always kept one outstanding meant the count
+/// never reached zero. `SERVER_PARALLEL` and `owes_slot_to_rival` close that
+/// off, so
+/// reaching this deadline is now the exception it was meant to be rather than
+/// the ordinary outcome of two clients sharing an endpoint.
 ///
 /// Comfortably above [`LAUNCH_TIMEOUT`], so a request waiting on its own launch
 /// can never expire before that launch has had its full budget.
@@ -96,6 +106,11 @@ pub struct Resident {
     ///
     /// The eviction guard. A slot with `inflight > 0` is never unloaded, so a
     /// swap can never cut off a live generation.
+    ///
+    /// Bounded by `SERVER_PARALLEL`: admitting more than the instance can
+    /// actually start would not serve anyone sooner, it would only move the
+    /// queue inside llama-server and keep this count off zero the whole time it
+    /// sat there.
     pub inflight: u32,
     /// When this model finished loading.
     pub resident_since: Instant,
@@ -284,9 +299,17 @@ impl QueueState {
         secondary: SecondarySlotDecision,
     ) -> AdmissionDecision {
         // The fast path, and the payoff of a second slot: a co-resident model
-        // serves without ever consulting the scheduler's fairness rules,
-        // because admitting it displaces nothing.
+        // serves without displacing anything, so it answers to the capacity of
+        // its own slot and not to the scheduler's fairness rules.
         if let Some(slot) = self.resident_slot(&ticket.model) {
+            if !self.may_serve(slot, now) {
+                // Held back by the slot's capacity, or standing aside for a
+                // rival the turn rules have promised it to. Either way this
+                // request is now genuinely waiting, so the deadline has to be
+                // tested here — nothing else on this branch would ever surface
+                // a 503, and a capped request would wait forever.
+                return self.expire_or_wait(ticket, now);
+            }
             self.forget(ticket);
             if let SlotState::Resident(r) = &mut self.slots[slot] {
                 r.inflight += 1;
@@ -300,7 +323,7 @@ impl QueueState {
             return AdmissionDecision::Wait;
         }
 
-        if now.duration_since(ticket.created_at) >= ADMISSION_DEADLINE {
+        if self.is_expired(ticket, now) {
             self.forget(ticket);
             return AdmissionDecision::Expired;
         }
@@ -345,6 +368,67 @@ impl QueueState {
         });
 
         AdmissionDecision::Launch { slot, evict }
+    }
+
+    /// Whether this request has outlasted [`ADMISSION_DEADLINE`].
+    fn is_expired(&self, ticket: &Ticket, now: Instant) -> bool {
+        now.duration_since(ticket.created_at) >= ADMISSION_DEADLINE
+    }
+
+    /// The answer for a request that cannot proceed: give up if it has waited
+    /// too long, otherwise go round again.
+    fn expire_or_wait(&mut self, ticket: &Ticket, now: Instant) -> AdmissionDecision {
+        if self.is_expired(ticket, now) {
+            self.forget(ticket);
+            return AdmissionDecision::Expired;
+        }
+        AdmissionDecision::Wait
+    }
+
+    /// Whether `slot`'s resident may take on one more request right now.
+    ///
+    /// Two things can stand in the way, and they bound different halves of the
+    /// same failure. The slot may already be serving everything its
+    /// llama-server was launched to serve at once, in which case forwarding
+    /// another would only queue it *inside* llama-server — invisible to the
+    /// dashboard, out of the queue's ordering, and holding `inflight` off zero
+    /// for as long as it sits there. Or a rival may have become entitled to the
+    /// slot, in which case granting now would re-pin a slot that is one release
+    /// away from changing hands.
+    fn may_serve(&self, slot: usize, now: Instant) -> bool {
+        let Some(resident) = self.slots[slot].resident() else {
+            return false;
+        };
+        resident.inflight < SERVER_PARALLEL && !self.owes_slot_to_rival(slot, now)
+    }
+
+    /// Whether `slot` is about to be handed to a waiting rival.
+    ///
+    /// Only an idle slot can be handed over at all, so a busy one has nothing
+    /// to stand aside for. Beyond that this is [`choose_slot`](Self::choose_slot)'s
+    /// own test asked on the rival's behalf: is a model waiting that needs a
+    /// slot, and have the turn rules stopped protecting the incumbent?
+    ///
+    /// Without this the cap alone would not be enough. It would create only an
+    /// *instant* at zero in-flight, and which of the woken requesters claims
+    /// that instant is a race — the incumbent's next request re-pins the slot
+    /// about as often as the rival takes it, which is a flaky fix rather than a
+    /// fix. Standing aside is what turns [`DRAIN_QUANTUM`] from a bound that
+    /// expires into one that actually hands the GPU over.
+    ///
+    /// Conservative in one direction on purpose: it does not work out *which*
+    /// slot the rival would be given, so a rival that could have co-loaded into
+    /// an empty secondary makes the primary stand aside for one request longer
+    /// than it strictly had to. That costs a little latency. Erring the other
+    /// way costs the stall this rule exists to prevent.
+    fn owes_slot_to_rival(&self, slot: usize, now: Instant) -> bool {
+        if !self.slots[slot].is_evictable() {
+            return false;
+        }
+        let Some(rival) = self.oldest_waiting_model() else {
+            return false;
+        };
+        self.swap_is_permitted(rival, now)
     }
 
     /// Pick the slot `model` should be launched into, if one can be had.


### PR DESCRIPTION
**Tier 1** — runtime behaviour (admission). No surface work needed: the constant is internal and all three surfaces already render queue depth from the shared backend, so CLI, Axum and Tauri get the fix without changes.

## The bug

A request for a second model sits out the full `ADMISSION_DEADLINE` and returns `503 admission_timeout`, while the resident model is visibly idle between requests. Model swapping deadlocks under any client that keeps a request outstanding.

## Root cause

gglib manufactures the "continuous overlapping load" that the admission design already documents as its one unbounded case. Three facts compose:

1. `command.rs` launches llama-server with `--parallel 1` — one request served at a time.
2. `QueueState::poll`'s resident fast path incremented `inflight` and returned `Serve` **unconditionally**. There was no capacity test anywhere in the queue; `inflight` was an unbounded `u32`.
3. `SlotState::is_evictable()` is `inflight == 0` — by design, since no swap may preempt a live generation.

So N overlapping requests took N leases and were all forwarded at once. llama-server served them one at a time and the other N−1 sat in its buffer — invisible to the dashboard, outside the queue's ordering, and holding `inflight` off zero the whole time. A client that always keeps one request outstanding meant the count never reached zero, `choose_slot` never offered the primary, and `DRAIN_QUANTUM` expired against a slot that could never change hands. The deadline was the only thing that ever ended the wait.

Two secondary harms fell out of the same cause: the backlog reported a queue depth of zero while genuinely backed up, and the quantum was effectively decorative under this traffic.

## The fix

Two rules. Neither works alone.

**The cap.** A resident slot admits at most `SERVER_PARALLEL` requests; the excess waits in the queue rather than inside llama-server. This bounds a drain to one request instead of the whole backlog. It has to be *exactly* `SERVER_PARALLEL` — a surplus held back to keep the upstream's pipeline fed would never let the count reach zero, which is the one moment a swap can happen in.

**The yield.** A resident slot stands aside once a rival is entitled to it, instead of renewing its lease. Without this the cap only produces an *instant* at zero in flight, and which of the woken requesters claims that instant is a race between tasks — the incumbent re-pins the slot about as often as the rival takes it, which is a flaky fix rather than a fix. `owes_slot_to_rival` asks `choose_slot`'s own question on the rival's behalf, so this reuses the turn rules rather than inventing a second notion of whose turn it is.

`--parallel 1` was a bare literal; it is now `SERVER_PARALLEL`, the single place the value is written down, read by both the flag emission and the queue so they cannot drift.

The deadline check also moved. It sat *below* the fast path, so a request held back by the cap would have waited forever — `expire_or_wait` covers both paths now.

## What deliberately did not change

- **The proxy.** Verified there is no self-deadlock: the `UpstreamDead` retry already drops its guard — and with it the lease — before re-admitting, so nothing waits on a slot it is itself holding. `admit()` simply blocks longer, where the streaming keepalive path already waits it out. Only a comment changed, in `forward.rs`.
- **`AdmissionQueue::lease()`** has no production callers, so the cap cannot be bypassed. `install()` grants the launching request's own lease on a fresh slot, which is within the cap.
- **`ResidentSimRuntime`** is a hand-rolled simulator that never touches the real `AdmissionQueue`, so the proxy's integration tests are untouched. All scheduling tests live in `gglib-runtime`, which is also what the crate boundary requires.

## Test coverage

Three new tests reproduce the stall and **fail on `main`**, verified by swapping `main`'s `state.rs` back in:

- `a_pipelined_client_cannot_pin_a_model_forever` — the headline. Queues the incumbent's next request before its current one returns, the way an agentic client does. On `main` the incumbent answers `Serve { slot: 0 }` and takes the slot straight back; the rival never gets the turn the quantum already promised it.
- `a_resident_slot_admits_only_what_llama_server_can_serve` — pins the cap.
- `a_capped_request_still_expires` — guards the ordering trap above.

Plus two that pass either way, by design:

- `the_backlog_is_visible_while_it_waits` — the backlog now reports real depth.
- `a_resident_model_is_not_throttled_without_a_rival` — a guard, not a reproduction: the yield rule must not throttle a model that has nothing to be fair to, which is the obvious way to get this wrong.

**Six existing tests encoded the uncapped contract and change with it.** The one worth naming is `serving_a_resident_model_leaves_nothing_queued`, which asserted that a backlog was invisible — that is the bug, so it is now `the_backlog_is_visible_while_it_waits` and asserts the opposite. The others (`a_resident_model_serves_immediately`, `a_waiter_is_served_by_the_launch_it_waited_for`, `a_burst_of_queued_requests_costs_a_single_swap`, `alternating_traffic_does_not_swap_per_request`, `co_resident_models_never_contend`) keep their original assertions and are restructured to drain serially rather than expecting simultaneous `Serve`s. `a_burst_of_queued_requests_costs_a_single_swap` still proves ten requests cost one swap; `alternating_traffic_does_not_swap_per_request` is tightened from `< 20` swaps to `<= 2`.

## Verification

`make pre-commit` equivalents all green: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `./scripts/check_boundaries.sh`, full `cargo test` (79 groups, 0 failures), `cargo test --doc`. No new rustdoc warnings.

Not run: the end-to-end walkthrough against a live daemon — this checkout has an empty model catalog, so reproducing the original 503 would need a multi-GB model download. The regression test's fail-on-`main` / pass-on-branch behaviour is the evidence in its place.

## Docs

`admission/README.md`'s Fairness section went from two rules to three, and both it and `ADMISSION_DEADLINE`'s doc comment previously asserted the behaviour being fixed ("a model under continuous overlapping load holds its slot for as long as the load lasts") — now scoped to what it actually still covers: one indivisible generation that runs long.
