### PR TITLE
feat(gui): console and code theming from design tokens

### DIFF
--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import 'highlight.js/styles/github-dark.css';
 import {
   ThreadPrimitive,
   useThreadRuntime,

--- a/src/components/ConsoleLogPanel/ConsoleLogPanel.css
+++ b/src/components/ConsoleLogPanel/ConsoleLogPanel.css
@@ -1,38 +1,42 @@
 /* Console Log Panel - ANSI colors (can't be expressed in Tailwind).
-   Scrollbars use the global thin style from styles/tailwind.css. */
+   Scrollbars use the global thin style from styles/tailwind.css.
+   Hues keep their ANSI meaning (red is red — mapping ANSI colors onto semantic
+   tokens would misrepresent what the server emitted); values are literal hex,
+   brightness-tuned for the graphite terminal background. Default fg/dim use
+   text tokens so plain log text follows the palette. */
 
 .console-log-line {
   padding: 1px 0;
-  color: #d4d4d4;
+  color: var(--color-text-secondary);
 }
 
 /* ANSI color classes from Anser */
-.console-log-line .ansi-black-fg { color: #000000; }
-.console-log-line .ansi-red-fg { color: #cd3131; }
-.console-log-line .ansi-green-fg { color: #0dbc79; }
-.console-log-line .ansi-yellow-fg { color: #e5e510; }
-.console-log-line .ansi-blue-fg { color: #2472c8; }
-.console-log-line .ansi-magenta-fg { color: #bc3fbc; }
-.console-log-line .ansi-cyan-fg { color: #11a8cd; }
-.console-log-line .ansi-white-fg { color: #e5e5e5; }
+.console-log-line .ansi-black-fg { color: #3d3d42; }
+.console-log-line .ansi-red-fg { color: #e06c60; }
+.console-log-line .ansi-green-fg { color: #57c98a; }
+.console-log-line .ansi-yellow-fg { color: #dcc95e; }
+.console-log-line .ansi-blue-fg { color: #6fa8e0; }
+.console-log-line .ansi-magenta-fg { color: #c586c0; }
+.console-log-line .ansi-cyan-fg { color: #56b6c2; }
+.console-log-line .ansi-white-fg { color: var(--color-text); }
 
-.console-log-line .ansi-bright-black-fg { color: #666666; }
-.console-log-line .ansi-bright-red-fg { color: #f14c4c; }
-.console-log-line .ansi-bright-green-fg { color: #23d18b; }
-.console-log-line .ansi-bright-yellow-fg { color: #f5f543; }
-.console-log-line .ansi-bright-blue-fg { color: #3b8eea; }
-.console-log-line .ansi-bright-magenta-fg { color: #d670d6; }
-.console-log-line .ansi-bright-cyan-fg { color: #29b8db; }
+.console-log-line .ansi-bright-black-fg { color: var(--color-text-muted); }
+.console-log-line .ansi-bright-red-fg { color: #f28b80; }
+.console-log-line .ansi-bright-green-fg { color: #6fe0a5; }
+.console-log-line .ansi-bright-yellow-fg { color: #f2e284; }
+.console-log-line .ansi-bright-blue-fg { color: #8fc0f2; }
+.console-log-line .ansi-bright-magenta-fg { color: #dda3d8; }
+.console-log-line .ansi-bright-cyan-fg { color: #7cd6e2; }
 .console-log-line .ansi-bright-white-fg { color: #ffffff; }
 
-.console-log-line .ansi-black-bg { background-color: #000000; }
-.console-log-line .ansi-red-bg { background-color: #cd3131; }
-.console-log-line .ansi-green-bg { background-color: #0dbc79; }
-.console-log-line .ansi-yellow-bg { background-color: #e5e510; }
-.console-log-line .ansi-blue-bg { background-color: #2472c8; }
-.console-log-line .ansi-magenta-bg { background-color: #bc3fbc; }
-.console-log-line .ansi-cyan-bg { background-color: #11a8cd; }
-.console-log-line .ansi-white-bg { background-color: #e5e5e5; }
+.console-log-line .ansi-black-bg { background-color: #3d3d42; }
+.console-log-line .ansi-red-bg { background-color: #e06c60; }
+.console-log-line .ansi-green-bg { background-color: #57c98a; }
+.console-log-line .ansi-yellow-bg { background-color: #dcc95e; }
+.console-log-line .ansi-blue-bg { background-color: #6fa8e0; }
+.console-log-line .ansi-magenta-bg { background-color: #c586c0; }
+.console-log-line .ansi-cyan-bg { background-color: #56b6c2; }
+.console-log-line .ansi-white-bg { background-color: var(--color-text); }
 
 .console-log-line .ansi-bold { font-weight: bold; }
 .console-log-line .ansi-dim { opacity: 0.7; }

--- a/src/components/ConsoleLogPanel/ConsoleLogPanel.tsx
+++ b/src/components/ConsoleLogPanel/ConsoleLogPanel.tsx
@@ -110,11 +110,11 @@ const ConsoleLogPanel: FC<ConsoleLogPanelProps> = ({ serverPort }) => {
 
       <div 
         ref={scrollContainerRef}
-        className="console-log-content flex-1 overflow-y-auto overflow-x-auto bg-[#1e1e1e] rounded-sm font-mono text-xs leading-[1.5] p-sm"
+        className="console-log-content flex-1 overflow-y-auto overflow-x-auto bg-terminal rounded-sm font-mono text-xs leading-[1.5] p-sm"
         onScroll={handleScroll}
       >
         {logs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full min-h-[200px] text-[#808080] text-center gap-sm">
+          <div className="flex flex-col items-center justify-center h-full min-h-[200px] text-text-muted text-center gap-sm">
             <span className="opacity-50" aria-hidden>
               <Icon icon={Monitor} size={28} />
             </span>

--- a/src/components/RangeSlider/RangeSlider.css
+++ b/src/components/RangeSlider/RangeSlider.css
@@ -5,8 +5,8 @@
   appearance: none;
   width: 16px;
   height: 16px;
-  background: var(--color-primary, #4a9eff);
-  border: 2px solid var(--color-surface, #2a2a2a);
+  background: var(--color-primary);
+  border: 2px solid var(--color-surface);
   border-radius: 50%;
   cursor: pointer;
   pointer-events: auto;
@@ -28,8 +28,8 @@
 .range-slider-thumb::-moz-range-thumb {
   width: 16px;
   height: 16px;
-  background: var(--color-primary, #4a9eff);
-  border: 2px solid var(--color-surface, #2a2a2a);
+  background: var(--color-primary);
+  border: 2px solid var(--color-surface);
   border-radius: 50%;
   cursor: pointer;
   pointer-events: auto;
@@ -52,11 +52,11 @@
 
 /* Disabled state */
 .range-slider-thumb:disabled::-webkit-slider-thumb {
-  background: var(--color-border, #3a3a3a);
+  background: var(--color-border);
   cursor: not-allowed;
 }
 
 .range-slider-thumb:disabled::-moz-range-thumb {
-  background: var(--color-border, #3a3a3a);
+  background: var(--color-border);
   cursor: not-allowed;
 }

--- a/src/styles/base/hljs.css
+++ b/src/styles/base/hljs.css
@@ -1,0 +1,107 @@
+/* highlight.js theme driven by design tokens (replaces the stock github-dark
+   import). Code blocks are L2 surfaces per the contract; syntax colors come
+   from the --code-* token group in variables.css so they move with the palette. */
+
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+
+code.hljs {
+  padding: 3px 5px;
+}
+
+.hljs {
+  color: var(--color-text);
+  background: var(--color-surface-elevated);
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-selector-class,
+.hljs-selector-id,
+.hljs-selector-attr,
+.hljs-doctag,
+.hljs-template-tag,
+.hljs-type,
+.hljs-attr,
+.hljs-variable.language_ {
+  color: var(--code-keyword);
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-selector-pseudo {
+  color: var(--code-string);
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-built_in,
+.hljs-symbol,
+.hljs-meta,
+.hljs-attribute,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-operator {
+  color: var(--code-number);
+}
+
+/* Interpolation bodies nest inside string spans — reset them to base text */
+.hljs-subst {
+  color: var(--color-text);
+}
+
+/* Prose-ish scopes: quiet, and italic only where italics read as prose. A
+   diff deletion is not a comment, so it is excluded here — see below. */
+.hljs-comment,
+.hljs-quote {
+  color: var(--code-comment);
+  font-style: italic;
+}
+
+/* Literal spans markdown hands back verbatim — quiet but upright. */
+.hljs-code,
+.hljs-formula {
+  color: var(--code-comment);
+}
+
+.hljs-title,
+.hljs-title.function_,
+.hljs-title.class_,
+.hljs-section,
+.hljs-bullet,
+.hljs-name {
+  color: var(--code-function);
+}
+
+/* Markdown headings carry weight, not just colour. */
+.hljs-section {
+  font-weight: var(--font-weight-semibold);
+}
+
+/* Diff bands. Colour alone is the weakest possible signal for the one case
+   where getting the direction wrong changes what the reader believes, so
+   added and removed lines get a wash behind them as well as a hue. */
+.hljs-addition {
+  color: var(--color-success);
+  background: var(--color-success-subtle);
+  display: inline-block;
+  width: 100%;
+}
+
+.hljs-deletion {
+  color: var(--color-danger);
+  background: var(--color-danger-subtle);
+  display: inline-block;
+  width: 100%;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: var(--font-weight-semibold);
+}

--- a/src/styles/base/variables.css
+++ b/src/styles/base/variables.css
@@ -69,6 +69,16 @@
   --color-offline: #8a8983;
   --color-error: #e05252;
 
+  /* Terminal (console log surface, one step below canvas) */
+  --color-terminal: #0a0a0c;
+
+  /* Syntax highlighting (consumed by base/hljs.css) */
+  --code-keyword: #85a9d6;
+  --code-string: #85c29d;
+  --code-number: #d9a35f;
+  --code-comment: var(--color-text-muted);
+  --code-function: #d9c886;
+
   /* ==================
      Spacing Scale
      ================== */

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -4,6 +4,7 @@
 @import "@fontsource/ibm-plex-mono/500.css";
 @import "@fontsource/ibm-plex-mono/600.css";
 @import "./base/variables.css";
+@import "./base/hljs.css";
 
 /* =============================================================================
    THEME: Bridge CSS custom properties from variables.css into Tailwind tokens.
@@ -84,6 +85,7 @@
   --color-online: var(--color-online);
   --color-offline: var(--color-offline);
   --color-error: var(--color-error);
+  --color-terminal: var(--color-terminal);
 
   /* ---------- Spacing ---------- */
   --spacing-xs: var(--spacing-xs);


### PR DESCRIPTION
PR 2/13 of the precision-instrument restyle — **stacked on** `feat(gui)/identity-tokens` (#757). Kills the last off-palette color islands.

## What changed
- **Chat code blocks**: the stock `highlight.js/styles/github-dark.css` import is gone; a token-driven `src/styles/base/hljs.css` replaces it, colored by a new `--code-*` group in `variables.css` — syntax color now moves with the palette. Structural rules (padding/overflow) preserved from the stock theme so layout doesn't shift. Scope coverage checked empirically against the lowlight `common` grammars (review caught and fixed `hljs-type`, `hljs-variable`/`template-variable`, and the `.hljs-subst` interpolation reset).
- **Console terminal** (`ConsoleLogPanel`): new `--color-terminal` token (`#0a0a0c`, one step below canvas) replaces `bg-[#1e1e1e]`; empty-state `text-[#808080]` → `text-text-muted`; ANSI palette retuned for the graphite background — hues keep their ANSI meaning (red stays red; mapping onto semantic tokens would misrepresent server output), default/dim line colors now use text tokens.
- **RangeSlider.css**: stale hardcoded `var()` fallbacks deleted (dead code).

## Evidence
- Raw-color stragglers in component files are now **zero** except the intentional ANSI literals and black shadow rgba (verified by grep in review).
- Contrast (computed): all ANSI normal/bright foregrounds 5.6–16.7:1 on the terminal background (ANSI black conventionally exempt); all `--code-*` colors 4.6–9.7:1 on the code-block surface.
- `npm run lint` / `test:run` (741 passed) / `build` all green.