### PR TITLE
fix(core): decouple DRY from the temperature-coupled trio

### DIFF
--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -268,17 +268,14 @@ fn snake_to_camel(s: &str) -> String {
 ///
 /// Purely an intermediate inside [`InferenceConfig::resolve_layers_with_sources`]:
 /// the two arms of the coupling rule each produce one of these, and the
-/// provenance record is built from it. A struct rather than a tuple because
-/// the set is seven wide — positional destructuring stopped being readable.
+/// provenance record is built from it. Named fields rather than a tuple
+/// because both arms and the provenance construction read it positionally
+/// otherwise, and the three are easy to transpose.
 #[derive(Debug, Clone, Copy)]
 struct CoupledLayers {
     repeat_penalty: Option<usize>,
     presence_penalty: Option<usize>,
     min_p: Option<usize>,
-    dry_multiplier: Option<usize>,
-    dry_base: Option<usize>,
-    dry_allowed_length: Option<usize>,
-    dry_penalty_last_n: Option<usize>,
 }
 
 impl InferenceConfig {
@@ -356,29 +353,44 @@ impl InferenceConfig {
     ///
     /// # Uncoupled parameters
     ///
-    /// `top_p`, `top_k`, and `max_tokens` gap-fill independently: each takes
-    /// the first `Some` value found scanning the layers top to bottom.
+    /// `top_p`, `top_k`, `max_tokens` and the four DRY parameters gap-fill
+    /// independently: each takes the first `Some` value found scanning the
+    /// layers top to bottom.
     ///
     /// # Coupled parameters
     ///
-    /// `presence_penalty`, `repeat_penalty`, `min_p` and the four DRY
-    /// parameters are only meaningful relative to how sharp the sampling
-    /// distribution is, so they travel with the `temperature` they were chosen
-    /// for. [`reasoning_profile`] pairs `temperature 1.0` with
-    /// `presence_penalty 1.5` deliberately; a sparse profile that sets
-    /// `temperature 0.2` and leaves the penalty unset must not inherit that
-    /// `1.5` — that would run a recipe no layer ever intended, a penalty tuned
-    /// for a broad distribution applied to a near-greedy one. The DRY
-    /// parameters join the set for the same reason: they are a repetition
-    /// penalty, and a DRY strength chosen for one temperature is not a
-    /// statement about another.
+    /// `presence_penalty`, `repeat_penalty` and `min_p` are only meaningful
+    /// relative to how sharp the sampling distribution is, so they travel with
+    /// the `temperature` they were chosen for. [`reasoning_profile`] pairs
+    /// `temperature 1.0` with `presence_penalty 1.5` deliberately; a sparse
+    /// profile that sets `temperature 0.2` and leaves the penalty unset must
+    /// not inherit that `1.5` — that would run a recipe no layer ever
+    /// intended, a penalty tuned for a broad distribution applied to a
+    /// near-greedy one.
     ///
     /// So: `temperature` resolves to the first layer that sets one. If some
-    /// layer does, the coupled set comes *only* from that same layer — never
+    /// layer does, the coupled trio comes *only* from that same layer — never
     /// a layer beneath it — falling to `floor` for anything that layer itself
     /// left unset. If **no** layer sets a temperature at all, nothing has been
-    /// tuned against anything, so the coupled set gap-fills normally, exactly
-    /// like the uncoupled parameters.
+    /// tuned against anything, so the trio gap-fills normally, exactly like
+    /// the uncoupled parameters.
+    ///
+    /// # Why DRY is *not* coupled
+    ///
+    /// It was, briefly, on the symmetry argument that a repetition penalty is
+    /// a repetition penalty. Verification showed the symmetry is false and the
+    /// cost is real. `presence_penalty` and `repeat_penalty` are flat logit
+    /// offsets competing directly with temperature's sharpening; DRY's
+    /// strength is governed by its own `dry_base` and `dry_allowed_length`,
+    /// and it targets verbatim sequence repetition — a failure mode that is
+    /// *worse* at low temperature, not milder.
+    ///
+    /// Coupling it meant a layer naming a DRY value but no temperature lost
+    /// that value silently whenever any lower layer named one, which is the
+    /// default state of every `reasoning`-tagged model. Since no shipped
+    /// profile and not [`reasoning_profile`] itself pairs a temperature with
+    /// DRY values, the coupling protected nothing and cost the most natural
+    /// way to switch DRY on. See #745.
     ///
     /// [`resolve_with_profile`]: Self::resolve_with_profile
     /// [`reasoning_profile`]: Self::reasoning_profile
@@ -414,18 +426,10 @@ impl InferenceConfig {
             result.repeat_penalty = c.repeat_penalty;
             result.presence_penalty = c.presence_penalty;
             result.min_p = c.min_p;
-            result.dry_multiplier = c.dry_multiplier;
-            result.dry_base = c.dry_base;
-            result.dry_allowed_length = c.dry_allowed_length;
-            result.dry_penalty_last_n = c.dry_penalty_last_n;
             return CoupledLayers {
                 repeat_penalty: c.repeat_penalty.and(Some(claim)),
                 presence_penalty: c.presence_penalty.and(Some(claim)),
                 min_p: c.min_p.and(Some(claim)),
-                dry_multiplier: c.dry_multiplier.and(Some(claim)),
-                dry_base: c.dry_base.and(Some(claim)),
-                dry_allowed_length: c.dry_allowed_length.and(Some(claim)),
-                dry_penalty_last_n: c.dry_penalty_last_n.and(Some(claim)),
             };
         }
 
@@ -435,10 +439,6 @@ impl InferenceConfig {
             repeat_penalty: first(&|c| c.repeat_penalty.is_some()),
             presence_penalty: first(&|c| c.presence_penalty.is_some()),
             min_p: first(&|c| c.min_p.is_some()),
-            dry_multiplier: first(&|c| c.dry_multiplier.is_some()),
-            dry_base: first(&|c| c.dry_base.is_some()),
-            dry_allowed_length: first(&|c| c.dry_allowed_length.is_some()),
-            dry_penalty_last_n: first(&|c| c.dry_penalty_last_n.is_some()),
         };
         result.repeat_penalty = found
             .repeat_penalty
@@ -447,18 +447,6 @@ impl InferenceConfig {
             .presence_penalty
             .and_then(|i| layers[i].and_then(|c| c.presence_penalty));
         result.min_p = found.min_p.and_then(|i| layers[i].and_then(|c| c.min_p));
-        result.dry_multiplier = found
-            .dry_multiplier
-            .and_then(|i| layers[i].and_then(|c| c.dry_multiplier));
-        result.dry_base = found
-            .dry_base
-            .and_then(|i| layers[i].and_then(|c| c.dry_base));
-        result.dry_allowed_length = found
-            .dry_allowed_length
-            .and_then(|i| layers[i].and_then(|c| c.dry_allowed_length));
-        result.dry_penalty_last_n = found
-            .dry_penalty_last_n
-            .and_then(|i| layers[i].and_then(|c| c.dry_penalty_last_n));
         found
     }
 
@@ -493,11 +481,22 @@ impl InferenceConfig {
         let top_k = first(&|c| c.top_k.is_some());
         let max_tokens = first(&|c| c.max_tokens.is_some());
         let temperature = first(&|c| c.temperature.is_some());
+        let dry_multiplier = first(&|c| c.dry_multiplier.is_some());
+        let dry_base = first(&|c| c.dry_base.is_some());
+        let dry_allowed_length = first(&|c| c.dry_allowed_length.is_some());
+        let dry_penalty_last_n = first(&|c| c.dry_penalty_last_n.is_some());
 
         result.top_p = top_p.and_then(|i| layers[i].and_then(|c| c.top_p));
         result.top_k = top_k.and_then(|i| layers[i].and_then(|c| c.top_k));
         result.max_tokens = max_tokens.and_then(|i| layers[i].and_then(|c| c.max_tokens));
         result.temperature = temperature.and_then(|i| layers[i].and_then(|c| c.temperature));
+        result.dry_multiplier =
+            dry_multiplier.and_then(|i| layers[i].and_then(|c| c.dry_multiplier));
+        result.dry_base = dry_base.and_then(|i| layers[i].and_then(|c| c.dry_base));
+        result.dry_allowed_length =
+            dry_allowed_length.and_then(|i| layers[i].and_then(|c| c.dry_allowed_length));
+        result.dry_penalty_last_n =
+            dry_penalty_last_n.and_then(|i| layers[i].and_then(|c| c.dry_penalty_last_n));
 
         let coupled_layers = Self::resolve_coupled(layers, temperature, &mut result);
 
@@ -530,21 +529,17 @@ impl InferenceConfig {
                 coupled,
             ),
             min_p: source(coupled_layers.min_p, floor.min_p.is_some(), coupled),
-            dry_multiplier: source(
-                coupled_layers.dry_multiplier,
-                floor.dry_multiplier.is_some(),
-                coupled,
-            ),
-            dry_base: source(coupled_layers.dry_base, floor.dry_base.is_some(), coupled),
+            dry_multiplier: source(dry_multiplier, floor.dry_multiplier.is_some(), false),
+            dry_base: source(dry_base, floor.dry_base.is_some(), false),
             dry_allowed_length: source(
-                coupled_layers.dry_allowed_length,
+                dry_allowed_length,
                 floor.dry_allowed_length.is_some(),
-                coupled,
+                false,
             ),
             dry_penalty_last_n: source(
-                coupled_layers.dry_penalty_last_n,
+                dry_penalty_last_n,
                 floor.dry_penalty_last_n.is_some(),
-                coupled,
+                false,
             ),
             max_tokens: source(max_tokens, floor.max_tokens.is_some(), false),
         };

--- a/crates/gglib-core/src/domain/sampling_provenance.rs
+++ b/crates/gglib-core/src/domain/sampling_provenance.rs
@@ -4,11 +4,10 @@
 //!
 //! [`InferenceConfig::resolve_layers`](crate::domain::InferenceConfig::resolve_layers)
 //! folds an ordered ladder of sampling layers into one config under two rules
-//! that are individually defensible and jointly opaque: the coupled set
-//! (`presence_penalty`, `repeat_penalty`, `min_p` and the four DRY
-//! parameters) travels with the `temperature` it was tuned against, and a
-//! model's stored defaults rank above or below global settings depending on
-//! whether a person set them.
+//! that are individually defensible and jointly opaque: the coupled trio
+//! (`presence_penalty`, `repeat_penalty`, `min_p`) travels with the
+//! `temperature` it was tuned against, and a model's stored defaults rank
+//! above or below global settings depending on whether a person set them.
 //!
 //! The resolved numbers alone cannot distinguish a value someone chose from
 //! one that fell out of a floor. `0.0` is a number; "`0.0`, from the floor,
@@ -152,7 +151,7 @@ impl FieldSources {
     ///
     /// The single iteration order every consumer renders, so the CLI's table
     /// and the pipeline's debug line cannot disagree about which parameter is
-    /// which. The coupled set is kept adjacent because it is only
+    /// which. The coupled trio is kept adjacent because it is only
     /// interpretable as a group.
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, ParamSource)> {
         [

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -180,12 +180,12 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
     //
     // The gate is provenance, not rank. A ladder rung would have been the
     // obvious way to express "outranks the auto-detected recipe", and it is
-    // wrong: a rung that names a `temperature` *claims the coupled set* under
-    // `resolve_layers`, so DRY and the penalties would drop to the floor
-    // behind it. Anyone who had set `--dry-multiplier` without also naming a
-    // temperature would silently lose DRY on every agentic turn — the exact
-    // harm this adjustment is supposed to avoid. Clamping after the fold
-    // leaves the coupled set untouched.
+    // wrong: a rung that names a `temperature` *claims the coupled trio* under
+    // `resolve_layers`, so `presence_penalty`, `repeat_penalty` and `min_p`
+    // would drop to the floor behind it. A `reasoning` model would silently
+    // lose the 1.5 presence penalty its own recipe pairs with its temperature
+    // on every agentic turn. Clamping after the fold leaves the trio
+    // untouched.
     //
     // Eligible sources are the auto-detected rung and the floor. An
     // auto-detected recipe is an unreviewed guess written at import time, and
@@ -809,8 +809,6 @@ mod tests {
     }
 
     /// The regression guard for #743: the adjustment must not disable DRY.
-    /// A ladder rung would have claimed the coupled set and dropped it to the
-    /// floor; clamping after the fold leaves it alone.
     #[test]
     fn dry_survives_an_agentic_turn() {
         let mut body = tools_body();
@@ -832,6 +830,34 @@ mod tests {
         assert_param(&body, "dry_multiplier", 0.8);
         // Global is a deliberate setting, so its temperature stands uncapped.
         assert_param(&body, "temperature", 0.8);
+    }
+
+    /// Regression guard for #745. DRY is deliberately *not* part of the
+    /// temperature-coupled trio, so a layer naming a DRY value but no
+    /// temperature keeps it even though a lower layer claims the temperature —
+    /// which is the default state of every `reasoning`-tagged model.
+    #[test]
+    fn dry_survives_without_a_temperature_in_the_same_layer() {
+        let mut body = json!({});
+        // The model's auto-detected recipe names a temperature, so it claims
+        // the trio. The profile names only DRY.
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(
+            &mut body,
+            &ctx,
+            &SamplingLayers {
+                profile: Some(InferenceConfig {
+                    dry_multiplier: Some(0.8),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_param(&body, "dry_multiplier", 0.8);
+        // The trio still comes from the claiming layer, untouched by this.
+        assert_param(&body, "presence_penalty", 1.5);
+        assert_param(&body, "temperature", 1.0);
     }
 
     /// The ceiling only ever lowers. A model already below it is untouched.

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -41,14 +41,24 @@ The full set of configurable parameters:
 
 ## Temperature coupling
 
-**`temperature`, `presence_penalty`, `repeat_penalty`, `min_p` and the four
-DRY parameters are coupled.**
-The rest are only meaningful relative to how sharp `temperature` makes the
+**`temperature`, `presence_penalty`, `repeat_penalty` and `min_p` are coupled.**
+The last three are only meaningful relative to how sharp `temperature` makes the
 sampling distribution, so they always come from whichever layer supplied the
 `temperature` — never a lower layer, which would apply a penalty tuned for a
 distribution nothing above it asked for. If that layer left one of them
 unset (or if no layer names a temperature at all, in which case the pair-up
 doesn't apply), it falls to the floor rather than to a lower layer's value.
+
+**The DRY parameters are not coupled**, and gap-fill independently like
+`top_p` and `top_k`. They were coupled briefly, on the argument that a
+repetition penalty is a repetition penalty. That symmetry is false:
+`presence_penalty` and `repeat_penalty` are flat logit offsets competing
+directly with temperature's sharpening, whereas DRY's strength is set by its
+own `dry_base` and `dry_allowed_length` and it targets verbatim sequence
+repetition — which gets *worse* at low temperature, not milder. Coupling it
+meant `gglib config profile set coding --dry-multiplier 0.8` silently resolved
+to `0.0` on any model whose defaults name a temperature, which is every
+`reasoning`-tagged model.
 
 The floor itself is class-aware for two fields, `presence_penalty` and
 `min_p`: a plain `0.0` presence penalty is fine for most models, but a


### PR DESCRIPTION
Closes #745

#741 added the four DRY parameters to the temperature-coupled set on the symmetry argument
that a repetition penalty is a repetition penalty. Verification showed the symmetry is false
and the cost is real.

## The measured bug

On Qwen3.5-4B, via `GET /slots`:

| profile | `dry_multiplier` on the wire |
|---|---|
| `--dry-multiplier 0.8` | **`0.0`** — silently discarded |
| `--temperature 0.9 --dry-multiplier 0.8` | `0.8` |

Any layer naming a DRY value but no temperature lost it whenever a lower layer named one —
which is the default state of every `reasoning`-tagged model, since they carry an
auto-detected recipe naming `temperature: 1.0`.

That made the bug hit the only paths anyone would actually use. DRY is off at the floor by
design, so setting it in a layer is the only way to switch it on at all, and both natural
ways to do that — `gglib config profile set … --dry-multiplier` and
`gglib model update --dry-multiplier` on a model with an auto-detected recipe — are exactly
the failing shape. No error, no warning, and a resolved `0.0` is indistinguishable on the
wire from llama.cpp's own default.

## Why the trio stays coupled and DRY does not

`presence_penalty` and `repeat_penalty` are flat logit offsets competing directly with how
sharp the temperature makes the distribution, so a value chosen for one temperature really is
meaningless at another. That is the rule's justification and it still holds.

DRY is not like that. Its strength is governed by its own `dry_base` and `dry_allowed_length`,
and it targets verbatim sequence repetition — a failure mode that gets *worse* at low
temperature, not milder. Coupling it bought nothing either: no builtin profile, and not
`reasoning_profile` itself, pairs a temperature with DRY values, so nothing was being
protected in exchange for the footgun.

## Change

The four DRY fields move out of `CoupledLayers` / `resolve_coupled` and into the uncoupled
gap-fill, alongside `top_p` and `top_k`. `CoupledLayers` is back to three fields, so the
comment justifying it as a struct on the grounds of being seven wide is replaced with the
reason that still applies.

Also corrects two comments that #744 wrote against the old rule — the post-fold clamp's
rationale in `sampling.rs` said a ladder rung would drop "DRY and the penalties" to the floor.
The clamp is still right, but for the trio: a rung claiming the temperature would cost a
reasoning model the 1.5 presence penalty its own recipe pairs with it.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the suites across the
  eight non-GUI crates — 0 failures. `cargo test --doc` passes. 854 tests in `gglib-core`.
- New regression test `dry_survives_without_a_temperature_in_the_same_layer`, which reproduces
  the reported shape: an auto-detected recipe claims the temperature, a profile names only
  DRY. It fails on `main`.
- **Live, on the merged binary against Qwen3.5-4B** — the same profile that measured `0.0`
  before now reports `dry_multiplier: 0.8` in `/slots`, with `temperature: 1.0` and
  `presence_penalty: 1.5` unchanged, confirming the trio still resolves from the claiming
  layer.

## Why this lands first

It unblocks the tune-sweep work. That sweep has to run candidates under the model's real
`ModelContext` to produce numbers that transfer to production — and the moment it does, the
model's auto-detected recipe claims the temperature and this bug eats every swept DRY value.
