### PR TITLE
feat(api,gui): model maintenance — capabilities, retag, and revision upgrade

### DIFF
--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -13,6 +13,7 @@ use gglib_core::{
 use crate::error::GuiError;
 use crate::sampling_explain::{self, SamplingExplanationDto};
 use crate::types::{
+    RetagResponse, UpgradeCheck, UpgradeOutcome,
     AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, SetCapabilitiesRequest,
     UpdateModelRequest,
 };
@@ -346,6 +347,143 @@ impl ModelOps {
             .map_err(|e| GuiError::Internal(format!("Failed to update model capabilities: {e}")))?;
 
         Ok(GuiModel::from_domain(model))
+    }
+
+    /// Re-run capability detection over the model's stored GGUF metadata.
+    ///
+    /// `full = false` only adds missing tags; `full = true` rebuilds the
+    /// system-tag namespace and re-derives the dialect spec. User-curated
+    /// tags outside that namespace survive either way. Returns `changed:
+    /// false` when the pass was a no-op.
+    pub async fn retag(&self, id: i64, full: bool) -> Result<RetagResponse, GuiError> {
+        // Resolve first so a stale id surfaces as NotFound, not Internal.
+        crate::helpers::resolve_model(self.deps.core.models(), id).await?;
+        let diff = self
+            .deps
+            .core
+            .models()
+            .retag_model(id, self.deps.gguf_parser.as_ref(), full)
+            .await
+            .map_err(|e| GuiError::Internal(format!("Retag failed: {e}")))?;
+
+        Ok(match diff {
+            Some(diff) => RetagResponse {
+                changed: diff.is_changed(),
+                added: diff.added,
+                removed: diff.removed,
+                spec_changed: diff.spec_changed,
+            },
+            None => RetagResponse {
+                changed: false,
+                added: Vec::new(),
+                removed: Vec::new(),
+                spec_changed: false,
+            },
+        })
+    }
+
+    /// Preconditions shared by the upgrade check and the upgrade itself.
+    fn upgrade_source(model: &gglib_core::Model) -> Result<(String, String), GuiError> {
+        let repo = model.hf_repo_id.clone().ok_or_else(|| {
+            GuiError::ValidationFailed("Model is not from HuggingFace, cannot update".into())
+        })?;
+        let quant = model.quantization.clone().ok_or_else(|| {
+            GuiError::ValidationFailed("Model has no quantization info stored".into())
+        })?;
+        Ok((repo, quant))
+    }
+
+    /// Whether a newer HuggingFace revision exists — the commit-SHA check
+    /// `gglib model upgrade` runs before downloading, distinct from the
+    /// shard-level diff on `/{id}/updates`.
+    ///
+    /// Not the same question as `gglib model check-updates`: with no recorded
+    /// revision this reports `has_update: true` (nothing to compare against)
+    /// where that command declines to answer. Callers should present a
+    /// `current_sha` of `None` as "no baseline recorded", not as a new release.
+    pub async fn check_upgrade(&self, id: i64) -> Result<UpgradeCheck, GuiError> {
+        let model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
+        let (repo, _quant) = Self::upgrade_source(&model)?;
+        let models_dir = gglib_core::paths::resolve_models_dir(None)
+            .map_err(|e| GuiError::Internal(format!("Could not resolve models dir: {e}")))?
+            .path;
+
+        let check =
+            gglib_download::cli_exec::check_update(&repo, model.hf_commit_sha.as_deref(), &models_dir)
+                .await
+                .map_err(|e| GuiError::Internal(format!("Update check failed: {e}")))?;
+
+        Ok(UpgradeCheck {
+            has_update: check.has_update,
+            current_sha: check.current_sha,
+            latest_sha: check.latest_sha,
+        })
+    }
+
+    /// Re-download the model at the latest HuggingFace revision and rewrite
+    /// the row — `gglib model upgrade`, shared by the CLI and the GUI route.
+    ///
+    /// Checks first and returns `updated: false` without downloading when the
+    /// model is already current. The HF token comes from the process
+    /// environment, matching the CLI. The call does not return until the
+    /// download finishes; queue integration is future work, as is any
+    /// serialisation between two upgrades of the same model (concurrent
+    /// callers both download and the last one wins the row).
+    pub async fn apply_upgrade(&self, id: i64) -> Result<UpgradeOutcome, GuiError> {
+        let mut model = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
+        let (repo, quant) = Self::upgrade_source(&model)?;
+        let models_dir = gglib_core::paths::resolve_models_dir(None)
+            .map_err(|e| GuiError::Internal(format!("Could not resolve models dir: {e}")))?
+            .path;
+
+        let check =
+            gglib_download::cli_exec::check_update(&repo, model.hf_commit_sha.as_deref(), &models_dir)
+                .await
+                .map_err(|e| GuiError::Internal(format!("Update check failed: {e}")))?;
+        if !check.has_update {
+            return Ok(UpgradeOutcome {
+                updated: false,
+                latest_sha: check.latest_sha,
+                file_path: None,
+            });
+        }
+
+        // Detached deliberately. The forced re-download deletes the existing
+        // file before writing its replacement, so if this ran inline in an
+        // Axum request future a client disconnect would drop it mid-transfer
+        // and leave the user with no model at all — while the row still
+        // pointed at the deleted path. Spawning means the download and the row
+        // rewrite always finish as a pair; only the reply is lost.
+        let core = self.deps.core.clone();
+        let request = gglib_download::cli_exec::CliUpdateRequest {
+            model_path: model.file_path.clone(),
+            repo_id: repo,
+            quantization: quant,
+            models_dir,
+            token: std::env::var("HF_TOKEN").ok(),
+        };
+
+        tokio::spawn(async move {
+            let result = gglib_download::cli_exec::update_model(request)
+                .await
+                .map_err(|e| GuiError::Internal(format!("Upgrade download failed: {e}")))?;
+
+            model.file_path = result.primary_path.clone();
+            model.hf_commit_sha = Some(result.commit_sha.clone());
+            model.last_update_check = Some(chrono::Utc::now());
+            core.models()
+                .update(&model)
+                .await
+                .map_err(|e| GuiError::Internal(format!("Failed to update model row: {e}")))?;
+
+            Ok(UpgradeOutcome {
+                updated: true,
+                latest_sha: result.commit_sha,
+                file_path: Some(result.primary_path.display().to_string()),
+            })
+        })
+        .await
+        .map_err(|e| GuiError::Internal(format!("Upgrade task panicked: {e}")))?
     }
 }
 

--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -13,9 +13,8 @@ use gglib_core::{
 use crate::error::GuiError;
 use crate::sampling_explain::{self, SamplingExplanationDto};
 use crate::types::{
-    RetagResponse, UpgradeCheck, UpgradeOutcome,
-    AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, SetCapabilitiesRequest,
-    UpdateModelRequest,
+    AddModelRequest, GuiModel, ModelDetailDto, RemoveModelRequest, RetagResponse,
+    SetCapabilitiesRequest, UpdateModelRequest, UpgradeCheck, UpgradeOutcome,
 };
 
 /// Dependencies for model operations.
@@ -408,10 +407,13 @@ impl ModelOps {
             .map_err(|e| GuiError::Internal(format!("Could not resolve models dir: {e}")))?
             .path;
 
-        let check =
-            gglib_download::cli_exec::check_update(&repo, model.hf_commit_sha.as_deref(), &models_dir)
-                .await
-                .map_err(|e| GuiError::Internal(format!("Update check failed: {e}")))?;
+        let check = gglib_download::cli_exec::check_update(
+            &repo,
+            model.hf_commit_sha.as_deref(),
+            &models_dir,
+        )
+        .await
+        .map_err(|e| GuiError::Internal(format!("Update check failed: {e}")))?;
 
         Ok(UpgradeCheck {
             has_update: check.has_update,
@@ -436,10 +438,13 @@ impl ModelOps {
             .map_err(|e| GuiError::Internal(format!("Could not resolve models dir: {e}")))?
             .path;
 
-        let check =
-            gglib_download::cli_exec::check_update(&repo, model.hf_commit_sha.as_deref(), &models_dir)
-                .await
-                .map_err(|e| GuiError::Internal(format!("Update check failed: {e}")))?;
+        let check = gglib_download::cli_exec::check_update(
+            &repo,
+            model.hf_commit_sha.as_deref(),
+            &models_dir,
+        )
+        .await
+        .map_err(|e| GuiError::Internal(format!("Update check failed: {e}")))?;
         if !check.has_update {
             return Ok(UpgradeOutcome {
                 updated: false,

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -461,6 +461,42 @@ pub struct SetCapabilitiesRequest {
     pub supports_reasoning: Option<bool>,
 }
 
+/// What a retag pass changed. Mirrors `gglib_core::services::RetagDiff`,
+/// with `changed` folded in so the wire needs no method call.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RetagResponse {
+    pub changed: bool,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub spec_changed: bool,
+}
+
+/// Whether a newer HuggingFace revision exists for a model.
+///
+/// `currentSha` is `None` when the model was imported without a recorded
+/// revision. The check treats that as "an update exists" (there is no
+/// baseline to compare against), so callers should present a missing
+/// baseline distinctly rather than as a genuine new revision.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeCheck {
+    pub has_update: bool,
+    pub current_sha: Option<String>,
+    pub latest_sha: String,
+}
+
+/// The outcome of applying an upgrade.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeOutcome {
+    /// False when the model was already at the latest revision.
+    pub updated: bool,
+    pub latest_sha: String,
+    /// The new on-disk path, present only when an upgrade ran.
+    pub file_path: Option<String>,
+}
+
 // ============================================================================
 // Settings Types
 // ============================================================================

--- a/crates/gglib-axum/src/handlers/model/models.rs
+++ b/crates/gglib-axum/src/handlers/model/models.rs
@@ -181,6 +181,41 @@ pub async fn filter_options(
     Ok(Json(state.models.get_filter_options().await?))
 }
 
+/// Request body for `POST /api/models/{id}/retag`.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct RetagBody {
+    #[serde(default)]
+    pub full: bool,
+}
+
+/// Re-run capability detection over a model's stored metadata —
+/// `gglib model retag` for one model.
+pub async fn retag(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(body): Json<RetagBody>,
+) -> Result<Json<gglib_app_services::types::RetagResponse>, HttpError> {
+    Ok(Json(state.models.retag(id, body.full).await?))
+}
+
+/// Commit-SHA update check — `gglib model check-updates` for one model,
+/// distinct from the shard-level diff on `/{id}/updates`.
+pub async fn check_upgrade(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<gglib_app_services::types::UpgradeCheck>, HttpError> {
+    Ok(Json(state.models.check_upgrade(id).await?))
+}
+
+/// Re-download at the latest HuggingFace revision and rewrite the row —
+/// `gglib model upgrade`. Blocking for the download's duration, like the CLI.
+pub async fn apply_upgrade(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<gglib_app_services::types::UpgradeOutcome>, HttpError> {
+    Ok(Json(state.models.apply_upgrade(id).await?))
+}
+
 pub async fn set_capabilities(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -182,10 +182,7 @@ fn model_routes() -> Router<AppState> {
             "/{id}/capabilities",
             axum::routing::patch(handlers::model::models::set_capabilities),
         )
-        .route(
-            "/{id}/retag",
-            post(handlers::model::models::retag),
-        )
+        .route("/{id}/retag", post(handlers::model::models::retag))
         .route(
             "/{id}/upgrade-check",
             get(handlers::model::models::check_upgrade),

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -182,6 +182,18 @@ fn model_routes() -> Router<AppState> {
             "/{id}/capabilities",
             axum::routing::patch(handlers::model::models::set_capabilities),
         )
+        .route(
+            "/{id}/retag",
+            post(handlers::model::models::retag),
+        )
+        .route(
+            "/{id}/upgrade-check",
+            get(handlers::model::models::check_upgrade),
+        )
+        .route(
+            "/{id}/upgrade",
+            post(handlers::model::models::apply_upgrade),
+        )
         // Full inspect view: GET /api/models/{id}/detail
         // Returns ModelDetailDto — superset of GuiModel with raw GGUF metadata,
         // MoE topology, HuggingFace provenance, inference defaults, and timestamps.

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -1141,3 +1141,73 @@ async fn proxy_start_pinned_accepts_a_minimal_body() {
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+/// The retag route is wired and accepts its body; an unknown id 404s after
+/// deserialization (the GUI's stale-list race, not a serde 400).
+#[tokio::test]
+async fn model_retag_is_wired_and_404s_on_unknown_id() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .method("POST")
+                .uri("/api/models/999999/retag")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"full": true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// Same contract for the upgrade pair.
+#[tokio::test]
+async fn model_upgrade_routes_are_wired_and_404_on_unknown_id() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
+
+    let check = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .uri("/api/models/999999/upgrade-check")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(check.status(), StatusCode::NOT_FOUND);
+
+    let apply = app
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .method("POST")
+                .uri("/api/models/999999/upgrade")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(apply.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/gglib-cli/src/handlers/model/download/update_model.rs
+++ b/crates/gglib-cli/src/handlers/model/download/update_model.rs
@@ -108,7 +108,10 @@ mod tests {
 
     #[test]
     fn short_sha_truncates_a_full_sha() {
-        assert_eq!(short_sha("0123456789abcdef0123456789abcdef01234567"), "01234567");
+        assert_eq!(
+            short_sha("0123456789abcdef0123456789abcdef01234567"),
+            "01234567"
+        );
     }
 
     #[test]

--- a/crates/gglib-cli/src/handlers/model/download/update_model.rs
+++ b/crates/gglib-cli/src/handlers/model/download/update_model.rs
@@ -1,78 +1,119 @@
 //! Update model handler.
 //!
-//! Updates a locally downloaded model to the latest version from HuggingFace.
+//! Upgrades a locally downloaded model to the latest HuggingFace revision.
+//! The check, the download and the row rewrite all live in
+//! [`ModelOps::check_upgrade`]/[`ModelOps::apply_upgrade`], the single shared
+//! implementation consumed by this CLI, the Axum WebUI and the Tauri app.
+//! What stays here is what only a terminal has: the plan, the prompt and the
+//! printed result.
 
-use anyhow::{Result, anyhow};
-use chrono::Utc;
-use gglib_download::cli_exec::{self, CliUpdateRequest};
+use std::sync::Arc;
+
+use anyhow::Result;
+use gglib_app_services::{ModelDeps, ModelOps};
 
 use crate::bootstrap::CliContext;
 use crate::handlers::model::resolver;
-use gglib_core::paths::resolve_models_dir;
 
 /// Execute the update-model command.
 ///
-/// Updates a model to the latest version from HuggingFace.
-pub async fn execute(ctx: &CliContext, identifier: &str) -> Result<()> {
-    let models_dir = resolve_models_dir(None)?.path;
+/// Upgrades a model to the latest revision from HuggingFace. `force` skips
+/// the confirmation prompt; everything else is identical to the GUI path.
+pub async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> Result<()> {
+    let model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
-    // Get model from database
-    let mut model = resolver::resolve_model_identifier(ctx, identifier).await?;
-
-    let hf_repo = model
-        .hf_repo_id
-        .as_ref()
-        .ok_or_else(|| anyhow!("Model is not from HuggingFace, cannot update"))?
-        .clone();
-
-    let quantization = model
-        .quantization
-        .as_ref()
-        .ok_or_else(|| anyhow!("Model has no quantization info stored"))?
-        .clone();
+    // `NoopModelRuntime` rather than `ctx.runner`: a one-shot CLI command has
+    // no shared `ProcessManager`, and the upgrade path never touches serving
+    // status. Same construction as `model capabilities`.
+    let ops = ModelOps::new(ModelDeps {
+        core: ctx.app.clone(),
+        runtime: Arc::new(gglib_core::ports::NoopModelRuntime),
+        gguf_parser: ctx.gguf_parser.clone(),
+    });
 
     println!("Updating model {} (ID: {})...", model.name, model.id);
-    println!("  Repository: {}", hf_repo);
-    println!("  Quantization: {}", quantization);
+    if let Some(repo) = model.hf_repo_id.as_deref() {
+        println!("  Repository: {repo}");
+    }
+    if let Some(quant) = model.quantization.as_deref() {
+        println!("  Quantization: {quant}");
+    }
 
-    // Check if update is available
-    let check_result =
-        cli_exec::check_update(&hf_repo, model.hf_commit_sha.as_deref(), &models_dir).await?;
+    let check = ops.check_upgrade(model.id).await?;
 
-    if !check_result.has_update {
+    if !check.has_update {
         println!(
             "✓ Model is already up to date (SHA: {})",
-            &check_result.latest_sha[..8]
+            short_sha(&check.latest_sha)
         );
         return Ok(());
     }
 
-    if let Some(ref current) = check_result.current_sha {
-        println!("  Current SHA: {}", &current[..8]);
+    match check.current_sha.as_deref() {
+        Some(current) => println!("  Current SHA: {}", short_sha(current)),
+        // No baseline recorded, so `has_update` above could not have said
+        // otherwise. Say that rather than implying a new release exists.
+        None => println!("  Current SHA: none recorded (cannot tell what changed)"),
     }
-    println!("  Latest SHA:  {}", &check_result.latest_sha[..8]);
+    println!("  Latest SHA:  {}", short_sha(&check.latest_sha));
 
-    // Build update request
-    let request = CliUpdateRequest {
-        model_path: model.file_path.clone(),
-        repo_id: hf_repo,
-        quantization,
-        models_dir,
-        token: std::env::var("HF_TOKEN").ok(),
-    };
+    // Confirmation prompt if not forced — this re-downloads the full model
+    // and overwrites the stored file path.
+    if !force {
+        println!();
+        println!("This will:");
+        println!("  • Re-download the model at the latest revision");
+        println!("  • Replace the current file and update the database row");
+        println!();
+        print!("Proceed? (y/N): ");
 
-    // Execute update
-    let result = cli_exec::update_model(request).await?;
+        use std::io::{self, Write};
+        io::stdout().flush()?;
 
-    // Update database record by modifying the model directly
-    model.file_path = result.primary_path.clone();
-    model.hf_commit_sha = Some(result.commit_sha.clone());
-    model.last_update_check = Some(Utc::now());
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
 
-    ctx.app.models().update(&model).await?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Upgrade cancelled.");
+            return Ok(());
+        }
+    }
 
-    println!("✓ Model updated successfully");
-    println!("  New SHA: {}", &result.commit_sha[..8]);
+    let outcome = ops.apply_upgrade(model.id).await?;
+
+    if outcome.updated {
+        println!("✓ Model updated successfully");
+        println!("  New SHA: {}", short_sha(&outcome.latest_sha));
+    } else {
+        // The revision moved back under us between check and apply.
+        println!(
+            "✓ Model is already up to date (SHA: {})",
+            short_sha(&outcome.latest_sha)
+        );
+    }
 
     Ok(())
+}
+
+/// First 8 characters of a commit SHA, without assuming there are 8.
+/// HuggingFace returns 40, but a truncated or empty value must not panic a
+/// command whose whole job is repairing a model.
+fn short_sha(sha: &str) -> &str {
+    &sha[..sha.len().min(8)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::short_sha;
+
+    #[test]
+    fn short_sha_truncates_a_full_sha() {
+        assert_eq!(short_sha("0123456789abcdef0123456789abcdef01234567"), "01234567");
+    }
+
+    #[test]
+    fn short_sha_tolerates_shorter_input() {
+        assert_eq!(short_sha("abc"), "abc");
+        assert_eq!(short_sha(""), "");
+    }
 }

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -130,10 +130,23 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
             model_id,
             quantization,
             list_quants,
-            skip_db: _skip_db,
+            skip_db,
             token,
             force,
         } => {
+            // Registration happens daemon-side as a queue lifecycle phase, so
+            // honouring this flag needs a protocol change. Say so rather than
+            // registering silently — but do not refuse the download: the flag
+            // was already a no-op, and failing here would break invocations
+            // that used to work. `--list-quants` never touched the database,
+            // so it is not worth a warning at all.
+            if skip_db && !list_quants {
+                eprintln!(
+                    "warning: --skip-db is not currently honoured — downloads register through \
+                     the daemon queue. The download will proceed and the model will be \
+                     registered; `gglib model remove <id>` drops the row and keeps the file."
+                );
+            }
             let args = download::DownloadArgs {
                 model_id: &model_id,
                 quantization: quantization.as_deref(),
@@ -146,11 +159,8 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
         ModelCommand::CheckUpdates { identifier, all } => {
             download::check_updates(ctx, identifier.as_deref(), all).await?;
         }
-        ModelCommand::Upgrade {
-            identifier,
-            force: _force,
-        } => {
-            download::update_model(ctx, &identifier).await?;
+        ModelCommand::Upgrade { identifier, force } => {
+            download::update_model(ctx, &identifier, force).await?;
         }
         ModelCommand::Search {
             query,

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -284,7 +284,9 @@ pub enum ModelCommand {
         /// List available quantizations for the model
         #[arg(long)]
         list_quants: bool,
-        /// Skip adding to database after download (models are registered by default)
+        /// Not currently honoured: the daemon owns the download and registers
+        /// the model when it completes. Downloads still run; use
+        /// `gglib model remove <id>` afterwards to drop the row and keep the file.
         #[arg(long)]
         skip_db: bool,
         /// HuggingFace token for private models (for `--list-quants` only).

--- a/crates/gglib-download/src/cli_exec/exec/mod.rs
+++ b/crates/gglib-download/src/cli_exec/exec/mod.rs
@@ -37,8 +37,10 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
         hf_hub::RepoType::Model,
         "main".to_string(),
     ));
-    let repo_info = repo
-        .info()
+    // Synchronous ureq call — see the note in `check_update`.
+    let repo_info = tokio::task::spawn_blocking(move || repo.info())
+        .await
+        .map_err(|e| anyhow!("Repo info task panicked: {e}"))?
         .map_err(|e| anyhow!("Failed to get repo info: {e}"))?;
     let commit_sha = repo_info.sha.clone();
     gglib_core::telemetry::console_println(&format!("Found repository, commit SHA: {commit_sha}"));
@@ -111,6 +113,11 @@ pub(super) async fn download(request: CliDownloadRequest) -> Result<CliDownloadR
 }
 
 /// Check if a model has an update available.
+///
+/// `has_update` is true when no `current_sha` is recorded: there is no
+/// baseline to compare against, so the caller cannot claim the model is
+/// current. Callers that surface this to a user should distinguish that case
+/// from a genuine new revision.
 pub async fn check_update(
     repo_id: &str,
     current_sha: Option<&str>,
@@ -123,8 +130,13 @@ pub async fn check_update(
         "main".to_string(),
     ));
 
-    let repo_info = repo
-        .info()
+    // `hf_hub`'s API here is the synchronous (ureq) client with no timeout, so
+    // calling it directly would park a tokio worker for the length of the
+    // round-trip. Now that the daemon reaches this path via the upgrade
+    // routes, that has to move off the async workers.
+    let repo_info = tokio::task::spawn_blocking(move || repo.info())
+        .await
+        .map_err(|e| anyhow!("Repo info task panicked: {e}"))?
         .map_err(|e| anyhow!("Failed to get repo info: {e}"))?;
 
     let latest_sha = repo_info.sha;

--- a/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
+++ b/src/components/ModelInspectorPanel/ModelInspectorPanel.tsx
@@ -1,10 +1,12 @@
-import { FC, useCallback, useEffect } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
+import { retagModel } from '../../services/transport/api/models/local';
 import { cn } from '../../utils/cn';
 import { appLogger } from '../../services/platform';
 import { GgufModel, ModelDetail, ServerInfo, HfModelSummary } from '../../types';
 import type { DownloadQueueStatus } from '../../services/transport/types/downloads';
 import { useSettings } from '../../hooks/useSettings';
 import { useToastContext } from '../../contexts/ToastContext';
+import { useConfirmContext } from '../../contexts/ConfirmContext';
 import { HfModelPreview } from '../HfModelPreview';
 import {
   useEditMode,
@@ -18,6 +20,7 @@ import {
   ModelMetadataGrid,
   ModelEditForm,
   InspectorTags,
+  InspectorCapabilities,
   ServeModal,
   DeleteModal,
   InspectorHeader,
@@ -75,6 +78,7 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
 }) => {
   const { settings } = useSettings();
   const { showToast } = useToastContext();
+  const { confirm } = useConfirmContext();
 
   // Install / verify / update modal state
   const modals = useInspectorModals();
@@ -103,6 +107,55 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
   const hasMtpTag = detail.tags.some(tag => tag.toLowerCase() === 'mtp');
 
   // Server actions hook
+  const [retagging, setRetagging] = useState(false);
+  const handleRetag = useCallback(
+    async (full: boolean) => {
+      if (model?.id == null) return;
+
+      // Rebuild drops detected tags the GGUF no longer yields, hand-added ones
+      // included — and those tags decide launch flags and response parsing.
+      if (full) {
+        const confirmed = await confirm({
+          title: 'Rebuild detected tags?',
+          description:
+            'Re-derives the capability tags and dialect spec from the GGUF. Detected tags it no ' +
+            'longer finds are dropped, including any you added by hand — a manual "reasoning" tag ' +
+            'forcing a reasoning format would be lost. Tags outside that set are untouched.',
+          confirmLabel: 'Rebuild',
+          variant: 'danger',
+        });
+        if (!confirmed) return;
+      }
+
+      setRetagging(true);
+      try {
+        const diff = await retagModel(model.id, full);
+        if (!diff.changed) {
+          showToast('Tags already up to date', 'success');
+        } else {
+          const parts = [
+            diff.added.length > 0 ? `added ${diff.added.length}` : null,
+            diff.removed.length > 0 ? `removed ${diff.removed.length}` : null,
+            diff.specChanged ? 'dialect spec re-derived' : null,
+          ].filter(Boolean);
+          // Counts, not full lists: the chips reload right below, and a
+          // removal is the half worth pausing on, so it gets longer on screen.
+          showToast(
+            `Retagged: ${parts.join(', ')}`,
+            'success',
+            diff.removed.length > 0 ? 8000 : undefined,
+          );
+        }
+        await detail.reload();
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : String(err), 'error');
+      } finally {
+        setRetagging(false);
+      }
+    },
+    [model?.id, detail, showToast, confirm],
+  );
+
   const serverActions = useServerActions({
     model,
     settings,
@@ -227,7 +280,18 @@ const ModelInspectorPanel: FC<ModelInspectorPanelProps> = ({
             onNewTagInputChange={detail.setNewTagInput}
             onAddTag={detail.addTag}
             onRemoveTag={detail.removeTag}
+            onRetag={handleRetag}
+            retagging={retagging}
           />
+
+          {!editMode.isEditMode && model?.id != null && (
+            <InspectorCapabilities
+              modelId={model.id}
+              capabilities={detail.modelDetail?.capabilities}
+              onChanged={() => void detail.reload()}
+              onError={(message: string) => showToast(message, 'error')}
+            />
+          )}
         </div>
       </div>
 

--- a/src/components/ModelInspectorPanel/components/InspectorCapabilities.tsx
+++ b/src/components/ModelInspectorPanel/components/InspectorCapabilities.tsx
@@ -1,0 +1,87 @@
+import { FC, useState } from 'react';
+import { Checkbox } from '../../ui/Checkbox';
+import { CAPABILITY_FLAGS, type CapabilityFlagName } from '../../../types';
+import { setModelCapabilities } from '../../../services/transport/api/models/local';
+
+interface InspectorCapabilitiesProps {
+  modelId: number;
+  /** The capability bitfield from the model detail. Absent/0 = pass-through. */
+  capabilities: number | undefined;
+  /** Called after a successful change so the owner can reload the detail. */
+  onChanged: () => void;
+  onError: (message: string) => void;
+}
+
+const FLAG_COPY: Record<CapabilityFlagName, { label: string; description: string }> = {
+  supportsSystemRole: {
+    label: 'Supports system role',
+    description: 'Off: system messages are converted to user messages before dispatch.',
+  },
+  requiresStrictTurns: {
+    label: 'Requires strict turns',
+    description: 'On: consecutive same-role messages are merged before dispatch.',
+  },
+  supportsToolCalls: {
+    label: 'Supports tool calls',
+    description: 'Off: tool definitions (tools/tool_choice) are stripped from requests.',
+  },
+  supportsReasoning: {
+    label: 'Supports reasoning',
+    description: 'Informational only — reasoning extraction follows the "reasoning" tag above.',
+  },
+};
+
+/**
+ * Capability flags editor — the GUI face of `gglib model capabilities`.
+ * Each toggle PATCHes one flag; the server returns the updated model and
+ * the owner reloads. All flags unset means pass-through mode.
+ */
+export const InspectorCapabilities: FC<InspectorCapabilitiesProps> = ({
+  modelId,
+  capabilities,
+  onChanged,
+  onError,
+}) => {
+  const [saving, setSaving] = useState(false);
+  const bits = capabilities ?? 0;
+
+  const toggle = async (flag: CapabilityFlagName, value: boolean) => {
+    setSaving(true);
+    try {
+      await setModelCapabilities(modelId, { [flag]: value });
+      onChanged();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="mb-xl">
+      <h3 className="m-0 mb-xs text-sm font-semibold text-text">Capabilities</h3>
+      <p className="m-0 mb-xs text-xs text-text-muted">
+        How the pipeline shapes messages for this model. Set at import from the GGUF; correct
+        them here when detection got it wrong. Separate from the tags above — re-detecting tags
+        does not change these.
+      </p>
+      <p className="m-0 mb-base text-xs text-text-muted">
+        {bits === 0
+          ? 'All unset: messages pass through untouched. Ticking any one box switches this model to enforced shaping, at which point the three boxes left unticked start being applied as “no”.'
+          : 'Enforced: every unticked box is applied as “no”, not as “unknown”. Untick all four to return to pass-through.'}
+      </p>
+      <div className="flex flex-col gap-sm">
+        {(Object.keys(CAPABILITY_FLAGS) as CapabilityFlagName[]).map((flag) => (
+          <Checkbox
+            key={flag}
+            checked={(bits & CAPABILITY_FLAGS[flag]) !== 0}
+            disabled={saving}
+            onChange={(e) => void toggle(flag, e.target.checked)}
+            label={FLAG_COPY[flag].label}
+            description={FLAG_COPY[flag].description}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/components/ModelInspectorPanel/components/InspectorTags.tsx
+++ b/src/components/ModelInspectorPanel/components/InspectorTags.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { Button } from '../../ui/Button';
 import { TagChips } from './TagChips';
 import { TagAddInput } from './TagAddInput';
 
@@ -8,10 +9,19 @@ interface InspectorTagsProps {
   onNewTagInputChange: (value: string) => void;
   onAddTag: () => void;
   onRemoveTag: (tag: string) => void;
+  /** Re-run capability detection; `full` rebuilds the system-tag namespace. */
+  onRetag: (full: boolean) => void;
+  retagging: boolean;
 }
 
 /**
  * Tag list plus the add-tag input, under a section heading.
+ *
+ * Tags drive launch flags and response parsing (`reasoning` selects the
+ * reasoning format, `format:*` the chat dialect), which is why Rebuild is
+ * destructive: it re-derives that whole namespace from the GGUF and drops
+ * anything in it that detection no longer produces, including tags added by
+ * hand. It is styled and confirmed as a destructive action for that reason.
  */
 export const InspectorTags: FC<InspectorTagsProps> = ({
   tags,
@@ -19,11 +29,36 @@ export const InspectorTags: FC<InspectorTagsProps> = ({
   onNewTagInputChange,
   onAddTag,
   onRemoveTag,
+  onRetag,
+  retagging,
 }) => (
   <section className="mb-xl">
-    <h3 className="m-0 mb-base text-sm font-semibold text-text">
-      Tags
-    </h3>
+    <div className="flex items-center justify-between gap-md mb-xs">
+      <h3 className="m-0 text-sm font-semibold text-text">Tags</h3>
+      <div className="flex gap-xs">
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={retagging}
+          onClick={() => onRetag(false)}
+        >
+          Re-detect
+        </Button>
+        <Button
+          variant="dangerGhost"
+          size="sm"
+          disabled={retagging}
+          onClick={() => onRetag(true)}
+        >
+          Rebuild
+        </Button>
+      </div>
+    </div>
+    <p className="m-0 mb-base text-xs text-text-muted">
+      Re-detect adds missing capability tags and removes nothing. Rebuild re-derives them from
+      the GGUF, dropping detected tags it no longer finds — including ones you added by hand,
+      such as a manual <code className="font-mono">reasoning</code> tag.
+    </p>
     <div className="flex flex-col gap-base">
       <TagChips tags={tags} onRemoveTag={onRemoveTag} />
       <TagAddInput value={newTagInput} onChange={onNewTagInputChange} onAdd={onAddTag} />

--- a/src/components/ModelInspectorPanel/components/index.ts
+++ b/src/components/ModelInspectorPanel/components/index.ts
@@ -9,6 +9,7 @@ export { TagAddInput } from './TagAddInput';
 export { ServeModal } from './ServeModal';
 export { DeleteModal } from './DeleteModal';
 export { InspectorTags } from './InspectorTags';
+export { InspectorCapabilities } from './InspectorCapabilities';
 export { InspectorHeader } from './InspectorHeader';
 export { InspectorFooter } from './InspectorFooter';
 export { InspectorEmptyState } from './InspectorEmptyState';

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -213,11 +213,11 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
       setTrustClientSampling(false); // Default is disabled
       setProxyLoopDetection(true); // Default is enabled
       resetDesktop();
-    setDownloadPathInput('');
-    network.reset();
-    agentGuards.reset();
+      setDownloadPathInput('');
+      network.reset();
+      agentGuards.reset();
     }
-  }, [info, settings, resetDesktop]);
+  }, [info, settings, resetDesktop, network, agentGuards]);
 
   const handleRefresh = useCallback(() => {
     refreshDir();

--- a/src/components/VerificationModal.tsx
+++ b/src/components/VerificationModal.tsx
@@ -14,6 +14,10 @@ import type { VerificationEvent } from '../services/transport/types/events';
 import { appLogger } from '../services/platform';
 import { useConfirmContext } from '../contexts/ConfirmContext';
 import type { VerificationReport, UpdateCheckResult, OverallHealth } from '../services/transport';
+import type { UpgradeCheck } from '../types';
+
+/** Commit SHAs are 40 hex chars; 8 is the conventional readable prefix. */
+const shortSha = (sha: string) => sha.slice(0, 8);
 
 interface VerificationModalProps {
   modelId: number;
@@ -25,6 +29,10 @@ interface VerificationModalProps {
 
 export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelName, open, onClose, mode }) => {
   const [verifying, setVerifying] = useState(false);
+  const [upgrading, setUpgrading] = useState(false);
+  const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
+  const [upgradeCheck, setUpgradeCheck] = useState<UpgradeCheck | null>(null);
+  const [upgradeCheckFailed, setUpgradeCheckFailed] = useState(false);
   const [progress, setProgress] = useState<{ shardName: string; percent: number } | null>(null);
   const [report, setReport] = useState<VerificationReport | null>(null);
   const [updateResult, setUpdateResult] = useState<UpdateCheckResult | null>(null);
@@ -49,6 +57,29 @@ export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelNa
 
     return () => unsubscribe();
   }, [open, modelId]);
+
+  // Answer "am I on the latest revision?" up front, so the upgrade below is a
+  // decision rather than a gamble. Cheap (one HF metadata call) and it is the
+  // only way to learn the answer without committing to a full re-download.
+  useEffect(() => {
+    if (!open || mode !== 'update') return;
+    let cancelled = false;
+    setUpgradeCheck(null);
+    setUpgradeCheckFailed(false);
+    void getTransport()
+      .checkModelUpgrade(modelId)
+      .then((check) => {
+        if (!cancelled) setUpgradeCheck(check);
+      })
+      .catch((err) => {
+        // Non-fatal: the section says so and still offers the re-download.
+        appLogger.warn('component', 'Upgrade check failed', { error: err, modelId });
+        if (!cancelled) setUpgradeCheckFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, mode, modelId]);
 
   const handleVerify = async () => {
     setVerifying(true);
@@ -83,6 +114,51 @@ export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelNa
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setCheckingUpdates(false);
+    }
+  };
+
+  /**
+   * SHA-level re-download (`gglib model upgrade`), distinct from the
+   * shard-repair path above: that fetches the shards whose contents changed,
+   * this replaces the whole model at a newer repository revision.
+   *
+   * Confirmed through the same dialog as repair, not a label swap — it
+   * replaces a file that may be tens of gigabytes. The modal is sealed while
+   * it runs; the download itself completes server-side regardless.
+   */
+  const handleUpgrade = async () => {
+    const confirmed = await confirm({
+      title: 'Re-download at the latest revision?',
+      description:
+        `This downloads the whole of "${modelName}" again and replaces the current file. ` +
+        'There is no progress reporting yet, and it can take a long time on a large model — ' +
+        'leave gglib running until it finishes.',
+      confirmLabel: 'Re-download',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+
+    setUpgrading(true);
+    setError(null);
+    setUpgradeMessage(null);
+    try {
+      const outcome = await getTransport().upgradeModel(modelId);
+      setUpgradeMessage(
+        outcome.updated
+          ? `Upgraded to revision ${shortSha(outcome.latestSha)}`
+          : `Already at the latest revision (${shortSha(outcome.latestSha)})`,
+      );
+      setUpgradeCheck({
+        hasUpdate: false,
+        currentSha: outcome.latestSha,
+        latestSha: outcome.latestSha,
+      });
+      appLogger.info('component', 'Model upgrade finished', { modelId, updated: outcome.updated });
+    } catch (err) {
+      appLogger.error('component', 'Model upgrade failed', { error: err, modelId });
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUpgrading(false);
     }
   };
 
@@ -148,6 +224,22 @@ export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelNa
 
   const hasUpdates = updateResult?.update_available ?? false;
 
+  /**
+   * The revision check in one sentence. A model imported without a recorded
+   * revision reports `hasUpdate` only because there is no baseline to compare
+   * against — calling that "an update is available" would be a guess, so it
+   * says what is actually known instead.
+   */
+  const revisionSummary = upgradeCheckFailed
+    ? 'Could not reach HuggingFace to compare revisions.'
+    : !upgradeCheck
+      ? 'Checking the repository revision…'
+      : upgradeCheck.currentSha == null
+        ? `No revision is recorded for this model, so there is nothing to compare. Re-downloading fetches ${shortSha(upgradeCheck.latestSha)} and records it.`
+        : upgradeCheck.hasUpdate
+          ? `A newer revision is available: ${shortSha(upgradeCheck.currentSha)} → ${shortSha(upgradeCheck.latestSha)}.`
+          : `Already at the latest revision (${shortSha(upgradeCheck.currentSha)}).`;
+
   const modalTitle = mode === 'verify' ? `Verify: ${modelName}` : `Check Updates: ${modelName}`;
 
   const footerAction =
@@ -168,7 +260,7 @@ export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelNa
       onClose={onClose}
       title={modalTitle}
       size="md"
-      preventClose={verifying || repairing || checkingUpdates}
+      preventClose={verifying || repairing || checkingUpdates || upgrading}
       footer={footerAction ?? undefined}
     >
       <div className="flex flex-col gap-4">
@@ -276,12 +368,12 @@ export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelNa
               {hasUpdates ? (
                 <>
                   <Icon icon={RefreshCw} size={20} className="text-blue-400" />
-                  <span className="font-semibold text-primary">Updates Available</span>
+                  <span className="font-semibold text-primary">Shard Updates Available</span>
                 </>
               ) : (
                 <>
                   <Icon icon={CheckCircle2} size={20} className="text-green-400" />
-                  <span className="font-semibold text-primary">Model is Up to Date</span>
+                  <span className="font-semibold text-primary">Shards Are Up to Date</span>
                 </>
               )}
             </div>
@@ -328,6 +420,32 @@ export const VerificationModal: FC<VerificationModalProps> = ({ modelId, modelNa
               </Button>
             )}
           </div>
+        )}
+
+        {/* Full-revision upgrade — the GUI face of `gglib model upgrade` */}
+        {mode === 'update' && (
+          <section className="flex flex-col gap-sm mt-xl">
+            <h3 className="m-0 text-sm font-semibold text-text">Full re-download</h3>
+            <p className="text-xs text-text-muted m-0">
+              The check above compares shard contents. This compares the repository revision and
+              replaces the entire model file with the newest one.
+            </p>
+            <p className="text-xs text-text-muted m-0">{revisionSummary}</p>
+            <Button
+              variant="secondary"
+              isLoading={upgrading}
+              disabled={upgrading || upgradeCheck?.hasUpdate === false}
+              onClick={handleUpgrade}
+              className="w-full"
+            >
+              {upgrading ? 'Re-downloading…' : 'Re-download at latest revision'}
+            </Button>
+            {upgradeMessage && (
+              <p className="text-xs text-text-muted m-0" role="status">
+                {upgradeMessage}
+              </p>
+            )}
+          </section>
         )}
 
       </div>

--- a/src/services/transport/api/client.ts
+++ b/src/services/transport/api/client.ts
@@ -72,7 +72,7 @@ export interface HttpClient {
  * Request options for HTTP client.
  */
 interface RequestOptions {
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: unknown;
 }
 
@@ -316,6 +316,14 @@ export async function post<T>(path: string, body?: unknown): Promise<T> {
 export async function put<T>(path: string, body: unknown): Promise<T> {
   const client = await getClient();
   return client.request<T>(path, { method: 'PUT', body });
+}
+
+/**
+ * Helper for PATCH requests.
+ */
+export async function patch<T>(path: string, body: unknown): Promise<T> {
+  const client = await getClient();
+  return client.request<T>(path, { method: 'PATCH', body });
 }
 
 /**

--- a/src/services/transport/api/models/local.ts
+++ b/src/services/transport/api/models/local.ts
@@ -3,7 +3,7 @@
  * Handles local model CRUD operations, search, filtering, and system info.
  */
 
-import { get, post, put, del } from '../client';
+import { del, get, patch, post, put } from '../client';
 import { TransportError } from '../../errors';
 import type { ModelId } from '../../types/ids';
 import type {
@@ -11,10 +11,13 @@ import type {
   ModelDetail,
   AddModelParams,
   UpdateModelParams,
-  SearchModelsParams,
   ModelFilterOptions,
   SystemMemoryInfo,
   ModelsDirectoryInfo,
+  RetagResponse,
+  SetCapabilitiesRequest,
+  UpgradeCheck,
+  UpgradeOutcome,
 } from '../../types/models';
 import type { SamplingExplanation } from '../../../../types';
 
@@ -111,32 +114,34 @@ export async function updateModel(params: UpdateModelParams): Promise<GgufModel>
 }
 
 /**
- * Search local models with filters.
+ * Re-run capability detection over a model's stored metadata
+ * (`gglib model retag`). `full` rebuilds the system-tag namespace.
  */
-export async function searchModels(params: SearchModelsParams): Promise<GgufModel[]> {
-  const queryParams = new URLSearchParams();
-  
-  if (params.query) {
-    queryParams.set('query', params.query);
-  }
-  if (params.tags?.length) {
-    queryParams.set('tags', params.tags.join(','));
-  }
-  if (params.quantizations?.length) {
-    queryParams.set('quantizations', params.quantizations.join(','));
-  }
-  if (params.minParams !== undefined) {
-    queryParams.set('min_params', String(params.minParams));
-  }
-  if (params.maxParams !== undefined) {
-    queryParams.set('max_params', String(params.maxParams));
-  }
-  
-  const queryString = queryParams.toString();
-  const path = queryString ? `/api/models/search?${queryString}` : '/api/models/search';
-  
-  return get<GgufModel[]>(path);
+export async function retagModel(modelId: number, full = false): Promise<RetagResponse> {
+  return post<RetagResponse>(`/api/models/${modelId}/retag`, { full });
 }
+
+/** Set or clear a model's capability flags. Returns the updated model. */
+export async function setModelCapabilities(
+  modelId: number,
+  request: SetCapabilitiesRequest,
+): Promise<GgufModel> {
+  return patch<GgufModel>(`/api/models/${modelId}/capabilities`, request);
+}
+
+/** Commit-SHA update check (`gglib model check-updates` for one model). */
+export async function checkModelUpgrade(modelId: number): Promise<UpgradeCheck> {
+  return get<UpgradeCheck>(`/api/models/${modelId}/upgrade-check`);
+}
+
+/**
+ * Re-download at the latest HuggingFace revision (`gglib model upgrade`).
+ * Blocking for the download's duration — callers show a busy state.
+ */
+export async function upgradeModel(modelId: number): Promise<UpgradeOutcome> {
+  return post<UpgradeOutcome>(`/api/models/${modelId}/upgrade`, null);
+}
+
 
 /**
  * Get available filter options (tags, quantizations, parameter ranges).

--- a/src/services/transport/types/models.ts
+++ b/src/services/transport/types/models.ts
@@ -20,6 +20,10 @@ import type {
   HfSortField,
   ModelFilterOptions,
   RangeValues,
+  RetagResponse,
+  SetCapabilitiesRequest,
+  UpgradeCheck,
+  UpgradeOutcome,
 } from '../../../types';
 
 // Re-export existing types that clients already use
@@ -39,6 +43,10 @@ export type {
   HfSortField,
   ModelFilterOptions,
   RangeValues,
+  RetagResponse,
+  SetCapabilitiesRequest,
+  UpgradeCheck,
+  UpgradeOutcome,
 };
 
 /**
@@ -62,17 +70,6 @@ export interface UpdateModelParams {
 }
 
 /**
- * Parameters for searching local models.
- */
-export interface SearchModelsParams {
-  query?: string;
-  tags?: string[];
-  quantizations?: string[];
-  minParams?: number;
-  maxParams?: number;
-}
-
-/**
  * Models transport operations.
  */
 export interface ModelsTransport {
@@ -89,7 +86,14 @@ export interface ModelsTransport {
   updateModel(params: UpdateModelParams): Promise<GgufModel>;
 
   // Filtering
-  searchModels(params: SearchModelsParams): Promise<GgufModel[]>;
+  /** Re-run capability detection (`gglib model retag`). */
+  retagModel(modelId: number, full?: boolean): Promise<RetagResponse>;
+  /** Set or clear capability flags. Returns the updated model. */
+  setModelCapabilities(modelId: number, request: SetCapabilitiesRequest): Promise<GgufModel>;
+  /** Commit-SHA update check for one model. */
+  checkModelUpgrade(modelId: number): Promise<UpgradeCheck>;
+  /** Re-download at the latest HuggingFace revision. Blocking. */
+  upgradeModel(modelId: number): Promise<UpgradeOutcome>;
   getModelFilterOptions(): Promise<ModelFilterOptions>;
 
   // HuggingFace browsing

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,46 @@ export interface InferenceConfig {
   seed?: number;
 }
 
+/** Capability bitflags, mirroring `gglib_core::domain::ModelCapabilities` (a bare u32 on the wire). */
+export const CAPABILITY_FLAGS = {
+  supportsSystemRole: 0b0001,
+  requiresStrictTurns: 0b0010,
+  supportsToolCalls: 0b0100,
+  supportsReasoning: 0b1000,
+} as const;
+
+export type CapabilityFlagName = keyof typeof CAPABILITY_FLAGS;
+
+/** `PATCH /api/models/{id}/capabilities` body — absent fields are left unchanged. */
+export interface SetCapabilitiesRequest {
+  supportsSystemRole?: boolean;
+  requiresStrictTurns?: boolean;
+  supportsToolCalls?: boolean;
+  supportsReasoning?: boolean;
+}
+
+/** What a retag pass changed (`POST /api/models/{id}/retag`). */
+export interface RetagResponse {
+  changed: boolean;
+  added: string[];
+  removed: string[];
+  specChanged: boolean;
+}
+
+/** Commit-SHA update check (`GET /api/models/{id}/upgrade-check`). */
+export interface UpgradeCheck {
+  hasUpdate: boolean;
+  currentSha?: string | null;
+  latestSha: string;
+}
+
+/** Outcome of `POST /api/models/{id}/upgrade`. */
+export interface UpgradeOutcome {
+  updated: boolean;
+  latestSha: string;
+  filePath?: string | null;
+}
+
 /**
  * A named sampling profile, selectable per request as `<model>:<profile>`.
  *
@@ -245,6 +285,8 @@ export interface ServerConfig {
 // ============================================================================
 
 export interface GgufModel {
+  /** Capability bitfield — see CAPABILITY_FLAGS. Absent/0 = unknown, pass-through. */
+  capabilities?: number;
   id?: number;
   name: string;
   filePath: string;

--- a/tests/ts/components/InspectorCapabilities.test.tsx
+++ b/tests/ts/components/InspectorCapabilities.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for the capabilities editor — the GUI face of
+ * `gglib model capabilities`. Bits render as checkboxes; each toggle
+ * PATCHes exactly one flag and reports back to the owner.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InspectorCapabilities } from '../../../src/components/ModelInspectorPanel/components/InspectorCapabilities';
+import { setModelCapabilities } from '../../../src/services/transport/api/models/local';
+
+vi.mock('../../../src/services/transport/api/models/local', () => ({
+  setModelCapabilities: vi.fn().mockResolvedValue({}),
+}));
+
+const mockSet = vi.mocked(setModelCapabilities);
+
+describe('InspectorCapabilities', () => {
+  beforeEach(() => {
+    mockSet.mockClear();
+  });
+
+  it('renders the bitfield as checkbox state', () => {
+    // supportsSystemRole (1) + supportsToolCalls (4)
+    render(
+      <InspectorCapabilities modelId={7} capabilities={0b0101} onChanged={vi.fn()} onError={vi.fn()} />,
+    );
+
+    expect(screen.getByLabelText(/Supports system role/)).toBeChecked();
+    expect(screen.getByLabelText(/Requires strict turns/)).not.toBeChecked();
+    expect(screen.getByLabelText(/Supports tool calls/)).toBeChecked();
+    expect(screen.getByLabelText(/Supports reasoning/)).not.toBeChecked();
+  });
+
+  it('names pass-through mode when every flag is unset', () => {
+    render(
+      <InspectorCapabilities modelId={7} capabilities={0} onChanged={vi.fn()} onError={vi.fn()} />,
+    );
+    expect(screen.getByText(/messages pass through untouched/)).toBeInTheDocument();
+  });
+
+  // The trap this warns about is real: a non-empty bitfield makes every
+  // unticked box mean "no", so ticking one flag silently enforces three.
+  it('warns that ticking one flag starts enforcing the rest', () => {
+    render(
+      <InspectorCapabilities modelId={7} capabilities={0} onChanged={vi.fn()} onError={vi.fn()} />,
+    );
+    expect(screen.getByText(/Ticking any one box/)).toBeInTheDocument();
+  });
+
+  it('says unticked means no once any flag is set', () => {
+    render(
+      <InspectorCapabilities modelId={7} capabilities={0b1000} onChanged={vi.fn()} onError={vi.fn()} />,
+    );
+    expect(screen.getByText(/every unticked box is applied as/)).toBeInTheDocument();
+    expect(screen.queryByText(/messages pass through untouched/)).not.toBeInTheDocument();
+  });
+
+  it('patches exactly the toggled flag and reports the change', async () => {
+    const onChanged = vi.fn();
+    render(
+      <InspectorCapabilities modelId={7} capabilities={0} onChanged={onChanged} onError={vi.fn()} />,
+    );
+
+    await userEvent.click(screen.getByLabelText(/Supports reasoning/));
+
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(mockSet).toHaveBeenCalledWith(7, { supportsReasoning: true });
+  });
+
+  it('routes failures to the owner instead of swallowing them', async () => {
+    mockSet.mockRejectedValueOnce(new Error('capabilities update failed'));
+    const onError = vi.fn();
+    render(
+      <InspectorCapabilities modelId={7} capabilities={0} onChanged={vi.fn()} onError={onError} />,
+    );
+
+    await userEvent.click(screen.getByLabelText(/Supports tool calls/));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('capabilities update failed'));
+  });
+});


### PR DESCRIPTION
## What

PR 9 of the GUI restyle + CLI/GUI parity stack. Brings model maintenance to the GUI: capability flags, tag re-detection, and the SHA-level upgrade — three things `gglib model` could do that the inspector could not.

Stacked on `feat(gui)/settings-parity` (#765). Review only the top two commits.

## Parity closed

| CLI | GUI |
|---|---|
| `gglib model capabilities --set/--unset` | Capabilities checkboxes in the inspector |
| `gglib model retag [--full]` | Re-detect / Rebuild on the Tags heading |
| `gglib model upgrade` | Full re-download in the update modal |

## Notes for review

**The upgrade download is spawned, not awaited inline.** A forced re-download deletes the existing file before writing its replacement. Run inline in the Axum request future, a client disconnect would drop it mid-transfer and leave the user with no model file at all, while the row still pointed at the deleted path. Spawning means the download and the row rewrite always complete as a pair; only the HTTP reply can be lost.

**The CLI is refactored onto the shared ops**, not forked from them. `update_model.rs` now resolves the identifier, calls `check_upgrade`, prints and prompts, then calls `apply_upgrade` — the same two calls the route makes. Costs one extra HF metadata request per upgrade (apply re-checks internally) and gains a single implementation of the orchestration.

**`check_upgrade` is not `gglib model check-updates`.** With no recorded revision it reports `hasUpdate: true` because there is no baseline, where that command declines to answer. Both the DTO doc and the modal say so rather than presenting a missing baseline as a new release.

**Known gaps, deliberately not in scope:** no progress reporting on the upgrade (the ops layer defers queue integration), and no server-side serialisation between two concurrent upgrades of the same model — both callers download and the last one wins the row. The GUI disables its own button while upgrading, so only multi-client double-fire is exposed.

## Not shipped

`--skip-db` is still not honoured — the daemon owns downloads and registers on completion — but it now says so on stderr and lets the download proceed, rather than refusing. Refusing would have broken invocations that previously worked, including `--list-quants`, which never touched the database at all. `gglib model remove <id>` drops the row while leaving the file, reproducing what the flag used to promise.

## Test plan

- `cargo test` across app-services, axum, cli, download — green, including new 404 route tests for retag and upgrade
- `npm test` — 788 passing, including three new tests pinning the capabilities copy in both bitfield states
- `npm run lint`, `npx tsc --noEmit`, `npm run build` — clean

