### PR TITLE
fix(core): cap agentic-turn temperature instead of flooring it

### DIFF
--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -596,9 +596,13 @@ pub struct UpdateSettingsRequest {
     // Proxy loop guard; explicit `null` re-enables (see `gglib_core::Settings`)
     #[serde(default, with = "serde_with::rust::double_option")]
     pub proxy_loop_detection: Option<Option<bool>>,
-    // Task-aware sampling; explicit `null` re-enables (see `gglib_core::Settings`)
-    #[serde(default, with = "serde_with::rust::double_option")]
-    pub tool_call_floor: Option<Option<bool>>,
+    // Agentic-turn sampling; explicit `null` re-enables (see `gglib_core::Settings`)
+    #[serde(
+        default,
+        alias = "toolCallFloor",
+        with = "serde_with::rust::double_option"
+    )]
+    pub agentic_sampling: Option<Option<bool>>,
     // Always-on proxy, desktop app only (see `gglib_core::Settings`)
     #[serde(default, with = "serde_with::rust::double_option")]
     pub proxy_autostart: Option<Option<bool>>,
@@ -629,7 +633,7 @@ impl From<UpdateSettingsRequest> for gglib_core::SettingsUpdate {
             proxy_api_key: request.proxy_api_key,
             trust_client_sampling: request.trust_client_sampling,
             proxy_loop_detection: request.proxy_loop_detection,
-            tool_call_floor: request.tool_call_floor,
+            agentic_sampling: request.agentic_sampling,
             proxy_autostart: request.proxy_autostart,
             close_to_tray: request.close_to_tray,
             start_at_login: request.start_at_login,

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -244,13 +244,12 @@ pub enum SettingsCommand {
         /// that legitimately replays identical batches.
         #[arg(long)]
         proxy_loop_detection: Option<bool>,
-        /// Sample tool-emission turns against a tighter floor. Enabled by
-        /// default: a request carrying tools decodes near-deterministically
-        /// with DRY off, because its output is structured and a malformed
-        /// tool call is the hardest failure to recover from. Only ever
-        /// supplies a floor, so any layer that names a parameter still wins.
+        /// Cap the temperature on agentic turns. Enabled by default: a
+        /// request carrying tools may emit structured output, so its
+        /// temperature is capped — but only over a value nobody chose (an
+        /// auto-detected recipe or the floor). Anything you set stands.
         #[arg(long)]
-        tool_call_floor: Option<bool>,
+        agentic_sampling: Option<bool>,
         /// Start the OpenAI-compatible proxy as soon as the desktop app
         /// launches, instead of waiting for it to be switched on. Combined
         /// with --start-at-login and --close-to-tray this keeps the endpoint

--- a/crates/gglib-cli/src/handlers/config/settings/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/settings/mod.rs
@@ -156,7 +156,7 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             proxy_api_key,
             trust_client_sampling,
             proxy_loop_detection,
-            tool_call_floor,
+            agentic_sampling,
             proxy_autostart,
             close_to_tray,
             start_at_login,
@@ -202,8 +202,8 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             if proxy_loop_detection.is_some() {
                 changed.insert("proxy-loop-detection");
             }
-            if tool_call_floor.is_some() {
-                changed.insert("tool-call-floor");
+            if agentic_sampling.is_some() {
+                changed.insert("agentic-sampling");
             }
             if proxy_autostart.is_some() {
                 changed.insert("proxy-autostart");
@@ -239,7 +239,7 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
                 proxy_api_key: proxy_api_key.map(Some),
                 trust_client_sampling: trust_client_sampling.map(Some),
                 proxy_loop_detection: proxy_loop_detection.map(Some),
-                tool_call_floor: tool_call_floor.map(Some),
+                agentic_sampling: agentic_sampling.map(Some),
                 proxy_autostart: proxy_autostart.map(Some),
                 close_to_tray: close_to_tray.map(Some),
                 start_at_login: start_at_login.map(Some),
@@ -287,8 +287,8 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             if let Some(Some(v)) = update.proxy_loop_detection {
                 prospective.proxy_loop_detection = Some(v);
             }
-            if let Some(Some(v)) = update.tool_call_floor {
-                prospective.tool_call_floor = Some(v);
+            if let Some(Some(v)) = update.agentic_sampling {
+                prospective.agentic_sampling = Some(v);
             }
             if let Some(Some(v)) = update.proxy_autostart {
                 prospective.proxy_autostart = Some(v);

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -124,16 +124,19 @@ pub struct InferenceConfig {
     /// - 0.0: Disabled (llama.cpp's default, and the floor here)
     /// - 0.8: A common starting point for long agentic sessions
     ///
-    /// Disabled by [`for_tool_call`]: structured tool output legitimately
-    /// repeats tokens, so penalising repetition there damages the JSON.
+    /// Left alone on agentic turns, deliberately. An earlier version forced
+    /// this to `0` whenever a request carried tools, reasoning that structured
+    /// output legitimately repeats tokens. Both halves were wrong: llama.cpp's
+    /// sequence breakers already default to `\n`, `:`, `"`, `*` — two of which
+    /// are pervasive in JSON — and agentic clients send `tools` on *every*
+    /// request, so the pin would have disabled DRY for whole sessions, which
+    /// is the workload it exists for.
     ///
-    /// llama.cpp's fifth DRY parameter, `--dry-sequence-breaker` (defaults
-    /// `\n`, `:`, `"`, `*`), is deliberately not modelled: it is a list of
-    /// strings, and every layer of this hierarchy — merge, coupling, the CLI
-    /// flags, the settings mirror — is built for scalars. Its defaults are
-    /// sensible for prose and code alike, so it is left to llama.cpp.
-    ///
-    /// [`for_tool_call`]: Self::for_tool_call
+    /// llama.cpp's fifth DRY parameter, `--dry-sequence-breaker`, is not
+    /// modelled: it is a list of strings, and every layer of this hierarchy —
+    /// merge, coupling, the CLI flags, the settings mirror — is built for
+    /// scalars. It is also the right lever if DRY is ever seen mangling a tool
+    /// call, so modelling it is the follow-up, not switching DRY off.
     pub dry_multiplier: Option<f32>,
 
     /// DRY penalty base, the exponent applied per token of matched sequence
@@ -644,45 +647,39 @@ impl InferenceConfig {
         }
     }
 
-    /// This floor, adjusted for a request that carries tools.
+    /// The highest temperature an agentic turn should decode at.
     ///
-    /// A tool-emission turn wants a near-deterministic decode: the output is
-    /// structured, there is a right answer, and creativity in a JSON envelope
-    /// is only ever a defect. This lowers the temperature and opens `top_p`
-    /// so the truncation is done by temperature alone.
+    /// A turn that carries tools may emit structured output, where creativity
+    /// is only ever a defect. This is the ceiling that caps it — applied by
+    /// [`crate::request_pipeline::sampling`] *after* resolution, and only over
+    /// a value nobody deliberately chose. It never raises a temperature.
     ///
-    /// # DRY is switched off, not left alone
+    /// # Why reasoning models get a much higher ceiling
     ///
-    /// Structured output legitimately repeats tokens — braces, quoted keys,
-    /// the same argument names across a batch of calls. A repetition penalty
-    /// there attacks the very structure that makes the call parseable, and a
-    /// malformed tool call is the failure this pipeline is least able to
-    /// recover from. So `dry_multiplier` is pinned to `0.0` regardless of what
-    /// the base floor says.
+    /// A `reasoning` model does not decode its tool call in isolation: the
+    /// `<think>` block and the call are one completion under one sampler
+    /// configuration, so any ceiling imposed for the sake of structured output
+    /// lands on the reasoning phase too. Both vendors warn about exactly this
+    /// — Qwen3 specifies ~0.6 for thinking mode and says not to use greedy
+    /// decoding, and DeepSeek-R1 specifies 0.5–0.7 for the same reason. Below
+    /// that range these models degrade into endless repetition, which the
+    /// proxy's own loop guard would then reject as a 400. Capping a thinking
+    /// model near-greedy manufactures the failure that guard exists to catch.
     ///
-    /// # What it deliberately does not touch
+    /// `0.3` for everything else is low enough to steady structured output
+    /// without being greedy.
     ///
-    /// `presence_penalty`, `repeat_penalty`, `min_p`, `top_k` and `max_tokens`
-    /// are carried through unchanged. That keeps [`reasoning_floor`]'s two carve-outs
-    /// intact for a `reasoning`-tagged model that is also calling tools: its
-    /// anti-repetition guard survives, and its deliberately disabled min-p is
-    /// not quietly re-enabled by a floor that has no opinion about Qwen3.6.
+    /// # Why a ceiling and not a floor
     ///
-    /// This is a *floor*, so every one of these values is still outranked by
-    /// any layer that names one.
-    ///
-    /// [`reasoning_floor`]: Self::reasoning_floor
+    /// The floor this replaced could never fire on the models that most needed
+    /// it. A `reasoning`-tagged model carries an auto-detected recipe naming
+    /// `temperature: 1.0`, and any layer outranks a floor — so the adjustment
+    /// was inert on precisely the models used for agentic coding. A ceiling
+    /// gated on provenance fires there and stays out of the way everywhere a
+    /// person actually made a choice.
     #[must_use]
-    pub const fn for_tool_call(self) -> Self {
-        Self {
-            temperature: Some(0.15),
-            top_p: Some(1.0),
-            dry_multiplier: Some(0.0),
-            dry_base: None,
-            dry_allowed_length: None,
-            dry_penalty_last_n: None,
-            ..self
-        }
+    pub const fn agentic_temperature_ceiling(is_reasoning: bool) -> f32 {
+        if is_reasoning { 0.6 } else { 0.3 }
     }
 
     /// Convert inference config to llama CLI arguments.

--- a/crates/gglib-core/src/request_pipeline/mod.rs
+++ b/crates/gglib-core/src/request_pipeline/mod.rs
@@ -15,7 +15,7 @@ pub use messages::shape_messages;
 pub use model_context::ModelContext;
 pub use request_shape::carries_tools;
 pub use resolve::resolve;
-pub use sampling::{DISABLE_TOOL_FLOOR_ENV, SamplingLayers, resolve_sampling};
+pub use sampling::{DISABLE_AGENTIC_SAMPLING_ENV, SamplingLayers, resolve_sampling};
 pub use tools::strip_unsupported_tools;
 pub use truncation::{CHARS_PER_TOKEN_APPROX, TruncationError, TruncationReport, truncate_history};
 

--- a/crates/gglib-core/src/request_pipeline/request_shape.rs
+++ b/crates/gglib-core/src/request_pipeline/request_shape.rs
@@ -7,7 +7,7 @@
 //!
 //! It lives here, rather than inside the stage that first needed it, because
 //! two stages read the same signal for different purposes —
-//! [`sampling`](super::sampling) selects a floor from it, and
+//! [`sampling`](super::sampling) caps the temperature from it, and
 //! [`constrain`](super::constrain) decides whether to originate a grammar —
 //! and a second copy of "does this request carry tools" would eventually
 //! answer differently from the first.
@@ -16,26 +16,40 @@ use serde_json::Value;
 
 /// Whether the request carries a non-empty `tools` array.
 ///
-/// # Why presence, and not `tool_choice: "required"`
+/// # This identifies an agentic turn, not a tool-emission turn
 ///
-/// Agentic clients overwhelmingly send `tool_choice: "auto"` — Cline, Roo
-/// Code and Copilot BYOK all do, and the in-process agent writes `"auto"`
-/// itself whenever it has tools to offer. A signal keyed on `"required"`
-/// would therefore describe almost no real traffic. Presence of tools is what
-/// actually distinguishes an agentic turn from a chat turn.
+/// The distinction matters and was learned the hard way. This answers *"could
+/// this turn produce a tool call?"*, never *"will it?"*. VS Code Copilot in
+/// agent mode sends the `tools` array on essentially every request —
+/// including prose, planning, summarising and thinking turns — so in the
+/// client this was built for, the answer is permanently yes.
+///
+/// Anything keyed on this therefore applies to a whole agentic session, not to
+/// the moment a call is emitted. Adjustments hanging off it must be safe for
+/// prose, because they will spend most of their time there.
+///
+/// # Why there is no better signal
+///
+/// Every candidate fails. `tool_choice` is `"auto"` on every turn. The last
+/// message's role does not predict what comes next. A history containing prior
+/// `tool_calls` only says "this is an agentic session", which is the thing
+/// already known. This is the same wall [`super::constrain`] documents for
+/// grammars: you cannot know before decoding whether the model will emit a
+/// call. The only true discriminator is mid-stream marker detection, which is
+/// a different and much larger piece of machinery.
 ///
 /// # Deliberately more lenient than the grammar path
 ///
 /// [`constrain`](super::constrain) needs the complete list of tool *names* to
 /// build a GBNF alternation, so it rejects a `tools` array in which any entry
 /// is missing `function.name`. That strictness is right for originating a
-/// grammar and wrong here: a request with one malformed tool entry is still a
-/// tool-emission turn, and should still be sampled like one.
+/// grammar and wrong here: a request with one malformed tool entry is still an
+/// agentic turn.
 ///
 /// A `tools` key that is present but not a non-empty array — `null`, `[]`, an
 /// object — reads as no tools. `tool_choice` is not consulted at all: it can
-/// appear without `tools` (nothing strips it), and on its own it does not
-/// make a turn a tool turn.
+/// appear without `tools` (nothing strips it), and on its own it does not make
+/// a turn agentic.
 #[must_use]
 pub fn carries_tools(body: &Value) -> bool {
     body.get("tools")
@@ -49,21 +63,21 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn a_non_empty_tools_array_is_a_tool_turn() {
+    fn a_non_empty_tools_array_is_an_agentic_turn() {
         let body = json!({"tools": [{"function": {"name": "read_file"}}]});
         assert!(carries_tools(&body));
     }
 
     /// The leniency that separates this from `constrain`'s `tool_names`: a
-    /// malformed entry still means the model is being asked for a call.
+    /// malformed entry still means tools are in scope for this turn.
     #[test]
-    fn a_tool_entry_without_a_name_is_still_a_tool_turn() {
+    fn a_tool_entry_without_a_name_is_still_an_agentic_turn() {
         let body = json!({"tools": [{"function": {}}]});
         assert!(carries_tools(&body));
     }
 
     #[test]
-    fn tool_choice_alone_is_not_a_tool_turn() {
+    fn tool_choice_alone_is_not_an_agentic_turn() {
         // `strip_unsupported_tools` removes `tools` but leaves a `tool_choice`
         // behind when there were no tools to begin with, so this shape reaches
         // the pipeline in practice.
@@ -72,7 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_or_malformed_tools_key_is_not_a_tool_turn() {
+    fn an_empty_or_malformed_tools_key_is_not_an_agentic_turn() {
         for body in [
             json!({"tools": []}),
             json!({"tools": null}),

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::ModelContext;
-use crate::domain::{DefaultsOrigin, InferenceConfig};
+use crate::domain::{DefaultsOrigin, InferenceConfig, ParamSource};
 
 /// The sampling layers that sit *below* the client's own request parameters.
 ///
@@ -46,34 +46,36 @@ pub struct SamplingLayers {
     /// [`Self::global`], which is why it lives here rather than as a
     /// separate parameter threaded through every caller.
     pub trust_client_sampling: bool,
-    /// Whether a request carrying tools resolves against
-    /// [`InferenceConfig::for_tool_call`] instead of the model's class floor.
+    /// Whether a request carrying tools gets the agentic-turn temperature
+    /// ceiling — see [`InferenceConfig::agentic_temperature_ceiling`].
     ///
     /// Set by the caller rather than defaulted on, because the two callers
-    /// decide it differently: the proxy reads `Settings.tool_call_floor`
+    /// decide it differently: the proxy reads `Settings.agentic_sampling`
     /// (opt-out — absent means on), while the in-process agent path has no
     /// settings snapshot and enables it unconditionally. `Default` leaves it
-    /// off so a bare `SamplingLayers::default()` keeps today's behaviour.
-    pub tool_call_floor: bool,
+    /// off so a bare `SamplingLayers::default()` applies no adjustment.
+    pub agentic_adjustments: bool,
 }
 
-/// Environment kill switch for the tool-call floor.
+/// Environment kill switch for the agentic-turn adjustments.
 ///
 /// Truthy values (case-insensitive `1`, `true`, `yes`, `on`) disable it for
 /// every caller, whatever their settings say — the same contract as
 /// [`DISABLE_GRAMMAR_ENV`].
 ///
 /// [`DISABLE_GRAMMAR_ENV`]: super::constrain::DISABLE_GRAMMAR_ENV
-pub const DISABLE_TOOL_FLOOR_ENV: &str = "GGLIB_DISABLE_TOOL_FLOOR";
+pub const DISABLE_AGENTIC_SAMPLING_ENV: &str = "GGLIB_DISABLE_AGENTIC_SAMPLING";
 
-/// Whether [`DISABLE_TOOL_FLOOR_ENV`] is set to a truthy value.
-fn tool_floor_disabled_via_env() -> bool {
-    std::env::var(DISABLE_TOOL_FLOOR_ENV).ok().is_some_and(|v| {
-        matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+/// Whether [`DISABLE_AGENTIC_SAMPLING_ENV`] is set to a truthy value.
+fn agentic_sampling_disabled_via_env() -> bool {
+    std::env::var(DISABLE_AGENTIC_SAMPLING_ENV)
+        .ok()
+        .is_some_and(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
 }
 
 /// Resolve the sampling hierarchy into `body`, then pin `cache_prompt`.
@@ -129,11 +131,11 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
         InferenceConfig::with_hardcoded_defaults()
     };
 
-    // A request carrying tools is asking for structured output, which wants a
-    // near-deterministic decode and no repetition penalty. The tool overrides
-    // compose *onto* the class floor rather than replacing it, so a
-    // `reasoning`-tagged model calling tools keeps its carve-outs — see
-    // `InferenceConfig::for_tool_call`.
+    let floor = class_floor;
+
+    // Whether an agentic-turn temperature ceiling is eligible to apply. Only
+    // eligibility — whether it actually bites depends on where the resolved
+    // temperature came from, which is not known until after the fold.
     //
     // Keyed on tools being present, not on `tool_choice: "required"`: agentic
     // clients send `"auto"` almost universally, so a `required`-only trigger
@@ -142,16 +144,10 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
     // Stage 2b has already removed `tools` for a model that cannot call them,
     // so this cannot fire on a model that would never emit a tool call —
     // except on a passthrough context, where nothing is known about the model
-    // and nothing was stripped. Sampling a request that *says* it has tools as
-    // a tool turn is the right reading of the only evidence available.
-    let tool_turn = layers.tool_call_floor
-        && !tool_floor_disabled_via_env()
+    // and nothing was stripped.
+    let agentic_turn = layers.agentic_adjustments
+        && !agentic_sampling_disabled_via_env()
         && super::request_shape::carries_tools(body);
-    let floor = if tool_turn {
-        class_floor.for_tool_call()
-    } else {
-        class_floor
-    };
 
     // `model` occupies one of two rungs depending on how it was set — never
     // both — so an auto-detected guess can't silently outrank global
@@ -176,7 +172,39 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
         ordered.iter().map(|(_, config)| *config).collect();
     // Values and provenance come from the same pass over the same ladder, so
     // the log can never name a layer the resolution did not use.
-    let (resolved, sources) = InferenceConfig::resolve_layers_with_sources(&layer_configs, &floor);
+    let (mut resolved, sources) =
+        InferenceConfig::resolve_layers_with_sources(&layer_configs, &floor);
+
+    // Cap the temperature for an agentic turn — but only over a value nobody
+    // deliberately chose.
+    //
+    // The gate is provenance, not rank. A ladder rung would have been the
+    // obvious way to express "outranks the auto-detected recipe", and it is
+    // wrong: a rung that names a `temperature` *claims the coupled set* under
+    // `resolve_layers`, so DRY and the penalties would drop to the floor
+    // behind it. Anyone who had set `--dry-multiplier` without also naming a
+    // temperature would silently lose DRY on every agentic turn — the exact
+    // harm this adjustment is supposed to avoid. Clamping after the fold
+    // leaves the coupled set untouched.
+    //
+    // Eligible sources are the auto-detected rung and the floor. An
+    // auto-detected recipe is an unreviewed guess written at import time, and
+    // already ranks below global settings for that reason; a task-aware
+    // ceiling outranking it is consistent with that. Anything a person
+    // actually set — cli, client, profile, per-model, global — stands.
+    let ceiling = InferenceConfig::agentic_temperature_ceiling(model_is_reasoning);
+    let auto_detected_rung = ordered.len() - 1;
+    let temperature_is_unchosen = matches!(
+        sources.temperature,
+        ParamSource::Floor | ParamSource::FloorCoupled | ParamSource::Unset
+    ) || sources.temperature
+        == ParamSource::Layer(auto_detected_rung);
+    let ceiling_applied = agentic_turn
+        && temperature_is_unchosen
+        && resolved.temperature.is_some_and(|t| t > ceiling);
+    if ceiling_applied {
+        resolved.temperature = Some(ceiling);
+    }
 
     if tracing::enabled!(tracing::Level::DEBUG) {
         let names: Vec<&str> = ordered.iter().map(|(name, _)| *name).collect();
@@ -193,17 +221,16 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
             dry_allowed_length = ?resolved.dry_allowed_length,
             dry_penalty_last_n = ?resolved.dry_penalty_last_n,
             from = %sources.describe(&names),
-            // Which floor was used. `sources` says a value came from "floor"
-            // but not which one, and the explain surfaces cannot show this at
-            // all — they resolve stored configuration with no request in hand.
-            // This log line is the only place the tool floor is observable.
-            floor = if tool_turn {
-                "tool_call"
-            } else if model_is_reasoning {
-                "reasoning"
-            } else {
-                "default"
-            },
+            // Which class floor was used. `sources` says a value came from
+            // "floor" but not which one, and the explain surfaces cannot show
+            // this at all — they resolve stored configuration with no request
+            // in hand.
+            floor = if model_is_reasoning { "reasoning" } else { "default" },
+            // Reported separately from `from`, which still names the rung the
+            // temperature *would* have come from. The ceiling does not replace
+            // that rung, it caps what it supplied.
+            agentic_turn,
+            agentic_ceiling = ceiling_applied.then_some(ceiling),
             "sampling resolved"
         );
     }
@@ -325,7 +352,7 @@ mod tests {
                 // profile" / "cli beats client" rows still exercise the
                 // client layer at all. See `client_sampling_is_ignored_by_default`.
                 trust_client_sampling: true,
-                tool_call_floor: false,
+                agentic_adjustments: false,
             };
             resolve_sampling(&mut body, &model_ctx(model.map(temp)), &layers);
             assert_param(&body, "temperature", expected);
@@ -355,7 +382,7 @@ mod tests {
                 profile: Some(temp(0.2)),
                 global: None,
                 trust_client_sampling: false,
-                tool_call_floor: false,
+                agentic_adjustments: false,
             },
         );
 
@@ -517,7 +544,7 @@ mod tests {
                 profile: Some(temp(0.2)),
                 global: None,
                 trust_client_sampling: false,
-                tool_call_floor: false,
+                agentic_adjustments: false,
             },
         );
 
@@ -704,96 +731,157 @@ mod tests {
         assert_param(&body, "top_p", 0.42);
     }
 
-    // ── The tool-call floor ───────────────────────────────────────────────
+    // ── The agentic-turn temperature ceiling ──────────────────────────────
 
     fn tools_body() -> Value {
         json!({"tools": [{"function": {"name": "read_file"}}]})
     }
 
-    fn tool_layers() -> SamplingLayers {
+    fn agentic_layers() -> SamplingLayers {
         SamplingLayers {
-            tool_call_floor: true,
+            agentic_adjustments: true,
             ..Default::default()
         }
     }
 
-    /// The point of the feature: an untuned model asked for a tool call
-    /// samples near-deterministically instead of at the neutral floor's 0.7.
+    /// A model whose defaults were written automatically at import, which is
+    /// what every `reasoning`-tagged model gets.
+    fn auto_detected_ctx(defaults: InferenceConfig, reasoning: bool) -> ModelContext {
+        ModelContext {
+            tags: if reasoning {
+                vec!["reasoning".to_owned()]
+            } else {
+                Vec::new()
+            },
+            inference_defaults: Some(defaults),
+            defaults_origin: Some(DefaultsOrigin::AutoDetected),
+            ..ModelContext::passthrough()
+        }
+    }
+
+    /// The case the ceiling exists for, and the one the floor it replaced
+    /// could never reach: a `reasoning` model's auto-written recipe names
+    /// `temperature: 1.0`, and any layer outranks a floor.
     #[test]
-    fn a_request_carrying_tools_lands_on_the_tool_floor() {
+    fn the_ceiling_caps_an_auto_detected_recipe() {
         let mut body = tools_body();
-        resolve_sampling(&mut body, &ModelContext::passthrough(), &tool_layers());
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(&mut body, &ctx, &agentic_layers());
 
-        assert_param(&body, "temperature", 0.15);
-        assert_param(&body, "top_p", 1.0);
-        assert_param(&body, "dry_multiplier", 0.0);
+        assert_param(&body, "temperature", 0.6);
     }
 
-    /// Same layers, no tools: nothing changes for a chat turn.
+    /// Reasoning models are capped far higher than everything else. Below
+    /// ~0.6 they degrade into endless repetition, and the `<think>` block
+    /// shares one sampler configuration with the tool call.
     #[test]
-    fn a_request_without_tools_keeps_the_class_floor() {
-        let mut body = json!({});
-        resolve_sampling(&mut body, &ModelContext::passthrough(), &tool_layers());
+    fn the_reasoning_ceiling_is_higher_than_the_plain_one() {
+        for (reasoning, expected) in [(true, 0.6), (false, 0.3)] {
+            let mut body = tools_body();
+            let ctx = auto_detected_ctx(
+                InferenceConfig {
+                    temperature: Some(1.0),
+                    ..Default::default()
+                },
+                reasoning,
+            );
+            resolve_sampling(&mut body, &ctx, &agentic_layers());
 
-        assert_param(&body, "temperature", 0.7);
-        assert_param(&body, "top_p", 0.95);
+            assert_param(&body, "temperature", expected);
+        }
     }
 
-    /// `strip_unsupported_tools` leaves a dangling `tool_choice` when there
-    /// were no tools to strip, so this shape reaches stage 4 in practice. It
-    /// is not a tool turn.
+    /// Deliberate configuration outranks the ceiling. This is the whole
+    /// reason the gate is provenance rather than rank.
     #[test]
-    fn a_dangling_tool_choice_without_tools_is_not_a_tool_turn() {
-        let mut body = json!({"tool_choice": "required"});
-        resolve_sampling(&mut body, &ModelContext::passthrough(), &tool_layers());
-
-        assert_param(&body, "temperature", 0.7);
-    }
-
-    /// The composition rule: a reasoning model calling tools gets the tool
-    /// floor's temperature but keeps the carve-outs `reasoning_floor` exists
-    /// for — its anti-repetition guard, and its deliberately disabled min-p.
-    #[test]
-    fn the_tool_floor_composes_onto_the_reasoning_floor() {
+    fn a_deliberate_temperature_is_never_capped() {
         let mut body = tools_body();
+        // `User` origin, so the recipe occupies the per-model rung rather than
+        // the auto-detected one.
         let ctx = ModelContext {
-            tags: vec!["reasoning".to_owned()],
+            inference_defaults: Some(temp(0.9)),
+            defaults_origin: Some(DefaultsOrigin::User),
             ..ModelContext::passthrough()
         };
-        resolve_sampling(&mut body, &ctx, &tool_layers());
-
-        assert_param(&body, "temperature", 0.15);
-        assert_param(&body, "presence_penalty", 1.0);
-        assert_param(&body, "min_p", 0.0);
-    }
-
-    /// It is a floor, not an override: anything a real layer names still wins.
-    #[test]
-    fn a_layer_still_outranks_the_tool_floor() {
-        let mut body = tools_body();
-        resolve_sampling(
-            &mut body,
-            &model_ctx(Some(temp(0.9))),
-            &SamplingLayers {
-                tool_call_floor: true,
-                ..Default::default()
-            },
-        );
+        resolve_sampling(&mut body, &ctx, &agentic_layers());
 
         assert_param(&body, "temperature", 0.9);
     }
 
-    /// The settings toggle, expressed as the layer flag the proxy sets from it.
+    /// The regression guard for #743: the adjustment must not disable DRY.
+    /// A ladder rung would have claimed the coupled set and dropped it to the
+    /// floor; clamping after the fold leaves it alone.
     #[test]
-    fn the_floor_does_nothing_when_the_caller_has_not_enabled_it() {
+    fn dry_survives_an_agentic_turn() {
         let mut body = tools_body();
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
         resolve_sampling(
             &mut body,
-            &ModelContext::passthrough(),
-            &SamplingLayers::default(),
+            &ctx,
+            &SamplingLayers {
+                agentic_adjustments: true,
+                global: Some(InferenceConfig {
+                    temperature: Some(0.8),
+                    dry_multiplier: Some(0.8),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
         );
 
-        assert_param(&body, "temperature", 0.7);
+        assert_param(&body, "dry_multiplier", 0.8);
+        // Global is a deliberate setting, so its temperature stands uncapped.
+        assert_param(&body, "temperature", 0.8);
+    }
+
+    /// The ceiling only ever lowers. A model already below it is untouched.
+    #[test]
+    fn the_ceiling_never_raises_a_temperature() {
+        let mut body = tools_body();
+        let ctx = auto_detected_ctx(temp(0.1), false);
+        resolve_sampling(&mut body, &ctx, &agentic_layers());
+
+        assert_param(&body, "temperature", 0.1);
+    }
+
+    /// `top_p` is left alone. The floor this replaced forced it to 1.0, which
+    /// contradicted Qwen's own guidance of 0.95 for thinking mode.
+    #[test]
+    fn the_ceiling_does_not_touch_top_p() {
+        let mut body = tools_body();
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(&mut body, &ctx, &agentic_layers());
+
+        assert_param(&body, "top_p", 0.95);
+    }
+
+    #[test]
+    fn a_request_without_tools_is_never_capped() {
+        let mut body = json!({});
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(&mut body, &ctx, &agentic_layers());
+
+        assert_param(&body, "temperature", 1.0);
+    }
+
+    /// `strip_unsupported_tools` leaves a dangling `tool_choice` when there
+    /// were no tools to strip, so this shape reaches stage 4 in practice.
+    #[test]
+    fn a_dangling_tool_choice_without_tools_is_not_an_agentic_turn() {
+        let mut body = json!({"tool_choice": "required"});
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(&mut body, &ctx, &agentic_layers());
+
+        assert_param(&body, "temperature", 1.0);
+    }
+
+    #[test]
+    fn the_ceiling_does_nothing_when_the_caller_has_not_enabled_it() {
+        let mut body = tools_body();
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(&mut body, &ctx, &SamplingLayers::default());
+
+        assert_param(&body, "temperature", 1.0);
     }
 
     // ── cache_prompt ──────────────────────────────────────────────────────

--- a/crates/gglib-core/src/settings.rs
+++ b/crates/gglib-core/src/settings.rs
@@ -153,23 +153,25 @@ pub struct Settings {
     /// the two paths cannot drift.
     pub proxy_loop_detection: Option<bool>,
 
-    // ── Task-aware sampling ─────────────────────────────────────────
-    /// Whether a request carrying tools resolves against
-    /// [`InferenceConfig::for_tool_call`](crate::domain::InferenceConfig::for_tool_call)
-    /// instead of the model's class floor.
+    // ── Agentic-turn sampling ───────────────────────────────────────
+    /// Whether a request carrying tools gets the agentic-turn temperature
+    /// ceiling — see
+    /// [`InferenceConfig::agentic_temperature_ceiling`](crate::domain::InferenceConfig::agentic_temperature_ceiling).
     ///
-    /// `None`/`Some(true)` → active (the default): a tool-emission turn is
-    /// sampled near-deterministically with DRY off, because its output is
-    /// structured and a malformed tool call is the failure the pipeline is
-    /// least able to recover from. `Some(false)` disables it, and every
-    /// request resolves against the reasoning or neutral floor as before.
+    /// `None`/`Some(true)` → active (the default): a turn that may emit
+    /// structured output has its temperature capped, but only over a value
+    /// nobody deliberately chose — an auto-detected recipe or the floor.
+    /// Anything set by a person stands. `Some(false)` disables the cap.
     ///
     /// Same polarity as [`Self::proxy_loop_detection`], and for the same
     /// reason: this is a correction the endpoint should not silently lose.
-    /// It only ever supplies a *floor*, so any layer that names a parameter
-    /// still outranks it — the escape hatch for one model is to set that
-    /// model's own defaults, not to turn this off globally.
-    pub tool_call_floor: Option<bool>,
+    ///
+    /// The `tool_call_floor` alias is the name this shipped under briefly in
+    /// #741, before verification showed the adjustment fires on every agentic
+    /// turn rather than only on tool emission. Kept so a config written in
+    /// that window still loads.
+    #[serde(alias = "tool_call_floor")]
+    pub agentic_sampling: Option<bool>,
 
     // ── Always-on proxy (desktop app) ───────────────────────────────
     /// Whether the desktop app starts the OpenAI-compatible proxy as soon as
@@ -218,7 +220,7 @@ impl Settings {
             max_tool_iterations: Some(crate::domain::agent::DEFAULT_MAX_ITERATIONS as u32),
             #[allow(clippy::cast_possible_truncation)]
             max_stagnation_steps: Some(crate::domain::agent::DEFAULT_MAX_STAGNATION_STEPS as u32),
-            tool_call_floor: None,
+            agentic_sampling: None,
             default_model_id: None,
             inference_defaults: None,
             inference_profiles: None,
@@ -309,8 +311,8 @@ impl Settings {
         if let Some(ref v) = other.proxy_loop_detection {
             self.proxy_loop_detection = *v;
         }
-        if let Some(ref v) = other.tool_call_floor {
-            self.tool_call_floor = *v;
+        if let Some(ref v) = other.agentic_sampling {
+            self.agentic_sampling = *v;
         }
         if let Some(ref v) = other.proxy_autostart {
             self.proxy_autostart = *v;
@@ -350,8 +352,8 @@ pub struct SettingsUpdate {
     pub proxy_api_key: Option<Option<String>>,
     pub trust_client_sampling: Option<Option<bool>>,
     pub proxy_loop_detection: Option<Option<bool>>,
-    /// See [`Settings::tool_call_floor`].
-    pub tool_call_floor: Option<Option<bool>>,
+    /// See [`Settings::agentic_sampling`].
+    pub agentic_sampling: Option<Option<bool>>,
     pub proxy_autostart: Option<Option<bool>>,
     pub close_to_tray: Option<Option<bool>>,
     pub start_at_login: Option<Option<bool>>,

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -360,15 +360,15 @@ request params  →  profile  →  model defaults  →  global settings  →  ha
    A `reasoning`-tagged model floors at `presence_penalty=1.0` and `min_p=0.0`
    instead — the two parameters whose floor is model-dependent.
 
-A request carrying a non-empty `tools` array resolves against a tighter floor
-still — `temperature=0.15`, `top_p=1.0`, and DRY forced off — composed onto
-whichever class floor applies, so a `reasoning`-tagged model calling tools keeps
-its carve-outs. Structured output legitimately repeats tokens, so a repetition
-penalty during tool emission attacks the structure that makes the call
-parseable. It keys on tools being present rather than `tool_choice: "required"`,
-because agentic clients send `"auto"` almost universally. Disable with
-`gglib config settings set --tool-call-floor false` or `GGLIB_DISABLE_TOOL_FLOOR=1`;
-see [Sampling resolution](../../docs/sampling.md#the-tool-call-floor).
+A request carrying a non-empty `tools` array has its temperature **capped** —
+`0.6` on a `reasoning`-tagged model, `0.3` otherwise — but only when the value
+that won came from an auto-detected recipe or the floor. Anything a person set
+stands. Reasoning models are capped far higher because the `<think>` block and
+the tool call share one sampler configuration, and both Qwen3 and DeepSeek-R1
+warn that near-greedy thinking degrades into endless repetition. DRY is not
+touched. Disable with `gglib config settings set --agentic-sampling false` or
+`GGLIB_DISABLE_AGENTIC_SAMPLING=1`; see
+[Sampling resolution](../../docs/sampling.md#the-agentic-turn-temperature-ceiling).
 
 Resolution runs through `InferenceConfig::resolve_with_profile`, the single
 source of truth for the merge order.  The resolved values are aggressively

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -954,8 +954,8 @@ async fn chat_completions(
         profile: request_profile.clone(),
         global: settings.inference_defaults.clone(),
         trust_client_sampling: settings.trust_client_sampling.unwrap_or(false),
-        // Opt-out: absent means on. See `Settings::tool_call_floor`.
-        tool_call_floor: settings.tool_call_floor != Some(false),
+        // Opt-out: absent means on. See `Settings::agentic_sampling`.
+        agentic_adjustments: settings.agentic_sampling != Some(false),
     };
 
     // Clone body before forwarding — Bytes is reference-counted so this is
@@ -1073,7 +1073,7 @@ async fn chat_completions(
                 profile: request_profile.clone(),
                 global: retry_settings.inference_defaults.clone(),
                 trust_client_sampling: retry_settings.trust_client_sampling.unwrap_or(false),
-                tool_call_floor: retry_settings.tool_call_floor != Some(false),
+                agentic_adjustments: retry_settings.agentic_sampling != Some(false),
             };
 
             // Fresh connection for the retried attempt — the original guard

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -343,9 +343,9 @@ impl LlmCompletionAdapter {
                 trust_client_sampling: true,
                 // Unconditionally on: there is no settings snapshot in
                 // process, and this path is the agent loop, whose turns with
-                // tools are exactly what the floor exists for. The
-                // `GGLIB_DISABLE_TOOL_FLOOR` env switch still reaches it.
-                tool_call_floor: true,
+                // tools are exactly what the ceiling exists for. The
+                // `GGLIB_DISABLE_AGENTIC_SAMPLING` env switch still reaches it.
+                agentic_adjustments: true,
                 ..Default::default()
             },
             self.model_context.context_budget_chars(),

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -296,33 +296,63 @@ gglib config profile set coding --dry-multiplier 0.8 --dry-allowed-length 3
 Left unset they are omitted from the request entirely and llama.cpp applies its
 own defaults (1.75, 2, and -1), which are reasonable starting points.
 
-## The tool-call floor
+## The agentic-turn temperature ceiling
 
-A request carrying a non-empty `tools` array is asking for structured output,
-and resolves against a tighter floor than a chat turn: `temperature 0.15`,
-`top_p 1.0`, and **DRY forced off**.
+A request carrying a non-empty `tools` array may emit structured output, so its
+temperature is **capped** — at `0.6` on a `reasoning`-tagged model and `0.3`
+otherwise.
 
-DRY is disabled there deliberately. Structured output legitimately repeats
-tokens — braces, quoted keys, the same argument names across a batch of calls —
-so a repetition penalty attacks the very structure that makes the call
-parseable, and a malformed tool call is the failure the pipeline is least able
-to recover from.
+### It is a ceiling, and it only overrules a guess
 
-It engages on tools being *present*, not on `tool_choice: "required"`. Real
-agentic clients send `"auto"` almost universally, so a `required`-only trigger
-would describe nearly no traffic.
+The cap applies *after* resolution, and only when the temperature that won came
+from a source nobody deliberately chose: an auto-detected recipe, or the floor.
+Anything set by a person — request, profile, per-model, global, CLI — stands
+untouched. It never raises a temperature, only lowers one.
 
-It composes onto whichever class floor applies rather than replacing it, so a
-`reasoning`-tagged model calling tools keeps both of that floor's carve-outs:
-its anti-repetition guard, and its deliberately disabled min-p.
+That gate is the point. This shipped first as a *floor*, and a floor could never
+reach the models that needed it: every `reasoning`-tagged model carries an
+auto-detected recipe naming `temperature: 1.0`, and any layer outranks a floor,
+so the adjustment was inert on exactly the models used for agentic coding. An
+auto-detected recipe is an unreviewed guess written at import time — it already
+ranks below global settings for that reason, and a task-aware cap overruling it
+is consistent with that.
 
-Being a floor, every value is still outranked by any layer that names one — the
-way to override it for one model is that model's own defaults, not the global
-switch. Disable it entirely with
-`gglib config settings set --tool-call-floor false`, or per-process with
-`GGLIB_DISABLE_TOOL_FLOOR=1`.
+### Why reasoning models are capped so much higher
 
-Two surfaces do not apply it, both by construction: `gglib model explain` and
+A reasoning model does not decode its tool call in isolation. The `<think>`
+block and the call are one completion under one sampler configuration, so a cap
+imposed for structured output lands on the reasoning phase too. Qwen3 specifies
+~0.6 for thinking mode and warns against greedy decoding; DeepSeek-R1 specifies
+0.5–0.7 for the same reason. Below that range these models degrade into endless
+repetition — which the proxy's own loop guard would then reject as a 400. A
+near-greedy cap on a thinking model manufactures the failure that guard exists
+to catch.
+
+### DRY is not touched
+
+An earlier version forced `dry_multiplier` to `0` on these turns, on the grounds
+that structured output legitimately repeats tokens. That was wrong twice over.
+llama.cpp's DRY already ships sequence breakers defaulting to `\n`, `:`, `"`,
+`*` — two of which are pervasive in JSON — so the case is mitigated upstream.
+And because agentic clients send `tools` on *every* request, disabling DRY for
+them would disable it for an entire session, which is exactly the workload it
+was added for.
+
+If DRY is ever observed mangling tool calls, the lever is
+`--dry-sequence-breaker`, not switching the sampler off.
+
+### Scope
+
+It engages on tools being *present*, not on `tool_choice: "required"`: agentic
+clients send `"auto"` almost universally, so a `required`-only trigger would
+describe nearly no traffic. The corollary is that this is an *agentic-turn*
+adjustment, not a tool-emission one — it applies to prose turns in an agentic
+session too, which is why the cap is mild rather than near-greedy.
+
+Disable it with `gglib config settings set --agentic-sampling false`, or
+per-process with `GGLIB_DISABLE_AGENTIC_SAMPLING=1`.
+
+Two surfaces cannot report it, both by construction: `gglib model explain` and
 the GUI's sampling provenance explain *stored configuration* with no request in
-hand, so they always report the reasoning or neutral floor. The proxy's
-`sampling resolved` debug line names the floor that actually ran.
+hand. The proxy's `sampling resolved` debug line carries `agentic_turn` and
+`agentic_ceiling` for the turns where it applied.


### PR DESCRIPTION
Closes #743

Replaces #741's `for_tool_call` floor with a class-aware temperature **ceiling**, applied
after resolution and gated on provenance. Verified on real hardware against Qwen3.5-4B —
the numbers below are measured from `/slots`, not asserted.

## Why the floor had to go

Three problems, all found by running #741 rather than reviewing it.

**It could not fire where it mattered.** Every `reasoning`-tagged model carries an
auto-detected recipe naming `temperature: 1.0`, and any layer outranks a floor. Measured: a
tools request against Qwen3.5-4B resolved identically to a chat request — `temperature 1.0`,
`top_p 0.95`. Reasoning tagging is automatic at import for Qwen3.x, DeepSeek-R1 and QwQ, so
the feature was inert on precisely the models used for agentic coding.

**The obvious fix would have been worse.** A reasoning model decodes its `<think>` block and
its tool call in *one completion under one sampler configuration* — confirmed, tool-carrying
requests returned populated `reasoning_content`. So `0.15` would have landed on the reasoning
phase. Qwen3 specifies ~0.6 for thinking and warns against greedy decoding; DeepSeek-R1
specifies 0.5–0.7. Below that they degenerate into endless repetition — which the proxy's own
loop guard (#723) would then reject as a 400. We would have manufactured the failure that
guard exists to catch.

**The name was wrong.** VS Code Copilot in agent mode sends `tools` on essentially every
request, prose included. `carries_tools` answers "could this turn produce a call?", never
"will it?", and nothing in a request distinguishes the two before decoding — the same wall
`constrain.rs` documents for grammars. This is an *agentic-turn* adjustment, which is why the
cap must be mild rather than near-greedy.

## What it does now

A ceiling of **0.6** on `reasoning`-tagged models and **0.3** otherwise, applied only when the
resolved temperature came from a source nobody chose — an auto-detected recipe, or the floor.
Anything set by a person stands. It never raises a temperature.

An auto-detected recipe is an unreviewed guess written at import time; `DefaultsOrigin` already
ranks it below global settings for that reason, so a task-aware cap overruling it is consistent
with the hierarchy rather than an exception to it.

### The trap this deliberately avoids

Expressing "outranks the auto-detected recipe" as a **ladder rung** is the obvious
implementation and is wrong. A rung naming a `temperature` *claims the coupled set* under
`resolve_layers`, so DRY and the penalties would drop to the floor behind it — and anyone who
had set `--dry-multiplier` without also naming a temperature would silently lose DRY on every
agentic turn. Clamping after the fold, gated on `sources.temperature`, leaves the coupled set
untouched.

### DRY is no longer pinned off

#741 forced `dry_multiplier: 0` on tool turns, arguing structured output legitimately repeats
tokens. Wrong twice: llama.cpp's DRY already ships sequence breakers defaulting to `\n`, `:`,
`"`, `*` — two of which are pervasive in JSON — so upstream mitigates the case; and because
agentic clients send `tools` on every request, the pin would have disabled DRY for entire
sessions, the exact workload it was added for.

Worth noting the pin was also a behavioural no-op: the neutral floor already carries
`dry_multiplier: 0.0`, so it never changed a resolved value. Removing it deletes a misleading
claim more than a behaviour.

`top_p` is no longer touched either — forcing `1.0` contradicted Qwen's own 0.95.

## Renames

`Settings.tool_call_floor` → `agentic_sampling` (with `#[serde(alias = "tool_call_floor")]`),
`--tool-call-floor` → `--agentic-sampling`, `GGLIB_DISABLE_TOOL_FLOOR` →
`GGLIB_DISABLE_AGENTIC_SAMPLING`, `SamplingLayers.tool_call_floor` → `agentic_adjustments`.
#741 is unreleased, so the exposure window is about a day, but a settings file written in it
still loads.

## Measured results

All from `GET /slots` on the live llama-server, Qwen3.5-4B (`reasoning`-tagged, auto-detected
recipe):

| request | temperature | top_p | dry_multiplier | |
|---|---|---|---|---|
| no tools | `1.0` | 0.95 | 0.0 | untouched — not an agentic turn |
| **with tools** | **`0.6`** | **0.95** | 0.0 | **ceiling fired**; was `1.0` under #741 |
| profile sets temp 0.9 + DRY 0.8, with tools | `0.9` | — | **`0.8`** | deliberate values stand; DRY survives |

`min_p 0.0` and `presence_penalty 1.5` stayed intact throughout, confirming the coupled set is
not hijacked.

For contrast, the same tools request under #741 measured `temperature 1.0` — the inertness this
PR fixes.

## A separate defect this surfaced

A profile setting `dry_multiplier` **without** also setting a temperature silently does
nothing: measured `dry_multiplier 0.0`. That is the temperature-coupling rule #741 introduced
when DRY joined the coupled set — the auto-detected layer claims the temperature, so the
profile's DRY is passed over. It is pre-existing, not caused by this PR, and not fixed here.
Filing separately.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full suites across
  `gglib-core`, `gglib-proxy`, `gglib-runtime`, `gglib-app-services`, `gglib-db`, `gglib-cli`,
  `gglib-axum`, `gglib-agent` — 0 failures. `cargo test --doc` passes.
- Nine rewritten/new tests in `sampling.rs` covering: the cap on an auto-detected recipe,
  0.6-vs-0.3 by tag, a deliberate temperature never capped, **DRY surviving an agentic turn**
  (the #743 regression guard), the cap never raising, `top_p` untouched, no-tools, a dangling
  `tool_choice`, and the toggle off.
- Live `/slots` verification above.

### Not verified

The non-reasoning `0.3` path — the only installed model is reasoning-tagged, and retagging it
to check would have been a worse test than the unit coverage. `0.6` and `0.3` remain vendor
guidance plus judgement; the tune sweep still cannot vary temperature ceilings or DRY, which is
the gap now blocking three decisions.
