### PR TITLE
feat(core,db): DefaultsOrigin::Measured — the rung a tune sweep's winner occupies

### DIFF
--- a/crates/gglib-app-services/src/sampling_explain.rs
+++ b/crates/gglib-app-services/src/sampling_explain.rs
@@ -83,6 +83,10 @@ pub enum DefaultsOriginDto {
     /// Read from the model author's `generation_config.json` at import.
     /// Ranks below global settings, exactly where `AutoDetected` does.
     Published,
+    /// A tune sweep's winner, measured on this installation. Ranks below
+    /// global settings like the other two — and unlike them, the agentic
+    /// ceiling never caps it.
+    Measured,
 }
 
 impl From<DefaultsOrigin> for DefaultsOriginDto {
@@ -91,6 +95,7 @@ impl From<DefaultsOrigin> for DefaultsOriginDto {
             DefaultsOrigin::User => Self::User,
             DefaultsOrigin::AutoDetected => Self::AutoDetected,
             DefaultsOrigin::Published => Self::Published,
+            DefaultsOrigin::Measured => Self::Measured,
         }
     }
 }

--- a/crates/gglib-cli/src/presentation/explain_display.rs
+++ b/crates/gglib-cli/src/presentation/explain_display.rs
@@ -261,6 +261,9 @@ fn describe(source: ParamSource, ctx: ExplainContext<'_>) -> String {
                 Some(DefaultsOrigin::Published) => {
                     "per-model defaults (published by the model author)".to_owned()
                 }
+                Some(DefaultsOrigin::Measured) => {
+                    "per-model defaults (measured by a tune sweep)".to_owned()
+                }
                 _ => "per-model defaults (auto-detected: reasoning tag)".to_owned(),
             },
             None => format!("layer {index}"),

--- a/crates/gglib-cli/src/presentation/inspect_display.rs
+++ b/crates/gglib-cli/src/presentation/inspect_display.rs
@@ -133,6 +133,12 @@ pub fn print_model_detail(dto: &ModelDetailDto, show_metadata: bool) {
                 Some(DefaultsOrigin::Published) => {
                     " (published by the model author — ranks below global settings)"
                 }
+                // Also below global — an automated apply is not a person —
+                // but the strongest evidence of the three, and the agentic
+                // ceiling defers to it.
+                Some(DefaultsOrigin::Measured) => {
+                    " (measured by a tune sweep — ranks below global settings)"
+                }
                 Some(DefaultsOrigin::User) => " (user-set)",
                 None => "",
             };

--- a/crates/gglib-core/src/domain/inference.rs
+++ b/crates/gglib-core/src/domain/inference.rs
@@ -312,6 +312,25 @@ pub enum DefaultsOrigin {
     /// this is not a value anybody in this installation decided, so the
     /// agentic-turn ceiling may still cap it and global settings still win.
     Published,
+    /// Written by a tune sweep: the winner of a measured comparison on this
+    /// model, this quant, this hardware — not a person's choice, and not a
+    /// guess either.
+    ///
+    /// Ranks **exactly where [`Self::AutoDetected`] does** — below global
+    /// settings. The principle that puts it there is the ladder's oldest one:
+    /// nothing a person chose may be outranked by anything a person did not,
+    /// and an automated apply is not a person. Like [`Self::Published`], it
+    /// never coexists with the other below-global origins: applying a winner
+    /// overwrites `inference_defaults`, so "above the guesses" holds by
+    /// replacement rather than by rank.
+    ///
+    /// Unlike both of them, the **agentic-turn ceiling never caps it**. The
+    /// sweep resolves its candidates against this model's real context
+    /// (#748) precisely so the winner transfers to production; a ceiling
+    /// capping the stored winner would un-measure it on exactly the turns it
+    /// was measured for. The ceiling exists to bound values nobody examined —
+    /// a measured temperature is the most examined value in the system.
+    Measured,
 }
 
 impl std::fmt::Display for DefaultsOrigin {
@@ -320,6 +339,7 @@ impl std::fmt::Display for DefaultsOrigin {
             Self::User => write!(f, "user"),
             Self::AutoDetected => write!(f, "auto_detected"),
             Self::Published => write!(f, "published"),
+            Self::Measured => write!(f, "measured"),
         }
     }
 }
@@ -332,8 +352,9 @@ impl std::str::FromStr for DefaultsOrigin {
             "user" => Ok(Self::User),
             "auto_detected" => Ok(Self::AutoDetected),
             "published" => Ok(Self::Published),
+            "measured" => Ok(Self::Measured),
             other => Err(format!(
-                "unknown defaults origin '{other}'; expected user, auto_detected or published"
+                "unknown defaults origin '{other}'; expected user, auto_detected, published or measured"
             )),
         }
     }
@@ -1428,7 +1449,9 @@ impl InferenceConfig {
         // `Published` would silently have ranked a fetched recipe *above*
         // global settings — the one thing an unreviewed origin must never do.
         let (user_model, auto_model) = match model_ctx.defaults_origin {
-            Some(DefaultsOrigin::AutoDetected | DefaultsOrigin::Published) => (None, model),
+            Some(
+                DefaultsOrigin::AutoDetected | DefaultsOrigin::Published | DefaultsOrigin::Measured,
+            ) => (None, model),
             Some(DefaultsOrigin::User) | None => (model, None),
         };
         Self::resolve_layers_with_sources(

--- a/crates/gglib-core/src/domain/sampling_provenance.rs
+++ b/crates/gglib-core/src/domain/sampling_provenance.rs
@@ -147,8 +147,11 @@ pub enum SamplingLayer {
     ModelUserSet,
     /// Global settings defaults.
     Global,
-    /// Per-model defaults written automatically from the model's `reasoning`
-    /// tag and never reviewed, so they rank below global settings.
+    /// Per-model defaults no person in this installation chose, so they rank
+    /// below global settings. Three origins share this rung by replacement —
+    /// the `reasoning`-tag guess, the model author's published recipe, and a
+    /// tune sweep's measured winner — and `DefaultsOrigin` says which one is
+    /// actually in it; the surfaces that name the rung read that, not this.
     ModelAutoDetected,
 }
 

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::ModelContext;
-use crate::domain::{DefaultsOrigin, FieldIssue, FieldSources, InferenceConfig};
+use crate::domain::{DefaultsOrigin, FieldIssue, FieldSources, InferenceConfig, ParamSource};
 
 /// The sampling layers that sit *below* the client's own request parameters.
 ///
@@ -331,6 +331,45 @@ fn strip_unmodelled_sampler_keys(body: &mut Value, trust_client_sampling: bool) 
     stripped
 }
 
+/// Which rung the model's stored defaults occupy, and the name that rung
+/// carries — both decided by [`DefaultsOrigin`] in one place, so resolution
+/// and its labelling cannot disagree.
+///
+/// Exhaustive on purpose — see the twin in `resolve_with_profile_explained`.
+/// A catch-all here would rank any future unreviewed origin above global
+/// settings, which is precisely backwards.
+///
+/// The name was the static `"model (auto-detected)"`, which lied in the
+/// debug line and the audit's provenance strings whenever the occupant was a
+/// published recipe — and would have credited gglib's guess for a tune
+/// sweep's winner the same way.
+const fn model_rung(
+    ctx: &ModelContext,
+) -> (
+    Option<&InferenceConfig>,
+    Option<&InferenceConfig>,
+    &'static str,
+) {
+    match ctx.defaults_origin {
+        Some(DefaultsOrigin::AutoDetected) => (
+            None,
+            ctx.inference_defaults.as_ref(),
+            "model (auto-detected)",
+        ),
+        Some(DefaultsOrigin::Published) => {
+            (None, ctx.inference_defaults.as_ref(), "model (published)")
+        }
+        Some(DefaultsOrigin::Measured) => {
+            (None, ctx.inference_defaults.as_ref(), "model (measured)")
+        }
+        Some(DefaultsOrigin::User) | None => (
+            ctx.inference_defaults.as_ref(),
+            None,
+            "model (auto-detected)",
+        ),
+    }
+}
+
 pub fn resolve_sampling(
     body: &mut Value,
     ctx: &ModelContext,
@@ -395,15 +434,7 @@ pub fn resolve_sampling(
     // both — so an auto-detected guess can't silently outrank global
     // settings the way a deliberate per-model choice should. See
     // `DefaultsOrigin` and `InferenceConfig::resolve_with_profile`.
-    // Exhaustive on purpose — see the twin in `resolve_with_profile_explained`.
-    // A catch-all here would rank any future unreviewed origin above global
-    // settings, which is precisely backwards.
-    let (user_model, auto_model) = match ctx.defaults_origin {
-        Some(DefaultsOrigin::AutoDetected | DefaultsOrigin::Published) => {
-            (None, ctx.inference_defaults.as_ref())
-        }
-        Some(DefaultsOrigin::User) | None => (ctx.inference_defaults.as_ref(), None),
-    };
+    let (user_model, auto_model, below_global_rung_name) = model_rung(ctx);
 
     // Highest priority first. The single ordering both resolution and
     // provenance reporting read from, so they can never drift apart.
@@ -413,7 +444,7 @@ pub fn resolve_sampling(
         ("profile", layers.profile.as_ref()),
         ("model", user_model),
         ("global", layers.global.as_ref()),
-        ("model (auto-detected)", auto_model),
+        (below_global_rung_name, auto_model),
     ];
     let layer_configs: Vec<Option<&InferenceConfig>> =
         ordered.iter().map(|(_, config)| *config).collect();
@@ -444,7 +475,17 @@ pub fn resolve_sampling(
     // not an omission; see `agentic_temperature_ceiling` for the experiment
     // that removed it (tune runs #12–#32) and ADR 0004's postscript.
     let auto_detected_rung = ordered.len() - 1;
-    let temperature_is_unchosen = !sources.temperature.is_deliberate_choice(auto_detected_rung);
+    // A measured recipe is the one below-global origin the ceiling defers
+    // to. The tune sweep resolved its candidates against this model's real
+    // context (#748) precisely so the winner transfers to production —
+    // capping the stored winner here would un-measure it on exactly the
+    // turns it was measured for. Only the *model rung* is exempted: a
+    // Measured model whose recipe names no temperature still resolves from
+    // the floor, and the floor stays cappable — nobody measured the floor.
+    let measured_model_rung = matches!(ctx.defaults_origin, Some(DefaultsOrigin::Measured))
+        && sources.temperature == ParamSource::Layer(auto_detected_rung);
+    let temperature_is_unchosen =
+        !sources.temperature.is_deliberate_choice(auto_detected_rung) && !measured_model_rung;
     let applied_ceiling =
         InferenceConfig::agentic_temperature_ceiling(model_is_reasoning).filter(|&ceiling| {
             agentic_turn
@@ -1226,6 +1267,96 @@ mod tests {
                 "{key} is modelled and must not be stripped"
             );
         }
+    }
+
+    // ── Measured defaults (DefaultsOrigin::Measured) ────────────────────────
+
+    /// A tune sweep's winner, with the same shape and tags. Only the origin
+    /// differs from [`auto_detected_ctx`] — which is the point: everything a
+    /// measured recipe does differently hangs off that one field.
+    fn measured_ctx(defaults: InferenceConfig, reasoning: bool) -> ModelContext {
+        ModelContext {
+            defaults_origin: Some(DefaultsOrigin::Measured),
+            ..auto_detected_ctx(defaults, reasoning)
+        }
+    }
+
+    /// The ladder's oldest principle holds for measurements too: nothing a
+    /// person chose may be outranked by anything a person did not, and an
+    /// automated apply is not a person.
+    #[test]
+    fn a_measured_recipe_ranks_below_global_settings() {
+        let mut body = json!({});
+        resolve_sampling(
+            &mut body,
+            &measured_ctx(temp(0.9), false),
+            &SamplingLayers {
+                global: Some(temp(0.5)),
+                ..Default::default()
+            },
+        );
+        assert_param(&body, "temperature", 0.5);
+    }
+
+    /// The regression guard this variant exists for. The sweep resolved its
+    /// candidates against the model's real context (#748) so the winner
+    /// transfers to production — a ceiling capping the stored winner would
+    /// un-measure it on exactly the turns it was measured for. The
+    /// auto-detected contrast in the same test pins that the exemption is the
+    /// origin, not a loosening of the ceiling.
+    #[test]
+    fn the_agentic_ceiling_never_caps_a_measured_temperature() {
+        let mut body = tools_body();
+        resolve_sampling(
+            &mut body,
+            &measured_ctx(temp(0.9), false),
+            &agentic_layers(),
+        );
+        assert_param(&body, "temperature", 0.9); // measured: stands
+
+        let mut body = tools_body();
+        resolve_sampling(
+            &mut body,
+            &auto_detected_ctx(temp(0.9), false),
+            &agentic_layers(),
+        );
+        assert_param(&body, "temperature", 0.3); // the same value as a guess: capped
+    }
+
+    /// Only the model rung is exempt. A measured recipe that names no
+    /// temperature resolves it from the floor, and nobody measured the floor.
+    #[test]
+    fn a_measured_model_resolving_temperature_from_the_floor_is_still_capped() {
+        let mut body = tools_body();
+        let recipe = InferenceConfig {
+            top_k: Some(20),
+            ..Default::default()
+        };
+        resolve_sampling(&mut body, &measured_ctx(recipe, false), &agentic_layers());
+        assert_param(&body, "temperature", 0.3); // floor 0.7, capped as ever
+    }
+
+    /// The below-global rung names its occupant, so the debug line and the
+    /// audit's provenance strings stop crediting gglib's guess for a
+    /// measurement — or for a model author's published recipe, which the
+    /// static label was already misnaming.
+    #[test]
+    fn the_below_global_rung_is_named_for_its_origin() {
+        let mut body = json!({});
+        let decision = resolve_sampling(
+            &mut body,
+            &measured_ctx(temp(0.9), false),
+            &SamplingLayers::default(),
+        );
+        assert_eq!(decision.layer_names[5], "model (measured)");
+
+        let mut body = json!({});
+        let ctx = ModelContext {
+            defaults_origin: Some(DefaultsOrigin::Published),
+            ..auto_detected_ctx(temp(0.9), false)
+        };
+        let decision = resolve_sampling(&mut body, &ctx, &SamplingLayers::default());
+        assert_eq!(decision.layer_names[5], "model (published)");
     }
 
     // ── Model defaults provenance (Model.defaults_origin) ───────────────────

--- a/crates/gglib-db/src/repositories/row_mappers.rs
+++ b/crates/gglib-db/src/repositories/row_mappers.rs
@@ -258,6 +258,25 @@ mod defaults_origin_tests {
         assert_eq!(origin, Some(DefaultsOrigin::AutoDetected));
     }
 
+    /// The measured origin round-trips through the same TEXT column with no
+    /// schema change — `Display` writes `"measured"`, `FromStr` reads it, and
+    /// the legacy backfill never manufactures it: a `Measured` row is always
+    /// explicitly written by an apply, so an unlabelled row can only be a
+    /// guess or a person's work.
+    #[test]
+    fn a_measured_origin_round_trips_and_is_never_backfilled() {
+        let origin = resolve_defaults_origin(
+            Some(DefaultsOrigin::Measured.to_string()),
+            Some(&InferenceConfig::reasoning_profile()),
+        );
+        assert_eq!(origin, Some(DefaultsOrigin::Measured));
+
+        // A legacy NULL beside any recipe backfills to a guess or to user —
+        // never to measured.
+        let backfilled = resolve_defaults_origin(None, Some(&InferenceConfig::reasoning_profile()));
+        assert_ne!(backfilled, Some(DefaultsOrigin::Measured));
+    }
+
     #[test]
     fn legacy_row_not_matching_the_reasoning_recipe_backfills_to_user() {
         let custom = InferenceConfig {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -234,7 +234,7 @@ export interface SamplingExplanation {
  * - `published` — the author's `generation_config.json`, read at import. Ranks
  *   exactly where `autoDetected` does; what differs is the evidence.
  */
-export type DefaultsOriginName = 'user' | 'autoDetected' | 'published';
+export type DefaultsOriginName = 'user' | 'autoDetected' | 'published' | 'measured';
 
 /**
  * What gglib does with one field's published recommendation.

--- a/src/utils/samplingProvenance.ts
+++ b/src/utils/samplingProvenance.ts
@@ -73,10 +73,14 @@ export function describeSource(entry: ParamProvenance, ctx: SourceContext): stri
         case 'global':
           return 'global settings';
         case 'modelAutoDetected':
-          // One rung, two possible sources — see `SourceContext.defaultsOrigin`.
-          return ctx.defaultsOrigin === 'published'
-            ? 'per-model defaults (published by the model author)'
-            : 'per-model defaults (auto-detected: reasoning tag)';
+          // One rung, three possible sources — see `SourceContext.defaultsOrigin`.
+          if (ctx.defaultsOrigin === 'published') {
+            return 'per-model defaults (published by the model author)';
+          }
+          if (ctx.defaultsOrigin === 'measured') {
+            return 'per-model defaults (measured by a tune sweep)';
+          }
+          return 'per-model defaults (auto-detected: reasoning tag)';
         default:
           return 'unknown layer';
       }


### PR DESCRIPTION
> **Stacked on #779.** Base is `fix(core,proxy)/untrusted-sampler-passthrough`, so this PR's diff shows only its own changes. Retarget to `main` once #779 merges.

Second PR of the closed-loop arc: the provenance rung a tune sweep's winner will occupy. PR 4's `tune --apply` writes rows with this origin; this PR makes the ladder, the ceiling, and every explain surface treat them correctly before any exist.

## The design question, and where it settled

A measured winner is not a person's choice, and not a guess either — the ladder had no way to say so. Where does it rank?

**Below global settings**, on the ladder's oldest principle: nothing a person chose may be outranked by anything a person did not, and an automated apply is not a person. The `Published` variant already documents the pattern this follows — a distinct variant *because of what it is, not where it sits*, sharing the below-global rung by **replacement** rather than by rank (applying a winner overwrites `inference_defaults`, so the origins never coexist on one model). No new rung, no `LADDER_RUNGS` change, no re-derived coupling behaviour.

## The one behavioural difference, and why it is the point

**The agentic-turn ceiling never caps a measured temperature.** This is the trap the naive implementation falls into: lumping `Measured` with `AutoDetected` makes `is_deliberate_choice` return false for it, and the non-reasoning 0.3 ceiling would cap a measured 0.9 on every agentic turn — un-measuring the winner on exactly the turns it was measured for. That is #748's transfer problem resurrected one layer up: the sweep resolves candidates against the model's real context precisely so tuned values mean the same thing in production.

The exemption is scoped to the model rung only: a measured recipe that names no temperature still resolves from the floor, and nobody measured the floor — it stays cappable. The regression test pins both directions *and* runs the same value through an auto-detected context in the same test, so the exemption is provably the origin and not a loosening of the ceiling.

## Fixed in passing

The below-global rung's label was the static `"model (auto-detected)"`, which already lied in the pipeline debug line and the sampling audit's provenance strings whenever the occupant was a **published** recipe — and would have credited gglib's guess for a measurement the same way. `model_rung` now decides occupancy and name in one exhaustive match (the twin of `resolve_with_profile_explained`'s, per that match's own comment about catch-alls ranking future origins backwards), so resolution and labelling cannot disagree. The CLI explain surface had the same bug in its `_` catch-all — a measured origin would have rendered as "auto-detected: reasoning tag".

## Surfaces

- `DefaultsOriginDto` + wire form (`measured`), TS `DefaultsOriginName` union, GUI provenance describe.
- `gglib model inspect`: ` (measured by a tune sweep — ranks below global settings)`.
- `gglib model explain` / GUI panel: `per-model defaults (measured by a tune sweep)`.
- DB: **no schema change** — the TEXT column round-trips `"measured"` through the existing `Display`/`FromStr` pair. A new mapper test pins the round-trip and that the legacy backfill never manufactures this origin (an unlabelled row can only be a guess or a person's work, because every `Measured` row is written explicitly).
- Import paths guard on `inference_defaults.is_none()`, so a re-import or tag refresh cannot clobber a measured recipe.

## Verification

- Full workspace `cargo test` green; 1016 tests in `gglib-core` (4 new: rank-below-global, the ceiling exemption with its auto-detected contrast, floor-still-capped, rung naming for measured and published). `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
- TS: 816 tests green, `tsc --noEmit` clean, eslint clean.
- `check_param_source_exhaustive.sh` and friends pass — no new `ParamSource` variant was needed, which is itself a design outcome: `Unset`/`Layer`/`Floor` semantics are untouched.

## What this deliberately does not include

The apply that writes these rows (PR 4), and the metadata trail (which tune run, margin vs drift) — that belongs to the apply's schema, decided when the apply exists. This PR is the resolution semantics only, so PR 4 can be reviewed as pure mechanism.
