### PR TITLE
feat(gui): agentic eval mode in the benchmark dashboard

### DIFF
--- a/src/components/Benchmark/Agentic/AgenticConfigForm.tsx
+++ b/src/components/Benchmark/Agentic/AgenticConfigForm.tsx
@@ -1,0 +1,170 @@
+import { FC, useState } from 'react';
+import { Play, Square } from 'lucide-react';
+import { Button } from '../../ui/Button';
+import { Icon } from '../../ui/Icon';
+import { Input } from '../../ui/Input';
+import { Select } from '../../ui/Select';
+import { Checkbox } from '../../ui/Checkbox';
+import { SuitePicker } from '../SuitePicker';
+import type { GgufModel } from '../../../types';
+import type { AgenticEvalConfig, TaskSuite } from '../../../types/benchmark';
+
+/** Mirrors the server's DEFAULT_SEEDS so the form shows what an untouched run uses. */
+const DEFAULT_SEEDS_TEXT = '12345, 67890, 11111';
+
+interface AgenticConfigFormProps {
+  models: GgufModel[];
+  isRunning: boolean;
+  onSubmit: (config: AgenticEvalConfig) => void;
+  onStop: () => void;
+}
+
+/**
+ * Agentic A/B eval configuration: model, seeds, arms, and task suite.
+ * Owns form values only — emits a fully-built `AgenticEvalConfig`.
+ */
+export const AgenticConfigForm: FC<AgenticConfigFormProps> = ({
+  models,
+  isRunning,
+  onSubmit,
+  onStop,
+}) => {
+  const [modelId, setModelId] = useState<number | ''>(
+    models.length > 0 && models[0].id != null ? models[0].id : '',
+  );
+  const [seedsText, setSeedsText] = useState(DEFAULT_SEEDS_TEXT);
+  const [ctxSize, setCtxSize] = useState('');
+  const [includeControl, setIncludeControl] = useState(true);
+  const [replicateRaw, setReplicateRaw] = useState(true);
+  const [controlSeeds, setControlSeeds] = useState('1');
+  const [suite, setSuite] = useState<TaskSuite | null>({ source: 'default' });
+
+  // Only whole decimal tokens count, capped at u32::MAX — anything else
+  // would fail serde on the Rust side with an opaque 422.
+  const seeds = seedsText
+    .split(',')
+    .map((s) => s.trim())
+    .filter((t) => /^\d+$/.test(t))
+    .map((t) => parseInt(t, 10))
+    .filter((n) => n <= 4294967295);
+
+  const handleSubmit = () => {
+    if (modelId === '' || suite == null) return;
+    const ctx = parseInt(ctxSize, 10);
+    onSubmit({
+      model_id: modelId,
+      task_suite: suite,
+      ctx_size: Number.isFinite(ctx) && ctx >= 512 ? ctx : null,
+      seeds,
+      include_control: includeControl,
+      replicate_raw: replicateRaw,
+      control_seeds: Math.max(1, parseInt(controlSeeds, 10) || 1),
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-base">
+      <div className="flex flex-col gap-xs">
+        <label htmlFor="agentic-model" className="text-xs font-semibold text-text">Model</label>
+        <Select
+          id="agentic-model"
+          size="sm"
+          value={modelId}
+          disabled={isRunning}
+          onChange={(e) => setModelId(e.target.value ? Number(e.target.value) : '')}
+        >
+          <option value="">Select a model…</option>
+          {models.map((m) => (
+            <option key={m.id} value={m.id ?? ''}>
+              {m.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <label htmlFor="agentic-seeds" className="text-xs font-semibold text-text">Seeds</label>
+        <Input
+          id="agentic-seeds"
+          type="text"
+          size="sm"
+          className="font-mono tabular-nums"
+          value={seedsText}
+          disabled={isRunning}
+          onChange={(e) => setSeedsText(e.target.value)}
+          placeholder="Comma-separated, empty = one unseeded run"
+        />
+        <p className="text-xs text-text-muted m-0">
+          {seeds.length >= 2
+            ? `Raw and gglib arms run every task once per seed (${seeds.length}×); the control repeats ${Math.min(seeds.length, Math.max(1, parseInt(controlSeeds, 10) || 1))} of them.`
+            : 'A single sample carries full decode variance — two or more seeds make the report a measurement.'}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <label htmlFor="agentic-ctx" className="text-xs font-semibold text-text">Context Size (optional)</label>
+        <Input
+          id="agentic-ctx"
+          type="number"
+          size="sm"
+          className="font-mono tabular-nums"
+          value={ctxSize}
+          disabled={isRunning}
+          min={512}
+          onChange={(e) => setCtxSize(e.target.value)}
+          placeholder="512 or more; blank = default from settings"
+        />
+      </div>
+
+      <div className="flex flex-col gap-sm">
+        <label className="text-xs font-semibold text-text">Validity arms</label>
+        <p className="text-xs text-text-muted m-0">
+          Every task runs through the raw pipeline (gglib bypassed) and the full gglib pipeline;
+          the arms below keep that comparison honest.
+        </p>
+        <Checkbox
+          checked={includeControl}
+          disabled={isRunning}
+          onChange={(e) => setIncludeControl(e.target.checked)}
+          label="Positive control (sampling deliberately broken)"
+        />
+        {includeControl && (
+          <div className="flex items-center gap-sm pl-lg">
+            <label htmlFor="agentic-control-seeds" className="text-xs text-text-muted">
+              Control seeds
+            </label>
+            <Input
+              id="agentic-control-seeds"
+              type="number"
+              size="sm"
+              className="w-16 font-mono tabular-nums"
+              value={controlSeeds}
+              disabled={isRunning}
+              min={1}
+              onChange={(e) => setControlSeeds(e.target.value)}
+            />
+          </div>
+        )}
+        <Checkbox
+          checked={replicateRaw}
+          disabled={isRunning}
+          onChange={(e) => setReplicateRaw(e.target.checked)}
+          label="A/A replicate (raw again, disjoint seeds)"
+        />
+      </div>
+
+      <SuitePicker disabled={isRunning} onSuiteChange={setSuite} />
+
+      <Button
+        variant={isRunning ? 'dangerGhost' : 'primary'}
+        size="lg"
+        fullWidth
+        disabled={!isRunning && (modelId === '' || suite == null)}
+        onClick={isRunning ? onStop : handleSubmit}
+        leftIcon={<Icon icon={isRunning ? Square : Play} size={16} />}
+      >
+        {isRunning ? 'Stop' : 'Run Eval'}
+      </Button>
+    </div>
+  );
+};

--- a/src/components/Benchmark/Agentic/AgenticHistoryList.tsx
+++ b/src/components/Benchmark/Agentic/AgenticHistoryList.tsx
@@ -1,0 +1,75 @@
+import { FC, useCallback, useEffect, useState } from 'react';
+import { Select } from '../../ui/Select';
+import { Button } from '../../ui/Button';
+import type { GgufModel } from '../../../types';
+import type { AgenticEvalReport } from '../../../types/benchmark';
+import { getModelAgenticHistory } from '../../../services/clients/benchmark';
+
+interface AgenticHistoryListProps {
+  models: GgufModel[];
+  onSelect: (report: AgenticEvalReport) => void;
+}
+
+/**
+ * Past agentic reports for a chosen model, most recent first. Reports carry
+ * no timestamp of their own, so entries are numbered with the newest as #1.
+ */
+export const AgenticHistoryList: FC<AgenticHistoryListProps> = ({ models, onSelect }) => {
+  const [modelId, setModelId] = useState<number | ''>('');
+  const [reports, setReports] = useState<AgenticEvalReport[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async (id: number) => {
+    setLoading(true);
+    try {
+      setReports(await getModelAgenticHistory(id));
+    } catch {
+      setReports([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (modelId !== '') void load(modelId);
+    else setReports([]);
+  }, [modelId, load]);
+
+  return (
+    <section className="flex flex-col gap-sm">
+      <h3 className="m-0 text-sm font-semibold text-text">Previous reports</h3>
+      <div className="flex items-center gap-sm max-w-[360px]">
+        <Select
+          size="sm"
+          value={modelId}
+          onChange={(e) => setModelId(e.target.value ? Number(e.target.value) : '')}
+          aria-label="Model for previous reports"
+        >
+          <option value="">Pick a model…</option>
+          {models.map((m) => (
+            <option key={m.id} value={m.id ?? ''}>
+              {m.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+      {loading && <p className="text-xs text-text-muted m-0">Loading…</p>}
+      {!loading && modelId !== '' && reports.length === 0 && (
+        <p className="text-xs text-text-muted m-0">No past reports for this model.</p>
+      )}
+      {reports.map((r, i) => (
+        <Button
+          key={i}
+          variant="secondary"
+          size="sm"
+          className="self-start font-mono tabular-nums"
+          onClick={() => onSelect(r)}
+        >
+          #{i + 1}
+          {i === 0 ? ' (latest)' : ''} · Δ composite {r.delta.composite >= 0 ? '+' : ''}
+          {r.delta.composite.toFixed(3)}
+        </Button>
+      ))}
+    </section>
+  );
+};

--- a/src/components/Benchmark/Agentic/AgenticLiveProgress.tsx
+++ b/src/components/Benchmark/Agentic/AgenticLiveProgress.tsx
@@ -1,0 +1,74 @@
+import type { FC } from 'react';
+import { Check, X } from 'lucide-react';
+import { Icon } from '../../ui/Icon';
+import { cn } from '../../../utils/cn';
+import type { EvalArm } from '../../../types/benchmark';
+
+/** How the CLI banner names each arm — kept identical so the two agree. */
+export const ARM_LABELS: Record<EvalArm, string> = {
+  raw: 'raw (pipeline bypassed)',
+  gglib: 'gglib (full pipeline)',
+  raw_replicate: 'raw again (A/A, disjoint seeds)',
+  control: 'control (sampling deliberately broken)',
+};
+
+export interface ArmProgress {
+  arm: EvalArm;
+  total: number;
+  done: number;
+  passed: number;
+}
+
+export interface TaskLogEntry {
+  arm: EvalArm;
+  taskId: string;
+  passed: boolean;
+}
+
+interface AgenticLiveProgressProps {
+  arms: ArmProgress[];
+  currentArm: EvalArm | null;
+  taskLog: TaskLogEntry[];
+}
+
+/** Per-arm progress rows plus the scrolling pass/fail task log. */
+export const AgenticLiveProgress: FC<AgenticLiveProgressProps> = ({
+  arms,
+  currentArm,
+  taskLog,
+}) => (
+  <div className="flex flex-col gap-sm">
+    <div className="flex flex-col gap-xs">
+      {arms.map((a) => (
+        <div key={a.arm} className="flex items-center justify-between gap-md">
+          <span
+            className={cn(
+              'text-sm',
+              a.arm === currentArm ? 'text-text font-medium' : 'text-text-muted',
+            )}
+          >
+            {ARM_LABELS[a.arm]}
+          </span>
+          <span className="text-sm text-text-secondary font-mono tabular-nums shrink-0">
+            {a.done}/{a.total} · {a.passed} passed
+          </span>
+        </div>
+      ))}
+    </div>
+
+    {taskLog.length > 0 && (
+      <div className="flex flex-col gap-xs max-h-[220px] overflow-y-auto bg-surface rounded-md p-sm">
+        {taskLog.map((entry, i) => (
+          <div key={i} className="flex items-center gap-sm text-xs">
+            <span className={entry.passed ? 'text-success' : 'text-danger'} aria-hidden>
+              <Icon icon={entry.passed ? Check : X} size={12} />
+            </span>
+            <span className="sr-only">{entry.passed ? 'passed' : 'failed'}</span>
+            <span className="text-text-secondary font-mono">{entry.taskId}</span>
+            <span className="text-text-muted ml-auto shrink-0">{entry.arm}</span>
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+);

--- a/src/components/Benchmark/Agentic/AgenticReport.tsx
+++ b/src/components/Benchmark/Agentic/AgenticReport.tsx
@@ -1,0 +1,155 @@
+import type { FC } from 'react';
+import { Download } from 'lucide-react';
+import { Button } from '../../ui/Button';
+import { Icon } from '../../ui/Icon';
+import { cn } from '../../../utils/cn';
+import { formatMs, formatTps } from '../format';
+import { AgenticReportVerdicts } from './AgenticReportVerdicts';
+import { AgenticTaskDrilldown } from './AgenticTaskDrilldown';
+import type { AgenticEvalReport } from '../../../types/benchmark';
+
+const score = (v: number | null | undefined) => (v == null ? '—' : v.toFixed(3));
+const signed = (v: number | null | undefined) =>
+  v == null ? '—' : `${v > 0 ? '+' : ''}${v.toFixed(3)}`;
+const factor = (v: number | null | undefined) => (v == null ? '—' : `${v.toFixed(2)}×`);
+
+const Td: FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => (
+  <td className={cn('px-md py-xs text-sm text-text font-mono tabular-nums', className)}>{children}</td>
+);
+const Th: FC<{ children?: React.ReactNode }> = ({ children }) => (
+  <th className="px-md py-xs text-left text-xs font-medium text-text-muted">{children}</th>
+);
+
+const deltaClass = (v: number | null | undefined) =>
+  v == null ? '' : v > 0 ? 'text-success' : v < 0 ? 'text-danger' : '';
+const factorClass = (v: number | null | undefined) =>
+  v == null ? '' : v > 1 ? 'text-success' : v < 1 ? 'text-danger' : '';
+
+/**
+ * The complete raw-vs-gglib report. Block order mirrors the CLI's renderer so
+ * the two surfaces tell the same story: identity, sample size, the axis
+ * table, validity verdicts, stability, efficiency, then the GUI-only
+ * per-task drill-down.
+ */
+export const AgenticReport: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const seedCount = report.seeds?.length ?? 0;
+  const loopDenominatorNote =
+    report.raw.loop_avoidance == null || report.gglib.loop_avoidance == null
+      ? `loop avoidance measured on ${report.raw.loop_eligible} raw and ${report.gglib.loop_eligible} gglib runs`
+      : null;
+
+  const download = () => {
+    // The CLI's export shape (--output) with explicit nulls where the browser
+    // has no provenance to offer — consumers of either file see the same keys.
+    const payload = { gglib_version: null, hardware: null, report };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `agentic-eval-${report.model_name.replace(/[^\w.-]+/g, '_')}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const axisRows: Array<[string, number | null | undefined, number | null | undefined, number | null | undefined]> = [
+    ['Tool accuracy', report.raw.tool_accuracy, report.gglib.tool_accuracy, report.delta.tool_accuracy],
+    ['Loop avoidance', report.raw.loop_avoidance, report.gglib.loop_avoidance, report.delta.loop_avoidance],
+    ['Task completion', report.raw.task_completion, report.gglib.task_completion, report.delta.task_completion],
+    ['Composite', report.raw.composite, report.gglib.composite, report.delta.composite],
+  ];
+
+  const efficiencyRows: Array<[string, string, string, number | null | undefined]> = [
+    ['Suite wall time', formatMs(report.raw.total_wall_ms), formatMs(report.gglib.total_wall_ms), report.delta.wall_time_speedup],
+    [
+      'Completion tokens',
+      report.raw.total_completion_tokens?.toLocaleString() ?? '—',
+      report.gglib.total_completion_tokens?.toLocaleString() ?? '—',
+      report.delta.completion_token_ratio,
+    ],
+    ['1st tool call', formatMs(report.raw.mean_time_to_first_tool_call_ms), formatMs(report.gglib.mean_time_to_first_tool_call_ms), null],
+    ['Throughput', formatTps(report.raw.tg_tps), formatTps(report.gglib.tg_tps), null],
+  ];
+
+  return (
+    <div className="bg-surface rounded-md p-base flex flex-col gap-md">
+      <div className="flex items-start justify-between gap-md">
+        <div>
+          <h2 className="m-0 text-lg font-semibold text-text">{report.model_name}</h2>
+          <p className="m-0 text-xs text-text-muted font-mono tabular-nums">
+            {report.param_count_b}B{report.quantization ? ` · ${report.quantization}` : ''} ·{' '}
+            {report.ctx_size.toLocaleString()} ctx
+          </p>
+        </div>
+        <Button variant="secondary" size="sm" onClick={download} leftIcon={<Icon icon={Download} size={14} />}>
+          Download JSON
+        </Button>
+      </div>
+
+      {seedCount >= 2 ? (
+        <p className="m-0 text-xs text-text-muted">
+          Scores are means of {seedCount} seeded runs per task{' '}
+          <span className="font-mono tabular-nums">({report.seeds!.join(', ')})</span>.
+        </p>
+      ) : (
+        <p className="m-0 text-xs text-warning">
+          Single sample per task — the figures carry full decode variance. Re-run with two or more
+          seeds before reading deltas as findings.
+        </p>
+      )}
+
+      <div className="overflow-x-auto bg-surface-elevated rounded-md">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b border-border-light">
+              <Th />
+              <Th>raw</Th>
+              <Th>gglib</Th>
+              <Th>delta</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {axisRows.map(([label, raw, gglib, delta]) => (
+              <tr key={label} className="border-b border-border-light last:border-b-0">
+                <td className="px-md py-xs text-sm text-text-muted">{label}</td>
+                <Td>{score(raw)}</Td>
+                <Td>{score(gglib)}</Td>
+                <Td className={deltaClass(delta)}>{signed(delta)}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {loopDenominatorNote && <p className="m-0 text-xs text-text-muted">{loopDenominatorNote}</p>}
+
+      <AgenticReportVerdicts report={report} />
+
+      <section className="flex flex-col gap-xs">
+        <h3 className="m-0 text-sm font-semibold text-text">Efficiency</h3>
+        <div className="overflow-x-auto bg-surface-elevated rounded-md">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-border-light">
+                <Th />
+                <Th>raw</Th>
+                <Th>gglib</Th>
+                <Th>factor</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {efficiencyRows.map(([label, raw, gglib, fac]) => (
+                <tr key={label} className="border-b border-border-light last:border-b-0">
+                  <td className="px-md py-xs text-sm text-text-muted">{label}</td>
+                  <Td>{raw}</Td>
+                  <Td>{gglib}</Td>
+                  <Td className={factorClass(fac)}>{factor(fac)}</Td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <AgenticTaskDrilldown report={report} />
+    </div>
+  );
+};

--- a/src/components/Benchmark/Agentic/AgenticReportVerdicts.tsx
+++ b/src/components/Benchmark/Agentic/AgenticReportVerdicts.tsx
@@ -1,0 +1,162 @@
+import type { FC } from 'react';
+import { Banner } from '../../ui/Banner';
+import type { AgenticEvalReport, ArmScores, EvalArm } from '../../../types/benchmark';
+import {
+  EFFECT_NOISE_RATIO,
+  controlVerdict,
+  effectVerdict,
+  passCounts,
+  unstableTasks,
+} from './verdicts';
+
+const fmt = (v: number) => v.toFixed(3);
+
+/** Arms with runs the harness never delivered to the model — means are floors, not measurements. */
+const UnmeasuredBlock: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const arms: Array<[EvalArm, ArmScores | null | undefined]> = [
+    ['raw', report.raw],
+    ['gglib', report.gglib],
+    ['raw_replicate', report.raw_replicate],
+    ['control', report.control],
+  ];
+  const partly = arms.filter(([, a]) => a && (a.unmeasured_runs ?? 0) > 0);
+  if (partly.length === 0) return null;
+
+  return (
+    <Banner variant="danger" title="Unmeasured runs">
+      {partly.map(([arm, a]) => (
+        <p key={arm} className="m-0 font-mono tabular-nums">
+          {arm}: {a!.unmeasured_runs}/{a!.runs ?? '?'} runs unmeasured
+        </p>
+      ))}
+      <p className="m-0">Read those arms as a floor, not a measurement.</p>
+    </Banner>
+  );
+};
+
+/** The A/A drift check: is the measured effect bigger than the eval's own noise? */
+const NoiseBlock: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const verdict = effectVerdict(report);
+  if (verdict == null) {
+    return (
+      <p className="text-xs text-text-muted m-0">
+        No A/A arm ran — read the composite delta as a direction, not a magnitude.
+      </p>
+    );
+  }
+  const exceeded = verdict.kind === 'exceeds_noise';
+  return (
+    <div className="flex flex-col gap-xs">
+      <p className={`text-sm m-0 ${exceeded ? 'text-text' : 'text-warning'}`}>
+        {exceeded ? 'Effect exceeds the eval’s own drift' : 'Effect is within the eval’s own drift'}
+        <span className="font-mono tabular-nums text-text-secondary">
+          {' '}
+          — effect {fmt(Math.abs(verdict.effect))}, drift {fmt(verdict.noise)} (bar:{' '}
+          {EFFECT_NOISE_RATIO.toFixed(1)}×)
+        </span>
+      </p>
+      <p className="text-xs text-text-muted m-0">
+        A sanity ratio, not a significance test — more seeds strengthen it, a bigger factor does not.
+      </p>
+    </div>
+  );
+};
+
+/** What the positive control demonstrated about this run's sensitivity. */
+const ControlBlock: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const verdict = controlVerdict(report);
+  if (verdict == null) {
+    return (
+      <p className="text-xs text-text-muted m-0">
+        No control arm ran — nothing was demonstrated about sensitivity either way.
+      </p>
+    );
+  }
+
+  const gapText = (
+    <span className="font-mono tabular-nums text-text-secondary">
+      {' '}
+      — gap {fmt(verdict.gap)}, gglib {fmt(report.gglib.composite)} vs control{' '}
+      {fmt(report.control!.composite)}
+    </span>
+  );
+
+  return (
+    <div className="flex flex-col gap-xs">
+      {verdict.kind === 'moved' && (
+        <p className="text-sm text-text m-0">Control moved — the eval detects broken sampling{gapText}</p>
+      )}
+      {verdict.kind === 'too_small' && (
+        <Banner variant="danger" title="Control barely moved">
+          Deliberately broken sampling scored within {fmt(verdict.gap)} of the real pipeline —
+          treat every delta in this report as uninterpretable.
+        </Banner>
+      )}
+      {verdict.kind === 'wrong_direction' && (
+        <Banner variant="danger" title="Control moved the wrong way">
+          Broken sampling scored above the real pipeline by {fmt(verdict.gap)} — this run cannot
+          support any conclusion.
+        </Banner>
+      )}
+      {(report.control?.seeds ?? 0) > 0 &&
+        (report.seeds?.length ?? 0) > (report.control?.seeds ?? 0) && (
+          <p className="text-xs text-text-muted m-0">
+            The control repeated {report.control?.seeds} of {report.seeds?.length} seeds.
+          </p>
+        )}
+      <p className="text-xs text-text-muted m-0">
+        Sensitivity at this gap says nothing about resolving a smaller effect.
+      </p>
+    </div>
+  );
+};
+
+/** Per-seed stability: tasks that disagreed with themselves across seeds. */
+const StabilityBlock: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const seedCount = report.seeds?.length ?? 0;
+  if (seedCount < 2) return null;
+  const unstable = unstableTasks(report);
+
+  if (unstable.length === 0) {
+    return (
+      <p className="text-xs text-text-muted m-0">
+        Every task returned the same verdict on all {seedCount} seeds in both arms.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-xs">
+      <p className="text-sm text-warning m-0">
+        {unstable.length} task{unstable.length === 1 ? '' : 's'} flipped between seeds:
+      </p>
+      {unstable.map((t) => {
+        const [rawPassed, gglibPassed] = passCounts(t);
+        return (
+          <p key={t.task_id} className="text-xs text-text-secondary m-0 font-mono tabular-nums">
+            {t.task_id} — raw {rawPassed}/{t.raw.length}, gglib {gglibPassed}/{t.gglib.length} seeds passed
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+/** The report's validity story, in the CLI's order: unmeasured, drift, control, stability. */
+export const AgenticReportVerdicts: FC<{ report: AgenticEvalReport }> = ({ report }) => (
+  <div className="flex flex-col gap-md">
+    <UnmeasuredBlock report={report} />
+    <section className="flex flex-col gap-xs">
+      <h3 className="m-0 text-sm font-semibold text-text">Drift (A/A)</h3>
+      <NoiseBlock report={report} />
+    </section>
+    <section className="flex flex-col gap-xs">
+      <h3 className="m-0 text-sm font-semibold text-text">Positive control</h3>
+      <ControlBlock report={report} />
+    </section>
+    <section className="flex flex-col gap-xs">
+      <h3 className="m-0 text-sm font-semibold text-text">Stability</h3>
+      <StabilityBlock report={report} />
+    </section>
+  </div>
+);

--- a/src/components/Benchmark/Agentic/AgenticTab.tsx
+++ b/src/components/Benchmark/Agentic/AgenticTab.tsx
@@ -1,0 +1,197 @@
+/**
+ * Agentic A/B eval mode: raw pipeline vs gglib pipeline, with validity arms.
+ *
+ * Mirrors TuneTab's streaming shape: the high-frequency
+ * `agentic_task_complete` events are buffered and flushed into state every
+ * 100 ms; coarse events (`agentic_arm_started`, `agentic_eval_complete`,
+ * `run_failed`) set state directly. Aborting the stream genuinely cancels
+ * the server-side run.
+ *
+ * @module components/Benchmark/Agentic/AgenticTab
+ */
+
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FlaskConical } from 'lucide-react';
+import { Icon } from '../../ui/Icon';
+import { Banner } from '../../ui/Banner';
+import { EmptyState } from '../../primitives';
+import { AgenticConfigForm } from './AgenticConfigForm';
+import { AgenticLiveProgress, type ArmProgress, type TaskLogEntry } from './AgenticLiveProgress';
+import { AgenticReport } from './AgenticReport';
+import { AgenticHistoryList } from './AgenticHistoryList';
+import type { GgufModel } from '../../../types';
+import type { AgenticEvalConfig, AgenticEvalReport, BenchmarkEvent } from '../../../types/benchmark';
+import { startAgenticRun } from '../../../services/clients/benchmark';
+
+interface AgenticRunState {
+  status: 'idle' | 'running' | 'complete' | 'failed';
+  arms: ArmProgress[];
+  currentArm: ArmProgress['arm'] | null;
+  taskLog: TaskLogEntry[];
+  report: AgenticEvalReport | null;
+  error?: string;
+}
+
+const IDLE: AgenticRunState = { status: 'idle', arms: [], currentArm: null, taskLog: [], report: null };
+
+interface AgenticTabProps {
+  models: GgufModel[];
+  /** Called when a run finishes, so the page can refresh the shared history. */
+  onRunComplete: () => void;
+}
+
+export const AgenticTab: FC<AgenticTabProps> = ({ models, onRunComplete }) => {
+  const [runState, setRunState] = useState<AgenticRunState>(IDLE);
+  const [historyReport, setHistoryReport] = useState<AgenticEvalReport | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const logBufferRef = useRef<TaskLogEntry[]>([]);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      if (flushTimerRef.current !== null) clearTimeout(flushTimerRef.current);
+    };
+  }, []);
+
+  const scheduleFlush = useCallback(() => {
+    if (flushTimerRef.current !== null) return;
+    flushTimerRef.current = setTimeout(() => {
+      flushTimerRef.current = null;
+      const entries = logBufferRef.current;
+      logBufferRef.current = [];
+      if (entries.length === 0) return;
+      setRunState((prev) => {
+        const arms = prev.arms.map((a) => {
+          const mine = entries.filter((e) => e.arm === a.arm);
+          if (mine.length === 0) return a;
+          return {
+            ...a,
+            done: a.done + mine.length,
+            passed: a.passed + mine.filter((e) => e.passed).length,
+          };
+        });
+        return { ...prev, arms, taskLog: [...prev.taskLog, ...entries] };
+      });
+    }, 100);
+  }, []);
+
+  const handleEvent = useCallback(
+    (event: BenchmarkEvent) => {
+      switch (event.type) {
+        case 'agentic_arm_started':
+          setRunState((prev) => ({
+            ...prev,
+            currentArm: event.arm,
+            arms: [...prev.arms, { arm: event.arm, total: event.total_tasks, done: 0, passed: 0 }],
+          }));
+          break;
+
+        case 'agentic_task_complete':
+          logBufferRef.current.push({ arm: event.arm, taskId: event.task_id, passed: event.passed });
+          scheduleFlush();
+          break;
+
+        case 'agentic_eval_complete':
+          setRunState((prev) => ({ ...prev, status: 'complete', report: event.report }));
+          onRunComplete();
+          break;
+
+        case 'run_failed':
+          setRunState((prev) => ({ ...prev, status: 'failed', error: event.error }));
+          break;
+      }
+    },
+    [scheduleFlush, onRunComplete],
+  );
+
+  const handleSubmit = useCallback(
+    (config: AgenticEvalConfig) => {
+      abortRef.current?.abort();
+      const abort = new AbortController();
+      abortRef.current = abort;
+      logBufferRef.current = [];
+      if (flushTimerRef.current !== null) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+      setHistoryReport(null);
+      setRunState({ ...IDLE, status: 'running' });
+
+      startAgenticRun(config, handleEvent, abort.signal)
+        .then(() => {
+          // The server can close the stream without any terminal event when a
+          // run dies before its first checkpoint — surface that, don't hang.
+          setRunState((prev) =>
+            prev.status === 'running'
+              ? { ...prev, status: 'failed', error: 'The eval stream ended without a report.' }
+              : prev,
+          );
+        })
+        .catch((err: Error) => {
+          if (err.name !== 'AbortError') {
+            setRunState((prev) => ({ ...prev, status: 'failed', error: err.message }));
+          }
+        });
+    },
+    [handleEvent],
+  );
+
+  const handleStop = useCallback(() => {
+    abortRef.current?.abort();
+    setRunState(IDLE);
+  }, []);
+
+  const shownReport = runState.report ?? historyReport;
+
+  return (
+    <div className="flex flex-1 overflow-hidden gap-0">
+      <aside className="w-[280px] shrink-0 flex flex-col gap-base p-base border-r border-border overflow-y-auto">
+        <AgenticConfigForm
+          models={models}
+          isRunning={runState.status === 'running'}
+          onSubmit={handleSubmit}
+          onStop={handleStop}
+        />
+        {runState.status === 'failed' && runState.error && (
+          <Banner variant="danger" title="Eval failed">
+            {runState.error}
+          </Banner>
+        )}
+      </aside>
+
+      <div className="flex-1 overflow-y-auto p-base flex flex-col gap-base">
+        {runState.status === 'idle' && !shownReport && (
+          <EmptyState
+            className="h-full"
+            icon={<Icon icon={FlaskConical} size={24} />}
+            title="No eval yet"
+            description="Pick a model and press Run Eval to measure the gglib pipeline against the raw one — with a positive control and an A/A arm keeping the answer honest."
+          />
+        )}
+
+        {runState.status === 'running' && runState.arms.length === 0 && (
+          <p className="text-sm text-text-muted m-0">
+            Loading the model and preparing arms — the first tasks appear here shortly…
+          </p>
+        )}
+
+        {(runState.status === 'running' ||
+          (runState.arms.length > 0 && runState.status !== 'idle')) && (
+          <AgenticLiveProgress
+            arms={runState.arms}
+            currentArm={runState.status === 'running' ? runState.currentArm : null}
+            taskLog={runState.taskLog}
+          />
+        )}
+
+        {shownReport && <AgenticReport report={shownReport} />}
+
+        {runState.status === 'idle' && (
+          <AgenticHistoryList models={models} onSelect={setHistoryReport} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Benchmark/Agentic/AgenticTaskDrilldown.tsx
+++ b/src/components/Benchmark/Agentic/AgenticTaskDrilldown.tsx
@@ -1,0 +1,69 @@
+import { FC, useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Button } from '../../ui/Button';
+import { Icon } from '../../ui/Icon';
+import { cn } from '../../../utils/cn';
+import { isUnstable, passCounts } from './verdicts';
+import type { AgenticEvalReport } from '../../../types/benchmark';
+
+const Td: FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => (
+  <td className={cn('px-md py-xs text-sm text-text font-mono tabular-nums', className)}>{children}</td>
+);
+const Th: FC<{ children?: React.ReactNode }> = ({ children }) => (
+  <th className="px-md py-xs text-left text-xs font-medium text-text-muted">{children}</th>
+);
+
+/** Collapsible per-task drill-down — detail the CLI does not print. */
+export const AgenticTaskDrilldown: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const [open, setOpen] = useState(false);
+  if (report.tasks.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-xs">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="self-start"
+        aria-expanded={open}
+        aria-controls="agentic-task-table"
+        onClick={() => setOpen(!open)}
+        leftIcon={
+          <Icon icon={ChevronRight} size={14} className={cn('transition-transform', open && 'rotate-90')} />
+        }
+      >
+        Per-task results ({report.tasks.length})
+      </Button>
+      {open && (
+        <div id="agentic-task-table" className="overflow-x-auto bg-surface-elevated rounded-md">
+          <table className="w-full text-xs border-collapse">
+            <thead>
+              <tr className="border-b border-border-light">
+                <Th>Task</Th>
+                <Th>Category</Th>
+                <Th>raw</Th>
+                <Th>gglib</Th>
+                <Th />
+              </tr>
+            </thead>
+            <tbody>
+              {report.tasks.map((t) => {
+                const [rawPassed, gglibPassed] = passCounts(t);
+                return (
+                  <tr key={t.task_id} className="border-b border-border-light last:border-b-0">
+                    <Td className="text-text-secondary">{t.task_id}</Td>
+                    <td className="px-md py-xs text-xs text-text-muted">{t.category}</td>
+                    <Td>{`${rawPassed}/${t.raw.length}`}</Td>
+                    <Td>{`${gglibPassed}/${t.gglib.length}`}</Td>
+                    <td className="px-md py-xs text-xs text-warning">
+                      {isUnstable(t) ? 'unstable' : ''}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/components/Benchmark/Agentic/README.md
+++ b/src/components/Benchmark/Agentic/README.md
@@ -1,0 +1,46 @@
+# Agentic
+
+![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-components-Benchmark-Agentic-loc.json)
+![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/ts-components-Benchmark-Agentic-complexity.json)
+
+<!-- module-docs:start -->
+
+Agentic-mode UI: the raw-vs-gglib A/B eval, run against a tool-calling task
+suite to measure what the gglib pipeline actually contributes over talking to
+llama-server directly. Validity arms (A/A drift and a three-way control) run
+alongside the comparison so a reported effect can be told apart from noise.
+
+This is the GUI counterpart of `gglib benchmark agentic`; both surfaces drive
+the same endpoints and the report follows the CLI renderer's block order.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `AgenticTab.tsx` | Orchestrator — owns all SSE/run state and composes the components below. Mirrors `TuneTab`'s streaming shape: high-frequency `agentic_task_complete` events are buffered and flushed every 100 ms; coarse events apply immediately. |
+| `AgenticConfigForm.tsx` | Model select, task-suite picker, context size, seeds, and the control/replicate toggles. Mirrors the server's `DEFAULT_SEEDS` so an untouched form shows what the run will actually use. |
+| `AgenticLiveProgress.tsx` | Per-arm progress and a scrolling pass/fail log. Arm names are kept identical to the CLI banner's so the two surfaces agree. |
+| `AgenticReport.tsx` | The finished report — identity block, axis table, efficiency table, and JSON export in the CLI's `--output` shape. |
+| `AgenticReportVerdicts.tsx` | Renders the derived verdicts: sample-size warning, A/A drift, three-way control, per-seed stability. |
+| `AgenticTaskDrilldown.tsx` | Per-task expansion of a completed run — no CLI equivalent. |
+| `AgenticHistoryList.tsx` | Past reports for a model, via the agentic-history endpoint. |
+| `verdicts.ts` | Client-side mirror of the Rust verdict methods. See below. |
+
+## Verdict Parity
+
+`AgenticEvalReport`'s verdicts are **methods** on the Rust type
+(`gglib_core::domain::benchmark::agentic`), not serialized fields, so they do
+not arrive on the wire and the GUI re-derives them in `verdicts.ts`. The two
+implementations must agree exactly: the composite-gap and noise-ratio
+thresholds, the boundary inclusivity on both control branches, the
+zero-effect guard, and the per-seed instability predicate. Both sides compute
+in f64, so there is no floating-point divergence to account for.
+
+The unit tests pin the TypeScript against dyadic fixtures, but note what that
+does and does not buy: each side is pinned to its own copy of the constants.
+Changing a threshold in the Rust leaves both suites green while the CLI and
+the GUI render contradictory verdicts for the same stored report. Treat the
+thresholds as a shared contract and change them in both places, or add a
+source-parsing guard in the style of `tests/ts/contracts/settingsBounds.test.ts`.
+
+<!-- module-docs:end -->

--- a/src/components/Benchmark/Agentic/verdicts.ts
+++ b/src/components/Benchmark/Agentic/verdicts.ts
@@ -1,0 +1,83 @@
+import type { AgenticEvalReport, AgenticTaskComparison } from '../../../types/benchmark';
+
+/**
+ * Client-side mirrors of `AgenticEvalReport`'s verdict methods
+ * (`gglib_core::domain::benchmark::agentic`) — the Rust computes these as
+ * methods, not serialized fields, so the GUI re-derives them. The thresholds
+ * and edge cases must match the Rust exactly; the unit tests pin them.
+ */
+
+/**
+ * A detection bar, not a quality bar: a control gap smaller than this means
+ * the measurement did not respond to a change that should have been
+ * impossible to miss. Mirrors `CONTROL_MIN_COMPOSITE_GAP`.
+ */
+export const CONTROL_MIN_COMPOSITE_GAP = 0.05;
+
+/**
+ * The smallest factor at which an effect and the eval's own drift are plainly
+ * not the same size. A sanity ratio, not a significance test. Mirrors
+ * `EFFECT_NOISE_RATIO`.
+ */
+export const EFFECT_NOISE_RATIO = 2.0;
+
+export type ControlVerdict =
+  | { kind: 'moved'; gap: number }
+  | { kind: 'too_small'; gap: number }
+  | { kind: 'wrong_direction'; gap: number };
+
+export type EffectVerdict =
+  | { kind: 'exceeds_noise'; effect: number; noise: number }
+  | { kind: 'within_noise'; effect: number; noise: number };
+
+/** What the positive control demonstrated, or `null` when it did not run. */
+export function controlVerdict(report: AgenticEvalReport): ControlVerdict | null {
+  const control = report.control;
+  if (control == null) return null;
+  const gap = report.gglib.composite - control.composite;
+  if (gap >= CONTROL_MIN_COMPOSITE_GAP) return { kind: 'moved', gap };
+  if (gap >= 0) return { kind: 'too_small', gap };
+  return { kind: 'wrong_direction', gap: -gap };
+}
+
+/** The eval's own drift: how far two identical raw arms landed apart. `null` when the A/A arm did not run. */
+export function noiseFloor(report: AgenticEvalReport): number | null {
+  const replicate = report.raw_replicate;
+  if (replicate == null) return null;
+  return Math.abs(report.raw.composite - replicate.composite);
+}
+
+/**
+ * Whether the measured effect is larger than the eval's own drift. `null`
+ * when no A/A arm ran — then the composite delta is a direction, not a
+ * magnitude. A zero effect never "exceeds" anything, however quiet the arm.
+ */
+export function effectVerdict(report: AgenticEvalReport): EffectVerdict | null {
+  const noise = noiseFloor(report);
+  if (noise == null) return null;
+  const effect = report.delta.composite;
+  if (Math.abs(effect) > 0 && Math.abs(effect) >= EFFECT_NOISE_RATIO * noise) {
+    return { kind: 'exceeds_noise', effect, noise };
+  }
+  return { kind: 'within_noise', effect, noise };
+}
+
+/** Per-arm pass counts for one task, in (raw, gglib) order. */
+export function passCounts(task: AgenticTaskComparison): [number, number] {
+  return [
+    task.raw.filter((r) => r.passed).length,
+    task.gglib.filter((r) => r.passed).length,
+  ];
+}
+
+/** Whether either arm disagreed with itself across seeds. */
+export function isUnstable(task: AgenticTaskComparison): boolean {
+  const mixed = (runs: AgenticTaskComparison['raw']) =>
+    runs.some((r) => r.passed) && runs.some((r) => !r.passed);
+  return mixed(task.raw) || mixed(task.gglib);
+}
+
+/** Tasks whose outcome was not stable across seeds under either arm. */
+export function unstableTasks(report: AgenticEvalReport): AgenticTaskComparison[] {
+  return report.tasks.filter(isUnstable);
+}

--- a/src/components/Benchmark/ModelMultiSelect.tsx
+++ b/src/components/Benchmark/ModelMultiSelect.tsx
@@ -1,0 +1,49 @@
+import type { FC } from 'react';
+import { Checkbox } from '../ui/Checkbox';
+import { cn } from '../../utils/cn';
+import type { GgufModel } from '../../types';
+
+interface ModelMultiSelectProps {
+  models: GgufModel[];
+  selectedIds: number[];
+  onToggle: (id: number) => void;
+  disabled?: boolean;
+}
+
+/** The benchmark config panel's model checkbox list. */
+export const ModelMultiSelect: FC<ModelMultiSelectProps> = ({
+  models,
+  selectedIds,
+  onToggle,
+  disabled = false,
+}) => (
+  <div className="flex flex-col gap-sm">
+    <label className="text-xs font-semibold text-text">
+      Models ({selectedIds.length} selected)
+    </label>
+    <div className="flex flex-col gap-xs max-h-[240px] overflow-y-auto border border-border rounded-md p-xs">
+      {models.length === 0 && <p className="text-xs text-text-muted p-xs">No models available</p>}
+      {models.map((m) => {
+        if (m.id == null) return null;
+        const checked = selectedIds.includes(m.id);
+        return (
+          <Checkbox
+            key={m.id}
+            checked={checked}
+            disabled={disabled}
+            onChange={() => onToggle(m.id!)}
+            wrapperClassName={cn(
+              'w-full p-xs rounded-sm transition-colors',
+              checked ? 'bg-primary-subtle' : 'hover:bg-surface-elevated',
+            )}
+            label={
+              <span className={cn('block truncate', checked ? 'text-text' : 'text-text-secondary')}>
+                {m.name}
+              </span>
+            }
+          />
+        );
+      })}
+    </div>
+  </div>
+);

--- a/src/components/Benchmark/PerfCompareResultCard.tsx
+++ b/src/components/Benchmark/PerfCompareResultCard.tsx
@@ -1,0 +1,108 @@
+import type { FC } from 'react';
+import { Zap } from 'lucide-react';
+import { Icon } from '../ui/Icon';
+import { Readout } from '../primitives';
+import { cn } from '../../utils/cn';
+import { formatMs, formatTps } from './format';
+import type {
+  BenchmarkModelResult,
+  ModelCompareResult,
+  ModelPerfResult,
+} from '../../types/benchmark';
+
+export interface ModelResultState {
+  modelId: number;
+  modelName: string;
+  status: 'pending' | 'running' | 'complete' | 'failed';
+  /** Throttle-buffered text delta accumulation. */
+  liveText: string;
+  result?: BenchmarkModelResult;
+  error?: string;
+}
+
+const CompareResult: FC<{ result: ModelCompareResult }> = ({ result: r }) => (
+  <div className="flex flex-col gap-sm">
+    <div className="bg-surface-elevated rounded-md p-base text-sm text-text whitespace-pre-wrap font-mono leading-relaxed">
+      {r.response_text}
+    </div>
+    <div className="flex gap-md text-xs text-text-muted flex-wrap font-mono tabular-nums">
+      {r.generation_tps != null && (
+        <span className="inline-flex items-center gap-xs">
+          <Icon icon={Zap} size={12} />
+          {formatTps(r.generation_tps)} gen
+        </span>
+      )}
+      {r.prompt_tps != null && <span>{formatTps(r.prompt_tps)} pp</span>}
+      {r.generation_ms != null && <span>{formatMs(r.generation_ms)} gen</span>}
+      {r.completion_tokens != null && <span>{r.completion_tokens} tokens</span>}
+      {r.was_truncated && <span className="text-warning font-sans">truncated</span>}
+    </div>
+  </div>
+);
+
+const PerfResult: FC<{ result: ModelPerfResult }> = ({ result: r }) => (
+  <div className="flex gap-lg flex-wrap text-sm">
+    <div className="bg-surface-elevated rounded-md p-md min-w-[90px]">
+      <Readout label="TG speed" value={r.tg_tps.toFixed(1)} unit="t/s" size="lg" align="center" />
+    </div>
+    <div className="bg-surface-elevated rounded-md p-md min-w-[90px]">
+      <Readout label="PP speed" value={r.pp_tps.toFixed(1)} unit="t/s" size="lg" align="center" />
+    </div>
+    <div className="bg-surface-elevated rounded-md p-md min-w-[90px]">
+      <Readout label="Backend" value={r.backend ?? '—'} size="sm" align="center" />
+    </div>
+    <div className="bg-surface-elevated rounded-md p-md min-w-[90px]">
+      <Readout label="Reps" value={r.repetitions} size="sm" align="center" />
+    </div>
+  </div>
+);
+
+interface PerfCompareResultCardProps {
+  model: ModelResultState;
+  /** Live text only renders for compare mode — perf has no token stream. */
+  showLiveText: boolean;
+}
+
+/** One model's card in the perf/compare results column. */
+export const PerfCompareResultCard: FC<PerfCompareResultCardProps> = ({ model: m, showLiveText }) => {
+  const statusColor = {
+    pending: 'text-text-muted',
+    running: 'text-primary',
+    complete: 'text-text-muted',
+    failed: 'text-danger',
+  }[m.status];
+
+  const statusLabel = {
+    pending: 'Pending',
+    running: 'Running…',
+    complete: 'Complete',
+    failed: 'Failed',
+  }[m.status];
+
+  return (
+    <div className="bg-surface rounded-md p-base flex flex-col gap-sm">
+      <div className="flex items-center gap-sm">
+        <span className="font-medium text-text truncate flex-1">{m.modelName}</span>
+        <span className={cn('text-xs font-medium', statusColor)}>{statusLabel}</span>
+      </div>
+
+      {m.status === 'running' && m.liveText && showLiveText && (
+        <div className="bg-surface-elevated rounded-md p-base text-sm text-text whitespace-pre-wrap font-mono leading-relaxed max-h-[300px] overflow-y-auto">
+          {m.liveText}
+          <span className="inline-block w-2 h-4 bg-primary animate-pulse ml-0.5 align-text-bottom" />
+        </div>
+      )}
+
+      {m.status === 'complete' && m.result && (
+        <>
+          {m.result.kind === 'compare' && <CompareResult result={m.result} />}
+          {m.result.kind === 'perf' && <PerfResult result={m.result} />}
+        </>
+      )}
+
+      {m.status === 'failed' && m.error && (
+        <div className="text-sm text-danger bg-danger-subtle rounded-md p-sm">{m.error}</div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Benchmark/PerfCompareTab.tsx
+++ b/src/components/Benchmark/PerfCompareTab.tsx
@@ -1,0 +1,181 @@
+/**
+ * Perf and Compare benchmark modes: config aside + live results column.
+ * Run state and streaming live in `usePerfCompareRun`.
+ *
+ * @module components/Benchmark/PerfCompareTab
+ */
+
+import { FC, useState } from 'react';
+import { cn } from '../../utils/cn';
+import { Play, Square, Zap } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Icon } from '../ui/Icon';
+import { Input } from '../ui/Input';
+import { Textarea } from '../ui/Textarea';
+import { EmptyState } from '../primitives';
+import { ModelMultiSelect } from './ModelMultiSelect';
+import { PerfCompareResultCard } from './PerfCompareResultCard';
+import { usePerfCompareRun } from './usePerfCompareRun';
+import type { GgufModel } from '../../types';
+
+interface PerfCompareTabProps {
+  mode: 'perf' | 'compare';
+  /** False while another benchmark tab is shown — the tab stays mounted so runs and form state survive. */
+  active?: boolean;
+  models: GgufModel[];
+  initialModelIds?: number[];
+  /** Called when a run finishes, so the page can refresh the shared history. */
+  onRunComplete: () => void;
+}
+
+export const PerfCompareTab: FC<PerfCompareTabProps> = ({
+  mode,
+  active = true,
+  models,
+  initialModelIds,
+  onRunComplete,
+}) => {
+  const [selectedModelIds, setSelectedModelIds] = useState<number[]>(
+    initialModelIds ?? (models.length > 0 && models[0].id != null ? [models[0].id] : []),
+  );
+  const [prompt, setPrompt] = useState('Tell me a short story about a robot.');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [ctxSize, setCtxSize] = useState('');
+  const [ppTokens, setPpTokens] = useState('512');
+  const [tgTokens, setTgTokens] = useState('128');
+  const [repetitions, setRepetitions] = useState('3');
+
+  const { runState, start, stop } = usePerfCompareRun(models, onRunComplete);
+  const isRunning = runState.status === 'running';
+
+  const handleStart = () => {
+    if (selectedModelIds.length === 0) return;
+    if (mode === 'compare') {
+      void start(
+        {
+          model_ids: selectedModelIds,
+          prompt,
+          system_prompt: systemPrompt.trim() || null,
+          ctx_size: parseInt(ctxSize, 10) || null,
+        },
+        'compare',
+        selectedModelIds,
+      );
+    } else {
+      void start(
+        {
+          model_ids: selectedModelIds,
+          pp_tokens: parseInt(ppTokens, 10) || 512,
+          tg_tokens: parseInt(tgTokens, 10) || 128,
+          repetitions: parseInt(repetitions, 10) || 3,
+        },
+        'perf',
+        selectedModelIds,
+      );
+    }
+  };
+
+  const toggleModel = (id: number) => {
+    setSelectedModelIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  };
+
+  const numberField = (
+    label: string,
+    value: string,
+    onChange: (v: string) => void,
+    extra?: { min?: number; max?: number; placeholder?: string },
+  ) => (
+    <div className="flex flex-col gap-xs">
+      <label className="text-xs font-semibold text-text">{label}</label>
+      <Input
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={isRunning}
+        size="sm"
+        className="font-mono tabular-nums"
+        {...extra}
+      />
+    </div>
+  );
+
+  return (
+    <div className={cn('flex flex-1 overflow-hidden gap-0', !active && 'hidden')}>
+      <aside className="w-[280px] shrink-0 flex flex-col gap-base p-base border-r border-border overflow-y-auto">
+        <ModelMultiSelect
+          models={models}
+          selectedIds={selectedModelIds}
+          onToggle={toggleModel}
+        />
+
+        {mode === 'compare' && (
+          <>
+            <div className="flex flex-col gap-xs">
+              <label className="text-xs font-semibold text-text">Prompt</label>
+              <Textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={4}
+                disabled={isRunning}
+                placeholder="Enter prompt…"
+              />
+            </div>
+            <div className="flex flex-col gap-xs">
+              <label className="text-xs font-semibold text-text">System Prompt (optional)</label>
+              <Textarea
+                value={systemPrompt}
+                onChange={(e) => setSystemPrompt(e.target.value)}
+                rows={2}
+                disabled={isRunning}
+                placeholder="Optional system prompt…"
+              />
+            </div>
+            {numberField('Context Size (optional)', ctxSize, setCtxSize, {
+              min: 512,
+              placeholder: 'Default from settings',
+            })}
+          </>
+        )}
+
+        {mode === 'perf' && (
+          <>
+            {numberField('PP Tokens', ppTokens, setPpTokens, { min: 1 })}
+            {numberField('TG Tokens', tgTokens, setTgTokens, { min: 1 })}
+            {numberField('Repetitions', repetitions, setRepetitions, { min: 1, max: 10 })}
+          </>
+        )}
+
+        <Button
+          variant={isRunning ? 'dangerGhost' : 'primary'}
+          size="lg"
+          fullWidth
+          disabled={selectedModelIds.length === 0}
+          onClick={isRunning ? stop : handleStart}
+          leftIcon={<Icon icon={isRunning ? Square : Play} size={16} />}
+        >
+          {isRunning ? 'Stop' : 'Run'}
+        </Button>
+
+        {runState.status === 'failed' && runState.error && (
+          <div className="text-xs text-danger bg-danger-subtle rounded-md p-sm">{runState.error}</div>
+        )}
+      </aside>
+
+      <div className="flex-1 overflow-y-auto p-base flex flex-col gap-base">
+        {runState.models.length === 0 && runState.status === 'idle' && (
+          <EmptyState
+            className="h-full"
+            icon={<Icon icon={Zap} size={24} />}
+            title="No benchmark yet"
+            description="Pick one or more models on the left, then press Run to measure prompt-processing and generation speed."
+          />
+        )}
+        {runState.models.map((m) => (
+          <PerfCompareResultCard key={m.modelId} model={m} showLiveText={mode === 'compare'} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Benchmark/README.md
+++ b/src/components/Benchmark/README.md
@@ -5,15 +5,27 @@
 
 <!-- module-docs:start -->
 
-Benchmark feature components. `BenchmarkPage.tsx` (in `src/pages/`) owns the
-`compare`/`perf` config form, live results, and history table directly; the
-`tune` mode (inference-parameter sweep for agentic tool-calling accuracy) is
-broken out into its own submodule here for maintainability.
+Benchmark feature components. `BenchmarkPage.tsx` (in `src/pages/`) is a thin
+shell — header, mode tabs, and the shared run-history strip — and every mode
+lives here as its own module.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `PerfCompareTab.tsx` | Perf/compare config aside + live results column |
+| `usePerfCompareRun.ts` | Run state + SSE streaming (100 ms `model_text_delta` throttle) |
+| `PerfCompareResultCard.tsx` | One model's live/complete/failed result card |
+| `ModelMultiSelect.tsx` | The config panel's model checkbox list |
+| `SuitePicker.tsx` | Default-vs-custom task-suite selector with client-side JSON parse |
+| `RunHistoryTable.tsx` | "Recent Runs" strip, shared by all modes |
+| `format.ts` | Shared tps/ms/date/delta/factor formatting |
 
 ## Sub-directories
 
 | Directory | Contents |
 |-----------|----------|
 | `Tune/` | Config form, live progress, and leaderboard components for tune-mode runs |
+| `Agentic/` | Raw-vs-gglib A/B eval: config form, live arm progress, the report (axis table, validity verdicts, efficiency, per-task drill-down), history list, and the client-side verdict derivations mirroring the Rust thresholds |
 
 <!-- module-docs:end -->

--- a/src/components/Benchmark/RunHistoryTable.tsx
+++ b/src/components/Benchmark/RunHistoryTable.tsx
@@ -1,0 +1,76 @@
+import type { FC } from 'react';
+import { Button } from '../ui/Button';
+import { cn } from '../../utils/cn';
+import { formatDate } from './format';
+import type { BenchmarkRun } from '../../types/benchmark';
+
+interface RunHistoryTableProps {
+  history: BenchmarkRun[];
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+/**
+ * The "Recent Runs" strip. Lives at page level so every mode shows it —
+ * previously it sat inside the perf/compare branch and tune had no history.
+ */
+export const RunHistoryTable: FC<RunHistoryTableProps> = ({ history, loading, onRefresh }) => (
+  <section className="border-t border-border-light shrink-0">
+    <div className="flex items-center gap-sm px-base py-sm border-b border-border-light">
+      <h2 className="text-sm font-semibold text-text m-0 flex-1">Recent Runs</h2>
+      <Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading}>
+        {loading ? 'Loading…' : 'Refresh'}
+      </Button>
+    </div>
+    <div className="overflow-x-auto max-h-[220px] overflow-y-auto">
+      {history.length === 0 ? (
+        <p className="text-xs text-text-muted p-base">No benchmark runs yet.</p>
+      ) : (
+        <table className="w-full text-xs border-collapse">
+          <thead className="sticky top-0 bg-background z-10">
+            <tr className="text-left text-text-muted border-b border-border">
+              <th className="px-base py-xs font-medium">ID</th>
+              <th className="px-base py-xs font-medium">Type</th>
+              <th className="px-base py-xs font-medium">Status</th>
+              <th className="px-base py-xs font-medium">Models</th>
+              <th className="px-base py-xs font-medium">Started</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.map((run) => (
+              <tr
+                key={run.id}
+                className="border-b border-border-light hover:bg-surface-elevated transition-colors"
+              >
+                <td className="px-base py-xs text-text-secondary font-mono tabular-nums">{run.id}</td>
+                <td className="px-base py-xs text-text-secondary">{run.run_type}</td>
+                <td className="px-base py-xs">
+                  <span className="inline-flex items-center gap-xs">
+                    {run.status === 'running' && (
+                      <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+                    )}
+                    <span
+                      className={cn(
+                        'text-text-muted',
+                        run.status === 'failed' && 'text-danger',
+                        run.status === 'running' && 'text-text',
+                      )}
+                    >
+                      {run.status}
+                    </span>
+                  </span>
+                </td>
+                <td className="px-base py-xs text-text-secondary font-mono tabular-nums">
+                  {run.model_ids.length}
+                </td>
+                <td className="px-base py-xs text-text-muted font-mono tabular-nums">
+                  {formatDate(run.created_at)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  </section>
+);

--- a/src/components/Benchmark/SuitePicker.tsx
+++ b/src/components/Benchmark/SuitePicker.tsx
@@ -1,0 +1,84 @@
+import { FC, useRef, useState } from 'react';
+import { Button } from '../ui/Button';
+import { Chip } from '../ui/Chip';
+import type { TaskSuite, TuneTask } from '../../types/benchmark';
+
+interface SuitePickerProps {
+  disabled: boolean;
+  /** `null` while a custom suite is selected but no valid file is loaded yet. */
+  onSuiteChange: (suite: TaskSuite | null) => void;
+}
+
+/**
+ * Default-vs-custom task-suite selector with the client-side JSON file parse.
+ * The uploaded file is the same shape `--task-suite path.json` reads from disk.
+ */
+export const SuitePicker: FC<SuitePickerProps> = ({ disabled, onSuiteChange }) => {
+  const [suiteMode, setSuiteMode] = useState<'default' | 'custom'>('default');
+  const [taskCount, setTaskCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const pickMode = (mode: 'default' | 'custom') => {
+    setSuiteMode(mode);
+    onSuiteChange(mode === 'default' ? { source: 'default' } : null);
+  };
+
+  const handleFileChange = async (file: File | null) => {
+    setError(null);
+    setTaskCount(null);
+    setFileName(file?.name ?? null);
+    onSuiteChange(null);
+    if (!file) return;
+    try {
+      const parsed = JSON.parse(await file.text()) as unknown;
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        throw new Error('Expected a non-empty JSON array of tasks');
+      }
+      setTaskCount(parsed.length);
+      onSuiteChange({ source: 'custom', tasks: parsed as TuneTask[] });
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-xs">
+      <label className="text-xs font-semibold text-text">Task Suite</label>
+      <div className="flex gap-sm">
+        <Chip selected={suiteMode === 'default'} disabled={disabled} onClick={() => pickMode('default')}>
+          Default
+        </Chip>
+        <Chip selected={suiteMode === 'custom'} disabled={disabled} onClick={() => pickMode('custom')}>
+          Custom
+        </Chip>
+      </div>
+      {suiteMode === 'custom' && (
+        <div className="flex flex-col gap-xs">
+          <input
+            ref={fileInputRef}
+            type="file"
+            tabIndex={-1}
+            aria-hidden="true"
+            accept=".json,application/json"
+            disabled={disabled}
+            onChange={(e) => void handleFileChange(e.target.files?.[0] ?? null)}
+            className="sr-only"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={disabled}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Choose task file…
+          </Button>
+          {fileName && <span className="text-xs text-text-muted">{fileName}</span>}
+          {taskCount != null && <p className="text-xs text-success m-0">{taskCount} task(s) loaded</p>}
+          {error && <p className="text-xs text-danger m-0">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Benchmark/Tune/TuneTab.tsx
+++ b/src/components/Benchmark/Tune/TuneTab.tsx
@@ -28,6 +28,8 @@ import { getTransport } from '../../../services/transport';
 
 interface TuneTabProps {
   models: GgufModel[];
+  /** Called when a run finishes, so the page can refresh the shared history. */
+  onRunComplete?: () => void;
 }
 
 interface TuneRunState {
@@ -48,7 +50,7 @@ const INITIAL_STATE: TuneRunState = {
   results: [],
 };
 
-export const TuneTab: FC<TuneTabProps> = ({ models }) => {
+export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
   const [runState, setRunState] = useState<TuneRunState>(INITIAL_STATE);
   const [applyingIndex, setApplyingIndex] = useState<number | null>(null);
   const [applyMessage, setApplyMessage] = useState<string | null>(null);
@@ -115,6 +117,7 @@ export const TuneTab: FC<TuneTabProps> = ({ models }) => {
 
         case 'run_complete':
           setRunState(prev => ({ ...prev, status: 'complete' }));
+          onRunComplete?.();
           break;
 
         case 'run_failed':
@@ -125,7 +128,7 @@ export const TuneTab: FC<TuneTabProps> = ({ models }) => {
           break;
       }
     },
-    [scheduleFlush],
+    [scheduleFlush, onRunComplete],
   );
 
   const handleApply = useCallback(async (result: TuneCandidateResult, modelId: number) => {

--- a/src/components/Benchmark/format.ts
+++ b/src/components/Benchmark/format.ts
@@ -1,0 +1,37 @@
+/** Shared formatting helpers for the benchmark surfaces. */
+
+export function formatTps(tps: number | null | undefined): string {
+  if (tps == null) return '—';
+  return `${tps.toFixed(1)} t/s`;
+}
+
+export function formatMs(ms: number | null | undefined): string {
+  if (ms == null) return '—';
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${ms.toFixed(0)} ms`;
+}
+
+export function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Signed two-decimal delta, e.g. "+0.09" / "−0.04" / "0.00". */
+export function formatDelta(value: number | null | undefined): string {
+  if (value == null) return '—';
+  const rounded = value.toFixed(2);
+  return value > 0 ? `+${rounded}` : rounded;
+}
+
+/** Multiplicative factor, e.g. "1.32×". */
+export function formatFactor(value: number | null | undefined): string {
+  if (value == null) return '—';
+  return `${value.toFixed(2)}×`;
+}

--- a/src/components/Benchmark/usePerfCompareRun.ts
+++ b/src/components/Benchmark/usePerfCompareRun.ts
@@ -1,0 +1,148 @@
+/**
+ * Run state + SSE streaming for the perf/compare benchmark modes.
+ *
+ * Owns the abort controller and the 100 ms `model_text_delta` throttle
+ * buffer; the tab component stays presentational.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { GgufModel } from '../../types';
+import type { BenchmarkEvent, CompareConfig, PerfConfig } from '../../types/benchmark';
+import { startCompareRun, startPerfRun } from '../../services/clients/benchmark';
+import type { ModelResultState } from './PerfCompareResultCard';
+
+export interface PerfCompareRunState {
+  runId?: number;
+  status: 'idle' | 'running' | 'complete' | 'failed';
+  error?: string;
+  models: ModelResultState[];
+}
+
+export function usePerfCompareRun(models: GgufModel[], onRunComplete: () => void) {
+  const [runState, setRunState] = useState<PerfCompareRunState>({ status: 'idle', models: [] });
+
+  const abortRef = useRef<AbortController | null>(null);
+  const textBufferRef = useRef<Map<number, string>>(new Map());
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      if (flushTimerRef.current !== null) clearTimeout(flushTimerRef.current);
+    };
+  }, []);
+
+  const scheduleFlush = useCallback(() => {
+    if (flushTimerRef.current !== null) return;
+    flushTimerRef.current = setTimeout(() => {
+      flushTimerRef.current = null;
+      const snapshot = new Map(textBufferRef.current);
+      textBufferRef.current = new Map();
+      if (snapshot.size === 0) return;
+      setRunState((prev) => ({
+        ...prev,
+        models: prev.models.map((m) => {
+          const buf = snapshot.get(m.modelId);
+          return buf != null ? { ...m, liveText: m.liveText + buf } : m;
+        }),
+      }));
+    }, 100);
+  }, []);
+
+  const handleEvent = useCallback(
+    (event: BenchmarkEvent) => {
+      switch (event.type) {
+        case 'model_started':
+          setRunState((prev) => ({
+            ...prev,
+            models: prev.models.map((m) =>
+              m.modelId === event.model_id ? { ...m, status: 'running' } : m,
+            ),
+          }));
+          break;
+
+        case 'model_text_delta':
+          textBufferRef.current.set(
+            event.model_id,
+            (textBufferRef.current.get(event.model_id) ?? '') + event.text,
+          );
+          scheduleFlush();
+          break;
+
+        case 'model_complete':
+          setRunState((prev) => ({
+            ...prev,
+            models: prev.models.map((m) =>
+              m.modelId === event.model_id ? { ...m, status: 'complete', result: event.result } : m,
+            ),
+          }));
+          break;
+
+        case 'model_failed':
+          setRunState((prev) => ({
+            ...prev,
+            models: prev.models.map((m) =>
+              m.modelId === event.model_id ? { ...m, status: 'failed', error: event.error } : m,
+            ),
+          }));
+          break;
+
+        case 'run_complete':
+          setRunState((prev) => ({ ...prev, status: 'complete', runId: event.run_id }));
+          onRunComplete();
+          break;
+
+        case 'run_failed':
+          setRunState((prev) => ({ ...prev, status: 'failed', error: event.error }));
+          break;
+      }
+    },
+    [scheduleFlush, onRunComplete],
+  );
+
+  const start = useCallback(
+    async (config: CompareConfig | PerfConfig, kind: 'compare' | 'perf', modelIds: number[]) => {
+      abortRef.current?.abort();
+      const abort = new AbortController();
+      abortRef.current = abort;
+
+      if (flushTimerRef.current !== null) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+        textBufferRef.current = new Map();
+      }
+
+      const modelStates: ModelResultState[] = modelIds.map((id) => {
+        const m = models.find((x) => x.id === id);
+        return { modelId: id, modelName: m?.name ?? `Model ${id}`, status: 'pending', liveText: '' };
+      });
+      setRunState({ status: 'running', models: modelStates });
+
+      try {
+        if (kind === 'compare') {
+          await startCompareRun(config as CompareConfig, handleEvent, abort.signal);
+        } else {
+          await startPerfRun(config as PerfConfig, handleEvent, abort.signal);
+        }
+        // A stream that closes with no terminal event must not hang the UI.
+        setRunState((prev) =>
+          prev.status === 'running'
+            ? { ...prev, status: 'failed', error: 'The benchmark stream ended without completing.' }
+            : prev,
+        );
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          setRunState((prev) => ({ ...prev, status: 'failed', error: (err as Error).message }));
+        }
+      }
+    },
+    [models, handleEvent],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    setRunState((prev) => ({ ...prev, status: 'idle' }));
+  }, []);
+
+  return { runState, start, stop };
+}

--- a/src/pages/BenchmarkPage.tsx
+++ b/src/pages/BenchmarkPage.tsx
@@ -1,76 +1,29 @@
 /**
  * Benchmark Dashboard page.
  *
- * Provides:
- * - Mode selector: "Compare" (side-by-side response quality) vs "Perf" (throughput)
- *   vs "Tune" (sampling-parameter sweep for agentic tool-calling accuracy)
- * - Config form: model multi-select, prompt (compare) or pp/tg/reps (perf)
- * - Live streaming results panel with 100 ms throttled text delta rendering
- * - History table of recent benchmark runs
- *
- * Throttle pattern: incoming `model_text_delta` events are buffered in a
- * `useRef<Map<number, string>>` and flushed into React state every 100 ms to
- * avoid per-keystroke re-renders during fast SSE streams. Tune mode
- * (`components/Benchmark/Tune/TuneTab`) reuses this exact pattern for its
- * own high-frequency `tune_task_complete` events — see that module's docs.
+ * Header + mode tabs + per-mode dispatch + the shared run-history strip.
+ * Each mode owns its own state and streaming:
+ * - Perf / Compare: `components/Benchmark/PerfCompareTab`
+ * - Tune: `components/Benchmark/Tune/TuneTab`
+ * - Agentic: `components/Benchmark/Agentic/AgenticTab`
  *
  * @module pages/BenchmarkPage
  */
 
-import {
-  FC,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { ArrowLeft, BarChart2, Play, Square, Zap } from 'lucide-react';
-import { Checkbox } from '../components/ui/Checkbox';
+import { FC, useCallback, useEffect, useState } from 'react';
+import { ArrowLeft, BarChart2 } from 'lucide-react';
 import { Tabs } from '../components/ui/Tabs';
-import { EmptyState, Readout } from '../components/primitives';
 import { Button } from '../components/ui/Button';
 import { Icon } from '../components/ui/Icon';
-import { Input } from '../components/ui/Input';
-import { Textarea } from '../components/ui/Textarea';
-import { cn } from '../utils/cn';
+import { PerfCompareTab } from '../components/Benchmark/PerfCompareTab';
+import { RunHistoryTable } from '../components/Benchmark/RunHistoryTable';
 import { TuneTab } from '../components/Benchmark/Tune/TuneTab';
+import { AgenticTab } from '../components/Benchmark/Agentic/AgenticTab';
 import type { GgufModel } from '../types';
-import type {
-  BenchmarkEvent,
-  BenchmarkModelResult,
-  BenchmarkRun,
-  CompareConfig,
-  ModelCompareResult,
-  ModelPerfResult,
-  PerfConfig,
-} from '../types/benchmark';
-import {
-  listBenchmarkRuns,
-  startCompareRun,
-  startPerfRun,
-} from '../services/clients/benchmark';
+import type { BenchmarkRun } from '../types/benchmark';
+import { listBenchmarkRuns } from '../services/clients/benchmark';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-type RunMode = 'compare' | 'perf' | 'tune';
-
-interface ModelResultState {
-  modelId: number;
-  modelName: string;
-  status: 'pending' | 'running' | 'complete' | 'failed';
-  liveText: string;  // throttle-buffered text delta accumulation
-  result?: BenchmarkModelResult;
-  error?: string;
-}
-
-interface RunState {
-  runId?: number;
-  status: 'idle' | 'running' | 'complete' | 'failed';
-  error?: string;
-  models: ModelResultState[];
-}
-
-// ─── Props ────────────────────────────────────────────────────────────────────
+type RunMode = 'compare' | 'perf' | 'tune' | 'agentic';
 
 interface BenchmarkPageProps {
   /** All available models for selection. */
@@ -80,70 +33,17 @@ interface BenchmarkPageProps {
   onClose: () => void;
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function formatTps(tps: number | null | undefined): string {
-  if (tps == null) return '—';
-  return `${tps.toFixed(1)} t/s`;
-}
-
-function formatMs(ms: number | null | undefined): string {
-  if (ms == null) return '—';
-  return ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${ms.toFixed(0)} ms`;
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
-}
-
-// ─── Component ────────────────────────────────────────────────────────────────
-
 const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClose }) => {
   const [mode, setMode] = useState<RunMode>('perf');
-
-  // Config form state
-  const [selectedModelIds, setSelectedModelIds] = useState<number[]>(
-    initialModelIds ?? (models.length > 0 && models[0].id != null ? [models[0].id] : []),
-  );
-  const [prompt, setPrompt] = useState('Tell me a short story about a robot.');
-  const [systemPrompt, setSystemPrompt] = useState('');
-  const [ctxSize, setCtxSize] = useState('');
-  const [ppTokens, setPpTokens] = useState('512');
-  const [tgTokens, setTgTokens] = useState('128');
-  const [repetitions, setRepetitions] = useState('3');
-
-  // Run state
-  const [runState, setRunState] = useState<RunState>({ status: 'idle', models: [] });
-
-  // History state
   const [history, setHistory] = useState<BenchmarkRun[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
-
-  // Abort controller for SSE cleanup
-  const abortRef = useRef<AbortController | null>(null);
-
-  // Throttle buffer: model_id → accumulated text not yet flushed to state
-  const textBufferRef = useRef<Map<number, string>>(new Map());
-  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // ─── History fetch ──────────────────────────────────────────────────────────
 
   const loadHistory = useCallback(async () => {
     setHistoryLoading(true);
     try {
-      const runs = await listBenchmarkRuns(20, 0);
-      setHistory(runs);
+      setHistory(await listBenchmarkRuns(20, 0));
     } catch {
-      // non-fatal; history may be unavailable during active run
+      // non-fatal; history may be unavailable during an active run
     } finally {
       setHistoryLoading(false);
     }
@@ -151,253 +51,13 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
 
   useEffect(() => {
     void loadHistory();
-    return () => {
-      // Cancel any in-flight SSE on unmount
-      abortRef.current?.abort();
-      if (flushTimerRef.current !== null) clearTimeout(flushTimerRef.current);
-    };
   }, [loadHistory]);
 
-  // ─── Throttled flush ────────────────────────────────────────────────────────
-
-  const scheduleFlush = useCallback(() => {
-    if (flushTimerRef.current !== null) return;
-    flushTimerRef.current = setTimeout(() => {
-      flushTimerRef.current = null;
-      const snapshot = new Map(textBufferRef.current);
-      textBufferRef.current = new Map();
-      if (snapshot.size === 0) return;
-      setRunState(prev => {
-        const next = { ...prev, models: prev.models.map(m => {
-          const buf = snapshot.get(m.modelId);
-          return buf != null ? { ...m, liveText: m.liveText + buf } : m;
-        }) };
-        return next;
-      });
-    }, 100);
-  }, []);
-
-  // ─── Event handler ──────────────────────────────────────────────────────────
-
-  const handleEvent = useCallback((event: BenchmarkEvent) => {
-    switch (event.type) {
-      case 'model_started':
-        setRunState(prev => ({
-          ...prev,
-          models: prev.models.map(m =>
-            m.modelId === event.model_id ? { ...m, status: 'running' } : m,
-          ),
-        }));
-        break;
-
-      case 'model_text_delta': {
-        // Buffer the delta; schedule throttled flush
-        textBufferRef.current.set(
-          event.model_id,
-          (textBufferRef.current.get(event.model_id) ?? '') + event.text,
-        );
-        scheduleFlush();
-        break;
-      }
-
-      case 'model_complete':
-        setRunState(prev => ({
-          ...prev,
-          models: prev.models.map(m =>
-            m.modelId === event.model_id
-              ? { ...m, status: 'complete', result: event.result }
-              : m,
-          ),
-        }));
-        break;
-
-      case 'model_failed':
-        setRunState(prev => ({
-          ...prev,
-          models: prev.models.map(m =>
-            m.modelId === event.model_id
-              ? { ...m, status: 'failed', error: event.error }
-              : m,
-          ),
-        }));
-        break;
-
-      case 'run_complete':
-        setRunState(prev => ({ ...prev, status: 'complete', runId: event.run_id }));
-        void loadHistory();
-        break;
-
-      case 'run_failed':
-        setRunState(prev => ({ ...prev, status: 'failed', error: event.error }));
-        break;
-    }
-  }, [scheduleFlush, loadHistory]);
-
-  // ─── Run start / stop ───────────────────────────────────────────────────────
-
-  const handleStart = useCallback(async () => {
-    if (selectedModelIds.length === 0) return;
-
-    // Cancel any previous run
-    abortRef.current?.abort();
-    const abort = new AbortController();
-    abortRef.current = abort;
-
-    // Flush any pending buffer immediately
-    if (flushTimerRef.current !== null) {
-      clearTimeout(flushTimerRef.current);
-      flushTimerRef.current = null;
-      textBufferRef.current = new Map();
-    }
-
-    // Build initial model states
-    const modelStates: ModelResultState[] = selectedModelIds.map(id => {
-      const m = models.find(x => x.id === id);
-      return {
-        modelId: id,
-        modelName: m?.name ?? `Model ${id}`,
-        status: 'pending',
-        liveText: '',
-      };
-    });
-
-    setRunState({ status: 'running', models: modelStates });
-
-    try {
-      if (mode === 'compare') {
-        const config: CompareConfig = {
-          model_ids: selectedModelIds,
-          prompt,
-          system_prompt: systemPrompt.trim() || null,
-          ctx_size: parseInt(ctxSize, 10) || null,
-        };
-        await startCompareRun(config, handleEvent, abort.signal);
-      } else {
-        const config: PerfConfig = {
-          model_ids: selectedModelIds,
-          pp_tokens: parseInt(ppTokens, 10) || 512,
-          tg_tokens: parseInt(tgTokens, 10) || 128,
-          repetitions: parseInt(repetitions, 10) || 3,
-        };
-        await startPerfRun(config, handleEvent, abort.signal);
-      }
-    } catch (err) {
-      if ((err as Error).name !== 'AbortError') {
-        setRunState(prev => ({
-          ...prev,
-          status: 'failed',
-          error: (err as Error).message,
-        }));
-      }
-    }
-  }, [mode, selectedModelIds, models, prompt, systemPrompt, ctxSize, ppTokens, tgTokens, repetitions, handleEvent]);
-
-  const handleStop = useCallback(() => {
-    abortRef.current?.abort();
-    setRunState(prev => ({ ...prev, status: 'idle' }));
-  }, []);
-
-  // ─── Model selection helpers ────────────────────────────────────────────────
-
-  const toggleModel = (id: number) => {
-    setSelectedModelIds(prev =>
-      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id],
-    );
-  };
-
-  const isRunning = runState.status === 'running';
-
-  // ─── Render helpers ─────────────────────────────────────────────────────────
-
-  const renderCompareResult = (r: ModelCompareResult) => (
-    <div className="flex flex-col gap-sm">
-      <div className="bg-surface rounded-md p-base text-sm text-text whitespace-pre-wrap font-mono leading-relaxed">
-        {r.response_text}
-      </div>
-      <div className="flex gap-md text-xs text-text-muted flex-wrap">
-        {r.generation_tps != null && (
-          <span className="inline-flex items-center gap-xs">
-            <Icon icon={Zap} size={12} />
-            {formatTps(r.generation_tps)} gen
-          </span>
-        )}
-        {r.prompt_tps != null && <span>{formatTps(r.prompt_tps)} pp</span>}
-        {r.generation_ms != null && <span>{formatMs(r.generation_ms)} gen</span>}
-        {r.completion_tokens != null && <span>{r.completion_tokens} tokens</span>}
-        {r.was_truncated && <span className="text-warning">truncated</span>}
-      </div>
-    </div>
-  );
-
-  const renderPerfResult = (r: ModelPerfResult) => (
-    <div className="flex gap-lg flex-wrap text-sm">
-      <div className="bg-surface rounded-md p-md min-w-[90px]">
-        <Readout label="TG speed" value={r.tg_tps.toFixed(1)} unit="t/s" size="lg" align="center" />
-      </div>
-      <div className="bg-surface rounded-md p-md min-w-[90px]">
-        <Readout label="PP speed" value={r.pp_tps.toFixed(1)} unit="t/s" size="lg" align="center" />
-      </div>
-      <div className="bg-surface rounded-md p-md min-w-[90px]">
-        <Readout label="Backend" value={r.backend ?? '—'} size="sm" align="center" />
-      </div>
-      <div className="bg-surface rounded-md p-md min-w-[90px]">
-        <Readout label="Reps" value={r.repetitions} size="sm" align="center" />
-      </div>
-    </div>
-  );
-
-  const renderModelCard = (m: ModelResultState) => {
-    const statusColor = {
-      pending: 'text-text-muted',
-      running: 'text-primary',
-      complete: 'text-text-muted',
-      failed: 'text-danger',
-    }[m.status];
-
-    const statusLabel = {
-      pending: 'Pending',
-      running: 'Running…',
-      complete: 'Complete',
-      failed: 'Failed',
-    }[m.status];
-
-    return (
-      <div key={m.modelId} className="bg-surface rounded-md p-base flex flex-col gap-sm">
-        <div className="flex items-center gap-sm">
-          <span className="font-medium text-text truncate flex-1">{m.modelName}</span>
-          <span className={cn('text-xs font-medium', statusColor)}>{statusLabel}</span>
-        </div>
-
-        {/* Live streaming text (compare mode) */}
-        {m.status === 'running' && m.liveText && mode === 'compare' && (
-          <div className="bg-surface-elevated rounded-md p-base text-sm text-text whitespace-pre-wrap font-mono leading-relaxed max-h-[300px] overflow-y-auto">
-            {m.liveText}
-            <span className="inline-block w-2 h-4 bg-primary animate-pulse ml-0.5 align-text-bottom" />
-          </div>
-        )}
-
-        {/* Completed result */}
-        {m.status === 'complete' && m.result && (
-          <>
-            {m.result.kind === 'compare' && renderCompareResult(m.result)}
-            {m.result.kind === 'perf' && renderPerfResult(m.result)}
-          </>
-        )}
-
-        {/* Error */}
-        {m.status === 'failed' && m.error && (
-          <div className="text-sm text-danger bg-danger-subtle rounded-md p-sm">{m.error}</div>
-        )}
-      </div>
-    );
-  };
-
-  // ─── Render ─────────────────────────────────────────────────────────────────
+  const refreshHistory = useCallback(() => void loadHistory(), [loadHistory]);
 
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
-      {/* Header */}
-      <header className="flex items-center gap-md px-base py-sm border-b border-border shrink-0">
+      <header className="flex items-center gap-md px-base py-sm border-b border-border-light shrink-0">
         <Button variant="ghost" size="sm" iconOnly onClick={onClose} aria-label="Close benchmark">
           <Icon icon={ArrowLeft} size={16} />
         </Button>
@@ -413,229 +73,25 @@ const BenchmarkPage: FC<BenchmarkPageProps> = ({ models, initialModelIds, onClos
             { id: 'perf', label: 'Perf' },
             { id: 'compare', label: 'Compare' },
             { id: 'tune', label: 'Tune' },
+            { id: 'agentic', label: 'Agentic' },
           ]}
         />
       </header>
 
-      {/* Body */}
-      {mode === 'tune' ? (
-        <TuneTab models={models} />
-      ) : (
-      <div className="flex flex-1 overflow-hidden gap-0">
-        {/* ── Left: Config panel ── */}
-        <aside className="w-[280px] shrink-0 flex flex-col gap-base p-base border-r border-border overflow-y-auto">
-          {/* Model selection */}
-          <div className="flex flex-col gap-sm">
-            <label className="text-xs font-semibold text-text">
-              Models ({selectedModelIds.length} selected)
-            </label>
-            <div className="flex flex-col gap-xs max-h-[240px] overflow-y-auto border border-border rounded-md p-xs">
-              {models.length === 0 && (
-                <p className="text-xs text-text-muted p-xs">No models available</p>
-              )}
-              {models.map(m => {
-                if (m.id == null) return null;
-                const checked = selectedModelIds.includes(m.id);
-                return (
-                  <Checkbox
-                    key={m.id}
-                    checked={checked}
-                    onChange={() => toggleModel(m.id!)}
-                    wrapperClassName={cn(
-                      'w-full p-xs rounded-sm transition-colors',
-                      checked ? 'bg-primary-subtle' : 'hover:bg-surface-elevated',
-                    )}
-                    label={<span className={cn('block truncate', checked ? 'text-text' : 'text-text-secondary')}>{m.name}</span>}
-                  />
-                );
-              })}
-            </div>
-          </div>
+      {mode === 'tune' && <TuneTab models={models} onRunComplete={refreshHistory} />}
+      {mode === 'agentic' && <AgenticTab models={models} onRunComplete={refreshHistory} />}
+      {/* Kept mounted while other tabs are open, matching the old page: an
+          in-flight perf/compare run keeps streaming and form state survives
+          mode switches. */}
+      <PerfCompareTab
+        mode={mode === 'compare' ? 'compare' : 'perf'}
+        active={mode === 'perf' || mode === 'compare'}
+        models={models}
+        initialModelIds={initialModelIds}
+        onRunComplete={refreshHistory}
+      />
 
-          {/* Compare config */}
-          {mode === 'compare' && (
-            <>
-              <div className="flex flex-col gap-xs">
-                <label className="text-xs font-semibold text-text">
-                  Prompt
-                </label>
-                <Textarea
-                  value={prompt}
-                  onChange={e => setPrompt(e.target.value)}
-                  rows={4}
-                  disabled={isRunning}
-                  placeholder="Enter prompt…"
-                />
-              </div>
-              <div className="flex flex-col gap-xs">
-                <label className="text-xs font-semibold text-text">
-                  System Prompt (optional)
-                </label>
-                <Textarea
-                  value={systemPrompt}
-                  onChange={e => setSystemPrompt(e.target.value)}
-                  rows={2}
-                  disabled={isRunning}
-                  placeholder="Optional system prompt…"
-                />
-              </div>
-              <div className="flex flex-col gap-xs">
-                <label className="text-xs font-semibold text-text">
-                  Context Size (optional)
-                </label>
-                <Input
-                  type="number"
-                  value={ctxSize}
-                  onChange={e => setCtxSize(e.target.value)}
-                  disabled={isRunning}
-                  min={512}
-                  size="sm"
-                  placeholder="Default from settings"
-                />
-              </div>
-            </>
-          )}
-
-          {/* Perf config */}
-          {mode === 'perf' && (
-            <>
-              <div className="flex flex-col gap-xs">
-                <label className="text-xs font-semibold text-text">
-                  PP Tokens
-                </label>
-                <Input
-                  type="number"
-                  value={ppTokens}
-                  onChange={e => setPpTokens(e.target.value)}
-                  disabled={isRunning}
-                  min={1}
-                  size="sm"
-                />
-              </div>
-              <div className="flex flex-col gap-xs">
-                <label className="text-xs font-semibold text-text">
-                  TG Tokens
-                </label>
-                <Input
-                  type="number"
-                  value={tgTokens}
-                  onChange={e => setTgTokens(e.target.value)}
-                  disabled={isRunning}
-                  min={1}
-                  size="sm"
-                />
-              </div>
-              <div className="flex flex-col gap-xs">
-                <label className="text-xs font-semibold text-text">
-                  Repetitions
-                </label>
-                <Input
-                  type="number"
-                  value={repetitions}
-                  onChange={e => setRepetitions(e.target.value)}
-                  disabled={isRunning}
-                  min={1}
-                  max={10}
-                  size="sm"
-                />
-              </div>
-            </>
-          )}
-
-          {/* Run / Stop button */}
-          <Button
-            variant={isRunning ? 'dangerGhost' : 'primary'}
-            size="lg"
-            fullWidth
-            disabled={selectedModelIds.length === 0}
-            onClick={isRunning ? handleStop : handleStart}
-            leftIcon={<Icon icon={isRunning ? Square : Play} size={16} />}
-          >
-            {isRunning ? 'Stop' : 'Run'}
-          </Button>
-
-          {runState.status === 'failed' && runState.error && (
-            <div className="text-xs text-danger bg-danger-subtle rounded-md p-sm">
-              {runState.error}
-            </div>
-          )}
-        </aside>
-
-        {/* ── Right: Results + History ── */}
-        <div className="flex-1 flex flex-col overflow-hidden">
-          {/* Live results area */}
-          <div className="flex-1 overflow-y-auto p-base flex flex-col gap-base">
-            {runState.models.length === 0 && runState.status === 'idle' && (
-              <EmptyState
-                className="h-full"
-                icon={<Icon icon={Zap} size={24} />}
-                title="No benchmark yet"
-                description="Pick one or more models on the left, then press Run to measure prompt-processing and generation speed."
-              />
-            )}
-            {runState.models.map(renderModelCard)}
-          </div>
-
-          {/* History section */}
-          <section className="border-t border-border-light shrink-0">
-            <div className="flex items-center gap-sm px-base py-sm border-b border-border-light">
-              <h2 className="text-sm font-semibold text-text m-0 flex-1">Recent Runs</h2>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={loadHistory}
-                disabled={historyLoading}
-              >
-                {historyLoading ? 'Loading…' : 'Refresh'}
-              </Button>
-            </div>
-            <div className="overflow-x-auto max-h-[220px] overflow-y-auto">
-              {history.length === 0 ? (
-                <p className="text-xs text-text-muted p-base">No benchmark runs yet.</p>
-              ) : (
-                <table className="w-full text-xs border-collapse">
-                  <thead className="sticky top-0 bg-background z-10">
-                    <tr className="text-left text-text-muted border-b border-border">
-                      <th className="px-base py-xs font-medium">ID</th>
-                      <th className="px-base py-xs font-medium">Type</th>
-                      <th className="px-base py-xs font-medium">Status</th>
-                      <th className="px-base py-xs font-medium">Models</th>
-                      <th className="px-base py-xs font-medium">Started</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {history.map(run => (
-                      <tr key={run.id} className="border-b border-border-light hover:bg-surface-elevated transition-colors">
-                        <td className="px-base py-xs text-text-secondary font-mono tabular-nums">{run.id}</td>
-                        <td className="px-base py-xs text-text-secondary">{run.run_type}</td>
-                        <td className="px-base py-xs">
-                          <span className="inline-flex items-center gap-xs">
-                            {run.status === 'running' && (
-                              <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
-                            )}
-                            <span
-                              className={cn(
-                                'text-text-muted',
-                                run.status === 'failed' && 'text-danger',
-                                run.status === 'running' && 'text-text',
-                              )}
-                            >
-                              {run.status}
-                            </span>
-                          </span>
-                        </td>
-                        <td className="px-base py-xs text-text-secondary font-mono tabular-nums">{run.model_ids.length}</td>
-                        <td className="px-base py-xs text-text-muted font-mono tabular-nums">{formatDate(run.created_at)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
-            </div>
-          </section>
-        </div>
-      </div>
-      )}
+      <RunHistoryTable history={history} loading={historyLoading} onRefresh={refreshHistory} />
     </div>
   );
 };

--- a/src/services/clients/benchmark.ts
+++ b/src/services/clients/benchmark.ts
@@ -12,11 +12,14 @@
 
 import { get, getAuthenticatedFetchConfig } from '../transport/api/client';
 import type {
+  AgenticEvalConfig,
+  AgenticEvalReport,
   BenchmarkEvent,
   BenchmarkRun,
   CompareConfig,
   GetBenchmarkRunResponse,
   ListBenchmarkRunsResponse,
+  ModelAgenticHistoryResponse,
   ModelBenchmarkHistoryResponse,
   ModelTuneHistoryResponse,
   PerfConfig,
@@ -74,6 +77,20 @@ export async function getModelTuneHistory(
     `/api/models/${modelId}/tune-history?limit=${limit}`,
   );
   return response.results;
+}
+
+/**
+ * GET /api/models/{id}/agentic-history — past raw-vs-gglib reports,
+ * most recent first. `limit` is clamped to 1..=100 server-side.
+ */
+export async function getModelAgenticHistory(
+  modelId: number,
+  limit = 20,
+): Promise<AgenticEvalReport[]> {
+  const response = await get<ModelAgenticHistoryResponse>(
+    `/api/models/${modelId}/agentic-history?limit=${limit}`,
+  );
+  return response.reports;
 }
 
 // ─── SSE streaming helpers ────────────────────────────────────────────────────
@@ -216,6 +233,40 @@ export async function startTuneRun(
     throw new Error(
       (body as { error?: string }).error ??
         `Tune run failed: ${response.status}`,
+    );
+  }
+
+  await consumeSseStream(response, onEvent);
+}
+
+/**
+ * POST /api/benchmark/agentic  (SSE)
+ * Start a raw-vs-gglib agentic eval and stream events via `onEvent`.
+ * Aborting the signal genuinely cancels the server-side run (the stream
+ * guard drop-cancels the eval task). Resolves when the stream ends.
+ */
+export async function startAgenticRun(
+  config: AgenticEvalConfig,
+  onEvent: (event: BenchmarkEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const { baseUrl, headers } = await getAuthenticatedFetchConfig();
+
+  const response = await fetch(`${baseUrl}/api/benchmark/agentic`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers as Record<string, string>),
+    },
+    body: JSON.stringify(config),
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: string }).error ??
+        `Agentic eval failed: ${response.status}`,
     );
   }
 

--- a/src/types/benchmark.ts
+++ b/src/types/benchmark.ts
@@ -302,6 +302,30 @@ export type BenchmarkEvent =
  */
 export type EvalArm = 'raw' | 'gglib' | 'raw_replicate' | 'control';
 
+/**
+ * Request body for `POST /api/benchmark/agentic`. Mirrors
+ * `gglib_core::domain::benchmark::agentic::AgenticEvalConfig`; every field
+ * except `model_id` and `task_suite` is serde-defaulted server-side.
+ */
+export interface AgenticEvalConfig {
+  model_id: number;
+  task_suite: TaskSuite;
+  /** Server default: { tool_accuracy: 0.4, loop_avoidance: 0.3, task_completion: 0.2, speed: 0.1 }. */
+  weights?: ScoreWeights;
+  ctx_size?: number | null;
+  /**
+   * Server default: [12345, 67890, 11111]. An EMPTY array is meaningful —
+   * one unseeded run per task, which carries full decode variance.
+   */
+  seeds?: number[];
+  /** Server default true — run the sampling-broken positive control arm. */
+  include_control?: boolean;
+  /** Server default true — re-run the raw arm on disjoint seeds (the A/A drift floor). */
+  replicate_raw?: boolean;
+  /** Server default 1; clamped into 1..=seeds.len() server-side. */
+  control_seeds?: number;
+}
+
 /** One arm's aggregate scores. Mirrors `gglib_core::domain::benchmark::agentic::ArmScores`. */
 export interface ArmScores {
   tool_accuracy: number;

--- a/tests/ts/components/agenticVerdicts.test.ts
+++ b/tests/ts/components/agenticVerdicts.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the client-side agentic verdict derivations.
+ *
+ * These mirror Rust methods on `AgenticEvalReport` (control_verdict,
+ * noise_floor, effect_verdict, is_unstable) — the assertions pin the exact
+ * thresholds and edge cases so the two implementations cannot drift.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CONTROL_MIN_COMPOSITE_GAP,
+  EFFECT_NOISE_RATIO,
+  controlVerdict,
+  effectVerdict,
+  isUnstable,
+  noiseFloor,
+  passCounts,
+  unstableTasks,
+} from '../../../src/components/Benchmark/Agentic/verdicts';
+import type {
+  AgenticEvalReport,
+  AgenticTaskComparison,
+  ArmScores,
+  TuneTaskResult,
+} from '../../../src/types/benchmark';
+
+function arm(composite: number): ArmScores {
+  return {
+    tool_accuracy: 0.5,
+    loop_eligible: 1,
+    task_completion: 0.5,
+    composite,
+    total_wall_ms: 1000,
+  } as ArmScores;
+}
+
+function report(overrides: Partial<AgenticEvalReport>): AgenticEvalReport {
+  return {
+    model_name: 'm',
+    param_count_b: 4,
+    ctx_size: 8192,
+    raw: arm(0.5),
+    gglib: arm(0.6),
+    delta: { tool_accuracy: 0, task_completion: 0, composite: 0.1 },
+    tasks: [],
+    ...overrides,
+  } as AgenticEvalReport;
+}
+
+function run(passed: boolean): TuneTaskResult {
+  return { passed } as TuneTaskResult;
+}
+
+function comparison(raw: boolean[], gglib: boolean[]): AgenticTaskComparison {
+  return {
+    task_id: 't',
+    category: 'tool_call' as AgenticTaskComparison['category'],
+    raw: raw.map(run),
+    gglib: gglib.map(run),
+  };
+}
+
+describe('controlVerdict', () => {
+  it('returns null when no control arm ran', () => {
+    expect(controlVerdict(report({ control: null }))).toBeNull();
+    expect(controlVerdict(report({}))).toBeNull();
+  });
+
+  it('reports moved at or above the detection gap', () => {
+    // Dyadic fixtures: 0.5 − 0.4375 = 0.0625 exactly, no float boundary fuzz.
+    const v = controlVerdict(report({ gglib: arm(0.5), control: arm(0.4375) }));
+    expect(v).toEqual({ kind: 'moved', gap: 0.0625 });
+    expect(CONTROL_MIN_COMPOSITE_GAP).toBe(0.05);
+  });
+
+  it('reports too_small for a nonnegative gap under the bar', () => {
+    const v = controlVerdict(report({ gglib: arm(0.5), control: arm(0.46875) }));
+    expect(v?.kind).toBe('too_small');
+  });
+
+  it('reports wrong_direction with the gap made positive', () => {
+    const v = controlVerdict(report({ gglib: arm(0.6), control: arm(0.7) }));
+    expect(v).toEqual({ kind: 'wrong_direction', gap: expect.closeTo(0.1, 10) });
+  });
+});
+
+describe('effectVerdict', () => {
+  it('returns null when no A/A arm ran', () => {
+    expect(effectVerdict(report({}))).toBeNull();
+  });
+
+  it('exceeds noise only at the 2.0x factor', () => {
+    // Dyadic fixtures: noise = |0.5 − 0.53125| = 0.03125; 2× = 0.0625 exactly.
+    const base = { raw: arm(0.5), raw_replicate: arm(0.53125) };
+    expect(EFFECT_NOISE_RATIO).toBe(2.0);
+    const exceeds = effectVerdict(
+      report({ ...base, delta: { tool_accuracy: 0, task_completion: 0, composite: 0.0625 } }),
+    );
+    expect(exceeds?.kind).toBe('exceeds_noise');
+    const within = effectVerdict(
+      report({ ...base, delta: { tool_accuracy: 0, task_completion: 0, composite: 0.046875 } }),
+    );
+    expect(within?.kind).toBe('within_noise');
+  });
+
+  it('never lets a zero effect exceed a zero noise floor', () => {
+    const v = effectVerdict(
+      report({
+        raw: arm(0.5),
+        raw_replicate: arm(0.5),
+        delta: { tool_accuracy: 0, task_completion: 0, composite: 0 },
+      }),
+    );
+    expect(v?.kind).toBe('within_noise');
+  });
+
+  it('measures noise as the absolute raw-vs-replicate distance', () => {
+    expect(noiseFloor(report({ raw: arm(0.5), raw_replicate: arm(0.45) }))).toBeCloseTo(0.05);
+  });
+});
+
+describe('task stability', () => {
+  it('counts each arm separately', () => {
+    expect(passCounts(comparison([true, false, false], [true, true, true]))).toEqual([1, 3]);
+  });
+
+  it('flags a flip in either arm as unstable', () => {
+    expect(isUnstable(comparison([true, false], [true, true]))).toBe(true);
+    expect(isUnstable(comparison([true, true], [false, true]))).toBe(true);
+    expect(isUnstable(comparison([true, true], [false, false]))).toBe(false);
+  });
+
+  it('collects unstable tasks from the report', () => {
+    const stable = comparison([true], [true]);
+    const unstable = comparison([true, false], [true, true]);
+    expect(unstableTasks(report({ tasks: [stable, unstable] }))).toEqual([unstable]);
+  });
+});


### PR DESCRIPTION
PR 6/13 — **stacked on** `docs(styles)/contract-and-polish` (#761). First parity PR: the raw-vs-gglib agentic A/B eval — previously CLI-only despite both endpoints existing — lands as the benchmark dashboard's fourth mode. Frontend-only; zero Rust changes.

## What's new
- **Wire layer**: `AgenticEvalConfig` TS mirror (field-for-field against the serde struct, including empty-seeds-means-unseeded), `startAgenticRun` (SSE; aborting genuinely cancels the server-side run) and `getModelAgenticHistory` — both endpoints were previously unused by the GUI.
- **Verdicts derived client-side** (`Agentic/verdicts.ts`): the Rust computes control/effect verdicts as methods, not serialized fields; the TS mirrors them exactly — thresholds (0.05 composite gap, 2.0× noise ratio), boundary inclusivity, the zero-effect guard, per-seed instability — pinned by 11 unit tests with dyadic fixtures so float boundaries can't drift.
- **The report** follows the CLI renderer's block order (identity, sample-size warning, axis table with sign-colored deltas, unmeasured-runs caveat, A/A drift verdict, three-way control verdict, per-seed stability, efficiency table) and exceeds it with a per-task drill-down and JSON export in the CLI's `--output` shape (explicit nulls for browser-absent provenance).
- **Past reports** browsable per model via the agentic-history endpoint.

## Decomposition (modularity rule)
`BenchmarkPage` (643 LOC) → a 100-line shell + per-mode modules (`PerfCompareTab` + `usePerfCompareRun` + result card + model select + `SuitePicker` + `format.ts`), every file under the 200-LOC budget. The history strip lifts to page level — tune mode finally shows run history. `TuneTab` gains an optional `onRunComplete` so all modes refresh it.

## Review gate: 17 raised, 17 confirmed, all fixed
Highlights: a stuck-on-'running' state when the server closes the stream with no terminal event (now guarded in both agentic and perf/compare stream finalizers); two decomposition regressions restored (perf/compare stays mounted across tab switches, so live runs and form state survive — matching the old page; mid-run model staging re-enabled); form inputs clamped to what the serde types accept (u32 seeds, ≥512 ctx) so users can't reach opaque 422s; label/control association, `aria-expanded` on the drill-down, sr-only pass/fail outcomes, and the CLI's corrective notes (control-seed repetition, per-arm loop-avoidance denominators in run units) carried over.

`npm run lint` / `test:run` (769 passed) / `build` all green.