### PR TITLE
feat(gui): settings parity — five CLI-only fields, profile templates, agent limits

### DIFF
--- a/crates/gglib-app-services/src/settings.rs
+++ b/crates/gglib-app-services/src/settings.rs
@@ -281,6 +281,7 @@ mod tests {
             trust_client_sampling: None,
             proxy_loop_detection: None,
             tool_call_repair: None,
+            agentic_sampling: Some(false),
             proxy_autostart: None,
             close_to_tray: None,
             start_at_login: None,
@@ -294,6 +295,9 @@ mod tests {
         // to `f64` in JSON, so an exact float compare tests the widening, not
         // the contract.
         assert!(entry["config"]["temperature"].is_number());
+        // Wire visibility is the point of adding agentic_sampling to the
+        // response DTO — a toggle that saves but cannot read back resets.
+        assert_eq!(json["agenticSampling"], false);
 
         // And the update request accepts the same shape back.
         let request: UpdateSettingsRequest = serde_json::from_value(serde_json::json!({

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -511,6 +511,11 @@ pub struct AppSettings {
     /// Whether a tool call failing schema validation is re-issued with
     /// `tool_choice: "required"`. Absent means on.
     pub tool_call_repair: Option<bool>,
+    /// Whether structured-output turns get their temperature capped when no
+    /// human chose one. Absent means on (see `gglib_core::Settings`). Was
+    /// write-only until the GUI grew a toggle — a toggle that saves but
+    /// cannot read back silently resets on every reopen.
+    pub agentic_sampling: Option<bool>,
     // Always-on proxy, desktop app only (see `gglib_core::Settings`)
     pub proxy_autostart: Option<bool>,
     pub close_to_tray: Option<bool>,
@@ -539,6 +544,7 @@ impl From<gglib_core::Settings> for AppSettings {
             trust_client_sampling: settings.trust_client_sampling,
             proxy_loop_detection: settings.proxy_loop_detection,
             tool_call_repair: settings.tool_call_repair,
+            agentic_sampling: settings.agentic_sampling,
             proxy_autostart: settings.proxy_autostart,
             close_to_tray: settings.close_to_tray,
             start_at_login: settings.start_at_login,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -10,6 +10,8 @@ import { AddMcpServerModal } from "./AddMcpServerModal";
 import { GeneralSettings } from "./SettingsModal/GeneralSettings";
 import { InferenceProfiles } from "./SettingsModal/InferenceProfiles";
 import { useDesktopSettings } from "./SettingsModal/useDesktopSettings";
+import { useNetworkSettings } from './SettingsModal/useNetworkSettings';
+import { useAgentGuardSettings } from './SettingsModal/useAgentGuardSettings';
 import { Modal } from "./ui/Modal";
 import { Button } from "./ui/Button";
 import { Tabs, type TabItem } from "./ui/Tabs";
@@ -56,6 +58,9 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
     reset: resetDesktop,
     updates: desktopUpdates,
   } = useDesktopSettings(settings);
+  const network = useNetworkSettings(settings);
+  const agentGuards = useAgentGuardSettings(settings);
+  const [downloadPathInput, setDownloadPathInput] = useState('');
   const [defaultModelInput, setDefaultModelInput] = useState("");
   const [inferenceDefaultsInput, setInferenceDefaultsInput] = useState<InferenceConfig | undefined>(undefined);
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
@@ -84,6 +89,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       setServerPortInput(settings.llamaBasePort?.toString() || "");
       setMaxQueueSizeInput(settings.maxDownloadQueueSize?.toString() || "");
       setProxyApiKeyInput(settings.proxyApiKey || "");
+      setDownloadPathInput(settings.defaultDownloadPath || "");
       setTitlePromptInput(settings.titleGenerationPrompt || "");
       setMaxToolIterationsInput(settings.maxToolIterations?.toString() || "");
       setShowFitIndicators(settings.showMemoryFitIndicators !== false);
@@ -130,6 +136,9 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           inferenceDefaults: inferenceDefaultsInput,
           trustClientSampling,
           proxyLoopDetection,
+          defaultDownloadPath: downloadPathInput.trim() || null,
+          ...network.updates,
+          ...agentGuards.updates,
           ...desktopUpdates,
         };
 
@@ -147,7 +156,14 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           updates.inferenceDefaults !== undefined ||
           updates.trustClientSampling !== undefined ||
           updates.proxyLoopDetection !== undefined ||
-          updates.proxyAutostart !== undefined;
+          updates.defaultDownloadPath !== undefined ||
+          updates.bindHost !== undefined ||
+          updates.shareLan !== undefined ||
+          updates.agenticSampling !== undefined ||
+          updates.maxStagnationSteps !== undefined ||
+          updates.proxyAutostart !== undefined ||
+          updates.closeToTray !== undefined ||
+          updates.startAtLogin !== undefined;
 
         if (hasUpdates) {
           await saveSettings(updates);
@@ -173,6 +189,9 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       trustClientSampling,
       proxyLoopDetection,
       desktopUpdates,
+      downloadPathInput,
+      network.updates,
+      agentGuards.updates,
       info,
       saveDir,
       saveSettings,
@@ -194,6 +213,9 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       setTrustClientSampling(false); // Default is disabled
       setProxyLoopDetection(true); // Default is enabled
       resetDesktop();
+    setDownloadPathInput('');
+    network.reset();
+    agentGuards.reset();
     }
   }, [info, settings, resetDesktop]);
 
@@ -280,6 +302,12 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
             setTitlePromptInput={setTitlePromptInput}
             inferenceDefaultsInput={inferenceDefaultsInput}
             setInferenceDefaultsInput={setInferenceDefaultsInput}
+            downloadPathInput={downloadPathInput}
+            setDownloadPathInput={setDownloadPathInput}
+            networkSettings={network.values}
+            setNetworkSetting={network.setValue}
+            agentGuardSettings={agentGuards.values}
+            setAgentGuardSetting={agentGuards.setValue}
             desktopSettings={desktopValues}
             setDesktopSetting={setDesktopSetting}
             trustClientSampling={trustClientSampling}

--- a/src/components/SettingsModal/GeneralSettings.tsx
+++ b/src/components/SettingsModal/GeneralSettings.tsx
@@ -11,11 +11,15 @@ import {
   SetupWizardRow,
 } from "./fields";
 import type { DesktopSettingsValues } from "./useDesktopSettings";
+import type { NetworkSettingsValues } from "./useNetworkSettings";
+import type { AgentGuardSettingsValues } from "./useAgentGuardSettings";
 
 interface GeneralSettingsProps {
   // Directory state
   pathInput: string;
   setPathInput: (value: string) => void;
+  downloadPathInput: string;
+  setDownloadPathInput: (value: string) => void;
   info: ModelsDirectoryInfo | null;
   sourceDescription: string | null;
 
@@ -32,6 +36,20 @@ interface GeneralSettingsProps {
   setProxyApiKeyInput: (value: string) => void;
   showFitIndicators: boolean;
   setShowFitIndicators: (value: boolean) => void;
+
+  // Network binding
+  networkSettings: NetworkSettingsValues;
+  setNetworkSetting: <K extends keyof NetworkSettingsValues>(
+    key: K,
+    value: NetworkSettingsValues[K],
+  ) => void;
+
+  // Agent guards
+  agentGuardSettings: AgentGuardSettingsValues;
+  setAgentGuardSetting: <K extends keyof AgentGuardSettingsValues>(
+    key: K,
+    value: AgentGuardSettingsValues[K],
+  ) => void;
 
   // Always-on proxy (desktop app)
   desktopSettings: DesktopSettingsValues;
@@ -98,6 +116,12 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
   loadingModels,
   isAdvancedOpen,
   setIsAdvancedOpen,
+  downloadPathInput,
+  setDownloadPathInput,
+  networkSettings,
+  setNetworkSetting,
+  agentGuardSettings,
+  setAgentGuardSetting,
   maxToolIterationsInput,
   setMaxToolIterationsInput,
   titlePromptInput,
@@ -127,6 +151,8 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
   return (
     <form id="settings-general-form" className="flex flex-col gap-xl" onSubmit={onSubmit}>
       <PathSettings
+        downloadPathInput={downloadPathInput}
+        setDownloadPathInput={setDownloadPathInput}
         pathInput={pathInput}
         setPathInput={setPathInput}
         info={info}
@@ -158,6 +184,8 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
       <SecuritySettings
         proxyApiKeyInput={proxyApiKeyInput}
         setProxyApiKeyInput={setProxyApiKeyInput}
+        network={networkSettings}
+        setNetworkSetting={setNetworkSetting}
         saving={saving}
       />
 
@@ -186,6 +214,8 @@ export const GeneralSettings: FC<GeneralSettingsProps> = ({
         setTrustClientSampling={setTrustClientSampling}
         proxyLoopDetection={proxyLoopDetection}
         setProxyLoopDetection={setProxyLoopDetection}
+        agentGuards={agentGuardSettings}
+        setAgentGuardSetting={setAgentGuardSetting}
         saving={saving}
       />
 

--- a/src/components/SettingsModal/InferenceProfileEditor.tsx
+++ b/src/components/SettingsModal/InferenceProfileEditor.tsx
@@ -34,6 +34,10 @@ const PARAMS: ParamSpec[] = [
   { key: "repeatPenalty", label: "Repeat penalty", hint: "typically 1.0 – 1.3", step: "0.05" },
   { key: "presencePenalty", label: "Presence penalty", hint: "0.0 – 2.0", step: "0.1" },
   { key: "minP", label: "Min-P", hint: "0.0 – 1.0", step: "0.01" },
+  { key: "dryMultiplier", label: "DRY multiplier", hint: "0 disables; typically 0.8", step: "0.1" },
+  { key: "dryBase", label: "DRY base", hint: "at least 1.0; typically 1.75", step: "0.05" },
+  { key: "dryAllowedLength", label: "DRY allowed length", hint: "0 or more", step: "1" },
+  { key: "dryPenaltyLastN", label: "DRY penalty last N", hint: "-1 = whole context", step: "1" },
 ];
 
 /**

--- a/src/components/SettingsModal/InferenceProfiles.tsx
+++ b/src/components/SettingsModal/InferenceProfiles.tsx
@@ -28,6 +28,10 @@ function summarize(config: InferenceConfig): string {
     repeatPenalty: "repeat-penalty",
     presencePenalty: "presence-penalty",
     minP: "min-p",
+    dryMultiplier: "dry-multiplier",
+    dryBase: "dry-base",
+    dryAllowedLength: "dry-allowed-length",
+    dryPenaltyLastN: "dry-penalty-last-n",
   };
   const parts = Object.entries(labels)
     .filter(([key]) => {
@@ -37,6 +41,35 @@ function summarize(config: InferenceConfig): string {
     .map(([key, label]) => `${label}=${config[key as keyof InferenceConfig]}`);
   return parts.length ? parts.join("  ") : "no parameters set";
 }
+
+/**
+ * The CLI's starter templates (`gglib config profile install-templates`),
+ * transcribed from `gglib_core::domain::inference_profile::builtin_templates`.
+ * Templates, not behaviour: installing them only seeds the user's own list.
+ * Sparse on purpose — a template that filled every field would silently
+ * override per-model tuning. Drift is guarded by a contract test that reads
+ * the Rust source.
+ */
+export const STARTER_PROFILES: InferenceProfile[] = [
+  {
+    name: 'coding',
+    description: 'Low-variance sampling for code generation and tool use.',
+    config: { temperature: 0.2, topP: 0.9 },
+    listInModels: false,
+  },
+  {
+    name: 'chat',
+    description: 'Balanced sampling for conversational use.',
+    config: { temperature: 0.7, topP: 0.95 },
+    listInModels: true,
+  },
+  {
+    name: 'creative',
+    description: 'Wider sampling for brainstorming and prose.',
+    config: { temperature: 1.1, topP: 0.98 },
+    listInModels: false,
+  },
+];
 
 export const InferenceProfiles: FC = () => {
   const [profiles, setProfiles] = useState<InferenceProfile[]>([]);
@@ -99,6 +132,22 @@ export const InferenceProfiles: FC = () => {
       void persist(profiles.filter((p) => p.name !== name));
     },
     [profiles, persist],
+  );
+
+  /**
+   * Seed the CLI's starter templates, skip-existing — the same merge
+   * `gglib config profile install-templates` performs (without --force).
+   */
+  const handleInstallTemplates = useCallback(() => {
+    const missing = STARTER_PROFILES.filter(
+      (t) => !profiles.some((p) => p.name === t.name),
+    );
+    if (missing.length === 0) return;
+    void persist([...profiles, ...missing]);
+  }, [profiles, persist]);
+
+  const templatesMissing = STARTER_PROFILES.some(
+    (t) => !profiles.some((p) => p.name === t.name),
   );
 
   if (loading) {
@@ -189,10 +238,22 @@ export const InferenceProfiles: FC = () => {
         </Stack>
       )}
 
-      <div>
+      <div className="flex items-center gap-sm">
         <Button disabled={saving} onClick={() => setEditing("")}>
           Add profile
         </Button>
+        {templatesMissing ? (
+          <Button
+            variant="secondary"
+            disabled={saving}
+            title="Seed the coding / chat / creative starter profiles; existing names are kept"
+            onClick={handleInstallTemplates}
+          >
+            Install starter profiles
+          </Button>
+        ) : (
+          <span className="text-xs text-text-muted">Starter profiles installed</span>
+        )}
       </div>
     </Stack>
   );

--- a/src/components/SettingsModal/fields/AdvancedSettings.tsx
+++ b/src/components/SettingsModal/fields/AdvancedSettings.tsx
@@ -5,8 +5,9 @@ import { Button } from '../../ui/Button';
 import { Textarea } from '../../ui/Textarea';
 import { InferenceParametersForm } from '../../InferenceParametersForm';
 import type { InferenceConfig } from '../../../types';
+import type { AgentGuardSettingsValues } from '../useAgentGuardSettings';
 import { Label } from '../../primitives';
-import { MAX_TOOL_ITERATIONS } from '../../../constants/settingsDefaults';
+import { MAX_STAGNATION_STEPS, MAX_TOOL_ITERATIONS } from '../../../constants/settingsDefaults';
 import { NumberSettingField } from './NumberSettingField';
 import { SettingField } from './SettingField';
 import { ToggleField } from './ToggleField';
@@ -25,6 +26,11 @@ interface AdvancedSettingsProps {
   setTrustClientSampling: (value: boolean) => void;
   proxyLoopDetection: boolean;
   setProxyLoopDetection: (value: boolean) => void;
+  agentGuards: AgentGuardSettingsValues;
+  setAgentGuardSetting: <K extends keyof AgentGuardSettingsValues>(
+    key: K,
+    value: AgentGuardSettingsValues[K],
+  ) => void;
   saving: boolean;
 }
 
@@ -45,6 +51,8 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
   setTrustClientSampling,
   proxyLoopDetection,
   setProxyLoopDetection,
+  agentGuards,
+  setAgentGuardSetting,
   saving,
 }) => (
   <>
@@ -136,6 +144,28 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
           stuck turn. Turn this off only for a client that legitimately replays identical
           batches.
         </ToggleField>
+
+        <ToggleField
+          id="agentic-sampling-input"
+          label="Agentic sampling cap"
+          checked={agentGuards.agenticSampling}
+          onChange={(value) => setAgentGuardSetting('agenticSampling', value)}
+          disabled={saving}
+        >
+          On by default: a turn that may emit structured output has its temperature
+          capped (0.6 on reasoning-tagged models, 0.3 otherwise) — but only over a
+          value nobody deliberately chose. Anything set by a person stands.
+        </ToggleField>
+
+        <NumberSettingField
+          id="max-stagnation-steps-input"
+          label="Max Stagnation Steps"
+          spec={MAX_STAGNATION_STEPS}
+          value={agentGuards.maxStagnationSteps}
+          onChange={(value) => setAgentGuardSetting('maxStagnationSteps', value)}
+          description="Consecutive no-progress steps before an agent loop stops. Shared by the built-in agent loop and the proxy's turn-level guard, so the two paths cannot drift."
+          disabled={saving}
+        />
       </div>
     )}
   </>

--- a/src/components/SettingsModal/fields/PathSettings.tsx
+++ b/src/components/SettingsModal/fields/PathSettings.tsx
@@ -8,6 +8,8 @@ import type { ModelsDirectoryInfo } from '../../../types';
 import { SettingField } from './SettingField';
 
 interface PathSettingsProps {
+  downloadPathInput: string;
+  setDownloadPathInput: (value: string) => void;
   pathInput: string;
   setPathInput: (value: string) => void;
   info: ModelsDirectoryInfo | null;
@@ -20,6 +22,8 @@ interface PathSettingsProps {
  * Models directory field plus its live "exists" / "writable" status pills.
  */
 export const PathSettings: FC<PathSettingsProps> = ({
+  downloadPathInput,
+  setDownloadPathInput,
   pathInput,
   setPathInput,
   info,
@@ -27,9 +31,10 @@ export const PathSettings: FC<PathSettingsProps> = ({
   onReset,
   saving,
 }) => (
+  <>
   <SettingField
     id="models-dir-input"
-    label="Default Download Path"
+    label="Models Directory"
     description={sourceDescription}
     action={
       info?.defaultPath && (
@@ -60,6 +65,10 @@ export const PathSettings: FC<PathSettingsProps> = ({
             >
               {!info.exists && <Icon icon={AlertTriangle} size={12} />}
               {info.exists ? 'Directory exists' : 'Directory will be created'}
+              {/* Writability is stated in every state, not just the happy one:
+                  a path that does not exist yet is exactly where a user most
+                  wants confirmation that it can be written before committing. */}
+              {info.writable && ' · writable'}
             </span>
             {!info.writable && (
               <span className="inline-flex items-center gap-xs text-xs text-danger">
@@ -72,4 +81,21 @@ export const PathSettings: FC<PathSettingsProps> = ({
       </div>
     )}
   </SettingField>
+
+  <SettingField
+    id="download-path-input"
+    label="Default Download Path"
+    defaultHint="models directory"
+    description="Staging area for downloads before they join the library. Distinct from the models directory above, which is where the library itself lives. Leave empty to download straight into it."
+  >
+    <Input
+      id="download-path-input"
+      value={downloadPathInput}
+      onChange={(event) => setDownloadPathInput(event.target.value)}
+      placeholder="models directory"
+      disabled={saving}
+      spellCheck={false}
+    />
+  </SettingField>
+  </>
 );

--- a/src/components/SettingsModal/fields/SecuritySettings.tsx
+++ b/src/components/SettingsModal/fields/SecuritySettings.tsx
@@ -1,10 +1,18 @@
 import { FC } from 'react';
 import { Input } from '../../ui/Input';
 import { SettingField } from './SettingField';
+import { ToggleField } from './ToggleField';
+
+import type { NetworkSettingsValues } from '../useNetworkSettings';
 
 interface SecuritySettingsProps {
   proxyApiKeyInput: string;
   setProxyApiKeyInput: (value: string) => void;
+  network: NetworkSettingsValues;
+  setNetworkSetting: <K extends keyof NetworkSettingsValues>(
+    key: K,
+    value: NetworkSettingsValues[K],
+  ) => void;
   saving: boolean;
 }
 
@@ -19,8 +27,11 @@ interface SecuritySettingsProps {
 export const SecuritySettings: FC<SecuritySettingsProps> = ({
   proxyApiKeyInput,
   setProxyApiKeyInput,
+  network,
+  setNetworkSetting,
   saving,
 }) => (
+  <>
   <SettingField
     id="proxy-api-key-input"
     label="Proxy API Key"
@@ -38,4 +49,37 @@ export const SecuritySettings: FC<SecuritySettingsProps> = ({
       spellCheck={false}
     />
   </SettingField>
+
+  <SettingField
+    id="bind-host-input"
+    label="Bind Host"
+    defaultHint="127.0.0.1"
+    description="Literal IP the daemon binds — a hostname is rejected so the TCP bind and the mDNS record stay unambiguous. The --host flag overrides this for a single run."
+  >
+    <Input
+      id="bind-host-input"
+      type="text"
+      className="font-mono"
+      value={network.bindHost}
+      onChange={(event) => setNetworkSetting('bindHost', event.target.value)}
+      placeholder="127.0.0.1"
+      disabled={saving}
+      autoComplete="off"
+      spellCheck={false}
+    />
+  </SettingField>
+
+  <ToggleField
+    id="share-lan-input"
+    label="Share on the local network"
+    checked={network.shareLan}
+    onChange={(value) => setNetworkSetting('shareLan', value)}
+    disabled={saving}
+  >
+    Binds the daemon beyond loopback: every device on your network can reach it, and
+    its management API can download models and start or stop inference on this
+    machine. The API key above is the only thing standing between the network and
+    those controls — set one before enabling this.
+  </ToggleField>
+  </>
 );

--- a/src/components/SettingsModal/useAgentGuardSettings.ts
+++ b/src/components/SettingsModal/useAgentGuardSettings.ts
@@ -1,0 +1,70 @@
+/**
+ * State for the agent-guard settings (agentic sampling cap, stagnation limit).
+ *
+ * Same rationale as `useDesktopSettings`: the group owns its own state and
+ * hands back a ready-made slice of the update request.
+ *
+ * @module components/SettingsModal/useAgentGuardSettings
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { AppSettings, UpdateSettingsRequest } from '../../types';
+
+export interface AgentGuardSettingsValues {
+  /** Inverse polarity on the wire: unset means enabled. */
+  agenticSampling: boolean;
+  /** Raw input string; blank = server default. */
+  maxStagnationSteps: string;
+}
+
+const DEFAULTS: AgentGuardSettingsValues = {
+  agenticSampling: true,
+  maxStagnationSteps: '',
+};
+
+export interface UseAgentGuardSettingsResult {
+  values: AgentGuardSettingsValues;
+  /** Restore the built-in defaults, for the form's Reset action. */
+  reset: () => void;
+  setValue: <K extends keyof AgentGuardSettingsValues>(
+    key: K,
+    value: AgentGuardSettingsValues[K],
+  ) => void;
+  updates: Pick<UpdateSettingsRequest, 'agenticSampling' | 'maxStagnationSteps'>;
+}
+
+/** Track the agent-guard fields, seeded from persisted settings. */
+export function useAgentGuardSettings(settings: AppSettings | null): UseAgentGuardSettingsResult {
+  const [values, setValues] = useState<AgentGuardSettingsValues>(DEFAULTS);
+
+  useEffect(() => {
+    if (settings) {
+      setValues({
+        // Unset means enabled, like proxyLoopDetection.
+        agenticSampling: settings.agenticSampling !== false,
+        maxStagnationSteps: settings.maxStagnationSteps?.toString() ?? '',
+      });
+    }
+  }, [settings]);
+
+  const reset = useCallback(() => setValues(DEFAULTS), []);
+
+  const setValue = useCallback(
+    <K extends keyof AgentGuardSettingsValues>(key: K, value: AgentGuardSettingsValues[K]) => {
+      setValues((previous) => ({ ...previous, [key]: value }));
+    },
+    [],
+  );
+
+  const parsed = parseInt(values.maxStagnationSteps.trim(), 10);
+
+  return {
+    values,
+    setValue,
+    reset,
+    updates: {
+      agenticSampling: values.agenticSampling,
+      maxStagnationSteps: Number.isFinite(parsed) ? parsed : null,
+    },
+  };
+}

--- a/src/components/SettingsModal/useNetworkSettings.ts
+++ b/src/components/SettingsModal/useNetworkSettings.ts
@@ -1,0 +1,72 @@
+/**
+ * State for the network-binding settings (bind host, LAN sharing).
+ *
+ * Same rationale as `useDesktopSettings`: the group owns its own state and
+ * hands back a ready-made slice of the update request, keeping the
+ * over-budget `SettingsModal` from growing more `useState` pairs.
+ *
+ * @module components/SettingsModal/useNetworkSettings
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { AppSettings, UpdateSettingsRequest } from '../../types';
+
+export interface NetworkSettingsValues {
+  /** Literal IP the daemon binds; empty = compiled-in default (127.0.0.1). */
+  bindHost: string;
+  shareLan: boolean;
+}
+
+const DEFAULTS: NetworkSettingsValues = {
+  bindHost: '',
+  shareLan: false,
+};
+
+export interface UseNetworkSettingsResult {
+  values: NetworkSettingsValues;
+  /** Restore the built-in defaults, for the form's Reset action. */
+  reset: () => void;
+  setValue: <K extends keyof NetworkSettingsValues>(
+    key: K,
+    value: NetworkSettingsValues[K],
+  ) => void;
+  /** The slice of the update request these fields own. */
+  updates: Pick<UpdateSettingsRequest, 'bindHost' | 'shareLan'>;
+}
+
+/**
+ * Track the network-binding fields, seeded from persisted settings.
+ * An emptied bind host means "back to the default", which is a `null`
+ * (clear the row) on the wire, not a blank string.
+ */
+export function useNetworkSettings(settings: AppSettings | null): UseNetworkSettingsResult {
+  const [values, setValues] = useState<NetworkSettingsValues>(DEFAULTS);
+
+  useEffect(() => {
+    if (settings) {
+      setValues({
+        bindHost: settings.bindHost ?? '',
+        shareLan: settings.shareLan === true,
+      });
+    }
+  }, [settings]);
+
+  const reset = useCallback(() => setValues(DEFAULTS), []);
+
+  const setValue = useCallback(
+    <K extends keyof NetworkSettingsValues>(key: K, value: NetworkSettingsValues[K]) => {
+      setValues((previous) => ({ ...previous, [key]: value }));
+    },
+    [],
+  );
+
+  return {
+    values,
+    setValue,
+    reset,
+    updates: {
+      bindHost: values.bindHost.trim() || null,
+      shareLan: values.shareLan,
+    },
+  };
+}

--- a/src/components/ToolsPopover/AgentLimitsSection.tsx
+++ b/src/components/ToolsPopover/AgentLimitsSection.tsx
@@ -1,0 +1,160 @@
+/**
+ * Agent limits inside the Tools popover — the GUI surface for
+ * `AgentRequestConfig`'s BYO-MCP knobs. Values persist client-side
+ * (`services/agentOverrides`), apply to every chat sent from this client,
+ * and are read fresh at each send.
+ */
+
+import { FC, useState } from 'react';
+import { Input } from '../ui/Input';
+import { Checkbox } from '../ui/Checkbox';
+import {
+  MAX_OBSERVATION_STEPS_CEILING,
+  MAX_PARALLEL_TOOLS_CEILING,
+  TOOL_TIMEOUT_MS_CEILING,
+  TOOL_TIMEOUT_MS_FLOOR,
+  readStoredAgentOverrides,
+  writeStoredAgentOverrides,
+  type StoredAgentOverrides,
+} from '../../services/agentOverrides';
+
+interface NumberRowProps {
+  id: string;
+  label: string;
+  placeholder: string;
+  min: number;
+  max: number;
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+}
+
+const NumberRow: FC<NumberRowProps> = ({ id, label, placeholder, min, max, value, onChange }) => (
+  <div className="flex items-center justify-between gap-sm">
+    <label htmlFor={id} className="text-xs text-text-secondary">
+      {label}
+    </label>
+    <Input
+      id={id}
+      type="number"
+      size="sm"
+      min={min}
+      max={max}
+      className="w-24 font-mono tabular-nums"
+      value={value ?? ''}
+      placeholder={placeholder}
+      onChange={(e) => {
+        const parsed = parseInt(e.target.value, 10);
+        onChange(
+          Number.isFinite(parsed) && parsed > 0
+            ? Math.min(Math.max(parsed, min), max)
+            : undefined,
+        );
+      }}
+    />
+  </div>
+);
+
+const clamp = (value: number | undefined, min: number, max: number) =>
+  value === undefined ? undefined : Math.min(Math.max(value, min), max);
+
+/** Stale stored values are clamped on seed so the UI never shows what the wire won't send. */
+function seedOverrides(): StoredAgentOverrides {
+  const stored = readStoredAgentOverrides();
+  return {
+    ...stored,
+    toolTimeoutMs: clamp(stored.toolTimeoutMs, TOOL_TIMEOUT_MS_FLOOR, TOOL_TIMEOUT_MS_CEILING),
+    maxParallelTools: clamp(stored.maxParallelTools, 1, MAX_PARALLEL_TOOLS_CEILING),
+    maxObservationSteps: clamp(stored.maxObservationSteps, 1, MAX_OBSERVATION_STEPS_CEILING),
+  };
+}
+
+export const AgentLimitsSection: FC = () => {
+  const [overrides, setOverrides] = useState<StoredAgentOverrides>(seedOverrides);
+  const classificationDisabled = overrides.observationTools?.length === 0;
+  const [observationText, setObservationText] = useState(() => {
+    const tools = seedOverrides().observationTools;
+    return tools && tools.length > 0 ? tools.join(', ') : '';
+  });
+
+  const update = (partial: Partial<StoredAgentOverrides>) => {
+    const next = { ...overrides, ...partial };
+    setOverrides(next);
+    writeStoredAgentOverrides(next);
+  };
+
+  const parseTools = (raw: string): string[] | undefined => {
+    const tools = raw
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    return tools.length > 0 ? tools : undefined;
+  };
+
+  return (
+    <div className="px-[14px] py-[10px] border-t border-border-light flex flex-col gap-sm">
+      <div className="flex items-baseline justify-between gap-sm">
+        <span className="text-xs font-semibold text-text">Agent limits</span>
+        <span className="text-2xs text-text-muted">applies to all chats on this device</span>
+      </div>
+      <NumberRow
+        id="agent-tool-timeout"
+        label="Tool timeout (ms)"
+        placeholder="30000"
+        min={TOOL_TIMEOUT_MS_FLOOR}
+        max={TOOL_TIMEOUT_MS_CEILING}
+        value={overrides.toolTimeoutMs}
+        onChange={(v) => update({ toolTimeoutMs: v })}
+      />
+      <NumberRow
+        id="agent-max-parallel"
+        label="Parallel tool calls"
+        placeholder="25"
+        min={1}
+        max={MAX_PARALLEL_TOOLS_CEILING}
+        value={overrides.maxParallelTools}
+        onChange={(v) => update({ maxParallelTools: v })}
+      />
+      <NumberRow
+        id="agent-max-observation"
+        label="Observation steps"
+        placeholder="15"
+        min={1}
+        max={MAX_OBSERVATION_STEPS_CEILING}
+        value={overrides.maxObservationSteps}
+        onChange={(v) => update({ maxObservationSteps: v })}
+      />
+      <Checkbox
+        checked={classificationDisabled}
+        onChange={(e) =>
+          update({
+            observationTools: e.target.checked ? [] : parseTools(observationText),
+          })
+        }
+        label={
+          <span className="text-xs text-text-secondary">Disable observation classification</span>
+        }
+      />
+      <div className="flex flex-col gap-xs">
+        <label htmlFor="agent-observation-tools" className="text-xs text-text-secondary">
+          Observation tools
+        </label>
+        <Input
+          id="agent-observation-tools"
+          type="text"
+          size="sm"
+          className="font-mono"
+          disabled={classificationDisabled}
+          value={observationText}
+          placeholder="built-ins (snapshot, screenshot, …)"
+          onChange={(e) => {
+            setObservationText(e.target.value);
+            update({ observationTools: parseTools(e.target.value) });
+          }}
+        />
+        <p className="m-0 text-2xs text-text-muted">
+          Comma-separated tool names counted as observations. Blank uses the built-ins.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ToolsPopover/ToolsPopover.tsx
+++ b/src/components/ToolsPopover/ToolsPopover.tsx
@@ -11,6 +11,7 @@ import { getToolRegistry, type ToolDefinition } from '../../services/tools';
 import { Icon } from '../ui/Icon';
 import { Button } from '../ui/Button';
 import { cn } from '../../utils/cn';
+import { AgentLimitsSection } from './AgentLimitsSection';
 
 /**
  * Get a human-readable name from a tool function name.
@@ -202,6 +203,8 @@ export const ToolsPopover: React.FC = () => {
               </div>
             </>
           )}
+
+          <AgentLimitsSection />
 
           <div className="px-[14px] py-2 border-t border-border bg-surface-elevated">
             <span className="text-2xs text-text-muted italic">

--- a/src/constants/settingsDefaults.ts
+++ b/src/constants/settingsDefaults.ts
@@ -79,3 +79,14 @@ export const MAX_TOOL_ITERATIONS: NumericSettingSpec = {
   min: '1',
   max: '50',
 };
+
+/**
+ * Maximum consecutive no-progress agent steps. No `validate_settings` entry
+ * on the Rust side — the ceiling here mirrors
+ * `MAX_STAGNATION_STEPS_CEILING` in `domain/agent/config.rs`.
+ */
+export const MAX_STAGNATION_STEPS: NumericSettingSpec = {
+  default: '5',
+  min: '1',
+  max: '100',
+};

--- a/src/hooks/useGglibRuntime/streamAgentChat.ts
+++ b/src/hooks/useGglibRuntime/streamAgentChat.ts
@@ -56,10 +56,14 @@ import { isAbortError } from '../../utils/errors';
 export interface PartialAgentConfig {
   /** Maps to `AgentConfig::max_iterations` (default 25). */
   max_iterations?: number;
-  /** Maps to `AgentConfig::max_parallel_tools` (default 5). */
+  /** Maps to `AgentConfig::max_parallel_tools` (default 25). */
   max_parallel_tools?: number;
   /** Maps to `AgentConfig::tool_timeout_ms` (default 30 000). */
   tool_timeout_ms?: number;
+  /** Tool names classified as observations; `[]` disables classification. */
+  observation_tools?: string[];
+  /** Maps to `AgentConfig::max_observation_steps` (default 15). */
+  max_observation_steps?: number;
 }
 
 export interface StreamAgentChatOptions {

--- a/src/hooks/useGglibRuntime/useGglibRuntime.ts
+++ b/src/hooks/useGglibRuntime/useGglibRuntime.ts
@@ -8,6 +8,7 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { agentOverridesToWire } from '../../services/agentOverrides';
 import { appLogger } from '../../services/platform';
 import {
   useExternalStoreRuntime,
@@ -163,6 +164,8 @@ export function useGglibRuntime(options: UseGglibRuntimeOptions = {}): UseGglibR
         setCurrentStreamingAssistantMessageId,
         config: {
           ...(maxToolIterations !== undefined && { max_iterations: maxToolIterations }),
+          // Per-chat limits from the Tools popover, read fresh per send.
+          ...agentOverridesToWire(),
         },
         supportsToolCalls,
         onSystemWarning,

--- a/src/services/agentOverrides.ts
+++ b/src/services/agentOverrides.ts
@@ -1,0 +1,87 @@
+/**
+ * Client-persisted agent overrides, applied to every chat sent from this
+ * client — the GUI counterpart of
+ * `gglib chat`'s `--tool-timeout-ms`, `--max-parallel`, `--observation-tool`,
+ * and `--max-observation-steps` flags.
+ *
+ * One store for the whole client, not per conversation. Stored in
+ * localStorage (`gglib.chat.agentOverrides`, following the
+ * `usePanelResize` key convention) rather than server settings: these are
+ * request-scoped knobs on `AgentRequestConfig`, not persisted server state.
+ * The runtime reads them fresh at send time via `readStoredAgentOverrides`,
+ * so the popover UI and the request path cannot drift within a session.
+ */
+
+const STORAGE_KEY = 'gglib.chat.agentOverrides';
+
+/** Bounds mirror `crates/gglib-core/src/domain/agent/config.rs`. */
+export const TOOL_TIMEOUT_MS_FLOOR = 100;
+export const TOOL_TIMEOUT_MS_CEILING = 60_000;
+export const MAX_PARALLEL_TOOLS_CEILING = 50;
+export const MAX_OBSERVATION_STEPS_CEILING = 100;
+
+export interface StoredAgentOverrides {
+  /** Per-tool-call timeout in ms (server default 30 000, ceiling 60 000). */
+  toolTimeoutMs?: number;
+  /** Parallel tool-call cap (server default 25, ceiling 50). */
+  maxParallelTools?: number;
+  /** Observation-classification step cap (server default 15, ceiling 100). */
+  maxObservationSteps?: number;
+  /**
+   * Tool names classified as observations. Absent = the server's built-ins;
+   * an empty array disables classification entirely.
+   */
+  observationTools?: string[];
+}
+
+export function readStoredAgentOverrides(): StoredAgentOverrides {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredAgentOverrides;
+    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeStoredAgentOverrides(overrides: StoredAgentOverrides): void {
+  try {
+    const entries = Object.entries(overrides).filter(([, v]) => v !== undefined);
+    if (entries.length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(entries)));
+    }
+  } catch {
+    // Storage unavailable (private mode) — overrides just don't persist.
+  }
+}
+
+/**
+ * The stored overrides as `AgentRequestConfig` wire fields (snake_case),
+ * clamped to the server's ceilings so a stale stored value cannot 4xx.
+ */
+export function agentOverridesToWire(): {
+  tool_timeout_ms?: number;
+  max_parallel_tools?: number;
+  max_observation_steps?: number;
+  observation_tools?: string[];
+} {
+  const stored = readStoredAgentOverrides();
+  return {
+    ...(stored.toolTimeoutMs !== undefined && {
+      tool_timeout_ms: Math.min(
+        Math.max(stored.toolTimeoutMs, TOOL_TIMEOUT_MS_FLOOR),
+        TOOL_TIMEOUT_MS_CEILING,
+      ),
+    }),
+    ...(stored.maxParallelTools !== undefined && {
+      max_parallel_tools: Math.min(stored.maxParallelTools, MAX_PARALLEL_TOOLS_CEILING),
+    }),
+    ...(stored.maxObservationSteps !== undefined && {
+      max_observation_steps: Math.min(stored.maxObservationSteps, MAX_OBSERVATION_STEPS_CEILING),
+    }),
+    ...(stored.observationTools !== undefined && { observation_tools: stored.observationTools }),
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -392,6 +392,20 @@ export interface AppSettings {
   closeToTray?: boolean | null;
   /** Whether the desktop app registers itself to launch on login. */
   startAtLogin?: boolean | null;
+  /**
+   * Maximum consecutive no-progress agent steps before the loop stops.
+   * Shared by the built-in agent loop and the proxy's turn-level guard.
+   */
+  maxStagnationSteps?: number | null;
+  /** Literal IP the daemon binds. Unset = the compiled-in 127.0.0.1. */
+  bindHost?: string | null;
+  /** Whether the daemon binds beyond loopback. Unset/false = localhost-only. */
+  shareLan?: boolean | null;
+  /**
+   * Whether a structured-output turn gets its temperature capped when no
+   * human chose one. Unset/true = active; anything set by a person stands.
+   */
+  agenticSampling?: boolean | null;
 }
 
 export interface UpdateSettingsRequest {
@@ -428,6 +442,14 @@ export interface UpdateSettingsRequest {
   closeToTray?: boolean | null | undefined;
   /** See `AppSettings.startAtLogin`. */
   startAtLogin?: boolean | null | undefined;
+  /** See `AppSettings.maxStagnationSteps`. */
+  maxStagnationSteps?: number | null | undefined;
+  /** See `AppSettings.bindHost`. */
+  bindHost?: string | null | undefined;
+  /** See `AppSettings.shareLan`. */
+  shareLan?: boolean | null | undefined;
+  /** See `AppSettings.agenticSampling`. */
+  agenticSampling?: boolean | null | undefined;
 }
 
 // ============================================================================

--- a/tests/ts/components/SettingsFields.test.tsx
+++ b/tests/ts/components/SettingsFields.test.tsx
@@ -42,13 +42,17 @@ const renderModelDefaults: RenderField = (value, onChange) =>
     />,
   );
 
-const renderAdvancedSettings: RenderField = (value, onChange) =>
+const renderAdvanced = (
+  overrides: Partial<{ maxToolIterationsInput: string; stagnation: string }>,
+  onChange: (value: string) => void,
+  target: 'iterations' | 'stagnation',
+) =>
   render(
     <AdvancedSettings
       isOpen
       onToggle={noop}
-      maxToolIterationsInput={value}
-      setMaxToolIterationsInput={onChange}
+      maxToolIterationsInput={overrides.maxToolIterationsInput ?? ''}
+      setMaxToolIterationsInput={target === 'iterations' ? onChange : noop}
       titlePromptInput=""
       setTitlePromptInput={noop}
       inferenceDefaultsInput={undefined}
@@ -57,9 +61,19 @@ const renderAdvancedSettings: RenderField = (value, onChange) =>
       setTrustClientSampling={noop}
       proxyLoopDetection
       setProxyLoopDetection={noop}
+      agentGuards={{ agenticSampling: true, maxStagnationSteps: overrides.stagnation ?? '' }}
+      setAgentGuardSetting={(key, value) => {
+        if (target === 'stagnation' && key === 'maxStagnationSteps') onChange(value as string);
+      }}
       saving={false}
     />,
   );
+
+const renderAdvancedSettings: RenderField = (value, onChange) =>
+  renderAdvanced({ maxToolIterationsInput: value }, onChange, 'iterations');
+
+const renderStagnationSettings: RenderField = (value, onChange) =>
+  renderAdvanced({ stagnation: value }, onChange, 'stagnation');
 
 /**
  * Every numeric field in the settings modal, with the values a user should
@@ -113,6 +127,13 @@ const FIELDS: {
     min: '1',
     max: '50',
     renderField: renderAdvancedSettings,
+  },
+  {
+    label: 'Max Stagnation Steps',
+    fallback: '5',
+    min: '1',
+    max: '100',
+    renderField: renderStagnationSettings,
   },
 ];
 

--- a/tests/ts/contracts/settingsParity.test.ts
+++ b/tests/ts/contracts/settingsParity.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Drift guards for PR8's settings-parity additions, in the style of
+ * `settingsBounds.test.ts`: read the Rust source off disk and assert the
+ * GUI's transcriptions match, so the two surfaces cannot drift silently.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { MAX_STAGNATION_STEPS } from '../../../src/constants/settingsDefaults';
+import { STARTER_PROFILES } from '../../../src/components/SettingsModal/InferenceProfiles';
+
+const rust = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+describe('starter profiles mirror builtin_templates()', () => {
+  const FILE = rust('crates/gglib-core/src/domain/inference_profile.rs');
+  const start = FILE.indexOf('pub fn builtin_templates()');
+  const SOURCE = FILE.slice(start, FILE.indexOf('\n}', start));
+
+  /** Extract one template's literal block from the function body by name. */
+  const templateBlock = (name: string): string => {
+    const index = SOURCE.indexOf(`name: "${name}"`);
+    expect(index, `template "${name}" not found in builtin_templates()`).toBeGreaterThan(-1);
+    return SOURCE.slice(index, SOURCE.indexOf('list_in_models', index) + 40);
+  };
+
+  it('transcribes every template the Rust defines, and no others', () => {
+    const rustNames = [...SOURCE.matchAll(/name: "([a-z-]+)"\.to_owned\(\)/g)].map((m) => m[1]);
+    expect(rustNames.length).toBeGreaterThan(0);
+    expect(STARTER_PROFILES.map((p) => p.name).sort()).toEqual([...new Set(rustNames)].sort());
+  });
+
+  it.each(STARTER_PROFILES.map((p) => [p.name, p] as const))(
+    'matches the Rust literal for %s',
+    (_name, profile) => {
+      const block = templateBlock(profile.name);
+      expect(block).toContain(`temperature: Some(${profile.config.temperature})`);
+      expect(block).toContain(`top_p: Some(${profile.config.topP})`);
+      expect(block).toContain(`list_in_models: ${profile.listInModels}`);
+      if (profile.description) {
+        expect(block).toContain(`Some("${profile.description}".to_owned())`);
+      }
+    },
+  );
+
+  it('keeps templates sparse — temperature and top-p only', () => {
+    for (const profile of STARTER_PROFILES) {
+      expect(Object.keys(profile.config).sort()).toEqual(['temperature', 'topP']);
+    }
+  });
+});
+
+describe('max stagnation steps tracks the agent default', () => {
+  it('has no validate_settings bound, capping only in the UI', () => {
+    const SETTINGS_RS = rust('crates/gglib-core/src/settings.rs');
+    expect(SETTINGS_RS).not.toMatch(/max_stagnation_steps[\s\S]{0,160}?contains/);
+  });
+
+  it('states the Rust default and ceiling', () => {
+    const CONFIG_RS = rust('crates/gglib-core/src/domain/agent/config.rs');
+    const defaultMatch = CONFIG_RS.match(/DEFAULT_MAX_STAGNATION_STEPS[^=]*=\s*(\d+)/);
+    const ceilingMatch = CONFIG_RS.match(/MAX_STAGNATION_STEPS_CEILING[^=]*=\s*(\d+)/);
+    expect(defaultMatch, 'DEFAULT_MAX_STAGNATION_STEPS not found').not.toBeNull();
+    expect(ceilingMatch, 'MAX_STAGNATION_STEPS_CEILING not found').not.toBeNull();
+    expect(MAX_STAGNATION_STEPS.default).toBe(defaultMatch![1]);
+    expect(MAX_STAGNATION_STEPS.max).toBe(ceilingMatch![1]);
+  });
+});


### PR DESCRIPTION
PR 8/13 — **stacked on** `feat(gui,services)/launch-options` (#764). The settings the CLI could set but the GUI could not.

## What changed
- **The wire fix that made the rest possible**: `agenticSampling` was write-only — present in `UpdateSettingsRequest` but missing from the `AppSettings` response, so any toggle would save and silently read back as unset. Now round-trips, with the exhaustive camelCase pin test extended to prove wire visibility.
- **Five settings surfaced**: the agentic sampling cap and max stagnation steps join the Advanced section (with the ADR-faithful copy — the cap only overrides values nobody deliberately chose); bind host (literal IP) and LAN sharing land beside the API key they depend on, carrying the CLI's security warning; and Default Download Path becomes a real settings row — which exposed that the field previously wearing that label was actually the models directory, now labeled truthfully. The dirty-check also gains the `closeToTray`/`startAtLogin` entries it was always missing.
- **Profiles**: the four DRY parameters the CLI supports but the editor omitted, and one-click starter-template seeding using the CLI's exact skip-existing merge — the three templates transcribed to TS and drift-guarded by a contract test that parses `builtin_templates()` from the Rust source.
- **Per-chat agent limits** (Tools popover): tool timeout, parallel-call cap, observation steps, and observation-tool classification — `AgentRequestConfig`'s deliberately-exposed knobs — stored client-side (labeled honestly as device-wide), clamped to the server's floor/ceilings both on input and at send. The audit's "retry toggle" was dropped: the DTO has no such field.

## Review gate: 24 raised, 18 confirmed, all fixed
Two blockers: a stale `useCallback` closure that silently discarded saves touching only the new fields (empirically proven with a modal-level repro, then fixed via the deps array), and a Rust test-compile break from the exhaustive DTO literal (the pin test now also asserts the new key). Also fixed: the disable-classification state not surviving popover remounts (now a real checkbox instead of a `none` sentinel), stale over-ceiling stored values rendering unclamped, the timeout floor (server clamps up to 100ms), Reset ignoring the new fields, DRY hint ranges, and the unreachable disabled-button explanation.

`cargo test -p gglib-app-services` (161) + `npm run lint/test:run/build` (782) all green.