### PR TITLE
fix(ts): type-check the build config and the test suite

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,11 +78,13 @@ export default [
           jsx: true,
         },
       },
+      // No node globals: this block covers src/, which is browser-only.
+      // `process` and `__dirname` were declared readonly here without a single
+      // use anywhere in src/ — the build tooling that needs them lives in
+      // vite.config.ts, which this block has never matched.
       globals: {
         ...globals.browser,
         ...globals.es2021,
-        process: 'readonly',
-        __dirname: 'readonly',
       },
     },
     plugins: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
@@ -2486,6 +2487,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -8730,6 +8741,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
     "build:tauri": "npm run build && touch web_ui/.tauri-stamp",
     "preview": "vite preview",
     "tauri": "tauri",
@@ -24,7 +24,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "lint": "eslint src/",
     "lint:boundaries": "eslint src/"
   },
@@ -53,6 +53,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -12,7 +12,7 @@ import { getTransport } from '../services/transport';
 
 export type ShowToastFn = (message: string, type?: "success" | "error" | "info" | "warning") => void;
 
-interface SettingsContextValue {
+export interface SettingsContextValue {
   settings: AppSettings | null;
   loading: boolean;
   saving: boolean;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,8 +1,42 @@
 @import "tailwindcss";
-@import "@fontsource-variable/ibm-plex-sans";
-@import "@fontsource/ibm-plex-mono/400.css";
-@import "@fontsource/ibm-plex-mono/500.css";
-@import "@fontsource/ibm-plex-mono/600.css";
+
+/* Fonts — latin and latin-ext only.
+ *
+ * The default fontsource entrypoints ship cyrillic, cyrillic-ext, greek and
+ * vietnamese as well: 36 font files, 508K of the emitted assets. Browsers never
+ * download the unused subsets (each @font-face carries a unicode-range), so
+ * this is not a page-load win — it is weight removed from every .dmg and .deb
+ * we ship, and from the web_ui directory the server hosts.
+ *
+ * The mono package publishes per-subset entrypoints. The variable sans does
+ * not, so its two faces are declared inline, copied from the package's
+ * wght.css. Re-check them when @fontsource-variable/ibm-plex-sans is upgraded.
+ */
+@import "@fontsource/ibm-plex-mono/latin-400.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+@import "@fontsource/ibm-plex-mono/latin-600.css";
+@import "@fontsource/ibm-plex-mono/latin-ext-400.css";
+@import "@fontsource/ibm-plex-mono/latin-ext-500.css";
+@import "@fontsource/ibm-plex-mono/latin-ext-600.css";
+
+@font-face {
+  font-family: 'IBM Plex Sans Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 700;
+  src: url('@fontsource-variable/ibm-plex-sans/files/ibm-plex-sans-latin-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 700;
+  src: url('@fontsource-variable/ibm-plex-sans/files/ibm-plex-sans-latin-ext-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
 @import "./base/variables.css";
 @import "./base/hljs.css";
 

--- a/tests/ts/components/Header.test.tsx
+++ b/tests/ts/components/Header.test.tsx
@@ -18,8 +18,8 @@ describe('Header', () => {
   const mockOnRefreshServers = vi.fn();
 
   const mockServers: ServerInfo[] = [
-    { model_id: 1, model_name: 'Test Model 1', port: MOCK_PROXY_PORT, status: 'running' },
-    { model_id: 2, model_name: 'Test Model 2', port: MOCK_PROXY_PORT + 1, status: 'running' },
+    { modelId: 1, modelName: 'Test Model 1', port: MOCK_PROXY_PORT, status: 'running' },
+    { modelId: 2, modelName: 'Test Model 2', port: MOCK_PROXY_PORT + 1, status: 'running' },
   ];
 
   const defaultProps = {

--- a/tests/ts/components/Toast.test.tsx
+++ b/tests/ts/components/Toast.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import React from 'react';
 import { ToastProvider, useToastContext } from '../../../src/contexts/ToastContext';
 import { ToastContainer } from '../../../src/components/Toast';
 
@@ -17,8 +16,6 @@ function renderToastSystem() {
     showToast = useToastContext().showToast;
     return null;
   };
-
-  const { toasts: _toasts, ...rest } = { toasts: [] as ReturnType<typeof useToastContext>['toasts'] };
 
   const Wrapper = () => {
     const ctx = useToastContext();

--- a/tests/ts/hooks/useDownloadCompletionEffects.test.ts
+++ b/tests/ts/hooks/useDownloadCompletionEffects.test.ts
@@ -7,10 +7,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import React from 'react';
 import { useDownloadCompletionEffects } from '../../../src/hooks/useDownloadCompletionEffects';
-import { ToastProvider } from '../../../src/contexts/ToastContext';
-import type { DownloadCompletionInfo } from '../../../src/download/api/types';
+import type { DownloadCompletionInfo } from '../../../src/services/transport/types/downloads';
 
 // Mock toast context
 const mockShowToast = vi.fn();

--- a/tests/ts/hooks/useDownloadManager.test.ts
+++ b/tests/ts/hooks/useDownloadManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDownloadManager } from '../../../src/hooks/useDownloadManager';
 

--- a/tests/ts/hooks/useMcpServers.test.ts
+++ b/tests/ts/hooks/useMcpServers.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useMcpServers } from '../../../src/hooks/useMcpServers';
-import type { McpServerInfo, McpTool } from '../../../src/services/transport';
+import type { McpServerInfo } from '../../../src/services/transport';
 
 const transport = vi.hoisted(() => ({
   listMcpServers: vi.fn(),
@@ -37,9 +37,8 @@ const {
   removeMcpServer,
   startMcpServer,
   stopMcpServer,
-  callMcpTool,
 } = transport;
-import { syncAllMcpTools, syncBuiltinTools } from '../../../src/services/tools';
+import { syncAllMcpTools } from '../../../src/services/tools';
 
 // ==========================================================================
 // Test Fixtures
@@ -56,6 +55,7 @@ const mockServerInfo: McpServerInfo = {
     },
     enabled: true,
     lifecycle: 'lazy' as const,
+    is_valid: true,
     env: [],
     created_at: '2024-01-01T00:00:00Z',
   },
@@ -63,32 +63,7 @@ const mockServerInfo: McpServerInfo = {
   tools: [],
 };
 
-const mockRunningServer: McpServerInfo = {
-  server: {
-    id: 2,
-    name: 'Running Server',
-    server_type: 'stdio',
-    config: {
-      command: 'npx',
-      args: ['-y', 'running-server'],
-    },
-    enabled: true,
-    lifecycle: 'lazy' as const,
-    env: [],
-    created_at: '2024-01-01T00:00:00Z',
-  },
-  status: 'running',
-  tools: [
-    { name: 'tool1', description: 'First tool' },
-    { name: 'tool2', description: 'Second tool' },
-  ],
-};
 
-const mockTools: (McpTool & { server_id: number })[] = [
-  { name: 'search', description: 'Search web', server_id: 1 },
-  { name: 'fetch', description: 'Fetch URL', server_id: 1 },
-  { name: 'read_file', description: 'Read file', server_id: 2 },
-];
 
 describe('useMcpServers', () => {
   beforeEach(() => {
@@ -185,6 +160,7 @@ describe('useMcpServers', () => {
         config: { command: 'test' },
         enabled: true,
         lifecycle: 'lazy' as const,
+        is_valid: true,
         env: [],
       };
       const savedServer = { ...newServer, id: 2, created_at: '2024-01-01T00:00:00Z' };
@@ -387,13 +363,13 @@ describe('useMcpServers', () => {
       // First call throws
       await expect(
         act(async () => {
-          await result.current.addServer({ name: 'New', type: 'stdio', enabled: true, lifecycle: 'lazy' as const, env: [] });
+          await result.current.addServer({ name: 'New', server_type: 'stdio', config: {}, enabled: true, lifecycle: 'lazy' as const, env: [] });
         })
       ).rejects.toThrow('First error');
 
       // Second call succeeds
       await act(async () => {
-        const server = await result.current.addServer({ name: 'New', type: 'stdio', enabled: true, lifecycle: 'lazy' as const, env: [] });
+        const server = await result.current.addServer({ name: 'New', server_type: 'stdio', config: {}, enabled: true, lifecycle: 'lazy' as const, env: [] });
         expect(server.id).toBe(2);
       });
     });

--- a/tests/ts/hooks/useMessageDeletion.test.ts
+++ b/tests/ts/hooks/useMessageDeletion.test.ts
@@ -172,7 +172,7 @@ describe('useMessageDeletion', () => {
 
     // The assistant keeps its tool call, with the result merged in.
     const assistant = reloaded[1];
-    const parts = assistant.content as Array<Record<string, unknown>>;
+    const parts = assistant.content as unknown as Array<Record<string, unknown>>;
     const toolPart = parts.find((p) => p.type === 'tool-call');
     expect(toolPart).toMatchObject({
       toolCallId: 'call-1',

--- a/tests/ts/hooks/useModels.test.ts
+++ b/tests/ts/hooks/useModels.test.ts
@@ -26,28 +26,27 @@ vi.mock('../../../src/services/platform', () => ({
   setSelectedModel: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { setSelectedModel } from '../../../src/services/platform';
 
 const mockModels: GgufModel[] = [
   {
     id: 1,
     name: 'llama-7b',
-    file_path: '/models/llama-7b.gguf',
-    param_count_b: 7.0,
+    filePath: '/models/llama-7b.gguf',
+    paramCountB: 7.0,
     architecture: 'llama',
     quantization: 'Q4_K_M',
-    context_length: 4096,
-    added_at: '2024-01-01T00:00:00Z',
+    contextLength: 4096,
+    addedAt: '2024-01-01T00:00:00Z',
   },
   {
     id: 2,
     name: 'mistral-7b',
-    file_path: '/models/mistral-7b.gguf',
-    param_count_b: 7.0,
+    filePath: '/models/mistral-7b.gguf',
+    paramCountB: 7.0,
     architecture: 'mistral',
     quantization: 'Q5_K_S',
-    context_length: 8192,
-    added_at: '2024-01-02T00:00:00Z',
+    contextLength: 8192,
+    addedAt: '2024-01-02T00:00:00Z',
   },
 ];
 

--- a/tests/ts/hooks/useServerActions.test.tsx
+++ b/tests/ts/hooks/useServerActions.test.tsx
@@ -46,6 +46,7 @@ function makeConfig(overrides: Partial<ServerActionsConfig>): ServerActionsConfi
     jinjaOverride: null,
     hasAgentTag: false,
     hasMtpTag: false,
+    pinProxy: false,
     mtpNMaxOverride: null,
     mtpPMinOverride: null,
     inferenceParams: undefined,

--- a/tests/ts/hooks/useSettings.test.tsx
+++ b/tests/ts/hooks/useSettings.test.tsx
@@ -25,11 +25,11 @@ const { getSettings, updateSettings } = transport;
 const fetchSettings = getSettings;
 
 const mockSettings: AppSettings = {
-  default_download_path: '/models',
-  default_context_size: 4096,
-  proxy_port: MOCK_PROXY_PORT,
-  llama_base_port: MOCK_BASE_PORT,
-  max_download_queue_size: 10,
+  defaultDownloadPath: '/models',
+  defaultContextSize: 4096,
+  proxyPort: MOCK_PROXY_PORT,
+  llamaBasePort: MOCK_BASE_PORT,
+  maxDownloadQueueSize: 10,
 };
 
 // Wrapper to provide SettingsProvider for hook tests
@@ -76,7 +76,7 @@ describe('useSettings', () => {
   it('saves settings and updates state', async () => {
     const updatedSettings: AppSettings = {
       ...mockSettings,
-      default_context_size: 8192,
+      defaultContextSize: 8192,
     };
     vi.mocked(updateSettings).mockResolvedValue(updatedSettings);
 
@@ -90,10 +90,10 @@ describe('useSettings', () => {
 
     let returnedSettings: AppSettings | undefined;
     await act(async () => {
-      returnedSettings = await result.current.save({ default_context_size: 8192 });
+      returnedSettings = await result.current.save({ defaultContextSize: 8192 });
     });
 
-    expect(updateSettings).toHaveBeenCalledWith({ default_context_size: 8192 });
+    expect(updateSettings).toHaveBeenCalledWith({ defaultContextSize: 8192 });
     expect(result.current.settings).toEqual(updatedSettings);
     expect(returnedSettings).toEqual(updatedSettings);
     expect(result.current.saving).toBe(false);
@@ -111,12 +111,12 @@ describe('useSettings', () => {
     });
 
     await act(async () => {
-      await result.current.save({ proxy_port: 9090 });
+      await result.current.save({ proxyPort: 9090 });
     });
 
     // After save completes, saving should be false
     expect(result.current.saving).toBe(false);
-    expect(updateSettings).toHaveBeenCalledWith({ proxy_port: 9090 });
+    expect(updateSettings).toHaveBeenCalledWith({ proxyPort: 9090 });
   });
 
   it('handles error when saving settings fails', async () => {
@@ -133,7 +133,7 @@ describe('useSettings', () => {
     let thrownError: unknown = null;
     await act(async () => {
       try {
-        await result.current.save({ default_context_size: -1 });
+        await result.current.save({ defaultContextSize: -1 });
       } catch (e) {
         thrownError = e;
       }
@@ -154,7 +154,7 @@ describe('useSettings', () => {
     expect(fetchSettings).toHaveBeenCalledTimes(1);
 
     // Update mock to return different data
-    const newSettings: AppSettings = { ...mockSettings, proxy_port: 9999 };
+    const newSettings: AppSettings = { ...mockSettings, proxyPort: 9999 };
     vi.mocked(fetchSettings).mockResolvedValue(newSettings);
 
     await act(async () => {
@@ -167,11 +167,11 @@ describe('useSettings', () => {
 
   it('handles null values in settings', async () => {
     const nullSettings: AppSettings = {
-      default_download_path: null,
-      default_context_size: null,
-      proxy_port: null,
-      llama_base_port: null,
-      max_download_queue_size: null,
+      defaultDownloadPath: null,
+      defaultContextSize: null,
+      proxyPort: null,
+      llamaBasePort: null,
+      maxDownloadQueueSize: null,
     };
     vi.mocked(fetchSettings).mockResolvedValue(nullSettings);
 
@@ -218,7 +218,7 @@ describe('useSettings', () => {
     
     await act(async () => {
       try {
-        await result.current.save({ proxy_port: 1 });
+        await result.current.save({ proxyPort: 1 });
       } catch {
         // Expected to throw
       }
@@ -230,7 +230,7 @@ describe('useSettings', () => {
     vi.mocked(updateSettings).mockResolvedValue(mockSettings);
 
     await act(async () => {
-      await result.current.save({ proxy_port: MOCK_PROXY_PORT });
+      await result.current.save({ proxyPort: MOCK_PROXY_PORT });
     });
 
     expect(result.current.error).toBeNull();

--- a/tests/ts/services/tools/mcpIntegration.test.ts
+++ b/tests/ts/services/tools/mcpIntegration.test.ts
@@ -2,7 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerMcpTools, unregisterMcpTools, getMcpSource } from '../../../../src/services/tools/mcpIntegration';
 import { resetToolRegistry, getToolRegistry } from '../../../../src/services/tools/registry';
 import { mcpGenericRenderer } from '../../../../src/services/tools/renderers';
-import type { McpTool } from '../../../../src/services/transport';
+import type { McpTool, McpServerId } from '../../../../src/services/transport';
+
+// ── McpServerId in tests ──────────────────────────────────────────────────────
+// McpServerId is `number` in production (src/services/transport/types/ids.ts),
+// but this suite registers servers under string ids on purpose: the ids embed
+// straight into the namespaced tool name (`mcp_${serverId}_${tool}`), and ids
+// like 'my.server' are what exercise the sanitizer's normalisation of dots and
+// spaces. Vitest erased the mismatch — these files were never type-checked —
+// so the cast is made explicit here rather than silently spread across ~30
+// call sites. If the defensive server-id sanitization is genuinely unreachable
+// now that ids are numeric, this helper is where that conversation starts.
+const srv = (id: string) => id as unknown as McpServerId;
+
 
 // =============================================================================
 // Module mocks
@@ -61,7 +73,7 @@ describe('registerMcpTools', () => {
   // ── Basic registration ─────────────────────────────────────────────────────
 
   it('registers tools with sanitized names and returns count', () => {
-    const count = registerMcpTools('my-server', [
+    const count = registerMcpTools(srv('my-server'), [
       makeTool('get-weather'),
       makeTool('list_files'),
     ]);
@@ -69,13 +81,13 @@ describe('registerMcpTools', () => {
   });
 
   it('registers tools under the correct source', () => {
-    registerMcpTools('srv1', [makeTool('get_time')]);
+    registerMcpTools(srv('srv1'), [makeTool('get_time')]);
     const registry = getToolRegistry();
     expect(registry.getSource('mcp_srv1_get_time')).toBe('mcp:srv1');
   });
 
   it('stores the sanitized name as the registry key', () => {
-    registerMcpTools('my.server', [makeTool('get data!')]);
+    registerMcpTools(srv('my.server'), [makeTool('get data!')]);
     const registry = getToolRegistry();
     // 'mcp_my.server_get data!' sanitizes to 'mcp_my_server_get_data'
     expect(registry.has('mcp_my_server_get_data')).toBe(true);
@@ -85,13 +97,13 @@ describe('registerMcpTools', () => {
   // ── Reverse name map ───────────────────────────────────────────────────────
 
   it('getOriginalName returns the raw MCP tool name for a sanitized key', () => {
-    registerMcpTools('my.server', [makeTool('get data!')]);
+    registerMcpTools(srv('my.server'), [makeTool('get data!')]);
     const registry = getToolRegistry();
     expect(registry.getOriginalName('mcp_my_server_get_data')).toBe('get data!');
   });
 
   it('getServerId returns the server ID for a sanitized key', () => {
-    registerMcpTools('my.server', [makeTool('get data!')]);
+    registerMcpTools(srv('my.server'), [makeTool('get data!')]);
     const registry = getToolRegistry();
     expect(registry.getServerId('mcp_my_server_get_data')).toBe('my.server');
   });
@@ -102,7 +114,7 @@ describe('registerMcpTools', () => {
   });
 
   it('lookup works for clean names with no sanitization needed', () => {
-    registerMcpTools('srv1', [makeTool('list_files')]);
+    registerMcpTools(srv('srv1'), [makeTool('list_files')]);
     const registry = getToolRegistry();
     expect(registry.getOriginalName('mcp_srv1_list_files')).toBe('list_files');
     expect(registry.getServerId('mcp_srv1_list_files')).toBe('srv1');
@@ -111,7 +123,7 @@ describe('registerMcpTools', () => {
   // ── Sanitization warnings ──────────────────────────────────────────────────
 
   it('logs a warn when sanitization changes the tool name', () => {
-    registerMcpTools('my.server', [makeTool('get data!')]);
+    registerMcpTools(srv('my.server'), [makeTool('get data!')]);
     expect(mockWarn).toHaveBeenCalledWith(
       'service.mcp',
       'MCP tool name was sanitized',
@@ -125,7 +137,7 @@ describe('registerMcpTools', () => {
 
   it('does not warn when no sanitization is needed', () => {
     mockWarn.mockClear();
-    registerMcpTools('srv1', [makeTool('get_weather')]);
+    registerMcpTools(srv('srv1'), [makeTool('get_weather')]);
     // mockWarn should not have been called with 'MCP tool name was sanitized'
     const sanitizeWarnings = mockWarn.mock.calls.filter(
       ([, msg]) => msg === 'MCP tool name was sanitized',
@@ -137,7 +149,7 @@ describe('registerMcpTools', () => {
 
   it('skips both tools when two names collide and logs a warning', () => {
     // 'get!data' and 'get?data' both sanitize to 'mcp_s_get_data'
-    const count = registerMcpTools('s', [makeTool('get!data'), makeTool('get?data')]);
+    const count = registerMcpTools(srv('s'), [makeTool('get!data'), makeTool('get?data')]);
     expect(count).toBe(0);
     const registry = getToolRegistry();
     expect(registry.has('mcp_s_get_data')).toBe(false);
@@ -149,7 +161,7 @@ describe('registerMcpTools', () => {
   });
 
   it('registers non-colliding tools even when some in the batch collide', () => {
-    const count = registerMcpTools('s', [
+    const count = registerMcpTools(srv('s'), [
       makeTool('get!data'),   // collides
       makeTool('get?data'),   // collides
       makeTool('list_files'), // safe
@@ -165,7 +177,7 @@ describe('registerMcpTools', () => {
     const mockCallMcpTool = transport.callMcpTool;
     mockCallMcpTool.mockResolvedValueOnce({ success: true, data: 'result' });
 
-    registerMcpTools('my.server', [makeTool('get data!')]);
+    registerMcpTools(srv('my.server'), [makeTool('get data!')]);
 
     const registry = getToolRegistry();
     // Execute via the sanitized key
@@ -181,7 +193,7 @@ describe('registerMcpTools', () => {
   // ── Renderer assignment ────────────────────────────────────────────────────
 
   it('assigns mcpGenericRenderer to tools without an output_schema', () => {
-    registerMcpTools('srv1', [makeTool('get_weather')]);
+    registerMcpTools(srv('srv1'), [makeTool('get_weather')]);
     const registry = getToolRegistry();
     expect(registry.getRenderer('mcp_srv1_get_weather')).toBe(mcpGenericRenderer);
   });
@@ -191,7 +203,7 @@ describe('registerMcpTools', () => {
       ...makeTool('search_results'),
       output_schema: { type: 'object', properties: { items: { type: 'array' } } },
     };
-    registerMcpTools('srv1', [toolWithSchema]);
+    registerMcpTools(srv('srv1'), [toolWithSchema]);
     const registry = getToolRegistry();
     const renderer = registry.getRenderer('mcp_srv1_search_results');
     expect(renderer).toBeDefined();
@@ -210,8 +222,8 @@ describe('unregisterMcpTools', () => {
   });
 
   it('removes registered tools and returns the count', () => {
-    registerMcpTools('srv1', [makeTool('get_weather'), makeTool('list_files')]);
-    const removed = unregisterMcpTools('srv1');
+    registerMcpTools(srv('srv1'), [makeTool('get_weather'), makeTool('list_files')]);
+    const removed = unregisterMcpTools(srv('srv1'));
     expect(removed).toBe(2);
     const registry = getToolRegistry();
     expect(registry.has('mcp_srv1_get_weather')).toBe(false);
@@ -219,24 +231,24 @@ describe('unregisterMcpTools', () => {
   });
 
   it('clears name-map entries for the unregistered server', () => {
-    registerMcpTools('my.server', [makeTool('get data!')]);
-    unregisterMcpTools('my.server');
+    registerMcpTools(srv('my.server'), [makeTool('get data!')]);
+    unregisterMcpTools(srv('my.server'));
     const registry = getToolRegistry();
     expect(registry.getOriginalName('mcp_my_server_get_data')).toBeUndefined();
     expect(registry.getServerId('mcp_my_server_get_data')).toBeUndefined();
   });
 
   it('does not remove tools from a different server', () => {
-    registerMcpTools('srv1', [makeTool('tool_a')]);
-    registerMcpTools('srv2', [makeTool('tool_b')]);
-    unregisterMcpTools('srv1');
+    registerMcpTools(srv('srv1'), [makeTool('tool_a')]);
+    registerMcpTools(srv('srv2'), [makeTool('tool_b')]);
+    unregisterMcpTools(srv('srv1'));
     const registry = getToolRegistry();
     expect(registry.has('mcp_srv2_tool_b')).toBe(true);
     expect(registry.getOriginalName('mcp_srv2_tool_b')).toBe('tool_b');
   });
 
   it('returns 0 when the server has no registered tools', () => {
-    expect(unregisterMcpTools('nonexistent')).toBe(0);
+    expect(unregisterMcpTools(srv('nonexistent'))).toBe(0);
   });
 });
 
@@ -246,7 +258,7 @@ describe('unregisterMcpTools', () => {
 
 describe('getMcpSource', () => {
   it('returns the correct source prefix format', () => {
-    expect(getMcpSource('my-server')).toBe('mcp:my-server');
-    expect(getMcpSource('123')).toBe('mcp:123');
+    expect(getMcpSource(srv('my-server'))).toBe('mcp:my-server');
+    expect(getMcpSource(srv('123'))).toBe('mcp:123');
   });
 });

--- a/tests/ts/services/tools/mcpSanitization.test.ts
+++ b/tests/ts/services/tools/mcpSanitization.test.ts
@@ -15,6 +15,19 @@ import { registerMcpTools } from '../../../../src/services/tools/mcpIntegration'
 import { resetToolRegistry, getToolRegistry } from '../../../../src/services/tools/registry';
 import type { McpTool } from '../../../../src/services/transport';
 import type { ToolCall } from '../../../../src/services/tools/types';
+import type { McpServerId } from '../../../../src/services/transport';
+
+// ── McpServerId in tests ──────────────────────────────────────────────────────
+// McpServerId is `number` in production (src/services/transport/types/ids.ts),
+// but this suite registers servers under string ids on purpose: the ids embed
+// straight into the namespaced tool name (`mcp_${serverId}_${tool}`), and ids
+// like 'my.server' are what exercise the sanitizer's normalisation of dots and
+// spaces. Vitest erased the mismatch — these files were never type-checked —
+// so the cast is made explicit here rather than silently spread across ~30
+// call sites. If the defensive server-id sanitization is genuinely unreachable
+// now that ids are numeric, this helper is where that conversation starts.
+const srv = (id: string) => id as unknown as McpServerId;
+
 
 // =============================================================================
 // Module mocks (same pattern as mcpIntegration.test.ts)
@@ -91,7 +104,7 @@ describe('MCP tool name sanitization round-trip', () => {
     // Tool 'get-weather.v2' from server 'test' sanitizes to 'mcp_test_get-weather_v2'
     callMcpTool.mockResolvedValueOnce({ success: true, data: 'sunny' });
 
-    registerMcpTools('test', [makeTool('get-weather.v2')]);
+    registerMcpTools(srv('test'), [makeTool('get-weather.v2')]);
 
     const toolCall = makeToolCall('mcp_test_get-weather_v2', { city: 'London' });
     await getToolRegistry().executeRawCall(toolCall);
@@ -108,7 +121,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('passes arguments through unmodified', async () => {
     callMcpTool.mockResolvedValueOnce({ success: true, data: null });
 
-    registerMcpTools('srv', [makeTool('echo')]);
+    registerMcpTools(srv('srv'), [makeTool('echo')]);
     const args = { message: 'hello', count: 3, flag: true };
 
     await getToolRegistry().executeRawCall(makeToolCall('mcp_srv_echo', args));
@@ -121,7 +134,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('returns a success result with data from the MCP server', async () => {
     callMcpTool.mockResolvedValueOnce({ success: true, data: { temp: 20, unit: 'C' } });
 
-    registerMcpTools('weather', [makeTool('get-temp')]);
+    registerMcpTools(srv('weather'), [makeTool('get-temp')]);
     const result = await getToolRegistry().executeRawCall(
       makeToolCall('mcp_weather_get-temp', { city: 'Paris' }),
     );
@@ -132,7 +145,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('returns an error result when the MCP server responds with failure', async () => {
     callMcpTool.mockResolvedValueOnce({ success: false, error: 'city not found' });
 
-    registerMcpTools('weather', [makeTool('get-temp')]);
+    registerMcpTools(srv('weather'), [makeTool('get-temp')]);
     const result = await getToolRegistry().executeRawCall(
       makeToolCall('mcp_weather_get-temp', { city: 'Atlantis' }),
     );
@@ -143,7 +156,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('falls back to a generic error message when MCP responds with success:false but no error string', async () => {
     callMcpTool.mockResolvedValueOnce({ success: false });
 
-    registerMcpTools('srv', [makeTool('flaky')]);
+    registerMcpTools(srv('srv'), [makeTool('flaky')]);
     const result = await getToolRegistry().executeRawCall(makeToolCall('mcp_srv_flaky'));
 
     expect(result).toMatchObject({ success: false });
@@ -155,7 +168,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('returns an error result when callMcpTool rejects (does not throw)', async () => {
     callMcpTool.mockRejectedValueOnce(new Error('network failure'));
 
-    registerMcpTools('srv', [makeTool('risky-op')]);
+    registerMcpTools(srv('srv'), [makeTool('risky-op')]);
     const result = await getToolRegistry().executeRawCall(makeToolCall('mcp_srv_risky-op'));
 
     expect(result).toMatchObject({
@@ -167,7 +180,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('handles non-Error rejections gracefully', async () => {
     callMcpTool.mockRejectedValueOnce('something broke');
 
-    registerMcpTools('srv', [makeTool('tool_a')]);
+    registerMcpTools(srv('srv'), [makeTool('tool_a')]);
     const result = await getToolRegistry().executeRawCall(makeToolCall('mcp_srv_tool_a'));
 
     expect(result).toMatchObject({ success: false });
@@ -177,7 +190,7 @@ describe('MCP tool name sanitization round-trip', () => {
   // ── Argument JSON parsing ──────────────────────────────────────────────────
 
   it('returns a parse-error result when the LLM sends invalid arguments JSON', async () => {
-    registerMcpTools('srv', [makeTool('my_tool')]);
+    registerMcpTools(srv('srv'), [makeTool('my_tool')]);
 
     const badCall: ToolCall = {
       id: 'call-bad',
@@ -213,7 +226,7 @@ describe('MCP tool name sanitization round-trip', () => {
       .mockResolvedValueOnce({ success: true, data: 'weather-result' })
       .mockResolvedValueOnce({ success: true, data: 'files-result' });
 
-    registerMcpTools('multi', [
+    registerMcpTools(srv('multi'), [
       makeTool('get-weather.v2'),
       makeTool('list files'),
     ]);
@@ -232,8 +245,8 @@ describe('MCP tool name sanitization round-trip', () => {
       .mockResolvedValueOnce({ success: true, data: 'from-alpha' })
       .mockResolvedValueOnce({ success: true, data: 'from-beta' });
 
-    registerMcpTools('alpha', [makeTool('ping')]);
-    registerMcpTools('beta',  [makeTool('ping')]);
+    registerMcpTools(srv('alpha'), [makeTool('ping')]);
+    registerMcpTools(srv('beta'),  [makeTool('ping')]);
 
     await getToolRegistry().executeRawCall(makeToolCall('mcp_alpha_ping', {}, 'c1'));
     await getToolRegistry().executeRawCall(makeToolCall('mcp_beta_ping',  {}, 'c2'));
@@ -246,7 +259,7 @@ describe('MCP tool name sanitization round-trip', () => {
 
   it('does not register either tool when two names collide, so calling the sanitized key returns an error', async () => {
     // 'get!data' and 'get?data' both sanitize to 'mcp_s_get_data' — both are skipped
-    registerMcpTools('s', [makeTool('get!data'), makeTool('get?data')]);
+    registerMcpTools(srv('s'), [makeTool('get!data'), makeTool('get?data')]);
 
     const result = await getToolRegistry().executeRawCall(makeToolCall('mcp_s_get_data'));
 
@@ -262,7 +275,7 @@ describe('MCP tool name sanitization round-trip', () => {
   it('works correctly when the tool name needs no sanitization at all', async () => {
     callMcpTool.mockResolvedValueOnce({ success: true, data: 42 });
 
-    registerMcpTools('srv', [makeTool('get_current_time')]);
+    registerMcpTools(srv('srv'), [makeTool('get_current_time')]);
     const result = await getToolRegistry().executeRawCall(
       makeToolCall('mcp_srv_get_current_time'),
     );

--- a/tests/ts/utils/mcp.test.ts
+++ b/tests/ts/utils/mcp.test.ts
@@ -18,6 +18,7 @@ const serverInfo = (status: McpServerInfo['status']): McpServerInfo => ({
     config: {},
     enabled: true,
     lifecycle: 'lazy' as const,
+    is_valid: true,
     env: [],
     created_at: '2024-01-01',
   },

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,28 @@
+{
+  // Options shared by every project in the solution. Each project adds its own
+  // `include`, `types` and `tsBuildInfoFile` on top.
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Project references */
+    "composite": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,15 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "ES2023", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
-  },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  // Solution file. `tsc -b` (npm run typecheck) builds every referenced project,
+  // which is what makes the build configs and the test suite type-checked at all
+  // — plain `tsc` ignores `references`, so for a long time only `src` was.
+  //
+  // Every project is composite + noEmit: composite is what `tsc -b` requires,
+  // noEmit (allowed together since TS 5.6) keeps it a pure type check, so no
+  // stray vite.config.js ever lands next to the source.
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,10 +1,14 @@
 {
+  // The build tooling itself. This was previously a stub that only `tsc -b`
+  // would have read — and nothing ran `tsc -b` — so vite.config.ts went
+  // unchecked and accumulated five errors, including a Tailwind option that
+  // does not exist and was being silently discarded at build time.
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "types": ["node"],
+    "tsBuildInfoFile": "node_modules/.tmp/tsconfig.node.tsbuildinfo"
   },
+  // eslint.config.js is deliberately absent: without allowJs, tsc would list it
+  // and silently skip it, which reads as coverage that does not exist.
   "include": ["vite.config.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  // The Vitest suite. Vitest transpiles without type checking, so nothing here
+  // was ever verified: one test imported a type from src/download/api/types,
+  // a directory that does not exist, and still passed because the import was
+  // type-only and therefore erased.
+  //
+  // `src` is included alongside `tests/ts` because the tests import from it and
+  // a composite project must list every file it sees. That means src is checked
+  // twice (once here, once by tsconfig.app.json), which costs a few seconds and
+  // keeps the app project free of the vitest globals declared below — src should
+  // not be able to reference `describe` or `expect`.
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"],
+    "tsBuildInfoFile": "node_modules/.tmp/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["tests/ts", "src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,102 +1,111 @@
-import { defineConfig, loadEnv } from "vite";
+/// <reference types="vitest/config" />
+import { defineConfig } from "vitest/config";
+import { loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vitejs.dev/config/
-export default defineConfig(async ({ mode }) => {
+//
+// defineConfig comes from vitest/config rather than vite so the `test` block
+// below is type-checked. This file is covered by tsconfig.node.json; before
+// that project existed it was never checked at all, and had accumulated five
+// errors — including a `content` option passed to the Tailwind plugin, which
+// accepts only `{ optimize }` and was discarding the array silently.
+export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), '');
   const backendPort = env.VITE_GGLIB_WEB_PORT || '9887';
 
   return {
-  plugins: [
-    react(),
-    tailwindcss({
-      content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-    }),
-  ],
+    // Tailwind v4 discovers its own sources by walking the project root and
+    // skipping anything gitignored, so there is nothing to configure here.
+    // Explicit control belongs in src/styles/tailwind.css via `@source`.
+    plugins: [react(), tailwindcss()],
 
-  // Build output to web_ui directory (served by gui-web command)
-  build: {
-    outDir: 'web_ui',
-    emptyOutDir: true,
-    rolldownOptions: {
-      // Two entries: the main app and the tray popover. The popover is its
-      // own document so it loads none of the model library or chat
-      // code — opening a 360px panel should not pay for the full app shell.
-      input: {
-        main: 'index.html',
-        tray: 'tray.html',
+    // Build output to web_ui directory (served by gui-web command)
+    build: {
+      outDir: 'web_ui',
+      emptyOutDir: true,
+      rolldownOptions: {
+        // Two entries: the main app and the tray popover. The popover is its
+        // own document so it loads none of the model library or chat
+        // code — opening a 360px panel should not pay for the full app shell.
+        input: {
+          main: 'index.html',
+          tray: 'tray.html',
+        },
+        output: {
+          manualChunks(id: string) {
+            if (id.includes('@assistant-ui/react')) return 'chat-runtime';
+            if (
+              id.includes('react-markdown') ||
+              id.includes('remark-gfm') ||
+              id.includes('rehype-highlight') ||
+              id.includes('highlight.js')
+            ) return 'markdown';
+          },
+        },
       },
-      output: {
-        manualChunks(id) {
-          if (id.includes('@assistant-ui/react')) return 'chat-runtime';
-          if (
-            id.includes('react-markdown') ||
-            id.includes('remark-gfm') ||
-            id.includes('rehype-highlight') ||
-            id.includes('highlight.js')
-          ) return 'markdown';
+      chunkSizeWarningLimit: 600,
+      // Skip gzipping every emitted asset just to print a size column. With the
+      // font subsets this is dozens of files per build for a number nobody acts on.
+      reportCompressedSize: false,
+    },
+
+    // Use relative paths for assets so they work in both dev and production
+    base: './',
+
+    // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+    //
+    // 1. prevent vite from obscuring rust errors
+    clearScreen: false,
+    // 2. Tauri expects a fixed port, fail if that port is not available
+    server: {
+      port: 5173,
+      strictPort: true,
+      watch: {
+        // 3. tell vite to ignore watching `src-tauri`
+        ignored: ["**/src-tauri/**"],
+      },
+      // Proxy API requests to the backend server during development
+      proxy: {
+        '/api': {
+          target: `http://localhost:${backendPort}`,
+          changeOrigin: true,
+          // Disable response buffering so SSE streams are forwarded immediately.
+          // Without this the proxy may buffer chunks, delaying event delivery.
+          configure: (proxy: { on: (event: string, cb: (res: { headers: Record<string, string | string[] | undefined> }) => void) => void }) => {
+            proxy.on('proxyRes', (proxyRes) => {
+              const ct = proxyRes.headers['content-type'] || '';
+              if (ct.includes('text/event-stream')) {
+                // Tell upstream caches / reverse-proxies not to buffer SSE
+                proxyRes.headers['X-Accel-Buffering'] = 'no';
+                proxyRes.headers['Cache-Control'] = 'no-cache';
+              }
+            });
+          },
         },
       },
     },
-    chunkSizeWarningLimit: 1024,
-  },
 
-  // Use relative paths for assets so they work in both dev and production
-  base: './',
-
-  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  //
-  // 1. prevent vite from obscuring rust errors
-  clearScreen: false,
-  // 2. Tauri expects a fixed port, fail if that port is not available
-  server: {
-    port: 5173,
-    strictPort: true,
-    watch: {
-      // 3. tell vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
-    },
-    // Proxy API requests to the backend server during development
-    proxy: {
-      '/api': {
-        target: `http://localhost:${backendPort}`,
-        changeOrigin: true,
-        // Disable response buffering so SSE streams are forwarded immediately.
-        // Without this the proxy may buffer chunks, delaying event delivery.
-        configure: (proxy) => {
-          proxy.on('proxyRes', (proxyRes) => {
-            const ct = proxyRes.headers['content-type'] || '';
-            if (ct.includes('text/event-stream')) {
-              // Tell upstream caches / reverse-proxies not to buffer SSE
-              proxyRes.headers['X-Accel-Buffering'] = 'no';
-              proxyRes.headers['Cache-Control'] = 'no-cache';
-            }
-          });
-        },
+    // Test configuration for Vitest
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./tests/ts/setup.ts'],
+      include: ['tests/ts/**/*.test.{ts,tsx}'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'json-summary', 'html'],
+        reportsDirectory: './coverage/ts',
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: [
+          'src/main.tsx',
+          'src/vite-env.d.ts',
+          'src/**/*.d.ts',
+        ],
       },
     },
-  },
-
-  // Test configuration for Vitest
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./tests/ts/setup.ts'],
-    include: ['tests/ts/**/*.test.{ts,tsx}'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'json-summary', 'html'],
-      reportsDirectory: './coverage/ts',
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: [
-        'src/main.tsx',
-        'src/vite-env.d.ts',
-        'src/**/*.d.ts',
-      ],
-    },
-  },
-};
+  };
 });


### PR DESCRIPTION
**Stack 3/4** — base `chore(cargo)/profiles-features-and-version-dedup` (#775). Retarget to `main` as the stack lands.

`npm run build` ran plain `tsc`, and `tsconfig.json` listed only `include: ["src"]` plus a `references` entry that plain `tsc` ignores. So `vite.config.ts` and all 61 test files were never type-checked. Between them: **67 errors**.

### Project layout

Split into a solution — `tsconfig.base.json` (shared), `tsconfig.app.json` (src), `tsconfig.node.json` (vite.config.ts), `tsconfig.test.json` (tests). Every project is `composite` + `noEmit`, which TS 5.6+ allows, so `tsc -b` is a pure type check and nothing lands beside the sources. The old `tsconfig.node.json` was `composite` with neither `noEmit` nor `outDir` — anyone who ran `tsc -b` would have got a `vite.config.js` in the repo root.

`typecheck` and `build` are now `tsc -b`. **PR 1's CI job picks this up with no workflow change** — the gate was declared once, its scope grows underneath it.

The test project includes `src` as well as `tests/ts`, because a composite project must list every file it sees. src is checked twice, which costs a few seconds and keeps the vitest globals out of the app project — src should not be able to reference `describe`.

### `vite.config.ts`

`defineConfig` now comes from `vitest/config` so the `test` block is typed. The **`content` array passed to the Tailwind plugin is gone**: `PluginOptions` accepts only `{ optimize }`, so that array had been silently discarded on every build since it was added. v4 detects its own sources.

Also: dropped `async` on a factory that never awaited, `chunkSizeWarningLimit` 1024 → 600, and `reportCompressedSize: false` so the build stops gzipping every asset for a number nobody reads.

### The test errors

Mostly one finding: fixtures still spelled fields in **snake_case** (`model_id`, `file_path`, `proxy_port`, `default_context_size`, `param_count_b`, `llama_base_port`) after the DTOs moved to camelCase — setting keys the code no longer reads, while the assertions passed anyway.

Alongside those:
- `useServerActions`' `makeConfig` never supplied the required `pinProxy`
- `addServer` was called with `type` and no `config` — a shape `NewMcpServer` never accepted
- three `McpServer` fixtures predated the required `is_valid`
- **`useDownloadCompletionEffects.test.ts` imported `DownloadCompletionInfo` from `src/download/api/types`, a directory that does not exist.** It passed only because Vitest erases type-only imports.

### One thing worth a look

The MCP suites register servers under **string** ids while `McpServerId` is `number`. The ids embed into the namespaced tool name, and `'my.server'` is what exercises the sanitizer's handling of dots and spaces. Rather than delete that coverage I made the cast explicit behind a documented `srv()` helper — whether that defensive path is still reachable now that ids are numeric is a real question, and the helper is where it gets asked.

`SettingsContextValue` is now exported: composite's declaration rules caught `useSettings` returning a type that could not be named.

### Fonts

The default fontsource entrypoints shipped cyrillic, cyrillic-ext, greek and vietnamese — 36 files, 508K of emitted assets. Browsers never downloaded the unused ones (every face carries a `unicode-range`), so **this is not a page-load win** — it is weight off every `.dmg` and `.deb`.

**36 files / 1.7M → 14 files / 1.4M.** The mono package has per-subset entrypoints; the variable sans does not, so its two faces are declared inline with a note to re-check on upgrade.

### Verification

- `npm run typecheck` (`tsc -b`, all four projects) — exit 0
- `npm run lint -- --max-warnings 0` — exit 0
- `npm run test:run` — **814 passing, unchanged**
- `git status` after a build — no stray `.js`/`.d.ts` at the repo root
- built CSS confirmed to reference hashed font assets, no bare specifiers left