### PR TITLE
feat(api,gui): llama.cpp management — status, updates, uninstall

### DIFF
--- a/crates/gglib-axum/src/handlers/config/setup.rs
+++ b/crates/gglib-axum/src/handlers/config/setup.rs
@@ -15,7 +15,9 @@ use crate::state::AppState;
 use gglib_app_services::setup::SetupStatus;
 use gglib_core::paths::{llama_cpp_dir, llama_server_path};
 use gglib_runtime::llama::{
-    Acceleration, BuildEvent, detect_optimal_acceleration, run_llama_source_build, vulkan_status,
+    Acceleration, BuildEvent, LlamaStatus, LlamaUpdateCheck, UninstallOutcome,
+    detect_optimal_acceleration, llama_status, llama_update_check, run_llama_source_build,
+    run_llama_update, uninstall_llama, update_acceleration, vulkan_status,
 };
 
 /// Get the full system setup status for the first-run wizard.
@@ -169,6 +171,148 @@ pub async fn build_llama_from_source(
         if let Err(e) =
             run_llama_source_build(acceleration, llama_dir, server_path, tx.clone()).await
         {
+            let _ = tx
+                .send(BuildEvent::Failed {
+                    message: e.to_string(),
+                })
+                .await;
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(build_event_to_sse);
+
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(std::time::Duration::from_secs(30))
+            .text("ping"),
+    )
+}
+
+/// What llama.cpp install is present, if any — the GUI face of
+/// `gglib config llama status`.
+///
+/// Local and cheap (no network), unlike [`check_llama_updates`].
+pub async fn llama_status_handler() -> Result<Json<LlamaStatus>, HttpError> {
+    // Probing spawns `llama-server --version` on a cold cache — blocking work
+    // that does not belong on an async worker.
+    tokio::task::spawn_blocking(llama_status)
+        .await
+        .map_err(|e| HttpError::Internal(format!("Status task panicked: {e}")))?
+        .map(Json)
+        .map_err(|e| HttpError::Internal(e.to_string()))
+}
+
+/// How far behind upstream the llama.cpp checkout is — the GUI face of
+/// `gglib config llama check-updates`.
+///
+/// POST rather than GET because it runs `git fetch`: it mutates the local
+/// checkout's remote refs and takes network time, so it belongs behind an
+/// explicit action rather than something a page can issue on load.
+pub async fn check_llama_updates() -> Result<Json<LlamaUpdateCheck>, HttpError> {
+    llama_update_check()
+        .await
+        .map(Json)
+        .map_err(|e| HttpError::Internal(e.to_string()))
+}
+
+/// Remove the llama.cpp installation — the GUI face of
+/// `gglib config llama uninstall --force`.
+///
+/// The confirmation is the GUI's to run; by the time this is called the
+/// decision is made.
+pub async fn uninstall_llama_handler() -> Result<Json<UninstallOutcome>, HttpError> {
+    if UPDATE_IN_FLIGHT.load(std::sync::atomic::Ordering::SeqCst) {
+        return Err(HttpError::Conflict(
+            "A llama.cpp build is running — uninstalling now would delete the checkout out \
+             from under it. Wait for it to finish."
+                .into(),
+        ));
+    }
+
+    uninstall_llama()
+        .await
+        .map(Json)
+        .map_err(|e| HttpError::Internal(e.to_string()))
+}
+
+/// Pull upstream and rebuild llama.cpp, streaming the same [`BuildEvent`]s as
+/// [`build_llama_from_source`] — the GUI face of `gglib config llama update`.
+///
+/// Rebuilds with the acceleration the current build recorded, so an update
+/// cannot silently change backend. Preflight failures are reported as a
+/// `failed` event rather than an HTTP status: by the time they are known the
+/// response has already committed to being a stream.
+/// One llama.cpp build at a time, process-wide.
+///
+/// Two concurrent builds share a source checkout and a binary destination, so
+/// the second corrupts the first. The GUI disables its own button, which does
+/// nothing about a second browser tab or a second client.
+static UPDATE_IN_FLIGHT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub async fn update_llama(
+) -> Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<BuildEvent>(64);
+
+    // Claim the slot before spawning; release it when the task ends whatever
+    // way it ends.
+    let claimed = UPDATE_IN_FLIGHT
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        )
+        .is_ok();
+
+    if !claimed {
+        let _ = tx
+            .try_send(BuildEvent::Failed {
+                message: "A llama.cpp build is already running.".to_string(),
+            });
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(build_event_to_sse);
+        return Sse::new(stream).keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(std::time::Duration::from_secs(30))
+                .text("ping"),
+        );
+    }
+
+    tokio::spawn(async move {
+        struct Guard;
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                UPDATE_IN_FLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let _guard = Guard;
+
+        async fn preflight() -> anyhow::Result<(Acceleration, std::path::PathBuf, std::path::PathBuf)>
+        {
+            let llama_dir = llama_cpp_dir().map_err(|e| anyhow::anyhow!("{e}"))?;
+            let server_path = llama_server_path().map_err(|e| anyhow::anyhow!("{e}"))?;
+            if !llama_dir.exists() {
+                anyhow::bail!(
+                    "llama.cpp source checkout not found. A prebuilt install has no repository \
+                     to update — reinstall from source first."
+                );
+            }
+            Ok((update_acceleration()?, llama_dir, server_path))
+        }
+
+        let (acceleration, llama_dir, server_path) = match preflight().await {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tx
+                    .send(BuildEvent::Failed {
+                        message: e.to_string(),
+                    })
+                    .await;
+                return;
+            }
+        };
+
+        if let Err(e) = run_llama_update(acceleration, llama_dir, server_path, tx.clone()).await {
             let _ = tx
                 .send(BuildEvent::Failed {
                     message: e.to_string(),

--- a/crates/gglib-axum/src/handlers/config/setup.rs
+++ b/crates/gglib-axum/src/handlers/config/setup.rs
@@ -247,11 +247,9 @@ pub async fn uninstall_llama_handler() -> Result<Json<UninstallOutcome>, HttpErr
 /// Two concurrent builds share a source checkout and a binary destination, so
 /// the second corrupts the first. The GUI disables its own button, which does
 /// nothing about a second browser tab or a second client.
-static UPDATE_IN_FLIGHT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static UPDATE_IN_FLIGHT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-pub async fn update_llama(
-) -> Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static> {
+pub async fn update_llama() -> Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static> {
     let (tx, rx) = tokio::sync::mpsc::channel::<BuildEvent>(64);
 
     // Claim the slot before spawning; release it when the task ends whatever
@@ -266,10 +264,9 @@ pub async fn update_llama(
         .is_ok();
 
     if !claimed {
-        let _ = tx
-            .try_send(BuildEvent::Failed {
-                message: "A llama.cpp build is already running.".to_string(),
-            });
+        let _ = tx.try_send(BuildEvent::Failed {
+            message: "A llama.cpp build is already running.".to_string(),
+        });
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(build_event_to_sse);
         return Sse::new(stream).keep_alive(
             axum::response::sse::KeepAlive::new()
@@ -287,8 +284,8 @@ pub async fn update_llama(
         }
         let _guard = Guard;
 
-        async fn preflight() -> anyhow::Result<(Acceleration, std::path::PathBuf, std::path::PathBuf)>
-        {
+        async fn preflight()
+        -> anyhow::Result<(Acceleration, std::path::PathBuf, std::path::PathBuf)> {
             let llama_dir = llama_cpp_dir().map_err(|e| anyhow::anyhow!("{e}"))?;
             let server_path = llama_server_path().map_err(|e| anyhow::anyhow!("{e}"))?;
             if !llama_dir.exists() {

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -314,6 +314,23 @@ fn config_routes() -> Router<AppState> {
             post(handlers::config::setup::build_llama_from_source),
         )
         .route(
+            "/system/llama-status",
+            get(handlers::config::setup::llama_status_handler),
+        )
+        // POST, not GET: this runs `git fetch`.
+        .route(
+            "/system/llama-check-updates",
+            post(handlers::config::setup::check_llama_updates),
+        )
+        .route(
+            "/system/update-llama",
+            post(handlers::config::setup::update_llama),
+        )
+        .route(
+            "/system/uninstall-llama",
+            post(handlers::config::setup::uninstall_llama_handler),
+        )
+        .route(
             "/system/setup-python",
             post(handlers::config::setup::setup_python),
         )

--- a/crates/gglib-axum/tests/integration_routes.rs
+++ b/crates/gglib-axum/tests/integration_routes.rs
@@ -1211,3 +1211,70 @@ async fn model_upgrade_routes_are_wired_and_404_on_unknown_id() {
         .unwrap();
     assert_eq!(apply.status(), StatusCode::NOT_FOUND);
 }
+
+/// The System settings tab loads this on mount, so a missing registration
+/// would surface as an empty panel rather than a loud failure.
+#[tokio::test]
+async fn llama_status_route_returns_json() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .uri("/api/config/system/llama-status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Reports whatever is installed on this machine, but the shape is fixed.
+    assert!(json["installed"].is_boolean());
+    assert!(json["binaryPath"].is_string());
+}
+
+/// `git fetch` is a mutation of local refs and takes network time, so this
+/// route is POST. A GET must not quietly work.
+#[tokio::test]
+async fn llama_check_updates_route_rejects_get() {
+    let ctx = match bootstrap(test_config()).await {
+        Ok(ctx) => ctx,
+        Err(_) => return,
+    };
+
+    let app = create_router(
+        std::sync::Arc::new(ctx),
+        &CorsConfig::AllowAll,
+        test_access(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .header("Host", "127.0.0.1:9887")
+                .uri("/api/config/system/llama-check-updates")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}

--- a/crates/gglib-runtime/src/llama/mod.rs
+++ b/crates/gglib-runtime/src/llama/mod.rs
@@ -18,6 +18,7 @@ pub mod progress;
 pub mod prompt;
 pub mod runtime_probe;
 mod server_availability;
+mod status;
 #[cfg(feature = "cli")]
 mod uninstall;
 #[cfg(feature = "cli")]
@@ -61,15 +62,19 @@ pub use detect::{
 pub use download::check_llama_installed;
 #[cfg(feature = "cli")]
 pub use ensure::ensure_llama_initialized;
+pub use status::{LlamaBuildInfo, LlamaStatus, llama_status};
 pub use validate::{handle_status, validate_llama_binary};
 
 // Installation (CLI only)
 #[cfg(feature = "cli")]
 pub use install::run_llama_source_build;
 #[cfg(feature = "cli")]
-pub use uninstall::handle_uninstall;
+pub use uninstall::{UninstallOutcome, handle_uninstall, uninstall_llama};
 #[cfg(feature = "cli")]
-pub use update::{handle_check_updates, handle_update};
+pub use update::{
+    LlamaUpdateCheck, handle_check_updates, handle_update, llama_update_check, run_llama_update,
+    update_acceleration,
+};
 
 // Args resolution
 pub use args::{

--- a/crates/gglib-runtime/src/llama/status.rs
+++ b/crates/gglib-runtime/src/llama/status.rs
@@ -1,0 +1,213 @@
+//! What is installed, as data.
+//!
+//! `gglib config llama status` used to compute and print in one pass, which
+//! left the GUI with only `llama_installed: bool` from the setup status. This
+//! module answers the same question as a value; [`super::handle_status`] is
+//! now a printer over it and the Axum `system/llama-status` route serialises
+//! it directly, so the two surfaces cannot drift.
+
+use super::config::BuildConfig;
+use gglib_core::domain::RuntimeCapabilities;
+use gglib_core::paths::{llama_config_path, llama_server_path};
+use serde::Serialize;
+
+/// The recorded build, when one exists.
+///
+/// Absent for a prebuilt download: that path never writes a `BuildConfig`.
+/// An installed binary with no build record is normal, not an error.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlamaBuildInfo {
+    /// Short git hash recorded when the binary was built.
+    pub version: String,
+    pub commit_sha: String,
+    pub build_date: String,
+    pub acceleration: String,
+    pub cmake_flags: Vec<String>,
+}
+
+impl From<BuildConfig> for LlamaBuildInfo {
+    fn from(config: BuildConfig) -> Self {
+        Self {
+            version: config.version,
+            commit_sha: config.commit_sha,
+            build_date: config.build_date.to_rfc3339(),
+            acceleration: config.acceleration,
+            cmake_flags: config.cmake_flags,
+        }
+    }
+}
+
+/// What the binary reports about itself when probed.
+///
+/// A projection of [`RuntimeCapabilities`] rather than that type itself:
+/// `RuntimeCapabilities` is a shared core type that is also `Deserialize`d
+/// from stored records, so it carries no `rename_all` and would put
+/// snake_case keys inside this otherwise-camelCase payload.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlamaRuntimeInfo {
+    /// llama.cpp build number, absent when the binary could not be identified.
+    pub build: Option<u32>,
+    pub commit: Option<String>,
+    pub version_line: String,
+    /// Native capability flags, already rendered for display. A string rather
+    /// than the bitflags themselves so their variant names do not become wire
+    /// API — no consumer branches on them, both surfaces only print them.
+    pub flags: String,
+}
+
+impl From<&RuntimeCapabilities> for LlamaRuntimeInfo {
+    fn from(caps: &RuntimeCapabilities) -> Self {
+        Self {
+            build: caps.build,
+            commit: caps.commit.clone(),
+            version_line: caps.version_line.clone(),
+            flags: format!("{:?}", caps.flags),
+        }
+    }
+}
+
+/// Everything `gglib config llama status` reports.
+///
+/// Two notions of "version" coexist here deliberately and must not be merged:
+/// [`LlamaBuildInfo::version`] is what gglib recorded when it built the
+/// binary, while [`Self::runtime`] is what the binary reports about itself
+/// when probed. They disagree for a hand-installed or prebuilt binary, and
+/// that disagreement is exactly what a user debugging a launch needs to see.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlamaStatus {
+    pub installed: bool,
+    pub binary_path: String,
+    pub config_path: String,
+    /// Whether the binary passed validation. False whenever `healthError` is set.
+    pub healthy: bool,
+    /// Why validation failed, including its remediation text.
+    pub health_error: Option<String>,
+    pub build: Option<LlamaBuildInfo>,
+    /// Set when a build record exists but could not be read.
+    pub build_error: Option<String>,
+    /// What the binary says it is. Absent when nothing is installed to probe;
+    /// present-but-unidentified when the probe could not parse a build number.
+    pub runtime: Option<LlamaRuntimeInfo>,
+}
+
+/// Inspect the installed llama.cpp, if any.
+///
+/// Degraded states are values, not errors: not installed, installed but
+/// failing validation, and installed without a build record are all reported
+/// in the returned struct. Only a failure to resolve the data directory
+/// itself is an `Err`.
+pub fn llama_status() -> anyhow::Result<LlamaStatus> {
+    let binary_path = llama_server_path().map_err(|e| anyhow::anyhow!("{}", e))?;
+    let config_path = llama_config_path().map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let mut status = LlamaStatus {
+        installed: binary_path.exists(),
+        binary_path: binary_path.display().to_string(),
+        config_path: config_path.display().to_string(),
+        healthy: false,
+        health_error: None,
+        build: None,
+        build_error: None,
+        runtime: None,
+    };
+
+    if !status.installed {
+        return Ok(status);
+    }
+
+    // Read the build record BEFORE validating. Reading a JSON file is safe on
+    // a broken binary, and provenance is exactly what someone debugging an
+    // unhealthy install needs — reporting "no build record" merely because we
+    // returned early would assert the install came from somewhere it did not.
+    if config_path.exists() {
+        match BuildConfig::load(&config_path) {
+            Ok(config) => status.build = Some(config.into()),
+            Err(e) => status.build_error = Some(e.to_string()),
+        }
+    }
+
+    match super::validate_llama_binary(&binary_path) {
+        Ok(()) => status.healthy = true,
+        Err(e) => {
+            status.health_error = Some(e.to_string());
+            // A binary that fails validation cannot be trusted to answer
+            // `--version` sensibly, so stop before probing it.
+            return Ok(status);
+        }
+    }
+
+    // Read through the probe rather than a local `--version` call so this
+    // surface and the launch banner cannot report different runtimes for the
+    // same binary.
+    status.runtime = Some((&super::runtime_probe::probe(&binary_path)).into());
+
+    Ok(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The GUI's `LlamaStatus` in `types/setup.ts` is hand-mirrored, so the
+    /// casing is a contract rather than an implementation detail.
+    #[test]
+    fn status_serialises_as_camel_case() {
+        let status = LlamaStatus {
+            installed: true,
+            binary_path: "/tmp/llama-server".into(),
+            config_path: "/tmp/llama-config.json".into(),
+            healthy: false,
+            health_error: Some("not executable".into()),
+            build: None,
+            build_error: None,
+            runtime: None,
+        };
+
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["binaryPath"], "/tmp/llama-server");
+        assert_eq!(json["configPath"], "/tmp/llama-config.json");
+        assert_eq!(json["healthError"], "not executable");
+        assert!(json.get("binary_path").is_none());
+    }
+
+    /// The runtime block is a projection, not the core type — serialising
+    /// `RuntimeCapabilities` directly would put snake_case keys inside this
+    /// camelCase payload, which is what the TS mirror silently tripped over.
+    #[test]
+    fn runtime_block_is_camel_case() {
+        let caps = gglib_core::domain::RuntimeCapabilities {
+            build: Some(9656),
+            commit: None,
+            version_line: "version: 9656 (deadbee)".into(),
+            flags: Default::default(),
+        };
+
+        let json = serde_json::to_value(LlamaRuntimeInfo::from(&caps)).unwrap();
+        assert_eq!(json["versionLine"], "version: 9656 (deadbee)");
+        assert_eq!(json["build"], 9656);
+        assert!(json.get("version_line").is_none());
+        // Rendered, not structural — no consumer branches on flag names.
+        assert!(json["flags"].is_string());
+    }
+
+    #[test]
+    fn build_info_carries_both_notions_of_version() {
+        let info = LlamaBuildInfo::from(BuildConfig {
+            version: "abc1234".into(),
+            commit_sha: "abc1234def".into(),
+            build_date: chrono::Utc::now(),
+            acceleration: "Metal".into(),
+            cmake_flags: vec!["-DGGML_METAL=ON".into()],
+        });
+
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["version"], "abc1234");
+        assert_eq!(json["commitSha"], "abc1234def");
+        assert_eq!(json["cmakeFlags"][0], "-DGGML_METAL=ON");
+        // RFC 3339 rather than a locale-formatted string: the GUI parses it.
+        assert!(json["buildDate"].as_str().unwrap().contains('T'));
+    }
+}

--- a/crates/gglib-runtime/src/llama/uninstall.rs
+++ b/crates/gglib-runtime/src/llama/uninstall.rs
@@ -2,18 +2,66 @@
 
 use anyhow::Result;
 use gglib_core::paths::gglib_data_dir;
+use serde::Serialize;
 use std::io::{self, Write};
 
-/// Handle the uninstall command.
+/// What an uninstall removed.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstallOutcome {
+    /// False when there was nothing to remove; `removedPaths` is then empty.
+    pub was_installed: bool,
+    pub removed_paths: Vec<String>,
+}
+
+/// Remove the llama.cpp installation: the source checkout, the binary
+/// directory and the build configuration.
 ///
-/// Removes the llama.cpp installation including binaries and configuration.
-/// If `force` is false, prompts the user for confirmation.
-pub async fn handle_uninstall(force: bool) -> Result<()> {
+/// Note this removes the whole `bin/` directory, so `llama-bench` goes with
+/// `llama-server` — everything a source build installs. Unconditional; the
+/// confirmation belongs to the caller.
+pub async fn uninstall_llama() -> Result<UninstallOutcome> {
     let gglib_dir = gglib_data_dir()?;
     let llama_dir = gglib_dir.join("llama.cpp");
     let bin_dir = gglib_dir.join("bin");
+    let config_path = gglib_dir.join("llama-config.json");
 
     if !llama_dir.exists() && !bin_dir.exists() {
+        return Ok(UninstallOutcome {
+            was_installed: false,
+            removed_paths: Vec::new(),
+        });
+    }
+
+    let mut removed_paths = Vec::new();
+
+    if llama_dir.exists() {
+        std::fs::remove_dir_all(&llama_dir)?;
+        removed_paths.push(llama_dir.display().to_string());
+    }
+
+    if bin_dir.exists() {
+        std::fs::remove_dir_all(&bin_dir)?;
+        removed_paths.push(bin_dir.display().to_string());
+    }
+
+    if config_path.exists() {
+        std::fs::remove_file(&config_path)?;
+        removed_paths.push(config_path.display().to_string());
+    }
+
+    Ok(UninstallOutcome {
+        was_installed: true,
+        removed_paths,
+    })
+}
+
+/// Handle the uninstall command.
+///
+/// Prompts unless `force`, then prints what [`uninstall_llama`] removed.
+pub async fn handle_uninstall(force: bool) -> Result<()> {
+    let gglib_dir = gglib_data_dir()?;
+    if !gglib_dir.join("llama.cpp").exists() && !gglib_dir.join("bin").exists() {
         println!("llama.cpp is not installed.");
         return Ok(());
     }
@@ -31,20 +79,9 @@ pub async fn handle_uninstall(force: bool) -> Result<()> {
 
     println!("Removing llama.cpp installation...");
 
-    if llama_dir.exists() {
-        std::fs::remove_dir_all(&llama_dir)?;
-        println!("✓ Removed {}", llama_dir.display());
-    }
-
-    if bin_dir.exists() {
-        std::fs::remove_dir_all(&bin_dir)?;
-        println!("✓ Removed {}", bin_dir.display());
-    }
-
-    let config_path = gglib_dir.join("llama-config.json");
-    if config_path.exists() {
-        std::fs::remove_file(&config_path)?;
-        println!("✓ Removed configuration");
+    let outcome = uninstall_llama().await?;
+    for path in &outcome.removed_paths {
+        println!("✓ Removed {}", path);
     }
 
     println!("llama.cpp uninstalled successfully.");

--- a/crates/gglib-runtime/src/llama/update.rs
+++ b/crates/gglib-runtime/src/llama/update.rs
@@ -1,14 +1,13 @@
 //! Update command for llama.cpp.
 
-use super::build::build_llama_cpp;
-use super::build_events::BuildEvent;
+use super::build_events::{BuildEvent, BuildPhase};
 use super::config::BuildConfig;
 use super::detect::{Acceleration, detect_optimal_acceleration};
-use super::install::install_binary;
 use anyhow::{Context, Result, bail};
 use gglib_core::paths::{llama_config_path, llama_cpp_dir, llama_server_path};
 use gglib_core::utils::process::cmd;
 use std::io::{self, Write};
+use std::path::PathBuf;
 use tokio::sync::mpsc;
 
 // Helper to convert PathError to anyhow::Error
@@ -16,44 +15,98 @@ fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
     r.map_err(|e| anyhow::anyhow!("{}", e))
 }
 
-/// Check for llama.cpp updates
-pub async fn handle_check_updates() -> Result<()> {
+/// How far behind upstream the local llama.cpp checkout is.
+///
+/// Why the source checkout can be missing while a binary exists: the prebuilt
+/// download path installs `llama-server` without ever cloning the repository,
+/// and only a source install can be compared against upstream.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlamaUpdateCheck {
+    pub installed: bool,
+    /// Whether the llama.cpp source checkout exists to compare against.
+    pub repo_present: bool,
+    /// Whether a comparison actually happened. False means `commitsBehind` is
+    /// 0 because nothing was compared, not because the checkout is current —
+    /// the two are indistinguishable otherwise, and reporting the second when
+    /// the first is true tells the user their install is up to date when we
+    /// have no idea.
+    pub comparable: bool,
+    pub current_version: Option<String>,
+    pub current_acceleration: Option<String>,
+    pub build_date: Option<String>,
+    pub commits_behind: u32,
+    /// Up to five one-line summaries of what landed upstream.
+    pub recent_commits: Vec<String>,
+}
+
+impl LlamaUpdateCheck {
+    /// The states where no comparison is possible: nothing installed, or a
+    /// prebuilt install with no source checkout, or no build record to read.
+    fn not_comparable(installed: bool, repo_present: bool) -> Self {
+        Self {
+            installed,
+            repo_present,
+            comparable: false,
+            current_version: None,
+            current_acceleration: None,
+            build_date: None,
+            commits_behind: 0,
+            recent_commits: Vec::new(),
+        }
+    }
+}
+
+/// Compare the local llama.cpp checkout against upstream.
+///
+/// Network-bound: this runs `git fetch`, so it belongs behind an explicit
+/// user action rather than a page load. Callers that only need what is
+/// installed want [`super::llama_status`] instead, which is local and cheap.
+pub async fn llama_update_check() -> Result<LlamaUpdateCheck> {
     let llama_dir = path_err(llama_cpp_dir())?;
     let binary_path = path_err(llama_server_path())?;
 
     if !binary_path.exists() {
-        println!("llama.cpp is not installed.");
-        println!("Run 'gglib config llama install' to install it.");
-        return Ok(());
+        return Ok(LlamaUpdateCheck::not_comparable(false, false));
     }
-
     if !llama_dir.exists() {
-        println!("Warning: llama.cpp repository not found.");
-        println!("Run 'gglib config llama rebuild' to reinstall.");
-        return Ok(());
+        return Ok(LlamaUpdateCheck::not_comparable(true, false));
     }
 
-    // Load current config
     let config_path = path_err(llama_config_path())?;
-    let config = if config_path.exists() {
-        BuildConfig::load(&config_path)?
-    } else {
-        println!("Warning: Build configuration not found.");
-        return Ok(());
-    };
+    if !config_path.exists() {
+        return Ok(LlamaUpdateCheck::not_comparable(true, true));
+    }
+    let config = BuildConfig::load(&config_path)?;
 
-    println!(
-        "Current version: {} ({})",
-        config.version,
-        config.build_date.format("%Y-%m-%d")
-    );
-    println!("Acceleration: {}", config.acceleration);
-    println!();
-    println!("Checking for updates...");
+    // `git fetch` is a network round-trip and every one of these is a
+    // blocking subprocess, so the whole group moves off the async workers.
+    let dir = llama_dir.clone();
+    let (commits_behind, recent_commits) =
+        tokio::task::spawn_blocking(move || fetch_and_count(&dir))
+            .await
+            .map_err(|e| anyhow::anyhow!("Update check task panicked: {e}"))??;
 
-    // Fetch latest from remote
+    Ok(LlamaUpdateCheck {
+        installed: true,
+        repo_present: true,
+        comparable: true,
+        current_version: Some(config.version),
+        current_acceleration: Some(config.acceleration),
+        build_date: Some(config.build_date.to_rfc3339()),
+        commits_behind,
+        recent_commits,
+    })
+}
+
+/// Fetch from origin and count how far behind `HEAD` is. Blocking.
+fn fetch_and_count(llama_dir: &std::path::Path) -> Result<(u32, Vec<String>)> {
+    let dir_str = llama_dir
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("llama.cpp path is not valid UTF-8"))?;
+
     let status = cmd("git")
-        .args(["-C", llama_dir.to_str().unwrap(), "fetch", "origin"])
+        .args(["-C", dir_str, "fetch", "origin"])
         .status()
         .context("Failed to fetch updates")?;
 
@@ -61,15 +114,8 @@ pub async fn handle_check_updates() -> Result<()> {
         bail!("Failed to fetch updates from remote");
     }
 
-    // Check if we're behind
     let output = cmd("git")
-        .args([
-            "-C",
-            llama_dir.to_str().unwrap(),
-            "rev-list",
-            "--count",
-            "HEAD..origin/master",
-        ])
+        .args(["-C", dir_str, "rev-list", "--count", "HEAD..origin/master"])
         .output()
         .context("Failed to check for updates")?;
 
@@ -79,30 +125,76 @@ pub async fn handle_check_updates() -> Result<()> {
         .unwrap_or(0);
 
     if commits_behind == 0 {
-        println!("✓ llama.cpp is up to date");
-        return Ok(());
+        return Ok((0, Vec::new()));
     }
 
-    // Get latest commit info
     let output = cmd("git")
         .args([
-            "-C",
-            llama_dir.to_str().unwrap(),
-            "log",
-            "--oneline",
-            "-n",
-            "5",
-            "HEAD..origin/master",
+            "-C", dir_str, "log", "--oneline", "-n", "5", "HEAD..origin/master",
         ])
         .output()
         .context("Failed to get commit log")?;
 
-    let commits = String::from_utf8_lossy(&output.stdout);
+    let recent = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .take(5)
+        .map(str::to_string)
+        .collect();
 
-    println!("✓ New version available ({} commits ahead)", commits_behind);
+    Ok((commits_behind, recent))
+}
+
+/// Check for llama.cpp updates — a printer over [`llama_update_check`].
+pub async fn handle_check_updates() -> Result<()> {
+    // The header comes from local state, so print it before the fetch rather
+    // than after: "Checking for updates..." should appear while the network
+    // call is happening, not once it has already returned.
+    let local_build = super::llama_status()
+        .ok()
+        .filter(|s| s.installed)
+        .and_then(|s| s.build);
+
+    if let Some(build) = local_build {
+        let built = build.build_date.split('T').next().unwrap_or("unknown");
+        println!("Current version: {} ({})", build.version, built);
+        println!("Acceleration: {}", build.acceleration);
+        println!();
+        println!("Checking for updates...");
+    }
+
+    let check = llama_update_check().await?;
+
+    if !check.installed {
+        println!("llama.cpp is not installed.");
+        println!("Run 'gglib config llama install' to install it.");
+        return Ok(());
+    }
+
+    if !check.repo_present {
+        println!("Warning: llama.cpp repository not found.");
+        println!("Run 'gglib config llama rebuild' to reinstall.");
+        return Ok(());
+    }
+
+    let Some(version) = check.current_version.as_deref() else {
+        println!("Warning: Build configuration not found.");
+        return Ok(());
+    };
+
+    let _ = version;
+
+    if check.commits_behind == 0 {
+        println!("✓ llama.cpp is up to date");
+        return Ok(());
+    }
+
+    println!(
+        "✓ New version available ({} commits ahead)",
+        check.commits_behind
+    );
     println!();
     println!("Recent changes:");
-    for line in commits.lines().take(5) {
+    for line in &check.recent_commits {
         println!("  {}", line);
     }
     println!();
@@ -111,7 +203,81 @@ pub async fn handle_check_updates() -> Result<()> {
     Ok(())
 }
 
-/// Update llama.cpp to the latest version
+/// The acceleration an update should rebuild with.
+///
+/// Whatever the current build recorded, so an update never silently changes
+/// backend; detection only decides when there is no record or the recorded
+/// name is not one we build for. Detection is deliberately fallible — it
+/// refuses to fall back to CPU — so this can fail with the install hints.
+pub fn update_acceleration() -> Result<Acceleration> {
+    let config_path = path_err(llama_config_path())?;
+    let recorded = config_path
+        .exists()
+        .then(|| BuildConfig::load(&config_path))
+        .transpose()?;
+
+    Ok(match recorded.as_ref().map(|c| c.acceleration.as_str()) {
+        Some("Metal") => Acceleration::Metal,
+        Some("CUDA") => Acceleration::Cuda,
+        Some("Vulkan") => Acceleration::Vulkan,
+        _ => detect_optimal_acceleration()?,
+    })
+}
+
+/// Pull upstream, then rebuild and reinstall — the shared update pipeline
+/// behind `gglib config llama update` and the `system/update-llama` route.
+///
+/// Differs from [`run_llama_source_build`] only in the pull: that reuses an
+/// existing checkout as-is, which is right for an install and wrong for an
+/// update. Everything after the pull is the same pipeline, so an update now
+/// installs `llama-bench` alongside `llama-server` and reports progress,
+/// neither of which the old inline implementation did.
+///
+/// [`run_llama_source_build`]: super::run_llama_source_build
+pub async fn run_llama_update(
+    acceleration: Acceleration,
+    llama_dir: PathBuf,
+    server_path: PathBuf,
+    tx: mpsc::Sender<BuildEvent>,
+) -> Result<()> {
+    let dir = llama_dir.clone();
+    let pull_tx = tx.clone();
+
+    // `git pull` is blocking subprocess work, so it belongs on a blocking
+    // thread with `blocking_send`, matching the rest of the pipeline.
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let _ = pull_tx.blocking_send(BuildEvent::PhaseStarted {
+            phase: BuildPhase::CloneOrUpdateRepo,
+        });
+        let _ = pull_tx.blocking_send(BuildEvent::Log {
+            message: "Pulling latest llama.cpp changes...".to_string(),
+        });
+
+        let dir_str = dir
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("llama.cpp path is not valid UTF-8"))?;
+        let status = cmd("git")
+            .args(["-C", dir_str, "pull", "origin", "master"])
+            .status()
+            .context("Failed to pull updates")?;
+        if !status.success() {
+            bail!("Failed to pull updates from origin/master");
+        }
+
+        let _ = pull_tx.blocking_send(BuildEvent::PhaseCompleted {
+            phase: BuildPhase::CloneOrUpdateRepo,
+        });
+        Ok(())
+    })
+    .await??;
+
+    super::run_llama_source_build(acceleration, llama_dir, server_path, tx).await
+}
+
+/// Update llama.cpp to the latest version.
+///
+/// Preconditions, the plan and the prompt live here; the work itself is
+/// [`run_llama_update`], shared with the GUI route.
 pub async fn handle_update() -> Result<()> {
     let llama_dir = path_err(llama_cpp_dir())?;
     let binary_path = path_err(llama_server_path())?;
@@ -128,24 +294,13 @@ pub async fn handle_update() -> Result<()> {
         return Ok(());
     }
 
-    // Load current config to preserve acceleration type
     let config_path = path_err(llama_config_path())?;
     let old_config = if config_path.exists() {
         Some(BuildConfig::load(&config_path)?)
     } else {
         None
     };
-
-    let acceleration = if let Some(ref config) = old_config {
-        match config.acceleration.as_str() {
-            "Metal" => Acceleration::Metal,
-            "CUDA" => Acceleration::Cuda,
-            "Vulkan" => Acceleration::Vulkan,
-            _ => detect_optimal_acceleration()?,
-        }
-    } else {
-        detect_optimal_acceleration()?
-    };
+    let acceleration = update_acceleration()?;
 
     println!("Updating llama.cpp...");
     println!();
@@ -173,60 +328,79 @@ pub async fn handle_update() -> Result<()> {
         return Ok(());
     }
 
-    // Pull latest changes
     println!();
-    println!("Pulling latest changes...");
-    let status = cmd("git")
-        .args([
-            "-C",
-            llama_dir.to_str().unwrap(),
-            "pull",
-            "origin",
-            "master",
-        ])
-        .status()
-        .context("Failed to pull updates")?;
+    let (tx, mut rx) = mpsc::channel::<BuildEvent>(64);
+    let update = tokio::spawn(run_llama_update(
+        acceleration,
+        llama_dir,
+        binary_path,
+        tx,
+    ));
 
-    if !status.success() {
-        bail!("Failed to pull updates");
+    // Previously this channel's receiver was dropped on the floor, so the
+    // build ran silently. Print what it reports.
+    while let Some(event) = rx.recv().await {
+        match event {
+            BuildEvent::Log { message } => println!("{message}"),
+            BuildEvent::PhaseStarted { phase } => println!("→ {phase:?}"),
+            BuildEvent::Completed {
+                version,
+                acceleration,
+            } => {
+                println!();
+                println!("✓ llama.cpp updated successfully!");
+                println!("  New version: {version}");
+                println!("  Acceleration: {acceleration}");
+            }
+            BuildEvent::Failed { message } => println!("✗ {message}"),
+            BuildEvent::PhaseCompleted { .. } | BuildEvent::Progress { .. } => {}
+        }
     }
 
-    println!("✓ Repository updated");
-
-    // Get new version info
-    let output = cmd("git")
-        .args([
-            "-C",
-            llama_dir.to_str().unwrap(),
-            "rev-parse",
-            "--short",
-            "HEAD",
-        ])
-        .output()
-        .context("Failed to get commit hash")?;
-    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    let output = cmd("git")
-        .args(["-C", llama_dir.to_str().unwrap(), "rev-parse", "HEAD"])
-        .output()
-        .context("Failed to get commit SHA")?;
-    let commit_sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    // Rebuild
-    let (build_tx, _build_rx) = mpsc::channel::<BuildEvent>(64);
-    build_llama_cpp(&llama_dir, acceleration, &build_tx)?;
-
-    // Install binaries
-    install_binary(&llama_dir, "llama-server", &binary_path)?;
-
-    // Save new configuration
-    let config = BuildConfig::new(version.clone(), commit_sha, acceleration);
-    config.save(&config_path)?;
-
-    println!();
-    println!("✓ llama.cpp updated successfully!");
-    println!("  New version: {}", version);
-    println!("  Acceleration: {}", acceleration.display_name());
+    update.await??;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `commitsBehind` of 0 with `repoPresent: false` means "cannot tell",
+    /// not "up to date" — the GUI branches on `repoPresent` first for exactly
+    /// this reason, so the distinction has to survive serialisation.
+    #[test]
+    fn not_comparable_is_distinct_from_up_to_date() {
+        let prebuilt = LlamaUpdateCheck::not_comparable(true, false);
+        assert!(prebuilt.installed);
+        assert!(!prebuilt.repo_present);
+        // The distinction the GUI depends on: 0 commits behind, but nothing
+        // was compared, so it must not be shown as "up to date".
+        assert!(!prebuilt.comparable);
+        assert_eq!(prebuilt.commits_behind, 0);
+        assert!(prebuilt.current_version.is_none());
+    }
+
+    #[test]
+    fn update_check_serialises_as_camel_case() {
+        let check = LlamaUpdateCheck {
+            installed: true,
+            repo_present: true,
+            comparable: true,
+            current_version: Some("abc1234".into()),
+            current_acceleration: Some("Metal".into()),
+            build_date: Some("2026-08-10T00:00:00Z".into()),
+            commits_behind: 3,
+            recent_commits: vec!["deadbee fix something".into()],
+        };
+
+        let json = serde_json::to_value(&check).unwrap();
+        assert_eq!(json["repoPresent"], true);
+        assert_eq!(json["comparable"], true);
+        assert_eq!(json["currentVersion"], "abc1234");
+        assert_eq!(json["currentAcceleration"], "Metal");
+        assert_eq!(json["commitsBehind"], 3);
+        assert_eq!(json["recentCommits"][0], "deadbee fix something");
+        assert!(json.get("repo_present").is_none());
+    }
 }

--- a/crates/gglib-runtime/src/llama/update.rs
+++ b/crates/gglib-runtime/src/llama/update.rs
@@ -119,10 +119,11 @@ fn fetch_and_count(llama_dir: &std::path::Path) -> Result<(u32, Vec<String>)> {
         .output()
         .context("Failed to check for updates")?;
 
-    let commits_behind = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse::<u32>()
-        .unwrap_or(0);
+    let commits_behind = parse_commits_behind(
+        output.status.success(),
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )?;
 
     if commits_behind == 0 {
         return Ok((0, Vec::new()));
@@ -130,7 +131,13 @@ fn fetch_and_count(llama_dir: &std::path::Path) -> Result<(u32, Vec<String>)> {
 
     let output = cmd("git")
         .args([
-            "-C", dir_str, "log", "--oneline", "-n", "5", "HEAD..origin/master",
+            "-C",
+            dir_str,
+            "log",
+            "--oneline",
+            "-n",
+            "5",
+            "HEAD..origin/master",
         ])
         .output()
         .context("Failed to get commit log")?;
@@ -142,6 +149,29 @@ fn fetch_and_count(llama_dir: &std::path::Path) -> Result<(u32, Vec<String>)> {
         .collect();
 
     Ok((commits_behind, recent))
+}
+
+/// Turn `git rev-list --count`'s result into a commit count.
+///
+/// A non-zero exit means the comparison never happened — no `origin/master`,
+/// a shallow clone, a corrupt checkout — and it must not be reported as zero.
+/// [`LlamaUpdateCheck`] treats `commits_behind: 0` alongside `comparable:
+/// true` as "up to date", the very distinction `not_comparable` exists to
+/// preserve, so swallowing a failure here renders a broken repository as a
+/// healthy one. An unparseable count on a *successful* exit is equally a
+/// broken assumption rather than a zero.
+fn parse_commits_behind(success: bool, stdout: &str, stderr: &str) -> Result<u32> {
+    if !success {
+        let detail = stderr.trim();
+        if detail.is_empty() {
+            bail!("Could not compare against origin/master");
+        }
+        bail!("Could not compare against origin/master: {detail}");
+    }
+
+    let raw = stdout.trim();
+    raw.parse::<u32>()
+        .with_context(|| format!("Unexpected `git rev-list --count` output: {raw:?}"))
 }
 
 /// Check for llama.cpp updates — a printer over [`llama_update_check`].
@@ -330,12 +360,7 @@ pub async fn handle_update() -> Result<()> {
 
     println!();
     let (tx, mut rx) = mpsc::channel::<BuildEvent>(64);
-    let update = tokio::spawn(run_llama_update(
-        acceleration,
-        llama_dir,
-        binary_path,
-        tx,
-    ));
+    let update = tokio::spawn(run_llama_update(acceleration, llama_dir, binary_path, tx));
 
     // Previously this channel's receiver was dropped on the floor, so the
     // build ran silently. Print what it reports.
@@ -379,6 +404,38 @@ mod tests {
         assert!(!prebuilt.comparable);
         assert_eq!(prebuilt.commits_behind, 0);
         assert!(prebuilt.current_version.is_none());
+    }
+
+    /// The counterpart hazard to the one above, on the live path: a failed
+    /// comparison used to parse as `unwrap_or(0)`, which the caller reports
+    /// with `comparable: true` — i.e. "up to date" — for a repository it
+    /// could not read at all.
+    #[test]
+    fn failed_comparison_is_an_error_not_zero() {
+        let err = parse_commits_behind(false, "", "fatal: bad revision 'origin/master'")
+            .expect_err("a non-zero git exit must not report zero commits behind");
+        assert!(
+            err.to_string().contains("bad revision"),
+            "the git failure should reach the caller: {err}"
+        );
+    }
+
+    #[test]
+    fn failed_comparison_without_stderr_still_errors() {
+        assert!(parse_commits_behind(false, "", "   ").is_err());
+    }
+
+    /// A clean exit with output git never produces means the assumption
+    /// behind the parse is wrong; that is not a zero either.
+    #[test]
+    fn unparseable_count_is_an_error() {
+        assert!(parse_commits_behind(true, "not-a-number", "").is_err());
+    }
+
+    #[test]
+    fn counts_parse_with_surrounding_whitespace() {
+        assert_eq!(parse_commits_behind(true, "0\n", "").unwrap(), 0);
+        assert_eq!(parse_commits_behind(true, "  42\n", "").unwrap(), 42);
     }
 
     #[test]

--- a/crates/gglib-runtime/src/llama/validate.rs
+++ b/crates/gglib-runtime/src/llama/validate.rs
@@ -1,8 +1,6 @@
 //! Binary validation and status checking for llama-server.
 
-use super::config::BuildConfig;
 use anyhow::{Context, Result, bail};
-use gglib_core::paths::{llama_config_path, llama_server_path};
 use gglib_core::utils::process::cmd;
 use std::path::Path;
 
@@ -50,12 +48,14 @@ fn validate_binary(path: &Path, binary_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Handle the status command
+/// Handle the status command.
+///
+/// A printer over [`super::llama_status`] — the same value the GUI's System
+/// tab renders, so the two surfaces cannot report different installs.
 pub async fn handle_status() -> Result<()> {
-    let binary_path = llama_server_path().map_err(|e| anyhow::anyhow!("{}", e))?;
-    let config_path = llama_config_path().map_err(|e| anyhow::anyhow!("{}", e))?;
+    let status = super::llama_status()?;
 
-    if !binary_path.exists() {
+    if !status.installed {
         println!("Status: Not installed");
         println!();
         println!("Run 'gglib config llama install' to install llama.cpp");
@@ -63,53 +63,54 @@ pub async fn handle_status() -> Result<()> {
     }
 
     println!("Status: Installed");
-    println!("Binary: {}", binary_path.display());
+    println!("Binary: {}", status.binary_path);
 
-    // Validate binary
-    match validate_llama_binary(&binary_path) {
-        Ok(_) => println!("Health: ✓ Functional"),
-        Err(e) => {
+    match &status.health_error {
+        None => println!("Health: ✓ Functional"),
+        Some(e) => {
             println!("Health: ✗ Error - {}", e);
             return Ok(());
         }
     }
 
-    // Load and display config
-    if config_path.exists() {
-        match BuildConfig::load(&config_path) {
-            Ok(config) => {
-                println!();
-                println!("Build Information:");
-                println!("  Version: {}", config.version);
-                println!("  Commit: {}", config.commit_sha);
-                println!(
+    match (&status.build, &status.build_error) {
+        (Some(build), _) => {
+            println!();
+            println!("Build Information:");
+            println!("  Version: {}", build.version);
+            println!("  Commit: {}", build.commit_sha);
+            // The DTO carries RFC 3339 for the wire; this command has always
+            // printed a human timestamp, so format it back at the print site.
+            match chrono::DateTime::parse_from_rfc3339(&build.build_date) {
+                Ok(dt) => println!(
                     "  Built: {}",
-                    config.build_date.format("%Y-%m-%d %H:%M:%S UTC")
-                );
-                println!("  Acceleration: {}", config.acceleration);
-                println!("  CMake flags: {}", config.cmake_flags.join(" "));
+                    dt.with_timezone(&chrono::Utc)
+                        .format("%Y-%m-%d %H:%M:%S UTC")
+                ),
+                Err(_) => println!("  Built: {}", build.build_date),
             }
-            Err(e) => {
-                println!();
-                println!("Warning: Could not load build config: {}", e);
-            }
+            println!("  Acceleration: {}", build.acceleration);
+            println!("  CMake flags: {}", build.cmake_flags.join(" "));
         }
-    } else {
-        println!();
-        println!("Warning: Build configuration not found");
+        (None, Some(e)) => {
+            println!();
+            println!("Warning: Could not load build config: {}", e);
+        }
+        (None, None) => {
+            println!();
+            println!("Warning: Build configuration not found");
+        }
     }
 
-    // What the binary is, and what it does natively. Read through the probe
-    // rather than a local `--version` call so this surface and the launch
-    // banner cannot report different runtimes for the same binary.
-    let caps = super::runtime_probe::probe(&binary_path);
-    println!();
-    println!("Binary version: {}", caps.version_line);
-    match caps.build {
-        Some(build) => println!("  Build: b{build}"),
-        None => println!("  Build: unidentified — gglib will apply every compensation"),
+    if let Some(caps) = &status.runtime {
+        println!();
+        println!("Binary version: {}", caps.version_line);
+        match caps.build {
+            Some(build) => println!("  Build: b{build}"),
+            None => println!("  Build: unidentified — gglib will apply every compensation"),
+        }
+        println!("  Native capabilities: {}", caps.flags);
     }
-    println!("  Native capabilities: {:?}", caps.flags);
 
     Ok(())
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import { McpServersPanel } from "./McpServersPanel";
 import { AddMcpServerModal } from "./AddMcpServerModal";
 import { GeneralSettings } from "./SettingsModal/GeneralSettings";
 import { InferenceProfiles } from "./SettingsModal/InferenceProfiles";
+import { SystemSettings } from "./SettingsModal/SystemSettings";
 import { useDesktopSettings } from "./SettingsModal/useDesktopSettings";
 import { useNetworkSettings } from './SettingsModal/useNetworkSettings';
 import { useAgentGuardSettings } from './SettingsModal/useAgentGuardSettings';
@@ -17,12 +18,13 @@ import { Button } from "./ui/Button";
 import { Tabs, type TabItem } from "./ui/Tabs";
 import type { McpServerInfo } from '../services/transport';
 
-type SettingsTab = "general" | "profiles" | "mcp";
+type SettingsTab = "general" | "profiles" | "mcp" | "system";
 
 const SETTINGS_TABS: TabItem<SettingsTab>[] = [
   { id: "general", label: "General" },
   { id: "profiles", label: "Inference Profiles" },
   { id: "mcp", label: "MCP Servers" },
+  { id: "system", label: "System" },
 ];
 
 interface SettingsModalProps {
@@ -325,6 +327,8 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
 
         {/* Inference Profiles Tab */}
         {activeTab === "profiles" && <InferenceProfiles />}
+
+        {activeTab === "system" && <SystemSettings />}
 
         {/* MCP Servers Tab */}
         {activeTab === "mcp" && (

--- a/src/components/SettingsModal/SystemSettings.tsx
+++ b/src/components/SettingsModal/SystemSettings.tsx
@@ -1,0 +1,251 @@
+/**
+ * System settings panel — the GUI face of `gglib config llama`.
+ *
+ * Answers three questions in the order a user asks them: what is installed,
+ * has upstream moved, and what can I do about it. Self-contained like
+ * `InferenceProfiles`; all state lives in `useSystemSettings`.
+ */
+
+import { FC } from 'react';
+import { Button } from '../ui/Button';
+import { Banner } from '../ui/Banner';
+import { Stack } from '../primitives';
+import { useConfirmContext } from '../../contexts/ConfirmContext';
+import { useSystemSettings } from './useSystemSettings';
+import type { LlamaStatus } from '../../types/setup';
+
+/** One label/value row. Values are mono so paths and hashes line up. */
+const Row: FC<{ label: string; value: string; mono?: boolean }> = ({
+  label,
+  value,
+  mono = true,
+}) => (
+  <div className="flex items-baseline justify-between gap-md">
+    <span className="text-xs text-text-muted shrink-0">{label}</span>
+    <span
+      className={`text-xs text-text-secondary text-right break-all ${mono ? 'font-mono tabular-nums' : ''}`}
+    >
+      {value}
+    </span>
+  </div>
+);
+
+/** Installed / degraded / absent, as a dot and a word. */
+const InstallState: FC<{ status: LlamaStatus }> = ({ status }) => {
+  const [dot, label] = !status.installed
+    ? ['bg-text-muted', 'Not installed']
+    : status.healthy
+      ? ['bg-success', 'Installed']
+      : ['bg-danger', 'Installed, not working'];
+
+  return (
+    <div className="flex items-center gap-xs">
+      <span className={`inline-block w-2 h-2 rounded-full ${dot}`} aria-hidden="true" />
+      <span className="text-sm font-semibold text-text">{label}</span>
+    </div>
+  );
+};
+
+export const SystemSettings: FC = () => {
+  const {
+    status,
+    statusError,
+    loadingStatus,
+    updateCheck,
+    checkingUpdates,
+    checkError,
+    runUpdateCheck,
+    updating,
+    updateProgress,
+    updateError,
+    updateResult,
+    runUpdate,
+    uninstalling,
+    uninstallResult,
+    runUninstall,
+  } = useSystemSettings();
+  const { confirm } = useConfirmContext();
+
+  const handleUninstall = async () => {
+    const confirmed = await confirm({
+      title: 'Uninstall llama.cpp?',
+      description:
+        'Removes the source checkout, the build configuration, and everything in the binary ' +
+        'directory — llama-server and llama-bench both. Your models are not touched, but no ' +
+        'model can be served until llama.cpp is installed again.',
+      confirmLabel: 'Uninstall',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    await runUninstall();
+  };
+
+  const handleUpdate = async () => {
+    const confirmed = await confirm({
+      title: 'Update llama.cpp?',
+      description:
+        'Pulls the latest upstream changes and rebuilds from source with the same acceleration ' +
+        'backend. Compiling takes several minutes and replaces the current binary. Running ' +
+        'servers keep using the old binary until they restart.',
+      confirmLabel: 'Update',
+    });
+    if (!confirmed) return;
+    runUpdate();
+  };
+
+  if (loadingStatus && !status) {
+    return <p className="text-sm text-text-muted m-0">Reading llama.cpp status…</p>;
+  }
+
+  return (
+    <Stack gap="xl">
+      {statusError && <Banner variant="danger">{statusError}</Banner>}
+
+      <section>
+        <div className="flex items-center justify-between gap-md mb-base">
+          <h3 className="m-0 text-sm font-semibold text-text">llama.cpp</h3>
+          {status && <InstallState status={status} />}
+        </div>
+
+        {status?.healthError && (
+          <Banner variant="danger" className="mb-base">
+            {status.healthError}
+          </Banner>
+        )}
+
+        {status && (
+          <Stack gap="xs">
+            <Row label="Binary" value={status.binaryPath} />
+            {status.build ? (
+              <>
+                <Row label="Built from" value={status.build.version} />
+                <Row label="Acceleration" value={status.build.acceleration} mono={false} />
+                <Row label="Built" value={status.build.buildDate.split('T')[0]} />
+              </>
+            ) : (
+              <Row
+                label="Build record"
+                value={
+                  status.buildError ??
+                  'none — a prebuilt binary, or one installed outside gglib'
+                }
+                mono={false}
+              />
+            )}
+            {status.runtime && (
+              <Row
+                label="Binary reports"
+                value={
+                  status.runtime.build
+                    ? `b${status.runtime.build}`
+                    : 'unidentified build — gglib applies every compensation'
+                }
+                mono={!!status.runtime.build}
+              />
+            )}
+          </Stack>
+        )}
+      </section>
+
+      {status?.installed && (
+        <section>
+          <h3 className="m-0 mb-xs text-sm font-semibold text-text">Updates</h3>
+          <p className="m-0 mb-base text-xs text-text-muted">
+            Compares the local source checkout against upstream. Contacts GitHub, so it only runs
+            when you ask.
+          </p>
+
+          {checkError && (
+            <Banner variant="danger" className="mb-base">
+              {checkError}
+            </Banner>
+          )}
+
+          {updateCheck && !updateCheck.comparable ? (
+            <Banner variant="info" className="mb-base">
+              {updateCheck.repoPresent
+                ? 'There is a source checkout but no build record, so there is nothing to compare against. Rebuilding from source will record one.'
+                : 'No source checkout, so there is nothing to compare — this is a prebuilt install. Rebuilding from source in the setup wizard makes updates available.'}
+            </Banner>
+          ) : updateCheck ? (
+            <Stack gap="xs" className="mb-base">
+              <p className="m-0 text-xs text-text-secondary">
+                {updateCheck.commitsBehind === 0
+                  ? 'Up to date with upstream.'
+                  : `${updateCheck.commitsBehind} commit(s) behind upstream.`}
+              </p>
+              {updateCheck.recentCommits.length > 0 && (
+                <ul className="m-0 pl-md list-disc">
+                  {updateCheck.recentCommits.map((line) => (
+                    <li key={line} className="text-xs text-text-muted font-mono break-all">
+                      {line}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Stack>
+          ) : null}
+
+          {updateError && (
+            <Banner variant="danger" className="mb-base">
+              {updateError}
+            </Banner>
+          )}
+          {updateResult && (
+            <Banner variant="success" className="mb-base">
+              {updateResult}
+            </Banner>
+          )}
+          {updating && (
+            <p className="m-0 mb-base text-xs text-text-secondary" role="status">
+              {updateProgress ?? 'Building…'}
+            </p>
+          )}
+
+          <div className="flex gap-sm">
+            <Button
+              variant="secondary"
+              size="sm"
+              isLoading={checkingUpdates}
+              disabled={checkingUpdates || updating}
+              onClick={runUpdateCheck}
+            >
+              Check for updates
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              isLoading={updating}
+              disabled={updating || updateCheck?.repoPresent === false}
+              onClick={() => void handleUpdate()}
+            >
+              Update and rebuild
+            </Button>
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h3 className="m-0 mb-xs text-sm font-semibold text-text">Uninstall</h3>
+        <p className="m-0 mb-base text-xs text-text-muted">
+          Removes llama.cpp and its binaries. Models stay on disk, but nothing can be served
+          until it is installed again.
+        </p>
+        {uninstallResult && (
+          <Banner variant="info" className="mb-base">
+            {uninstallResult}
+          </Banner>
+        )}
+        <Button
+          variant="dangerGhost"
+          size="sm"
+          isLoading={uninstalling}
+          disabled={uninstalling || updating || !status?.installed}
+          onClick={() => void handleUninstall()}
+        >
+          Uninstall llama.cpp
+        </Button>
+      </section>
+    </Stack>
+  );
+};

--- a/src/components/SettingsModal/useSystemSettings.ts
+++ b/src/components/SettingsModal/useSystemSettings.ts
@@ -1,0 +1,210 @@
+/**
+ * State for the System settings tab: what llama.cpp is installed, whether
+ * upstream has moved, and the update/uninstall actions.
+ *
+ * Split by cost. Status is local and loads on mount; the update check runs
+ * `git fetch` and only ever runs when asked. The update itself streams build
+ * events, so the tab can show progress instead of an indefinite spinner.
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import {
+  checkLlamaUpdates,
+  getLlamaStatus,
+  streamLlamaUpdate,
+  uninstallLlama,
+} from '../../services/transport/api/setup';
+import type { BuildEvent, LlamaStatus, LlamaUpdateCheck } from '../../types/setup';
+import { appLogger } from '../../services/platform';
+
+/** Human-readable names for the build phases, in the order they run. */
+const PHASE_LABELS: Record<string, string> = {
+  dependency_check: 'Checking dependencies',
+  clone_or_update_repo: 'Updating repository',
+  configure: 'Configuring',
+  compile: 'Compiling',
+  install_binaries: 'Installing binaries',
+};
+
+/**
+ * Build state lives outside React.
+ *
+ * A llama.cpp rebuild takes minutes and keeps running on the daemon whatever
+ * the UI does. If this lived in component state, switching tabs or closing
+ * Settings would discard it and the user would come back to a panel claiming
+ * nothing is happening while a compile is running — and could start a second
+ * one. Module scope means a remount re-attaches to the build in progress.
+ */
+interface BuildState {
+  updating: boolean;
+  progress: string | null;
+  error: string | null;
+  result: string | null;
+}
+
+let buildState: BuildState = { updating: false, progress: null, error: null, result: null };
+const buildListeners = new Set<() => void>();
+
+function setBuildState(patch: Partial<BuildState>) {
+  buildState = { ...buildState, ...patch };
+  buildListeners.forEach((l) => l());
+}
+
+function subscribeBuild(listener: () => void) {
+  buildListeners.add(listener);
+  return () => {
+    buildListeners.delete(listener);
+  };
+}
+
+export interface SystemSettingsState {
+  status: LlamaStatus | null;
+  statusError: string | null;
+  loadingStatus: boolean;
+  reloadStatus: () => void;
+
+  updateCheck: LlamaUpdateCheck | null;
+  checkingUpdates: boolean;
+  checkError: string | null;
+  runUpdateCheck: () => void;
+
+  updating: boolean;
+  /** Current build phase, or the last log line — whatever is most recent. */
+  updateProgress: string | null;
+  updateError: string | null;
+  updateResult: string | null;
+  runUpdate: () => void;
+
+  uninstalling: boolean;
+  uninstallResult: string | null;
+  runUninstall: () => Promise<void>;
+}
+
+export function useSystemSettings(): SystemSettingsState {
+  const [status, setStatus] = useState<LlamaStatus | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [loadingStatus, setLoadingStatus] = useState(true);
+
+  const [updateCheck, setUpdateCheck] = useState<LlamaUpdateCheck | null>(null);
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+  const [checkError, setCheckError] = useState<string | null>(null);
+
+  const build = useSyncExternalStore(subscribeBuild, () => buildState);
+
+  const [uninstalling, setUninstalling] = useState(false);
+  const [uninstallResult, setUninstallResult] = useState<string | null>(null);
+
+  const reloadStatus = useCallback(() => {
+    setLoadingStatus(true);
+    setStatusError(null);
+    void getLlamaStatus()
+      .then(setStatus)
+      .catch((err: unknown) => {
+        setStatusError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setLoadingStatus(false));
+  }, []);
+
+  useEffect(() => {
+    reloadStatus();
+    // Deliberately no teardown for the build stream: it is owned by the module
+    // store, not by this component, so leaving the tab does not stop us
+    // listening and coming back shows the build still in progress.
+  }, [reloadStatus]);
+
+  const runUpdateCheck = useCallback(() => {
+    setCheckingUpdates(true);
+    setCheckError(null);
+    void checkLlamaUpdates()
+      .then(setUpdateCheck)
+      .catch((err: unknown) => {
+        setCheckError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setCheckingUpdates(false));
+  }, []);
+
+  const runUpdate = useCallback(() => {
+    if (buildState.updating) return;
+    setBuildState({ updating: true, error: null, result: null, progress: 'Starting…' });
+
+    streamLlamaUpdate(
+      (event: BuildEvent) => {
+        switch (event.type) {
+          case 'phase_started':
+            setBuildState({ progress: PHASE_LABELS[event.phase] ?? event.phase });
+            break;
+          case 'log':
+            setBuildState({ progress: event.message });
+            break;
+          case 'completed':
+            setBuildState({
+              updating: false,
+              progress: null,
+              result: `Rebuilt at ${event.version} (${event.acceleration})`,
+            });
+            setUpdateCheck(null);
+            reloadStatus();
+            break;
+          case 'failed':
+            setBuildState({ updating: false, progress: null, error: event.message });
+            break;
+          default:
+            break;
+        }
+      },
+      (message) => {
+        appLogger.error('component', 'llama update stream failed', { message });
+        setBuildState({ updating: false, progress: null, error: message });
+      },
+      // A stream that ends without `completed` or `failed` — daemon restart,
+      // network drop — must not leave the panel spinning forever.
+      () => {
+        if (buildState.updating) {
+          setBuildState({
+            updating: false,
+            progress: null,
+            error: 'The connection to the build ended before it reported a result. It may still be running — reopen this tab to check.',
+          });
+        }
+      },
+    );
+  }, [reloadStatus]);
+
+  const runUninstall = useCallback(async () => {
+    setUninstalling(true);
+    setUninstallResult(null);
+    try {
+      const outcome = await uninstallLlama();
+      setUninstallResult(
+        outcome.wasInstalled
+          ? `Removed ${outcome.removedPaths.length} path(s)`
+          : 'Nothing was installed',
+      );
+      setUpdateCheck(null);
+      reloadStatus();
+    } catch (err) {
+      setStatusError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUninstalling(false);
+    }
+  }, [reloadStatus]);
+
+  return {
+    status,
+    statusError,
+    loadingStatus,
+    reloadStatus,
+    updateCheck,
+    checkingUpdates,
+    checkError,
+    runUpdateCheck,
+    updating: build.updating,
+    updateProgress: build.progress,
+    updateError: build.error,
+    updateResult: build.result,
+    runUpdate,
+    uninstalling,
+    uninstallResult,
+    runUninstall,
+  };
+}

--- a/src/services/transport/api/setup.ts
+++ b/src/services/transport/api/setup.ts
@@ -4,8 +4,16 @@
  */
 
 import { get, post } from './client';
-import { getApiBaseUrl, getAuthHeaders } from './client';
-import type { SetupStatus, LlamaInstallProgress, VulkanStatus } from '../../../types/setup';
+import { parseFrame, streamSse } from './sse';
+import type {
+  SetupStatus,
+  LlamaInstallProgress,
+  VulkanStatus,
+  LlamaStatus,
+  LlamaUpdateCheck,
+  LlamaUninstallOutcome,
+  BuildEvent,
+} from '../../../types/setup';
 
 /**
  * Get the current system setup status.
@@ -36,70 +44,19 @@ export function streamLlamaInstall(
   onComplete: () => void,
   onError: (error: string) => void,
 ): () => void {
-  const controller = new AbortController();
-  const baseUrl = getApiBaseUrl();
-  const headers = getAuthHeaders();
-
-  // Use fetch directly for SSE streaming (POST request)
-  fetch(`${baseUrl}/api/config/system/install-llama`, {
-    method: 'POST',
-    headers: {
-      ...headers,
-      Accept: 'text/event-stream',
+  return streamSse('/api/config/system/install-llama', {
+    onFrame: (frame) => {
+      if (frame.event === 'progress') {
+        const progress = parseFrame<LlamaInstallProgress>(frame);
+        if (progress) onProgress(progress);
+      } else if (frame.event === 'complete') {
+        onComplete();
+      } else if (frame.event === 'error') {
+        onError(parseFrame<{ message?: string }>(frame)?.message ?? 'Unknown error');
+      }
     },
-    signal: controller.signal,
-  })
-    .then(async (response) => {
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      if (!response.body) {
-        throw new Error('No response body for SSE stream');
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-
-        let currentEventType = '';
-        for (const line of lines) {
-          if (line.startsWith('event: ')) {
-            currentEventType = line.slice(7).trim();
-          } else if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            try {
-              if (currentEventType === 'progress') {
-                const progress: LlamaInstallProgress = JSON.parse(data);
-                onProgress(progress);
-              } else if (currentEventType === 'complete') {
-                onComplete();
-              } else if (currentEventType === 'error') {
-                const errorData = JSON.parse(data);
-                onError(errorData.message || 'Unknown error');
-              }
-            } catch {
-              // Ignore parse errors for partial data
-            }
-            currentEventType = '';
-          }
-        }
-      }
-    })
-    .catch((err) => {
-      if (err.name !== 'AbortError') {
-        onError(err.message || 'Installation failed');
-      }
-    });
-
-  return () => controller.abort();
+    onError,
+  });
 }
 
 /**
@@ -107,4 +64,52 @@ export function streamLlamaInstall(
  */
 export async function setupPython(): Promise<void> {
   return post<void>('/api/config/system/setup-python');
+}
+
+/**
+ * What llama.cpp install is present — version, health, acceleration, and what
+ * the binary reports about itself. Local and cheap; safe on mount.
+ */
+export async function getLlamaStatus(): Promise<LlamaStatus> {
+  return get<LlamaStatus>('/api/config/system/llama-status');
+}
+
+/**
+ * How far behind upstream the llama.cpp checkout is.
+ *
+ * POST because it runs `git fetch` — seconds of network, not a page-load
+ * request. Only meaningful for a source install; a prebuilt one has no
+ * repository to compare (`repoPresent: false`).
+ */
+export async function checkLlamaUpdates(): Promise<LlamaUpdateCheck> {
+  return post<LlamaUpdateCheck>('/api/config/system/llama-check-updates');
+}
+
+/** Remove llama.cpp: source checkout, binaries and build config. */
+export async function uninstallLlama(): Promise<LlamaUninstallOutcome> {
+  return post<LlamaUninstallOutcome>('/api/config/system/uninstall-llama');
+}
+
+/**
+ * Pull upstream and rebuild llama.cpp, streaming build progress.
+ *
+ * Same event vocabulary as building from source. Aborting stops the stream,
+ * not the build — the compile continues on the daemon.
+ */
+export function streamLlamaUpdate(
+  onEvent: (event: BuildEvent) => void,
+  onError: (error: string) => void,
+  /** Called when the stream closes cleanly, whether or not it reported a result. */
+  onClose?: () => void,
+): () => void {
+  return streamSse('/api/config/system/update-llama', {
+    onFrame: (frame) => {
+      // Every payload carries its own `type`, so the SSE event name is
+      // redundant here and the parsed object is the single source of truth.
+      const event = parseFrame<BuildEvent>(frame);
+      if (event) onEvent(event);
+    },
+    onClose,
+    onError,
+  });
 }

--- a/src/services/transport/api/sse.ts
+++ b/src/services/transport/api/sse.ts
@@ -1,0 +1,102 @@
+/**
+ * Reading a POST server-sent-event stream.
+ *
+ * `EventSource` cannot issue a POST, so every streaming endpoint gglib
+ * exposes has to be read by hand off `fetch`. This is that loop, written
+ * once: llama install, build-from-source and update all speak the same
+ * `event:`/`data:` wire format and differ only in which event names they
+ * emit and what the payloads mean.
+ */
+
+import { getApiBaseUrl, getAuthHeaders } from './client';
+
+/** One decoded frame: the SSE event name and its raw `data:` payload. */
+export interface SseFrame {
+  event: string;
+  data: string;
+}
+
+export interface StreamSseHandlers {
+  /** Called for every frame, in arrival order. */
+  onFrame: (frame: SseFrame) => void;
+  /** Called once when the server closes the stream cleanly. */
+  onClose?: () => void;
+  /** Transport-level failure. Not called when the caller aborts. */
+  onError: (message: string) => void;
+}
+
+/**
+ * POST to `path` and read the SSE response until it closes.
+ *
+ * Returns an abort function. Aborting stops reading and disconnects; it does
+ * not stop whatever the server started, so callers whose work continues
+ * server-side after a disconnect should say so in the UI.
+ */
+export function streamSse(
+  path: string,
+  handlers: StreamSseHandlers,
+  body?: unknown,
+): () => void {
+  const controller = new AbortController();
+
+  void fetch(`${getApiBaseUrl()}${path}`, {
+    method: 'POST',
+    headers: {
+      ...getAuthHeaders(),
+      Accept: 'text/event-stream',
+      ...(body !== undefined && { 'Content-Type': 'application/json' }),
+    },
+    ...(body !== undefined && { body: JSON.stringify(body) }),
+    signal: controller.signal,
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      if (!response.body) {
+        throw new Error('No response body for SSE stream');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let currentEvent = '';
+
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        // A frame can straddle a chunk boundary, so the trailing partial
+        // line stays in the buffer until the next read completes it.
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith('data: ')) {
+            handlers.onFrame({ event: currentEvent, data: line.slice(6) });
+            currentEvent = '';
+          }
+        }
+      }
+
+      handlers.onClose?.();
+    })
+    .catch((err: unknown) => {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      handlers.onError(err instanceof Error ? err.message : String(err));
+    });
+
+  return () => controller.abort();
+}
+
+/** Parse a frame's payload, returning undefined rather than throwing. */
+export function parseFrame<T>(frame: SseFrame): T | undefined {
+  try {
+    return JSON.parse(frame.data) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/types/setup.ts
+++ b/src/types/setup.ts
@@ -11,6 +11,7 @@ export interface GpuInfo {
   cudaVersion?: string | null;
   vulkanHeadersInstalled: boolean;
   vulkanGlslcInstalled: boolean;
+  vulkanSpirvHeadersInstalled: boolean;
 }
 
 /** Models directory status. */
@@ -67,3 +68,82 @@ export interface VulkanStatus {
   readyForBuild: boolean;
   missing: MissingPackage[];
 }
+
+/** What gglib recorded when it built the binary. Absent for a prebuilt install. */
+export interface LlamaBuildInfo {
+  version: string;
+  commitSha: string;
+  /** RFC 3339. */
+  buildDate: string;
+  acceleration: string;
+  cmakeFlags: string[];
+}
+
+/** Native capabilities the binary reports for itself when probed. */
+export interface LlamaRuntimeCapabilities {
+  /** llama.cpp build number, absent when the binary could not be identified. */
+  build?: number | null;
+  commit?: string | null;
+  versionLine: string;
+  /** Capability flags, pre-rendered for display — do not parse. */
+  flags: string;
+}
+
+/**
+ * The installed llama.cpp, as reported by `gglib config llama status`.
+ *
+ * `build` and `runtime` are two different notions of version and can legitimately
+ * disagree: the first is what gglib recorded at build time, the second is what
+ * the binary says about itself. A hand-installed or prebuilt binary has no
+ * `build` at all.
+ */
+export interface LlamaStatus {
+  installed: boolean;
+  binaryPath: string;
+  configPath: string;
+  healthy: boolean;
+  healthError?: string | null;
+  build?: LlamaBuildInfo | null;
+  buildError?: string | null;
+  runtime?: LlamaRuntimeCapabilities | null;
+}
+
+/** How far behind upstream the llama.cpp source checkout is. */
+export interface LlamaUpdateCheck {
+  installed: boolean;
+  /** False for a prebuilt install: there is no repository to compare. */
+  repoPresent: boolean;
+  /**
+   * Whether a comparison actually ran. When false, `commitsBehind` is 0
+   * because nothing was compared — never present that as "up to date".
+   */
+  comparable: boolean;
+  currentVersion?: string | null;
+  currentAcceleration?: string | null;
+  buildDate?: string | null;
+  commitsBehind: number;
+  recentCommits: string[];
+}
+
+/** What an uninstall removed. */
+export interface LlamaUninstallOutcome {
+  wasInstalled: boolean;
+  removedPaths: string[];
+}
+
+/** Build pipeline phases, in order. */
+export type BuildPhase =
+  | 'dependency_check'
+  | 'clone_or_update_repo'
+  | 'configure'
+  | 'compile'
+  | 'install_binaries';
+
+/** Streaming build events, shared by install-from-source and update. */
+export type BuildEvent =
+  | { type: 'phase_started'; phase: BuildPhase }
+  | { type: 'log'; message: string }
+  | { type: 'progress'; current: number; total: number }
+  | { type: 'phase_completed'; phase: BuildPhase }
+  | { type: 'completed'; version: string; acceleration: string }
+  | { type: 'failed'; message: string };

--- a/tests/ts/services/sse.test.ts
+++ b/tests/ts/services/sse.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the shared POST-SSE reader. The interesting property is that a
+ * frame may straddle a network chunk boundary — the naive version of this
+ * loop drops the split frame, and all three llama endpoints depend on it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { streamSse, parseFrame } from '../../../src/services/transport/api/sse';
+
+vi.mock('../../../src/services/transport/api/client', () => ({
+  getApiBaseUrl: () => 'http://localhost:1234',
+  getAuthHeaders: () => ({}),
+}));
+
+/** A Response whose body yields the given string chunks, in order. */
+function streamingResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: () =>
+          Promise.resolve(
+            i < chunks.length
+              ? { done: false, value: encoder.encode(chunks[i++]) }
+              : { done: true, value: undefined },
+          ),
+      }),
+    },
+  } as unknown as Response;
+}
+
+/** Let the reader drain — each chunk costs a microtask turn. */
+const drain = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('streamSse', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('decodes event name and data for each frame', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      streamingResponse(['event: log\ndata: {"message":"hi"}\n\n']),
+    );
+
+    const frames: { event: string; data: string }[] = [];
+    streamSse('/x', { onFrame: (f) => frames.push(f), onError: vi.fn() });
+    await drain();
+
+    expect(frames).toEqual([{ event: 'log', data: '{"message":"hi"}' }]);
+  });
+
+  it('reassembles a frame split across chunk boundaries', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      streamingResponse(['event: comp', 'leted\ndata: {"vers', 'ion":"b1"}\n\n']),
+    );
+
+    const frames: { event: string; data: string }[] = [];
+    streamSse('/x', { onFrame: (f) => frames.push(f), onError: vi.fn() });
+    await drain();
+
+    expect(frames).toEqual([{ event: 'completed', data: '{"version":"b1"}' }]);
+  });
+
+  it('reports a non-ok response as an error rather than silence', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response);
+
+    const onError = vi.fn();
+    streamSse('/x', { onFrame: vi.fn(), onError });
+    await drain();
+
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('500'));
+  });
+
+  it('stays quiet when the caller aborts', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    vi.mocked(fetch).mockRejectedValue(abortError);
+
+    const onError = vi.fn();
+    const abort = streamSse('/x', { onFrame: vi.fn(), onError });
+    abort();
+    await drain();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseFrame', () => {
+  it('returns undefined for malformed payloads instead of throwing', () => {
+    expect(parseFrame({ event: 'log', data: '{not json' })).toBeUndefined();
+  });
+
+  it('parses a well-formed payload', () => {
+    expect(parseFrame<{ a: number }>({ event: 'log', data: '{"a":1}' })).toEqual({ a: 1 });
+  });
+});


### PR DESCRIPTION
## What

PR 10 of the stack. Brings llama.cpp management into the GUI as a new **System** tab in Settings — status, update check, update, uninstall. Until now the only llama.cpp surface was the first-run wizard, which knew nothing beyond whether the binary file existed.

Stacked on `feat(api,gui)/model-maintenance` (#766). Review only the top two commits.

## Parity closed

| CLI | GUI |
|---|---|
| `gglib config llama status` | System tab, install/health/build panel |
| `gglib config llama check-updates` | "Check for updates" |
| `gglib config llama update` | "Update and rebuild", streaming build phases |
| `gglib config llama uninstall` | "Uninstall llama.cpp", confirmed |

## The shape of the refactor

Each handler computed and printed in one pass. They now return values and the CLI handlers are printers over them, so both surfaces read the same data:

- `llama_status()` — local and cheap, safe to load on mount
- `llama_update_check()` — network-bound (`git fetch`), only on an explicit action
- `uninstall_llama()` — returns what it removed; confirmation belongs to the caller
- `run_llama_update()` — `git pull`, then the existing `run_llama_source_build` pipeline

## Two bugs fixed by construction

The old inline `handle_update` created a `BuildEvent` channel and dropped the receiver (`let (build_tx, _build_rx) = ...`), so the build ran silently *and* blocked the async thread — the source-build pipeline already does this correctly with `spawn_blocking`. It also installed `llama-server` without `llama-bench`, which the shared pipeline installs. Routing update through that pipeline fixes both, and the CLI gains progress output it never had.

## Design notes

**`check-updates` is POST, not GET.** It runs `git fetch`, which writes local refs and takes seconds of network. A GET invites a page to issue it on load. There is a test asserting GET is rejected.

**"No source checkout" is not "up to date".** A prebuilt install has no repository to compare against, and `commitsBehind: 0` there means "cannot tell". The DTO carries `repoPresent` and the panel branches on it first.

**Two notions of version are kept apart.** `build` is what gglib recorded when it compiled the binary; `runtime` is what the binary reports when probed. They legitimately disagree for a prebuilt or hand-installed binary, and that disagreement is what someone debugging a launch needs to see.

**The SSE reader is now shared.** `services/transport/api/sse.ts` replaces the hand-rolled loop that update would have been the third copy of. The old one had a real hazard: a frame split across a network chunk boundary. That case is now tested.

## Also

`GpuInfo` in TypeScript was missing `vulkanSpirvHeadersInstalled`, which the Rust DTO has always sent.

`assistant_ui`'s three handlers were in scope for this PR and are deliberately left alone — they shell out to `npm` against a relative `node_modules`, so they only work from a repo checkout with a dev toolchain and are meaningless for an installed binary. Proposed for deletion in PR 13 rather than exposure here.

## Test plan

- `cargo test` across runtime, axum, cli, app-services — green; new tests pin the camelCase wire contracts (the TS types are hand-mirrored) and the not-comparable-vs-up-to-date distinction
- Two new route tests: `llama-status` returns the expected JSON shape, `llama-check-updates` rejects GET
- `npm test` — 794 passing, including six new tests for the SSE reader
- `npm run lint`, `npx tsc --noEmit`, `npm run build`, `cargo clippy` — clean
