### PR TITLE
chore(cargo): optimize dev deps, resolver 3, per-crate tokio, one version source

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -131,14 +131,24 @@ jobs:
         run: |
           VERSION="${{ steps.validate.outputs.version }}"
           
-          # Check that key files were updated
-          for file in package.json src-tauri/tauri.conf.json; do
+          # Check that key files were updated. src-tauri/tauri.conf.json is not
+          # in this list: it no longer carries a "version" key, because Tauri
+          # falls back to the Cargo.toml version when the key is absent.
+          for file in package.json; do
             if ! grep -q "\"version\": \"$VERSION\"" "$file"; then
               echo "::error::$file was not updated correctly"
               exit 1
             fi
             echo "✓ Verified $file"
           done
+
+          # Guard the fallback: a re-added "version" key would silently pin the
+          # app metadata and reintroduce the drift this removal eliminated.
+          if grep -q '"version"' src-tauri/tauri.conf.json; then
+            echo "::error::src-tauri/tauri.conf.json must not declare a version; Tauri inherits it from Cargo.toml"
+            exit 1
+          fi
+          echo "✓ Verified src-tauri/tauri.conf.json inherits its version"
 
       - name: Create Pull Request
         id: create-pr
@@ -162,8 +172,8 @@ jobs:
             - ✓ `package.json`
             - ✓ `src-tauri/Cargo.toml`
             - ✓ `src-tauri/Cargo.lock`
-            - ✓ `src-tauri/tauri.conf.json`
             - ✓ All workspace crates (via inheritance)
+            - ✓ `src-tauri/tauri.conf.json` (via Tauri's Cargo.toml fallback)
             
             ### Next Steps
             Once this PR is merged, the [Release workflow](.github/workflows/release.yml) will automatically:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,7 +7349,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
-resolver = "2"
+# Edition-2024 packages default to resolver 3, but a virtual manifest has no
+# edition to infer from and must state it. Resolver 3 adds MSRV-aware version
+# selection; rust-toolchain.toml pins 1.97.1, well past the 1.84 it needs.
+resolver = "3"
 members = [
     "crates/gglib-core",
     "crates/gglib-db",
@@ -33,8 +36,18 @@ authors = ["mmogr"]
 # Workspace-wide dependencies: ONLY truly universal crates
 # Adapter-specific deps (sqlx, clap, tauri, axum) are defined locally per crate
 [workspace.dependencies]
-# Async runtime
-tokio = { version = "1.0", features = ["full"] }
+# Async runtime.
+#
+# Deliberately NO features here. Features declared in [workspace.dependencies]
+# are additive and unconditional — every inheriting crate gets them — so listing
+# any would defeat the per-crate sets below. Each crate declares exactly what it
+# uses via `tokio = { workspace = true, features = [...] }`.
+#
+# Note this does not shorten a full workspace build: Cargo unifies features
+# across the graph, and gglib-download/gglib-runtime between them already need
+# most of `full`. The win is honest manifests and cheap single-crate builds
+# (`cargo check -p gglib-sse` no longer compiles process, net and signal).
+tokio = { version = "1.0" }
 tokio-test = "0.4"
 
 # Futures / async streams
@@ -142,6 +155,16 @@ codegen-units = 16
 [profile.dev]
 opt-level = 0
 
+# Optimize dependencies even in debug builds. Our own code stays at opt-level 0
+# so incremental rebuilds remain fast, but third-party crates compile once and
+# stay optimized — which matters a lot here, where debug builds hash multi-GB
+# GGUF files through sha2 and stream downloads through reqwest/rustls.
+[profile.dev.package."*"]
+opt-level = 3
+
 [profile.test]
 opt-level = 0
+
+[profile.test.package."*"]
+opt-level = 3
 

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ CARGO_ENV := $(shell if [ -f "$$HOME/.cargo/env" ]; then echo ". $$HOME/.cargo/e
 CARGO_BIN := $(shell if [ -x "$$HOME/.cargo/bin/cargo" ]; then echo "$$HOME/.cargo/bin/cargo"; else echo cargo; fi)
 CARGO := $(CARGO_ENV) $(CARGO_BIN)
 
-# Cargo Optimization Flags
-export CARGO_PROFILE_RELEASE_LTO := thin
-export CARGO_PROFILE_RELEASE_CODEGEN_UNITS := 16
+# Release optimization flags live in [profile.release] in Cargo.toml, not here.
+# They used to be exported as CARGO_PROFILE_RELEASE_LTO/_CODEGEN_UNITS with the
+# same values the manifest already had; because the env vars take precedence,
+# any future edit to Cargo.toml would have been silently ignored under `make`.
 
 # Bootstrap dependency check - runs WITHOUT requiring Rust compilation
 check-deps-bootstrap:

--- a/crates/gglib-agent/Cargo.toml
+++ b/crates/gglib-agent/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 # Composition (wiring LlmCompletionAdapter + McpToolExecutorAdapter into
 # AgentLoop) is performed by each entrypoint crate (gglib-axum, gglib-cli).
 gglib-core   = { path = "../gglib-core" }
-tokio        = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 futures-util = { workspace = true }
 futures-core = { workspace = true }
 async-trait  = { workspace = true }

--- a/crates/gglib-app-services/Cargo.toml
+++ b/crates/gglib-app-services/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 dirs = { workspace = true }
 
 # Async
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 async-trait = "0.1"
 tokio-util = "0.7"

--- a/crates/gglib-axum/Cargo.toml
+++ b/crates/gglib-axum/Cargo.toml
@@ -26,7 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "rt", "signal", "sync", "time"] }
 tokio-util = "0.7"
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/gglib-bootstrap/Cargo.toml
+++ b/crates/gglib-bootstrap/Cargo.toml
@@ -20,7 +20,7 @@ gglib-gguf = { path = "../gglib-gguf" }
 gglib-hf = { path = "../gglib-hf" }
 
 # Async runtime — full features match the adapters that consume this crate
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 async-trait = { workspace = true }
 
 # Error handling

--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { workspace = true }
 serde_json = { workspace = true }
 hf-hub = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 anyhow = { workspace = true }
 dotenvy = "0.15"
 rustyline = "14"

--- a/crates/gglib-core/Cargo.toml
+++ b/crates/gglib-core/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { workspace = true }
 dirs = { workspace = true }
 bitflags = { version = "2.6", features = ["serde"] }
 uuid = { version = "1.11", features = ["serde", "v4"] }
-tokio = { workspace = true, features = ["process", "sync", "fs", "rt"] }
+tokio = { workspace = true, features = ["fs", "process", "rt", "sync", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }

--- a/crates/gglib-db/Cargo.toml
+++ b/crates/gglib-db/Cargo.toml
@@ -15,7 +15,7 @@ test-utils = []
 gglib-core = { path = "../gglib-core" }
 
 # Universal dependencies
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -31,6 +31,8 @@ libsqlite3-sys = { version = "0.30", features = ["bundled", "unlock_notify"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# #[tokio::test] on the inline unit tests; additive with the [dependencies] set.
+tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-test = { workspace = true }
 
 [lints.rust]

--- a/crates/gglib-download/Cargo.toml
+++ b/crates/gglib-download/Cargo.toml
@@ -17,7 +17,7 @@ gglib-core.workspace = true
 gglib-hf.workspace = true
 
 # Async runtime
-tokio = { workspace = true, features = ["process", "io-util", "sync", "time", "macros"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt", "signal", "sync", "time"] }
 tokio-util = "0.7"
 async-trait.workspace = true
 

--- a/crates/gglib-hf/Cargo.toml
+++ b/crates/gglib-hf/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 gglib-core.workspace = true
 
 # Async runtime
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 async-trait.workspace = true
 
 # Serialization
@@ -34,4 +34,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 mockall.workspace = true
+# #[tokio::test] on the inline unit tests; additive with the [dependencies] set.
+tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-test.workspace = true

--- a/crates/gglib-integration-tests/Cargo.toml
+++ b/crates/gglib-integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ gglib-core = { workspace = true }
 gglib-db = { workspace = true }
 gglib-hf = { workspace = true }
 gglib-gguf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 chrono = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/gglib-mcp/Cargo.toml
+++ b/crates/gglib-mcp/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 gglib-core = { path = "../gglib-core" }
 
 # Async runtime
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "sync", "time"] }
 
 # Async trait
 async-trait = { workspace = true }

--- a/crates/gglib-proxy/Cargo.toml
+++ b/crates/gglib-proxy/Cargo.toml
@@ -22,7 +22,7 @@ gglib-sse = { workspace = true }
 
 # HTTP server
 axum = { workspace = true }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { workspace = true, features = ["fs", "macros", "net", "rt-multi-thread", "sync", "time"] }
 
 # CORS middleware — the Tauri GUI's webview runs on the `tauri://localhost`
 # (and `http://tauri.localhost` on Windows) origin, which browsers treat as

--- a/crates/gglib-runtime/Cargo.toml
+++ b/crates/gglib-runtime/Cargo.toml
@@ -19,7 +19,7 @@ gglib-mcp = { path = "../gglib-mcp" }
 gglib-proxy = { path = "../gglib-proxy" }
 
 # Runtime dependencies
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/gglib-sse/Cargo.toml
+++ b/crates/gglib-sse/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 # without inverting the hexagonal layering rules enforced by
 # scripts/check_boundaries.sh.
 axum = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures-util = { workspace = true }
 serde = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "vite": "^8.0.0",
     "vitest": "^4.0.16"
   },
-  "//overrides": "brace-expansion is forced to ^5.0.8 for GHSA-mh99-v99m-4gvg, EXCEPT under minimatch@3, which requires the 1.x CommonJS function export and throws 'expand is not a function' on 5.x \u2014 that breaks eslint before it reads a single file. minimatch@3 reaches us through eslint-plugin-react, whose latest release still pins ^3.1.2. Do not flatten this back to a blanket override (npm audit fix --force will try); it takes `npm run lint` down completely.",
+  "//overrides": "brace-expansion is forced to ^5.0.8 for GHSA-mh99-v99m-4gvg, EXCEPT under minimatch@3, which requires the 1.x CommonJS function export and throws 'expand is not a function' on 5.x — that breaks eslint before it reads a single file. minimatch@3 reaches us through eslint-plugin-react, whose latest release still pins ^3.1.2. Do not flatten this back to a blanket override (npm audit fix --force will try); it takes `npm run lint` down completely.",
   "overrides": {
     "brace-expansion": "^5.0.8",
     "minimatch@3": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -220,9 +220,10 @@ python3 ./scripts/sync_versions.py
 
 **Syncs to**:
 - `package.json` (npm/frontend)
-- `src-tauri/tauri.conf.json` (Tauri app metadata)
 
 Cargo crates use `version.workspace = true` so they inherit automatically.
+`src-tauri/tauri.conf.json` declares no `version` key: Tauri falls back to the
+`Cargo.toml` version when it is absent, so the app metadata inherits too.
 
 ---
 

--- a/scripts/sync_versions.py
+++ b/scripts/sync_versions.py
@@ -5,7 +5,10 @@ Sync version from workspace Cargo.toml to package files that don't use workspace
 The workspace Cargo.toml [workspace.package] version is the source of truth.
 Workspace crates (including src-tauri) use `version.workspace = true`, so this script only syncs to:
 - package.json (npm/frontend)
-- src-tauri/tauri.conf.json (Tauri app metadata)
+
+src-tauri/tauri.conf.json is deliberately NOT in that list: it no longer carries
+a "version" key. Tauri falls back to the version in Cargo.toml when the key is
+absent, so the app metadata tracks the workspace automatically.
 
 All Cargo.toml files are checked but skipped if they use workspace inheritance.
 """
@@ -77,7 +80,10 @@ def update_json(path, version):
         data['version'] = version
         
     with open(path, 'w') as f:
-        json.dump(data, f, indent=2)
+        # ensure_ascii=False: the default escapes non-ASCII, so every run
+        # rewrote the em dash in package.json's "//overrides" note to a
+        # literal backslash-u escape, producing a spurious diff each bump.
+        json.dump(data, f, indent=2, ensure_ascii=False)
         f.write('\n')
     print(f"  ✓ {path}")
 
@@ -99,11 +105,11 @@ def main():
     for toml in sorted(crate_tomls):
         update_cargo_toml(toml, version)
     
-    # Sync JSON files (these don't support workspace inheritance)
+    # Sync JSON files (these don't support workspace inheritance).
+    # tauri.conf.json is absent on purpose — see the module docstring.
     print("\nJSON files:")
     update_json('package.json', version)
-    update_json('src-tauri/tauri.conf.json', version)
-    
+
     print(f"\n✓ All files synced to version {version}")
     
     print("Done!")

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ gglib-tauri.workspace = true
 gglib-axum.workspace = true
 gglib-app-services.workspace = true
 reqwest.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 # Note: axum and tower-http are used via gglib-axum re-exports, no direct dependency needed
 dotenvy.workspace = true
 tracing.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,5 @@
 {
   "productName": "GGLib GUI",
-  "version": "0.13.0",
   "identifier": "com.gglib.gui",
   "build": {
     "beforeBuildCommand": "npm run build:tauri",


### PR DESCRIPTION
**Stack 2/4** — base `ci(workflows)/lockfile-cache-and-gates` (#774). Retarget to `main` once that merges.

### `[profile.dev.package."*"] opt-level = 3`

Optimize dependencies in debug builds; our own code stays at 0 so incremental rebuilds are unaffected. Deps compile once and stay optimized — which matters here, where debug builds hash multi-GB GGUFs through `sha2` and stream downloads through `reqwest`/`rustls`. Same for `[profile.test]`.

### Resolver 2 → 3

Edition-2024 packages default to resolver 3, but a virtual manifest has no edition to infer from and must state it. The pinned 1.97.1 toolchain is well past the 1.84 required. `Cargo.lock` is unchanged by the switch.

### Per-crate tokio features

The workspace entry inherited `features = ["full"]` into all 14 consumers; it now declares **no features at all**, because features listed in `[workspace.dependencies]` are additive and unconditional and would defeat the per-crate sets. `gglib-proxy` also bypassed the workspace entry with its own full-featured copy.

Sets were derived by scanning for tokio-specific paths, then converged with `cargo check -p <crate> --all-targets`. Three seeds were grep false positives, dropped after reading the call sites:

| seed | reality |
|---|---|
| `io-std` in gglib-cli, gglib-runtime | matched `std::io::stdout` |
| `process` in gglib-cli, gglib-mcp, src-tauri | matched `std::process::Command` |

`gglib-hf` and `gglib-db` got a `[dev-dependencies]` entry instead — only their inline `#[tokio::test]` blocks need `macros`/`rt`.

**Setting expectations:** this does *not* shorten a full workspace build. Cargo unifies features across the graph and `gglib-download`/`gglib-runtime` between them already need most of `full`. The measurable effect is `parking_lot` leaving the tokio build, plus genuinely cheap single-crate builds and manifests that state what they use.

### One version source

`Makefile` exported `CARGO_PROFILE_RELEASE_LTO`/`_CODEGEN_UNITS`, duplicating `[profile.release]` with identical values — and since env vars win, a later manifest edit would have been silently ignored under `make`. Deleted.

`"version"` is removed from `src-tauri/tauri.conf.json`, leaving `Cargo.toml` the only source. Tauri falls back to the crate version when absent — verified in the vendored sources, not just the docs:

- `tauri-codegen/src/context.rs:273` emits `env!("CARGO_PKG_VERSION")` for `PackageInfo`
- `tauri-winres` defaults `FileVersion`/`ProductVersion` to the same, so Windows resources are unaffected

`sync_versions.py` and `bump-version.yml` no longer patch or verify the key. The workflow now **fails if it comes back**, since a re-added key would silently pin the metadata again.

Also fixes `sync_versions.py` writing JSON with `ensure_ascii=True`, which rewrote the em dash in `package.json`'s `//overrides` note to an escape on every run.

### Verification

- `cargo check --workspace --all-targets` clean; `cargo check -p <crate> --all-targets` clean for all 15 + `gglib-app`
- `cargo test --workspace` — **79 test binaries, 0 failures**. This matters: a missing tokio feature is a *runtime* panic (`time driver not enabled`), not a compile error.
- `cargo metadata --locked` clean for both manifests
- release build → `gglib 0.12.2`, confirming the version fallback
- `python3 scripts/sync_versions.py` → no drift