### PR TITLE
fix(runtime): stall-based admission deadline, and a fresh ticket after a failed serve

### DIFF
--- a/crates/gglib-runtime/src/process/admission/README.md
+++ b/crates/gglib-runtime/src/process/admission/README.md
@@ -68,6 +68,13 @@ time — it is indivisible, so the rival behind it waits. [`ADMISSION_DEADLINE`]
 is the backstop there: the request gives up and gets a 503 with `Retry-After`,
 and the caller controls its own backoff from there.
 
+The deadline measures **stall, not age**. A waiter's clock is paused while any
+launch is in flight (a load is bounded work, not a wedge — the first request on
+a cold daemon used to 503 against its own model load here) and resets whenever
+the queue provably moves: a lease released, a launch landing or failing, a slot
+evicted. Only a queue that does *nothing* for the whole deadline expires a
+waiter, which is exactly the hog-or-wedge case the backstop exists for.
+
 This is why admission returns a lease rather than just a target — see
 [`AdmissionLease`](gglib_core::ports::AdmissionLease).
 

--- a/crates/gglib-runtime/src/process/admission/queue_tests.rs
+++ b/crates/gglib-runtime/src/process/admission/queue_tests.rs
@@ -654,7 +654,13 @@ async fn a_waiter_never_expires_while_a_launch_is_in_flight() {
     // The first requester on a cold daemon drives the launch...
     let (driver, decision) = request(&q, "qwen-coder");
     assert!(
-        matches!(decision, AdmissionDecision::Launch { slot: PRIMARY_SLOT, evict: None }),
+        matches!(
+            decision,
+            AdmissionDecision::Launch {
+                slot: PRIMARY_SLOT,
+                evict: None
+            }
+        ),
         "cold daemon: first request must launch, got {decision:?}"
     );
 
@@ -748,6 +754,30 @@ async fn a_request_expires_once_its_deadline_passes() {
     tokio::time::advance(ADMISSION_DEADLINE + std::time::Duration::from_secs(1)).await;
 
     assert_eq!(q.poll(&rival, NEVER_FITS), AdmissionDecision::Expired);
+}
+
+/// A ticket `poll` has granted is *forgotten*, and a forgotten ticket is
+/// invisible to the scheduler: it can never be the oldest waiter, so it can
+/// never win a launch — even with an empty slot there for the taking. The
+/// residency layer must therefore re-enqueue before going round again after a
+/// failed serve; this test pins the invisibility that makes that mandatory.
+#[tokio::test]
+async fn a_granted_ticket_is_forgotten_and_cannot_win_again() {
+    let q = queue();
+    let lease = make_resident(&q, "qwen-coder", 1);
+    drop(lease);
+
+    let (ticket, decision) = request(&q, "qwen-coder");
+    assert_eq!(decision, AdmissionDecision::Serve { slot: PRIMARY_SLOT });
+
+    // The serve fell through — the resident failed its health check and was
+    // recycled. Balance the Serve's in-flight increment, then evict.
+    drop(q.claim(PRIMARY_SLOT));
+    q.evict(PRIMARY_SLOT);
+
+    // The slot is empty and this request still wants the model, but the
+    // granted ticket cannot reach the front of any queue again.
+    assert_eq!(q.poll(&ticket, NEVER_FITS), AdmissionDecision::Wait);
 }
 
 /// An expired or abandoned request must stop holding the front of the queue,

--- a/crates/gglib-runtime/src/process/admission/queue_tests.rs
+++ b/crates/gglib-runtime/src/process/admission/queue_tests.rs
@@ -642,6 +642,100 @@ async fn a_third_model_evicts_the_secondary_not_the_primary() {
 
 // ── giving up ─────────────────────────────────────────────────────────────
 
+/// The cold-start papercut (observed three times in one benchmarking day): a
+/// request that arrives while a model launch is in flight must wait the load
+/// out, not expire in the queue. The load is bounded by [`LAUNCH_TIMEOUT`],
+/// so pausing the stall clock here cannot extend a wait indefinitely.
+#[tokio::test]
+async fn a_waiter_never_expires_while_a_launch_is_in_flight() {
+    tokio::time::pause();
+    let q = queue();
+
+    // The first requester on a cold daemon drives the launch...
+    let (driver, decision) = request(&q, "qwen-coder");
+    assert!(
+        matches!(decision, AdmissionDecision::Launch { slot: PRIMARY_SLOT, evict: None }),
+        "cold daemon: first request must launch, got {decision:?}"
+    );
+
+    // ...and both a same-model waiter and a rival queue behind the load.
+    let (waiter, d) = request(&q, "qwen-coder");
+    assert_eq!(d, AdmissionDecision::Wait);
+    let (rival, d) = request(&q, "nomic-embed");
+    assert_eq!(d, AdmissionDecision::Wait);
+
+    // The load takes far longer than the deadline. Neither waiter may expire
+    // while it is in flight.
+    tokio::time::advance(ADMISSION_DEADLINE * 2).await;
+    assert_eq!(
+        q.poll(&waiter, NEVER_FITS),
+        AdmissionDecision::Wait,
+        "a waiter for the loading model must sit out the load"
+    );
+    assert_eq!(
+        q.poll(&rival, NEVER_FITS),
+        AdmissionDecision::Wait,
+        "a launch in flight is progress, not a stall — the rival's clock is paused"
+    );
+
+    // The load lands. The turn aged past its quantum while it ran, so the
+    // fairness rules now owe the slot to the rival — the waiter keeps
+    // waiting, which is the point: *waiting*, not expired.
+    drop(driver);
+    let lease = q.install(PRIMARY_SLOT, resident(1, "qwen-coder"));
+    drop(lease);
+    assert_eq!(q.poll(&waiter, NEVER_FITS), AdmissionDecision::Wait);
+
+    // Once the rival hangs up, the waiter the old deadline would have 503'd
+    // is served from the resident its launch produced.
+    q.abandon(&rival);
+    assert_eq!(
+        q.poll(&waiter, NEVER_FITS),
+        AdmissionDecision::Serve { slot: PRIMARY_SLOT },
+        "survived the load and got served"
+    );
+}
+
+/// Progress resets the stall clock; only a true stall expires. A waiter that
+/// keeps losing freed capacity to a racing re-acquire is behind a *moving*
+/// queue and must not be expired on the old absolute clock — but once the
+/// queue stops moving entirely, the deadline still fires.
+#[tokio::test]
+async fn progress_resets_the_stall_clock_and_a_true_stall_still_expires() {
+    tokio::time::pause();
+    let q = queue();
+    let lease = make_resident(&q, "qwen-coder", 1);
+
+    let (capped, d) = request(&q, "qwen-coder");
+    assert_eq!(d, AdmissionDecision::Wait, "slot at capacity");
+
+    // Nearly the whole deadline passes with nothing happening...
+    tokio::time::advance(ADMISSION_DEADLINE - std::time::Duration::from_secs(1)).await;
+    assert_eq!(q.poll(&capped, NEVER_FITS), AdmissionDecision::Wait);
+
+    // ...then a generation finishes, and a pipelined rival immediately takes
+    // the freed capacity back before this waiter's next poll. The state looks
+    // identical; the epoch is what proves the queue moved.
+    drop(lease);
+    let release = q.lease(PRIMARY_SLOT).expect("slot is resident");
+    assert_eq!(
+        q.poll(&capped, NEVER_FITS),
+        AdmissionDecision::Wait,
+        "progress observed: the stall clock resets instead of expiring"
+    );
+
+    // Under the old absolute deadline this poll sat at nearly 2x the budget
+    // and would have expired. Under stall semantics the clock restarted at
+    // the release, so the waiter is still merely waiting...
+    tokio::time::advance(ADMISSION_DEADLINE - std::time::Duration::from_secs(1)).await;
+    assert_eq!(q.poll(&capped, NEVER_FITS), AdmissionDecision::Wait);
+
+    // ...until a full deadline passes with no progress at all.
+    tokio::time::advance(std::time::Duration::from_secs(2)).await;
+    assert_eq!(q.poll(&capped, NEVER_FITS), AdmissionDecision::Expired);
+    drop(release);
+}
+
 /// A request that never reaches the front gives up with a deadline rather than
 /// holding a connection open forever.
 #[tokio::test]

--- a/crates/gglib-runtime/src/process/admission/state.rs
+++ b/crates/gglib-runtime/src/process/admission/state.rs
@@ -51,25 +51,43 @@ pub const DRAIN_QUANTUM: Duration = Duration::from_secs(20);
 /// spawn.
 pub const LAUNCH_TIMEOUT: Duration = Duration::from_secs(150);
 
-/// How long a request may sit in the queue before giving up with a 503.
+/// How long a request may wait **with no queue progress** before giving up
+/// with a 503.
 ///
-/// The hard cap on waiting, and the only bound that holds unconditionally.
+/// A *stall* deadline, not a wall clock. It used to run from enqueue
+/// regardless of what the queue was doing, which made two very different
+/// situations expire identically: a genuinely wedged queue, and a first
+/// request on a cold daemon waiting out a model load that was proceeding
+/// normally — the second being a real failure observed three times in one
+/// day of benchmarking (a retry immediately succeeded each time, because the
+/// load the timeout had abandoned was in fact landing).
+///
+/// So the clock now measures time since the queue last did anything on
+/// anyone's behalf, and two things hold it back:
+///
+/// - **A launch in flight pauses every waiter's clock.** A loading slot is
+///   the opposite of a stall, and it is bounded on its own: [`LAUNCH_TIMEOUT`]
+///   abandons an overrunning launch and frees the slot, at which point the
+///   clock runs again. Waiting out a load can therefore extend a wait by at
+///   most one launch budget at a time, never indefinitely.
+/// - **Progress resets the clock.** A lease released (a generation finished),
+///   a launch landing or failing, a slot evicted — each proves the queue is
+///   moving, so a waiter behind it is queued, not stuck.
+///
+/// What still expires is exactly what this deadline always existed for.
 /// [`DRAIN_QUANTUM`] bounds how long a *turn* lasts, but a turn cannot end
 /// while the outgoing model still has requests in flight — no swap may preempt
-/// a live generation. What that leaves uncovered is one request that runs for a
-/// very long time: a single generation is indivisible, so the rival behind it
-/// has no bound but this one.
+/// a live generation. A single generation is indivisible, so the rival behind
+/// it has no bound but this one: an in-flight count that stays pinned with no
+/// release for this long is a hog or a wedge, and the waiter behind it gets
+/// its 503.
 ///
 /// It used to cover a great deal more. A model under *overlapping* load could
 /// hold its slot indefinitely, because nothing capped how many requests were in
 /// flight at once and a client that always kept one outstanding meant the count
 /// never reached zero. `SERVER_PARALLEL` and `owes_slot_to_rival` close that
-/// off, so
-/// reaching this deadline is now the exception it was meant to be rather than
-/// the ordinary outcome of two clients sharing an endpoint.
-///
-/// Comfortably above [`LAUNCH_TIMEOUT`], so a request waiting on its own launch
-/// can never expire before that launch has had its full budget.
+/// off, so reaching this deadline is now the exception it was meant to be
+/// rather than the ordinary outcome of two clients sharing an endpoint.
 pub const ADMISSION_DEADLINE: Duration = Duration::from_secs(180);
 
 /// A model loaded in VRAM, and everything the fast path needs to know about it.
@@ -179,6 +197,17 @@ struct Waiter {
     /// When it started waiting, reported on the dashboard as the queue depth's
     /// age so a user can see a backlog forming.
     enqueued_at: Instant,
+    /// When this waiter last saw the queue do anything — the reference point
+    /// [`ADMISSION_DEADLINE`] measures from. Reset on every progress event and
+    /// held back while a launch is in flight; `enqueued_at` stays untouched so
+    /// the dashboard keeps reporting the true wait.
+    stalled_since: Instant,
+    /// The [`QueueState::progress_epoch`] this waiter has already accounted
+    /// for. A counter rather than re-deriving from state, because progress is
+    /// a *transition* — a release followed by an immediate re-acquire leaves
+    /// the state looking identical, and the waiter behind it would otherwise
+    /// never learn the queue had moved.
+    seen_epoch: u64,
 }
 
 /// A registered place in the queue.
@@ -245,6 +274,11 @@ pub(super) struct QueueState {
     /// The most recent second-slot verdict, kept so the dashboard can explain
     /// an idle secondary rather than just showing it empty.
     pub(super) secondary_slot: SecondarySlotStatus,
+    /// Bumped on every event that proves the queue is moving: a launch
+    /// starting, landing or failing, a lease released, a slot evicted.
+    /// Waiters compare against it to tell a queue that is working through
+    /// its backlog from one that has stalled — see [`ADMISSION_DEADLINE`].
+    progress_epoch: u64,
 }
 
 impl Default for QueueState {
@@ -256,6 +290,7 @@ impl Default for QueueState {
             turn: None,
             stats: Stats::default(),
             secondary_slot: SecondarySlotStatus::default(),
+            progress_epoch: 0,
         }
     }
 }
@@ -272,6 +307,8 @@ impl QueueState {
             .push_back(Waiter {
                 seq,
                 enqueued_at: now,
+                stalled_since: now,
+                seen_epoch: self.progress_epoch,
             });
         Ticket {
             model: model.to_owned(),
@@ -372,13 +409,56 @@ impl QueueState {
             model: ticket.model.clone(),
             started_at: now,
         });
+        // A launch starting is progress for everyone behind it.
+        self.record_progress();
 
         AdmissionDecision::Launch { slot, evict }
     }
 
-    /// Whether this request has outlasted [`ADMISSION_DEADLINE`].
-    fn is_expired(&self, ticket: &Ticket, now: Instant) -> bool {
-        now.duration_since(ticket.created_at) >= ADMISSION_DEADLINE
+    /// Whether this request has outlasted [`ADMISSION_DEADLINE`] — measured
+    /// against queue *progress*, not against arrival.
+    ///
+    /// `&mut self` because deciding this is also bookkeeping: a waiter that
+    /// observes progress records having seen it, and a waiter behind an
+    /// in-flight launch has its stall clock held at `now`.
+    fn is_expired(&mut self, ticket: &Ticket, now: Instant) -> bool {
+        // A launch in flight is the opposite of a stall: it is bounded by
+        // LAUNCH_TIMEOUT, and both of its outcomes change the queue. This is
+        // the cold-start case that motivated stall semantics — the first
+        // request on a fresh daemon must wait out the model load, not time
+        // out in the queue while the load it needs is landing.
+        let loading = self.is_loading();
+        let epoch = self.progress_epoch;
+        let Some(waiter) = self.waiter_mut(ticket) else {
+            // Not in the queue — the ticket was already granted or forgotten,
+            // so nothing should be asking. Answer with the old absolute rule
+            // rather than guessing.
+            return now.duration_since(ticket.created_at) >= ADMISSION_DEADLINE;
+        };
+        if loading {
+            waiter.stalled_since = now;
+            return false;
+        }
+        if waiter.seen_epoch != epoch {
+            waiter.seen_epoch = epoch;
+            waiter.stalled_since = now;
+            return false;
+        }
+        now.duration_since(waiter.stalled_since) >= ADMISSION_DEADLINE
+    }
+
+    /// The queue-side record behind `ticket`, if it is still waiting.
+    fn waiter_mut(&mut self, ticket: &Ticket) -> Option<&mut Waiter> {
+        self.waiting
+            .get_mut(&ticket.model)?
+            .iter_mut()
+            .find(|w| w.seq == ticket.seq)
+    }
+
+    /// Record an event that proves the queue is moving. Every waiter's next
+    /// poll resets its stall clock against this.
+    fn record_progress(&mut self) {
+        self.progress_epoch = self.progress_epoch.wrapping_add(1);
     }
 
     /// The answer for a request that cannot proceed: give up if it has waited
@@ -541,6 +621,7 @@ impl QueueState {
     /// Record that a launch completed and `resident` now occupies `slot`.
     pub(super) fn install(&mut self, slot: usize, resident: Resident) {
         self.slots[slot] = SlotState::Resident(Box::new(resident));
+        self.record_progress();
     }
 
     /// Record that a launch into `slot` failed, freeing it for another attempt.
@@ -548,6 +629,7 @@ impl QueueState {
         if matches!(self.slots[slot], SlotState::Loading { .. }) {
             self.slots[slot] = SlotState::Empty;
         }
+        self.record_progress();
     }
 
     /// Release one in-flight reference to `slot`.
@@ -555,6 +637,10 @@ impl QueueState {
         if let Some(SlotState::Resident(r)) = self.slots.get_mut(slot) {
             r.inflight = r.inflight.saturating_sub(1);
         }
+        // A generation finished. The waiter this matters to may lose the
+        // freed capacity to a racing re-acquire before its next poll, so the
+        // epoch — not the resulting state — is what tells it the queue moved.
+        self.record_progress();
     }
 
     /// Increment the in-flight count for `slot`, when a caller has re-acquired
@@ -573,6 +659,7 @@ impl QueueState {
     /// the user's decision rather than the scheduler's.
     pub(super) fn evict(&mut self, slot: usize) -> Option<Resident> {
         let previous = std::mem::replace(&mut self.slots[slot], SlotState::Empty);
+        self.record_progress();
         match previous {
             SlotState::Resident(r) => Some(*r),
             SlotState::Empty | SlotState::Loading { .. } => None,

--- a/crates/gglib-runtime/src/process/residency/mod.rs
+++ b/crates/gglib-runtime/src/process/residency/mod.rs
@@ -246,7 +246,7 @@ impl ResidentSet {
     ) -> Result<Admission, ModelRuntimeError> {
         let model_name = request.spec.name.clone();
         let resolved_ctx = request.context.0;
-        let queued = QueuedTicket {
+        let mut queued = QueuedTicket {
             queue: Arc::clone(&self.queue),
             ticket: self.queue.enqueue(&model_name),
         };
@@ -268,7 +268,15 @@ impl ResidentSet {
                         return Ok(admission);
                     }
                     // The resident turned out to be unusable and has been
-                    // evicted; go round again and launch a fresh one.
+                    // evicted; go round again and launch a fresh one — with a
+                    // *fresh ticket*. `poll` forgot this one the moment it
+                    // granted the serve, and a forgotten ticket is invisible
+                    // to the scheduler: it can never be the oldest waiter, so
+                    // it can never win a launch, and its only remaining exit
+                    // was waiting out the deadline for a 503. A busy server
+                    // failing its health check put real requests on exactly
+                    // that path.
+                    queued.ticket = self.queue.enqueue(&model_name);
                 }
                 AdmissionDecision::Launch { slot, evict } => {
                     return self.launch(core, &request, slot, evict).await;

--- a/crates/gglib-runtime/src/process/residency/mod.rs
+++ b/crates/gglib-runtime/src/process/residency/mod.rs
@@ -282,10 +282,11 @@ impl ResidentSet {
                 AdmissionDecision::Expired => {
                     warn!(
                         model = %model_name,
-                        "request outlasted the admission queue deadline — surfacing 503"
+                        "admission queue made no progress for the whole deadline — surfacing 503"
                     );
                     return Err(ModelRuntimeError::AdmissionTimeout(format!(
-                        "waited for '{model_name}' without reaching the front of the queue"
+                        "the queue made no progress while '{model_name}' waited — \
+                         no launch running, no generation finishing"
                     )));
                 }
             }


### PR DESCRIPTION
Two admission-queue defects behind the "Admission timeout: waited without reaching the front of the queue" 503s observed three times during the 2026-08-10 benchmarking sessions (each cured by an immediate retry).

## 1. The deadline measured age, not stall (`015cb89b`)

`ADMISSION_DEADLINE` ran on a fixed 180 s wall clock from enqueue, blind to whether the queue was wedged or working. A first request on a cold daemon could expire against the very model load it was waiting for.

The deadline now measures time since the queue last made progress:

- **A launch in flight pauses every waiter's clock.** A load is bounded work — `LAUNCH_TIMEOUT` still abandons an overrun and frees the slot — so the pause extends a wait by at most one launch budget at a time.
- **Progress resets the clock**: a lease released, a launch landing or failing, a slot evicted. Tracked as an epoch counter on `QueueState` rather than re-derived from state, because progress is a transition — a release followed by an instant re-acquire leaves the state looking identical.

What still expires is exactly what the deadline existed for: an in-flight count pinned with no release for the whole window. The three pre-existing expiry tests pass unchanged (their scenarios are true stalls); two new tests pin the pause and the reset. Dashboard queue-age reporting is untouched.

## 2. A failed serve looped a forgotten ticket (`6d549356`)

`poll()` forgets a ticket when it grants a `Serve`. When `serve()` then rejects the resident (failed health check, context mismatch) and recycles it, the admission loop went round again polling that forgotten ticket — invisible to the scheduler, in no waiting queue, unable to ever win a launch even with the slot it just freed sitting empty. Its only exit was expiring into the same 503. Likely the live mechanism for the mid-benchmark occurrence: a llama-server too busy with a runaway generation to answer `/health` sends the next request down exactly this path.

The loop now re-enqueues a fresh ticket before going round. A queue-level test pins the invisibility fact that makes this mandatory.

## Verification

- 301 gglib-runtime tests green (3 new), full workspace green, clippy clean under `--all-features -D warnings`.
- Cold end-to-end smoke test: daemon spawn → llama-server launch → model load → first admission → mini tune run, served in 45 s with no 503.