### PR TITLE
feat(api,gui): MCP connection test, model recommendation, daemon stop

### DIFF
--- a/crates/gglib-app-services/src/mcp.rs
+++ b/crates/gglib-app-services/src/mcp.rs
@@ -9,7 +9,7 @@ use gglib_mcp::{
 use crate::error::GuiError;
 use crate::types::{
     CreateMcpServerRequest, McpEnvEntryDto, McpServerConfigDto, McpServerDto, McpServerInfo,
-    McpServerStatusDto, McpToolCallRequest, McpToolCallResponse, McpToolInfo,
+    McpServerStatusDto, McpTestResult, McpToolCallRequest, McpToolCallResponse, McpToolInfo,
     UpdateMcpServerRequest,
 };
 
@@ -247,6 +247,56 @@ impl McpOps {
             .await
             .map_err(|e| GuiError::Internal(e.to_string()))?;
         Ok(tools.iter().map(Self::tool_to_info).collect())
+    }
+
+    /// Test a configured server end to end — `gglib mcp test`.
+    ///
+    /// Starts a throwaway instance of the stored configuration, lists what it
+    /// offers, then stops it. Distinct from [`Self::list_tools`], which needs
+    /// the server already running and so says nothing about whether it *can*
+    /// start. This is the answer to "is this config right?", and without it
+    /// the only way to find out is a chat that silently has no tools.
+    pub async fn test_connection(&self, id: i64) -> Result<McpTestResult, GuiError> {
+        // Resolve the executable first, exactly as the start path does. Without
+        // this a freshly-added stdio server — whose resolved_path_cache is
+        // still empty — fails the test with "executable path must be absolute"
+        // while Start on the same row succeeds, which reads as the test being
+        // broken rather than the config being fine.
+        let _ = self.mcp.ensure_resolved(id).await;
+
+        let server = self
+            .mcp
+            .get_server(id)
+            .await
+            .map_err(|_| GuiError::NotFound {
+                entity: "MCP server",
+                id: id.to_string(),
+            })?;
+
+        let candidate = NewMcpServer {
+            name: server.name.clone(),
+            server_type: server.server_type,
+            config: server.config.clone(),
+            enabled: server.enabled,
+            lifecycle: server.lifecycle,
+            env: server.env.clone(),
+        };
+
+        // A failed connection is the expected outcome of a misconfiguration,
+        // not a fault — report it as a result the UI can render beside the
+        // config rather than an error that replaces the panel.
+        match self.mcp.test_connection(candidate).await {
+            Ok(tools) => Ok(McpTestResult {
+                ok: true,
+                error: None,
+                tools: tools.iter().map(Self::tool_to_info).collect(),
+            }),
+            Err(e) => Ok(McpTestResult {
+                ok: false,
+                error: Some(e.to_string()),
+                tools: Vec::new(),
+            }),
+        }
     }
 
     /// Call a tool on a running MCP server.

--- a/crates/gglib-app-services/src/setup.rs
+++ b/crates/gglib-app-services/src/setup.rs
@@ -234,6 +234,17 @@ impl SetupOps {
             .map_err(|e| GuiError::Internal(format!("Failed to remove Python environment: {e}")))
     }
 
+    /// A model sized to this machine, from the same shortlist `gglib up` uses
+    /// on a first run.
+    ///
+    /// `None` when nothing fits, which is a real answer rather than an error:
+    /// a machine too small for the smallest candidate has to be told so, not
+    /// handed a recommendation it cannot run.
+    pub fn recommend_model(&self) -> Option<gglib_core::domain::recommendation::Recommendation> {
+        let memory = self.deps.system_probe.get_system_memory_info();
+        gglib_core::domain::recommendation::recommend(&memory)
+    }
+
     /// Everything the diagnostics panel shows: dependency matrix, resolved
     /// paths, detected acceleration, accelerator state.
     ///

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -803,6 +803,22 @@ pub struct McpToolInfo {
     pub title: Option<String>,
 }
 
+/// The outcome of `gglib mcp test`: did the server start, and what does it
+/// offer.
+///
+/// A failed connection is a result, not an error — a misconfigured command is
+/// the ordinary case this exists to diagnose, so `ok: false` carries the
+/// reason rather than the request failing.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpTestResult {
+    pub ok: bool,
+    /// Why the connection failed. Absent when `ok`.
+    pub error: Option<String>,
+    /// What the server offered. Empty unless `ok`.
+    pub tools: Vec<McpToolInfo>,
+}
+
 /// Request to call an MCP tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolCallRequest {

--- a/crates/gglib-axum/src/dto/diagnostics.rs
+++ b/crates/gglib-axum/src/dto/diagnostics.rs
@@ -125,6 +125,51 @@ pub struct DiagnosticsDto {
     pub fast_downloads: FastDownloadsDto,
 }
 
+/// A hardware-sized model suggestion — what `gglib up` picks on a first run.
+///
+/// `null` from the route rather than an empty object when nothing fits: "no
+/// model in the shortlist fits this machine" is a real answer and the UI has
+/// to say so, not show a recommendation card with blanks in it.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecommendationDto {
+    pub repo: String,
+    pub quantization: String,
+    /// Why this model, in the user's terms.
+    pub rationale: String,
+    /// Weights plus KV cache at the candidate's context, at the quantization
+    /// the runtime actually launches with.
+    pub required_bytes: u64,
+    /// The memory figure it was sized against.
+    pub budget_bytes: u64,
+    /// Where that figure came from: `"vram" | "unifiedMemory" | "systemRam"`.
+    pub budget_source: String,
+    pub headroom_bytes: u64,
+    pub context: u64,
+}
+
+impl From<gglib_core::domain::recommendation::Recommendation> for RecommendationDto {
+    fn from(rec: gglib_core::domain::recommendation::Recommendation) -> Self {
+        use gglib_core::domain::recommendation::BudgetSource;
+
+        Self {
+            repo: rec.candidate.repo.to_string(),
+            quantization: rec.candidate.quantization.to_string(),
+            rationale: rec.candidate.rationale.to_string(),
+            required_bytes: rec.candidate.required_bytes(),
+            budget_bytes: rec.budget_bytes,
+            budget_source: match rec.budget_source {
+                BudgetSource::Vram => "vram",
+                BudgetSource::UnifiedMemory => "unifiedMemory",
+                BudgetSource::SystemRam => "systemRam",
+            }
+            .to_string(),
+            headroom_bytes: rec.headroom_bytes,
+            context: rec.candidate.context,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gglib-axum/src/handlers/config/setup.rs
+++ b/crates/gglib-axum/src/handlers/config/setup.rs
@@ -10,7 +10,7 @@ use futures_util::stream::Stream;
 use serde::{Deserialize, Serialize};
 
 use crate::dto::diagnostics::{
-    AccelerationDto, DiagnosticsDto, FastDownloadsDto, ResolvedPathsDto,
+    AccelerationDto, DiagnosticsDto, FastDownloadsDto, RecommendationDto, ResolvedPathsDto,
 };
 use crate::dto::system::VulkanStatusDto;
 use crate::error::HttpError;
@@ -383,4 +383,16 @@ fn build_event_to_sse(event: BuildEvent) -> Result<Event, Infallible> {
     };
     let data = serde_json::to_string(&event).unwrap_or_default();
     Ok(Event::default().event(event_type).data(data))
+}
+
+/// A hardware-sized model suggestion — the shortlist `gglib up` picks from,
+/// sized against this machine's memory.
+///
+/// Returns `null` when nothing in the shortlist fits. That is a real answer,
+/// not an error: a machine too small for the smallest candidate needs to be
+/// told so, not handed a recommendation it cannot run.
+pub async fn recommend_model(
+    State(state): State<AppState>,
+) -> Result<Json<Option<RecommendationDto>>, HttpError> {
+    Ok(Json(state.setup.recommend_model().map(Into::into)))
 }

--- a/crates/gglib-axum/src/handlers/mcp.rs
+++ b/crates/gglib-axum/src/handlers/mcp.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 use crate::error::HttpError;
 use crate::state::AppState;
 use gglib_app_services::types::{
-    CreateMcpServerRequest, McpServerInfo, McpToolCallRequest, McpToolCallResponse, McpToolInfo,
-    UpdateMcpServerRequest,
+    CreateMcpServerRequest, McpServerInfo, McpTestResult, McpToolCallRequest, McpToolCallResponse,
+    McpToolInfo, UpdateMcpServerRequest,
 };
 
 /// List all MCP servers.
@@ -61,6 +61,19 @@ pub async fn list_tools(
     Path(id): Path<i64>,
 ) -> Result<Json<Vec<McpToolInfo>>, HttpError> {
     Ok(Json(state.mcp_ops.list_tools(id).await?))
+}
+
+/// Test a server's stored configuration end to end — `gglib mcp test`.
+///
+/// Starts a throwaway instance, lists its tools, stops it. A failed
+/// connection returns 200 with `ok: false` and the reason: a bad command is
+/// the ordinary case this exists to diagnose, and the caller wants to render
+/// it beside the config rather than handle an error.
+pub async fn test_connection(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<McpTestResult>, HttpError> {
+    Ok(Json(state.mcp_ops.test_connection(id).await?))
 }
 
 /// Request body for calling an MCP tool (includes server ID).

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -97,6 +97,7 @@ pub(crate) fn api_routes() -> Router<AppState> {
             post(handlers::mcp::resolve_path),
         )
         .route("/mcp/servers/{id}/tools", get(handlers::mcp::list_tools))
+        .route("/mcp/servers/{id}/test", post(handlers::mcp::test_connection))
         .route("/mcp/tools/call", post(handlers::mcp::call_tool))
         // Proxy API
         .route("/proxy/status", get(handlers::proxy::status))
@@ -341,6 +342,10 @@ fn config_routes() -> Router<AppState> {
         .route(
             "/system/diagnostics",
             get(handlers::config::setup::diagnostics),
+        )
+        .route(
+            "/system/recommend-model",
+            get(handlers::config::setup::recommend_model),
         )
 }
 

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -97,7 +97,10 @@ pub(crate) fn api_routes() -> Router<AppState> {
             post(handlers::mcp::resolve_path),
         )
         .route("/mcp/servers/{id}/tools", get(handlers::mcp::list_tools))
-        .route("/mcp/servers/{id}/test", post(handlers::mcp::test_connection))
+        .route(
+            "/mcp/servers/{id}/test",
+            post(handlers::mcp::test_connection),
+        )
         .route("/mcp/tools/call", post(handlers::mcp::call_tool))
         // Proxy API
         .route("/proxy/status", get(handlers::proxy::status))

--- a/crates/gglib-mcp/src/service.rs
+++ b/crates/gglib-mcp/src/service.rs
@@ -730,13 +730,22 @@ impl McpService {
     }
 
     /// Test connection to a server configuration (starts, gets tools, then stops).
+    ///
+    /// The throwaway instance is registered under a unique negative id rather
+    /// than a fixed one. Real servers use positive ids, so negatives are free;
+    /// a *constant* negative was not, because two overlapping tests would both
+    /// claim it and the first to finish would stop the other's process — one
+    /// user would see a working configuration reported as broken.
     pub async fn test_connection(
         &self,
         new_server: NewMcpServer,
     ) -> Result<Vec<McpTool>, McpServiceError> {
-        // Create a temporary server with fake ID for testing
+        static NEXT_TEST_ID: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(-2);
+        let test_id = NEXT_TEST_ID.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+
+        // Create a temporary server with a private id for testing
         let test_server = McpServer {
-            id: -1,
+            id: test_id,
             name: new_server.name,
             server_type: new_server.server_type,
             config: new_server.config,
@@ -749,17 +758,19 @@ impl McpService {
             last_error: None,
         };
 
-        let tools = self
+        let started = self
             .manager
             .start_server(test_server)
             .await
-            .map_err(|e| McpServiceError::StartFailed(e.to_string()))?;
+            .map_err(|e| McpServiceError::StartFailed(e.to_string()));
 
-        // Stop the test server
-        self.manager
-            .stop_server(-1)
-            .await
-            .map_err(|e| McpServiceError::StopFailed(e.to_string()))?;
+        // Stop unconditionally: a start that failed part-way can still have
+        // left a process behind, and leaking one per failed test is worse than
+        // a redundant stop.
+        let stopped = self.manager.stop_server(test_id).await;
+
+        let tools = started?;
+        stopped.map_err(|e| McpServiceError::StopFailed(e.to_string()))?;
 
         Ok(tools)
     }

--- a/src/components/HuggingFaceBrowser/HuggingFaceBrowser.tsx
+++ b/src/components/HuggingFaceBrowser/HuggingFaceBrowser.tsx
@@ -10,6 +10,7 @@ import { IconButton } from '../ui/IconButton';
 import { Input } from "../ui/Input";
 import { Select } from "../ui/Select";
 import { Stack, Row, EmptyState, Label } from "../primitives";
+import { RecommendedModel } from '../ModelLibraryPanel/RecommendedModel';
 
 interface HuggingFaceBrowserProps {
   /** Callback when a model is selected (clicked) for preview */
@@ -64,6 +65,9 @@ const HuggingFaceBrowser: FC<HuggingFaceBrowserProps> = ({
     <Stack gap="base" className="h-full overflow-hidden">
       {/* Search Section */}
       <Stack gap="sm" className="p-4 bg-surface border-b border-border-light">
+        {/* Seeds the box rather than downloading: browsing results is still
+            the user's decision, and the suggestion is advice, not an action. */}
+        <RecommendedModel onUseRepo={setSearchQuery} />
         <Row gap="sm" align="end">
           <Stack gap="xs" className="flex-1">
             <Label size="xs" muted>Search models</Label>

--- a/src/components/McpServersPanel.tsx
+++ b/src/components/McpServersPanel.tsx
@@ -16,7 +16,7 @@ import { cn } from "../utils/cn";
 import { useConfirmContext } from "../contexts/ConfirmContext";
 import { useToastContext } from "../contexts/ToastContext";
 import { getTransport } from '../services/transport';
-import type { McpServerInfo } from '../services/transport';
+import type { McpServerInfo, McpTestResult } from '../services/transport';
 import { isServerRunning, hasServerError, getServerErrorMessage } from '../utils/mcp';
 
 const statusRow = "inline-flex items-center gap-xs text-xs text-text-muted";
@@ -44,6 +44,13 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
 
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
+  // Scoped to one server: a test result belongs beside the config it tested,
+  // not in a panel-wide banner.
+  const [testResult, setTestResult] = useState<{ id: number; result: McpTestResult } | null>(null);
+  // Panel-wide, not per-row: two overlapping tests would each start a
+  // throwaway instance, and the failure surfaces against whichever row the
+  // user clicked second.
+  const [testing, setTesting] = useState(false);
 
   const { confirm } = useConfirmContext();
   const { showToast } = useToastContext();
@@ -134,6 +141,39 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
       }
     },
     [showToast]
+  );
+
+  /**
+   * `gglib mcp test` — start a throwaway instance, list what it offers, stop
+   * it. The question this answers ("is this config right?") has no other
+   * answer short of a chat that silently has no tools, and unlike Start it
+   * leaves nothing running.
+   */
+  const handleTest = useCallback(
+    async (info: McpServerInfo) => {
+      const id = info.server.id;
+
+      setActionError(null);
+      setTestResult(null);
+      setActionLoading(id);
+      setTesting(true);
+      try {
+        const result = await getTransport().testMcpServer(id);
+        setTestResult({ id, result });
+        if (result.ok) {
+          showToast(
+            `${info.server.name}: connected, ${result.tools.length} tool(s)`,
+            'success',
+          );
+        }
+      } catch (e) {
+        setActionError(e instanceof Error ? e.message : 'Test failed');
+      } finally {
+        setActionLoading(null);
+        setTesting(false);
+      }
+    },
+    [showToast],
   );
 
   const getStatusBadge = (info: McpServerInfo) => {
@@ -290,6 +330,32 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
                       {getServerErrorMessage(info)}
                     </div>
                   )}
+                  {testResult?.id === id && (
+                    testResult.result.ok ? (
+                      <div className="mt-xs">
+                        <div className="text-xs text-success">
+                          Connected — {testResult.result.tools.length} tool(s) offered
+                        </div>
+                        {testResult.result.tools.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-xs mt-xs">
+                            {testResult.result.tools.map((tool) => (
+                              <span
+                                key={tool.name}
+                                className="inline-flex px-sm py-0.5 bg-surface-elevated text-text-secondary text-xs rounded-sm font-mono"
+                                title={tool.description ?? undefined}
+                              >
+                                {tool.name}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="text-xs text-danger mt-xs p-xs bg-danger-subtle rounded-sm">
+                        Connection failed — {testResult.result.error}
+                      </div>
+                    )
+                  )}
                 </Stack>
                 <div className="flex gap-xs shrink-0">
                   {!info.server.is_valid && info.server.server_type === "stdio" && (
@@ -304,6 +370,16 @@ export const McpServersPanel: FC<McpServersPanelProps> = ({
                       Auto-fix
                     </Button>
                   )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleTest(info)}
+                    disabled={isLoading || testing}
+                    title="Start a throwaway instance, list its tools, then stop it"
+                  >
+                    {isLoading ? "..." : "Test"}
+                  </Button>
                   {isRunning ? (
                     <Button
                       type="button"

--- a/src/components/ModelLibraryPanel/RecommendedModel.tsx
+++ b/src/components/ModelLibraryPanel/RecommendedModel.tsx
@@ -1,0 +1,94 @@
+/**
+ * The hardware-sized suggestion `gglib up` makes on a first run, surfaced
+ * where models are actually chosen.
+ *
+ * The shortlist and the sizing already existed in the domain layer; only the
+ * terminal could see them. Browsing HuggingFace with no idea what your machine
+ * can hold is the problem this solves — the search results say nothing about
+ * whether a 30B will fit in 16 GB.
+ */
+
+import { FC, useEffect, useState } from 'react';
+import { Button } from '../ui/Button';
+import { getRecommendedModel } from '../../services/transport/api/setup';
+import type { ModelRecommendation } from '../../types/setup';
+import { appLogger } from '../../services/platform';
+import { formatMemorySize } from '../../hooks/useSystemMemory';
+
+const BUDGET_COPY: Record<ModelRecommendation['budgetSource'], string> = {
+  vram: 'GPU memory',
+  unifiedMemory: 'unified memory',
+  systemRam: 'system memory',
+};
+
+interface RecommendedModelProps {
+  /** Put the repo in the search box rather than downloading behind their back. */
+  onUseRepo: (repo: string) => void;
+}
+
+export const RecommendedModel: FC<RecommendedModelProps> = ({ onUseRepo }) => {
+  const [recommendation, setRecommendation] = useState<ModelRecommendation | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  // A failed request and a successful "nothing fits" are different answers.
+  // Rendering the second for the first tells the user their machine is too
+  // small on the strength of a network error.
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getRecommendedModel()
+      .then((rec) => {
+        if (!cancelled) setRecommendation(rec);
+      })
+      .catch((err: unknown) => {
+        // Advisory: browsing works without it, so a failure stays silent.
+        appLogger.warn('component.model', 'Could not read model recommendation', { error: err });
+        if (!cancelled) setFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // `null` means nothing in the shortlist fits, which is worth saying — a
+  // machine that cannot run the smallest candidate should not be left
+  // browsing models it has no chance of loading.
+  if (loaded && !recommendation && !failed) {
+    return (
+      <p className="m-0 py-sm text-xs text-text-muted">
+        No model in gglib's shortlist fits this machine's memory. Smaller or more heavily
+        quantized models may still work — the fit indicators on each result show what will.
+      </p>
+    );
+  }
+
+  if (!recommendation) return null;
+
+  return (
+    <div className="py-sm flex items-baseline justify-between gap-md flex-wrap">
+      <div className="min-w-0">
+        <p className="m-0 text-xs text-text-secondary">
+          Suggested for this machine:{' '}
+          <span className="font-mono text-text">{recommendation.repo}</span>
+        </p>
+        <p className="m-0 text-2xs text-text-muted">
+          {recommendation.rationale}. Needs{' '}
+          <span className="font-mono tabular-nums">
+            {formatMemorySize(recommendation.requiredBytes)}
+          </span>{' '}
+          of your{' '}
+          <span className="font-mono tabular-nums">
+            {formatMemorySize(recommendation.budgetBytes)}
+          </span>{' '}
+          {BUDGET_COPY[recommendation.budgetSource]}.
+        </p>
+      </div>
+      <Button variant="ghost" size="sm" onClick={() => onUseRepo(recommendation.repo)}>
+        Find it
+      </Button>
+    </div>
+  );
+};

--- a/src/components/SettingsModal/SystemSettings.tsx
+++ b/src/components/SettingsModal/SystemSettings.tsx
@@ -6,11 +6,12 @@
  * `InferenceProfiles`; all state lives in `useSystemSettings`.
  */
 
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Button } from '../ui/Button';
 import { Banner } from '../ui/Banner';
 import { Stack } from '../primitives';
 import { useConfirmContext } from '../../contexts/ConfirmContext';
+import { getTransport } from '../../services/transport';
 import { useSystemSettings } from './useSystemSettings';
 import { DiagnosticsPanel } from './DiagnosticsPanel';
 import type { LlamaStatus } from '../../types/setup';
@@ -66,6 +67,39 @@ export const SystemSettings: FC = () => {
     runUninstall,
   } = useSystemSettings();
   const { confirm } = useConfirmContext();
+  const [shuttingDown, setShuttingDown] = useState(false);
+  const [shutdownRequested, setShutdownRequested] = useState(false);
+
+  /**
+   * `gglib daemon stop`. Lives here rather than in the tray panel, which
+   * deliberately keeps window-level actions on the native menu — and unlike
+   * that menu's Quit, this reaches the daemon from the web UI too, where
+   * there is otherwise no way to stop it.
+   *
+   * A failed request is not an error: the daemon is shutting down as it
+   * replies, so losing the response is the expected outcome.
+   */
+  const handleShutdown = async () => {
+    const confirmed = await confirm({
+      title: 'Stop the daemon?',
+      description:
+        'Stops every running model and shuts down the backend this interface talks to. ' +
+        'Nothing on disk is affected, but you will need to start gglib again to use it.',
+      confirmLabel: 'Stop',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+
+    setShuttingDown(true);
+    try {
+      await getTransport().shutdownDaemon();
+    } catch {
+      // Expected — the connection dies with the daemon.
+    } finally {
+      setShuttingDown(false);
+      setShutdownRequested(true);
+    }
+  };
 
   const handleUninstall = async () => {
     const confirmed = await confirm({
@@ -249,6 +283,30 @@ export const SystemSettings: FC = () => {
       </section>
 
       <DiagnosticsPanel />
+
+      <section>
+        <h3 className="m-0 mb-xs text-sm font-semibold text-text">Daemon</h3>
+        <p className="m-0 mb-base text-xs text-text-muted">
+          Everything here runs against the gglib daemon. Stopping it stops every running model
+          with it, and this interface loses its backend until the daemon is started again — from
+          a terminal with <code className="font-mono">gglib daemon start</code>, or by reopening
+          the desktop app.
+        </p>
+        {shutdownRequested && (
+          <Banner variant="info" className="mb-base">
+            Shutdown requested. This interface will stop responding.
+          </Banner>
+        )}
+        <Button
+          variant="dangerGhost"
+          size="sm"
+          isLoading={shuttingDown}
+          disabled={shuttingDown || shutdownRequested}
+          onClick={() => void handleShutdown()}
+        >
+          Stop the daemon
+        </Button>
+      </section>
     </Stack>
   );
 };

--- a/src/services/transport/api/mcp.ts
+++ b/src/services/transport/api/mcp.ts
@@ -13,6 +13,7 @@ import type {
   McpTool,
   McpToolResult,
   ResolutionStatus,
+  McpTestResult,
 } from '../types/mcp';
 
 /**
@@ -133,4 +134,16 @@ export async function callMcpTool(
  */
 export async function resolveMcpServerPath(id: McpServerId): Promise<ResolutionStatus> {
   return post<ResolutionStatus>(`/api/mcp/servers/${id}/resolve`, {});
+}
+
+/**
+ * Test a server's stored configuration — `gglib mcp test`.
+ *
+ * Starts a throwaway instance, lists its tools, stops it. Unlike starting the
+ * server for real, this answers "is this config right?" without leaving a
+ * process running, and it is the only way to find out short of a chat that
+ * silently has no tools.
+ */
+export async function testMcpServer(id: McpServerId): Promise<McpTestResult> {
+  return post<McpTestResult>(`/api/mcp/servers/${id}/test`, {});
 }

--- a/src/services/transport/api/proxy.ts
+++ b/src/services/transport/api/proxy.ts
@@ -35,3 +35,15 @@ export async function startPinnedProxy(request: StartPinnedRequest): Promise<Pro
 export async function stopProxy(): Promise<void> {
   await post<void>('/api/proxy/stop', null);
 }
+
+/**
+ * Shut the daemon down — the GUI face of `gglib daemon stop`.
+ *
+ * The daemon owns every running inference server, so this stops those too and
+ * leaves the app without a backend until it is started again. The request may
+ * not get a clean response: the server is shutting down as it replies, so a
+ * transport error here often means it worked.
+ */
+export async function shutdownDaemon(): Promise<void> {
+  return post<void>('/api/daemon/shutdown');
+}

--- a/src/services/transport/api/setup.ts
+++ b/src/services/transport/api/setup.ts
@@ -14,6 +14,7 @@ import type {
   LlamaUninstallOutcome,
   BuildEvent,
   Diagnostics,
+  ModelRecommendation,
 } from '../../../types/setup';
 
 /**
@@ -132,4 +133,13 @@ export async function enableFastDownloads(): Promise<void> {
 /** Remove it. Downloads revert to native HTTP — slower, not broken. */
 export async function disableFastDownloads(): Promise<{ removed: boolean }> {
   return post<{ removed: boolean }>('/api/config/system/disable-fast-downloads');
+}
+
+/**
+ * A model sized to this machine, from the same shortlist `gglib up` uses.
+ *
+ * Resolves to `null` when nothing fits — that is the answer, not a failure.
+ */
+export async function getRecommendedModel(): Promise<ModelRecommendation | null> {
+  return get<ModelRecommendation | null>('/api/config/system/recommend-model');
 }

--- a/src/services/transport/errors.ts
+++ b/src/services/transport/errors.ts
@@ -241,7 +241,13 @@ export async function readData<T>(response: Response): Promise<T> {
       return undefined as T;
     }
 
-    if (!body.success && body.error) {
+    // Legacy `{success, error}` envelope. `success` must actually be present:
+    // non-2xx responses already returned above, so any `error` key reaching
+    // here belongs to a normal result DTO. Testing `body.error` alone made
+    // every DTO with an `error` field unreturnable — a 200 carrying
+    // `{ok: false, error: "..."}` was thrown as a transport failure instead of
+    // being handed to the caller that models failure as data.
+    if (typeof body === 'object' && 'success' in body && !body.success && body.error) {
       throw new TransportError('INTERNAL', body.error);
     }
 

--- a/src/services/transport/types/mcp.ts
+++ b/src/services/transport/types/mcp.ts
@@ -174,4 +174,21 @@ export interface McpTransport {
 
   /** Resolve MCP server executable path (for diagnostics/auto-fix). */
   resolveMcpServerPath(id: McpServerId): Promise<ResolutionStatus>;
+
+  /** Start a throwaway instance to check the config, then stop it. */
+  testMcpServer(id: McpServerId): Promise<McpTestResult>;
+}
+
+/**
+ * The outcome of testing a server's configuration.
+ *
+ * A failed connection is a result, not an error: a wrong command is the
+ * ordinary case this diagnoses, so `ok: false` carries the reason.
+ */
+export interface McpTestResult {
+  ok: boolean;
+  /** Why it failed. Absent when `ok`. */
+  error?: string | null;
+  /** What the server offered. Empty unless `ok`. */
+  tools: McpTool[];
 }

--- a/src/services/transport/types/proxy.ts
+++ b/src/services/transport/types/proxy.ts
@@ -67,4 +67,12 @@ export interface ProxyTransport {
 
   /** Stop the proxy server. */
   stopProxy(): Promise<void>;
+
+  /**
+   * Shut the daemon down — `gglib daemon stop`.
+   *
+   * Stops every running inference server with it, and the app loses its
+   * backend until the daemon is started again. Confirm before calling.
+   */
+  shutdownDaemon(): Promise<void>;
 }

--- a/src/types/setup.ts
+++ b/src/types/setup.ts
@@ -196,3 +196,22 @@ export interface Diagnostics {
   acceleration: AccelerationInfo;
   fastDownloads: FastDownloadsInfo;
 }
+
+/**
+ * A hardware-sized model suggestion — the shortlist `gglib up` picks from.
+ *
+ * The route returns `null` when nothing fits, which is a real answer: a
+ * machine too small for the smallest candidate should be told so.
+ */
+export interface ModelRecommendation {
+  repo: string;
+  quantization: string;
+  /** Why this model, in the user's terms. */
+  rationale: string;
+  /** Weights plus KV cache at the candidate's context. */
+  requiredBytes: number;
+  budgetBytes: number;
+  budgetSource: 'vram' | 'unifiedMemory' | 'systemRam';
+  headroomBytes: number;
+  context: number;
+}

--- a/tests/ts/components/RecommendedModel.test.tsx
+++ b/tests/ts/components/RecommendedModel.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for the hardware-sized model suggestion.
+ *
+ * The case that matters most is the null one: "nothing fits this machine" is
+ * a real answer, and rendering a card with blanks in it would be worse than
+ * saying so.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecommendedModel } from '../../../src/components/ModelLibraryPanel/RecommendedModel';
+import { getRecommendedModel } from '../../../src/services/transport/api/setup';
+import type { ModelRecommendation } from '../../../src/types/setup';
+
+vi.mock('../../../src/services/transport/api/setup', () => ({
+  getRecommendedModel: vi.fn(),
+}));
+
+const mockGet = vi.mocked(getRecommendedModel);
+
+const rec: ModelRecommendation = {
+  repo: 'unsloth/Qwen3-30B-A3B-GGUF',
+  quantization: 'Q4_K_M',
+  rationale: 'mixture-of-experts: 30B of knowledge, ~3B active per token',
+  // Binary GB, matching formatMemorySize: 21 GiB and 32 GiB exactly.
+  requiredBytes: 21 * 1024 ** 3,
+  budgetBytes: 32 * 1024 ** 3,
+  budgetSource: 'unifiedMemory',
+  headroomBytes: 11_000_000_000,
+  context: 32_768,
+};
+
+describe('RecommendedModel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('names the model with what it needs and what the machine has', async () => {
+    mockGet.mockResolvedValue(rec);
+
+    render(<RecommendedModel onUseRepo={vi.fn()} />);
+
+    expect(await screen.findByText('unsloth/Qwen3-30B-A3B-GGUF')).toBeInTheDocument();
+    // Binary units, the same convention as the fit indicators and `gglib up`.
+    expect(screen.getByText('21.0 GB')).toBeInTheDocument();
+    expect(screen.getByText('32.0 GB')).toBeInTheDocument();
+    expect(screen.getByText(/unified memory/)).toBeInTheDocument();
+  });
+
+  it('says so when nothing in the shortlist fits', async () => {
+    mockGet.mockResolvedValue(null);
+
+    render(<RecommendedModel onUseRepo={vi.fn()} />);
+
+    expect(await screen.findByText(/No model in gglib's shortlist fits/)).toBeInTheDocument();
+  });
+
+  it('seeds the search box rather than starting a download', async () => {
+    mockGet.mockResolvedValue(rec);
+    const onUseRepo = vi.fn();
+
+    render(<RecommendedModel onUseRepo={onUseRepo} />);
+    await userEvent.click(await screen.findByRole('button', { name: /Find it/ }));
+
+    expect(onUseRepo).toHaveBeenCalledWith('unsloth/Qwen3-30B-A3B-GGUF');
+  });
+
+  it('stays out of the way when the lookup fails', async () => {
+    mockGet.mockRejectedValue(new Error('offline'));
+
+    const { container } = render(<RecommendedModel onUseRepo={vi.fn()} />);
+
+    // Wait for the rejection to settle first — asserting immediately would
+    // pass against the broken behaviour, which only renders after `loaded`.
+    await vi.waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+
+    // A transport failure must never be reported as "nothing fits": that is a
+    // claim about the user's hardware drawn from a network error.
+    expect(screen.queryByText(/No model in gglib's shortlist fits/)).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## What

PR 12 of the stack, and the last feature PR. Three remaining CLI-only capabilities reach the GUI: MCP connection testing, hardware-sized model recommendation, and stopping the daemon.

Stacked on `feat(api,gui)/system-diagnostics` (#768). Review only the top two commits.

## Parity closed

| CLI | GUI |
|---|---|
| `gglib mcp test <server>` | Test button on each MCP server row |
| `gglib up`'s model choice | Suggestion above the HuggingFace search |
| `gglib daemon stop` | "Stop the daemon" in the System tab |

## Design notes

**Test is not Start.** `list_tools` needs the server already running, so it cannot answer "is this config right?" — the question a misconfigured command actually raises. `test_connection` starts a throwaway instance, lists what it offers and stops it, leaving nothing behind. A failed connection returns `ok: false` with the reason rather than an error status: a wrong command is the ordinary case this exists to diagnose, and the UI wants to render it beside the config that caused it.

**The recommendation seeds the search box, it doesn't download.** `gglib_core::domain::recommendation` already had the shortlist and the sizing maths; only `gglib up` could reach it. It goes above the HuggingFace search because that is where the question arises — the results say nothing about whether a 30B fits in 16 GB. Choosing stays the user's. When nothing in the shortlist fits, the panel says so rather than rendering a card with blanks in it, and a failed lookup renders nothing at all since browsing has to keep working.

**Daemon stop is in Settings, not the tray.** I initially put it in the tray panel and then took it out: that file's own module doc says window-level actions are deliberately absent because they live on the native tray menu, handled in Rust. The System tab is the better home anyway — unlike the native Quit, it reaches the daemon from the web UI too, where there is otherwise no way to stop it. A lost response is treated as success, since the daemon is shutting down as it replies.

## Test plan

- `npm test` — 806 passing, including 4 new tests for the recommendation (named model with its sizing, the nothing-fits case, seeding-not-downloading, and silence on failure)
- `cargo test` across app-services and axum — green
- `npm run lint`, `npx tsc --noEmit`, `npm run build` — clean
