### PR TITLE
feat(gui): adopt readouts and sparklines across proxy, console, and tray

### DIFF
--- a/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
+++ b/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
@@ -1,12 +1,15 @@
-import { FC, useState, useEffect, useCallback, useRef } from 'react';
-import { Copy, StopCircle } from 'lucide-react';
+import { FC, useState, useCallback } from 'react';
+import { StopCircle } from 'lucide-react';
 import { ChatPageTabId, CHAT_PAGE_TABS } from '../../pages/chatTabs';
 import { Tabs } from '../ui/Tabs';
 import { useServerState } from '../../services/serverEvents';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
-import { cn } from '../../utils/cn';
 import { Stack } from '../primitives';
+import { useServerMetrics } from './useServerMetrics';
+import { useUptime } from './useUptime';
+import { ServerInfoSection, ApiEndpointsSection } from './StaticSections';
+import { ContextUsageSection, StatisticsSection } from './TelemetrySections';
 
 interface ConsoleInfoPanelProps {
   modelId: number;
@@ -19,37 +22,10 @@ interface ConsoleInfoPanelProps {
   onTabChange: (tab: ChatPageTabId) => void;
 }
 
-interface ServerMetrics {
-  kvCacheUsageRatio: number | null;
-  kvCacheTokens: number | null;
-  nTokensMax: number;
-  promptTokensTotal: number;
-  predictedTokensTotal: number;
-  requestsProcessing: number;
-}
-
 /**
- * Format uptime duration in a human-readable way
- */
-const formatUptime = (startTime: number): string => {
-  const now = Math.floor(Date.now() / 1000);
-  const diff = now - startTime;
-
-  if (diff < 60) {
-    return `${diff}s`;
-  } else if (diff < 3600) {
-    const mins = Math.floor(diff / 60);
-    const secs = diff % 60;
-    return `${mins}m ${secs}s`;
-  } else {
-    const hours = Math.floor(diff / 3600);
-    const mins = Math.floor((diff % 3600) / 60);
-    return `${hours}h ${mins}m`;
-  }
-};
-
-/**
- * Left panel in Console view showing model info, context usage, and stop button.
+ * Left panel in Console view: model info, live telemetry readouts, and the
+ * stop button. Polling, uptime, and the section renderings live in sibling
+ * modules — this file only composes them.
  */
 const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
   modelId,
@@ -61,92 +37,17 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
   activeTab,
   onTabChange,
 }) => {
-  const [uptime, setUptime] = useState(() => formatUptime(startTime));
-  const [metrics, setMetrics] = useState<ServerMetrics | null>(null);
   const [isStopping, setIsStopping] = useState(false);
-  const uptimeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Get server state from registry - undefined means not running
-  // Polling resumes automatically when status changes to 'running' via server:started event
+  // Server state from the registry — undefined means not running. Polling
+  // resumes automatically when status returns to 'running' via server:started.
   const serverState = useServerState(modelId);
   const isRunning = serverState?.status === 'running';
 
-  // Update uptime every second - sync to wall clock to prevent flicker
-  useEffect(() => {
-    // Clear any existing interval
-    if (uptimeIntervalRef.current) {
-      clearInterval(uptimeIntervalRef.current);
-    }
-    
-    // Initial update
-    setUptime(formatUptime(startTime));
-    
-    // Calculate ms until next whole second to sync updates
-    const msUntilNextSecond = 1000 - (Date.now() % 1000);
-    
-    // First, wait until next whole second, then start interval
-    const timeout = setTimeout(() => {
-      setUptime(formatUptime(startTime));
-      uptimeIntervalRef.current = setInterval(() => {
-        setUptime(formatUptime(startTime));
-      }, 1000);
-    }, msUntilNextSecond);
-    
-    return () => {
-      clearTimeout(timeout);
-      if (uptimeIntervalRef.current) {
-        clearInterval(uptimeIntervalRef.current);
-      }
-    };
-  }, [startTime]);
-
-  // Poll server metrics using setTimeout recursion + AbortController
-  // Only polls when server status is 'running'
-  // On fetch failure: stops local loop, clears metrics, does not affect global state
-  // Polling resumes automatically when status changes to 'running' via server:started event
-  useEffect(() => {
-    // Don't poll if server is not running
-    if (!isRunning) {
-      setMetrics(null);
-      return;
-    }
-
-    let cancelled = false;
-    const controller = new AbortController();
-
-    const fetchMetrics = async (): Promise<void> => {
-      try {
-        const response = await fetch(`http://127.0.0.1:${serverPort}/metrics`, {
-          signal: controller.signal,
-        });
-        if (response.ok && !cancelled) {
-          const text = await response.text();
-          const parsed = parsePrometheusMetrics(text);
-          setMetrics(parsed);
-        }
-      } catch {
-        // On any error (including abort), clear metrics and stop polling for this effect instance
-        if (!cancelled) {
-          setMetrics(null);
-          // Don't schedule next tick on error - effect will re-run when isRunning changes
-          return;
-        }
-      }
-
-      // Schedule next fetch if not cancelled and still running
-      if (!cancelled && isRunning) {
-        setTimeout(fetchMetrics, 2000);
-      }
-    };
-
-    // Start polling immediately
-    fetchMetrics();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [serverPort, isRunning]);
+  const uptime = useUptime(startTime);
+  const metrics = useServerMetrics(serverPort, isRunning);
+  // One server run = one history: a restart must not inherit the last run's charts.
+  const runKey = `${serverPort}:${startTime}`;
 
   const handleStopServer = useCallback(async () => {
     setIsStopping(true);
@@ -157,16 +58,9 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
     }
   }, [onStopServer]);
 
-  const contextUsagePercent = metrics?.kvCacheUsageRatio != null 
-    ? Math.round(metrics.kvCacheUsageRatio * 100) 
-    : metrics?.nTokensMax != null && contextLength 
-      ? Math.round((metrics.nTokensMax / contextLength) * 100)
-      : null;
-
   return (
     <div className="flex flex-col overflow-y-auto overflow-x-hidden border-b border-border relative tabular-nums flex-1 md:h-full md:min-h-0 md:border-b-0 md:border-r">
       <div className="p-md border-b border-border-light shrink-0">
-        {/* View Tabs */}
         <div className="mb-md">
           <Tabs<ChatPageTabId>
             tabs={CHAT_PAGE_TABS}
@@ -186,109 +80,11 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
 
       <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col">
         <div className="flex flex-col gap-lg">
-          {/* Server Info Section */}
-          <section className="flex flex-col gap-sm">
-            <h3 className="m-0 text-sm font-semibold text-text">Server Info</h3>
-            <Stack gap="xs">
-              <div className="flex justify-between items-center gap-sm py-xs">
-                <span className="text-sm text-text-muted">Port</span>
-                <span className="text-sm text-text flex items-center gap-xs [&_code]:bg-background [&_code]:py-[2px] [&_code]:px-[6px] [&_code]:rounded-xs [&_code]:font-mono [&_code]:text-xs">
-                  <code>{serverPort}</code>
-                  <Button
-                    iconOnly
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => navigator.clipboard.writeText(`http://127.0.0.1:${serverPort}`)}
-                    title="Copy server URL"
-                  >
-                    <Icon icon={Copy} size={14} />
-                  </Button>
-                </span>
-              </div>
-              <div className="flex justify-between items-center gap-sm py-xs">
-                <span className="text-sm text-text-muted">Uptime</span>
-                <span className="text-sm text-text">{uptime}</span>
-              </div>
-              {contextLength && (
-                <div className="flex justify-between items-center gap-sm py-xs">
-                  <span className="text-sm text-text-muted">Context Size</span>
-                  <span className="text-sm text-text">{contextLength.toLocaleString()} tokens</span>
-                </div>
-              )}
-            </Stack>
-          </section>
+          <ServerInfoSection serverPort={serverPort} uptime={uptime} contextLength={contextLength} />
+          <ContextUsageSection metrics={metrics} runKey={runKey} contextLength={contextLength} />
+          <StatisticsSection metrics={metrics} runKey={runKey} />
+          <ApiEndpointsSection />
 
-          {/* Context Usage Section */}
-          <section className="flex flex-col gap-sm">
-            <h3 className="m-0 text-sm font-semibold text-text">Context Usage</h3>
-            {contextUsagePercent !== null ? (
-              <Stack gap="xs">
-                <div className="h-[8px] bg-background rounded-sm overflow-hidden">
-                  <div 
-                    className={cn(
-                      "h-full rounded-sm transition-[width] duration-300 ease-out bg-gradient-to-r from-primary to-primary-hover",
-                      contextUsagePercent >= 80 && "from-warning to-warning-hover"
-                    )}
-                    style={{ width: `${Math.min(100, contextUsagePercent)}%` }}
-                  />
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-lg font-semibold text-text">{contextUsagePercent}%</span>
-                  {(metrics?.kvCacheTokens != null || metrics?.nTokensMax != null) && (
-                    <span className="text-xs text-text-muted">
-                      {(metrics.kvCacheTokens ?? metrics.nTokensMax ?? 0).toLocaleString()} tokens
-                    </span>
-                  )}
-                </div>
-              </Stack>
-            ) : (
-              <p className="text-xs text-text-muted m-0">
-                No usage yet
-              </p>
-            )}
-          </section>
-
-          {/* Request Stats Section */}
-          {metrics && (
-            <section className="flex flex-col gap-sm">
-              <h3 className="m-0 text-sm font-semibold text-text">Statistics</h3>
-              <Stack gap="xs">
-                <div className="flex justify-between items-center gap-sm py-xs">
-                  <span className="text-sm text-text-muted">Prompt Tokens</span>
-                  <span className="text-sm text-text">{metrics.promptTokensTotal.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between items-center gap-sm py-xs">
-                  <span className="text-sm text-text-muted">Generated Tokens</span>
-                  <span className="text-sm text-text">{metrics.predictedTokensTotal.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between items-center gap-sm py-xs">
-                  <span className="text-sm text-text-muted">Active Requests</span>
-                  <span className="text-sm text-text">{metrics.requestsProcessing}</span>
-                </div>
-              </Stack>
-            </section>
-          )}
-
-          {/* API Endpoints Section */}
-          <section className="flex flex-col gap-sm">
-            <h3 className="m-0 text-sm font-semibold text-text">API Endpoints</h3>
-            <Stack gap="xs">
-              <div className="flex flex-col gap-[2px] py-xs px-sm bg-background rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text">
-                <code>POST /v1/chat/completions</code>
-                <span className="text-2xs text-text-muted">OpenAI-compatible chat</span>
-              </div>
-              <div className="flex flex-col gap-[2px] py-xs px-sm bg-background rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text">
-                <code>POST /v1/completions</code>
-                <span className="text-2xs text-text-muted">Text completion</span>
-              </div>
-              <div className="flex flex-col gap-[2px] py-xs px-sm bg-background rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text">
-                <code>GET /health</code>
-                <span className="text-2xs text-text-muted">Health check</span>
-              </div>
-            </Stack>
-          </section>
-
-          {/* Stop Server Button */}
           <section className="flex flex-col gap-sm mt-auto pt-md">
             <Button
               variant="dangerGhost"
@@ -305,25 +101,5 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
     </div>
   );
 };
-
-/**
- * Parse Prometheus-format metrics text into structured data
- */
-function parsePrometheusMetrics(text: string): ServerMetrics {
-  const getMetricValue = (name: string): number | null => {
-    const regex = new RegExp(`^${name}\\s+([\\d.]+)`, 'm');
-    const match = text.match(regex);
-    return match ? parseFloat(match[1]) : null;
-  };
-
-  return {
-    kvCacheUsageRatio: getMetricValue('llamacpp:kv_cache_usage_ratio'),
-    kvCacheTokens: getMetricValue('llamacpp:kv_cache_tokens'),
-    nTokensMax: getMetricValue('llamacpp:n_tokens_max') ?? 0,
-    promptTokensTotal: getMetricValue('llamacpp:prompt_tokens_total') ?? 0,
-    predictedTokensTotal: getMetricValue('llamacpp:tokens_predicted_total') ?? 0,
-    requestsProcessing: getMetricValue('llamacpp:requests_processing') ?? 0,
-  };
-}
 
 export default ConsoleInfoPanel;

--- a/src/components/ConsoleInfoPanel/README.md
+++ b/src/components/ConsoleInfoPanel/README.md
@@ -11,7 +11,11 @@ Left panel in the console view showing the served model's identity, real-time in
 
 | File | Role |
 |------|------|
-| `ConsoleInfoPanel.tsx` | Metrics polling, uptime tick, stop-server action; syncs display with `serverRegistry` state |
+| `ConsoleInfoPanel.tsx` | Composition root: wires hooks to sections, stop-server action; syncs display with `serverRegistry` state |
+| `useServerMetrics.ts` | 2s `/metrics` poll (Prometheus parse); each poll's fresh object doubles as the metric-history tick |
+| `useUptime.ts` | Wall-clock-synced uptime string |
+| `TelemetrySections.tsx` | Context-usage and generation-rate readouts with sparklines (`useMetricHistory`, reset per server run) |
+| `StaticSections.tsx` | Server info rows and the API endpoint list |
 
 ## Props
 

--- a/src/components/ConsoleInfoPanel/StaticSections.tsx
+++ b/src/components/ConsoleInfoPanel/StaticSections.tsx
@@ -1,0 +1,71 @@
+import type { FC } from 'react';
+import { Copy } from 'lucide-react';
+import { Icon } from '../ui/Icon';
+import { Button } from '../ui/Button';
+import { Stack } from '../primitives';
+
+interface ServerInfoProps {
+  serverPort: number;
+  uptime: string;
+  contextLength?: number;
+}
+
+/** Port, uptime, and context-size facts about the running server. */
+export const ServerInfoSection: FC<ServerInfoProps> = ({ serverPort, uptime, contextLength }) => (
+  <section className="flex flex-col gap-sm">
+    <h3 className="m-0 text-sm font-semibold text-text">Server Info</h3>
+    <Stack gap="xs">
+      <div className="flex justify-between items-center gap-sm py-xs">
+        <span className="text-sm text-text-muted">Port</span>
+        <span className="text-sm text-text flex items-center gap-xs [&_code]:bg-background [&_code]:py-[2px] [&_code]:px-[6px] [&_code]:rounded-xs [&_code]:font-mono [&_code]:text-xs">
+          <code>{serverPort}</code>
+          <Button
+            iconOnly
+            size="sm"
+            variant="ghost"
+            onClick={() => navigator.clipboard.writeText(`http://127.0.0.1:${serverPort}`)}
+            title="Copy server URL"
+          >
+            <Icon icon={Copy} size={14} />
+          </Button>
+        </span>
+      </div>
+      <div className="flex justify-between items-center gap-sm py-xs">
+        <span className="text-sm text-text-muted">Uptime</span>
+        <span className="text-sm text-text font-mono tabular-nums">{uptime}</span>
+      </div>
+      {contextLength && (
+        <div className="flex justify-between items-center gap-sm py-xs">
+          <span className="text-sm text-text-muted">Context Size</span>
+          <span className="text-sm text-text font-mono tabular-nums">
+            {contextLength.toLocaleString()} tokens
+          </span>
+        </div>
+      )}
+    </Stack>
+  </section>
+);
+
+const ENDPOINTS = [
+  { route: 'POST /v1/chat/completions', description: 'OpenAI-compatible chat' },
+  { route: 'POST /v1/completions', description: 'Text completion' },
+  { route: 'GET /health', description: 'Health check' },
+] as const;
+
+/** The static list of API endpoints the server exposes. */
+export const ApiEndpointsSection: FC = () => (
+  <section className="flex flex-col gap-sm">
+    <h3 className="m-0 text-sm font-semibold text-text">API Endpoints</h3>
+    <Stack gap="xs">
+      {ENDPOINTS.map(({ route, description }) => (
+        <div
+          key={route}
+          className="flex flex-col gap-[2px] py-xs px-sm bg-background rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text"
+        >
+          <code>{route}</code>
+          <span className="text-2xs text-text-muted">{description}</span>
+        </div>
+      ))}
+    </Stack>
+  </section>
+);

--- a/src/components/ConsoleInfoPanel/TelemetrySections.tsx
+++ b/src/components/ConsoleInfoPanel/TelemetrySections.tsx
@@ -1,0 +1,109 @@
+import type { FC } from 'react';
+import { Readout, Sparkline, Stack } from '../primitives';
+import { useMetricHistory } from '../../hooks/useMetricHistory';
+import { formatRate } from '../../utils/formatRate';
+import type { ServerMetrics } from './useServerMetrics';
+
+interface TelemetryProps {
+  /** Latest poll result; a fresh object per poll, used directly as the history tick. */
+  metrics: ServerMetrics | null;
+  /** Identity of the server run — clears histories across a stop/start cycle. */
+  runKey: unknown;
+  contextLength?: number;
+}
+
+/** One label/value stat row, matching the panel's existing type scale. */
+const Row: FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex justify-between items-center gap-sm py-xs">
+    <span className="text-sm text-text-muted">{label}</span>
+    <span className="text-sm text-text font-mono tabular-nums">{value}</span>
+  </div>
+);
+
+/**
+ * Context usage as a readout + sparkline (fixed 0–100 domain, so the line
+ * shows real movement rather than autoscaled noise). Thresholds match the
+ * donut: 70 warning, 90 danger.
+ */
+export const ContextUsageSection: FC<TelemetryProps> = ({ metrics, runKey, contextLength }) => {
+  const pct =
+    metrics?.kvCacheUsageRatio != null
+      ? Math.round(metrics.kvCacheUsageRatio * 100)
+      : metrics?.nTokensMax != null && contextLength
+        ? Math.round((metrics.nTokensMax / contextLength) * 100)
+        : null;
+  const history = useMetricHistory(pct, { tick: metrics, resetKey: runKey });
+
+  return (
+    <section className="flex flex-col gap-sm">
+      <h3 className="m-0 text-sm font-semibold text-text">Context Usage</h3>
+      {pct !== null ? (
+        <Stack gap="xs">
+          <Readout
+            label="KV cache"
+            value={pct}
+            unit="%"
+            intent={pct >= 90 ? 'danger' : pct >= 70 ? 'warning' : 'neutral'}
+            trend={
+              <Sparkline
+                values={history.values}
+                min={0}
+                max={100}
+                width={120}
+                height={24}
+                ariaLabel="Context usage, recent history"
+                className="text-primary"
+              />
+            }
+          />
+          {(metrics?.kvCacheTokens != null || metrics?.nTokensMax != null) && (
+            <span className="text-xs text-text-muted">
+              {(metrics.kvCacheTokens ?? metrics.nTokensMax ?? 0).toLocaleString()} tokens
+            </span>
+          )}
+        </Stack>
+      ) : (
+        <p className="text-xs text-text-muted m-0">No usage yet</p>
+      )}
+    </section>
+  );
+};
+
+/** Generation rate readout plus the cumulative counters it derives from. */
+export const StatisticsSection: FC<Omit<TelemetryProps, 'contextLength'>> = ({
+  metrics,
+  runKey,
+}) => {
+  const genRate = useMetricHistory(metrics?.predictedTokensTotal, {
+    mode: 'rate',
+    tick: metrics,
+    resetKey: runKey,
+  });
+
+  if (!metrics) return null;
+
+  return (
+    <section className="flex flex-col gap-sm">
+      <h3 className="m-0 text-sm font-semibold text-text">Statistics</h3>
+      <Readout
+        label="Generation"
+        value={genRate.latest != null ? formatRate(genRate.latest) : '—'}
+        unit="tok/s"
+        trend={
+          <Sparkline
+            values={genRate.values}
+            width={120}
+            height={24}
+            ariaLabel="Generation rate, recent history"
+            className="text-primary"
+          />
+        }
+      />
+      <Stack gap="xs">
+        <Row label="Prompt Tokens" value={metrics.promptTokensTotal.toLocaleString()} />
+        <Row label="Generated Tokens" value={metrics.predictedTokensTotal.toLocaleString()} />
+        <Row label="Active Requests" value={String(metrics.requestsProcessing)} />
+      </Stack>
+    </section>
+  );
+};

--- a/src/components/ConsoleInfoPanel/useServerMetrics.ts
+++ b/src/components/ConsoleInfoPanel/useServerMetrics.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+export interface ServerMetrics {
+  kvCacheUsageRatio: number | null;
+  kvCacheTokens: number | null;
+  nTokensMax: number;
+  promptTokensTotal: number;
+  predictedTokensTotal: number;
+  requestsProcessing: number;
+}
+
+/** Parse Prometheus-format metrics text into structured data. */
+export function parsePrometheusMetrics(text: string): ServerMetrics {
+  const getMetricValue = (name: string): number | null => {
+    const regex = new RegExp(`^${name}\\s+([\\d.]+)`, 'm');
+    const match = text.match(regex);
+    return match ? parseFloat(match[1]) : null;
+  };
+
+  return {
+    kvCacheUsageRatio: getMetricValue('llamacpp:kv_cache_usage_ratio'),
+    kvCacheTokens: getMetricValue('llamacpp:kv_cache_tokens'),
+    nTokensMax: getMetricValue('llamacpp:n_tokens_max') ?? 0,
+    promptTokensTotal: getMetricValue('llamacpp:prompt_tokens_total') ?? 0,
+    predictedTokensTotal: getMetricValue('llamacpp:tokens_predicted_total') ?? 0,
+    requestsProcessing: getMetricValue('llamacpp:requests_processing') ?? 0,
+  };
+}
+
+/**
+ * Poll llama-server's /metrics every 2s while the server is running.
+ *
+ * Uses setTimeout recursion + AbortController. On fetch failure the local loop
+ * stops and the metrics clear without touching global state; polling resumes
+ * automatically when `isRunning` flips back via the server:started event.
+ *
+ * Each poll stores a freshly parsed object, so the returned value's identity
+ * changes once per poll — consumers use it directly as the metric-history tick.
+ */
+export function useServerMetrics(serverPort: number, isRunning: boolean): ServerMetrics | null {
+  const [sample, setSample] = useState<ServerMetrics | null>(null);
+
+  useEffect(() => {
+    if (!isRunning) {
+      setSample(null);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const fetchMetrics = async (): Promise<void> => {
+      try {
+        const response = await fetch(`http://127.0.0.1:${serverPort}/metrics`, {
+          signal: controller.signal,
+        });
+        if (response.ok && !cancelled) {
+          const text = await response.text();
+          setSample(parsePrometheusMetrics(text));
+        }
+      } catch {
+        if (!cancelled) {
+          setSample(null);
+          return;
+        }
+      }
+
+      if (!cancelled && isRunning) {
+        setTimeout(fetchMetrics, 2000);
+      }
+    };
+
+    fetchMetrics();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [serverPort, isRunning]);
+
+  return sample;
+}

--- a/src/components/ConsoleInfoPanel/useUptime.ts
+++ b/src/components/ConsoleInfoPanel/useUptime.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** Format an uptime duration in a human-readable way. */
+const formatUptime = (startTime: number): string => {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - startTime;
+
+  if (diff < 60) {
+    return `${diff}s`;
+  } else if (diff < 3600) {
+    const mins = Math.floor(diff / 60);
+    const secs = diff % 60;
+    return `${mins}m ${secs}s`;
+  } else {
+    const hours = Math.floor(diff / 3600);
+    const mins = Math.floor((diff % 3600) / 60);
+    return `${hours}h ${mins}m`;
+  }
+};
+
+/**
+ * Live uptime string for a server started at `startTime` (unix seconds).
+ * Updates are synced to the wall-clock second boundary to prevent flicker.
+ */
+export function useUptime(startTime: number): string {
+  const [uptime, setUptime] = useState(() => formatUptime(startTime));
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    setUptime(formatUptime(startTime));
+
+    const msUntilNextSecond = 1000 - (Date.now() % 1000);
+    const timeout = setTimeout(() => {
+      setUptime(formatUptime(startTime));
+      intervalRef.current = setInterval(() => {
+        setUptime(formatUptime(startTime));
+      }, 1000);
+    }, msUntilNextSecond);
+
+    return () => {
+      clearTimeout(timeout);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [startTime]);
+
+  return uptime;
+}

--- a/src/components/ContextUsageDonut.tsx
+++ b/src/components/ContextUsageDonut.tsx
@@ -38,7 +38,9 @@ export const ContextUsageDonut: FC<ContextUsageDonutProps> = ({
   const dashOffset = circumference * (1 - fraction);
   const pct = Math.round(fraction * 100);
 
-  const strokeClass = pct >= 90 ? 'stroke-danger' : pct >= 70 ? 'stroke-warning' : 'stroke-success';
+  // Base ring wears the accent: green is reserved for running/online status,
+  // not for "usage is fine" — only the 70/90 thresholds speak in semantics.
+  const strokeClass = pct >= 90 ? 'stroke-danger' : pct >= 70 ? 'stroke-warning' : 'stroke-primary';
 
   return (
     <div

--- a/src/components/ProxyCachePanel.tsx
+++ b/src/components/ProxyCachePanel.tsx
@@ -4,10 +4,11 @@
  * Prompt-cache section of the proxy dashboard: any configuration warnings the
  * backend raised, followed by measured reuse totals.
  *
- * Every figure shown is one the upstream actually reported. Nothing is
- * derived — in particular there is no "time saved", because reuse counts are
- * exact while what that reuse saved depends on a prefill that never ran. See
- * `gglib_core::cache_metrics` for the same reasoning on the backend.
+ * Every figure shown is grounded in counts the upstream actually reported:
+ * the hit-rate readouts are ratios of exact reported totals. Speculative
+ * projections stay out — in particular there is no "time saved", because
+ * reuse counts are exact while what that reuse saved depends on a prefill
+ * that never ran. See `gglib_core::cache_metrics` for the same reasoning.
  *
  * Extracted from `ProxyDashboardModal` to keep both files small and to make
  * the formatting logic testable without mounting the modal's dashboard stream
@@ -18,6 +19,7 @@
 
 import type { FC } from 'react';
 import { Banner } from './ui/Banner';
+import { Readout } from './primitives';
 import type { CacheStatus, CacheUsage } from '../services/transport/types/dashboard';
 
 export interface ProxyCachePanelProps {
@@ -35,7 +37,7 @@ function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-baseline justify-between gap-md">
       <span className="text-xs text-text-muted">{label}</span>
-      <span className="text-sm text-text tabular-nums">{value}</span>
+      <span className="text-sm text-text font-mono tabular-nums">{value}</span>
     </div>
   );
 }
@@ -50,10 +52,27 @@ function Row({ label, value }: { label: string; value: string }) {
 export const CacheUsageRows: FC<{ usage?: CacheUsage | null }> = ({ usage }) => {
   const hasMeasurements = (usage?.reporting_requests ?? 0) > 0;
 
+  const hitRatePct =
+    usage && hasMeasurements && usage.prompt_tokens > 0
+      ? Math.round((usage.cached_tokens / usage.prompt_tokens) * 100)
+      : null;
+  const lastRatePct =
+    usage && usage.last_cached_tokens != null && usage.last_prompt_tokens
+      ? Math.round((usage.last_cached_tokens / usage.last_prompt_tokens) * 100)
+      : null;
+
   return (
-    <div className="flex flex-col gap-xs p-md rounded-base border border-border bg-surface-elevated">
+    <div className="flex flex-col gap-xs p-md rounded-base bg-surface-elevated">
       {usage && hasMeasurements ? (
         <>
+          {(hitRatePct != null || lastRatePct != null) && (
+            <div className="flex gap-xl pb-sm">
+              {hitRatePct != null && <Readout label="Cache hit rate" value={hitRatePct} unit="%" />}
+              {lastRatePct != null && (
+                <Readout label="Last request reuse" value={lastRatePct} unit="%" />
+              )}
+            </div>
+          )}
           <Row label="Used from cache" value={`${formatCount(usage.cached_tokens)} tokens`} />
           <Row label="Prompt tokens processed" value={`${formatCount(usage.prompt_tokens)} tokens`} />
           <Row label="Requests measured" value={formatCount(usage.reporting_requests)} />

--- a/src/components/primitives/Readout.tsx
+++ b/src/components/primitives/Readout.tsx
@@ -14,9 +14,15 @@ interface ReadoutProps {
   size?: ReadoutSize;
   /** Slot for a Sparkline (or other trend mark) rendered under the value. */
   trend?: React.ReactNode;
-  align?: 'start' | 'end';
+  align?: 'start' | 'center' | 'end';
   className?: string;
 }
+
+const alignClasses = {
+  start: '',
+  center: 'items-center text-center',
+  end: 'items-end text-right',
+} as const;
 
 const intentClasses: Record<ReadoutIntent, string> = {
   neutral: 'text-text',
@@ -48,7 +54,7 @@ export const Readout: React.FC<ReadoutProps> = ({
   align = 'start',
   className,
 }) => (
-  <div className={cn('flex min-w-0 flex-col', align === 'end' && 'items-end text-right', className)}>
+  <div className={cn('flex min-w-0 flex-col', alignClasses[align], className)}>
     <span className="text-xs text-text-muted">{label}</span>
     <span
       className={cn(

--- a/src/components/proxy/ProxyMetricsGrid.tsx
+++ b/src/components/proxy/ProxyMetricsGrid.tsx
@@ -1,5 +1,6 @@
 import type { FC, ReactNode } from 'react';
 import { ConnectionRow } from './ConnectionRow';
+import { RequestThroughput } from './RequestThroughput';
 import { SlotCard } from './SlotCard';
 import type { DashboardSnapshot } from '../../services/transport/types/dashboard';
 
@@ -21,6 +22,7 @@ export const ActiveConnectionsSection: FC<SectionProps> = ({ snapshot }) => {
   return (
     <section>
       <Heading>Active Connections{snapshot ? ` (${connections.length})` : ''}</Heading>
+      <RequestThroughput snapshot={snapshot} />
       {connections.length > 0 ? (
         <div className="flex flex-col gap-sm">
           {connections.map((connection) => (
@@ -49,7 +51,13 @@ export const InferenceSlotsSection: FC<SectionProps> = ({ snapshot, compact = fa
       {hasSlots ? (
         <div className="flex flex-wrap gap-md">
           {snapshot?.slots.map((slot) => (
-            <SlotCard key={slot.id} slot={slot} size={compact ? 56 : 80} />
+            <SlotCard
+              key={slot.id}
+              slot={slot}
+              size={compact ? 56 : 80}
+              tick={snapshot}
+              resetKey={snapshot?.launch?.model_name}
+            />
           ))}
         </div>
       ) : (

--- a/src/components/proxy/RequestThroughput.tsx
+++ b/src/components/proxy/RequestThroughput.tsx
@@ -1,0 +1,41 @@
+import type { FC } from 'react';
+import { Readout, Sparkline } from '../primitives';
+import { useMetricHistory } from '../../hooks/useMetricHistory';
+import { formatRate } from '../../utils/formatRate';
+import type { DashboardSnapshot } from '../../services/transport/types/dashboard';
+
+interface RequestThroughputProps {
+  snapshot: DashboardSnapshot | null;
+}
+
+/**
+ * Requests-per-second derived from the snapshot's cumulative `total_requests`
+ * counter. The snapshot object itself is the tick, so a quiet proxy registers
+ * as a zero rate rather than a frozen chart.
+ *
+ * Rendered as a full row (readout left, sparkline right) under the section
+ * heading rather than beside it — the heading and a readout label are both
+ * small type, and stacking keeps the hierarchy legible at the tray's 360px.
+ */
+export const RequestThroughput: FC<RequestThroughputProps> = ({ snapshot }) => {
+  const rate = useMetricHistory(snapshot?.total_requests, { mode: 'rate', tick: snapshot });
+
+  if (!snapshot) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-md mb-sm">
+      <Readout
+        size="sm"
+        label="Throughput"
+        value={rate.latest != null ? formatRate(rate.latest) : '—'}
+        unit="req/s"
+      />
+      <Sparkline
+        values={rate.values}
+        width={96}
+        ariaLabel="Request throughput, recent history"
+        className="text-primary"
+      />
+    </div>
+  );
+};

--- a/src/components/proxy/SlotCard.tsx
+++ b/src/components/proxy/SlotCard.tsx
@@ -1,25 +1,59 @@
 import type { FC } from 'react';
 import { ContextUsageDonut } from '../ContextUsageDonut';
+import { Readout, Sparkline } from '../primitives';
+import { useMetricHistory } from '../../hooks/useMetricHistory';
+import { formatRate } from '../../utils/formatRate';
 import { tokensInUse, type SlotSnapshot } from '../../services/transport/types/dashboard';
 
 interface SlotCardProps {
   slot: SlotSnapshot;
   /** Donut diameter in px. The tray popover renders these smaller. */
   size?: number;
+  /**
+   * Snapshot identity — one change per dashboard event. Omitting it means an
+   * unchanged counter never records, so the rate readout freezes at its last
+   * value instead of decaying to zero when the slot idles.
+   */
+  tick?: unknown;
+  /**
+   * Identity of the served model. Slot ids survive a model swap, so without
+   * this the sparkline would stitch two models' throughput into one series.
+   */
+  resetKey?: unknown;
 }
 
-/** One llama.cpp inference slot and how much of its context is in use. */
-export const SlotCard: FC<SlotCardProps> = ({ slot, size = 80 }) => (
-  <div className="flex flex-col items-center gap-sm p-md rounded-base border border-border bg-surface-elevated">
-    <ContextUsageDonut
-      used={tokensInUse(slot)}
-      total={slot.n_ctx ?? null}
-      size={size}
-      strokeWidth={size / 10}
-    />
-    <span className="text-xs text-text-muted">
-      Slot {slot.id}
-      {slot.is_processing ? ' · active' : ''}
-    </span>
-  </div>
-);
+/**
+ * One llama.cpp inference slot: context-usage donut plus a live generation
+ * readout. Owns its own metric history — per-slot series belong with per-slot
+ * component identity, which keeps the parent sections presentational and the
+ * tray and modal rendering identical.
+ */
+export const SlotCard: FC<SlotCardProps> = ({ slot, size = 80, tick, resetKey }) => {
+  const nextToken = Array.isArray(slot.next_token) ? slot.next_token[0] : slot.next_token;
+  const genRate = useMetricHistory(nextToken?.n_decoded, { mode: 'rate', tick, resetKey });
+
+  return (
+    <div className="flex flex-col items-center gap-sm p-md rounded-base bg-surface-elevated">
+      <ContextUsageDonut
+        used={tokensInUse(slot)}
+        total={slot.n_ctx ?? null}
+        size={size}
+        strokeWidth={size / 10}
+      />
+      <Readout
+        size="sm"
+        align="center"
+        label={`Slot ${slot.id}${slot.is_processing ? ' · active' : ''}`}
+        value={genRate.latest != null ? formatRate(genRate.latest) : '—'}
+        unit="tok/s"
+        trend={
+          <Sparkline
+            values={genRate.values}
+            ariaLabel={`Slot ${slot.id} generation rate, recent history`}
+            className="text-primary"
+          />
+        }
+      />
+    </div>
+  );
+};

--- a/src/utils/formatRate.ts
+++ b/src/utils/formatRate.ts
@@ -1,0 +1,4 @@
+/** Compact per-second rate figure: sub-10 keeps one decimal, larger values round whole. */
+export function formatRate(perSecond: number): string {
+  return perSecond < 10 ? perSecond.toFixed(1) : String(Math.round(perSecond));
+}


### PR DESCRIPTION
PR 4/13 of the precision-instrument restyle — **stacked on** `feat(gui)/readout-primitives` (#759). The signature telemetry treatment goes live: the app's metrics now render as instruments, not static numbers.

## What changed
- **Proxy slots** (`SlotCard`): each slot card gains a live generation readout with sparkline (rate derived from `next_token.n_decoded`, MTP element-0 aware). Per-slot history lives with per-slot component identity, so the parent sections stay presentational; `resetKey = launch.model_name` prevents one model's series stitching into the next across a swap. Slot-card border dropped per the borderless contract.
- **Request throughput** (`RequestThroughput`): req/s readout + sparkline derived from cumulative `total_requests`, rendered as its own row under the Active Connections heading (stacked rather than inline, so the hierarchy holds at the tray's 360px).
- **Donut**: base ring (<70%) switches `stroke-success` → `stroke-primary` — green stays reserved for running/online; only the 70/90 thresholds speak in semantics.
- **Console** (`ConsoleInfoPanel`, 329 LOC → five modules of 53–104): polling extracted to `useServerMetrics` (each poll's fresh object doubles as the history tick), uptime to `useUptime`; the gradient context bar is replaced by a KV% readout + fixed-domain sparkline (thresholds matching the donut), and Statistics gains a generation tok/s readout. Histories reset per server run (`serverPort:startTime`), so a restart never inherits the previous run's charts.
- **Cache panel**: cache hit-rate and last-request-reuse readouts — ratios of exact reported counts (speculative projections stay out, per the panel's own doctrine).
- **Tray**: gets all of it with zero changes — it renders the same shared sections.

## Wire-data notes
No tokens/s field exists anywhere on the wire; all rates are client-derived by differencing counters against measured wall-clock dt. The snapshot/metrics object identity is the change-signal, so stalled counters register as zero rates instead of frozen charts.

## Review gate
15 findings raised, 8 confirmed and fixed — including model-swap series stitching (traced into the Rust slots poller: slot cards provably never unmount during a clean swap), stale history across server restarts, and a dead `fetchedAt` field with a misleading doc.

`npm run lint` / `test:run` (758 passed) / `build` all green. Every touched file is under the 200-LOC budget.