### PR TITLE
feat(gui): precision-instrument identity — IBM Plex + graphite/amber tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@assistant-ui/react": "^0.11.48",
-    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@radix-ui/react-dialog": "^1.1.2",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
@@ -66,7 +67,7 @@
     "vite": "^8.0.0",
     "vitest": "^4.0.16"
   },
-  "//overrides": "brace-expansion is forced to ^5.0.8 for GHSA-mh99-v99m-4gvg, EXCEPT under minimatch@3, which requires the 1.x CommonJS function export and throws 'expand is not a function' on 5.x \u2014 that breaks eslint before it reads a single file. minimatch@3 reaches us through eslint-plugin-react, whose latest release still pins ^3.1.2. Do not flatten this back to a blanket override (npm audit fix --force will try); it takes `npm run lint` down completely.",
+  "//overrides": "brace-expansion is forced to ^5.0.8 for GHSA-mh99-v99m-4gvg, EXCEPT under minimatch@3, which requires the 1.x CommonJS function export and throws 'expand is not a function' on 5.x — that breaks eslint before it reads a single file. minimatch@3 reaches us through eslint-plugin-react, whose latest release still pins ^3.1.2. Do not flatten this back to a blanket override (npm audit fix --force will try); it takes `npm run lint` down completely.",
   "overrides": {
     "brace-expansion": "^5.0.8",
     "minimatch@3": {

--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -32,7 +32,7 @@ Tokens follow a **semantic layering** approach:
 
 ```css
 /* Foundation tokens (primitives) */
---color-primary: #6c8cff;
+--color-primary: #f08c26;
 --spacing-base: 1rem;
 
 /* Semantic aliases (purpose-based) */
@@ -445,7 +445,7 @@ has an accessible name.
   destructive actions elsewhere are `dangerGhost` (muted at rest, red on hover).
 - Green means running/online only, expressed as a **dot + neutral text** —
   never a filled pill.
-- Blue is selection, focus, links, and the single primary CTA.
+- Amber (`primary`) is selection, focus, links, and the single primary CTA.
 
 ### Type hierarchy
 

--- a/src/styles/base/variables.css
+++ b/src/styles/base/variables.css
@@ -8,55 +8,55 @@
      ================== */
 
   /* Primary Colors */
-  --color-primary: #6c8cff;
-  --color-primary-hover: #5878ec;
-  --color-primary-light: #93aaff;
-  --color-primary-dark: #3d55b8;
-  --color-primary-subtle: rgba(108, 140, 255, 0.12);
-  --color-primary-border: rgba(108, 140, 255, 0.3);
+  --color-primary: #f08c26;
+  --color-primary-hover: #de7d1b;
+  --color-primary-light: #f7a950;
+  --color-primary-dark: #b5641a;
+  --color-primary-subtle: rgba(240, 140, 38, 0.12);
+  --color-primary-border: rgba(240, 140, 38, 0.35);
 
   /* Semantic Colors */
-  --color-success: #3fc48f;
-  --color-success-hover: #2fa878;
-  --color-success-subtle: rgba(63, 196, 143, 0.12);
-  --color-success-border: rgba(63, 196, 143, 0.3);
-  --color-warning: #d9a23c;
-  --color-warning-hover: #c08b2b;
-  --color-warning-subtle: rgba(217, 162, 60, 0.12);
-  --color-warning-border: rgba(217, 162, 60, 0.3);
-  --color-danger: #e0655a;
-  --color-danger-hover: #c94f44;
-  --color-danger-subtle: rgba(224, 101, 90, 0.12);
-  --color-danger-border: rgba(224, 101, 90, 0.3);
-  --color-info: #6c8cff;
+  --color-success: #45bd85;
+  --color-success-hover: #38a873;
+  --color-success-subtle: rgba(69, 189, 133, 0.12);
+  --color-success-border: rgba(69, 189, 133, 0.3);
+  --color-warning: #e8d666;
+  --color-warning-hover: #d4c14f;
+  --color-warning-subtle: rgba(232, 214, 102, 0.12);
+  --color-warning-border: rgba(232, 214, 102, 0.3);
+  --color-danger: #e05252;
+  --color-danger-hover: #c94343;
+  --color-danger-subtle: rgba(224, 82, 82, 0.12);
+  --color-danger-border: rgba(224, 82, 82, 0.3);
+  --color-info: #7fa6cc;
 
-  /* Neutral Colors - Dark Theme (cool slate-tinted ramp) */
-  --color-background: #0c0e12;
-  --color-background-elevated: #12151a;
-  --color-background-overlay: #161a21;
-  --color-background-hover: #1b202a;
-  --color-background-active: #222836;
-  --color-background-input: #0f1218;
+  /* Neutral Colors - Dark Theme (graphite ramp, near-achromatic) */
+  --color-background: #0e0e10;
+  --color-background-elevated: #131316;
+  --color-background-overlay: #17171a;
+  --color-background-hover: #1d1d21;
+  --color-background-active: #26262b;
+  --color-background-input: #101013;
 
   /* Surface Colors */
-  --color-surface: #161a21;
-  --color-surface-elevated: #1d222c;
-  --color-surface-hover: #242b37;
+  --color-surface: #17171a;
+  --color-surface-elevated: #202024;
+  --color-surface-hover: #28282d;
   /* Alias: fixes broken bg-surface-raised references in components */
   --color-surface-raised: var(--color-surface-elevated);
 
   /* Border Colors (white-alpha hairlines so they read on every surface level) */
-  --color-border: rgba(255, 255, 255, 0.08);
-  --color-border-light: rgba(255, 255, 255, 0.05);
-  --color-border-hover: rgba(255, 255, 255, 0.14);
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-light: rgba(255, 255, 255, 0.06);
+  --color-border-hover: rgba(255, 255, 255, 0.16);
   --color-border-focus: var(--color-primary);
 
   /* Text Colors */
-  --color-text: #e7eaf0;
-  --color-text-secondary: #a9b1bf;
-  --color-text-muted: #7e8795;
-  --color-text-disabled: #58606d;
-  --color-text-inverse: #0c0e12;
+  --color-text: #edece8;
+  --color-text-secondary: #a9a8a2;
+  --color-text-muted: #8a8983;
+  --color-text-disabled: #5b5a55;
+  --color-text-inverse: #0e0e10;
 
   /* Semantic Aliases - for component consistency */
   --color-background-secondary: var(--color-background-elevated);
@@ -65,9 +65,9 @@
   --color-accent: var(--color-primary-light);
 
   /* Status Colors */
-  --color-online: #3fc48f;
-  --color-offline: #7e8795;
-  --color-error: #e0655a;
+  --color-online: #45bd85;
+  --color-offline: #8a8983;
+  --color-error: #e05252;
 
   /* ==================
      Spacing Scale
@@ -86,9 +86,9 @@
      Typography Scale
      ================== */
 
-  --font-family-base: 'Inter Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  --font-family-base: 'IBM Plex Sans Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  --font-family-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code',
+  --font-family-mono: 'IBM Plex Mono', 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code',
     'Fira Mono', 'Roboto Mono', monospace;
 
   /* Font Sizes (desktop-density scale: 14px base UI type) */
@@ -130,10 +130,10 @@
 
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
   --shadow-base: 0 1px 3px 0 rgba(0, 0, 0, 0.45), 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(255, 255, 255, 0.04);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
-  --shadow-xl: 0 16px 40px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.05);
-  --shadow-2xl: 0 24px 64px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.07);
+  --shadow-xl: 0 16px 40px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.07);
+  --shadow-2xl: 0 24px 64px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.08);
 
   /* ==================
      Transitions

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
-@import "@fontsource-variable/inter";
+@import "@fontsource-variable/ibm-plex-sans";
+@import "@fontsource/ibm-plex-mono/400.css";
+@import "@fontsource/ibm-plex-mono/500.css";
+@import "@fontsource/ibm-plex-mono/600.css";
 @import "./base/variables.css";
 
 /* =============================================================================


### PR DESCRIPTION
First PR of the precision-instrument GUI restyle (stacked series, 1/13). Identity tokens only — **zero component-file edits**.

## What changed
- **Fonts**: IBM Plex Sans (variable) replaces Inter; IBM Plex Mono 400/500/600 replaces the system mono stack. Self-hosted via fontsource; the single import site in `src/styles/tailwind.css` covers both the main and tray windows.
- **Palette** (`src/styles/base/variables.css`, values only — every token name unchanged, so the `@theme inline` bridge and all component classes work untouched): near-achromatic graphite ladder with larger elevation steps (`#0e0e10 → #17171a → #202024`), warm-white text ramp, signal-amber `#f08c26` primary replacing periwinkle `#6c8cff`, warning pushed to yellow-gold `#e8d666` (clear of the amber accent), danger `#e05252`, success `#45bd85`, `--color-info` decoupled from primary (`#7fa6cc`).
- Contract §10's color-allocation line updated (blue → amber); the full §10 rewrite lands later in the stack.

## Evidence
- Palette validator: CVD separation PASS, normal-vision floor 15.1 PASS, contrast-vs-surface PASS. (The validator's lightness-band/chroma checks target multi-series chart palettes, which these accent/status roles never form — sparklines and thresholds are single-color with icon+text per contract.)
- WCAG: accent-as-text 7.23:1 on surface; dark-text-on-amber primary button 7.79:1; muted text ≥ 4.63:1 on every surface including `surface-elevated` (raised from a 4.33:1 fail caught in review — main's old value also failed this pair at 4.39:1).
- `npm run lint` / `npm run test:run` (741 passed) / `npm run build` all green; visual spot-check on the dev server (main window + tray).
- Tauri note: fonts are Vite-bundled woff2, no desktop-specific config; WKWebView weight-rendering eyeball pending with the next desktop build.

## Deliberately deferred to PR 2 (`feat(gui)/console-code-theming`)
Console ANSI palette, `ConsoleLogPanel` raw hexes, and the highlight.js `github-dark` theme — the last off-palette islands.