### PR TITLE
feat(gui,services): pinned serve and full proxy launch options

### DIFF
--- a/crates/gglib-app-services/src/launch_options.rs
+++ b/crates/gglib-app-services/src/launch_options.rs
@@ -1,0 +1,318 @@
+//! The pinned-launch cascade, shared by every surface that pins the proxy.
+//!
+//! `gglib serve` and the GUI's pinned start must produce byte-identical
+//! launch options for the same inputs — both call [`plan_pinned_launch`];
+//! the CLI keeps its banners by reading the plan's resolved fields rather
+//! than recomputing them. [`crate::ServerOps`]'s bare-start builder remains
+//! a deliberate sibling: its explicit tier passes raw values through because
+//! the spawn path re-gates them per launch.
+
+use std::path::PathBuf;
+
+use gglib_core::domain::{InferenceConfig, ModelSamplingContext};
+use gglib_core::ports::PinnedSpec;
+use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
+use gglib_core::{Model, Settings};
+use gglib_runtime::llama::{MtpResolution, resolve_mtp_args};
+use gglib_runtime::unified_server_config::{GlobalDefaults, UnifiedServerConfig};
+
+use crate::types::StartServerRequest;
+
+/// Proxy-process inputs for a pinned launch — the tier-3 half of the cascade.
+///
+/// Every field is "no opinion" when unset; [`GlobalDefaults`]' hardened
+/// defaults (loopback bind, default ports) apply underneath.
+#[derive(Debug, Clone, Default)]
+pub struct ProxyGlobals {
+    pub host: Option<String>,
+    pub proxy_port: Option<u16>,
+    pub llama_base_port: Option<u16>,
+    /// Caller-supplied fallback context — overrides the settings default on
+    /// the cascade's third rung. The CLI passes `None` (its `serve` has no
+    /// such flag); the GUI start-pinned body may carry one.
+    pub default_ctx: Option<u64>,
+    /// Master switch for disk KV-slot persistence.
+    pub cache_enabled: bool,
+    pub slot_dir: Option<PathBuf>,
+    pub api_key: Option<String>,
+    pub allowed_hosts: Vec<String>,
+}
+
+/// Everything a pinned start needs, resolved once.
+#[derive(Debug, Clone)]
+pub struct PinnedLaunch {
+    /// The two cascade tiers, kept whole so callers can derive the proxy
+    /// config (`to_proxy_config`) without re-assembly.
+    pub unified: UnifiedServerConfig,
+    /// The pin itself: model name + fully resolved launch options.
+    pub pinned: PinnedSpec,
+    /// Sampling after the full merge hierarchy — what the CLI banner prints.
+    pub inference: InferenceConfig,
+    /// MTP resolution (explicit overrides layered over model tags).
+    pub mtp: MtpResolution,
+    /// The context size the model will actually get.
+    pub effective_ctx: u64,
+}
+
+/// Resolve a pinned launch from a model, settings, and per-call overrides.
+///
+/// `request.context_length` is already numeric — the CLI resolves its
+/// `--ctx-size max` affordance against the model before calling this.
+/// `request.mlock == false` means "no opinion", never "disable": the flag's
+/// absence must leave lower tiers free to apply.
+#[must_use]
+pub fn plan_pinned_launch(
+    model: &Model,
+    settings: &Settings,
+    request: &StartServerRequest,
+    globals: ProxyGlobals,
+) -> PinnedLaunch {
+    let model_ctx = ModelSamplingContext::for_model(model);
+    let inference = request
+        .inference_params
+        .clone()
+        .unwrap_or_default()
+        .resolve_with_defaults(
+            model.inference_defaults.as_ref(),
+            settings.inference_defaults.as_ref(),
+            model_ctx,
+        );
+
+    let mtp = resolve_mtp_args(request.mtp_draft_n_max, request.mtp_draft_p_min, &model.tags);
+
+    let mut tier3 = GlobalDefaults {
+        default_ctx: globals.default_ctx.or(settings.default_context_size),
+        cache_enabled: globals.cache_enabled,
+        slot_dir: globals.slot_dir,
+        api_key: globals.api_key,
+        allowed_hosts: globals.allowed_hosts,
+        ..Default::default()
+    };
+    if let Some(host) = globals.host {
+        tier3.host = host;
+    }
+    if let Some(port) = globals.proxy_port {
+        tier3.proxy_port = port;
+    }
+    if let Some(port) = globals.llama_base_port {
+        tier3.llama_base_port = port;
+    }
+
+    let unified = UnifiedServerConfig {
+        explicit: ServerConfigOptions {
+            context_size: request.context_length,
+            port: request.port,
+            model_server_ctx: model
+                .server_defaults
+                .as_ref()
+                .and_then(|s| s.context_length),
+            mlock: request.mlock.then_some(true),
+            jinja: request.jinja,
+            reasoning_format: request.reasoning_format.clone(),
+            inference_params: Some(inference.clone()),
+            mtp_draft_n_max: mtp.enabled.then_some(mtp.draft_n_max),
+            mtp_draft_p_min: mtp.enabled.then_some(mtp.draft_p_min),
+            ..Default::default()
+        },
+        globals: tier3,
+    };
+
+    let launch_overrides = unified.resolved_options();
+    let effective_ctx = resolve_context_size(&launch_overrides);
+
+    PinnedLaunch {
+        pinned: PinnedSpec {
+            name: model.name.clone(),
+            launch_overrides,
+        },
+        unified,
+        inference,
+        mtp,
+        effective_ctx,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model() -> Model {
+        Model {
+            dialect_spec: None,
+            id: 1,
+            name: "test-model".to_string(),
+            model_key: String::new(),
+            file_path: std::path::PathBuf::from("/tmp/model.gguf"),
+            param_count_b: 7.0,
+            architecture: None,
+            quantization: None,
+            context_length: Some(131_072),
+            expert_count: None,
+            expert_used_count: None,
+            expert_shared_count: None,
+            metadata: std::collections::HashMap::new(),
+            added_at: chrono::Utc::now(),
+            hf_repo_id: None,
+            hf_commit_sha: None,
+            hf_filename: None,
+            download_date: None,
+            last_update_check: None,
+            tags: vec![],
+            inference_defaults: None,
+            defaults_origin: None,
+            server_defaults: None,
+            capabilities: gglib_core::domain::capabilities::ModelCapabilities::default(),
+            benchmark_summary: None,
+        }
+    }
+
+    fn request() -> StartServerRequest {
+        StartServerRequest::default()
+    }
+
+    /// The explicit tier outranks the model's server defaults, which outrank
+    /// the settings default — the same precedence `gglib serve` documents.
+    #[test]
+    fn context_resolves_explicit_over_model_over_settings() {
+        let mut m = model();
+        m.server_defaults = Some(gglib_core::domain::ServerConfig {
+            context_length: Some(16_384),
+            ..Default::default()
+        });
+        let settings = Settings {
+            default_context_size: Some(8192),
+            ..Default::default()
+        };
+
+        let explicit = plan_pinned_launch(
+            &m,
+            &settings,
+            &StartServerRequest {
+                context_length: Some(4096),
+                ..request()
+            },
+            ProxyGlobals::default(),
+        );
+        assert_eq!(explicit.effective_ctx, 4096);
+
+        let model_tier = plan_pinned_launch(&m, &settings, &request(), ProxyGlobals::default());
+        assert_eq!(model_tier.effective_ctx, 16_384);
+
+        m.server_defaults = None;
+        let settings_tier = plan_pinned_launch(&m, &settings, &request(), ProxyGlobals::default());
+        assert_eq!(settings_tier.effective_ctx, 8192);
+    }
+
+    /// `mlock: false` is the flag's absence, not a request to disable — the
+    /// invariant the CLI's `--mlock` handling depends on.
+    #[test]
+    fn absent_mlock_expresses_no_opinion() {
+        let plan = plan_pinned_launch(
+            &model(),
+            &Settings::default(),
+            &request(),
+            ProxyGlobals::default(),
+        );
+        assert_eq!(plan.pinned.launch_overrides.mlock, None);
+    }
+
+    /// Resolved sampling must land on the pin's launch options — sampling
+    /// rides the pinned model, never a proxy-wide override.
+    #[test]
+    fn resolved_sampling_reaches_the_pin() {
+        let plan = plan_pinned_launch(
+            &model(),
+            &Settings::default(),
+            &StartServerRequest {
+                inference_params: Some(InferenceConfig {
+                    temperature: Some(0.4),
+                    ..Default::default()
+                }),
+                ..request()
+            },
+            ProxyGlobals::default(),
+        );
+        let params = plan.pinned.launch_overrides.inference_params.as_ref().unwrap();
+        assert_eq!(params.temperature, Some(0.4));
+    }
+
+    /// The cache master switch outranks the directory: cache off means no
+    /// slot path reaches llama-server, byte-for-byte.
+    #[test]
+    fn cache_master_switch_gates_the_slot_dir() {
+        let off = plan_pinned_launch(
+            &model(),
+            &Settings::default(),
+            &request(),
+            ProxyGlobals {
+                cache_enabled: false,
+                slot_dir: Some(PathBuf::from("/custom/slots")),
+                ..Default::default()
+            },
+        );
+        assert_eq!(off.pinned.launch_overrides.slot_save_path, None);
+
+        let on = plan_pinned_launch(
+            &model(),
+            &Settings::default(),
+            &request(),
+            ProxyGlobals {
+                cache_enabled: true,
+                slot_dir: Some(PathBuf::from("/custom/slots")),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            on.pinned.launch_overrides.slot_save_path,
+            Some(PathBuf::from("/custom/slots"))
+        );
+    }
+
+    /// The request's llama port must reach the pin's launch options — the
+    /// ServeModal's Port field on the pinned path (review-gate blocker).
+    #[test]
+    fn request_port_reaches_the_pin() {
+        let plan = plan_pinned_launch(
+            &model(),
+            &Settings::default(),
+            &StartServerRequest {
+                port: Some(9345),
+                ..request()
+            },
+            ProxyGlobals::default(),
+        );
+        assert_eq!(plan.pinned.launch_overrides.port, Some(9345));
+    }
+
+    /// A caller-supplied fallback context overrides the settings default on
+    /// the third rung without touching the explicit tier.
+    #[test]
+    fn caller_default_ctx_overrides_the_settings_rung() {
+        let settings = Settings {
+            default_context_size: Some(8192),
+            ..Default::default()
+        };
+        let plan = plan_pinned_launch(
+            &model(),
+            &settings,
+            &request(),
+            ProxyGlobals {
+                default_ctx: Some(16_384),
+                ..Default::default()
+            },
+        );
+        assert_eq!(plan.effective_ctx, 16_384);
+    }
+
+    /// Unset proxy globals keep the hardened defaults — loopback bind above all.
+    #[test]
+    fn default_globals_bind_loopback() {
+        let plan = plan_pinned_launch(
+            &model(),
+            &Settings::default(),
+            &request(),
+            ProxyGlobals::default(),
+        );
+        assert_eq!(plan.unified.to_proxy_config().host, "127.0.0.1");
+    }
+}

--- a/crates/gglib-app-services/src/launch_options.rs
+++ b/crates/gglib-app-services/src/launch_options.rs
@@ -78,7 +78,11 @@ pub fn plan_pinned_launch(
             model_ctx,
         );
 
-    let mtp = resolve_mtp_args(request.mtp_draft_n_max, request.mtp_draft_p_min, &model.tags);
+    let mtp = resolve_mtp_args(
+        request.mtp_draft_n_max,
+        request.mtp_draft_p_min,
+        &model.tags,
+    );
 
     let mut tier3 = GlobalDefaults {
         default_ctx: globals.default_ctx.or(settings.default_context_size),
@@ -177,7 +181,6 @@ mod tests {
         let mut m = model();
         m.server_defaults = Some(gglib_core::domain::ServerConfig {
             context_length: Some(16_384),
-            ..Default::default()
         });
         let settings = Settings {
             default_context_size: Some(8192),
@@ -232,7 +235,12 @@ mod tests {
             },
             ProxyGlobals::default(),
         );
-        let params = plan.pinned.launch_overrides.inference_params.as_ref().unwrap();
+        let params = plan
+            .pinned
+            .launch_overrides
+            .inference_params
+            .as_ref()
+            .unwrap();
         assert_eq!(params.temperature, Some(0.4));
     }
 

--- a/crates/gglib-app-services/src/lib.rs
+++ b/crates/gglib-app-services/src/lib.rs
@@ -18,8 +18,8 @@ mod error;
 mod helpers;
 
 pub mod benchmark;
-pub mod launch_options;
 mod downloads;
+pub mod launch_options;
 mod mcp;
 mod models;
 mod proxy;

--- a/crates/gglib-app-services/src/lib.rs
+++ b/crates/gglib-app-services/src/lib.rs
@@ -18,6 +18,7 @@ mod error;
 mod helpers;
 
 pub mod benchmark;
+pub mod launch_options;
 mod downloads;
 mod mcp;
 mod models;

--- a/crates/gglib-app-services/src/proxy.rs
+++ b/crates/gglib-app-services/src/proxy.rs
@@ -97,6 +97,29 @@ impl ProxyOps {
         }
     }
 
+    /// Resolve a pinned-launch plan for a model — the same cascade
+    /// `gglib serve` runs, shared via [`crate::launch_options`].
+    ///
+    /// Fails with `NotFound` when the model id is stale, which is the
+    /// GUI's stale-list race rather than an internal error.
+    pub async fn plan_pinned(
+        &self,
+        model_id: i64,
+        request: &crate::types::StartServerRequest,
+        globals: crate::launch_options::ProxyGlobals,
+    ) -> Result<crate::launch_options::PinnedLaunch, GuiError> {
+        let model = crate::helpers::resolve_model(self.core.models(), model_id).await?;
+        let settings = self
+            .core
+            .settings()
+            .get()
+            .await
+            .map_err(|e| GuiError::Internal(format!("Failed to load settings: {e}")))?;
+        Ok(crate::launch_options::plan_pinned_launch(
+            &model, &settings, request, globals,
+        ))
+    }
+
     /// Start the proxy server, optionally pinned to a single model.
     ///
     /// Delegates to the supervisor using the shared `ModelRuntimePort`

--- a/crates/gglib-axum/src/handlers/proxy.rs
+++ b/crates/gglib-axum/src/handlers/proxy.rs
@@ -141,6 +141,60 @@ fn to_runtime_config(cfg: &StartProxyConfig, settings: &AppSettings) -> RuntimeP
     }
 }
 
+/// Request body for `POST /api/proxy/start-pinned`.
+///
+/// The GUI names a model and its overrides; the daemon runs the same
+/// cascade as `gglib serve` (`gglib_app_services::launch_options`) so the
+/// two surfaces cannot drift. `options` uses the camelCase wire form of the
+/// bare `/api/servers/start` body; `proxy` the snake_case form of
+/// `/api/proxy/start`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct StartPinnedBody {
+    pub model_id: i64,
+    #[serde(default)]
+    pub options: gglib_app_services::types::StartServerRequest,
+    #[serde(default)]
+    pub proxy: StartProxyConfig,
+}
+
+/// Start the proxy pinned to one model, resolving the launch cascade
+/// server-side — the GUI counterpart of `gglib serve`.
+pub async fn start_pinned(
+    State(state): State<AppState>,
+    Json(body): Json<StartPinnedBody>,
+) -> Result<Json<ProxyStatus>, HttpError> {
+    let globals = gglib_app_services::launch_options::ProxyGlobals {
+        host: body.proxy.host.clone(),
+        proxy_port: body.proxy.port,
+        llama_base_port: body.proxy.llama_base_port,
+        default_ctx: body.proxy.default_context,
+        cache_enabled: body.proxy.cache.unwrap_or(false),
+        slot_dir: body.proxy.slot_dir.clone(),
+        api_key: body.proxy.api_key.clone(),
+        allowed_hosts: body.proxy.allowed_hosts.clone(),
+    };
+
+    let plan = state
+        .proxy
+        .plan_pinned(body.model_id, &body.options, globals)
+        .await?;
+
+    // Delegate to the ordinary start path with the planned pin. Slot dir and
+    // default context ride the cascade exactly as the CLI sends them: the
+    // master switch has been applied and the context fully resolved.
+    let proxy_config = plan.unified.to_proxy_config();
+    let cfg = StartProxyConfig {
+        pinned: Some(plan.pinned),
+        slot_dir: proxy_config.slot_dir,
+        default_context: Some(proxy_config.default_context),
+        // Sampling rides the pinned model's launch options, exactly as the
+        // CLI sends it — never a proxy-wide override.
+        inference_override: None,
+        ..body.proxy
+    };
+    start(State(state), Json(Some(cfg))).await
+}
+
 /// Get current proxy status.
 pub async fn status(State(state): State<AppState>) -> Json<ProxyStatus> {
     Json(fetch_status(&state).await)

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -101,6 +101,7 @@ pub(crate) fn api_routes() -> Router<AppState> {
         // Proxy API
         .route("/proxy/status", get(handlers::proxy::status))
         .route("/proxy/start", post(handlers::proxy::start))
+        .route("/proxy/start-pinned", post(handlers::proxy::start_pinned))
         .route("/proxy/stop", post(handlers::proxy::stop))
         // Daemon lifecycle
         .route("/daemon/shutdown", post(handlers::daemon::shutdown))

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -1054,3 +1054,90 @@ async fn proxy_start_fallback_to_hardcoded_default_when_no_settings() {
         "POST /api/proxy/start with empty body should not return 400 when falling back to hard-coded default"
     );
 }
+
+/// The pinned-start route must run the serve cascade server-side: a full-shape
+/// body with a stale model id proves the route is wired, both nested bodies
+/// deserialize (camelCase options + snake_case proxy), and resolution fails as
+/// a 404 — the GUI's stale-list race — rather than a serde 400/422.
+#[tokio::test]
+async fn proxy_start_pinned_resolves_the_model_or_404s() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
+
+    let request_body = serde_json::json!({
+        "model_id": 999_999,
+        "options": {
+            "contextLength": 4096,
+            "jinja": true,
+            "mtpDraftNMax": 2,
+            "mtpDraftPMin": 0.75,
+            "inferenceParams": { "temperature": 0.4, "minP": 0.05, "presencePenalty": 1.1 },
+            "mlock": true
+        },
+        "proxy": {
+            "port": 0,
+            "cache": true,
+            "cache_disk_gb": 5,
+            "api_key": "test-key",
+            "allowed_hosts": ["example.test"]
+        }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .method("POST")
+                .uri("/api/proxy/start-pinned")
+                .header("content-type", "application/json")
+                .body(Body::from(request_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "a stale model id must 404 after deserialization succeeded"
+    );
+}
+
+/// A minimal pinned-start body must also deserialize — every field except
+/// `model_id` is optional, mirroring `Partial<ProxyConfig>` on the GUI side.
+#[tokio::test]
+async fn proxy_start_pinned_accepts_a_minimal_body() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .method("POST")
+                .uri("/api/proxy/start-pinned")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"model_id": 999999}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -15,12 +15,12 @@ use crate::bootstrap::CliContext;
 use crate::daemon_client::{self, StartProxyBody};
 use crate::presentation::style;
 use crate::shared_args::{AccessArgs, CacheArgs, ContextArgs, MtpArgs, SamplingArgs, ServeOptions};
-use gglib_core::ports::PinnedSpec;
-use gglib_core::server_config::{ServerConfigOptions, parse_ctx_size_flag, resolve_context_size};
-use gglib_runtime::llama::{CliPrompt, ensure_llama_initialized, resolve_mtp_args};
-use gglib_runtime::unified_server_config::{GlobalDefaults, UnifiedServerConfig};
+use gglib_app_services::launch_options::{ProxyGlobals, plan_pinned_launch};
+use gglib_app_services::types::StartServerRequest;
+use gglib_core::server_config::parse_ctx_size_flag;
+use gglib_runtime::llama::{CliPrompt, ensure_llama_initialized};
 
-use super::shared::{log_inference_info, log_mlock_info, resolve_inference_config};
+use super::shared::{log_inference_info, log_mlock_info};
 
 /// Execute the serve command.
 ///
@@ -55,50 +55,37 @@ pub async fn execute(
     // length is what makes `--ctx-size max` work.
     let ctx_arg = parse_ctx_size_flag(context.ctx_size.as_deref())?;
 
-    let inference_config =
-        resolve_inference_config(ctx, sampling.into_inference_config(), &model).await?;
-
-    let mtp_args = resolve_mtp_args(mtp.mtp_draft_n_max, mtp.mtp_draft_p_min, &model.tags);
-
-    // Everything the CLI knows, expressed as the three tiers. The cascade and
-    // the translation into llama-server flags both happen downstream, so this
-    // handler never assembles a command line of its own.
-    let unified = UnifiedServerConfig {
-        explicit: ServerConfigOptions {
-            context_size: ctx_arg.and_then(|arg| arg.resolve(model.context_length)),
-            model_server_ctx: model
-                .server_defaults
-                .as_ref()
-                .and_then(|s| s.context_length),
-            // `false` is the flag's absence, not a request to disable mlock —
-            // leaving it None lets a future global default apply.
-            mlock: context.mlock.then_some(true),
+    // The cascade itself is shared with the GUI's pinned start
+    // (`gglib_app_services::launch_options`), so the two surfaces cannot
+    // drift; this handler only maps flags into the shared request shape and
+    // prints the banners from the resolved plan.
+    let plan = plan_pinned_launch(
+        &model,
+        &settings,
+        &StartServerRequest {
+            context_length: ctx_arg.and_then(|arg| arg.resolve(model.context_length)),
+            port: None,
             jinja: options.jinja.then_some(true),
-            inference_params: Some(inference_config.clone()),
-            mtp_draft_n_max: mtp_args.enabled.then_some(mtp_args.draft_n_max),
-            mtp_draft_p_min: mtp_args.enabled.then_some(mtp_args.draft_p_min),
-            ..Default::default()
+            reasoning_format: None,
+            mtp_draft_n_max: mtp.mtp_draft_n_max,
+            mtp_draft_p_min: mtp.mtp_draft_p_min,
+            inference_params: Some(sampling.into_inference_config()),
+            mlock: context.mlock,
         },
-        // The cache master switch and directory are tier 3: `resolved_options`
-        // applies `cache_enabled` over `slot_save_path`, which is how
-        // `--cache` reaches llama-server on the pinned model's launch options
-        // at all. The remaining model-independent cache flags travel in the
-        // daemon start body (`--cache-disk-gb` becomes its disk budget).
-        globals: GlobalDefaults {
-            host: options.host.clone(),
-            proxy_port: options.port,
-            llama_base_port: options.llama_port,
-            default_ctx: settings.default_context_size,
+        ProxyGlobals {
+            host: Some(options.host.clone()),
+            default_ctx: None,
+            proxy_port: Some(options.port),
+            llama_base_port: Some(options.llama_port),
             cache_enabled: cache.cache,
             slot_dir: cache.slot_dir.clone(),
             api_key: access.api_key.clone(),
             allowed_hosts: access.allowed_hosts.clone(),
-            ..Default::default()
         },
-    };
-
-    let launch_overrides = unified.resolved_options();
-    let effective_ctx = resolve_context_size(&launch_overrides);
+    );
+    let inference_config = plan.inference.clone();
+    let mtp_args = plan.mtp.clone();
+    let effective_ctx = plan.effective_ctx;
 
     style::print_info_banner("Info", "\u{2139}\u{fe0f}");
     eprintln!("  Using model: {} (ID: {})", model.name, model.id);
@@ -125,7 +112,7 @@ pub async fn execute(
         );
     }
 
-    let proxy_config = unified.to_proxy_config();
+    let proxy_config = plan.unified.to_proxy_config();
 
     super::proxy::warn_construction_time_flags(&cache, options.llama_port);
 
@@ -143,10 +130,7 @@ pub async fn execute(
             // Sampling rides the pinned model's launch options rather than a
             // proxy-wide override, so it lands on the llama-server command
             // line exactly as every other launch surface applies it.
-            pinned: Some(PinnedSpec {
-                name: model.name.clone(),
-                launch_overrides,
-            }),
+            pinned: Some(plan.pinned),
             cache_disk_gb: cache.cache_disk_gb,
             inference_override: None,
             api_key: proxy_config.api_key,

--- a/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
+++ b/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
@@ -120,6 +120,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
     mtpNMaxOverride: serveModal.mtpNMaxOverride,
     mtpPMinOverride: serveModal.mtpPMinOverride,
     inferenceParams: serveModal.inferenceParams,
+    pinProxy: serveModal.pinProxy,
     onStopServer,
     onRemoveModel,
     onUpdateModel,
@@ -255,6 +256,8 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
           mtpNMaxOverride={serveModal.mtpNMaxOverride}
           mtpPMinOverride={serveModal.mtpPMinOverride}
           inferenceParams={serveModal.inferenceParams}
+          pinProxy={serveModal.pinProxy}
+          onPinProxyChange={serveModal.setPinProxy}
           onContextChange={serveModal.setCustomContext}
           onPortChange={serveModal.setCustomPort}
           onJinjaChange={serveModal.setJinjaOverride}

--- a/src/components/ModelInspectorPanel/components/ServeModal.tsx
+++ b/src/components/ModelInspectorPanel/components/ServeModal.tsx
@@ -26,6 +26,8 @@ interface ServeModalProps {
   /** null = use default 0.75 */
   mtpPMinOverride: number | null;
   inferenceParams: InferenceConfig | undefined;
+  /** Serve as a pinned proxy (`gglib serve`) instead of a bare model start. */
+  pinProxy: boolean;
   // Handlers
   onContextChange: (value: string) => void;
   onPortChange: (value: string) => void;
@@ -34,6 +36,7 @@ interface ServeModalProps {
   onMtpNMaxChange: (value: number | null) => void;
   onMtpPMinChange: (value: number | null) => void;
   onInferenceParamsChange: (params: InferenceConfig) => void;
+  onPinProxyChange: (pin: boolean) => void;
   onClose: () => void;
   onStart: () => void;
 }
@@ -53,6 +56,8 @@ export const ServeModal: FC<ServeModalProps> = ({
   mtpNMaxOverride,
   mtpPMinOverride,
   inferenceParams,
+  pinProxy,
+  onPinProxyChange,
   onContextChange,
   onPortChange,
   onJinjaChange,
@@ -97,7 +102,13 @@ export const ServeModal: FC<ServeModalProps> = ({
             isLoading={isServing}
             leftIcon={!isServing ? <Icon icon={Play} size={14} /> : undefined}
           >
-            {isServing ? 'Loading model…' : 'Start Server'}
+            {isServing
+              ? pinProxy
+                ? 'Starting pinned proxy…'
+                : 'Loading model…'
+              : pinProxy
+                ? 'Start Pinned Proxy'
+                : 'Start Server'}
           </Button>
         </>
       }
@@ -178,6 +189,17 @@ export const ServeModal: FC<ServeModalProps> = ({
               : 'will be enabled automatically for agent-tagged models to support structured prompts.'}
           </Banner>
         )}
+
+        <div className="mb-lg">
+          <Checkbox
+            id="pin-proxy-toggle"
+            checked={pinProxy}
+            onChange={(e) => onPinProxyChange(e.target.checked)}
+            disabled={isServing}
+            label="Pin the proxy to this model"
+            description="The OpenAI endpoint serves only this model and refuses requests naming any other — the GUI equivalent of gglib serve, for clients that cannot switch models."
+          />
+        </div>
 
         <div className="mb-lg">
           <div className="flex items-center justify-between gap-sm">

--- a/src/components/ModelInspectorPanel/hooks/useServeModal.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServeModal.ts
@@ -12,6 +12,8 @@ export interface ServeModalState {
   mtpPMinOverride: number | null;
   isServing: boolean;
   inferenceParams: InferenceConfig | undefined;
+  /** Serve as a pinned proxy (`gglib serve`) instead of a bare model start. */
+  pinProxy: boolean;
   setShowServeModal: (show: boolean) => void;
   setCustomContext: (context: string) => void;
   setCustomPort: (port: string) => void;
@@ -20,6 +22,7 @@ export interface ServeModalState {
   setMtpPMinOverride: (override: number | null) => void;
   setIsServing: (serving: boolean) => void;
   setInferenceParams: (params: InferenceConfig | undefined) => void;
+  setPinProxy: (pin: boolean) => void;
   openServeModal: () => void;
   closeServeModal: () => void;
   resetServeModal: () => void;
@@ -37,6 +40,7 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
   const [mtpPMinOverride, setMtpPMinOverride] = useState<number | null>(null);
   const [isServing, setIsServing] = useState(false);
   const [inferenceParams, setInferenceParams] = useState<InferenceConfig | undefined>(undefined);
+  const [pinProxy, setPinProxy] = useState(false);
 
   // Reset overrides and inference params when model changes
   useEffect(() => {
@@ -44,6 +48,7 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
     setMtpNMaxOverride(null);
     setMtpPMinOverride(null);
     setInferenceParams(undefined);
+    setPinProxy(false);
   }, [modelId]);
 
   const openServeModal = useCallback(() => {
@@ -67,6 +72,7 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
     setMtpPMinOverride(null);
     setIsServing(false);
     setInferenceParams(undefined);
+    setPinProxy(false);
   }, []);
 
   return {
@@ -78,6 +84,7 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
     mtpPMinOverride,
     isServing,
     inferenceParams,
+    pinProxy,
     setShowServeModal,
     setCustomContext,
     setCustomPort,
@@ -86,6 +93,7 @@ export function useServeModal(modelId: number | undefined): ServeModalState {
     setMtpPMinOverride,
     setIsServing,
     setInferenceParams,
+    setPinProxy,
     openServeModal,
     closeServeModal,
     resetServeModal,

--- a/src/components/ModelInspectorPanel/hooks/useServerActions.ts
+++ b/src/components/ModelInspectorPanel/hooks/useServerActions.ts
@@ -4,6 +4,7 @@ import type { GgufModel, ServeConfig, ServerInfo, AppSettings, InferenceConfig }
 import { useToastContext } from '../../../contexts/ToastContext';
 import { TransportError, LlamaServerNotInstalledMetadata } from '../../../services/transport/errors';
 import { getTransport } from '../../../services/transport';
+import { toStartServerRequest } from '../../../services/transport/mappers';
 import { formatError } from '../../../utils/errors';
 
 export interface ServerActionsConfig {
@@ -24,6 +25,8 @@ export interface ServerActionsConfig {
   mtpNMaxOverride: number | null;
   mtpPMinOverride: number | null;
   inferenceParams: InferenceConfig | undefined;
+  /** Serve as a pinned proxy instead of a bare model start. */
+  pinProxy: boolean;
   editedServerDefaults: import('../../../types').ServerConfig | null | undefined;
   // Callbacks
   onStopServer: (modelId: number) => Promise<void>;
@@ -83,6 +86,7 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
     closeServeModal,
     closeDeleteModal,
     resetEditState,
+    pinProxy,
   } = config;
 
   const activeServer = model?.id ? servers.find(s => s.modelId === model.id) : undefined;
@@ -138,6 +142,38 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
         minP: inferenceParams?.minP,
       };
 
+      if (pinProxy) {
+        // The GUI's `gglib serve`: the daemon plans the pin server-side.
+        // Send only what the user explicitly typed — pre-resolving context
+        // client-side would bypass the cascade's model-defaults rung and
+        // freeze the settings default as an explicit override.
+        const customCtx = customContext.trim() ? parseInt(customContext.trim(), 10) : NaN;
+        try {
+          const status = await getTransport().startPinnedProxy({
+            model_id: model.id,
+            options: {
+              ...toStartServerRequest(serveConfig),
+              contextLength: Number.isFinite(customCtx) && customCtx > 0 ? customCtx : undefined,
+            },
+          });
+          closeServeModal();
+          showToast(
+            `Proxy pinned to ${model.name}${status.port ? ` on port ${status.port}` : ''}`,
+            'success',
+          );
+          onStartServer();
+        } catch (err) {
+          const raw = err instanceof Error ? err.message : String(err);
+          showToast(
+            raw.includes('already running')
+              ? 'The proxy is already running — stop it from the Proxy menu, then pin.'
+              : `Could not pin the proxy: ${raw}`,
+            'error',
+          );
+        }
+        return;
+      }
+
       const result = await getTransport().serveModel(serveConfig);
       closeServeModal();
       onStartServer();
@@ -172,7 +208,7 @@ export function useServerActions(config: ServerActionsConfig): ServerActionsResu
     } finally {
       setIsServing(false);
     }
-  }, [model, settings, customContext, customPort, jinjaOverride, hasAgentTag, hasMtpTag, mtpNMaxOverride, mtpPMinOverride, inferenceParams, onStartServer, onServerStarted, closeServeModal, setIsServing, showToast, onLlamaServerNotInstalled]);
+  }, [model, settings, customContext, customPort, jinjaOverride, hasAgentTag, hasMtpTag, mtpNMaxOverride, mtpPMinOverride, inferenceParams, onStartServer, onServerStarted, closeServeModal, setIsServing, showToast, onLlamaServerNotInstalled, pinProxy]);
 
   const handleToggleServer = useCallback(async () => {
     if (!model?.id) return;

--- a/src/components/ProxyControl.tsx
+++ b/src/components/ProxyControl.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useRef } from "react";
+import { FC, useEffect, useState, useRef } from "react";
 import { ChevronDown, ChevronUp, LayoutDashboard, Repeat2, Trash2 } from "lucide-react";
 import { getTransport } from "../services/transport";
 import { clearProxyCache } from "../services/clients/proxyDashboard";
@@ -9,6 +9,7 @@ import { useSettings } from "../hooks/useSettings";
 import { Icon } from "./ui/Icon";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
+import { Checkbox } from "./ui/Checkbox";
 import { cn } from '../utils/cn';
 import { Stack, Label } from './primitives';
 import { useToastContext } from '../contexts/ToastContext';
@@ -31,8 +32,6 @@ interface ProxyControlProps {
   buttonActiveClassName?: string;
   statusDotClassName?: string;
   statusDotActiveClassName?: string;
-  /** Whether KV cache persistence is enabled on the running proxy. */
-  cacheEnabled?: boolean;
   /** Icon-only trigger for narrow headers; the label moves to title/aria-label. */
   compact?: boolean;
 }
@@ -42,7 +41,6 @@ const ProxyControl: FC<ProxyControlProps> = ({
   buttonActiveClassName,
   statusDotClassName,
   statusDotActiveClassName,
-  cacheEnabled = false,
   compact = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -58,6 +56,11 @@ const ProxyControl: FC<ProxyControlProps> = ({
   });
   const [loading, setLoading] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [cache, setCache] = useState(false);
+  const [cacheDiskGb, setCacheDiskGb] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [allowedHosts, setAllowedHosts] = useState('');
+  const [pinnedModel, setPinnedModel] = useState<string | null>(null);
   const [showDashboard, setShowDashboard] = useState(false);
   const [clearing, setClearing] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -66,15 +69,44 @@ const ProxyControl: FC<ProxyControlProps> = ({
   // Close dropdown when clicking outside
   useClickOutside(dropdownRef, () => setIsOpen(false), isOpen);
 
+  // The registry tracks running/port; the pin only travels on the status
+  // response, so fetch it when the popover opens.
+  useEffect(() => {
+    if (!isOpen || !proxyState.running) {
+      setPinnedModel(null);
+      return;
+    }
+    let cancelled = false;
+    void getTransport()
+      .getProxyStatus()
+      .then((s) => {
+        if (!cancelled) setPinnedModel(s.pinned_model ?? null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, proxyState.running]);
+
   const handleStart = async () => {
     try {
       setLoading(true);
-      // Only include default_context when the user explicitly set one —
-      // omitting it lets the backend resolve the default from settings.
+      // Only include fields the user explicitly set — omitting them lets
+      // the backend resolve defaults from settings.
       const { default_context, ...rest } = config;
-      await getTransport().startProxy(
-        default_context !== undefined ? { ...rest, default_context } : rest,
-      );
+      const hosts = allowedHosts
+        .split(',')
+        .map((h) => h.trim())
+        .filter(Boolean);
+      const diskGb = parseInt(cacheDiskGb, 10);
+      await getTransport().startProxy({
+        ...rest,
+        ...(default_context !== undefined ? { default_context } : {}),
+        ...(cache ? { cache: true } : {}),
+        ...(cache && Number.isFinite(diskGb) && diskGb > 0 ? { cache_disk_gb: diskGb } : {}),
+        ...(apiKey.trim() ? { api_key: apiKey.trim() } : {}),
+        ...(hosts.length > 0 ? { allowed_hosts: hosts } : {}),
+      });
     } catch (err) {
       showToast(`Failed to start proxy: ${formatError(err)}`, 'error');
     } finally {
@@ -126,7 +158,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
       </Button>
 
       {isOpen && (
-        <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 min-w-[min(350px,calc(100vw-32px))] max-h-[calc(100vh-100px)] overflow-y-auto bg-surface-elevated rounded-lg shadow-xl p-base z-dropdown text-text phone:absolute phone:top-[calc(100%+var(--spacing-sm))] phone:right-0 phone:left-auto phone:translate-x-0 phone:translate-y-0 phone:min-w-[350px] phone:max-h-none phone:overflow-visible">
+        <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 min-w-[min(350px,calc(100vw-32px))] max-h-[calc(100vh-100px)] overflow-y-auto bg-surface-elevated rounded-lg shadow-xl p-base z-dropdown text-text phone:absolute phone:top-[calc(100%+var(--spacing-sm))] phone:right-0 phone:left-auto phone:translate-x-0 phone:translate-y-0 phone:min-w-[350px] phone:max-h-[80vh] phone:overflow-y-auto">
           <div className="flex justify-between items-center mb-base pb-md border-b border-border-light">
             <h3 className="m-0 text-lg font-semibold text-text">OpenAI Proxy</h3>
             <ProxyStatusPill running={proxyState.running} />
@@ -134,6 +166,12 @@ const ProxyControl: FC<ProxyControlProps> = ({
 
           {proxyState.running ? (
             <>
+              {pinnedModel && (
+                <p className="text-xs text-text-muted mb-md">
+                  Pinned to <span className="font-mono text-text-secondary">{pinnedModel}</span> — requests
+                  naming other models are refused.
+                </p>
+              )}
               <div className="mb-base">
                 <Stack gap="xs" className="mb-sm">
                   <Label size="xs" muted>Endpoint URL</Label>
@@ -168,7 +206,7 @@ const ProxyControl: FC<ProxyControlProps> = ({
                     setClearing(false);
                   }
                 }}
-                disabled={clearing || !cacheEnabled}
+                disabled={clearing}
                 leftIcon={<Icon icon={Trash2} size={14} />}
               >
                 {clearing ? 'Clearing...' : 'Clear Cache'}
@@ -186,25 +224,30 @@ const ProxyControl: FC<ProxyControlProps> = ({
               {showSettings && (
                 <div className="mb-md">
                   <div className="mb-md">
-                    <Label size="xs" muted className="mb-xs">Host</Label>
+                    <Label size="xs" muted className="mb-xs" htmlFor="proxy-host">Host</Label>
                     <Input
+                      id="proxy-host"
                       type="text"
                       value={config.host}
                       onChange={(e) => setConfig({ ...config, host: e.target.value })}
                     />
                   </div>
                   <div className="mb-md">
-                    <Label size="xs" muted className="mb-xs">Proxy port</Label>
+                    <Label size="xs" muted className="mb-xs" htmlFor="proxy-port">Proxy port</Label>
                     <Input
+                      id="proxy-port"
                       type="number"
+                      className="font-mono tabular-nums"
                       value={config.port}
                       onChange={(e) => setConfig({ ...config, port: parseInt(e.target.value) })}
                     />
                   </div>
-                  <div>
-                    <Label size="xs" muted className="mb-xs">Default context</Label>
+                  <div className="mb-md">
+                    <Label size="xs" muted className="mb-xs" htmlFor="proxy-default-context">Default context</Label>
                     <Input
+                      id="proxy-default-context"
                       type="number"
+                      className="font-mono tabular-nums"
                       value={config.default_context ?? ''}
                       placeholder={`${settings?.defaultContextSize ?? 'server default'} (from settings)`}
                       onChange={(e) => {
@@ -214,6 +257,48 @@ const ProxyControl: FC<ProxyControlProps> = ({
                           default_context: Number.isNaN(parsed) ? undefined : parsed,
                         });
                       }}
+                    />
+                  </div>
+                  <div className="mb-md">
+                    <Checkbox
+                      checked={cache}
+                      onChange={(e) => setCache(e.target.checked)}
+                      label="Persist KV cache slots to disk"
+                      description="Keeps prompt caches across model swaps and restarts."
+                    />
+                    {cache && (
+                      <div className="mt-sm">
+                        <Label size="xs" muted className="mb-xs" htmlFor="proxy-cache-disk">Disk budget (GiB)</Label>
+                        <Input
+                          id="proxy-cache-disk"
+                          type="number"
+                          min={1}
+                          className="font-mono tabular-nums"
+                          value={cacheDiskGb}
+                          placeholder="Default budget"
+                          onChange={(e) => setCacheDiskGb(e.target.value)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <div className="mb-md">
+                    <Label size="xs" muted className="mb-xs" htmlFor="proxy-api-key">API key</Label>
+                    <Input
+                      id="proxy-api-key"
+                      type="text"
+                      value={apiKey}
+                      placeholder="None — endpoint is open on this host"
+                      onChange={(e) => setApiKey(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label size="xs" muted className="mb-xs" htmlFor="proxy-allowed-hosts">Allowed hosts</Label>
+                    <Input
+                      id="proxy-allowed-hosts"
+                      type="text"
+                      value={allowedHosts}
+                      placeholder="Comma-separated, beyond loopback"
+                      onChange={(e) => setAllowedHosts(e.target.value)}
                     />
                   </div>
                 </div>

--- a/src/pages/TrayPanel.tsx
+++ b/src/pages/TrayPanel.tsx
@@ -58,6 +58,25 @@ export const TrayPanel: FC = () => {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [pinnedModel, setPinnedModel] = useState<string | null>(null);
+
+  // The pin only travels on the status response, not the registry events.
+  useEffect(() => {
+    if (!proxy.running) {
+      setPinnedModel(null);
+      return;
+    }
+    let cancelled = false;
+    void getTransport()
+      .getProxyStatus()
+      .then((s) => {
+        if (!cancelled) setPinnedModel(s.pinned_model ?? null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [proxy.running]);
 
   // The panel is its own window, so it needs its own subscription — the main
   // window's may not exist yet, or at all.
@@ -138,6 +157,11 @@ export const TrayPanel: FC = () => {
               <span className="text-xs text-text-muted h-4">
                 {copied ? 'Copied to clipboard' : connected ? 'Live' : 'Connecting…'}
               </span>
+              {pinnedModel && (
+                <span className="text-xs text-text-muted">
+                  Pinned to <span className="font-mono text-text-secondary">{pinnedModel}</span>
+                </span>
+              )}
             </div>
 
             <ProxyMetricsGrid snapshot={snapshot} compact />

--- a/src/services/transport/api/proxy.ts
+++ b/src/services/transport/api/proxy.ts
@@ -4,7 +4,7 @@
  */
 
 import { get, post } from './client';
-import type { ProxyConfig, ProxyStatus } from '../types/proxy';
+import type { ProxyConfig, ProxyStatus, StartPinnedRequest } from '../types/proxy';
 
 /**
  * Get current proxy server status.
@@ -18,6 +18,15 @@ export async function getProxyStatus(): Promise<ProxyStatus> {
  */
 export async function startProxy(config?: Partial<ProxyConfig>): Promise<ProxyStatus> {
   return post<ProxyStatus>('/api/proxy/start', config);
+}
+
+/**
+ * Start the proxy pinned to one model. The daemon resolves the launch
+ * cascade (sampling, MTP, context, cache) server-side, exactly as
+ * `gglib serve` does.
+ */
+export async function startPinnedProxy(request: StartPinnedRequest): Promise<ProxyStatus> {
+  return post<ProxyStatus>('/api/proxy/start-pinned', request);
 }
 
 /**

--- a/src/services/transport/mappers.ts
+++ b/src/services/transport/mappers.ts
@@ -28,6 +28,8 @@ export interface StartServerRequest {
     topK?: number;
     maxTokens?: number;
     repeatPenalty?: number;
+    presencePenalty?: number;
+    minP?: number;
   };
 }
 
@@ -42,18 +44,22 @@ export interface StartServerRequest {
  */
 export function toStartServerRequest(config: ServeConfig): StartServerRequest {
   // Build inference params object only if any values are set
-  const hasInferenceParams = config.temperature !== undefined || 
-    config.topP !== undefined || 
-    config.topK !== undefined || 
-    config.maxTokens !== undefined || 
-    config.repeatPenalty !== undefined;
-  
+  const hasInferenceParams = config.temperature !== undefined ||
+    config.topP !== undefined ||
+    config.topK !== undefined ||
+    config.maxTokens !== undefined ||
+    config.repeatPenalty !== undefined ||
+    config.presencePenalty !== undefined ||
+    config.minP !== undefined;
+
   const inferenceParams = hasInferenceParams ? {
     temperature: config.temperature,
     topP: config.topP,
     topK: config.topK,
     maxTokens: config.maxTokens,
     repeatPenalty: config.repeatPenalty,
+    presencePenalty: config.presencePenalty,
+    minP: config.minP,
   } : undefined;
 
   return {

--- a/src/services/transport/types/proxy.ts
+++ b/src/services/transport/types/proxy.ts
@@ -3,13 +3,41 @@
  * Handles multi-model proxy server management.
  */
 
+import type { InferenceConfig } from '../../../types';
+import type { StartServerRequest } from '../mappers';
+
 /**
- * Proxy server configuration.
+ * Proxy server configuration — the full `StartProxyConfig` wire surface
+ * (snake_case keys, matching the Rust serde form).
  */
 export interface ProxyConfig {
   host: string;
   port: number;
   default_context: number;
+  /** Master switch for disk KV-slot persistence. */
+  cache?: boolean;
+  /** Slot directory; omitted = default when cache is on. */
+  slot_dir?: string;
+  /** Byte budget (GiB) for the on-disk slot eviction sweep. */
+  cache_disk_gb?: number;
+  /** Proxy-wide sampling override (camelCase inner keys — `InferenceConfig`
+      serializes camelCase on both sides, so this passes through unmapped). */
+  inference_override?: InferenceConfig;
+  /** Require this bearer key on the OpenAI surface. */
+  api_key?: string;
+  /** Extra Host-header allowlist entries beyond loopback. */
+  allowed_hosts?: string[];
+}
+
+/**
+ * Request body for `POST /api/proxy/start-pinned` — the GUI counterpart of
+ * `gglib serve`. The daemon runs the launch cascade server-side.
+ */
+export interface StartPinnedRequest {
+  model_id: number;
+  /** Per-model launch overrides, same camelCase shape as `/api/servers/start`. */
+  options?: StartServerRequest;
+  proxy?: Partial<ProxyConfig>;
 }
 
 /**
@@ -20,6 +48,8 @@ export interface ProxyStatus {
   port: number;
   current_model?: string;
   model_port?: number;
+  /** The model this proxy run is pinned to; absent for the auto-swapping proxy. */
+  pinned_model?: string | null;
 }
 
 /**
@@ -31,6 +61,9 @@ export interface ProxyTransport {
 
   /** Start the multi-model proxy server. */
   startProxy(config?: Partial<ProxyConfig>): Promise<ProxyStatus>;
+
+  /** Start the proxy pinned to one model — the GUI counterpart of `gglib serve`. */
+  startPinnedProxy(request: StartPinnedRequest): Promise<ProxyStatus>;
 
   /** Stop the proxy server. */
   stopProxy(): Promise<void>;


### PR DESCRIPTION
PR 7/13 — **stacked on** `feat(gui)/benchmark-agentic` (#763). The first Rust-touching PR of the stack: the `gglib serve` cascade becomes shared infrastructure, and the GUI gains pinned serving plus the rest of the proxy launch surface.

## Rust
- **`gglib_app_services::launch_options::plan_pinned_launch`** — the pinned-launch cascade (five-level sampling resolution, MTP tag detection, three-tier context/cache merge) now exists exactly once. The CLI `serve` handler is a thin flag-mapper over it; the review gate *proved* equivalence with a six-case old-vs-new fixture test (defaults-only, everything-set, `--ctx-size max`, MTP explicit-disable, MTP tag-auto with default slot dir, bare model), comparing launch options, proxy config, effective context, resolved sampling, and MTP resolution. Banner output unchanged.
- **`POST /api/proxy/start-pinned`** — the GUI counterpart of `gglib serve`: name a model id plus overrides (camelCase `options`, snake_case `proxy`, matching their existing wire forms) and the daemon plans the pin server-side. Delegates to the existing start path, so the already-pinned-conflict semantics hold. `inference_override` is forced `None` on this path — sampling rides the pin, exactly as the CLI sends it.
- 7 cascade unit tests + 2 integration tests; all crate suites green.

## GUI
- **ServeModal**: "Pin the proxy to this model" — the primary button becomes "Start Pinned Proxy" when checked; the daemon runs the cascade (the modal sends only what the user typed, so the model-defaults rung applies server-side); 409s surface as GUI-appropriate copy, not CLI remedies.
- **Proxy popover**: Connection options grow disk KV-cache (with GiB budget), API key, and allowed hosts; the popover and the **tray** both show the running pin. Clear Cache is no longer dead-gated on a prop its call site never passed.
- **Transport**: `ProxyConfig` widened to the full `StartProxyConfig` surface, `ProxyStatus.pinned_model`, `startPinnedProxy`. Pre-existing mapper bug fixed: presence-penalty/min-P-only sampling configs are no longer silently dropped (interface and payload both).

## Review gate: 20 raised, 17 confirmed (3 refuted), all addressed
The blocker: the ServeModal port field was validated then silently ignored on the pinned path — `request.port` now reaches the pin's launch options (regression-tested). Also fixed: client-side context pre-resolution bypassing the daemon cascade, `default_context` accepted-but-discarded on the new body, popover overflow/label-association/mono gaps.

Known accepted gap (pre-existing, unchanged): `llama_base_port` is accepted by `StartProxyConfig` but unread by the runtime config — no UI was built for it.

`cargo test` (app-services, axum, cli) + `npm run lint/test:run/build` all green.