### PR TITLE
docs(styles): contract update + full-app polish sweep

### DIFF
--- a/src/components/AddMcpServerModal.tsx
+++ b/src/components/AddMcpServerModal.tsx
@@ -7,6 +7,7 @@ import type { McpServerType } from "../services/transport/types/mcp";
 import { Modal } from "./ui/Modal";
 import { Banner } from './ui/Banner';
 import { Checkbox } from './ui/Checkbox';
+import { Select } from './ui/Select';
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
 import { ServerTemplatePicker, type ServerTemplate } from "./AddMcpServerModal/ServerTemplatePicker";
@@ -256,17 +257,16 @@ export const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
               <label className="text-sm font-semibold text-text" htmlFor="mcp-lifecycle">
                 Lifecycle
               </label>
-              <select
+              <Select
                 id="mcp-lifecycle"
                 value={lifecycle}
                 onChange={(e) => setLifecycle(e.target.value as 'eager' | 'lazy' | 'manual')}
                 disabled={saving}
-                className="rounded-base border border-input-border bg-input px-sm py-xs text-sm text-text focus:outline-none focus:ring-1 focus:ring-primary"
               >
                 <option value="lazy">Lazy — start on first tool use</option>
                 <option value="eager">Eager — start when app launches</option>
                 <option value="manual">Manual — never auto-spawn</option>
-              </select>
+              </Select>
               <Checkbox
                 checked={enabled}
                 onChange={(e) => setEnabled(e.target.checked)}

--- a/src/components/AddModel.tsx
+++ b/src/components/AddModel.tsx
@@ -6,6 +6,7 @@ import { Button } from "./ui/Button";
 import { Banner } from './ui/Banner';
 import { Icon } from "./ui/Icon";
 import { Input } from "./ui/Input";
+import { Label } from "./primitives";
 import { getTransport } from '../services/transport';
 
 interface AddModelProps {
@@ -54,12 +55,12 @@ const AddModel: FC<AddModelProps> = ({ onModelAdded }) => {
   };
 
   return (
-    <div className="bg-surface rounded-lg p-xl max-w-[800px] shadow-md border border-border">
-      <h2>Add New Model</h2>
+    <div className="bg-surface rounded-md p-xl max-w-[800px]">
+      <h2 className="text-lg font-semibold text-text mb-lg">Add local model</h2>
 
       <form onSubmit={handleSubmit} className="add-model-form">
         <div className="mb-lg">
-          <label htmlFor="filePath">Model File Path:</label>
+          <Label size="xs" muted htmlFor="filePath" className="mb-xs">Model file path</Label>
           <div className="flex flex-col items-stretch gap-sm md:flex-row md:flex-wrap">
             <Input
               type="text"
@@ -71,6 +72,7 @@ const AddModel: FC<AddModelProps> = ({ onModelAdded }) => {
             />
             <Button
               type="button"
+              variant="secondary"
               onClick={handleBrowse}
               leftIcon={<Icon icon={FolderOpen} size={14} />}
               className="w-full md:w-auto"

--- a/src/components/Benchmark/Tune/TuneConfigForm.tsx
+++ b/src/components/Benchmark/Tune/TuneConfigForm.tsx
@@ -9,10 +9,12 @@
  * @module components/Benchmark/Tune/TuneConfigForm
  */
 
-import { FC, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 import { Checkbox } from '../../ui/Checkbox';
 import { Button } from '../../ui/Button';
 import { Input } from '../../ui/Input';
+import { Select } from '../../ui/Select';
+import { Chip } from '../../ui/Chip';
 import type { GgufModel } from '../../../types';
 import type { TuneConfig, TuneTask } from '../../../types/benchmark';
 
@@ -49,6 +51,8 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
   const [suiteMode, setSuiteMode] = useState<'default' | 'custom'>('default');
   const [customTasks, setCustomTasks] = useState<TuneTask[] | null>(null);
   const [customSuiteError, setCustomSuiteError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [seedFromGguf, setSeedFromGguf] = useState(true);
   const [seedFromFamilyPresets, setSeedFromFamilyPresets] = useState(true);
@@ -122,8 +126,8 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
         <label className="text-xs font-semibold text-text">
           Model
         </label>
-        <select
-          className="w-full bg-surface border border-border rounded-md px-sm py-xs text-sm text-text"
+        <Select
+          size="sm"
           value={modelId}
           disabled={disabled}
           onChange={e => setModelId(e.target.value ? Number(e.target.value) : '')}
@@ -134,7 +138,7 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
               {m.name}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
 
       <div className="flex flex-col gap-xs">
@@ -205,34 +209,38 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
           Task Suite
         </label>
         <div className="flex gap-sm">
-          <Button
-            variant={suiteMode === 'default' ? 'primary' : 'secondary'}
-            size="sm"
-            fullWidth
-            disabled={disabled}
-            onClick={() => setSuiteMode('default')}
-          >
+          <Chip selected={suiteMode === 'default'} disabled={disabled} onClick={() => setSuiteMode('default')}>
             Default
-          </Button>
-          <Button
-            variant={suiteMode === 'custom' ? 'primary' : 'secondary'}
-            size="sm"
-            fullWidth
-            disabled={disabled}
-            onClick={() => setSuiteMode('custom')}
-          >
+          </Chip>
+          <Chip selected={suiteMode === 'custom'} disabled={disabled} onClick={() => setSuiteMode('custom')}>
             Custom
-          </Button>
+          </Chip>
         </div>
         {suiteMode === 'custom' && (
           <div className="flex flex-col gap-xs">
             <input
+              ref={fileInputRef}
               type="file"
+              tabIndex={-1}
+              aria-hidden="true"
               accept=".json,application/json"
               disabled={disabled}
-              onChange={e => handleFileChange(e.target.files?.[0] ?? null)}
-              className="text-xs text-text-secondary"
+              onChange={e => {
+                const file = e.target.files?.[0] ?? null;
+                setFileName(file?.name ?? null);
+                handleFileChange(file);
+              }}
+              className="sr-only"
             />
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={disabled}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Choose task file…
+            </Button>
+            {fileName && <span className="text-xs text-text-muted">{fileName}</span>}
             {customTasks && (
               <p className="text-xs text-success">{customTasks.length} task(s) loaded</p>
             )}

--- a/src/components/Benchmark/Tune/TuneLeaderboard.tsx
+++ b/src/components/Benchmark/Tune/TuneLeaderboard.tsx
@@ -9,6 +9,7 @@
 
 import { FC } from 'react';
 import { Button } from '../../ui/Button';
+import { Chip } from '../../ui/Chip';
 import { cn } from '../../../utils/cn';
 import type { TuneCandidateResult } from '../../../types/benchmark';
 
@@ -78,35 +79,31 @@ export const TuneLeaderboard: FC<TuneLeaderboardProps> = ({
             key={i}
             className="border-b border-border-light hover:bg-surface-elevated transition-colors"
           >
-            <td className="px-base py-xs text-text-secondary">{i + 1}</td>
+            <td className="px-base py-xs text-text-secondary font-mono tabular-nums">{i + 1}</td>
             <td className="px-base py-xs text-text-secondary">{sourceLabel(result.source)}</td>
-            <td className="px-base py-xs text-text-secondary">
+            <td className="px-base py-xs text-text-secondary font-mono tabular-nums">
               {result.config.temperature?.toFixed(2) ?? '—'}
             </td>
-            <td className="px-base py-xs text-text-secondary">
+            <td className="px-base py-xs text-text-secondary font-mono tabular-nums">
               {result.config.dryMultiplier?.toFixed(2) ?? '—'}
             </td>
-            <td className="px-base py-xs text-text-secondary">
+            <td className="px-base py-xs text-text-secondary font-mono tabular-nums">
               {result.config.topP?.toFixed(2) ?? '—'}
             </td>
-            <td className="px-base py-xs font-semibold text-text">
+            <td className="px-base py-xs font-semibold text-text font-mono tabular-nums">
               {result.composite_score.toFixed(3)}
             </td>
-            <td className="px-base py-xs text-text-secondary">
+            <td className="px-base py-xs text-text-secondary font-mono tabular-nums">
               {(averageToolMatch(result) * 100).toFixed(0)}%
             </td>
-            <td className="px-base py-xs text-text-secondary">
+            <td className="px-base py-xs text-text-secondary font-mono tabular-nums">
               {(loopFreeRate(result) * 100).toFixed(0)}%
             </td>
             <td className="px-base py-xs">
               {result.pruned ? (
-                <span className="py-xs px-sm rounded-sm font-medium bg-warning-subtle text-warning">
-                  pruned
-                </span>
+                <Chip size="sm" variant="warning">pruned</Chip>
               ) : (
-                <span className="py-xs px-sm rounded-sm font-medium bg-success-subtle text-success">
-                  survived
-                </span>
+                <span className="text-text-muted">survived</span>
               )}
             </td>
             <td className={cn('px-base py-xs')}>

--- a/src/components/Benchmark/Tune/TuneLiveProgress.tsx
+++ b/src/components/Benchmark/Tune/TuneLiveProgress.tsx
@@ -58,7 +58,7 @@ export const TuneLiveProgress: FC<TuneLiveProgressProps> = ({
         />
       </div>
 
-      <div className="flex flex-col gap-xs max-h-[220px] overflow-y-auto border border-border rounded-md p-sm">
+      <div className="flex flex-col gap-xs max-h-[220px] overflow-y-auto bg-surface rounded-md p-sm">
         {taskLog.length === 0 && prunedLog.length === 0 && (
           <p className="text-xs text-text-muted">Waiting for events…</p>
         )}

--- a/src/components/Benchmark/Tune/TuneTab.tsx
+++ b/src/components/Benchmark/Tune/TuneTab.tsx
@@ -16,6 +16,7 @@
 
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { AlertTriangle, Target } from 'lucide-react';
+import { EmptyState } from '../../primitives';
 import { Icon } from '../../ui/Icon';
 import type { GgufModel } from '../../../types';
 import type { BenchmarkEvent, TuneCandidateResult, TuneConfig } from '../../../types/benchmark';
@@ -191,12 +192,12 @@ export const TuneTab: FC<TuneTabProps> = ({ models }) => {
       <div className="flex-1 flex flex-col overflow-hidden">
         <div className="flex-1 overflow-y-auto p-base flex flex-col gap-base">
           {runState.status === 'idle' ? (
-            <div className="flex flex-col items-center justify-center h-full text-text-muted gap-sm">
-              <Icon icon={Target} size={32} className="opacity-30" />
-              <p className="text-sm">
-                Configure a sweep and press Run Tune to find the best sampling settings.
-              </p>
-            </div>
+            <EmptyState
+              className="h-full"
+              icon={<Icon icon={Target} size={24} />}
+              title="No tune run yet"
+              description="Configure a sweep and press Run Tune to score sampling candidates against the task suite."
+            />
           ) : (
             <>
               <TuneLiveProgress
@@ -208,7 +209,7 @@ export const TuneTab: FC<TuneTabProps> = ({ models }) => {
               {applyMessage && (
                 <div className="text-xs text-text bg-surface rounded-md p-sm">{applyMessage}</div>
               )}
-              <div className="border border-border rounded-md overflow-x-auto">
+              <div className="bg-surface rounded-md overflow-x-auto">
                 <TuneLeaderboard
                   results={runState.results}
                   applyingIndex={applyingIndex}

--- a/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
+++ b/src/components/ChatMessagesPanel/ChatMessagesPanel.tsx
@@ -201,7 +201,7 @@ const ChatMessagesPanel: React.FC<ChatMessagesPanelProps> = ({
         />
 
         {/* Messages area */}
-        <div className="flex-1 min-h-0 flex flex-col border border-border rounded-base bg-background overflow-hidden">
+        <div className="flex-1 min-h-0 flex flex-col rounded-md bg-background overflow-hidden">
           {messageLoading ? (
             <div className="flex items-center justify-center h-full text-text-muted">Loading messages…</div>
           ) : (

--- a/src/components/ChatMessagesPanel/components/ChatPanelHeader.tsx
+++ b/src/components/ChatMessagesPanel/components/ChatPanelHeader.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { Download, Pencil, RotateCcw, Sparkles } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { Icon } from '../../ui/Icon';
+import { Chip } from '../../ui/Chip';
 import { Input } from '../../ui/Input';
 import { ToolsPopover } from '../../ToolsPopover';
 import { ToolSupportIndicator } from '../../ToolSupportIndicator';
@@ -92,9 +93,13 @@ export const ChatPanelHeader: FC<ChatPanelHeaderProps> = ({
           <Icon icon={Sparkles} size={14} />
         )}
       </Button>
-      <span className={cn('text-xs py-xs px-sm rounded-full bg-background text-text-muted shrink-0', isThreadRunning && 'bg-primary/10 text-primary animate-research-pulse')}>
+      <Chip
+        size="md"
+        variant={isThreadRunning ? 'primary' : 'neutral'}
+        className={cn('shrink-0', isThreadRunning && 'animate-research-pulse')}
+      >
         {isThreadRunning ? 'Responding…' : 'Idle'}
-      </span>
+      </Chip>
       <ToolSupportIndicator
         supports={supportsToolCalls ?? null}
         hasToolsConfigured={getToolRegistry().getEnabledDefinitions().length > 0}

--- a/src/components/ChatMessagesPanel/components/ComposerFooter.tsx
+++ b/src/components/ChatMessagesPanel/components/ComposerFooter.tsx
@@ -18,13 +18,13 @@ export const ComposerFooter: FC<ComposerFooterProps> = ({
   isThreadRunning,
   onStopGeneration,
 }) => (
-  <div className="border-t border-border p-md shrink-0">
+  <div className="border-t border-border-light p-md shrink-0">
     {isThreadRunning && (
       <div className="text-sm text-primary mb-sm animate-research-pulse">Assistant is thinking…</div>
     )}
     <ComposerPrimitive.Root className="flex gap-sm items-end">
       <ComposerPrimitive.Input
-        className="flex-1 py-sm px-md border border-border rounded-base bg-surface text-text text-sm font-[inherit] resize-none min-h-[40px] max-h-[150px] focus:outline-none focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex-1 py-sm px-md border border-border rounded-base bg-background-input text-text text-sm placeholder:text-text-disabled resize-none min-h-[40px] max-h-[150px] outline-none focus-visible:border-border-focus focus-visible:ring-2 focus-visible:ring-primary/10 hover:border-border-hover disabled:opacity-50 disabled:cursor-not-allowed"
         placeholder={
           isServerConnected
             ? 'Type your message. Shift + Enter for newline'

--- a/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
+++ b/src/components/ChatMessagesPanel/components/MessageBubbles.tsx
@@ -21,7 +21,7 @@ import { cn } from '../../../utils/cn';
 
 /** Shared styling for small action buttons in message bubble footers. */
 const ACTION_BTN =
-  'bg-transparent border-none cursor-pointer py-xs px-sm rounded-base text-sm opacity-70 transition-all duration-150 hover:opacity-100 hover:bg-surface-elevated';
+  'bg-transparent border-none cursor-pointer py-xs px-sm rounded-base text-sm opacity-70 transition-all duration-150 hover:opacity-100 hover:bg-surface-elevated focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-primary';
 
 /**
  * Message bubble for assistant responses.
@@ -72,7 +72,7 @@ export const AssistantMessageBubble: React.FC = () => {
   const isCurrentlyThinking = isStreaming && !!thinkingText && !contentText;
 
   return (
-    <MessagePrimitive.Root className="group flex flex-col gap-sm p-md rounded-base bg-surface border border-border phone:mr-xl">
+    <MessagePrimitive.Root className="group flex flex-col gap-sm p-md rounded-md bg-surface phone:mr-xl">
       <div className="flex items-center gap-sm">
         <div className="text-lg" aria-hidden>
           <Icon icon={Bot} size={18} />
@@ -103,8 +103,10 @@ export const AssistantMessageBubble: React.FC = () => {
         )}
       </div>
       <ToolExecutionProgress />
-      <ActionBarPrimitive.Root className="flex gap-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-        <ActionBarPrimitive.Copy />
+      <ActionBarPrimitive.Root className="flex gap-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 focus-within:opacity-100">
+        <ActionBarPrimitive.Copy className={ACTION_BTN} title="Copy message" aria-label="Copy message">
+          <Icon icon={Copy} size={14} />
+        </ActionBarPrimitive.Copy>
       </ActionBarPrimitive.Root>
     </MessagePrimitive.Root>
   );
@@ -142,7 +144,7 @@ export const UserMessageBubble: React.FC = () => {
       <div className="leading-[1.6]">
         <MarkdownMessageContent />
       </div>
-      <ActionBarPrimitive.Root className="flex gap-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+      <ActionBarPrimitive.Root className="flex gap-sm opacity-0 transition-opacity duration-200 group-hover:opacity-100 focus-within:opacity-100">
         <ActionBarPrimitive.Copy className={ACTION_BTN} title="Copy message" aria-label="Copy message">
           <Icon icon={Copy} size={14} />
         </ActionBarPrimitive.Copy>

--- a/src/components/ChatMessagesPanel/components/SystemPromptSection.tsx
+++ b/src/components/ChatMessagesPanel/components/SystemPromptSection.tsx
@@ -83,7 +83,7 @@ export const SystemPromptSection: FC<SystemPromptSectionProps> = ({ conversation
   };
 
   return (
-    <section className="border border-border rounded-base p-md bg-background flex flex-col gap-sm shrink-0">
+    <section className="rounded-md p-md bg-surface-elevated flex flex-col gap-sm shrink-0">
       <div className="flex justify-between gap-md items-start">
         <div>
           <p className="text-xs font-medium text-text-muted m-0 mb-xs">System prompt</p>
@@ -113,7 +113,7 @@ export const SystemPromptSection: FC<SystemPromptSectionProps> = ({ conversation
         <>
           <Textarea
             ref={textareaRef}
-            className="w-full p-sm border border-border rounded-sm bg-surface text-text text-sm font-[inherit] resize-y min-h-[80px] focus:outline-none focus:border-primary"
+            className="min-h-[80px] resize-y"
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             placeholder={DEFAULT_SYSTEM_PROMPT}

--- a/src/components/ChatMessagesPanel/components/ThinkingBlock.tsx
+++ b/src/components/ChatMessagesPanel/components/ThinkingBlock.tsx
@@ -122,9 +122,9 @@ const ThinkingBlock: React.FC<ThinkingBlockProps> = ({
   };
 
   return (
-    <div className={cn('mb-[0.75rem] border border-border rounded-md bg-surface overflow-hidden', isStreaming && 'border-primary-border')}>
+    <div className={'mb-md rounded-md bg-surface-elevated overflow-hidden'}>
       <div
-        className="flex items-center gap-[0.5rem] py-[0.625rem] px-[0.875rem] cursor-pointer select-none transition-colors duration-150 hover:bg-background-hover focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-[-2px]"
+        className="flex items-center gap-sm py-sm px-md cursor-pointer select-none transition-colors duration-150 hover:bg-background-hover focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-[-2px]"
         role="button"
         tabIndex={0}
         onClick={handleToggle}
@@ -137,12 +137,12 @@ const ThinkingBlock: React.FC<ThinkingBlockProps> = ({
           className={cn('text-text-muted transition-transform duration-200 shrink-0', isExpanded && 'rotate-90')}
         />
         <Icon icon={Brain} size={14} className="text-text-muted shrink-0" />
-        <span className="text-sm font-medium text-text-muted">{getLabel()}</span>
+        <span className="text-sm font-medium text-text-muted font-mono tabular-nums">{getLabel()}</span>
         {isStreaming && <span className="w-[12px] h-[12px] border-2 border-text-muted border-t-transparent rounded-full animate-spin-360 ml-auto shrink-0" />}
       </div>
       
       <div className={cn('max-h-0 overflow-hidden transition-[max-height] duration-[0.25s] ease-out', isExpanded && 'max-h-[500px] overflow-y-auto')}>
-        <div className="px-[0.875rem] pb-[0.75rem] border-t border-border">
+        <div className="px-md pb-md">
           <div className="text-sm leading-[1.5] text-text-muted [&_p]:my-[0.5rem] [&_p:first-child]:mt-[0.75rem] [&_p:last-child]:mb-0 [&_ul]:my-[0.5rem] [&_ul]:pl-[1.25rem] [&_ol]:my-[0.5rem] [&_ol]:pl-[1.25rem] [&_li]:my-[0.25rem]">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}

--- a/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
+++ b/src/components/ConsoleInfoPanel/ConsoleInfoPanel.tsx
@@ -59,7 +59,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
   }, [onStopServer]);
 
   return (
-    <div className="flex flex-col overflow-y-auto overflow-x-hidden border-b border-border relative tabular-nums flex-1 md:h-full md:min-h-0 md:border-b-0 md:border-r">
+    <div className="flex flex-col overflow-y-auto overflow-x-hidden relative tabular-nums flex-1 md:h-full md:min-h-0">
       <div className="p-md border-b border-border-light shrink-0">
         <div className="mb-md">
           <Tabs<ChatPageTabId>
@@ -78,8 +78,7 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col">
-        <div className="flex flex-col gap-lg">
+      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col gap-lg p-md">
           <ServerInfoSection serverPort={serverPort} uptime={uptime} contextLength={contextLength} />
           <ContextUsageSection metrics={metrics} runKey={runKey} contextLength={contextLength} />
           <StatisticsSection metrics={metrics} runKey={runKey} />
@@ -96,7 +95,6 @@ const ConsoleInfoPanel: FC<ConsoleInfoPanelProps> = ({
               {isStopping ? 'Stopping...' : 'Stop Server'}
             </Button>
           </section>
-        </div>
       </div>
     </div>
   );

--- a/src/components/ConsoleInfoPanel/StaticSections.tsx
+++ b/src/components/ConsoleInfoPanel/StaticSections.tsx
@@ -17,7 +17,7 @@ export const ServerInfoSection: FC<ServerInfoProps> = ({ serverPort, uptime, con
     <Stack gap="xs">
       <div className="flex justify-between items-center gap-sm py-xs">
         <span className="text-sm text-text-muted">Port</span>
-        <span className="text-sm text-text flex items-center gap-xs [&_code]:bg-background [&_code]:py-[2px] [&_code]:px-[6px] [&_code]:rounded-xs [&_code]:font-mono [&_code]:text-xs">
+        <span className="text-sm text-text flex items-center gap-xs [&_code]:bg-surface-elevated [&_code]:py-[2px] [&_code]:px-[6px] [&_code]:rounded-sm [&_code]:font-mono [&_code]:text-xs">
           <code>{serverPort}</code>
           <Button
             iconOnly
@@ -60,10 +60,10 @@ export const ApiEndpointsSection: FC = () => (
       {ENDPOINTS.map(({ route, description }) => (
         <div
           key={route}
-          className="flex flex-col gap-[2px] py-xs px-sm bg-background rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text"
+          className="flex flex-col gap-[2px] py-xs px-sm bg-surface-elevated rounded-sm [&_code]:font-mono [&_code]:text-xs [&_code]:text-text"
         >
           <code>{route}</code>
-          <span className="text-2xs text-text-muted">{description}</span>
+          <span className="text-xs text-text-muted">{description}</span>
         </div>
       ))}
     </Stack>

--- a/src/components/ConsoleInfoPanel/TelemetrySections.tsx
+++ b/src/components/ConsoleInfoPanel/TelemetrySections.tsx
@@ -57,7 +57,7 @@ export const ContextUsageSection: FC<TelemetryProps> = ({ metrics, runKey, conte
             }
           />
           {(metrics?.kvCacheTokens != null || metrics?.nTokensMax != null) && (
-            <span className="text-xs text-text-muted">
+            <span className="text-xs text-text-muted font-mono tabular-nums">
               {(metrics.kvCacheTokens ?? metrics.nTokensMax ?? 0).toLocaleString()} tokens
             </span>
           )}

--- a/src/components/ConsoleLogPanel/ConsoleLogPanel.tsx
+++ b/src/components/ConsoleLogPanel/ConsoleLogPanel.tsx
@@ -4,6 +4,7 @@ import { ClipboardCopy, Pause, Play, Trash2, Monitor } from 'lucide-react';
 import { useServerLogs, ServerLogEntry } from '../../hooks/useServerLogs';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
+import { EmptyState } from '../primitives';
 import './ConsoleLogPanel.css';
 
 interface ConsoleLogPanelProps {
@@ -75,16 +76,16 @@ const ConsoleLogPanel: FC<ConsoleLogPanelProps> = ({ serverPort }) => {
     <div className="flex flex-col overflow-y-auto overflow-x-hidden relative flex-1 bg-surface md:h-full md:min-h-0">
       <div className="p-md border-b border-border-light shrink-0">
         <div className="flex items-center justify-between gap-md">
-          <h3 className="m-0 text-base font-semibold text-text">Server Output</h3>
+          <h3 className="m-0 text-lg font-semibold text-text">Server Output</h3>
           <div className="flex gap-xs">
             <Button
-              variant={isAutoScroll ? 'primary' : 'secondary'}
+              variant="secondary"
               size="sm"
               onClick={handleToggleAutoScroll}
-              title={isAutoScroll ? 'Auto-scroll enabled' : 'Auto-scroll disabled'}
+              title={isAutoScroll ? 'Following new output' : 'Auto-scroll paused'}
               leftIcon={<Icon icon={isAutoScroll ? Play : Pause} size={14} />}
             >
-              {isAutoScroll ? 'Auto' : 'Paused'}
+              {isAutoScroll ? 'Following' : 'Paused'}
             </Button>
             <Button
               variant="secondary"
@@ -108,21 +109,21 @@ const ConsoleLogPanel: FC<ConsoleLogPanelProps> = ({ serverPort }) => {
         </div>
       </div>
 
-      <div 
+      <div
         ref={scrollContainerRef}
-        className="console-log-content flex-1 overflow-y-auto overflow-x-auto bg-terminal rounded-sm font-mono text-xs leading-[1.5] p-sm"
+        tabIndex={0}
+        role="log"
+        aria-label="Server output"
+        className="console-log-content flex-1 overflow-y-auto overflow-x-auto bg-terminal font-mono text-xs leading-[1.5] p-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
         onScroll={handleScroll}
       >
         {logs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full min-h-[200px] text-text-muted text-center gap-sm">
-            <span className="opacity-50" aria-hidden>
-              <Icon icon={Monitor} size={28} />
-            </span>
-            <p className="m-0">Waiting for server output...</p>
-            <p className="m-0 text-xs opacity-70">
-              Logs will appear here as the server processes requests
-            </p>
-          </div>
+          <EmptyState
+            className="h-full font-sans"
+            icon={<Icon icon={Monitor} size={24} />}
+            title="Waiting for server output"
+            description="Logs appear here once the server starts handling requests"
+          />
         ) : (
           <div className="whitespace-pre-wrap break-all">
             {logs.map((entry, index) => (

--- a/src/components/ConversationListPanel/ConversationListPanel.tsx
+++ b/src/components/ConversationListPanel/ConversationListPanel.tsx
@@ -8,6 +8,8 @@ import { IconButton } from '../ui/IconButton';
 import { Input } from '../ui/Input';
 import { Stack } from '../primitives';
 import { cn } from '../../utils/cn';
+import { EmptyState } from '../primitives';
+import { ConversationListSkeleton } from './ConversationListSkeleton';
 import type { ConversationSummary } from '../../services/transport';
 
 interface ConversationListPanelProps {
@@ -117,11 +119,17 @@ const ConversationListPanel: FC<ConversationListPanelProps> = ({
 
       <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col">
         {loading ? (
-          <div className="flex items-center justify-center p-xl text-text-muted text-center">Loading conversations…</div>
+          <ConversationListSkeleton />
         ) : filteredConversations.length === 0 ? (
-          <div className="flex items-center justify-center p-xl text-text-muted text-center">
-            {searchQuery ? 'No matching conversations' : 'No conversations yet'}
-          </div>
+          <EmptyState
+            className="p-xl"
+            title={searchQuery ? 'No matching conversations' : 'No conversations yet'}
+            description={
+              searchQuery
+                ? 'Try a different search term.'
+                : 'Send a message to start your first conversation.'
+            }
+          />
         ) : (
           <div role="listbox" aria-label="Conversations" className="flex flex-col">
             {filteredConversations.map((conversation) => (

--- a/src/components/ConversationListPanel/ConversationListSkeleton.tsx
+++ b/src/components/ConversationListPanel/ConversationListSkeleton.tsx
@@ -6,7 +6,7 @@ import { Skeleton, Stack } from '../primitives';
  * Mirrors the ConversationListPanel button: title line + relative timestamp.
  */
 const SkeletonItem: React.FC = () => (
-  <div className="py-md px-base border border-border rounded-base">
+  <div className="py-sm px-md">
     <Stack gap="xs">
       <Skeleton variant="text" width="70%" />
       <Skeleton variant="text" width="35%" height="0.75em" />
@@ -20,9 +20,17 @@ const SkeletonItem: React.FC = () => (
  * Rendered inside the flex-1 overflow container of ConversationListPanel.
  */
 export const ConversationListSkeleton: React.FC = () => (
-  <div className="flex flex-col gap-sm" aria-hidden="true">
-    {Array.from({ length: 5 }, (_, i) => (
-      <SkeletonItem key={i} />
-    ))}
-  </div>
+  <>
+    {/* The shimmer is decorative and hidden from assistive tech, but it
+        replaced a literal "Loading conversations…" string that screen readers
+        announced — so the announcement is kept explicitly. */}
+    <span className="sr-only" role="status">
+      Loading conversations…
+    </span>
+    <div className="flex flex-col gap-sm" aria-hidden="true">
+      {Array.from({ length: 5 }, (_, i) => (
+        <SkeletonItem key={i} />
+      ))}
+    </div>
+  </>
 );

--- a/src/components/FilterPopover/FilterPopover.tsx
+++ b/src/components/FilterPopover/FilterPopover.tsx
@@ -179,14 +179,14 @@ const FilterPopover: FC<FilterPopoverProps> = ({
   const currentSpeedMax = filters.speedRange?.[1] ?? filterOptions?.speed_range?.max ?? 200;
 
   return (
-    <div className="absolute top-full right-0 mt-xs bg-surface-elevated border border-border rounded-lg shadow-lg min-w-[280px] max-w-[320px] z-popover overflow-hidden" ref={popoverRef}>
-      <div className="flex items-center justify-between py-sm px-md border-b border-border bg-surface-elevated">
+    <div className="absolute top-full right-0 mt-xs bg-surface-elevated rounded-lg shadow-lg min-w-[280px] max-w-[320px] z-popover overflow-hidden" ref={popoverRef}>
+      <div className="flex items-center justify-between py-sm px-md border-b border-border-light bg-surface-elevated">
         <span className="text-sm font-semibold text-text">Sort & Filter</span>
         {hasActiveFilters && (
           <Button
             variant="ghost"
             size="sm"
-            className="py-[4px] px-[8px] text-xs font-medium text-primary border border-primary rounded-sm hover:bg-primary hover:text-text-inverse"
+            className="text-primary"
             onClick={onClearFilters}
             title="Clear all filters (sort preference is kept)"
           >

--- a/src/components/GlobalDownloadStatus/DownloadQueuePopover.tsx
+++ b/src/components/GlobalDownloadStatus/DownloadQueuePopover.tsx
@@ -4,6 +4,7 @@ import { appLogger } from '../../services/platform';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import type { DownloadQueueItem } from '../../services/transport/types/downloads';
 import { Icon } from '../ui/Icon';
+import { Chip } from '../ui/Chip';
 import { IconButton } from '../ui/IconButton';
 import { getTransport } from '../../services/transport';
 
@@ -153,10 +154,10 @@ const DownloadQueuePopover: FC<DownloadQueuePopoverProps> = ({
 
   return (
     <div
-      className="absolute top-full left-0 mt-xs bg-surface-elevated border border-border rounded-lg shadow-lg min-w-[280px] max-w-[360px] z-popover overflow-hidden"
+      className="absolute top-full left-0 mt-xs bg-surface-elevated rounded-lg shadow-lg min-w-[280px] max-w-[360px] z-popover overflow-hidden"
       ref={popoverRef}
     >
-      <div className="flex items-center justify-between px-md py-sm border-b border-border bg-surface-elevated">
+      <div className="flex items-center justify-between px-md py-sm border-b border-border-light bg-surface-elevated">
         <span className="text-sm font-semibold text-text-primary">Download Queue</span>
         <span className="text-xs text-text-secondary bg-surface px-2 py-[2px] rounded-sm">{groupedItems.length} {groupedItems.length === 1 ? 'item' : 'items'}</span>
       </div>
@@ -164,7 +165,7 @@ const DownloadQueuePopover: FC<DownloadQueuePopoverProps> = ({
         {groupedItems.map((item, index) => (
           <div
             key={item.group_id || item.id}
-            className="flex items-center gap-sm px-md py-sm border-b border-border last:border-b-0 hover:bg-surface-hover transition-colors duration-150"
+            className="flex items-center gap-sm px-md py-sm hover:bg-surface-hover transition-colors duration-150"
           >
             {/* Reorder buttons */}
             <div className="flex flex-col gap-[2px] shrink-0">
@@ -197,9 +198,9 @@ const DownloadQueuePopover: FC<DownloadQueuePopoverProps> = ({
               </div>
               <div className="flex items-center gap-xs flex-wrap">
                 {item.shard_count > 1 && (
-                  <span className="text-xs bg-primary-subtle text-primary-light px-[6px] py-[1px] rounded-sm font-medium">
+                  <Chip variant="primary" size="sm" className="font-mono tabular-nums">
                     {item.shard_count} parts
-                  </span>
+                  </Chip>
                 )}
               </div>
             </div>

--- a/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
+++ b/src/components/GlobalDownloadStatus/GlobalDownloadStatus.tsx
@@ -7,7 +7,7 @@ import { formatBytes, formatDuration, formatRate } from '../../utils/format';
 import DownloadQueuePopover from './DownloadQueuePopover';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
-import { Stack } from '../primitives';
+import { Readout, Stack } from '../primitives';
 import { cn } from '../../utils/cn';
 import { Chip } from '../ui/Chip';
 
@@ -76,13 +76,13 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
     const remaining = Math.max(0, uniqueTotal - shownCount);
 
     return (
-      <div className="bg-background border-b border-border rounded-none p-base mb-0">
+      <div className="bg-background border-b border-border-light rounded-none p-base mb-0">
         <div className="flex flex-col gap-sm">
           <div className="flex items-center gap-sm">
-            <span className="text-xl" aria-hidden>
+            <span className="text-success" aria-hidden>
               <Icon icon={CheckCircle2} size={16} />
             </span>
-            <span className="text-base font-semibold text-success">
+            <span className="text-sm font-semibold text-text">
               {uniqueTotal === 1 ? 'Download Complete' : `${uniqueTotal} Downloads Complete`}
             </span>
           </div>
@@ -90,7 +90,7 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
             {displayItems.length > 0 ? (
               <>
                 {displayItems.map((item, idx) => (
-                  <div key={idx} className="text-sm text-text py-xs border-b border-border last:border-b-0">
+                  <div key={idx} className="text-sm text-text py-xs">
                     <span className="text-sm" aria-hidden>
                       <Icon icon={Box} size={14} />
                     </span>
@@ -98,13 +98,13 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
                   </div>
                 ))}
                 {remaining > 0 && (
-                  <div className="text-sm text-text py-xs border-b border-border last:border-b-0">
+                  <div className="text-sm text-text py-xs">
                     …and {remaining} more
                   </div>
                 )}
               </>
             ) : (
-              <div className="text-sm text-text py-xs border-b border-border last:border-b-0">
+              <div className="text-sm text-text py-xs">
                 <span className="text-sm" aria-hidden>
                   <Icon icon={Box} size={14} />
                 </span>
@@ -148,7 +148,7 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
   })();
 
   return (
-    <div className="bg-background border-b border-border rounded-none p-base mb-0">
+    <div className="bg-background border-b border-border-light rounded-none p-base mb-0">
       <div className="flex flex-col gap-sm">
         <div className="flex items-center justify-between gap-md">
           <div className="flex items-center gap-sm">
@@ -197,14 +197,14 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
           <div className="flex-1 h-2 bg-surface-elevated rounded-sm overflow-hidden">
             <div
               className={cn(
-                'h-full bg-linear-to-r from-primary to-info rounded-sm transition-[width] duration-200 ease-linear',
+                'h-full bg-primary rounded-sm transition-[width] duration-200 ease-linear',
                 percentage === undefined && 'w-[30%] animate-indeterminate'
               )}
               style={percentage !== undefined ? { width: `${percentage}%` } : {}}
             />
           </div>
-          <span className="text-sm font-semibold text-text min-w-[48px] text-right">
-            {percentage !== undefined ? `${percentage.toFixed(1)}%` : '...'}
+          <span className="text-sm font-mono font-medium tabular-nums text-text min-w-[48px] text-right">
+            {percentage !== undefined ? `${percentage.toFixed(1)}%` : '…'}
           </span>
         </div>
 
@@ -213,25 +213,25 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
           estimator warms up. Conditionally rendering them made the row reflow
           a second or two into every download.
         */}
-        <div className="flex gap-md flex-wrap">
-          {progress?.downloaded !== undefined && progress?.total !== undefined && (
-            <span className="text-xs text-text-secondary">
-              {formatBytes(progress.downloaded)} / {formatBytes(progress.total)}
-            </span>
-          )}
-          <span className="text-xs text-text-secondary tabular-nums">
-            {formatRate(progress?.speedBps)}
-          </span>
-          <span className="text-xs text-text-secondary tabular-nums">
-            ETA: {formatDuration(progress?.etaSeconds)}
-          </span>
+        <div className="flex gap-lg flex-wrap">
+          <Readout
+            size="sm"
+            label="Downloaded"
+            value={
+              progress?.downloaded !== undefined && progress?.total !== undefined
+                ? `${formatBytes(progress.downloaded)} / ${formatBytes(progress.total)}`
+                : '—'
+            }
+          />
+          <Readout size="sm" label="Speed" value={formatRate(progress?.speedBps)} />
+          <Readout size="sm" label="ETA" value={formatDuration(progress?.etaSeconds)} />
         </div>
 
         {isSharded && shard && (
           <div className="bg-surface-elevated rounded-base p-sm mt-xs">
             <div className="flex items-center justify-between mb-xs">
-              <span className="text-xs font-medium text-warning">
-                Shard {shard.index + 1}/{shard.total}
+              <span className="text-xs text-text-muted">
+                Shard <span className="font-mono tabular-nums">{shard.index + 1}/{shard.total}</span>
               </span>
               {shard.filename && (
                 <span className="text-xs text-text-secondary font-mono" title={shard.filename}>
@@ -241,7 +241,7 @@ const GlobalDownloadStatus: FC<GlobalDownloadStatusProps> = ({
             </div>
             <div className="h-1 bg-surface-hover rounded-sm overflow-hidden">
               <div
-                className="h-full bg-warning rounded-sm transition-[width] duration-200 ease-linear"
+                className="h-full bg-primary rounded-sm transition-[width] duration-200 ease-linear"
                 style={{
                   width:
                     shard.totalBytes && shard.totalBytes > 0

--- a/src/components/HuggingFaceBrowser/HuggingFaceBrowser.tsx
+++ b/src/components/HuggingFaceBrowser/HuggingFaceBrowser.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+import { ModelCardSkeleton } from './ModelCardSkeleton';
 import { AlertTriangle, ArrowDown, ArrowUp, Search } from "lucide-react";
 import { HfModelSummary, HfSortField } from "../../types";
 import { ModelCard } from "./components/ModelCard";
@@ -62,7 +63,7 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
   return (
     <Stack gap="base" className="h-full overflow-hidden">
       {/* Search Section */}
-      <Stack gap="sm" className="p-4 bg-surface border-b border-border">
+      <Stack gap="sm" className="p-4 bg-surface border-b border-border-light">
         <Row gap="sm" align="end">
           <Stack gap="xs" className="flex-1">
             <Label size="xs" muted>Search models</Label>
@@ -151,10 +152,11 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
 
         {/* Loading State */}
         {loading && (
-          <div className="flex flex-col items-center justify-center p-12 text-center text-text-muted">
-            <div className="w-8 h-8 border-3 border-border border-t-primary-light rounded-full animate-spin mb-4"></div>
-            <span>Searching HuggingFace...</span>
-          </div>
+          <Stack gap="sm" aria-label="Loading models">
+            {Array.from({ length: 6 }, (_, i) => (
+              <ModelCardSkeleton key={i} />
+            ))}
+          </Stack>
         )}
 
         {/* Empty State */}

--- a/src/components/HuggingFaceBrowser/ModelCardSkeleton.tsx
+++ b/src/components/HuggingFaceBrowser/ModelCardSkeleton.tsx
@@ -8,7 +8,7 @@ import { Skeleton, Stack, Row } from '../primitives';
  */
 export const ModelCardSkeleton: React.FC = () => (
   <div
-    className="bg-surface-elevated border border-border rounded-xl overflow-hidden"
+    className="bg-surface-elevated rounded-md overflow-hidden"
     aria-hidden="true"
   >
     <div className="px-4 py-[0.9rem]">

--- a/src/components/HuggingFaceBrowser/components/ModelCard.tsx
+++ b/src/components/HuggingFaceBrowser/components/ModelCard.tsx
@@ -34,14 +34,25 @@ export const ModelCard: FC<ModelCardProps> = ({
   };
 
   return (
-    <div 
+    <div
       className={cn(
-        'bg-surface-elevated rounded-md mb-3 overflow-hidden transition-all duration-200 ease-linear hover:bg-surface-hover',
+        'relative bg-surface-elevated rounded-md mb-3 overflow-hidden transition-all duration-200 ease-linear hover:bg-surface-hover',
         isSelected && 'bg-primary-subtle ring-1 ring-primary-border hover:bg-primary/15'
       )}
-      onClick={onSelect}
     >
-      <div className="px-4 py-[0.9rem] cursor-pointer">
+      {/* Stretched select control: a real button underlaying the card keeps the
+          nested HuggingFace button an independent sibling — no interactive
+          nesting, and each control keeps its own native keyboard activation. */}
+      {/* eslint-disable-next-line no-restricted-syntax -- sr-only stretched select control; Button's chrome would fight the card */}
+      <button
+        type="button"
+        aria-pressed={isSelected}
+        onClick={onSelect}
+        className="absolute inset-0 w-full cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      >
+        <span className="sr-only">Select {model.name}</span>
+      </button>
+      <div className="px-4 py-[0.9rem]">
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <h3 className="text-base font-semibold text-text m-0 mb-[0.35rem] overflow-hidden text-ellipsis whitespace-nowrap flex items-center gap-2">
@@ -49,7 +60,7 @@ export const ModelCard: FC<ModelCardProps> = ({
               <IconButton
                 label="Open on HuggingFace"
                 size="sm"
-                className="shrink-0"
+                className="shrink-0 relative z-10"
                 onClick={handleOpenHuggingFace}
               >
                 <Icon icon={ExternalLink} size={14} />
@@ -60,13 +71,13 @@ export const ModelCard: FC<ModelCardProps> = ({
           <div className="flex gap-4 items-center shrink-0">
             {/* Neutral: parameter count is a fact, not a warning. */}
             {model.parameters_b && (
-              <span className="px-2 py-[0.2rem] bg-background text-text-secondary border border-border rounded-sm text-xs font-semibold">
+              <span className="px-2 py-[0.2rem] bg-background text-text-secondary rounded-sm text-xs font-mono tabular-nums">
                 {model.parameters_b.toFixed(1)}B
               </span>
             )}
             {supportsTools && (
               <span 
-                className="px-[0.35rem] py-[0.15rem] bg-primary-subtle text-primary-light rounded-sm text-sm cursor-help transition-colors duration-150 ease-linear hover:bg-primary/20"
+                className="relative z-10 px-[0.35rem] py-[0.15rem] bg-primary-subtle text-primary-light rounded-sm text-sm cursor-help transition-colors duration-150 ease-linear hover:bg-primary/20"
                 title="This model likely supports tool/function calling"
               >
                 <Icon icon={Wrench} size={14} />
@@ -76,13 +87,13 @@ export const ModelCard: FC<ModelCardProps> = ({
               <span className="text-base" aria-hidden>
                 <Icon icon={Download} size={14} />
               </span>
-              {formatNumber(model.downloads)}
+              <span className="font-mono tabular-nums">{formatNumber(model.downloads)}</span>
             </span>
             <span className="flex items-center gap-[0.35rem] text-sm text-text-secondary">
               <span className="text-base" aria-hidden>
                 <Icon icon={Heart} size={14} />
               </span>
-              {formatNumber(model.likes)}
+              <span className="font-mono tabular-nums">{formatNumber(model.likes)}</span>
             </span>
           </div>
         </div>

--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -11,7 +11,7 @@ import { useMcpServers } from "../hooks/useMcpServers";
 import { Icon } from "./ui/Icon";
 import { Banner } from './ui/Banner';
 import { Button } from "./ui/Button";
-import { Stack } from './primitives';
+import { EmptyState, Stack } from './primitives';
 import { cn } from "../utils/cn";
 import { useConfirmContext } from "../contexts/ConfirmContext";
 import { useToastContext } from "../contexts/ToastContext";
@@ -19,7 +19,8 @@ import { getTransport } from '../services/transport';
 import type { McpServerInfo } from '../services/transport';
 import { isServerRunning, hasServerError, getServerErrorMessage } from '../utils/mcp';
 
-const statusBadge = "inline-flex items-center px-sm py-0.5 text-xs font-semibold rounded-full";
+const statusRow = "inline-flex items-center gap-xs text-xs text-text-muted";
+const statusDot = "w-1.5 h-1.5 rounded-full";
 
 
 interface McpServersPanelProps {
@@ -137,15 +138,31 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
 
   const getStatusBadge = (info: McpServerInfo) => {
     if (isServerRunning(info)) {
-      return <span className={cn(statusBadge, "bg-success-subtle text-success")}>Running</span>;
+      return (
+        <span className={statusRow}>
+          <span aria-hidden className={cn(statusDot, 'bg-success')} />Running
+        </span>
+      );
     }
     if (hasServerError(info)) {
-      return <span className={cn(statusBadge, "bg-danger-subtle text-danger")}>Error</span>;
+      return (
+        <span className={cn(statusRow, 'text-danger')}>
+          <span aria-hidden className={cn(statusDot, 'bg-danger')} />Error
+        </span>
+      );
     }
     if (info.status === "starting") {
-      return <span className={cn(statusBadge, "bg-warning-subtle text-warning")}>Starting...</span>;
+      return (
+        <span className={statusRow}>
+          <span aria-hidden className={cn(statusDot, 'bg-warning')} />Starting…
+        </span>
+      );
     }
-    return <span className={cn(statusBadge, "bg-background-tertiary text-text-secondary")}>Stopped</span>;
+    return (
+      <span className={statusRow}>
+        <span aria-hidden className={cn(statusDot, 'bg-text-muted')} />Stopped
+      </span>
+    );
   };
 
   if (loading) {
@@ -202,22 +219,18 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
       )}
 
       {servers.length === 0 ? (
-        <div className="text-center p-xl text-text-secondary">
-          <p className="m-0 mb-sm">No MCP servers configured.</p>
-          <p className="text-sm mb-md">
-            MCP servers provide tools that can be called by the LLM during chat.
-            Add servers for web search, file access, and more.
-          </p>
-          {onAddServer && (
-            <Button
-              type="button"
-              variant="primary"
-              onClick={onAddServer}
-            >
-              Add Your First Server
-            </Button>
-          )}
-        </div>
+        <EmptyState
+          className="p-xl"
+          title="No MCP servers configured"
+          description="MCP servers provide tools that can be called by the LLM during chat. Add servers for web search, file access, and more."
+          action={
+            onAddServer && (
+              <Button type="button" variant="primary" onClick={onAddServer}>
+                Add Your First Server
+              </Button>
+            )
+          }
+        />
       ) : (
         <div className="flex flex-col gap-md">
           {servers.map((info) => {
@@ -226,7 +239,7 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
             const isRunning = isServerRunning(info);
 
             return (
-              <div key={id} className="flex justify-between items-start gap-md p-md bg-background-secondary border border-border rounded-base">
+              <div key={id} className="flex justify-between items-start gap-md p-md bg-background-secondary rounded-md">
                 <Stack gap="xs" className="flex-1 min-w-0">
                   <div className="flex items-center gap-sm">
                     <span className="font-semibold text-text">{info.server.name}</span>
@@ -304,7 +317,7 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
                   ) : (
                     <Button
                       type="button"
-                      variant="primary"
+                      variant="secondary"
                       size="sm"
                       onClick={() => handleStart(info)}
                       disabled={isLoading || !info.server.enabled}

--- a/src/components/ModelInspectorPanel/components/DeleteModal.tsx
+++ b/src/components/ModelInspectorPanel/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Trash2, Loader2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { Icon } from '../../ui/Icon';
 import { Modal } from '../../ui/Modal';
@@ -21,15 +21,6 @@ export const DeleteModal: FC<DeleteModalProps> = ({
   onClose,
   onConfirm,
 }) => {
-  const deleteLabel = isDeleting ? (
-    <>
-      <Loader2 className="spinner" />
-      Deleting...
-    </>
-  ) : (
-    'Delete'
-  );
-
   return (
     <Modal
       open={true}
@@ -45,16 +36,16 @@ export const DeleteModal: FC<DeleteModalProps> = ({
           <Button
             variant="danger"
             onClick={onConfirm}
-            disabled={isDeleting}
+            isLoading={isDeleting}
             leftIcon={!isDeleting ? <Icon icon={Trash2} size={14} /> : undefined}
           >
-            {deleteLabel}
+            {isDeleting ? 'Deleting…' : 'Delete'}
           </Button>
         </>
       }
     >
       <p>Are you sure you want to remove <strong>"{model.name}"</strong> from the database?</p>
-      <p className="text-text-muted text-sm mt-4">
+      <p className="text-text-muted text-sm mt-md">
         Note: The model file will remain on disk and won't be deleted.
       </p>
     </Modal>

--- a/src/components/ModelInspectorPanel/components/InfoRow.tsx
+++ b/src/components/ModelInspectorPanel/components/InfoRow.tsx
@@ -26,7 +26,7 @@ export const InfoRow: FC<InfoRowProps> = ({ label, children, mono, className, la
     <dd
       className={cn(
         'text-text text-sm m-0 min-w-0 break-words',
-        mono && 'font-mono text-xs break-all',
+        mono && 'font-mono tabular-nums text-xs break-all',
         className,
       )}
     >

--- a/src/components/ModelInspectorPanel/components/InspectorHeader.tsx
+++ b/src/components/ModelInspectorPanel/components/InspectorHeader.tsx
@@ -33,13 +33,13 @@ export const InspectorHeader: FC<InspectorHeaderProps> = ({
       {isEditMode ? (
         <Input
           type="text"
-          className="w-full m-0 text-xl font-semibold"
+          className="w-full m-0 text-lg font-semibold"
           value={editedName}
           onChange={(e) => onEditedNameChange(e.target.value)}
           placeholder="Model name"
         />
       ) : (
-        <h2 className="m-0 text-xl font-semibold truncate">{modelName}</h2>
+        <h2 className="m-0 text-lg font-semibold truncate">{modelName}</h2>
       )}
 
       {!isEditMode && (

--- a/src/components/ModelInspectorPanel/components/ModelEditForm.tsx
+++ b/src/components/ModelInspectorPanel/components/ModelEditForm.tsx
@@ -6,6 +6,8 @@ import { openUrl } from '../../../services/platform';
 import { Icon } from '../../ui/Icon';
 import { IconButton } from '../../ui/IconButton';
 import { Input } from '../../ui/Input';
+import { InfoRow } from './InfoRow';
+import { MetadataSection } from './MetadataSection';
 import { InferenceParametersForm } from '../../InferenceParametersForm';
 import { useSamplingExplanation } from '../hooks/useSamplingExplanation';
 
@@ -46,92 +48,80 @@ export const ModelEditForm: FC<ModelEditFormProps> = ({
   return (
     <>
       <section className="mb-xl">
-        <h3 className="m-0 mb-base text-sm font-semibold text-text">Model Information</h3>
-      <div className="flex flex-col gap-md">
-        <div className="flex justify-between items-start gap-base">
-          <span className="text-text-muted text-sm shrink-0">Size:</span>
-          <span className="text-text text-sm text-right break-words">{formatParamCount(model.paramCountB, model.expertUsedCount, model.expertCount)}</span>
-        </div>
-        {model.architecture && (
-          <div className="flex justify-between items-start gap-base">
-            <span className="text-text-muted text-sm shrink-0">Architecture:</span>
-            <span className="text-text text-sm text-right break-words">{model.architecture}</span>
-          </div>
-        )}
-        <div className="flex justify-between items-start gap-base">
-          <span className="text-text-muted text-sm shrink-0">Quantization:</span>
-          <Input
-            type="text"
-            className="min-w-[200px] flex-1"
-            value={editedQuantization}
-            onChange={(e) => onQuantizationChange(e.target.value)}
-            placeholder="e.g., Q4_0"
-          />
-        </div>
-        {/* Context Length — editable override */}
-        <div className="flex justify-between items-start gap-base">
-          <span className="text-text-muted text-sm shrink-0">Context Length:</span>
-          <div className="flex items-center gap-2">
+        <MetadataSection title="Model Information">
+          <InfoRow label="Size" className="font-mono tabular-nums">
+            {formatParamCount(model.paramCountB, model.expertUsedCount, model.expertCount)}
+          </InfoRow>
+          {model.architecture && <InfoRow label="Architecture">{model.architecture}</InfoRow>}
+          <InfoRow label="Quantization">
             <Input
-              type="number"
-              min={256}
-              step={1}
-              value={editedServerDefaults?.contextLength ?? ''}
-              onChange={(e) => {
-                const val = e.target.value ? parseInt(e.target.value, 10) : undefined;
-                onServerDefaultsChange(val !== undefined ? { contextLength: val } : null);
-              }}
-              placeholder="Use default"
-              className="w-32"
+              type="text"
+              className="w-full font-mono tabular-nums"
+              value={editedQuantization}
+              onChange={(e) => onQuantizationChange(e.target.value)}
+              placeholder="e.g., Q4_0"
             />
-            {editedServerDefaults !== undefined && (
-              <IconButton
-                label={editedServerDefaults === null ? "Revert 'clear' action" : "Clear override"}
-                size="sm"
-                onClick={() => {
-                  // Toggle: null (clear) ↔ object with current model value (revert to model default)
-                  if (editedServerDefaults === null) {
-                    onServerDefaultsChange(model.serverDefaults ?? {});
-                  } else {
-                    onServerDefaultsChange(null);
-                  }
+          </InfoRow>
+          <InfoRow label="Context Length">
+            <span className="flex items-center gap-sm">
+              <Input
+                type="number"
+                min={256}
+                step={1}
+                value={editedServerDefaults?.contextLength ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value ? parseInt(e.target.value, 10) : undefined;
+                  onServerDefaultsChange(val !== undefined ? { contextLength: val } : null);
                 }}
-              >
-                <Icon icon={editedServerDefaults === null ? Undo2 : X} size={14} />
-              </IconButton>
-            )}
-          </div>
-        </div>
-        <div className="flex justify-between items-start gap-base">
-          <span className="text-text-muted text-sm shrink-0">Path:</span>
-          <Input
-            type="text"
-            className="min-w-[200px] flex-1 font-mono text-xs"
-            value={editedFilePath}
-            onChange={(e) => onFilePathChange(e.target.value)}
-            placeholder="File path"
-          />
-        </div>
-        {model.hfRepoId && (
-          <div className="flex justify-between items-start gap-base">
-            <span className="text-text-muted text-sm shrink-0">HuggingFace:</span>
-            <span className="text-text text-sm text-right break-words flex items-center gap-sm">
-              <span className="font-mono text-sm text-text">{model.hfRepoId}</span>
-              <IconButton
-                label="Open on HuggingFace"
-                size="sm"
-                className="shrink-0"
-                onClick={() => {
-                  const url = getHuggingFaceUrl(model.hfRepoId);
-                  if (url) openUrl(url);
-                }}
-              >
-                <Icon icon={ExternalLink} size={14} />
-              </IconButton>
+                placeholder="Use default"
+                className="w-32 font-mono tabular-nums"
+              />
+              {editedServerDefaults !== undefined && (
+                <IconButton
+                  label={editedServerDefaults === null ? "Revert 'clear' action" : "Clear override"}
+                  size="sm"
+                  onClick={() => {
+                    // Toggle: null (clear) ↔ object with current model value (revert to model default)
+                    if (editedServerDefaults === null) {
+                      onServerDefaultsChange(model.serverDefaults ?? {});
+                    } else {
+                      onServerDefaultsChange(null);
+                    }
+                  }}
+                >
+                  <Icon icon={editedServerDefaults === null ? Undo2 : X} size={14} />
+                </IconButton>
+              )}
             </span>
-          </div>
-        )}
-      </div>
+          </InfoRow>
+          <InfoRow label="Path">
+            <Input
+              type="text"
+              className="w-full font-mono text-xs"
+              value={editedFilePath}
+              onChange={(e) => onFilePathChange(e.target.value)}
+              placeholder="File path"
+            />
+          </InfoRow>
+          {model.hfRepoId && (
+            <InfoRow label="HuggingFace">
+              <span className="flex items-center gap-sm">
+                <span className="font-mono text-sm text-text break-all">{model.hfRepoId}</span>
+                <IconButton
+                  label="Open on HuggingFace"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => {
+                    const url = getHuggingFaceUrl(model.hfRepoId);
+                    if (url) openUrl(url);
+                  }}
+                >
+                  <Icon icon={ExternalLink} size={14} />
+                </IconButton>
+              </span>
+            </InfoRow>
+          )}
+        </MetadataSection>
     </section>
     
     <InferenceParametersForm

--- a/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
+++ b/src/components/ModelInspectorPanel/components/ModelMetadataGrid.tsx
@@ -42,19 +42,19 @@ export const ModelMetadataGrid: FC<ModelMetadataGridProps> = ({
   return (
     <section className="mb-xl">
       <MetadataSection title="Model Information">
-        <InfoRow label="Size">
+        <InfoRow label="Size" className="font-mono tabular-nums">
           {formatParamCount(model.paramCountB, model.expertUsedCount, model.expertCount)}
         </InfoRow>
 
         {model.architecture && <InfoRow label="Architecture">{model.architecture}</InfoRow>}
 
         {model.quantization && (
-          <InfoRow label="Quantization" className="font-semibold">
+          <InfoRow label="Quantization" className="font-mono tabular-nums">
             {model.quantization}
           </InfoRow>
         )}
 
-        <InfoRow label="Context Length">{formatContextLength(model)}</InfoRow>
+        <InfoRow label="Context Length" className="font-mono tabular-nums">{formatContextLength(model)}</InfoRow>
 
         <InfoRow label="Path" mono>
           <span className="inline-flex items-start gap-sm">

--- a/src/components/ModelInspectorPanel/components/SamplingProvenanceSection.tsx
+++ b/src/components/ModelInspectorPanel/components/SamplingProvenanceSection.tsx
@@ -112,7 +112,7 @@ export const SamplingProvenanceSection: FC<SamplingProvenanceSectionProps> = ({
           const author = published.get(entry.param);
           return (
             <InfoRow key={entry.param} label={PARAM_LABELS[entry.param] ?? entry.param}>
-              <span className="tabular-nums">
+              <span className="font-mono tabular-nums">
                 {formatParamValue(entry.param, resolvedValue(explanation.resolved, entry.param))}
               </span>
               <span className="text-text-muted"> {describeSource(entry, ctx)}</span>

--- a/src/components/ModelInspectorPanel/components/ServeModal.tsx
+++ b/src/components/ModelInspectorPanel/components/ServeModal.tsx
@@ -1,8 +1,9 @@
 import { FC, useState } from 'react';
 import { Checkbox } from '../../ui/Checkbox';
-import { Loader2, Play, ChevronDown, ChevronRight } from 'lucide-react';
+import { Play, ChevronDown, ChevronRight } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { Icon } from '../../ui/Icon';
+import { Banner } from '../../ui/Banner';
 import { Input } from '../../ui/Input';
 import { Modal } from '../../ui/Modal';
 import { InferenceParametersForm } from '../../InferenceParametersForm';
@@ -93,22 +94,15 @@ export const ServeModal: FC<ServeModalProps> = ({
           <Button
             variant="primary"
             onClick={onStart}
-            disabled={isServing}
+            isLoading={isServing}
             leftIcon={!isServing ? <Icon icon={Play} size={14} /> : undefined}
           >
-            {isServing ? (
-              <>
-                <Loader2 className="spinner" />
-                Loading model...
-              </>
-            ) : (
-              'Start Server'
-            )}
+            {isServing ? 'Loading model…' : 'Start Server'}
           </Button>
         </>
       }
     >
-        <div className="flex justify-between items-center mb-lg p-base bg-background rounded-md border border-border">
+        <div className="flex justify-between items-center mb-lg p-base bg-background rounded-md">
           <strong>{model.name}</strong>
           <span className="text-text-secondary text-sm">{formatParamCount(model.paramCountB, model.expertUsedCount, model.expertCount)}</span>
         </div>
@@ -121,7 +115,7 @@ export const ServeModal: FC<ServeModalProps> = ({
           <Input
             id="context-input"
             type="number"
-            className="w-full p-md bg-background-input border border-border rounded-base text-text text-base transition duration-200 focus:outline-none focus:border-border-focus focus:ring-2 focus:ring-primary/10"
+            className="font-mono tabular-nums"
             placeholder={
               settings?.defaultContextSize
                 ? `Default: ${settings.defaultContextSize.toLocaleString()}`
@@ -149,7 +143,7 @@ export const ServeModal: FC<ServeModalProps> = ({
           <Input
             id="port-input"
             type="number"
-            className="w-full p-md bg-background-input border border-border rounded-base text-text text-base transition duration-200 focus:outline-none focus:border-border-focus focus:ring-2 focus:ring-primary/10"
+            className="font-mono tabular-nums"
             placeholder={
               settings?.llamaBasePort
                 ? `Auto (from ${settings.llamaBasePort})`
@@ -167,25 +161,22 @@ export const ServeModal: FC<ServeModalProps> = ({
         </div>
 
         {hasAgentTag && (
-          <div className="flex flex-col gap-sm py-sm px-md rounded-md border border-border bg-primary-subtle text-text text-sm mb-md" role="status">
-            <div className="font-semibold">Agent tag detected</div>
-            <p>
-              Jinja templates {jinjaOverride === false 
-                ? 'would normally be auto-enabled for agent-tagged models, but you have disabled them for this launch.' 
-                : 'will be enabled automatically for agent-tagged models to support structured prompts.'}
-            </p>
-            {jinjaOverride !== null && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={onJinjaReset}
-                disabled={isServing}
-              >
-                Reset to auto-detect
-              </Button>
-            )}
-          </div>
+          <Banner
+            variant="info"
+            title="Agent tag detected"
+            className="mb-md"
+            action={
+              jinjaOverride !== null && (
+                <Button type="button" variant="ghost" size="sm" onClick={onJinjaReset} disabled={isServing}>
+                  Reset to auto-detect
+                </Button>
+              )
+            }
+          >
+            Jinja templates {jinjaOverride === false
+              ? 'would normally be auto-enabled for agent-tagged models, but you have disabled them for this launch.'
+              : 'will be enabled automatically for agent-tagged models to support structured prompts.'}
+          </Banner>
         )}
 
         <div className="mb-lg">
@@ -210,25 +201,28 @@ export const ServeModal: FC<ServeModalProps> = ({
 
         {/* MTP Speculative Decoding section (shown for all models; auto-banner when tagged) */}
         {hasMtpTag && (
-          <div className="flex flex-col gap-sm py-sm px-md rounded-md border border-border bg-primary-subtle text-text text-sm mb-md" role="status">
-            <div className="font-semibold">MTP speculative decoding detected</div>
-            <p>
-              {mtpNMaxOverride === 0
-                ? 'Speculative decoding would normally be auto-enabled for this model, but you have disabled it for this launch.'
-                : 'This model contains embedded MTP draft heads. Speculative decoding will be enabled automatically (n-max=2, p-min=0.75).'}
-            </p>
-            {mtpNMaxOverride !== null && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => { onMtpNMaxChange(null); onMtpPMinChange(null); }}
-                disabled={isServing}
-              >
-                Reset to auto-detect
-              </Button>
-            )}
-          </div>
+          <Banner
+            variant="info"
+            title="MTP speculative decoding detected"
+            className="mb-md"
+            action={
+              mtpNMaxOverride !== null && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => { onMtpNMaxChange(null); onMtpPMinChange(null); }}
+                  disabled={isServing}
+                >
+                  Reset to auto-detect
+                </Button>
+              )
+            }
+          >
+            {mtpNMaxOverride === 0
+              ? 'Speculative decoding would normally be auto-enabled for this model, but you have disabled it for this launch.'
+              : 'This model contains embedded MTP draft heads. Speculative decoding will be enabled automatically (n-max=2, p-min=0.75).'}
+          </Banner>
         )}
 
         <div className="mb-lg">
@@ -271,7 +265,7 @@ export const ServeModal: FC<ServeModalProps> = ({
                 <Input
                   id="mtp-n-max"
                   type="number"
-                  className="w-full p-md bg-background-input border border-border rounded-base text-text text-base"
+                  className="font-mono tabular-nums"
                   placeholder={isAutoMtp ? 'Auto (2)' : '2'}
                   value={mtpNMaxOverride !== null && mtpNMaxOverride > 0 ? String(mtpNMaxOverride) : ''}
                   onChange={(e) => {
@@ -295,7 +289,7 @@ export const ServeModal: FC<ServeModalProps> = ({
                 <Input
                   id="mtp-p-min"
                   type="number"
-                  className="w-full p-md bg-background-input border border-border rounded-base text-text text-base"
+                  className="font-mono tabular-nums"
                   placeholder={isAutoMtp ? 'Auto (0.75)' : '0.75'}
                   value={mtpPMinOverride !== null ? String(mtpPMinOverride) : ''}
                   onChange={(e) => {

--- a/src/components/ModelLibraryPanel/AddDownloadContent.tsx
+++ b/src/components/ModelLibraryPanel/AddDownloadContent.tsx
@@ -4,6 +4,7 @@ import AddModel from '../AddModel';
 import { HuggingFaceBrowser } from '../HuggingFaceBrowser';
 import { HfModelSummary } from '../../types';
 import { Icon } from '../ui/Icon';
+import { Banner } from '../ui/Banner';
 import { Tabs, type TabItem } from '../ui/Tabs';
 
 export type AddDownloadSubTab = 'add' | 'browse';
@@ -51,10 +52,9 @@ const AddDownloadContent: FC<AddDownloadContentProps> = ({
   return (
     <div className="flex flex-col h-full min-h-0">
       {downloadSystemError && (
-        <div className="px-2.5 py-2 border border-border rounded-md mb-2.5">
-          <strong>Downloads unavailable.</strong>
-          <div className="mt-1 whitespace-pre-wrap">{downloadSystemError}</div>
-        </div>
+        <Banner variant="danger" title="Downloads unavailable" className="mb-md">
+          <span className="whitespace-pre-wrap">{downloadSystemError}</span>
+        </Banner>
       )}
       {/* px-base matches the gutter on the search row and list rows. Without
           it this control bled to the panel's left edge and clipped its icon. */}

--- a/src/components/ModelLibraryPanel/ModelLibraryPanel.tsx
+++ b/src/components/ModelLibraryPanel/ModelLibraryPanel.tsx
@@ -144,8 +144,8 @@ const ModelLibraryPanel: FC<ModelLibraryPanelProps> = ({
         </Button>
       )}
       <ProxyControl
+        compact
         buttonClassName="relative text-base w-auto h-auto py-xs px-sm gap-xs inline-flex"
-        buttonActiveClassName="text-success"
         statusDotClassName="absolute top-[2px] right-[2px] w-[6px] h-[6px] rounded-full bg-transparent"
         statusDotActiveClassName="bg-success animate-pulse"
       />

--- a/src/components/ModelLibraryPanel/ModelListSkeleton.tsx
+++ b/src/components/ModelLibraryPanel/ModelListSkeleton.tsx
@@ -6,7 +6,7 @@ import { Skeleton, Stack, Row } from '../primitives';
  * Mirrors the ModelsListContent row: name line + param/arch/quant badges.
  */
 const SkeletonRow: React.FC = () => (
-  <div className="py-md px-base border-b border-border w-full">
+  <div className="py-sm px-md border-l-[3px] border-l-transparent w-full">
     <Stack gap="sm">
       <Skeleton variant="text" width="55%" />
       <Row gap="md" align="center">
@@ -21,11 +21,21 @@ const SkeletonRow: React.FC = () => (
 /**
  * Full-panel skeleton for the model library list.
  * Replaces the "Loading models..." text while the model list is being fetched.
+ *
+ * The shimmer is decorative, so it is hidden from assistive tech — but it
+ * replaced a literal "Loading models..." string that screen readers used to
+ * announce, so the announcement is carried here explicitly rather than lost
+ * with the text.
  */
 export const ModelListSkeleton: React.FC = () => (
-  <div aria-hidden="true">
-    {Array.from({ length: 6 }, (_, i) => (
-      <SkeletonRow key={i} />
-    ))}
-  </div>
+  <>
+    <span className="sr-only" role="status">
+      Loading models…
+    </span>
+    <div aria-hidden="true">
+      {Array.from({ length: 6 }, (_, i) => (
+        <SkeletonRow key={i} />
+      ))}
+    </div>
+  </>
 );

--- a/src/components/ModelLibraryPanel/ModelsListContent.tsx
+++ b/src/components/ModelLibraryPanel/ModelsListContent.tsx
@@ -5,6 +5,7 @@ import { formatParamCount } from '../../utils/format';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
 import { EmptyState } from '../primitives/EmptyState';
+import { ModelListSkeleton } from './ModelListSkeleton';
 import { cn } from '../../utils/cn';
 import { Chip } from '../ui/Chip';
 
@@ -31,7 +32,7 @@ const ModelsListContent: FC<ModelsListContentProps> = ({
   };
 
   if (loading && models.length === 0) {
-    return <div className="flex items-center justify-center p-3xl text-text-muted">Loading models...</div>;
+    return <ModelListSkeleton />;
   }
 
   if (models.length === 0) {
@@ -81,7 +82,10 @@ const ModelsListContent: FC<ModelsListContentProps> = ({
               <div className="font-medium text-sm flex items-center gap-sm w-full break-words">
                 {model.name}
                 {isRunning && (
-                  <Chip variant="success" size="sm">Running</Chip>
+                  <span className="inline-flex items-center gap-xs text-xs text-text-muted shrink-0">
+                    <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-success" />
+                    Running
+                  </span>
                 )}
               </div>
               <div className="flex items-center gap-md text-xs text-text-muted flex-wrap">
@@ -95,7 +99,7 @@ const ModelsListContent: FC<ModelsListContentProps> = ({
                   <Chip size="sm" className="font-mono">{model.quantization}</Chip>
                 )}
                 {tps != null && (
-                  <Chip size="sm" leftIcon={<Icon icon={Zap} size={11} />} className="tabular-nums">
+                  <Chip size="sm" leftIcon={<Icon icon={Zap} size={11} />} className="font-mono tabular-nums">
                     {tps.toFixed(0)} t/s
                   </Chip>
                 )}

--- a/src/components/ProxyAdmissionPanel.tsx
+++ b/src/components/ProxyAdmissionPanel.tsx
@@ -82,14 +82,14 @@ const SLOT_ICON: Record<SecondarySlotState, LucideIcon> = {
 
 /** One resident model and what it is doing. */
 const ResidentSlot: FC<{ slot: ResidentSlotSnapshot }> = ({ slot }) => (
-  <div className="flex items-baseline justify-between gap-md p-md rounded-base border border-border bg-surface-elevated">
+  <div className="flex items-baseline justify-between gap-md p-md rounded-base bg-surface-elevated">
     <div className="flex items-baseline gap-sm min-w-0">
       <span className="text-sm text-text truncate">{slot.model_name}</span>
       <span className="text-xs text-text-muted shrink-0">
         {slot.is_primary ? 'primary' : 'secondary'}
       </span>
     </div>
-    <span className="text-xs text-text-muted tabular-nums shrink-0">
+    <span className="text-xs text-text-muted font-mono tabular-nums shrink-0">
       {slot.inflight > 0 ? `${formatCount(slot.inflight)} in flight · ` : 'idle · '}
       {formatResidency(slot.resident_for_secs)}
     </span>
@@ -100,7 +100,7 @@ const ResidentSlot: FC<{ slot: ResidentSlotSnapshot }> = ({ slot }) => (
 const QueuedModel: FC<{ queued: QueuedModelSnapshot }> = ({ queued }) => (
   <div className="flex items-baseline justify-between gap-md">
     <span className="text-xs text-text-muted truncate">{queued.model_name}</span>
-    <span className="text-sm text-text tabular-nums shrink-0">
+    <span className="text-sm text-text font-mono tabular-nums shrink-0">
       {formatCount(queued.waiting)} waiting · oldest {formatWait(queued.oldest_wait_ms)}
     </span>
   </div>
@@ -126,7 +126,7 @@ export const ProxyAdmissionPanel: FC<ProxyAdmissionPanelProps> = ({ admission })
         <p className="text-sm text-text-muted">No model is loaded yet.</p>
       )}
 
-      <div className="flex items-start gap-sm p-md rounded-base border border-border bg-surface-elevated">
+      <div className="flex items-start gap-sm p-md rounded-base bg-surface-elevated">
         <Icon
           icon={SLOT_ICON[secondary.state]}
           className={`shrink-0 mt-[2px] ${secondarySlotTone(secondary.state)}`}
@@ -136,7 +136,7 @@ export const ProxyAdmissionPanel: FC<ProxyAdmissionPanelProps> = ({ admission })
       </div>
 
       {queued.length > 0 && (
-        <div className="flex flex-col gap-xs p-md rounded-base border border-border bg-surface-elevated">
+        <div className="flex flex-col gap-xs p-md rounded-base bg-surface-elevated">
           {queued.map((entry) => (
             <QueuedModel key={entry.model_name} queued={entry} />
           ))}
@@ -150,11 +150,11 @@ export const ProxyAdmissionPanel: FC<ProxyAdmissionPanelProps> = ({ admission })
       */}
       <div className="flex items-baseline justify-between gap-md">
         <span className="text-xs text-text-muted">Requests admitted</span>
-        <span className="text-sm text-text tabular-nums">{formatCount(totalQueued)}</span>
+        <span className="text-sm text-text font-mono tabular-nums">{formatCount(totalQueued)}</span>
       </div>
       <div className="flex items-baseline justify-between gap-md">
         <span className="text-xs text-text-muted">Model swaps</span>
-        <span className="text-sm text-text tabular-nums">{formatCount(totalSwaps)}</span>
+        <span className="text-sm text-text font-mono tabular-nums">{formatCount(totalSwaps)}</span>
       </div>
     </div>
   );

--- a/src/components/ProxyControl.tsx
+++ b/src/components/ProxyControl.tsx
@@ -33,6 +33,8 @@ interface ProxyControlProps {
   statusDotActiveClassName?: string;
   /** Whether KV cache persistence is enabled on the running proxy. */
   cacheEnabled?: boolean;
+  /** Icon-only trigger for narrow headers; the label moves to title/aria-label. */
+  compact?: boolean;
 }
 
 const ProxyControl: FC<ProxyControlProps> = ({
@@ -41,6 +43,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
   statusDotClassName,
   statusDotActiveClassName,
   cacheEnabled = false,
+  compact = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const proxyState = useProxyState();
@@ -57,7 +60,6 @@ const ProxyControl: FC<ProxyControlProps> = ({
   const [showSettings, setShowSettings] = useState(false);
   const [showDashboard, setShowDashboard] = useState(false);
   const [clearing, setClearing] = useState(false);
-  const [clearMessage, setClearMessage] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { showToast } = useToastContext();
 
@@ -113,18 +115,20 @@ const ProxyControl: FC<ProxyControlProps> = ({
         className={buttonClasses}
         onClick={() => setIsOpen(!isOpen)}
         type="button"
+        title={compact ? 'Proxy' : undefined}
+        aria-label={compact ? 'Proxy' : undefined}
       >
         <span aria-hidden>
           <Icon icon={Repeat2} size={16} />
         </span>
-        <span>Proxy</span>
+        {!compact && <span>Proxy</span>}
         {proxyState.running && <span className={dotClasses}></span>}
       </Button>
 
       {isOpen && (
-        <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 min-w-[min(350px,calc(100vw-32px))] max-h-[calc(100vh-100px)] overflow-y-auto bg-background-overlay rounded-lg shadow-xl p-base z-dropdown text-text phone:absolute phone:top-[calc(100%+var(--spacing-sm))] phone:right-0 phone:left-auto phone:translate-x-0 phone:translate-y-0 phone:min-w-[350px] phone:max-h-none phone:overflow-visible">
-          <div className="flex justify-between items-center mb-base pb-md border-b border-border">
-            <h3 className="m-0 text-lg text-text">OpenAI Proxy</h3>
+        <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 min-w-[min(350px,calc(100vw-32px))] max-h-[calc(100vh-100px)] overflow-y-auto bg-surface-elevated rounded-lg shadow-xl p-base z-dropdown text-text phone:absolute phone:top-[calc(100%+var(--spacing-sm))] phone:right-0 phone:left-auto phone:translate-x-0 phone:translate-y-0 phone:min-w-[350px] phone:max-h-none phone:overflow-visible">
+          <div className="flex justify-between items-center mb-base pb-md border-b border-border-light">
+            <h3 className="m-0 text-lg font-semibold text-text">OpenAI Proxy</h3>
             <ProxyStatusPill running={proxyState.running} />
           </div>
 
@@ -132,7 +136,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
             <>
               <div className="mb-base">
                 <Stack gap="xs" className="mb-sm">
-                  <Label size="xs" muted>URL:</Label>
+                  <Label size="xs" muted>Endpoint URL</Label>
                   <EndpointCopyBar host={config.host} port={activePort} onCopied={handleCopied} />
                 </Stack>
               </div>
@@ -146,29 +150,22 @@ const ProxyControl: FC<ProxyControlProps> = ({
                 View Dashboard
               </Button>
 
-              {clearMessage && (
-                <div className="text-xs mb-md p-sm rounded-base bg-muted/50 text-foreground">
-                  {clearMessage}
-                </div>
-              )}
               <Button
                 variant="secondary"
                 className="w-full p-sm mb-md rounded-base text-sm font-medium"
                 onClick={async () => {
                   setClearing(true);
-                  setClearMessage(null);
                   try {
                     const result = await clearProxyCache(
                       config.host,
                       activePort,
                       settings?.proxyApiKey
                     );
-                    setClearMessage(result.message || 'Cache cleared');
-                  } catch (err: any) {
-                    setClearMessage(`Failed: ${err.message}`);
+                    showToast(result.message || 'Cache cleared', 'success');
+                  } catch (err) {
+                    showToast(`Failed to clear cache: ${formatError(err)}`, 'error');
                   } finally {
                     setClearing(false);
-                    setTimeout(() => setClearMessage(null), 5000);
                   }
                 }}
                 disabled={clearing || !cacheEnabled}
@@ -189,7 +186,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
               {showSettings && (
                 <div className="mb-md">
                   <div className="mb-md">
-                    <label className="block text-xs font-semibold text-text mb-xs">Host:</label>
+                    <Label size="xs" muted className="mb-xs">Host</Label>
                     <Input
                       type="text"
                       value={config.host}
@@ -197,7 +194,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
                     />
                   </div>
                   <div className="mb-md">
-                    <label className="block text-xs font-semibold text-text mb-xs">Proxy Port:</label>
+                    <Label size="xs" muted className="mb-xs">Proxy port</Label>
                     <Input
                       type="number"
                       value={config.port}
@@ -205,7 +202,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
                     />
                   </div>
                   <div>
-                    <label className="block text-xs font-semibold text-text mb-xs">Default Context:</label>
+                    <Label size="xs" muted className="mb-xs">Default context</Label>
                     <Input
                       type="number"
                       value={config.default_context ?? ''}
@@ -223,12 +220,12 @@ const ProxyControl: FC<ProxyControlProps> = ({
               )}
 
               <Button
-                variant="ghost"
-                className="w-full p-sm bg-transparent border border-border rounded-base cursor-pointer text-sm text-text-secondary mb-md transition-all hover:bg-surface-hover"
+                variant="outline"
+                className="w-full mb-md"
                 onClick={() => setShowSettings(!showSettings)}
                 leftIcon={<Icon icon={showSettings ? ChevronUp : ChevronDown} size={14} />}
               >
-                {showSettings ? 'Hide' : 'Show'} Settings
+                Connection options
               </Button>
 
               <ProxyToggleButton
@@ -238,7 +235,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
                 onStop={handleStop}
               />
 
-              <div className="mt-md pt-md border-t border-border">
+              <div className="mt-md pt-md border-t border-border-light">
                 <small className="text-text-muted text-xs leading-normal">
                   Configure OpenWebUI or other OpenAI-compatible clients to use this proxy.
                   Models will auto-swap based on requests.

--- a/src/components/ProxyDashboardModal.tsx
+++ b/src/components/ProxyDashboardModal.tsx
@@ -70,14 +70,14 @@ export const ProxyDashboardModal: FC<ProxyDashboardModalProps> = ({
           panel can tell the user which.
         */}
         <section>
-          <h3 className="text-xs font-semibold text-text mb-sm">
+          <h3 className="m-0 text-sm font-semibold text-text mb-sm">
             VRAM Residency
           </h3>
           <ProxyAdmissionPanel admission={snapshot?.admission} />
         </section>
 
         <section>
-          <h3 className="text-xs font-semibold text-text mb-sm">
+          <h3 className="m-0 text-sm font-semibold text-text mb-sm">
             Launch Decisions
           </h3>
           <ProxyLaunchPanel launch={snapshot?.launch} />
@@ -89,19 +89,19 @@ export const ProxyDashboardModal: FC<ProxyDashboardModalProps> = ({
           llama-server agrees it received it.
         */}
         <section>
-          <h3 className="text-xs font-semibold text-text mb-sm">
+          <h3 className="m-0 text-sm font-semibold text-text mb-sm">
             Sampling Readback
           </h3>
           <ProxySamplingPanel audit={snapshot?.sampling_audit} />
         </section>
 
         <section>
-          <h3 className="text-xs font-semibold text-text mb-sm">Prompt Cache</h3>
+          <h3 className="m-0 text-sm font-semibold text-text mb-sm">Prompt Cache</h3>
           <ProxyCachePanel cache={snapshot?.cache} />
         </section>
 
         <section>
-          <h3 className="text-xs font-semibold text-text mb-sm">
+          <h3 className="m-0 text-sm font-semibold text-text mb-sm">
             Agent Cache (GUI Chat)
           </h3>
           {/*

--- a/src/components/ProxyLaunchPanel.tsx
+++ b/src/components/ProxyLaunchPanel.tsx
@@ -55,11 +55,11 @@ export const ProxyLaunchPanel: FC<ProxyLaunchPanelProps> = ({ launch }) => {
     <div className="flex flex-col gap-sm">
       <p className="text-sm font-semibold text-text">{headline(launch)}</p>
 
-      <div className="flex flex-col gap-xs p-md rounded-base border border-border bg-surface-elevated">
+      <div className="flex flex-col gap-xs p-md rounded-base bg-surface-elevated">
         {launch.decisions.map((decision) => (
           <div key={decision.label} className="flex items-baseline gap-md">
             <span className="text-xs text-text-muted w-16 shrink-0">{decision.label}</span>
-            <span className="text-sm text-text">{decision.value}</span>
+            <span className="text-sm text-text font-mono tabular-nums">{decision.value}</span>
             {/*
               The provenance is why this panel exists rather than a config
               dump, but it is the secondary read — dimmed so the eye takes the

--- a/src/components/ProxySamplingPanel.tsx
+++ b/src/components/ProxySamplingPanel.tsx
@@ -51,7 +51,7 @@ function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-baseline justify-between gap-md">
       <span className="text-xs text-text-muted">{label}</span>
-      <span className="text-sm text-text tabular-nums">{value}</span>
+      <span className="text-sm text-text font-mono tabular-nums">{value}</span>
     </div>
   );
 }
@@ -318,7 +318,7 @@ const DivergenceRows: FC<{ divergences: SamplingDivergence[] }> = ({ divergences
     return null;
   }
   return (
-    <div className="flex flex-col gap-xs p-md rounded-base border border-border bg-surface-elevated">
+    <div className="flex flex-col gap-xs p-md rounded-base bg-surface-elevated">
       {divergences.map((d, i) => (
         <div key={`${d.field}-${i}`} className="flex items-baseline gap-md">
           <span className="text-xs text-text-muted w-32 shrink-0">{d.field}</span>

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -67,7 +67,7 @@ const RangeSlider: FC<RangeSliderProps> = ({
       {label && (
         <div className="flex justify-between items-center mb-sm">
           <span className="text-sm font-medium text-text">{label}</span>
-          <span className="text-xs font-semibold text-primary bg-surface-elevated py-[2px] px-[6px] rounded-sm">
+          <span className="text-xs font-semibold text-primary bg-surface-elevated py-[2px] px-[6px] rounded-sm font-mono tabular-nums">
             {formatValue(minValue)} — {formatValue(maxValue)}
           </span>
         </div>
@@ -115,8 +115,8 @@ const RangeSlider: FC<RangeSliderProps> = ({
 
       {/* Min/Max labels */}
       <div className="flex justify-between mt-xs">
-        <span className="text-xs text-text-muted">{formatValue(min)}</span>
-        <span className="text-xs text-text-muted">{formatValue(max)}</span>
+        <span className="text-xs text-text-muted font-mono tabular-nums">{formatValue(min)}</span>
+        <span className="text-xs text-text-muted font-mono tabular-nums">{formatValue(max)}</span>
       </div>
     </div>
   );

--- a/src/components/SettingsModal/InferenceProfiles.tsx
+++ b/src/components/SettingsModal/InferenceProfiles.tsx
@@ -148,7 +148,7 @@ export const InferenceProfiles: FC = () => {
           {profiles.map((profile) => (
             <div
               key={profile.name}
-              className="p-md border border-border rounded-base flex items-start justify-between gap-md"
+              className="p-md bg-surface rounded-md flex items-start justify-between gap-md"
             >
               <div className="min-w-0">
                 <div className="flex items-center gap-sm">

--- a/src/components/SettingsModal/fields/PathSettings.tsx
+++ b/src/components/SettingsModal/fields/PathSettings.tsx
@@ -1,4 +1,6 @@
 import { FC } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Icon } from '../../ui/Icon';
 import { cn } from '../../../utils/cn';
 import { Input } from '../../ui/Input';
 import { Button } from '../../ui/Button';
@@ -45,25 +47,28 @@ export const PathSettings: FC<PathSettingsProps> = ({
       disabled={saving}
     />
     {info && (
-      <div className="flex gap-sm flex-wrap" role="status" aria-live="polite">
-        <span
-          className={cn(
-            'inline-flex items-center h-6 px-2 rounded-base text-xs font-medium',
-            info.exists ? 'bg-success-subtle text-success' : 'bg-warning-subtle text-warning',
-          )}
-          aria-label={info.exists ? 'Directory exists' : 'Directory will be created (warning)'}
-        >
-          {info.exists ? 'Directory exists' : 'Directory will be created'}
-        </span>
-        <span
-          className={cn(
-            'inline-flex items-center h-6 px-2 rounded-base text-xs font-medium',
-            info.writable ? 'bg-success-subtle text-success' : 'bg-danger-subtle text-danger',
-          )}
-          aria-label={info.writable ? 'Writable' : 'Not writable (error)'}
-        >
-          {info.writable ? 'Writable' : 'Not writable'}
-        </span>
+      <div className="flex gap-sm flex-wrap items-center" role="status" aria-live="polite">
+        {info.exists && info.writable ? (
+          <span className="text-xs text-text-muted">Directory exists · writable</span>
+        ) : (
+          <>
+            <span
+              className={cn(
+                'inline-flex items-center gap-xs text-xs',
+                info.exists ? 'text-text-muted' : 'text-warning',
+              )}
+            >
+              {!info.exists && <Icon icon={AlertTriangle} size={12} />}
+              {info.exists ? 'Directory exists' : 'Directory will be created'}
+            </span>
+            {!info.writable && (
+              <span className="inline-flex items-center gap-xs text-xs text-danger">
+                <Icon icon={AlertTriangle} size={12} />
+                Not writable
+              </span>
+            )}
+          </>
+        )}
       </div>
     )}
   </SettingField>

--- a/src/components/SetupWizard/SetupWizard.tsx
+++ b/src/components/SetupWizard/SetupWizard.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '../ui/Button';
+import { Banner } from '../ui/Banner';
 import { Icon } from '../ui/Icon';
 import { cn } from '../../utils/cn';
 import { formatBytes } from '../../utils/format';
@@ -184,11 +185,11 @@ export const SetupWizard: FC<SetupWizardProps> = ({ onComplete }) => {
 
 const WizardShell: FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="fixed inset-0 bg-background z-50 flex items-center justify-center">
-    <div className="w-full max-w-[42rem] max-h-[90vh] bg-surface rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden">
+    <div className="w-full max-w-[42rem] max-h-[90vh] bg-surface-elevated rounded-lg shadow-2xl flex flex-col overflow-hidden">
       {/* Header */}
-      <div className="px-8 pt-6 pb-4 border-b border-border">
+      <div className="px-8 pt-6 pb-4 border-b border-border-light">
         <div className="flex items-center gap-3">
-          <div className="h-8 w-8 rounded-lg bg-primary/20 flex items-center justify-center">
+          <div className="h-8 w-8 rounded-lg bg-primary-subtle flex items-center justify-center">
             <Icon icon={Sparkles} size={18} className="text-primary" />
           </div>
           <div>
@@ -407,10 +408,7 @@ const LlamaInstallStep: FC<{
             llama.cpp is already installed and ready to use.
           </p>
         </div>
-        <div className="bg-success/10 border border-success/30 rounded-lg p-4 flex items-center gap-3">
-          <Icon icon={CheckCircle2} size={20} className="text-success shrink-0" />
-          <span className="text-sm text-text">llama.cpp binaries are installed</span>
-        </div>
+        <Banner variant="success">llama.cpp binaries are installed</Banner>
         <StepNavigation onBack={onBack} onNext={onNext} />
       </div>
     );
@@ -435,15 +433,9 @@ const LlamaInstallStep: FC<{
 
       {/* Install error */}
       {installError && (
-        <div className="bg-danger/10 border border-danger/30 rounded-lg p-4">
-          <div className="flex items-start gap-3">
-            <Icon icon={AlertCircle} size={18} className="text-danger shrink-0 mt-0.5" />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-danger mb-1">Installation failed</p>
-              <p className="text-xs text-text-secondary break-all">{installError}</p>
-            </div>
-          </div>
-        </div>
+        <Banner variant="danger" title="Installation failed">
+          <span className="break-all">{installError}</span>
+        </Banner>
       )}
 
       {/* Progress bar */}
@@ -455,8 +447,8 @@ const LlamaInstallStep: FC<{
               style={{ width: progress.total > 0 ? `${(progress.downloaded / progress.total) * 100}%` : '0%' }}
             />
           </div>
-          <div className="flex justify-between text-xs text-text-secondary">
-            <span>{progress.total > 0 ? `${((progress.downloaded / progress.total) * 100).toFixed(1)}%` : 'Starting...'}</span>
+          <div className="flex justify-between text-xs text-text-secondary font-mono tabular-nums">
+            <span>{progress.total > 0 ? `${((progress.downloaded / progress.total) * 100).toFixed(1)}%` : 'Starting…'}</span>
             {progress.total > 0 && (
               <span>{formatBytes(progress.downloaded)} / {formatBytes(progress.total)}</span>
             )}
@@ -543,10 +535,7 @@ const PythonSetupStep: FC<{
             optimized transfer for maximum speed.
           </p>
         </div>
-        <div className="bg-success/10 border border-success/30 rounded-lg p-4 flex items-center gap-3">
-          <Icon icon={CheckCircle2} size={20} className="text-success shrink-0" />
-          <span className="text-sm text-text">Download accelerator is ready</span>
-        </div>
+        <Banner variant="success">Download accelerator is ready</Banner>
         <StepNavigation onBack={onBack} onNext={onNext} />
       </div>
     );
@@ -565,39 +554,32 @@ const PythonSetupStep: FC<{
       </div>
 
       {!status.pythonAvailable && (
-        <div className="bg-warning/10 border border-warning/30 rounded-lg p-4 flex items-start gap-3">
-          <Icon icon={AlertCircle} size={18} className="text-warning shrink-0 mt-0.5" />
-          <div>
-            <p className="text-sm font-medium text-warning mb-1">Python not found</p>
-            <p className="text-xs text-text-secondary">
-              The accelerator needs Python 3.9 or newer. Skip this step and downloads
-              will run directly, which needs nothing installed. To use it later,
-              install Python and either re-run this wizard from Settings or run{' '}
-              <code>gglib config fast-downloads enable</code>.
-            </p>
-          </div>
-        </div>
+        <Banner variant="warning" title="Python not found">
+          The accelerator needs Python 3.9 or newer. Skip this step and downloads
+          will run directly, which needs nothing installed. To use it later,
+          install Python and either re-run this wizard from Settings or run{' '}
+          <code>gglib config fast-downloads enable</code>.
+        </Banner>
       )}
 
       {/* Setup error with retry */}
       {setupError && (
-        <div className="bg-danger/10 border border-danger/30 rounded-lg p-4">
-          <div className="flex items-start gap-3">
-            <Icon icon={AlertCircle} size={18} className="text-danger shrink-0 mt-0.5" />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-danger mb-1">Setup failed</p>
-              <p className="text-xs text-text-secondary break-all mb-3">{setupError}</p>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSetup}
-                leftIcon={<Icon icon={RefreshCw} size={14} />}
-              >
-                Retry
-              </Button>
-            </div>
-          </div>
-        </div>
+        <Banner
+          variant="danger"
+          title="Setup failed"
+          action={
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleSetup}
+              leftIcon={<Icon icon={RefreshCw} size={14} />}
+            >
+              Retry
+            </Button>
+          }
+        >
+          <span className="break-all">{setupError}</span>
+        </Banner>
       )}
 
       {/* Loading */}
@@ -643,7 +625,7 @@ const PythonSetupStep: FC<{
 const CompleteStep: FC<{ status: SetupStatus; onFinish: () => void }> = ({ status, onFinish }) => (
   <div className="flex flex-col gap-6">
     <div className="text-center py-4">
-      <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-success/20 mb-4">
+      <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-success-subtle mb-4">
         <Icon icon={CheckCircle2} size={32} className="text-success" />
       </div>
       <h2 className="text-xl font-semibold text-text mb-2">You&apos;re all set!</h2>
@@ -680,10 +662,10 @@ const InfoCard: FC<{
   value: string;
   variant: 'success' | 'neutral';
 }> = ({ icon: CardIcon, label, value, variant }) => (
-  <div className="bg-background-secondary rounded-lg p-3 border border-border flex items-center gap-3">
+  <div className="bg-background-secondary rounded-md p-3 flex items-center gap-3">
     <div className={cn(
       'w-8 h-8 rounded-lg flex items-center justify-center shrink-0',
-      variant === 'success' ? 'bg-success/20' : 'bg-background-tertiary',
+      variant === 'success' ? 'bg-success-subtle' : 'bg-background-tertiary',
     )}>
       <Icon icon={CardIcon} size={16} className={variant === 'success' ? 'text-success' : 'text-text-secondary'} />
     </div>
@@ -695,11 +677,8 @@ const InfoCard: FC<{
 );
 
 const StatusBadge: FC<{ ok: boolean; label: string }> = ({ ok, label }) => (
-  <span className={cn(
-    'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium',
-    ok ? 'bg-success/20 text-success' : 'bg-warning/20 text-warning',
-  )}>
-    <span className={cn('w-1.5 h-1.5 rounded-full', ok ? 'bg-success' : 'bg-warning')} />
+  <span className="inline-flex items-center gap-xs text-xs text-text-muted">
+    <span aria-hidden className={cn('w-1.5 h-1.5 rounded-full', ok ? 'bg-success' : 'bg-warning')} />
     {label}
   </span>
 );

--- a/src/components/proxy/ConnectionRow.tsx
+++ b/src/components/proxy/ConnectionRow.tsx
@@ -23,7 +23,7 @@ interface ConnectionRowProps {
  * inventing a denominator.
  */
 export const ConnectionRow: FC<ConnectionRowProps> = ({ connection }) => (
-  <div className="p-md rounded-base border border-border bg-surface-elevated">
+  <div className="p-md rounded-base bg-surface-elevated">
     <div className="flex items-center justify-between mb-sm">
       <span className="text-sm font-semibold text-text truncate">{connection.model_name}</span>
       <span className="text-xs text-text-muted">{phaseLabels[connection.phase]}</span>

--- a/src/components/proxy/EndpointCopyBar.tsx
+++ b/src/components/proxy/EndpointCopyBar.tsx
@@ -35,17 +35,10 @@ export const EndpointCopyBar: FC<EndpointCopyBarProps> = ({ host, port, onCopied
 
   return (
     <div className="flex gap-sm items-center">
-      <code className="flex-1 bg-surface-elevated p-sm rounded-base text-sm border border-border font-mono truncate">
+      <code className="flex-1 bg-surface-elevated p-sm rounded-base text-sm font-mono truncate">
         {url}
       </code>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={copy}
-        className="bg-primary border-none rounded-base p-sm cursor-pointer text-base text-text-inverse transition-all hover:bg-primary-hover hover:scale-105"
-        title="Copy URL"
-        iconOnly
-      >
+      <Button variant="ghost" size="sm" onClick={copy} title="Copy URL" iconOnly>
         <Icon icon={ClipboardCopy} size={14} />
       </Button>
     </div>

--- a/src/components/proxy/ProxyMetricsGrid.tsx
+++ b/src/components/proxy/ProxyMetricsGrid.tsx
@@ -11,8 +11,9 @@ interface SectionProps {
   compact?: boolean;
 }
 
-const Heading: FC<{ children: ReactNode }> = ({ children }) => (
-  <h3 className="text-xs font-semibold text-text mb-sm">{children}</h3>
+/** Section heading on the contract's type ladder — shared so proxy surfaces can't drift. */
+export const SectionHeading: FC<{ children: ReactNode }> = ({ children }) => (
+  <h3 className="m-0 text-sm font-semibold text-text mb-sm">{children}</h3>
 );
 
 /** In-flight requests, with a count once a snapshot has arrived. */
@@ -21,7 +22,7 @@ export const ActiveConnectionsSection: FC<SectionProps> = ({ snapshot }) => {
 
   return (
     <section>
-      <Heading>Active Connections{snapshot ? ` (${connections.length})` : ''}</Heading>
+      <SectionHeading>Active Connections{snapshot ? ` (${connections.length})` : ''}</SectionHeading>
       <RequestThroughput snapshot={snapshot} />
       {connections.length > 0 ? (
         <div className="flex flex-col gap-sm">
@@ -47,7 +48,7 @@ export const InferenceSlotsSection: FC<SectionProps> = ({ snapshot, compact = fa
 
   return (
     <section>
-      <Heading>Inference Slots</Heading>
+      <SectionHeading>Inference Slots</SectionHeading>
       {hasSlots ? (
         <div className="flex flex-wrap gap-md">
           {snapshot?.slots.map((slot) => (

--- a/src/components/proxy/ProxyStatusPill.tsx
+++ b/src/components/proxy/ProxyStatusPill.tsx
@@ -7,20 +7,19 @@ interface ProxyStatusPillProps {
 }
 
 /**
- * Running/stopped badge for the proxy.
+ * Running/stopped indicator for the proxy: status dot + neutral text, per the
+ * contract's green-is-a-dot-never-a-fill rule.
  *
  * Stopped is idle, not an error — danger red is reserved for failures, so a
  * stopped proxy uses the neutral offline colour. See `--color-offline` in
  * `styles/base/variables.css`.
  */
 export const ProxyStatusPill: FC<ProxyStatusPillProps> = ({ running, className }) => (
-  <span
-    className={cn(
-      'px-md py-xs rounded-lg text-xs font-semibold',
-      running ? 'bg-success-subtle text-success' : 'bg-background-hover text-offline',
-      className,
-    )}
-  >
+  <span className={cn('inline-flex items-center gap-xs text-xs text-text-muted', className)}>
+    <span
+      aria-hidden
+      className={cn('w-1.5 h-1.5 rounded-full', running ? 'bg-success' : 'bg-offline')}
+    />
     {running ? 'Running' : 'Stopped'}
   </span>
 );

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -15,6 +15,8 @@ export interface ChipProps {
   selected?: boolean;
   /** When present the chip renders as a real button with hover/focus affordances. */
   onClick?: () => void;
+  /** Only meaningful with onClick — disables the toggle button. */
+  disabled?: boolean;
   /** Renders a small remove control inside the chip (e.g. tag chips). */
   onRemove?: () => void;
   /** Accessible name for the remove control. Defaults to "Remove". */
@@ -50,6 +52,7 @@ export function Chip({
   leftIcon,
   selected = false,
   onClick,
+  disabled = false,
   onRemove,
   removeLabel = "Remove",
   className,
@@ -88,10 +91,11 @@ export function Chip({
         type="button"
         onClick={onClick}
         title={title}
+        disabled={disabled}
         aria-pressed={selected}
         className={cn(
           shared,
-          "cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+          "cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50 disabled:cursor-not-allowed",
           !selected && "hover:bg-surface-hover hover:text-text",
         )}
       >

--- a/src/pages/BenchmarkPage.tsx
+++ b/src/pages/BenchmarkPage.tsx
@@ -24,8 +24,10 @@ import {
   useRef,
   useState,
 } from 'react';
-import { ArrowLeft, BarChart2, Play, Square, Target, Zap } from 'lucide-react';
+import { ArrowLeft, BarChart2, Play, Square, Zap } from 'lucide-react';
 import { Checkbox } from '../components/ui/Checkbox';
+import { Tabs } from '../components/ui/Tabs';
+import { EmptyState, Readout } from '../components/primitives';
 import { Button } from '../components/ui/Button';
 import { Icon } from '../components/ui/Icon';
 import { Input } from '../components/ui/Input';
@@ -329,23 +331,17 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
 
   const renderPerfResult = (r: ModelPerfResult) => (
     <div className="flex gap-lg flex-wrap text-sm">
-      <div className="flex flex-col items-center gap-xs bg-surface rounded-md p-md min-w-[90px]">
-        <span className="text-xs text-text-muted">TG Speed</span>
-        <span className="text-xl font-bold text-primary">{r.tg_tps.toFixed(1)}</span>
-        <span className="text-xs text-text-muted">t/s</span>
+      <div className="bg-surface rounded-md p-md min-w-[90px]">
+        <Readout label="TG speed" value={r.tg_tps.toFixed(1)} unit="t/s" size="lg" align="center" />
       </div>
-      <div className="flex flex-col items-center gap-xs bg-surface rounded-md p-md min-w-[90px]">
-        <span className="text-xs text-text-muted">PP Speed</span>
-        <span className="text-xl font-bold text-success">{r.pp_tps.toFixed(1)}</span>
-        <span className="text-xs text-text-muted">t/s</span>
+      <div className="bg-surface rounded-md p-md min-w-[90px]">
+        <Readout label="PP speed" value={r.pp_tps.toFixed(1)} unit="t/s" size="lg" align="center" />
       </div>
-      <div className="flex flex-col items-center gap-xs bg-surface rounded-md p-md min-w-[90px]">
-        <span className="text-xs text-text-muted">Backend</span>
-        <span className="text-sm font-medium text-text">{r.backend ?? '—'}</span>
+      <div className="bg-surface rounded-md p-md min-w-[90px]">
+        <Readout label="Backend" value={r.backend ?? '—'} size="sm" align="center" />
       </div>
-      <div className="flex flex-col items-center gap-xs bg-surface rounded-md p-md min-w-[90px]">
-        <span className="text-xs text-text-muted">Reps</span>
-        <span className="text-sm font-medium text-text">{r.repetitions}</span>
+      <div className="bg-surface rounded-md p-md min-w-[90px]">
+        <Readout label="Reps" value={r.repetitions} size="sm" align="center" />
       </div>
     </div>
   );
@@ -354,7 +350,7 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
     const statusColor = {
       pending: 'text-text-muted',
       running: 'text-primary',
-      complete: 'text-success',
+      complete: 'text-text-muted',
       failed: 'text-danger',
     }[m.status];
 
@@ -366,7 +362,7 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
     }[m.status];
 
     return (
-      <div key={m.modelId} className="border border-border rounded-lg p-base flex flex-col gap-sm">
+      <div key={m.modelId} className="bg-surface rounded-md p-base flex flex-col gap-sm">
         <div className="flex items-center gap-sm">
           <span className="font-medium text-text truncate flex-1">{m.modelName}</span>
           <span className={cn('text-xs font-medium', statusColor)}>{statusLabel}</span>
@@ -374,7 +370,7 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
 
         {/* Live streaming text (compare mode) */}
         {m.status === 'running' && m.liveText && mode === 'compare' && (
-          <div className="bg-surface rounded-md p-base text-sm text-text whitespace-pre-wrap font-mono leading-relaxed max-h-[300px] overflow-y-auto">
+          <div className="bg-surface-elevated rounded-md p-base text-sm text-text whitespace-pre-wrap font-mono leading-relaxed max-h-[300px] overflow-y-auto">
             {m.liveText}
             <span className="inline-block w-2 h-4 bg-primary animate-pulse ml-0.5 align-text-bottom" />
           </div>
@@ -407,30 +403,18 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
         </Button>
         <Icon icon={BarChart2} size={18} className="text-primary" />
         <h1 className="text-base font-semibold text-text m-0 flex-1">Benchmark Dashboard</h1>
-        <div className="flex gap-xs">
-          <Button
-            variant={mode === 'perf' ? 'primary' : 'secondary'}
-            size="sm"
-            onClick={() => setMode('perf')}
-          >
-            Perf
-          </Button>
-          <Button
-            variant={mode === 'compare' ? 'primary' : 'secondary'}
-            size="sm"
-            onClick={() => setMode('compare')}
-          >
-            Compare
-          </Button>
-          <Button
-            variant={mode === 'tune' ? 'primary' : 'secondary'}
-            size="sm"
-            leftIcon={<Icon icon={Target} size={14} />}
-            onClick={() => setMode('tune')}
-          >
-            Tune
-          </Button>
-        </div>
+        <Tabs<RunMode>
+          aria-label="Benchmark mode"
+          size="sm"
+          divider={false}
+          activeId={mode}
+          onChange={setMode}
+          tabs={[
+            { id: 'perf', label: 'Perf' },
+            { id: 'compare', label: 'Compare' },
+            { id: 'tune', label: 'Tune' },
+          ]}
+        />
       </header>
 
       {/* Body */}
@@ -582,17 +566,19 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
           {/* Live results area */}
           <div className="flex-1 overflow-y-auto p-base flex flex-col gap-base">
             {runState.models.length === 0 && runState.status === 'idle' && (
-              <div className="flex flex-col items-center justify-center h-full text-text-muted gap-sm">
-                <Icon icon={Zap} size={32} className="opacity-30" />
-                <p className="text-sm">Select models and press Run to start a benchmark.</p>
-              </div>
+              <EmptyState
+                className="h-full"
+                icon={<Icon icon={Zap} size={24} />}
+                title="No benchmark yet"
+                description="Pick one or more models on the left, then press Run to measure prompt-processing and generation speed."
+              />
             )}
             {runState.models.map(renderModelCard)}
           </div>
 
           {/* History section */}
-          <section className="border-t border-border shrink-0">
-            <div className="flex items-center gap-sm px-base py-sm border-b border-border">
+          <section className="border-t border-border-light shrink-0">
+            <div className="flex items-center gap-sm px-base py-sm border-b border-border-light">
               <h2 className="text-sm font-semibold text-text m-0 flex-1">Recent Runs</h2>
               <Button
                 variant="ghost"
@@ -620,27 +606,26 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
                   <tbody>
                     {history.map(run => (
                       <tr key={run.id} className="border-b border-border-light hover:bg-surface-elevated transition-colors">
-                        <td className="px-base py-xs text-text-secondary">{run.id}</td>
+                        <td className="px-base py-xs text-text-secondary font-mono tabular-nums">{run.id}</td>
+                        <td className="px-base py-xs text-text-secondary">{run.run_type}</td>
                         <td className="px-base py-xs">
-                          <span className={cn(
-                            'py-xs px-sm rounded-sm font-medium',
-                            run.run_type === 'perf' ? 'bg-primary-subtle text-primary' : 'bg-warning-subtle text-warning',
-                          )}>
-                            {run.run_type}
+                          <span className="inline-flex items-center gap-xs">
+                            {run.status === 'running' && (
+                              <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+                            )}
+                            <span
+                              className={cn(
+                                'text-text-muted',
+                                run.status === 'failed' && 'text-danger',
+                                run.status === 'running' && 'text-text',
+                              )}
+                            >
+                              {run.status}
+                            </span>
                           </span>
                         </td>
-                        <td className="px-base py-xs">
-                          <span className={cn(
-                            'py-xs px-sm rounded-sm font-medium',
-                            run.status === 'complete' && 'text-success bg-success-subtle',
-                            run.status === 'running' && 'text-primary bg-primary-subtle',
-                            run.status === 'failed' && 'text-danger bg-danger-subtle',
-                          )}>
-                            {run.status}
-                          </span>
-                        </td>
-                        <td className="px-base py-xs text-text-secondary">{run.model_ids.length}</td>
-                        <td className="px-base py-xs text-text-muted">{formatDate(run.created_at)}</td>
+                        <td className="px-base py-xs text-text-secondary font-mono tabular-nums">{run.model_ids.length}</td>
+                        <td className="px-base py-xs text-text-muted font-mono tabular-nums">{formatDate(run.created_at)}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/pages/TrayPanel.tsx
+++ b/src/pages/TrayPanel.tsx
@@ -121,7 +121,7 @@ export const TrayPanel: FC = () => {
 
   return (
     <div className="flex flex-col h-screen bg-background text-text overflow-hidden tabular-nums">
-      <header className="flex items-center justify-between px-base py-md border-b border-border shrink-0">
+      <header className="flex items-center justify-between px-base py-md border-b border-border-light shrink-0">
         <span className="text-sm font-semibold">gglib</span>
         <ProxyStatusPill running={proxy.running} />
       </header>
@@ -155,7 +155,7 @@ export const TrayPanel: FC = () => {
         )}
       </div>
 
-      <footer className="px-base py-md border-t border-border shrink-0 flex flex-col gap-sm">
+      <footer className="px-base py-md border-t border-border-light shrink-0 flex flex-col gap-sm">
         <ProxyToggleButton
           running={proxy.running}
           pending={pending}

--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -446,13 +446,36 @@ has an accessible name.
 - Green means running/online only, expressed as a **dot + neutral text** —
   never a filled pill.
 - Amber (`primary`) is selection, focus, links, and the single primary CTA.
+- Warning is always an icon or label **plus text**, never color alone —
+  accent amber and warning gold are hue neighbors by design, so the words
+  carry the distinction.
 
 ### Type hierarchy
 
 No all-caps micro-labels. Panel/modal titles `text-lg font-semibold`;
 section headings `text-sm font-semibold text-text`; body and controls
-`text-sm`; meta `text-xs text-text-muted`; ports/paths/quant strings
-`font-mono text-xs tabular-nums`. `text-2xs` is reserved for badge numerals.
+`text-sm`; meta `text-xs text-text-muted`; ports/paths/quant strings and
+**all numeric telemetry** (counts, rates, percentages, sizes)
+`font-mono tabular-nums`. `text-2xs` is reserved for badge numerals and
+readout unit suffixes.
+
+### Readouts & live charts
+
+Every live metric renders through `primitives/Readout`: mono `tabular-nums`
+value, quiet unit suffix, label in `text-xs text-text-muted`. Intent colors
+the value only — labels and units always stay quiet, and warning/danger
+intents never appear without the label naming the metric.
+
+Exactly **one sparkline style app-wide**: `primitives/Sparkline` with its
+defaults (currentColor stroke, 2px terminus dot, faint `stroke-border`
+baseline) — no per-screen variants; only width/height flex with context.
+A sparkline never appears without an adjacent current-value Readout.
+Percentage series pin the domain (`min={0} max={100}`) so lines show real
+movement, not autoscaled noise.
+
+Usage-meter severity thresholds (donut, KV readouts) are **70 warning /
+90 danger**; below 70 meters wear `primary` — green is reserved for
+running/online and never means "usage is fine".
 
 ### Density & radius
 

--- a/tests/ts/components/proxyShared.test.tsx
+++ b/tests/ts/components/proxyShared.test.tsx
@@ -52,13 +52,15 @@ describe('ProxyStatusPill', () => {
 
   /**
    * A stopped proxy is idle, not broken. Danger red is reserved for real
-   * failures, so the stopped pill must not carry it.
+   * failures, so the stopped indicator must not carry it — its dot wears the
+   * neutral offline colour and the text stays quiet.
    */
   it('styles a stopped proxy as idle rather than as an error', () => {
     render(<ProxyStatusPill running={false} />);
-    const pill = screen.getByText('Stopped');
-    expect(pill.className).toContain('text-offline');
-    expect(pill.className).not.toContain('danger');
+    const indicator = screen.getByText('Stopped');
+    expect(indicator.querySelector('.bg-offline')).not.toBeNull();
+    expect(indicator.className).not.toContain('danger');
+    expect(indicator.innerHTML).not.toContain('danger');
   });
 });
 


### PR DESCRIPTION
PR 5/13 — **stacked on** `feat(gui)/readout-adoption` (#760). Completes the restyle phase: the contract catches up with the shipped identity, and a whole-app polish sweep brings every screen onto it.

## Contract (§10)
- New **Readouts & live charts** rules: every live metric renders through `Readout`; exactly one sparkline style app-wide; sparklines never appear without an adjacent current-value readout; percentage series pin their domain; 70/90 usage thresholds; meters wear `primary` below 70 (green stays reserved for running/online).
- **Warning never speaks in color alone** (accent amber and warning gold are hue neighbors by design).
- The mono rule extends to **all numeric telemetry** (counts, rates, percentages, sizes).

## The sweep (51 files, applied in one voice)
Eight parallel screen critics raised 64 findings; a synthesis judge verified them against the code and distilled a 20-item worklist — every item applied: filled status pills retired for the dot idiom (10 files), download/benchmark metrics routed through `Readout`, mono numerals everywhere, borders stripped from in-flow surfaces (19 files), one-solid-primary-per-surface enforced (the Benchmark mode switcher is now real `Tabs`), hand-rolled callouts → `Banner`, form-control overrides removed, raw `<select>`s/file-input → primitives, floating-surface chrome normalized, type-ladder drift fixed, orphaned skeletons finally wired, `EmptyState` adopted, focus-visible gaps closed, dead classes removed. Net −20 lines.

## Review gate + regression proof
- Gate: 42 findings raised, **11 confirmed and fixed** — including a genuine blocker the sweep itself introduced (the HF model card's new keyboard handler hijacked its nested HuggingFace button; now a stretched-select-button pattern with no interactive nesting), a lost `disabled` state on the tune-suite toggle (ui/Chip gained a `disabled` prop), three mono-numeral stragglers, and ARIA cleanups.
- **Nothing-lost sweep: all 8 screens verified intact** — every baseline capability still renders, is reachable, and is wired.
- Also: the library header's Proxy trigger gains a `compact` (icon+dot) mode, fixing its clipped label at sidebar width.

## Noted exceptions
- `BenchmarkPage` (643 LOC) and `SetupWizard` (~740 LOC) exceed the 200-LOC budget and were materially touched, but their decomposition is deliberately not in this PR: BenchmarkPage's split is already planned as part of PR 6 (agentic mode), and the wizard's belongs in a dedicated refactor rather than a 51-file polish commit.
- `ProxyLaunchPanel`'s headline keeps proportional type (it leads with the model name); its decision values are now mono.

`npm run lint` / `test:run` (758 passed) / `build` all green.