### PR TITLE
feat(api,gui): system diagnostics — dependencies, paths, accelerator

### DIFF
--- a/crates/gglib-app-services/src/setup.rs
+++ b/crates/gglib-app-services/src/setup.rs
@@ -220,6 +220,102 @@ impl SetupOps {
             .await
             .map_err(|e| GuiError::Internal(format!("Failed to setup Python environment: {e}")))
     }
+
+    /// Remove the accelerator's environment; downloads revert to native HTTP.
+    ///
+    /// The mirror of [`Self::setup_python_env`] — `gglib config fast-downloads
+    /// disable`. Downloads keep working either way; this only removes the
+    /// faster path.
+    ///
+    /// Returns whether anything was there to remove, so a caller can tell
+    /// "disabled it" from "already off" rather than guessing.
+    pub fn remove_python_env(&self) -> Result<bool, GuiError> {
+        gglib_download::cli_exec::remove_fast_helper()
+            .map_err(|e| GuiError::Internal(format!("Failed to remove Python environment: {e}")))
+    }
+
+    /// Everything the diagnostics panel shows: dependency matrix, resolved
+    /// paths, detected acceleration, accelerator state.
+    ///
+    /// Assembled in one call because they are read together — this is the
+    /// "why isn't this working" surface, and someone comparing a missing
+    /// dependency against a resolved path should not be watching four
+    /// spinners. Individually cheap: no network, and no subprocess beyond the
+    /// version probes `check_all_dependencies` already runs.
+    pub fn diagnostics(&self) -> Result<Diagnostics, GuiError> {
+        let dependencies = self.deps.system_probe.check_all_dependencies();
+
+        let paths = gglib_core::paths::ResolvedPaths::resolve()
+            .map_err(|e| GuiError::Internal(format!("Failed to resolve paths: {e}")))?;
+
+        // Detection refuses to fall back to CPU so callers can surface install
+        // hints. That refusal is an answer here, not a failed request.
+        let acceleration = match gglib_runtime::llama::detect_optimal_acceleration() {
+            Ok(accel) => AccelerationInfo {
+                detected: Some(accel.display_name().to_string()),
+                detection_error: None,
+            },
+            Err(e) => AccelerationInfo {
+                detected: None,
+                detection_error: Some(e.to_string()),
+            },
+        };
+
+        let fast_downloads = match gglib_download::cli_exec::fast_helper_status() {
+            Ok(status) => FastDownloadsInfo {
+                provisioned: status.provisioned,
+                env_dir: status.env_dir.display().to_string(),
+                legacy_path: status.legacy_path,
+                builder: status.builder,
+                available_builder: status.available_builder.to_string(),
+                error: None,
+            },
+            Err(e) => FastDownloadsInfo {
+                provisioned: false,
+                env_dir: String::new(),
+                legacy_path: false,
+                builder: None,
+                available_builder: String::new(),
+                error: Some(e.to_string()),
+            },
+        };
+
+        Ok(Diagnostics {
+            dependencies,
+            paths,
+            acceleration,
+            fast_downloads,
+        })
+    }
+}
+
+/// What acceleration a build would use, with detection failure carried as data.
+#[derive(Debug, Clone)]
+pub struct AccelerationInfo {
+    pub detected: Option<String>,
+    pub detection_error: Option<String>,
+}
+
+/// The optional `hf_xet` download accelerator's state.
+#[derive(Debug, Clone)]
+pub struct FastDownloadsInfo {
+    pub provisioned: bool,
+    pub env_dir: String,
+    pub legacy_path: bool,
+    pub builder: Option<String>,
+    pub available_builder: String,
+    /// Why the status could not be read, when it could not.
+    pub error: Option<String>,
+}
+
+/// The system diagnostics bundle — `gglib config check-deps`, `paths` and
+/// `fast-downloads status` as one value.
+#[derive(Debug, Clone)]
+pub struct Diagnostics {
+    pub dependencies: Vec<gglib_core::utils::system::Dependency>,
+    pub paths: gglib_core::paths::ResolvedPaths,
+    pub acceleration: AccelerationInfo,
+    pub fast_downloads: FastDownloadsInfo,
 }
 
 #[cfg(test)]

--- a/crates/gglib-axum/src/dto/diagnostics.rs
+++ b/crates/gglib-axum/src/dto/diagnostics.rs
@@ -1,0 +1,164 @@
+//! Wire types for the system diagnostics surface.
+//!
+//! `gglib config check-deps` / `paths` / `fast-downloads status` print
+//! directly from types that live in `gglib-core` and `gglib-download` and
+//! carry no `Serialize`. Rather than derive serde onto domain types for the
+//! benefit of one HTTP route, this mirrors them here — the same boundary
+//! [`VulkanStatusDto`] already draws.
+//!
+//! [`VulkanStatusDto`]: super::system::VulkanStatusDto
+
+use gglib_core::paths::{ModelsDirSource, ResolvedPaths};
+use gglib_core::utils::system::{Dependency, DependencyStatus};
+use serde::Serialize;
+
+/// One dependency's state.
+///
+/// `status` is flattened to a string plus an optional version rather than an
+/// externally-tagged enum: the GUI switches on three cases and the extra
+/// nesting buys nothing.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyDto {
+    pub name: String,
+    /// `"present" | "missing" | "optional"`.
+    pub status: String,
+    /// Present only when `status` is `"present"`.
+    pub version: Option<String>,
+    pub description: String,
+    pub required: bool,
+    pub install_hint: Option<String>,
+}
+
+impl From<&Dependency> for DependencyDto {
+    fn from(dep: &Dependency) -> Self {
+        let (status, version) = match &dep.status {
+            DependencyStatus::Present { version } => ("present", Some(version.clone())),
+            DependencyStatus::Missing => ("missing", None),
+            DependencyStatus::Optional => ("optional", None),
+        };
+
+        Self {
+            name: dep.name.clone(),
+            status: status.to_string(),
+            version,
+            description: dep.description.clone(),
+            required: dep.required,
+            install_hint: dep.install_hint.clone(),
+        }
+    }
+}
+
+/// Where everything resolves to — `gglib config paths`, the golden-truth tool
+/// for "which directory is it actually using?".
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedPathsDto {
+    pub data_root: String,
+    pub resource_root: String,
+    pub database_path: String,
+    pub llama_server_path: String,
+    pub models_dir: String,
+    /// How the models directory was chosen: `"explicit" | "envVar" | "default"`.
+    pub models_source: String,
+}
+
+impl From<ResolvedPaths> for ResolvedPathsDto {
+    fn from(paths: ResolvedPaths) -> Self {
+        Self {
+            data_root: paths.data_root.display().to_string(),
+            resource_root: paths.resource_root.display().to_string(),
+            database_path: paths.database_path.display().to_string(),
+            llama_server_path: paths.llama_server_path.display().to_string(),
+            models_dir: paths.models_dir.display().to_string(),
+            models_source: match paths.models_source {
+                ModelsDirSource::Explicit => "explicit",
+                ModelsDirSource::EnvVar => "envVar",
+                ModelsDirSource::Default => "default",
+            }
+            .to_string(),
+        }
+    }
+}
+
+/// What acceleration a build would use.
+///
+/// Detection is deliberately fallible — it refuses to fall back to CPU so
+/// callers can surface install hints — so the failure is carried as data
+/// rather than failing the whole diagnostics request.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccelerationDto {
+    pub detected: Option<String>,
+    pub detection_error: Option<String>,
+}
+
+/// The optional `hf_xet` download accelerator.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FastDownloadsDto {
+    /// Whether a usable environment is present — the same question, and the
+    /// same answer, that selects the backend for a download.
+    pub provisioned: bool,
+    pub env_dir: String,
+    /// True when the environment sits at the pre-rename location.
+    pub legacy_path: bool,
+    /// Which tool built it, per its marker.
+    pub builder: Option<String>,
+    /// The tool that would build it now.
+    pub available_builder: String,
+    /// Why the status could not be read, when it could not.
+    pub error: Option<String>,
+}
+
+/// Everything the diagnostics panel shows, in one request.
+///
+/// One route rather than four because these are read together: the panel is
+/// "why isn't this working", and a user comparing a missing dependency
+/// against a resolved path should not be watching four spinners.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticsDto {
+    pub dependencies: Vec<DependencyDto>,
+    pub paths: ResolvedPathsDto,
+    pub acceleration: AccelerationDto,
+    pub fast_downloads: FastDownloadsDto,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn present_dependency_carries_its_version() {
+        let dep = Dependency {
+            name: "cmake".into(),
+            status: DependencyStatus::Present {
+                version: "3.28.1".into(),
+            },
+            description: "Build system".into(),
+            required: true,
+            install_hint: Some("brew install cmake".into()),
+        };
+
+        let json = serde_json::to_value(DependencyDto::from(&dep)).unwrap();
+        assert_eq!(json["status"], "present");
+        assert_eq!(json["version"], "3.28.1");
+        assert_eq!(json["installHint"], "brew install cmake");
+    }
+
+    #[test]
+    fn missing_dependency_has_no_version() {
+        let dep = Dependency {
+            name: "git".into(),
+            status: DependencyStatus::Missing,
+            description: "Version control".into(),
+            required: true,
+            install_hint: None,
+        };
+
+        let json = serde_json::to_value(DependencyDto::from(&dep)).unwrap();
+        assert_eq!(json["status"], "missing");
+        assert!(json["version"].is_null());
+    }
+}

--- a/crates/gglib-axum/src/dto/mod.rs
+++ b/crates/gglib-axum/src/dto/mod.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("README.md")]
+pub mod diagnostics;
 pub mod system;
 
 pub use system::SystemMemoryInfoDto;

--- a/crates/gglib-axum/src/handlers/config/setup.rs
+++ b/crates/gglib-axum/src/handlers/config/setup.rs
@@ -9,6 +9,7 @@ use futures_util::StreamExt;
 use futures_util::stream::Stream;
 use serde::{Deserialize, Serialize};
 
+use crate::dto::diagnostics::{AccelerationDto, DiagnosticsDto, FastDownloadsDto, ResolvedPathsDto};
 use crate::dto::system::VulkanStatusDto;
 use crate::error::HttpError;
 use crate::state::AppState;
@@ -85,6 +86,48 @@ pub async fn install_llama(
 pub async fn setup_python(State(state): State<AppState>) -> Result<Json<()>, HttpError> {
     state.setup.setup_python_env().await?;
     Ok(Json(()))
+}
+
+/// Remove the fast-download helper environment — downloads revert to native
+/// HTTP, which is a speed change, not a loss of capability.
+pub async fn disable_fast_downloads(
+    State(state): State<AppState>,
+) -> Result<Json<DisableFastDownloadsResponse>, HttpError> {
+    Ok(Json(DisableFastDownloadsResponse {
+        removed: state.setup.remove_python_env()?,
+    }))
+}
+
+/// Whether disabling actually removed anything, so the GUI can say
+/// "disabled" rather than claiming a change that did not happen.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisableFastDownloadsResponse {
+    pub removed: bool,
+}
+
+/// System diagnostics: dependency matrix, resolved paths, detected
+/// acceleration and accelerator state — `gglib config check-deps`, `paths`
+/// and `fast-downloads status` in one response.
+pub async fn diagnostics(State(state): State<AppState>) -> Result<Json<DiagnosticsDto>, HttpError> {
+    let d = state.setup.diagnostics()?;
+
+    Ok(Json(DiagnosticsDto {
+        dependencies: d.dependencies.iter().map(Into::into).collect(),
+        paths: ResolvedPathsDto::from(d.paths),
+        acceleration: AccelerationDto {
+            detected: d.acceleration.detected,
+            detection_error: d.acceleration.detection_error,
+        },
+        fast_downloads: FastDownloadsDto {
+            provisioned: d.fast_downloads.provisioned,
+            env_dir: d.fast_downloads.env_dir,
+            legacy_path: d.fast_downloads.legacy_path,
+            builder: d.fast_downloads.builder,
+            available_builder: d.fast_downloads.available_builder,
+            error: d.fast_downloads.error,
+        },
+    }))
 }
 
 /// SSE progress events for llama installation.

--- a/crates/gglib-axum/src/handlers/config/setup.rs
+++ b/crates/gglib-axum/src/handlers/config/setup.rs
@@ -9,7 +9,9 @@ use futures_util::StreamExt;
 use futures_util::stream::Stream;
 use serde::{Deserialize, Serialize};
 
-use crate::dto::diagnostics::{AccelerationDto, DiagnosticsDto, FastDownloadsDto, ResolvedPathsDto};
+use crate::dto::diagnostics::{
+    AccelerationDto, DiagnosticsDto, FastDownloadsDto, ResolvedPathsDto,
+};
 use crate::dto::system::VulkanStatusDto;
 use crate::error::HttpError;
 use crate::state::AppState;

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -334,6 +334,14 @@ fn config_routes() -> Router<AppState> {
             "/system/setup-python",
             post(handlers::config::setup::setup_python),
         )
+        .route(
+            "/system/disable-fast-downloads",
+            post(handlers::config::setup::disable_fast_downloads),
+        )
+        .route(
+            "/system/diagnostics",
+            get(handlers::config::setup::diagnostics),
+        )
 }
 
 /// The router core shared by [`create_router`] and [`create_spa_router`]:

--- a/src/components/SettingsModal/DiagnosticsPanel.tsx
+++ b/src/components/SettingsModal/DiagnosticsPanel.tsx
@@ -1,0 +1,215 @@
+/**
+ * Diagnostics — `gglib config check-deps`, `paths` and `fast-downloads
+ * status` as one panel in the System tab.
+ *
+ * This is the "why isn't this working" surface, so it leads with what is
+ * wrong: missing required dependencies first, with their install commands,
+ * then the resolved paths that answer "which directory is it actually using".
+ */
+
+import { FC } from 'react';
+import { Button } from '../ui/Button';
+import { Banner } from '../ui/Banner';
+import { Stack } from '../primitives';
+import { useDiagnostics } from './useDiagnostics';
+import type { DependencyInfo, ResolvedPaths } from '../../types/setup';
+
+/** Status dot plus name; the dot carries no meaning on its own, so the word stays. */
+const DependencyRow: FC<{ dep: DependencyInfo }> = ({ dep }) => {
+  const dot =
+    dep.status === 'present'
+      ? 'bg-success'
+      : dep.required
+        ? 'bg-danger'
+        : 'bg-text-muted';
+
+  return (
+    <div className="flex items-baseline justify-between gap-md py-2xs">
+      <div className="flex items-baseline gap-xs min-w-0">
+        <span
+          className={`inline-block w-2 h-2 rounded-full shrink-0 ${dot}`}
+          aria-hidden="true"
+        />
+        <span className="text-xs text-text font-mono">{dep.name}</span>
+        {!dep.required && <span className="text-2xs text-text-muted">optional</span>}
+      </div>
+      <span className="text-xs text-text-secondary font-mono tabular-nums text-right">
+        {dep.status === 'present' ? (dep.version ?? 'present') : dep.status}
+      </span>
+    </div>
+  );
+};
+
+const PATH_LABELS: [keyof ResolvedPaths, string][] = [
+  ['modelsDir', 'Models'],
+  ['dataRoot', 'Data'],
+  ['databasePath', 'Database'],
+  ['llamaServerPath', 'llama-server'],
+  ['resourceRoot', 'Resources'],
+];
+
+const MODELS_SOURCE_COPY: Record<ResolvedPaths['modelsSource'], string> = {
+  explicit: 'set explicitly',
+  envVar: 'from the environment',
+  default: 'platform default',
+};
+
+export const DiagnosticsPanel: FC = () => {
+  const {
+    diagnostics,
+    loading,
+    error,
+    reload,
+    togglingAccelerator,
+    acceleratorError,
+    toggleAccelerator,
+  } = useDiagnostics();
+
+  if (loading && !diagnostics) {
+    return <p className="text-sm text-text-muted m-0">Running diagnostics…</p>;
+  }
+
+  if (error) {
+    return (
+      <Banner variant="danger" action={<Button size="sm" variant="secondary" onClick={reload}>Retry</Button>}>
+        {error}
+      </Banner>
+    );
+  }
+
+  if (!diagnostics) return null;
+
+  const { dependencies, paths, acceleration, fastDownloads } = diagnostics;
+  const missingRequired = dependencies.filter((d) => d.required && d.status !== 'present');
+  // Several dependencies share an install command (one apt line covering
+  // three packages, say); printing it once per dependency is just noise.
+  const installHints = [
+    ...new Set(missingRequired.map((d) => d.installHint).filter(Boolean) as string[]),
+  ];
+
+  return (
+    <Stack gap="xl">
+      <section>
+        <div className="flex items-center justify-between gap-md mb-xs">
+          <h3 className="m-0 text-sm font-semibold text-text">Dependencies</h3>
+          <Button variant="ghost" size="sm" isLoading={loading} onClick={reload}>
+            Re-check
+          </Button>
+        </div>
+
+        {missingRequired.length > 0 && (
+          <Banner variant="warning" className="mb-base">
+            <Stack gap="xs">
+              <span>
+                {missingRequired.length} required{' '}
+                {missingRequired.length === 1 ? 'dependency is' : 'dependencies are'} missing.
+                These are the tools needed to build gglib itself from source; a downloaded
+                build does not need them, and they are listed here because
+                <code className="font-mono"> gglib config check-deps</code> reports them.
+              </span>
+              {installHints.map((hint) => (
+                <code key={hint} className="text-xs font-mono break-all">
+                  {hint}
+                </code>
+              ))}
+            </Stack>
+          </Banner>
+        )}
+
+        <div className="flex flex-col">
+          {dependencies.map((dep) => (
+            <DependencyRow key={dep.name} dep={dep} />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h3 className="m-0 mb-xs text-sm font-semibold text-text">Acceleration</h3>
+        {acceleration.detected ? (
+          <p className="m-0 text-xs text-text-secondary">
+            A build here would use{' '}
+            <span className="font-mono">{acceleration.detected}</span>.
+          </p>
+        ) : (
+          <Banner variant="warning">
+            {acceleration.detectionError ??
+              'No supported GPU acceleration was detected on this machine.'}
+          </Banner>
+        )}
+      </section>
+
+      <section>
+        <h3 className="m-0 mb-xs text-sm font-semibold text-text">Paths</h3>
+        <p className="m-0 mb-base text-xs text-text-muted">
+          Where gglib actually reads and writes — the answer when a model or setting seems to
+          have gone missing.
+        </p>
+        <Stack gap="xs">
+          {PATH_LABELS.map(([key, label]) => (
+            <div key={key} className="flex items-baseline justify-between gap-md">
+              <span className="text-xs text-text-muted shrink-0">{label}</span>
+              <span className="text-xs text-text-secondary font-mono text-right break-all">
+                {paths[key]}
+              </span>
+            </div>
+          ))}
+          <p className="m-0 text-2xs text-text-muted text-right">
+            Models directory {MODELS_SOURCE_COPY[paths.modelsSource]}.
+          </p>
+        </Stack>
+      </section>
+
+      <section>
+        <h3 className="m-0 mb-xs text-sm font-semibold text-text">Download accelerator</h3>
+        <p className="m-0 mb-base text-xs text-text-muted">
+          The optional hf_xet helper speeds up HuggingFace downloads. Downloads work without it,
+          over plain HTTP — this is a speed setting, not a requirement.
+        </p>
+
+        {fastDownloads.error && (
+          <Banner variant="danger" className="mb-base">
+            {fastDownloads.error}
+          </Banner>
+        )}
+        {acceleratorError && (
+          <Banner variant="danger" className="mb-base">
+            {acceleratorError}
+          </Banner>
+        )}
+
+        <Stack gap="xs" className="mb-base">
+          <div className="flex items-baseline justify-between gap-md">
+            <span className="text-xs text-text-muted">Status</span>
+            <span className="text-xs text-text-secondary">
+              {fastDownloads.provisioned ? 'Enabled' : 'Not enabled'}
+            </span>
+          </div>
+          {fastDownloads.provisioned && fastDownloads.builder && (
+            <div className="flex items-baseline justify-between gap-md">
+              <span className="text-xs text-text-muted">Built with</span>
+              <span className="text-xs text-text-secondary font-mono">{fastDownloads.builder}</span>
+            </div>
+          )}
+          {fastDownloads.envDir && (
+            <div className="flex items-baseline justify-between gap-md">
+              <span className="text-xs text-text-muted">Environment</span>
+              <span className="text-xs text-text-secondary font-mono text-right break-all">
+                {fastDownloads.envDir}
+              </span>
+            </div>
+          )}
+        </Stack>
+
+        <Button
+          variant={fastDownloads.provisioned ? 'dangerGhost' : 'secondary'}
+          size="sm"
+          isLoading={togglingAccelerator}
+          disabled={togglingAccelerator}
+          onClick={() => void toggleAccelerator(!fastDownloads.provisioned)}
+        >
+          {fastDownloads.provisioned ? 'Disable accelerator' : 'Enable accelerator'}
+        </Button>
+      </section>
+    </Stack>
+  );
+};

--- a/src/components/SettingsModal/SystemSettings.tsx
+++ b/src/components/SettingsModal/SystemSettings.tsx
@@ -12,6 +12,7 @@ import { Banner } from '../ui/Banner';
 import { Stack } from '../primitives';
 import { useConfirmContext } from '../../contexts/ConfirmContext';
 import { useSystemSettings } from './useSystemSettings';
+import { DiagnosticsPanel } from './DiagnosticsPanel';
 import type { LlamaStatus } from '../../types/setup';
 
 /** One label/value row. Values are mono so paths and hashes line up. */
@@ -246,6 +247,8 @@ export const SystemSettings: FC = () => {
           Uninstall llama.cpp
         </Button>
       </section>
+
+      <DiagnosticsPanel />
     </Stack>
   );
 };

--- a/src/components/SettingsModal/useDiagnostics.ts
+++ b/src/components/SettingsModal/useDiagnostics.ts
@@ -1,0 +1,87 @@
+/**
+ * State for the diagnostics half of the System tab.
+ *
+ * Everything here is read together in one request, so there is one loading
+ * state rather than four. The accelerator toggle re-reads afterwards because
+ * enabling it changes what the panel reports.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  disableFastDownloads,
+  enableFastDownloads,
+  getDiagnostics,
+} from '../../services/transport/api/setup';
+import type { Diagnostics } from '../../types/setup';
+
+export interface DiagnosticsState {
+  diagnostics: Diagnostics | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+
+  /** True while the accelerator is being provisioned or removed. */
+  togglingAccelerator: boolean;
+  acceleratorError: string | null;
+  toggleAccelerator: (enable: boolean) => Promise<void>;
+}
+
+export function useDiagnostics(): DiagnosticsState {
+  const [diagnostics, setDiagnostics] = useState<Diagnostics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [togglingAccelerator, setTogglingAccelerator] = useState(false);
+  const [acceleratorError, setAcceleratorError] = useState<string | null>(null);
+
+  // Returns the promise so callers that must not settle before the panel
+  // reflects new state (the accelerator toggle) can await it.
+  const reload = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    return getDiagnostics()
+      .then(setDiagnostics)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const toggleAccelerator = useCallback(
+    async (enable: boolean) => {
+      setTogglingAccelerator(true);
+      setAcceleratorError(null);
+      try {
+        if (enable) {
+          await enableFastDownloads();
+        } else {
+          await disableFastDownloads();
+        }
+        // Await the refetch before clearing the busy flag: provisioning takes
+        // minutes, and clearing early makes the button snap back to "Enable"
+        // for a beat, which reads as though the work failed.
+        await reload();
+      } catch (err) {
+        // Provisioning fails for ordinary reasons (no Python), and the
+        // message carries the remedy — surface it rather than a generic error.
+        setAcceleratorError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setTogglingAccelerator(false);
+      }
+    },
+    [reload],
+  );
+
+  return {
+    diagnostics,
+    loading,
+    error,
+    reload,
+    togglingAccelerator,
+    acceleratorError,
+    toggleAccelerator,
+  };
+}

--- a/src/services/transport/api/setup.ts
+++ b/src/services/transport/api/setup.ts
@@ -13,6 +13,7 @@ import type {
   LlamaUpdateCheck,
   LlamaUninstallOutcome,
   BuildEvent,
+  Diagnostics,
 } from '../../../types/setup';
 
 /**
@@ -112,4 +113,23 @@ export function streamLlamaUpdate(
     onClose,
     onError,
   });
+}
+
+/**
+ * Dependency matrix, resolved paths, detected acceleration and accelerator
+ * state — `gglib config check-deps`, `paths` and `fast-downloads status` in
+ * one request, because the panel reads them together.
+ */
+export async function getDiagnostics(): Promise<Diagnostics> {
+  return get<Diagnostics>('/api/config/system/diagnostics');
+}
+
+/** Provision the hf_xet download accelerator. */
+export async function enableFastDownloads(): Promise<void> {
+  return post<void>('/api/config/system/setup-python');
+}
+
+/** Remove it. Downloads revert to native HTTP — slower, not broken. */
+export async function disableFastDownloads(): Promise<{ removed: boolean }> {
+  return post<{ removed: boolean }>('/api/config/system/disable-fast-downloads');
 }

--- a/src/types/setup.ts
+++ b/src/types/setup.ts
@@ -147,3 +147,52 @@ export type BuildEvent =
   | { type: 'phase_completed'; phase: BuildPhase }
   | { type: 'completed'; version: string; acceleration: string }
   | { type: 'failed'; message: string };
+
+/** One system dependency's state, from `gglib config check-deps`. */
+export interface DependencyInfo {
+  name: string;
+  status: 'present' | 'missing' | 'optional';
+  /** Present only when `status` is `'present'`. */
+  version?: string | null;
+  description: string;
+  required: boolean;
+  installHint?: string | null;
+}
+
+/** Where everything resolves to — `gglib config paths`. */
+export interface ResolvedPaths {
+  dataRoot: string;
+  resourceRoot: string;
+  databasePath: string;
+  llamaServerPath: string;
+  modelsDir: string;
+  /** How the models directory was chosen. */
+  modelsSource: 'explicit' | 'envVar' | 'default';
+}
+
+/**
+ * What acceleration a build would use. Detection refuses to fall back to CPU,
+ * so a failure here is an answer with install hints, not a broken request.
+ */
+export interface AccelerationInfo {
+  detected?: string | null;
+  detectionError?: string | null;
+}
+
+/** The optional hf_xet download accelerator. Downloads work without it. */
+export interface FastDownloadsInfo {
+  provisioned: boolean;
+  envDir: string;
+  legacyPath: boolean;
+  builder?: string | null;
+  availableBuilder: string;
+  error?: string | null;
+}
+
+/** The full diagnostics bundle behind the System tab. */
+export interface Diagnostics {
+  dependencies: DependencyInfo[];
+  paths: ResolvedPaths;
+  acceleration: AccelerationInfo;
+  fastDownloads: FastDownloadsInfo;
+}

--- a/tests/ts/components/DiagnosticsPanel.test.tsx
+++ b/tests/ts/components/DiagnosticsPanel.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for the diagnostics panel — the GUI face of `gglib config
+ * check-deps` / `paths` / `fast-downloads status`.
+ *
+ * The load-bearing behaviours: missing *required* dependencies are called out
+ * with their install command, an optional one is not treated as a failure,
+ * and the accelerator reads as a speed setting rather than a requirement.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DiagnosticsPanel } from '../../../src/components/SettingsModal/DiagnosticsPanel';
+import {
+  getDiagnostics,
+  disableFastDownloads,
+  enableFastDownloads,
+} from '../../../src/services/transport/api/setup';
+import type { Diagnostics } from '../../../src/types/setup';
+
+vi.mock('../../../src/services/transport/api/setup', () => ({
+  getDiagnostics: vi.fn(),
+  enableFastDownloads: vi.fn().mockResolvedValue(undefined),
+  disableFastDownloads: vi.fn().mockResolvedValue({ removed: true }),
+}));
+
+const base: Diagnostics = {
+  dependencies: [
+    { name: 'cmake', status: 'present', version: '3.28.1', description: 'Build', required: true },
+    {
+      name: 'git',
+      status: 'missing',
+      description: 'Version control',
+      required: true,
+      installHint: 'brew install git',
+    },
+    { name: 'python3', status: 'missing', description: 'Optional helper', required: false },
+  ],
+  paths: {
+    dataRoot: '/home/u/.local/share/gglib',
+    resourceRoot: '/home/u/.local/share/gglib',
+    databasePath: '/home/u/.local/share/gglib/gglib.db',
+    llamaServerPath: '/home/u/.local/share/gglib/bin/llama-server',
+    modelsDir: '/models',
+    modelsSource: 'envVar',
+  },
+  acceleration: { detected: 'Metal' },
+  fastDownloads: {
+    provisioned: false,
+    envDir: '/home/u/.local/share/gglib/py',
+    legacyPath: false,
+    availableBuilder: 'uv',
+  },
+};
+
+const mockGet = vi.mocked(getDiagnostics);
+
+describe('DiagnosticsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(base);
+  });
+
+  it('calls out missing required dependencies with their install command', async () => {
+    render(<DiagnosticsPanel />);
+
+    expect(await screen.findByText(/1 required dependency is missing/)).toBeInTheDocument();
+    expect(screen.getByText('brew install git')).toBeInTheDocument();
+  });
+
+  it('prints a shared install command once, not once per dependency', async () => {
+    mockGet.mockResolvedValue({
+      ...base,
+      dependencies: [
+        { name: 'git', status: 'missing', description: 'a', required: true, installHint: 'apt install build-essential' },
+        { name: 'cmake', status: 'missing', description: 'b', required: true, installHint: 'apt install build-essential' },
+      ],
+    });
+
+    render(<DiagnosticsPanel />);
+
+    expect(await screen.findAllByText('apt install build-essential')).toHaveLength(1);
+  });
+
+  it('attributes missing dependencies to building gglib, not to llama.cpp', async () => {
+    render(<DiagnosticsPanel />);
+    expect(await screen.findByText(/build gglib itself from source/)).toBeInTheDocument();
+  });
+
+  it('does not count an optional dependency as missing', async () => {
+    render(<DiagnosticsPanel />);
+    // python3 is also absent, but only `git` is required.
+    expect(await screen.findByText(/1 required dependency is missing/)).toBeInTheDocument();
+  });
+
+  it('reports a clean run without a warning banner', async () => {
+    mockGet.mockResolvedValue({
+      ...base,
+      dependencies: [base.dependencies[0], base.dependencies[2]],
+    });
+
+    render(<DiagnosticsPanel />);
+
+    await screen.findByText('cmake');
+    expect(screen.queryByText(/required.*missing/)).not.toBeInTheDocument();
+  });
+
+  it('names where the models directory came from', async () => {
+    render(<DiagnosticsPanel />);
+    expect(
+      await screen.findByText(/Models directory from the environment/),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a detection failure instead of implying CPU will be used', async () => {
+    mockGet.mockResolvedValue({
+      ...base,
+      acceleration: { detected: null, detectionError: 'No supported GPU acceleration found' },
+    });
+
+    render(<DiagnosticsPanel />);
+    expect(await screen.findByText(/No supported GPU acceleration found/)).toBeInTheDocument();
+  });
+
+  it('enables the accelerator and re-reads the state', async () => {
+    render(<DiagnosticsPanel />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Enable accelerator/ }));
+
+    await waitFor(() => expect(enableFastDownloads).toHaveBeenCalled());
+    // Enabling changes what the panel reports, so it must refetch.
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('offers disabling when already provisioned', async () => {
+    mockGet.mockResolvedValue({
+      ...base,
+      fastDownloads: { ...base.fastDownloads, provisioned: true, builder: 'uv' },
+    });
+
+    render(<DiagnosticsPanel />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Disable accelerator/ }));
+    await waitFor(() => expect(disableFastDownloads).toHaveBeenCalled());
+  });
+
+  it('keeps a provisioning failure visible with its remedy', async () => {
+    vi.mocked(enableFastDownloads).mockRejectedValueOnce(new Error('No Python interpreter found'));
+
+    render(<DiagnosticsPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: /Enable accelerator/ }));
+
+    expect(await screen.findByText(/No Python interpreter found/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

PR 11 of the stack. Adds a diagnostics panel to the System tab: dependency matrix, resolved paths, detected acceleration, and the optional download accelerator.

Stacked on `feat(api,gui)/llama-management` (#767). Review only the top two commits.

## Parity closed

| CLI | GUI |
|---|---|
| `gglib config check-deps` | Dependencies section, with install commands for what's missing |
| `gglib config paths` | Paths section, including how the models dir was resolved |
| `gglib config fast-downloads status` | Download accelerator status |
| `gglib config fast-downloads enable` / `disable` | One toggle |

## Design notes

**One request, not four.** `SetupOps::diagnostics()` assembles the whole bundle. These are read together — this is the "why isn't this working" surface, and someone comparing a missing dependency against a resolved path shouldn't watch four spinners resolve independently. It stays cheap: no network, no subprocess beyond the version probes `check_all_dependencies` already runs.

**Detection failure is data, not a 500.** `detect_optimal_acceleration` deliberately refuses to fall back to CPU so callers can surface install hints. Failing the diagnostics request on it would hide exactly what the panel exists to report, so it lands as `detectionError`.

**DTOs mirrored rather than derived.** `Dependency` and `ResolvedPaths` live in `gglib-core` without serde. Rather than derive `Serialize` onto domain types for one route's benefit, the wire shapes live in `gglib-axum`'s `dto` module — the boundary `VulkanStatusDto` already draws.

**The panel leads with what's wrong.** Missing *required* dependencies get a warning banner with their install commands; a missing optional one is not dressed up as a failure. The accelerator is described as a speed setting, because downloads work fine without it over plain HTTP — and a provisioning failure keeps its own message, since "no Python interpreter found" is actionable where a generic error isn't.

## Test plan

- `npm test` — 802 passing, including 8 new tests covering required-vs-optional handling, the clean case, models-dir provenance copy, detection failure, and both accelerator directions incl. failure
- `cargo test` across app-services and axum — green; DTO tests pin that a present dependency carries its version and a missing one doesn't
- `npm run lint`, `npx tsc --noEmit`, `npm run build` — clean
