### PR TITLE
fix(benchmark): tune against the real model, bound the grid, and sweep DRY

### DIFF
--- a/crates/gglib-app-services/src/benchmark/agentic.rs
+++ b/crates/gglib-app-services/src/benchmark/agentic.rs
@@ -112,18 +112,10 @@ pub async fn run_agentic_eval(
     };
     let base_url = admission.target.base_url.clone();
 
-    // The gglib arm's per-model facts, straight from the catalog row.
-    let model_context = ModelContext {
-        capabilities: model.capabilities,
-        // Same tag fallback the catalog resolution path applies in
-        // `From<&ModelSummary> for ModelContext`.
-        dialect: gglib_core::normalize::registry::dialect_for_tags(&model.tags),
-        tags: model.tags.clone(),
-        inference_defaults: model.inference_defaults.clone(),
-        defaults_origin: model.defaults_origin,
-        context_length: model.context_length,
-        catalog_resolved: true,
-    };
+    // The gglib arm's per-model facts, straight from the catalog row. Shared
+    // with the tune sweep, which needs the identical context so a tuned value
+    // means the same thing in both.
+    let model_context = super::tune::model_context_for(&model);
 
     let mut arm_results: Vec<Vec<TuneTaskResult>> = Vec::with_capacity(2);
     for arm in [EvalArm::Raw, EvalArm::Gglib] {

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -58,15 +58,23 @@ pub async fn run_tune(
 
     // Built and bounded before the run row exists, so an oversized grid is
     // refused outright rather than recorded as a run that failed.
+    //
+    // Reported as `RunFailed` rather than returned as `Err`: the Axum handler
+    // spawns this future and only logs a returned error to tracing, so an
+    // `Err` here would abort the run with the caller seeing nothing at all.
+    // Every other early failure in this function reports the same way.
     let candidates = build_candidates(&config.sweep, &model, &config);
-    anyhow::ensure!(
-        candidates.len() <= MAX_CANDIDATES,
-        "this sweep would run {} candidates, over the {MAX_CANDIDATES} limit. \
-         Every candidate costs at least one agent loop per pre-screen task, and \
-         pruning only starts after the whole grid has run, so the cost is the \
-         full count. Reduce the values per dimension, or sweep fewer dimensions.",
-        candidates.len()
-    );
+    if candidates.len() > MAX_CANDIDATES {
+        let msg = format!(
+            "this sweep would run {} candidates, over the {MAX_CANDIDATES} limit. \
+             Every candidate costs at least one agent loop per pre-screen task, and \
+             pruning only starts after the whole grid has run, so the cost is the \
+             full count. Reduce the values per dimension, or sweep fewer dimensions.",
+            candidates.len()
+        );
+        let _ = tx.send(BenchmarkEvent::RunFailed { error: msg }).await;
+        return Ok(());
+    }
 
     let config_json = serde_json::to_string(&config).ok();
     let run_id = deps

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -17,6 +17,7 @@ use gglib_core::domain::benchmark::tune::task::{TaskCategory, TuneTask};
 use gglib_core::domain::benchmark::{BenchmarkEvent, BenchmarkRunType};
 use gglib_core::domain::{InferenceConfig, Model};
 use gglib_core::ports::{LlmCompletionPort, RunningTarget, ToolExecutorPort, UsageSink};
+use gglib_core::request_pipeline::ModelContext;
 use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
 use gglib_core::settings::DEFAULT_CONTEXT_SIZE;
 use gglib_runtime::LlmCompletionAdapter;
@@ -55,6 +56,18 @@ pub async fn run_tune(
         .await
         .with_context(|| format!("model {} not found", config.model_id))?;
 
+    // Built and bounded before the run row exists, so an oversized grid is
+    // refused outright rather than recorded as a run that failed.
+    let candidates = build_candidates(&config.sweep, &model, &config);
+    anyhow::ensure!(
+        candidates.len() <= MAX_CANDIDATES,
+        "this sweep would run {} candidates, over the {MAX_CANDIDATES} limit. \
+         Every candidate costs at least one agent loop per pre-screen task, and \
+         pruning only starts after the whole grid has run, so the cost is the \
+         full count. Reduce the values per dimension, or sweep fewer dimensions.",
+        candidates.len()
+    );
+
     let config_json = serde_json::to_string(&config).ok();
     let run_id = deps
         .bench_repo
@@ -67,8 +80,6 @@ pub async fn run_tune(
         )
         .await
         .context("failed to create tune run record")?;
-
-    let candidates = build_candidates(&config.sweep, &model, &config);
 
     // ── Load the model once — every candidate only varies per-request
     // sampling parameters, never the loaded llama-server process. ──────────
@@ -119,6 +130,7 @@ pub async fn run_tune(
         .collect();
 
     let total = candidates.len();
+    let model_context = model_context_for(&model);
     let mut prescreen_results: Vec<Vec<TuneTaskResult>> = Vec::with_capacity(total);
 
     for (idx, (candidate_config, _)) in candidates.iter().enumerate() {
@@ -140,7 +152,15 @@ pub async fn run_tune(
 
         let mut results = Vec::with_capacity(prescreen_tasks.len());
         for task in &prescreen_tasks {
-            let result = run_task(&deps.http_client, target, &model, candidate_config, task).await;
+            let result = run_task(
+                &deps.http_client,
+                target,
+                &model,
+                &model_context,
+                candidate_config,
+                task,
+            )
+            .await;
             let _ = tx
                 .send(BenchmarkEvent::TuneTaskComplete {
                     candidate_index: idx,
@@ -174,8 +194,15 @@ pub async fn run_tune(
 
         if is_survivor {
             for task in &remaining_tasks {
-                let result =
-                    run_task(&deps.http_client, target, &model, &candidate_config, task).await;
+                let result = run_task(
+                    &deps.http_client,
+                    target,
+                    &model,
+                    &model_context,
+                    &candidate_config,
+                    task,
+                )
+                .await;
                 let _ = tx
                     .send(BenchmarkEvent::TuneTaskComplete {
                         candidate_index: idx,
@@ -245,6 +272,44 @@ fn select_prescreen_tasks(tasks: &[TuneTask]) -> Vec<TuneTask> {
     }
 }
 
+/// Hard ceiling on the candidate count, checked before any model work.
+///
+/// Every candidate costs at least `prescreen_tasks` real agent loops, and
+/// pruning cannot save you from a large grid: [`select_survivors`] runs only
+/// *after* the whole grid has completed the pre-screen round, and keeps a
+/// floor of three. So cost grows linearly in candidates with no upper bound —
+/// five axes at four values each is already 1,024 candidates and something
+/// like a day of generation.
+///
+/// This is a runaway guard, not a policy. It sits far above any sweep worth
+/// running, so hitting it means a dimension was mistyped or a grid was not
+/// thought through.
+const MAX_CANDIDATES: usize = 256;
+
+/// The per-model facts a candidate should resolve against.
+///
+/// Shared with the raw-vs-gglib agentic eval, which needs exactly the same
+/// thing for its `gglib` arm. Without it a candidate resolves against
+/// [`ModelContext::passthrough`], which quietly changes three things: a
+/// `reasoning`-tagged model is tuned against the neutral floor instead of
+/// `reasoning_floor`, the agentic temperature ceiling resolves to the
+/// non-reasoning 0.3 rather than 0.6, and no dialect or capability shaping
+/// applies. Values tuned that way do not transfer to production, which is the
+/// whole point of tuning them.
+pub(super) fn model_context_for(model: &Model) -> ModelContext {
+    ModelContext {
+        capabilities: model.capabilities,
+        // Same tag fallback the catalog resolution path applies in
+        // `From<&ModelSummary> for ModelContext`.
+        dialect: gglib_core::normalize::registry::dialect_for_tags(&model.tags),
+        tags: model.tags.clone(),
+        inference_defaults: model.inference_defaults.clone(),
+        defaults_origin: model.defaults_origin,
+        context_length: model.context_length,
+        catalog_resolved: true,
+    }
+}
+
 /// Build the full candidate list: the user's [`SweepSpec`] grid, plus
 /// optional seeded candidates from GGUF author defaults and per-family
 /// presets.
@@ -282,6 +347,7 @@ fn build_candidate_grid(sweep: &SweepSpec) -> Vec<InferenceConfig> {
     let top_ks = sweep_dimension(&sweep.top_k);
     let min_ps = sweep_dimension(&sweep.min_p);
     let repeat_penalties = sweep_dimension(&sweep.repeat_penalty);
+    let dry_multipliers = sweep_dimension(&sweep.dry_multiplier);
 
     let mut grid = Vec::new();
     for &temperature in &temps {
@@ -289,24 +355,24 @@ fn build_candidate_grid(sweep: &SweepSpec) -> Vec<InferenceConfig> {
             for &top_k in &top_ks {
                 for &min_p in &min_ps {
                     for &repeat_penalty in &repeat_penalties {
-                        grid.push(InferenceConfig {
-                            temperature,
-                            top_p,
-                            top_k,
-                            min_p,
-                            repeat_penalty,
-                            max_tokens: None,
-                            presence_penalty: None,
-                            // Not a sweep dimension yet: adding DRY to the
-                            // grid multiplies the candidate count by four
-                            // more axes. Sweeping it needs its own
-                            // `SweepSpec` fields and a deliberate decision
-                            // about grid size.
-                            dry_multiplier: None,
-                            dry_base: None,
-                            dry_allowed_length: None,
-                            dry_penalty_last_n: None,
-                        });
+                        for &dry_multiplier in &dry_multipliers {
+                            grid.push(InferenceConfig {
+                                temperature,
+                                top_p,
+                                top_k,
+                                min_p,
+                                repeat_penalty,
+                                dry_multiplier,
+                                max_tokens: None,
+                                presence_penalty: None,
+                                // Not dimensions: llama.cpp's defaults
+                                // (1.75, 2, 64) are reasonable, and varying
+                                // them too would multiply the grid by 81.
+                                dry_base: None,
+                                dry_allowed_length: None,
+                                dry_penalty_last_n: None,
+                            });
+                        }
                     }
                 }
             }
@@ -379,6 +445,7 @@ async fn run_task(
     http_client: &reqwest::Client,
     target: &RunningTarget,
     model: &Model,
+    model_context: &ModelContext,
     candidate: &InferenceConfig,
     task: &TuneTask,
 ) -> TuneTaskResult {
@@ -391,6 +458,9 @@ async fn run_task(
                     Some(model.name.clone()),
                 )
                 .with_sampling(Some(candidate.clone()))
+                // Resolve against the real model, not `passthrough` — see
+                // `model_context_for`.
+                .with_model_context(model_context.clone())
                 .with_usage_sink(Some(usage)),
             )
         },
@@ -738,9 +808,7 @@ mod tests {
         let sweep = SweepSpec {
             temperature: vec![0.2, 0.8],
             top_p: vec![0.9],
-            top_k: vec![],
-            min_p: vec![],
-            repeat_penalty: vec![],
+            ..Default::default()
         };
         let grid = build_candidate_grid(&sweep);
         assert_eq!(grid.len(), 2);
@@ -748,6 +816,66 @@ mod tests {
         assert!(grid.iter().any(|c| c.temperature == Some(0.8)));
         assert!(grid.iter().all(|c| c.top_p == Some(0.9)));
         assert!(grid.iter().all(|c| c.top_k.is_none()));
+    }
+
+    /// The new axis, and the reason it exists: `0.0` is a real candidate
+    /// meaning "DRY off", so one sweep measures off against two strengths.
+    #[test]
+    fn dry_multiplier_is_a_sweep_dimension() {
+        let sweep = SweepSpec {
+            dry_multiplier: vec![0.0, 0.4, 0.8],
+            ..Default::default()
+        };
+        let grid = build_candidate_grid(&sweep);
+        assert_eq!(grid.len(), 3);
+        for expected in [0.0, 0.4, 0.8] {
+            assert!(
+                grid.iter().any(|c| c.dry_multiplier == Some(expected)),
+                "missing dry_multiplier {expected}"
+            );
+        }
+        // The other three DRY parameters are not dimensions; they stay unset
+        // so llama.cpp's own defaults apply.
+        assert!(grid.iter().all(|c| c.dry_base.is_none()));
+        assert!(grid.iter().all(|c| c.dry_allowed_length.is_none()));
+        assert!(grid.iter().all(|c| c.dry_penalty_last_n.is_none()));
+    }
+
+    /// The grid multiplies, so the guard has to be checked against a product
+    /// rather than any single dimension's length.
+    #[test]
+    fn six_dimensions_multiply() {
+        let sweep = SweepSpec {
+            temperature: vec![0.2, 0.8],
+            top_p: vec![0.9, 0.95],
+            top_k: vec![20, 40],
+            min_p: vec![0.0, 0.05],
+            repeat_penalty: vec![1.0, 1.1],
+            dry_multiplier: vec![0.0, 0.8],
+        };
+        assert_eq!(build_candidate_grid(&sweep).len(), 64);
+    }
+
+    /// `MAX_CANDIDATES` is a runaway guard, so it must sit above any sweep
+    /// worth running and below the point where a mistyped grid burns a day.
+    #[test]
+    fn the_candidate_cap_admits_a_realistic_sweep_and_rejects_a_runaway() {
+        let realistic = SweepSpec {
+            temperature: vec![0.2, 0.5, 0.8],
+            dry_multiplier: vec![0.0, 0.4, 0.8],
+            ..Default::default()
+        };
+        assert!(build_candidate_grid(&realistic).len() <= MAX_CANDIDATES);
+
+        let runaway = SweepSpec {
+            temperature: vec![0.1, 0.2, 0.4, 0.6],
+            top_p: vec![0.8, 0.9, 0.95, 1.0],
+            top_k: vec![10, 20, 40, 80],
+            min_p: vec![0.0, 0.02, 0.05, 0.1],
+            repeat_penalty: vec![1.0, 1.05, 1.1, 1.2],
+            dry_multiplier: vec![0.0, 0.4, 0.8, 1.2],
+        };
+        assert!(build_candidate_grid(&runaway).len() > MAX_CANDIDATES);
     }
 
     #[test]

--- a/crates/gglib-axum/src/handlers/benchmark/tune.rs
+++ b/crates/gglib-axum/src/handlers/benchmark/tune.rs
@@ -45,7 +45,7 @@ use crate::state::AppState;
 /// {
 ///   "model_id": 1,
 ///   "task_suite": { "source": "default" },
-///   "sweep": { "temperature": [0.2, 0.5, 0.8], "top_p": [0.9, 0.95], "top_k": [], "min_p": [], "repeat_penalty": [] },
+///   "sweep": { "temperature": [0.2, 0.5, 0.8], "top_p": [0.9, 0.95], "top_k": [], "min_p": [], "repeat_penalty": [], "dry_multiplier": [0.0, 0.8] },
 ///   "seed_from_gguf": true,
 ///   "seed_from_family_presets": true,
 ///   "weights": { "tool_accuracy": 0.4, "loop_avoidance": 0.3, "task_completion": 0.2, "speed": 0.1 },

--- a/crates/gglib-cli/src/benchmark_commands.rs
+++ b/crates/gglib-cli/src/benchmark_commands.rs
@@ -87,8 +87,10 @@ pub enum BenchmarkCommand {
         /// Sweep a sampling parameter across candidate values, e.g.
         /// `--sweep temperature=0.2,0.5,0.8`. Repeatable — one flag per
         /// dimension (`temperature`, `top_p`, `top_k`, `min_p`,
-        /// `repeat_penalty`). A dimension left unswept is not varied; the
-        /// normal per-model/global/hardcoded fallback chain fills it in.
+        /// `repeat_penalty`, `dry_multiplier`). A dimension left unswept is
+        /// not varied; the normal per-model/global/hardcoded fallback chain
+        /// fills it in. The grid is the cartesian product, so dimensions
+        /// multiply.
         #[arg(long = "sweep", value_name = "DIM=V1,V2,...")]
         sweep: Vec<String>,
 

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -564,9 +564,10 @@ fn parse_sweep_args(args: &[String]) -> Result<SweepSpec> {
             "top_k" => sweep.top_k = parse_i32_list(values)?,
             "min_p" => sweep.min_p = parse_f32_list(values)?,
             "repeat_penalty" => sweep.repeat_penalty = parse_f32_list(values)?,
+            "dry_multiplier" => sweep.dry_multiplier = parse_f32_list(values)?,
             other => anyhow::bail!(
                 "unknown --sweep dimension '{other}': expected one of \
-                 temperature, top_p, top_k, min_p, repeat_penalty"
+                 temperature, top_p, top_k, min_p, repeat_penalty, dry_multiplier"
             ),
         }
     }
@@ -927,4 +928,86 @@ fn render_perf_complete(r: &ModelPerfResult) {
         SUCCESS = style::SUCCESS,
         RESET = style::RESET
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_every_sweep_dimension() {
+        let args: Vec<String> = [
+            "temperature=0.2,0.8",
+            "top_p=0.9",
+            "top_k=20,40",
+            "min_p=0,0.05",
+            "repeat_penalty=1.0,1.1",
+            "dry_multiplier=0,0.4,0.8",
+        ]
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+
+        let sweep = parse_sweep_args(&args).expect("all six dimensions are valid");
+
+        assert_eq!(sweep.temperature, vec![0.2, 0.8]);
+        assert_eq!(sweep.top_p, vec![0.9]);
+        assert_eq!(sweep.top_k, vec![20, 40]);
+        assert_eq!(sweep.min_p, vec![0.0, 0.05]);
+        assert_eq!(sweep.repeat_penalty, vec![1.0, 1.1]);
+        assert_eq!(sweep.dry_multiplier, vec![0.0, 0.4, 0.8]);
+    }
+
+    /// An unswept dimension is empty, which downstream reads as "don't vary
+    /// this" rather than "no candidates".
+    #[test]
+    fn unswept_dimensions_stay_empty() {
+        let args = vec!["temperature=0.5".to_owned()];
+        let sweep = parse_sweep_args(&args).unwrap();
+
+        assert_eq!(sweep.temperature, vec![0.5]);
+        assert!(sweep.top_p.is_empty());
+        assert!(sweep.dry_multiplier.is_empty());
+    }
+
+    /// The error names the dimension the caller got wrong *and* the valid set,
+    /// since a typo is the likeliest cause.
+    #[test]
+    fn an_unknown_dimension_is_rejected_by_name() {
+        let args = vec!["dry_base=1.75".to_owned()];
+        let err = parse_sweep_args(&args).unwrap_err().to_string();
+
+        assert!(err.contains("dry_base"), "{err}");
+        assert!(err.contains("dry_multiplier"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_equals_is_rejected() {
+        let args = vec!["temperature".to_owned()];
+        let err = parse_sweep_args(&args).unwrap_err().to_string();
+
+        assert!(err.contains("DIM=V1,V2"), "{err}");
+    }
+
+    #[test]
+    fn a_non_numeric_value_is_rejected() {
+        let args = vec!["temperature=0.2,hot".to_owned()];
+        assert!(parse_sweep_args(&args).is_err());
+
+        let args = vec!["top_k=20,many".to_owned()];
+        assert!(parse_sweep_args(&args).is_err());
+    }
+
+    #[test]
+    fn values_may_be_padded_with_spaces() {
+        let sweep = parse_sweep_args(&["temperature=0.2, 0.8 ".to_owned()]).unwrap();
+        assert_eq!(sweep.temperature, vec![0.2, 0.8]);
+    }
+
+    /// Negative values matter for `dry_penalty_last_n`-style integers even
+    /// though it is not a dimension today, and `parse_i32_list` is shared.
+    #[test]
+    fn integer_lists_accept_negatives() {
+        assert_eq!(parse_i32_list("-1,0,64").unwrap(), vec![-1, 0, 64]);
+    }
 }

--- a/crates/gglib-core/src/domain/benchmark/tune/config.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/config.rs
@@ -69,6 +69,15 @@ pub struct SweepSpec {
     /// Candidate repeat-penalty values.
     #[serde(default)]
     pub repeat_penalty: Vec<f32>,
+    /// Candidate DRY multiplier values. `0.0` disables DRY, so a sweep of
+    /// `0.0,0.4,0.8` measures "off" against two strengths in one run.
+    ///
+    /// Only the multiplier is a dimension. `dry_base`, `dry_allowed_length`
+    /// and `dry_penalty_last_n` keep llama.cpp's defaults (1.75, 2, 64):
+    /// varying all four would multiply the grid by 81 for parameters whose
+    /// shipped values are already reasonable.
+    #[serde(default)]
+    pub dry_multiplier: Vec<f32>,
 }
 
 impl SweepSpec {

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -268,17 +268,14 @@ fn snake_to_camel(s: &str) -> String {
 ///
 /// Purely an intermediate inside [`InferenceConfig::resolve_layers_with_sources`]:
 /// the two arms of the coupling rule each produce one of these, and the
-/// provenance record is built from it. A struct rather than a tuple because
-/// the set is seven wide — positional destructuring stopped being readable.
+/// provenance record is built from it. Named fields rather than a tuple
+/// because both arms and the provenance construction read it positionally
+/// otherwise, and the three are easy to transpose.
 #[derive(Debug, Clone, Copy)]
 struct CoupledLayers {
     repeat_penalty: Option<usize>,
     presence_penalty: Option<usize>,
     min_p: Option<usize>,
-    dry_multiplier: Option<usize>,
-    dry_base: Option<usize>,
-    dry_allowed_length: Option<usize>,
-    dry_penalty_last_n: Option<usize>,
 }
 
 impl InferenceConfig {
@@ -356,29 +353,44 @@ impl InferenceConfig {
     ///
     /// # Uncoupled parameters
     ///
-    /// `top_p`, `top_k`, and `max_tokens` gap-fill independently: each takes
-    /// the first `Some` value found scanning the layers top to bottom.
+    /// `top_p`, `top_k`, `max_tokens` and the four DRY parameters gap-fill
+    /// independently: each takes the first `Some` value found scanning the
+    /// layers top to bottom.
     ///
     /// # Coupled parameters
     ///
-    /// `presence_penalty`, `repeat_penalty`, `min_p` and the four DRY
-    /// parameters are only meaningful relative to how sharp the sampling
-    /// distribution is, so they travel with the `temperature` they were chosen
-    /// for. [`reasoning_profile`] pairs `temperature 1.0` with
-    /// `presence_penalty 1.5` deliberately; a sparse profile that sets
-    /// `temperature 0.2` and leaves the penalty unset must not inherit that
-    /// `1.5` — that would run a recipe no layer ever intended, a penalty tuned
-    /// for a broad distribution applied to a near-greedy one. The DRY
-    /// parameters join the set for the same reason: they are a repetition
-    /// penalty, and a DRY strength chosen for one temperature is not a
-    /// statement about another.
+    /// `presence_penalty`, `repeat_penalty` and `min_p` are only meaningful
+    /// relative to how sharp the sampling distribution is, so they travel with
+    /// the `temperature` they were chosen for. [`reasoning_profile`] pairs
+    /// `temperature 1.0` with `presence_penalty 1.5` deliberately; a sparse
+    /// profile that sets `temperature 0.2` and leaves the penalty unset must
+    /// not inherit that `1.5` — that would run a recipe no layer ever
+    /// intended, a penalty tuned for a broad distribution applied to a
+    /// near-greedy one.
     ///
     /// So: `temperature` resolves to the first layer that sets one. If some
-    /// layer does, the coupled set comes *only* from that same layer — never
+    /// layer does, the coupled trio comes *only* from that same layer — never
     /// a layer beneath it — falling to `floor` for anything that layer itself
     /// left unset. If **no** layer sets a temperature at all, nothing has been
-    /// tuned against anything, so the coupled set gap-fills normally, exactly
-    /// like the uncoupled parameters.
+    /// tuned against anything, so the trio gap-fills normally, exactly like
+    /// the uncoupled parameters.
+    ///
+    /// # Why DRY is *not* coupled
+    ///
+    /// It was, briefly, on the symmetry argument that a repetition penalty is
+    /// a repetition penalty. Verification showed the symmetry is false and the
+    /// cost is real. `presence_penalty` and `repeat_penalty` are flat logit
+    /// offsets competing directly with temperature's sharpening; DRY's
+    /// strength is governed by its own `dry_base` and `dry_allowed_length`,
+    /// and it targets verbatim sequence repetition — a failure mode that is
+    /// *worse* at low temperature, not milder.
+    ///
+    /// Coupling it meant a layer naming a DRY value but no temperature lost
+    /// that value silently whenever any lower layer named one, which is the
+    /// default state of every `reasoning`-tagged model. Since no shipped
+    /// profile and not [`reasoning_profile`] itself pairs a temperature with
+    /// DRY values, the coupling protected nothing and cost the most natural
+    /// way to switch DRY on. See #745.
     ///
     /// [`resolve_with_profile`]: Self::resolve_with_profile
     /// [`reasoning_profile`]: Self::reasoning_profile
@@ -414,18 +426,10 @@ impl InferenceConfig {
             result.repeat_penalty = c.repeat_penalty;
             result.presence_penalty = c.presence_penalty;
             result.min_p = c.min_p;
-            result.dry_multiplier = c.dry_multiplier;
-            result.dry_base = c.dry_base;
-            result.dry_allowed_length = c.dry_allowed_length;
-            result.dry_penalty_last_n = c.dry_penalty_last_n;
             return CoupledLayers {
                 repeat_penalty: c.repeat_penalty.and(Some(claim)),
                 presence_penalty: c.presence_penalty.and(Some(claim)),
                 min_p: c.min_p.and(Some(claim)),
-                dry_multiplier: c.dry_multiplier.and(Some(claim)),
-                dry_base: c.dry_base.and(Some(claim)),
-                dry_allowed_length: c.dry_allowed_length.and(Some(claim)),
-                dry_penalty_last_n: c.dry_penalty_last_n.and(Some(claim)),
             };
         }
 
@@ -435,10 +439,6 @@ impl InferenceConfig {
             repeat_penalty: first(&|c| c.repeat_penalty.is_some()),
             presence_penalty: first(&|c| c.presence_penalty.is_some()),
             min_p: first(&|c| c.min_p.is_some()),
-            dry_multiplier: first(&|c| c.dry_multiplier.is_some()),
-            dry_base: first(&|c| c.dry_base.is_some()),
-            dry_allowed_length: first(&|c| c.dry_allowed_length.is_some()),
-            dry_penalty_last_n: first(&|c| c.dry_penalty_last_n.is_some()),
         };
         result.repeat_penalty = found
             .repeat_penalty
@@ -447,18 +447,6 @@ impl InferenceConfig {
             .presence_penalty
             .and_then(|i| layers[i].and_then(|c| c.presence_penalty));
         result.min_p = found.min_p.and_then(|i| layers[i].and_then(|c| c.min_p));
-        result.dry_multiplier = found
-            .dry_multiplier
-            .and_then(|i| layers[i].and_then(|c| c.dry_multiplier));
-        result.dry_base = found
-            .dry_base
-            .and_then(|i| layers[i].and_then(|c| c.dry_base));
-        result.dry_allowed_length = found
-            .dry_allowed_length
-            .and_then(|i| layers[i].and_then(|c| c.dry_allowed_length));
-        result.dry_penalty_last_n = found
-            .dry_penalty_last_n
-            .and_then(|i| layers[i].and_then(|c| c.dry_penalty_last_n));
         found
     }
 
@@ -493,11 +481,22 @@ impl InferenceConfig {
         let top_k = first(&|c| c.top_k.is_some());
         let max_tokens = first(&|c| c.max_tokens.is_some());
         let temperature = first(&|c| c.temperature.is_some());
+        let dry_multiplier = first(&|c| c.dry_multiplier.is_some());
+        let dry_base = first(&|c| c.dry_base.is_some());
+        let dry_allowed_length = first(&|c| c.dry_allowed_length.is_some());
+        let dry_penalty_last_n = first(&|c| c.dry_penalty_last_n.is_some());
 
         result.top_p = top_p.and_then(|i| layers[i].and_then(|c| c.top_p));
         result.top_k = top_k.and_then(|i| layers[i].and_then(|c| c.top_k));
         result.max_tokens = max_tokens.and_then(|i| layers[i].and_then(|c| c.max_tokens));
         result.temperature = temperature.and_then(|i| layers[i].and_then(|c| c.temperature));
+        result.dry_multiplier =
+            dry_multiplier.and_then(|i| layers[i].and_then(|c| c.dry_multiplier));
+        result.dry_base = dry_base.and_then(|i| layers[i].and_then(|c| c.dry_base));
+        result.dry_allowed_length =
+            dry_allowed_length.and_then(|i| layers[i].and_then(|c| c.dry_allowed_length));
+        result.dry_penalty_last_n =
+            dry_penalty_last_n.and_then(|i| layers[i].and_then(|c| c.dry_penalty_last_n));
 
         let coupled_layers = Self::resolve_coupled(layers, temperature, &mut result);
 
@@ -530,21 +529,17 @@ impl InferenceConfig {
                 coupled,
             ),
             min_p: source(coupled_layers.min_p, floor.min_p.is_some(), coupled),
-            dry_multiplier: source(
-                coupled_layers.dry_multiplier,
-                floor.dry_multiplier.is_some(),
-                coupled,
-            ),
-            dry_base: source(coupled_layers.dry_base, floor.dry_base.is_some(), coupled),
+            dry_multiplier: source(dry_multiplier, floor.dry_multiplier.is_some(), false),
+            dry_base: source(dry_base, floor.dry_base.is_some(), false),
             dry_allowed_length: source(
-                coupled_layers.dry_allowed_length,
+                dry_allowed_length,
                 floor.dry_allowed_length.is_some(),
-                coupled,
+                false,
             ),
             dry_penalty_last_n: source(
-                coupled_layers.dry_penalty_last_n,
+                dry_penalty_last_n,
                 floor.dry_penalty_last_n.is_some(),
-                coupled,
+                false,
             ),
             max_tokens: source(max_tokens, floor.max_tokens.is_some(), false),
         };

--- a/crates/gglib-core/src/domain/sampling_provenance.rs
+++ b/crates/gglib-core/src/domain/sampling_provenance.rs
@@ -4,11 +4,10 @@
 //!
 //! [`InferenceConfig::resolve_layers`](crate::domain::InferenceConfig::resolve_layers)
 //! folds an ordered ladder of sampling layers into one config under two rules
-//! that are individually defensible and jointly opaque: the coupled set
-//! (`presence_penalty`, `repeat_penalty`, `min_p` and the four DRY
-//! parameters) travels with the `temperature` it was tuned against, and a
-//! model's stored defaults rank above or below global settings depending on
-//! whether a person set them.
+//! that are individually defensible and jointly opaque: the coupled trio
+//! (`presence_penalty`, `repeat_penalty`, `min_p`) travels with the
+//! `temperature` it was tuned against, and a model's stored defaults rank
+//! above or below global settings depending on whether a person set them.
 //!
 //! The resolved numbers alone cannot distinguish a value someone chose from
 //! one that fell out of a floor. `0.0` is a number; "`0.0`, from the floor,
@@ -152,7 +151,7 @@ impl FieldSources {
     ///
     /// The single iteration order every consumer renders, so the CLI's table
     /// and the pipeline's debug line cannot disagree about which parameter is
-    /// which. The coupled set is kept adjacent because it is only
+    /// which. The coupled trio is kept adjacent because it is only
     /// interpretable as a group.
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, ParamSource)> {
         [

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -180,12 +180,12 @@ pub fn resolve_sampling(body: &mut Value, ctx: &ModelContext, layers: &SamplingL
     //
     // The gate is provenance, not rank. A ladder rung would have been the
     // obvious way to express "outranks the auto-detected recipe", and it is
-    // wrong: a rung that names a `temperature` *claims the coupled set* under
-    // `resolve_layers`, so DRY and the penalties would drop to the floor
-    // behind it. Anyone who had set `--dry-multiplier` without also naming a
-    // temperature would silently lose DRY on every agentic turn — the exact
-    // harm this adjustment is supposed to avoid. Clamping after the fold
-    // leaves the coupled set untouched.
+    // wrong: a rung that names a `temperature` *claims the coupled trio* under
+    // `resolve_layers`, so `presence_penalty`, `repeat_penalty` and `min_p`
+    // would drop to the floor behind it. A `reasoning` model would silently
+    // lose the 1.5 presence penalty its own recipe pairs with its temperature
+    // on every agentic turn. Clamping after the fold leaves the trio
+    // untouched.
     //
     // Eligible sources are the auto-detected rung and the floor. An
     // auto-detected recipe is an unreviewed guess written at import time, and
@@ -809,8 +809,6 @@ mod tests {
     }
 
     /// The regression guard for #743: the adjustment must not disable DRY.
-    /// A ladder rung would have claimed the coupled set and dropped it to the
-    /// floor; clamping after the fold leaves it alone.
     #[test]
     fn dry_survives_an_agentic_turn() {
         let mut body = tools_body();
@@ -832,6 +830,34 @@ mod tests {
         assert_param(&body, "dry_multiplier", 0.8);
         // Global is a deliberate setting, so its temperature stands uncapped.
         assert_param(&body, "temperature", 0.8);
+    }
+
+    /// Regression guard for #745. DRY is deliberately *not* part of the
+    /// temperature-coupled trio, so a layer naming a DRY value but no
+    /// temperature keeps it even though a lower layer claims the temperature —
+    /// which is the default state of every `reasoning`-tagged model.
+    #[test]
+    fn dry_survives_without_a_temperature_in_the_same_layer() {
+        let mut body = json!({});
+        // The model's auto-detected recipe names a temperature, so it claims
+        // the trio. The profile names only DRY.
+        let ctx = auto_detected_ctx(InferenceConfig::reasoning_profile(), true);
+        resolve_sampling(
+            &mut body,
+            &ctx,
+            &SamplingLayers {
+                profile: Some(InferenceConfig {
+                    dry_multiplier: Some(0.8),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_param(&body, "dry_multiplier", 0.8);
+        // The trio still comes from the claiming layer, untouched by this.
+        assert_param(&body, "presence_penalty", 1.5);
+        assert_param(&body, "temperature", 1.0);
     }
 
     /// The ceiling only ever lowers. A model already below it is untouched.

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -41,14 +41,24 @@ The full set of configurable parameters:
 
 ## Temperature coupling
 
-**`temperature`, `presence_penalty`, `repeat_penalty`, `min_p` and the four
-DRY parameters are coupled.**
-The rest are only meaningful relative to how sharp `temperature` makes the
+**`temperature`, `presence_penalty`, `repeat_penalty` and `min_p` are coupled.**
+The last three are only meaningful relative to how sharp `temperature` makes the
 sampling distribution, so they always come from whichever layer supplied the
 `temperature` — never a lower layer, which would apply a penalty tuned for a
 distribution nothing above it asked for. If that layer left one of them
 unset (or if no layer names a temperature at all, in which case the pair-up
 doesn't apply), it falls to the floor rather than to a lower layer's value.
+
+**The DRY parameters are not coupled**, and gap-fill independently like
+`top_p` and `top_k`. They were coupled briefly, on the argument that a
+repetition penalty is a repetition penalty. That symmetry is false:
+`presence_penalty` and `repeat_penalty` are flat logit offsets competing
+directly with temperature's sharpening, whereas DRY's strength is set by its
+own `dry_base` and `dry_allowed_length` and it targets verbatim sequence
+repetition — which gets *worse* at low temperature, not milder. Coupling it
+meant `gglib config profile set coding --dry-multiplier 0.8` silently resolved
+to `0.0` on any model whose defaults name a temperature, which is every
+`reasoning`-tagged model.
 
 The floor itself is class-aware for two fields, `presence_penalty` and
 `min_p`: a plain `0.0` presence penalty is fine for most models, but a

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -302,6 +302,14 @@ gglib model update qwen3.6 --dry-multiplier 0.8
 gglib config profile set coding --dry-multiplier 0.8 --dry-allowed-length 3
 ```
 
+To pick a value from measurement rather than guesswork, sweep it. `0.0` is a
+real candidate meaning "off", so one run compares disabled against two
+strengths on your own model and task suite:
+
+```bash
+gglib benchmark tune <model> --sweep dry_multiplier=0,0.4,0.8
+```
+
 `dry_base`, `dry_allowed_length` and `dry_penalty_last_n` have no floor value.
 Left unset they are omitted from the request entirely and llama.cpp applies its
 own defaults (1.75, 2, and -1), which are reasonable starting points.

--- a/src/components/Benchmark/Tune/TuneConfigForm.tsx
+++ b/src/components/Benchmark/Tune/TuneConfigForm.tsx
@@ -41,6 +41,7 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
   const [topK, setTopK] = useState('');
   const [minP, setMinP] = useState('');
   const [repeatPenalty, setRepeatPenalty] = useState('');
+  const [dryMultiplier, setDryMultiplier] = useState('');
 
   const [suiteMode, setSuiteMode] = useState<'default' | 'custom'>('default');
   const [customTasks, setCustomTasks] = useState<TuneTask[] | null>(null);
@@ -93,6 +94,7 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
         top_k: parseNumberList(topK),
         min_p: parseNumberList(minP),
         repeat_penalty: parseNumberList(repeatPenalty),
+        dry_multiplier: parseNumberList(dryMultiplier),
       },
       seed_from_gguf: seedFromGguf,
       seed_from_family_presets: seedFromFamilyPresets,
@@ -165,6 +167,12 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
             repeat_penalty
           </label>
           <Input value={repeatPenalty} onChange={e => setRepeatPenalty(e.target.value)} disabled={disabled} size="sm" placeholder="1.0,1.1" />
+        </div>
+        <div className="flex flex-col gap-xs">
+          <label className="text-xs font-semibold text-text">
+            dry_multiplier
+          </label>
+          <Input value={dryMultiplier} onChange={e => setDryMultiplier(e.target.value)} disabled={disabled} size="sm" placeholder="0,0.4,0.8" />
         </div>
       </div>
 

--- a/src/components/Benchmark/Tune/TuneLeaderboard.tsx
+++ b/src/components/Benchmark/Tune/TuneLeaderboard.tsx
@@ -63,6 +63,7 @@ export const TuneLeaderboard: FC<TuneLeaderboardProps> = ({
           <th className="px-base py-xs font-medium">#</th>
           <th className="px-base py-xs font-medium">Source</th>
           <th className="px-base py-xs font-medium">Temp</th>
+          <th className="px-base py-xs font-medium">DRY</th>
           <th className="px-base py-xs font-medium">top_p</th>
           <th className="px-base py-xs font-medium">Score</th>
           <th className="px-base py-xs font-medium">Tool Acc.</th>
@@ -81,6 +82,9 @@ export const TuneLeaderboard: FC<TuneLeaderboardProps> = ({
             <td className="px-base py-xs text-text-secondary">{sourceLabel(result.source)}</td>
             <td className="px-base py-xs text-text-secondary">
               {result.config.temperature?.toFixed(2) ?? '—'}
+            </td>
+            <td className="px-base py-xs text-text-secondary">
+              {result.config.dryMultiplier?.toFixed(2) ?? '—'}
             </td>
             <td className="px-base py-xs text-text-secondary">
               {result.config.topP?.toFixed(2) ?? '—'}

--- a/src/types/benchmark.ts
+++ b/src/types/benchmark.ts
@@ -183,6 +183,8 @@ export interface SweepSpec {
   top_k: number[];
   min_p: number[];
   repeat_penalty: number[];
+  /** DRY multiplier; `0.0` disables DRY, so it is a meaningful candidate. */
+  dry_multiplier: number[];
 }
 
 /** Weights combining per-candidate metrics into a composite score. */


### PR DESCRIPTION
Closes #747

> **Stacked on #746.** Base is `fix(core)/decouple-dry-from-temperature`, so this diff shows
> only its own changes. Retarget to `main` once #746 merges. The dependency is real, not
> cosmetic: this PR makes the sweep resolve candidates against the model's actual
> `ModelContext`, and until #746 lands that means the auto-detected recipe claims the
> temperature and eats every swept DRY value.

Three problems in one code path. The missing axis is the smallest of them.

## 1. Candidates were not tuned against the real model

`run_task` never called `.with_model_context(...)`, so every candidate resolved against
`ModelContext::passthrough()`. Three consequences, all silent:

- a `reasoning`-tagged model was tuned against the neutral floor, not `reasoning_floor` —
  different `min_p`, different `presence_penalty`
- the agentic temperature ceiling resolved to the non-reasoning **0.3**, so any candidate not
  naming a temperature ran at 0.3 rather than the floor's 0.7
- no dialect or capability shaping applied

Tuned values did not transfer to production. The raw-vs-gglib eval already built the right
context for its `gglib` arm, so that construction moves into `model_context_for` and both
callers share it — a tuned value now means the same thing in both places by construction,
rather than by two copies happening to agree.

## 2. Nothing bounded the candidate count

Not `build_candidate_grid`, not `build_candidates`, not `run_tune` — which reads
`candidates.len()` only as a progress denominator — and not the Axum handler.

`prune_fraction` is not a cap: `select_survivors` runs only *after* the whole grid has
completed the pre-screen round, and keeps a floor of three. Cost is linear in candidates with
no ceiling. Five axes at three values each was already 243 candidates and 486 real agent loops
before a single pruning decision.

`MAX_CANDIDATES = 256` is checked before the run row is created, so an oversized grid is
refused outright rather than recorded as a run that failed. It sits far above any sweep worth
running; hitting it means a dimension was mistyped.

## 3. No DRY axis

DRY is inert at the floor on the explicit grounds that switching it on "belongs to a per-model
or per-profile layer with sweep data behind it". There was no way to produce that data.

Adds `dry_multiplier` only. `0.0` is a real candidate meaning "off", so one run compares
disabled against two strengths. `dry_base`, `dry_allowed_length` and `dry_penalty_last_n` keep
llama.cpp's defaults — varying all four would multiply the grid by 81 for parameters whose
shipped values are already fine.

Threaded through the four places the dimension list is hardcoded (parser, its error string,
clap help, the TS type and GUI form) plus a leaderboard column, without which a swept value
would be invisible in the UI.

## A bug this PR introduced, and how it was caught

The cap first returned `Err`. The Axum handler spawns `run_tune` and only logs a returned
error to tracing, so the CLI printed its banner, exited **0**, and ran nothing — a
4,097-candidate sweep silently did nothing at all. Found by running it, not by review. It now
reports `RunFailed`, the way every other early failure in this function already does.

## Measured on Qwen3.5-4B

```
$ gglib benchmark tune --model Qwen3.5-4B --sweep temperature=… ×6 dimensions, 4 values each
✗ Run failed: this sweep would run 4097 candidates, over the 256 limit. Every candidate
  costs at least one agent loop per pre-screen task, and pruning only starts after the
  whole grid has run, so the cost is the full count. Reduce the values per dimension, or
  sweep fewer dimensions.
```

Note 4097, not 4096 — the count includes seeded candidates, which cost runs too.

```
$ gglib benchmark tune --model Qwen3.5-4B --sweep dry_multiplier=0,0.8 \
    --seed-from-family-presets false --seed-from-gguf false
[candidate 1/2]
[candidate 2/2]
```

`GET /slots` during the run, alternating with the candidates:

| | temperature | dry_multiplier |
|---|---|---|
| candidate 1 | **0.6** | `0.0` |
| candidate 2 | **0.6** | **`0.8`** |

`0.6` is the reasoning ceiling. On `main` these candidates resolve at **0.3**, because the
passthrough context reports the model as non-reasoning — that difference is problem 1, visible
on the wire.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the suites across the
  eight non-GUI crates — 0 failures.
- Four new grid tests: the DRY axis, that the other three DRY parameters stay unset, that six
  dimensions multiply, and that the cap admits a realistic sweep while rejecting a runaway.
- **`parse_sweep_args` had no tests, in a file with no test module at all.** It has seven now:
  every dimension, the unswept-is-empty contract, both rejection paths, whitespace tolerance,
  and negative integers.
- The live run above.

## Not included

Sweeping the temperature ceiling. It is unnecessary: a candidate naming a temperature is the
client layer, and the ceiling only caps values nobody chose — so a swept temperature bypasses
it, and the winner, stored as a per-model default, is never capped. The 0.6/0.3 values only
affect untuned models, which is a question for the agentic A/B eval.
