### PR TITLE
feat(gui): Readout, Sparkline, and useMetricHistory primitives

### DIFF
--- a/src/components/primitives/Readout.tsx
+++ b/src/components/primitives/Readout.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export type ReadoutIntent = 'neutral' | 'accent' | 'warning' | 'danger';
+export type ReadoutSize = 'sm' | 'md' | 'lg';
+
+interface ReadoutProps {
+  label: string;
+  value: string | number;
+  /** Quiet suffix rendered beside the value (e.g. "tok/s", "%", "MiB"). */
+  unit?: string;
+  /** Colors the value only — labels and units always stay quiet. */
+  intent?: ReadoutIntent;
+  size?: ReadoutSize;
+  /** Slot for a Sparkline (or other trend mark) rendered under the value. */
+  trend?: React.ReactNode;
+  align?: 'start' | 'end';
+  className?: string;
+}
+
+const intentClasses: Record<ReadoutIntent, string> = {
+  neutral: 'text-text',
+  accent: 'text-primary',
+  warning: 'text-warning',
+  danger: 'text-danger',
+};
+
+const sizeClasses: Record<ReadoutSize, string> = {
+  sm: 'text-sm',
+  md: 'text-lg',
+  lg: 'text-2xl',
+};
+
+/**
+ * Readout - the single treatment for a live metric.
+ *
+ * Values wear mono + tabular figures so columns of telemetry align. Per the
+ * design contracts every live metric renders through a Readout, and a
+ * Sparkline never appears without one — pass it through `trend`.
+ */
+export const Readout: React.FC<ReadoutProps> = ({
+  label,
+  value,
+  unit,
+  intent = 'neutral',
+  size = 'md',
+  trend,
+  align = 'start',
+  className,
+}) => (
+  <div className={cn('flex min-w-0 flex-col', align === 'end' && 'items-end text-right', className)}>
+    <span className="text-xs text-text-muted">{label}</span>
+    <span
+      className={cn(
+        'font-mono font-medium tabular-nums leading-tight',
+        sizeClasses[size],
+        intentClasses[intent],
+      )}
+    >
+      {value}
+      {unit ? <span className="text-2xs font-normal text-text-muted"> {unit}</span> : null}
+    </span>
+    {trend ? <span className="mt-xs">{trend}</span> : null}
+  </div>
+);

--- a/src/components/primitives/Sparkline.tsx
+++ b/src/components/primitives/Sparkline.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+interface SparklineProps {
+  values: number[];
+  width?: number;
+  height?: number;
+  /** Fixed domain (e.g. 0–100 for percentages) so the line doesn't autoscale noise. */
+  min?: number;
+  max?: number;
+  strokeWidth?: number;
+  ariaLabel: string;
+  className?: string;
+}
+
+/**
+ * Sparkline - the app's single micro-chart style for live telemetry.
+ *
+ * Pure SVG and non-interactive: the adjacent Readout carries the current
+ * value, so the mark needs no tooltip layer. Stroke follows currentColor —
+ * set intent with a text color utility at the call site (e.g. text-primary).
+ * Renders only the faint baseline until two samples exist.
+ */
+export const Sparkline: React.FC<SparklineProps> = ({
+  values,
+  width = 64,
+  height = 20,
+  min,
+  max,
+  strokeWidth = 1.5,
+  ariaLabel,
+  className,
+}) => {
+  const pad = 3;
+  let points: Array<[number, number]> = [];
+
+  if (values.length >= 2) {
+    const lo = min ?? Math.min(...values);
+    const hi = max ?? Math.max(...values);
+    const span = hi - lo || 1;
+    const stepX = (width - pad * 2) / (values.length - 1);
+    points = values.map((v, i) => [
+      pad + i * stepX,
+      height - pad - ((v - lo) / span) * (height - pad * 2),
+    ]);
+  }
+
+  const last = points[points.length - 1];
+
+  return (
+    <svg
+      role="img"
+      aria-label={ariaLabel}
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn('block shrink-0', className)}
+    >
+      <line
+        x1={0}
+        y1={height - 0.5}
+        x2={width}
+        y2={height - 0.5}
+        strokeWidth={1}
+        className="stroke-border"
+      />
+      {last && (
+        <>
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            points={points.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(' ')}
+          />
+          <circle cx={last[0]} cy={last[1]} r={2} fill="currentColor" />
+        </>
+      )}
+    </svg>
+  );
+};

--- a/src/components/primitives/index.ts
+++ b/src/components/primitives/index.ts
@@ -5,3 +5,6 @@ export { Label } from './Label';
 export { EmptyState } from './EmptyState';
 export { Skeleton } from './Skeleton';
 export type { SkeletonProps } from './Skeleton';
+export { Readout } from './Readout';
+export type { ReadoutIntent, ReadoutSize } from './Readout';
+export { Sparkline } from './Sparkline';

--- a/src/hooks/useMetricHistory.ts
+++ b/src/hooks/useMetricHistory.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from 'react';
+
+export type MetricHistoryMode = 'value' | 'rate';
+
+interface UseMetricHistoryOptions {
+  /** Ring-buffer size; oldest samples fall off. */
+  capacity?: number;
+  /**
+   * 'value' pushes each sample as-is; 'rate' treats the sample as a cumulative
+   * counter and pushes its per-second delta, measured against wall-clock time
+   * (stream cadence is not guaranteed regular, so dt must be measured).
+   */
+  mode?: MetricHistoryMode;
+  /** Changing this clears the buffer (e.g. the model/slot the series belongs to). */
+  resetKey?: unknown;
+  /**
+   * Change-signal for when to record. Defaults to the sample itself, which
+   * misses repeats — pass the snapshot's timestamp/sequence so an unchanged
+   * counter still registers (a stalled counter is a zero rate, not no data).
+   */
+  tick?: unknown;
+}
+
+interface MetricHistory {
+  values: number[];
+  latest: number | null;
+}
+
+/**
+ * Accumulates a bounded history of a live metric for Readout/Sparkline use.
+ * Rate mode clamps negative deltas to zero — counters reset when a model is
+ * swapped or a server restarts, and a reset is not a negative rate.
+ */
+const UNSET = Symbol('useMetricHistory.unset');
+
+export function useMetricHistory(
+  sample: number | null | undefined,
+  { capacity = 60, mode = 'value', resetKey, tick }: UseMetricHistoryOptions = {},
+): MetricHistory {
+  const [values, setValues] = useState<number[]>([]);
+  const prevCounterRef = useRef<{ value: number; at: number } | null>(null);
+  const lastSignalRef = useRef<unknown>(UNSET);
+
+  useEffect(() => {
+    setValues([]);
+    prevCounterRef.current = null;
+    lastSignalRef.current = UNSET;
+  }, [resetKey]);
+
+  const changeSignal = tick === undefined ? sample : tick;
+
+  useEffect(() => {
+    if (sample == null || Number.isNaN(sample)) return;
+
+    // Only the change-signal records — mode/capacity are in the deps for
+    // correctness but must not act as record triggers.
+    if (Object.is(lastSignalRef.current, changeSignal)) return;
+    lastSignalRef.current = changeSignal;
+
+    if (mode === 'value') {
+      setValues(prev => [...prev, sample].slice(-capacity));
+      return;
+    }
+
+    const now = Date.now();
+    const prev = prevCounterRef.current;
+    prevCounterRef.current = { value: sample, at: now };
+    if (!prev) return;
+
+    const dtSeconds = (now - prev.at) / 1000;
+    if (dtSeconds <= 0) return;
+
+    const rate = Math.max(0, (sample - prev.value) / dtSeconds);
+    setValues(prevValues => [...prevValues, rate].slice(-capacity));
+  }, [sample, changeSignal, mode, capacity]);
+
+  return { values, latest: values.length > 0 ? values[values.length - 1] : null };
+}

--- a/tests/ts/components/Readout.test.tsx
+++ b/tests/ts/components/Readout.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Tests for the Readout primitive.
+ *
+ * The single treatment for live metrics: mono tabular value, quiet unit,
+ * intent coloring the value only, and the trend slot.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Readout } from '../../../src/components/primitives/Readout';
+
+describe('Readout', () => {
+  it('renders label, value, and unit', () => {
+    render(<Readout label="Generation" value="127.4" unit="tok/s" />);
+
+    expect(screen.getByText('Generation')).toBeInTheDocument();
+    expect(screen.getByText('127.4')).toBeInTheDocument();
+    expect(screen.getByText('tok/s')).toBeInTheDocument();
+  });
+
+  it('renders the value in mono with tabular figures', () => {
+    render(<Readout label="KV cache" value={62} unit="%" />);
+
+    const value = screen.getByText('62');
+    expect(value.className).toContain('font-mono');
+    expect(value.className).toContain('tabular-nums');
+  });
+
+  it('colors only the value with the intent, never the label or unit', () => {
+    render(<Readout label="KV cache" value={92} unit="%" intent="danger" />);
+
+    expect(screen.getByText('92').className).toContain('text-danger');
+    expect(screen.getByText('KV cache').className).toContain('text-text-muted');
+    expect(screen.getByText('%').className).toContain('text-text-muted');
+  });
+
+  it('renders the trend slot under the value', () => {
+    render(
+      <Readout
+        label="Generation"
+        value="127.4"
+        unit="tok/s"
+        trend={<svg data-testid="trend-mark" />}
+      />,
+    );
+
+    expect(screen.getByTestId('trend-mark')).toBeInTheDocument();
+  });
+});

--- a/tests/ts/components/Sparkline.test.tsx
+++ b/tests/ts/components/Sparkline.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for the Sparkline primitive.
+ *
+ * The app's single micro-chart style: accessible-name requirement, the
+ * under-two-samples baseline placeholder, currentColor marks, and the
+ * fixed-domain option.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Sparkline } from '../../../src/components/primitives/Sparkline';
+
+describe('Sparkline', () => {
+  it('exposes an accessible name as an image', () => {
+    render(<Sparkline values={[1, 2, 3]} ariaLabel="Generation rate, last 60 samples" />);
+
+    expect(
+      screen.getByRole('img', { name: 'Generation rate, last 60 samples' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders only the baseline until two samples exist', () => {
+    const { container } = render(<Sparkline values={[42]} ariaLabel="Warming up" />);
+
+    expect(container.querySelector('line')).not.toBeNull();
+    expect(container.querySelector('polyline')).toBeNull();
+    expect(container.querySelector('circle')).toBeNull();
+  });
+
+  it('renders the line and a terminus dot in currentColor once data exists', () => {
+    const { container } = render(<Sparkline values={[1, 5, 3]} ariaLabel="Series" />);
+
+    const polyline = container.querySelector('polyline');
+    const dot = container.querySelector('circle');
+    expect(polyline?.getAttribute('stroke')).toBe('currentColor');
+    expect(dot?.getAttribute('fill')).toBe('currentColor');
+  });
+
+  it('places the terminus dot on the last sample', () => {
+    const { container } = render(
+      <Sparkline values={[0, 10]} width={64} height={20} ariaLabel="Series" />,
+    );
+
+    const polyline = container.querySelector('polyline');
+    const dot = container.querySelector('circle');
+    const lastPoint = polyline?.getAttribute('points')?.split(' ').at(-1);
+    const [lastX, lastY] = (lastPoint ?? '').split(',').map(Number);
+    expect(lastX).toBeCloseTo(Number(dot?.getAttribute('cx')), 2);
+    expect(lastY).toBeCloseTo(Number(dot?.getAttribute('cy')), 2);
+  });
+
+  it('respects a fixed domain instead of autoscaling', () => {
+    const { container } = render(
+      <Sparkline values={[50, 50]} min={0} max={100} height={20} ariaLabel="Percent" />,
+    );
+
+    const points = container.querySelector('polyline')?.getAttribute('points')?.split(' ');
+    const y = Number(points?.[0]?.split(',')[1]);
+    expect(y).toBeCloseTo(10, 1);
+  });
+});

--- a/tests/ts/hooks/useMetricHistory.test.ts
+++ b/tests/ts/hooks/useMetricHistory.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for useMetricHistory hook.
+ *
+ * Ring-buffer accumulation for Readout/Sparkline telemetry: value mode,
+ * counter-derived rate mode with measured dt, negative-delta clamping,
+ * capacity trimming, tick-driven repeats, and resetKey clearing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMetricHistory } from '../../../src/hooks/useMetricHistory';
+
+describe('useMetricHistory', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('accumulates samples in value mode', () => {
+    const { result, rerender } = renderHook(({ s }) => useMetricHistory(s), {
+      initialProps: { s: 10 },
+    });
+    rerender({ s: 20 });
+    rerender({ s: 30 });
+
+    expect(result.current.values).toEqual([10, 20, 30]);
+    expect(result.current.latest).toBe(30);
+  });
+
+  it('ignores null, undefined, and NaN samples', () => {
+    const { result, rerender } = renderHook(
+      ({ s }: { s: number | null | undefined }) => useMetricHistory(s),
+      { initialProps: { s: 5 as number | null | undefined } },
+    );
+    rerender({ s: null });
+    rerender({ s: undefined });
+    rerender({ s: Number.NaN });
+
+    expect(result.current.values).toEqual([5]);
+  });
+
+  it('trims to capacity, dropping the oldest samples', () => {
+    const { result, rerender } = renderHook(
+      ({ s }) => useMetricHistory(s, { capacity: 3 }),
+      { initialProps: { s: 1 } },
+    );
+    for (const s of [2, 3, 4, 5]) rerender({ s });
+
+    expect(result.current.values).toEqual([3, 4, 5]);
+  });
+
+  it('derives rates from cumulative counters using measured elapsed time', () => {
+    const { result, rerender } = renderHook(
+      ({ s }) => useMetricHistory(s, { mode: 'rate' }),
+      { initialProps: { s: 100 } },
+    );
+    expect(result.current.values).toEqual([]);
+
+    vi.advanceTimersByTime(2000);
+    rerender({ s: 300 });
+
+    expect(result.current.values).toEqual([100]);
+    expect(result.current.latest).toBe(100);
+  });
+
+  it('clamps negative counter deltas to zero', () => {
+    const { result, rerender } = renderHook(
+      ({ s }) => useMetricHistory(s, { mode: 'rate' }),
+      { initialProps: { s: 300 } },
+    );
+    vi.advanceTimersByTime(1000);
+    rerender({ s: 50 });
+
+    expect(result.current.values).toEqual([0]);
+  });
+
+  it('registers a zero rate when the counter stalls but the tick advances', () => {
+    const { result, rerender } = renderHook(
+      ({ s, t }) => useMetricHistory(s, { mode: 'rate', tick: t }),
+      { initialProps: { s: 100, t: 1 } },
+    );
+    vi.advanceTimersByTime(1000);
+    rerender({ s: 100, t: 2 });
+
+    expect(result.current.values).toEqual([0]);
+  });
+
+  it('does not record when only options change', () => {
+    const { result, rerender } = renderHook(
+      ({ s, c }) => useMetricHistory(s, { capacity: c }),
+      { initialProps: { s: 42, c: 60 } },
+    );
+    rerender({ s: 42, c: 59 });
+    rerender({ s: 42, c: 58 });
+
+    expect(result.current.values).toEqual([42]);
+  });
+
+  it('clears the buffer when resetKey changes', () => {
+    const { result, rerender } = renderHook(
+      ({ s, k }) => useMetricHistory(s, { resetKey: k }),
+      { initialProps: { s: 10, k: 'model-a' } },
+    );
+    rerender({ s: 20, k: 'model-a' });
+    expect(result.current.values).toEqual([10, 20]);
+
+    rerender({ s: 20, k: 'model-b' });
+    expect(result.current.values).toEqual([]);
+
+    rerender({ s: 30, k: 'model-b' });
+    expect(result.current.values).toEqual([30]);
+  });
+});


### PR DESCRIPTION
PR 3/13 of the precision-instrument restyle — **stacked on** `feat(gui)/console-code-theming` (#758). Purely additive: the signature telemetry primitives, adopted by nothing yet (adoption is the next PR).

## What's new
- **`Readout`** (`src/components/primitives/Readout.tsx`): the single treatment for a live metric — quiet `text-xs` label, `font-mono tabular-nums` value, quiet unit suffix, `intent` coloring the value only, `trend` slot, `align` for right-edge columns.
- **`Sparkline`** (`src/components/primitives/Sparkline.tsx`): the app's one micro-chart style — pure SVG, `currentColor` stroke (intent set by text-color utility at the call site), 2px terminus dot, faint `stroke-border` baseline, flat placeholder under two samples, optional fixed `min`/`max` domain for % series, non-interactive by design (the adjacent Readout is the value label). `role="img"` + required `ariaLabel`.
- **`useMetricHistory`** (`src/hooks/useMetricHistory.ts`): bounded ring buffer feeding the above. `'value'` mode pushes samples; `'rate'` mode differences cumulative counters against **measured** wall-clock dt (SSE cadence isn't guaranteed) and clamps negative deltas (counter resets aren't negative rates). `tick` change-signal lets a stalled counter register as a zero rate; `resetKey` clears on model/slot swap. Recording is gated on the change-signal actually changing — option changes (capacity/mode) never act as record triggers (review-caught).

## Tests
17 new tests: value/rate/clamp/stall/reset/capacity/options-gate semantics for the hook; label/value/unit/intent/trend rendering for Readout; accessible-name, placeholder, currentColor, terminus placement, and fixed-domain behavior for Sparkline.

`npm run lint` / `test:run` (758 passed) / `build` all green.