### PR TITLE
feat(benchmark): eval gates — paired statistics and multi-pair A/A drift

### DIFF
--- a/crates/gglib-app-services/src/benchmark/agentic.rs
+++ b/crates/gglib-app-services/src/benchmark/agentic.rs
@@ -25,7 +25,7 @@ use gglib_core::domain::InferenceConfig;
 use gglib_core::domain::benchmark::agentic::{
     AgenticEvalConfig, AgenticEvalReport, AgenticTaskComparison, ArmScores,
     CONTROL_MIN_COMPOSITE_GAP, ControlVerdict, EFFECT_NOISE_RATIO, EffectVerdict, EvalArm,
-    control_sampling, replicate_seeds,
+    PairedEffect, control_sampling, replicate_seed_set, replicate_seeds,
 };
 use gglib_core::domain::benchmark::tune::result::TuneTaskResult;
 use gglib_core::domain::benchmark::tune::task::{ExpectedOutcome, TuneTask};
@@ -203,7 +203,13 @@ pub async fn run_agentic_eval(
     // control's scores to the pipeline.
     let raw_results = take_arm(&mut arm_results, EvalArm::Raw);
     let gglib_results = take_arm(&mut arm_results, EvalArm::Gglib);
-    let replicate_results = take_arm(&mut arm_results, EvalArm::RawReplicate);
+    // Every A/A pair, in plan order — take_arm removes the first match, so
+    // draining repeatedly yields them in the order they ran.
+    let mut replicate_runs: Vec<Vec<Vec<TuneTaskResult>>> = Vec::new();
+    while let Some(run) = take_arm(&mut arm_results, EvalArm::RawReplicate) {
+        replicate_runs.push(run);
+    }
+    let replicate_results = replicate_runs.first().cloned();
     let control_results = take_arm(&mut arm_results, EvalArm::Control);
 
     // Each arm is scored against *its own* seed count, not the run's: the
@@ -222,6 +228,10 @@ pub async fn run_agentic_eval(
     let raw = score_arm(&raw_results, EvalArm::Raw).unwrap_or_else(|| empty_scores(&config));
     let gglib = score_arm(&gglib_results, EvalArm::Gglib).unwrap_or_else(|| empty_scores(&config));
     let raw_replicate = score_arm(&replicate_results, EvalArm::RawReplicate);
+    let raw_replicates: Vec<_> = replicate_runs
+        .iter()
+        .filter_map(|run| score_arm(&Some(run.clone()), EvalArm::RawReplicate))
+        .collect();
     let control = score_arm(&control_results, EvalArm::Control);
     let delta = AgenticEvalReport::delta_of(&raw, &gglib);
 
@@ -256,7 +266,17 @@ pub async fn run_agentic_eval(
         } else {
             Vec::new()
         },
+        replicate_seed_sets: (1..=replicate_runs.len())
+            .filter_map(|pair| u32::try_from(pair).ok())
+            .map(|pair| replicate_seed_set(&config.seeds, pair))
+            .collect(),
         raw_replicate,
+        raw_replicates,
+        paired: None,
+    };
+    let report = AgenticEvalReport {
+        paired: PairedEffect::from_tasks(&report.tasks),
+        ..report
     };
 
     // Said out loud, because a control that failed to move invalidates every
@@ -378,20 +398,32 @@ fn plan_arms(config: &AgenticEvalConfig) -> Vec<ArmPlan> {
     ];
 
     if config.replicate_raw {
-        // Unseeded, the A/A arm is simply the same request twice — which still
-        // measures drift, since nothing was pinned in the first place.
-        let seeds = if config.seeds.is_empty() {
-            primary.clone()
-        } else {
-            replicate_seeds(&config.seeds)
-                .into_iter()
-                .map(Some)
-                .collect()
-        };
-        plans.push(ArmPlan {
-            arm: EvalArm::RawReplicate,
-            seeds,
-        });
+        // One plan per requested pair, each on its own derived seed set —
+        // pair 1 is the legacy set, so a multi-pair run's first pair stays
+        // comparable with every single-pair run before it. Clamped at one:
+        // zero pairs with replicate_raw on would be an A/A arm that does not
+        // run while the config says it does.
+        for pair in 1..=u32::try_from(config.replicate_pairs.max(1)).unwrap_or(1) {
+            // Unseeded, the A/A arm is simply the same request again — which
+            // still measures drift, since nothing was pinned in the first
+            // place. Only one such pair is meaningful: with no seeds to
+            // stride, every further pair would be literally the same plan.
+            let seeds = if config.seeds.is_empty() {
+                if pair > 1 {
+                    break;
+                }
+                primary.clone()
+            } else {
+                replicate_seed_set(&config.seeds, pair)
+                    .into_iter()
+                    .map(Some)
+                    .collect()
+            };
+            plans.push(ArmPlan {
+                arm: EvalArm::RawReplicate,
+                seeds,
+            });
+        }
     }
 
     if config.include_control {

--- a/crates/gglib-cli/src/benchmark_commands.rs
+++ b/crates/gglib-cli/src/benchmark_commands.rs
@@ -203,6 +203,14 @@ pub enum BenchmarkCommand {
         #[arg(long)]
         no_replicate: bool,
 
+        /// How many A/A pairs to run. One pair estimates the eval's drift
+        /// from a single degree of freedom; each extra pair re-runs the raw
+        /// arm on another derived seed set, and the drift becomes a mean over
+        /// every pairwise gap — the honest strengthening, per the effect
+        /// verdict's own docs
+        #[arg(long, default_value_t = 1, value_name = "N")]
+        replicate_pairs: usize,
+
         /// How many of `--seeds` the positive control repeats. One is enough:
         /// broken sampling makes the model ramble, so the control is by far
         /// the most expensive arm, and it only has to clear a detection

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -94,6 +94,7 @@ pub async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
             seeds,
             no_control,
             no_replicate,
+            replicate_pairs,
             control_seeds,
             json,
             output,
@@ -106,6 +107,7 @@ pub async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
                 seeds,
                 !no_control,
                 !no_replicate,
+                replicate_pairs,
                 control_seeds,
                 json,
                 output,
@@ -317,6 +319,7 @@ async fn cmd_agentic(
     seeds: Option<Vec<u32>>,
     include_control: bool,
     replicate_raw: bool,
+    replicate_pairs: usize,
     control_seeds: usize,
     json: bool,
     output: Option<std::path::PathBuf>,
@@ -339,6 +342,7 @@ async fn cmd_agentic(
         seeds: seeds.clone(),
         include_control,
         replicate_raw,
+        replicate_pairs,
         control_seeds,
     };
 
@@ -514,6 +518,7 @@ fn render_agentic_report(report: &AgenticEvalReport) {
 
     render_unmeasured_block(report);
     render_noise_block(report);
+    render_paired_block(report);
     render_control_block(report);
     render_stability_block(report);
     render_efficiency_block(report);
@@ -593,7 +598,12 @@ fn render_noise_block(report: &AgenticEvalReport) {
 
     // An unseeded run has no seed list to name, and "re-run on 0 disjoint
     // seeds" would describe an arm that did in fact run.
-    let how = if report.replicate_seeds.is_empty() {
+    let how = if report.raw_replicates.len() > 1 {
+        format!(
+            "re-run {n} times on disjoint seed sets",
+            n = report.raw_replicates.len(),
+        )
+    } else if report.replicate_seeds.is_empty() {
         "re-run unseeded".to_owned()
     } else {
         format!(
@@ -610,10 +620,14 @@ fn render_noise_block(report: &AgenticEvalReport) {
         MUTED = style::MUTED,
         RESET = style::RESET,
     );
+    let over = match verdict.pairs() {
+        0 | 1 => String::new(),
+        pairs => format!(" (mean over {pairs} pairwise gaps)"),
+    };
     if verdict.exceeds_noise() {
         eprintln!(
             "  {SUCCESS}effect exceeds drift{RESET}: the {effect:+.3} composite delta is {ratio} \
-             the {noise:.3} this eval moves with nothing changed.",
+             the {noise:.3} this eval moves with nothing changed{over}.",
             effect = verdict.effect(),
             noise = verdict.noise(),
             SUCCESS = style::SUCCESS,
@@ -622,8 +636,8 @@ fn render_noise_block(report: &AgenticEvalReport) {
     } else {
         eprintln!(
             "  {WARN}effect is within drift{RESET}: the {effect:+.3} composite delta is {ratio} \
-             the {noise:.3} this eval moves with nothing changed, under the {min:.0}× needed to \
-             call it more than noise.",
+             the {noise:.3} this eval moves with nothing changed{over}, under the {min:.0}× \
+             needed to call it more than noise.",
             effect = verdict.effect(),
             noise = verdict.noise(),
             min = EFFECT_NOISE_RATIO,
@@ -646,6 +660,45 @@ fn render_noise_block(report: &AgenticEvalReport) {
         MUTED = style::MUTED,
         RESET = style::RESET,
     );
+}
+
+/// The paired view: the same cells the delta above averages, compared as
+/// matched pairs — which is what removes the eval's identical-arm spread
+/// from the comparison.
+fn render_paired_block(report: &AgenticEvalReport) {
+    let Some(paired) = report.paired_effect() else {
+        return;
+    };
+    eprintln!();
+    let p = paired.p_value.map_or_else(
+        || {
+            format!(
+                "too few non-tied pairs for a p — read {wins}W against {losses}L directly",
+                wins = paired.wins,
+                losses = paired.losses,
+            )
+        },
+        |p| format!("Wilcoxon one-sided p = {p:.4}"),
+    );
+    eprintln!(
+        "  paired: {wins}W–{losses}L–{ties}T over {pairs} (task, seed) {pair_word}, \
+         mean Δ {mean:+.3} on tool-match; {p}",
+        wins = paired.wins,
+        losses = paired.losses,
+        ties = paired.ties,
+        pairs = paired.pairs,
+        pair_word = plural(paired.pairs, "pair"),
+        mean = paired.mean_delta,
+    );
+    if paired.unmeasured_pairs > 0 {
+        eprintln!(
+            "  {WARN}{n} {pairs} dropped: at least one side never reached the model.{RESET}",
+            n = paired.unmeasured_pairs,
+            pairs = plural(paired.unmeasured_pairs, "pair"),
+            WARN = style::WARNING,
+            RESET = style::RESET,
+        );
+    }
 }
 
 /// The positive control's verdict.

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -651,12 +651,18 @@ fn render_noise_block(report: &AgenticEvalReport) {
             RESET = style::RESET,
         );
     }
-    // Printed on success as well as failure. A ratio computed from a single
-    // pair is the kind of number that gets quoted as though it were a p-value,
-    // and the caveat has to travel with it.
+    // Printed on success as well as failure. A ratio computed from a
+    // handful of gaps is the kind of number that gets quoted as though it
+    // were a p-value, and the caveat has to travel with it — sized to the
+    // run: the single-pair wording on a three-gap estimate misstates the
+    // degrees of freedom in the caveat about degrees of freedom (caught on
+    // the first live multi-pair run).
+    let df = match verdict.pairs() {
+        0 | 1 => "one A/A pair estimates that drift from a single degree of freedom".to_owned(),
+        pairs => format!("{pairs} pairwise gaps back that drift estimate"),
+    };
     eprintln!(
-        "  {MUTED}one A/A pair estimates that drift from a single degree of freedom — this is a \
-         sanity ratio, not a significance test{RESET}",
+        "  {MUTED}{df} — this is a sanity ratio, not a significance test{RESET}",
         MUTED = style::MUTED,
         RESET = style::RESET,
     );

--- a/crates/gglib-core/src/domain/benchmark/agentic.rs
+++ b/crates/gglib-core/src/domain/benchmark/agentic.rs
@@ -82,6 +82,19 @@ pub struct AgenticEvalConfig {
     /// its direction.
     #[serde(default = "default_replicate_raw")]
     pub replicate_raw: bool,
+    /// How many A/A pairs to run. See [`EvalArm::RawReplicate`].
+    ///
+    /// `1` is the historical single-pair behaviour and the default. A single
+    /// pair estimates the eval's drift from one degree of freedom — enough to
+    /// stop a delta inside its own noise being called a finding, and not
+    /// enough to say how noisy the eval actually is. Every additional pair
+    /// re-runs the raw arm on another derived, disjoint seed set, and the
+    /// drift estimate becomes the mean pairwise gap over all replicate runs
+    /// plus the primary — which is the "more pairs" the
+    /// [`EFFECT_NOISE_RATIO`] doc has always named as the honest
+    /// strengthening.
+    #[serde(default = "default_replicate_pairs")]
+    pub replicate_pairs: usize,
     /// How many of [`Self::seeds`] the positive control repeats, from the
     /// front. Clamped into `1..=seeds.len()`.
     ///
@@ -126,6 +139,10 @@ const fn default_control_seeds() -> usize {
     1
 }
 
+const fn default_replicate_pairs() -> usize {
+    1
+}
+
 /// Offset added to each primary seed to derive the A/A arm's seeds.
 ///
 /// The 32-bit golden-ratio constant, chosen for nothing but being a fixed,
@@ -151,9 +168,21 @@ pub const REPLICATE_SEED_OFFSET: u32 = 0x9E37_79B9;
 /// recorded in [`AgenticEvalReport::replicate_seeds`] rather than left implicit.
 #[must_use]
 pub fn replicate_seeds(seeds: &[u32]) -> Vec<u32> {
+    replicate_seed_set(seeds, 1)
+}
+
+/// The seed set for A/A pair `pair` (1-based): the primary seeds offset by
+/// `pair` strides of [`REPLICATE_SEED_OFFSET`].
+///
+/// Pair 1 is exactly [`replicate_seeds`], so a multi-pair run's first pair
+/// reproduces the single-pair run's numbers. Strides of a fixed constant
+/// rather than fresh draws for the same reason the offset itself is fixed: a
+/// noise floor that changes every run cannot be compared against anything.
+#[must_use]
+pub fn replicate_seed_set(seeds: &[u32], pair: u32) -> Vec<u32> {
     seeds
         .iter()
-        .map(|seed| seed.wrapping_add(REPLICATE_SEED_OFFSET))
+        .map(|seed| seed.wrapping_add(REPLICATE_SEED_OFFSET.wrapping_mul(pair)))
         .collect()
 }
 
@@ -463,6 +492,25 @@ pub struct AgenticEvalReport {
     /// recomputed from [`replicate_seeds`].
     #[serde(default)]
     pub replicate_seeds: Vec<u32>,
+    /// Every A/A pair's scores, in pair order, when more than one ran.
+    ///
+    /// [`Self::raw_replicate`] stays populated with the first pair so a
+    /// single-pair report — and every report written before this field —
+    /// reads exactly as it always did. A legacy row deserializes this empty,
+    /// and [`Self::noise_floor`] falls back to the single pair.
+    #[serde(default)]
+    pub raw_replicates: Vec<ArmScores>,
+    /// The seed set behind each entry of [`Self::raw_replicates`].
+    #[serde(default)]
+    pub replicate_seed_sets: Vec<Vec<u32>>,
+    /// The paired per-`(task, seed)` comparison, computed at assembly.
+    ///
+    /// Stored rather than derived-only, unlike the verdicts: those re-derive
+    /// from two floats in any language, while this one carries a rank test
+    /// nobody should maintain twice. [`Self::paired_effect`] re-derives it
+    /// from the drill-down for reports written before the field existed.
+    #[serde(default)]
+    pub paired: Option<PairedEffect>,
 }
 
 /// The smallest composite gap the control arm must open for the apparatus to
@@ -552,8 +600,14 @@ pub enum EffectVerdict {
         /// `gglib − raw`, signed: a negative effect that clears the noise floor
         /// is still a finding, just not the hoped-for one.
         effect: f64,
-        /// `|raw − raw_replicate|`, the drift between two identical arms.
+        /// The mean pairwise drift among identical raw runs.
         noise: f64,
+        /// Pairwise gaps behind `noise` — the estimate's degrees of freedom.
+        /// A verdict over one pair and one over six are not the same strength
+        /// of claim, and rendering them identically invites exactly the
+        /// misreading the A/A arm exists to prevent.
+        #[serde(default = "one")]
+        pairs: usize,
     },
     /// The effect is not clearly larger than the drift between two runs of the
     /// same arm. It is not thereby *absent* — it is unresolved at this seed
@@ -561,8 +615,11 @@ pub enum EffectVerdict {
     WithinNoise {
         /// `gglib − raw`, signed.
         effect: f64,
-        /// `|raw − raw_replicate|`, the drift between two identical arms.
+        /// The mean pairwise drift among identical raw runs.
         noise: f64,
+        /// Pairwise gaps behind `noise`.
+        #[serde(default = "one")]
+        pairs: usize,
     },
 }
 
@@ -576,7 +633,7 @@ impl EffectVerdict {
     #[must_use]
     pub fn ratio(&self) -> Option<f64> {
         let (effect, noise) = match *self {
-            Self::ExceedsNoise { effect, noise } | Self::WithinNoise { effect, noise } => {
+            Self::ExceedsNoise { effect, noise, .. } | Self::WithinNoise { effect, noise, .. } => {
                 (effect, noise)
             }
         };
@@ -588,6 +645,14 @@ impl EffectVerdict {
     pub const fn effect(&self) -> f64 {
         match *self {
             Self::ExceedsNoise { effect, .. } | Self::WithinNoise { effect, .. } => effect,
+        }
+    }
+
+    /// How many pairwise drift gaps stand behind [`Self::noise`].
+    #[must_use]
+    pub const fn pairs(&self) -> usize {
+        match *self {
+            Self::ExceedsNoise { pairs, .. } | Self::WithinNoise { pairs, .. } => pairs,
         }
     }
 
@@ -654,14 +719,54 @@ impl AgenticEvalReport {
         self.control_verdict().map(|v| v.demonstrated_sensitivity())
     }
 
-    /// The eval's own drift: how far two identical raw arms landed apart.
+    /// The eval's own drift: the mean pairwise composite gap over every run
+    /// of the identical raw configuration — the primary plus each A/A pair.
     ///
-    /// `None` when the A/A arm did not run, which is distinct from a measured
-    /// zero for the same reason `Blind` is distinct from zero divergences.
+    /// With one A/A pair this is exactly the old single-gap number. With `K`
+    /// pairs it averages the `C(K+1, 2)` pairwise gaps among `K + 1` runs of
+    /// the same arm, which estimates the same quantity from more than one
+    /// degree of freedom. A mean absolute gap, not a standard deviation:
+    /// [`EFFECT_NOISE_RATIO`] was calibrated against a gap, and changing the
+    /// estimator and the threshold at once would make old and new verdicts
+    /// incomparable.
+    ///
+    /// `None` when no A/A arm ran, which is distinct from a measured zero for
+    /// the same reason `Blind` is distinct from zero divergences.
     #[must_use]
     pub fn noise_floor(&self) -> Option<f64> {
-        let replicate = self.raw_replicate.as_ref()?;
-        Some((self.raw.composite - replicate.composite).abs())
+        let gaps = self.drift_gaps();
+        #[allow(clippy::cast_precision_loss)]
+        match gaps.len() {
+            0 => None,
+            n => Some(gaps.iter().sum::<f64>() / n as f64),
+        }
+    }
+
+    /// How many pairwise gaps stand behind [`Self::noise_floor`] — the
+    /// degrees of freedom a reader should weigh the verdict by.
+    #[must_use]
+    pub fn noise_pairs(&self) -> usize {
+        self.drift_gaps().len()
+    }
+
+    /// Pairwise absolute composite gaps among every run of the raw
+    /// configuration. Empty when no A/A arm ran.
+    fn drift_gaps(&self) -> Vec<f64> {
+        let mut composites = vec![self.raw.composite];
+        if self.raw_replicates.is_empty() {
+            if let Some(replicate) = self.raw_replicate.as_ref() {
+                composites.push(replicate.composite);
+            }
+        } else {
+            composites.extend(self.raw_replicates.iter().map(|r| r.composite));
+        }
+        let mut gaps = Vec::new();
+        for (i, a) in composites.iter().enumerate() {
+            for b in &composites[i + 1..] {
+                gaps.push((a - b).abs());
+            }
+        }
+        gaps
     }
 
     /// Whether the measured effect is larger than the eval's own drift.
@@ -676,11 +781,20 @@ impl AgenticEvalReport {
         // A zero effect never "exceeds" anything, however quiet the arm was:
         // with both terms at zero the inequality would hold vacuously and
         // report no difference as a finding.
+        let pairs = self.noise_pairs();
         Some(
             if effect.abs() > 0.0 && effect.abs() >= EFFECT_NOISE_RATIO * noise {
-                EffectVerdict::ExceedsNoise { effect, noise }
+                EffectVerdict::ExceedsNoise {
+                    effect,
+                    noise,
+                    pairs,
+                }
             } else {
-                EffectVerdict::WithinNoise { effect, noise }
+                EffectVerdict::WithinNoise {
+                    effect,
+                    noise,
+                    pairs,
+                }
             },
         )
     }
@@ -701,7 +815,8 @@ impl AgenticEvalReport {
     /// `None` when no pair has both sides measured.
     #[must_use]
     pub fn paired_effect(&self) -> Option<PairedEffect> {
-        PairedEffect::from_tasks(&self.tasks)
+        self.paired
+            .or_else(|| PairedEffect::from_tasks(&self.tasks))
     }
 
     /// Compute the per-axis delta from the two arms' scores.
@@ -971,6 +1086,9 @@ mod tests {
             control,
             raw_replicate: None,
             replicate_seeds: vec![],
+            raw_replicates: vec![],
+            replicate_seed_sets: vec![],
+            paired: None,
         }
     }
 
@@ -1580,6 +1698,46 @@ mod tests {
         assert_eq!(paired.pairs, 10);
         assert_eq!(paired.wins, 7);
         assert_eq!(paired.p_value, None);
+    }
+
+    // ── Multi-pair A/A drift ────────────────────────────────────────────────
+
+    /// Three runs of the identical configuration give three pairwise gaps,
+    /// and the floor is their mean — more degrees of freedom, same estimator.
+    #[test]
+    fn noise_floor_over_multiple_pairs_averages_all_pairwise_gaps() {
+        let mut report = report_with(None, 0.9);
+        report.raw = scores(0.5, None, 0.7);
+        report.raw_replicates = vec![scores(0.5, None, 0.6), scores(0.5, None, 0.8)];
+        // gaps: |0.7−0.6| = 0.1, |0.7−0.8| = 0.1, |0.6−0.8| = 0.2
+        let floor = report.noise_floor().expect("replicates ran");
+        assert!((floor - 0.4 / 3.0).abs() < 1e-12, "{floor}");
+        assert_eq!(report.noise_pairs(), 3);
+        assert_eq!(report.effect_verdict().expect("has drift").pairs(), 3);
+    }
+
+    /// A report written before the multi-pair field existed — populated
+    /// `raw_replicate`, empty `raw_replicates` — reads exactly as it always
+    /// did: one gap, one pair.
+    #[test]
+    fn a_legacy_single_pair_report_reads_exactly_as_before() {
+        let report = report_with_replicate(0.2, 0.05);
+        assert!((report.noise_floor().unwrap() - 0.05).abs() < 1e-12);
+        assert_eq!(report.noise_pairs(), 1);
+        assert_eq!(report.effect_verdict().unwrap().pairs(), 1);
+    }
+
+    /// Pair 1 must reproduce the single-pair seed set, or a multi-pair run's
+    /// first pair would not be comparable with every run recorded before it.
+    #[test]
+    fn the_first_replicate_seed_set_is_the_legacy_one() {
+        assert_eq!(
+            replicate_seed_set(&DEFAULT_SEEDS, 1),
+            replicate_seeds(&DEFAULT_SEEDS)
+        );
+        let second = replicate_seed_set(&DEFAULT_SEEDS, 2);
+        assert_ne!(second, replicate_seeds(&DEFAULT_SEEDS));
+        assert_ne!(second, DEFAULT_SEEDS.to_vec());
     }
 
     /// The report derives it from the drill-down it already stores, so a

--- a/crates/gglib-core/src/domain/benchmark/agentic.rs
+++ b/crates/gglib-core/src/domain/benchmark/agentic.rs
@@ -694,6 +694,16 @@ impl AgenticEvalReport {
         self.tasks.iter().filter(|t| t.is_unstable()).collect()
     }
 
+    /// The paired per-`(task, seed)` comparison, derived from the drill-down.
+    ///
+    /// Derived rather than stored, like the verdicts above it — which also
+    /// means a legacy report's stored per-seed detail yields it retroactively.
+    /// `None` when no pair has both sides measured.
+    #[must_use]
+    pub fn paired_effect(&self) -> Option<PairedEffect> {
+        PairedEffect::from_tasks(&self.tasks)
+    }
+
     /// Compute the per-axis delta from the two arms' scores.
     #[must_use]
     pub fn delta_of(raw: &ArmScores, gglib: &ArmScores) -> ArmDelta {
@@ -715,6 +725,170 @@ impl AgenticEvalReport {
             ),
         }
     }
+}
+
+/// The paired view of the raw-versus-gglib comparison.
+///
+/// The two real arms run the **same seeds on the same tasks**, so every
+/// `(task, seed)` cell is a matched pair — and pairing is what removes the
+/// eval's identical-arm spread from the comparison. The ceiling experiment
+/// (tune runs #12–#32, ADR 0004's postscript) resolved a +0.067 effect
+/// through noise wider than that *only* because it paired per run; the same
+/// data has been sitting in [`AgenticEvalReport::tasks`] all along, compared
+/// only as arm means.
+///
+/// Pairs are on [`TuneTaskResult::tool_match_score`] — the one graded
+/// per-run quality scalar. Pass/fail flips remain visible per task in
+/// [`AgenticTaskComparison::pass_counts`]; folding them in here would double
+/// count, since the match score is most of what decides `passed`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PairedEffect {
+    /// Matched `(task, seed)` pairs in which both arms produced a real
+    /// observation.
+    pub pairs: usize,
+    /// Pairs both arms ran but at least one side never reached the model —
+    /// dropped from every number here, and reported so the drop is visible.
+    pub unmeasured_pairs: usize,
+    /// Pairs the gglib arm scored strictly higher.
+    pub wins: usize,
+    /// Pairs the raw arm scored strictly higher.
+    pub losses: usize,
+    /// Pairs with identical scores. On a suite where most tasks pass cleanly
+    /// under both arms this is the largest bucket, and that is information:
+    /// the arms mostly agree.
+    pub ties: usize,
+    /// Mean of `gglib − raw` over the measured pairs.
+    pub mean_delta: f64,
+    /// One-sided Wilcoxon signed-rank *p* for "gglib scores higher", by
+    /// normal approximation with tie correction.
+    ///
+    /// `None` below [`WILCOXON_MIN_PAIRS`] non-tied pairs — the approximation
+    /// is not trustworthy there, and rendering a statistic the design cannot
+    /// support is worse than rendering none (the [`EffectVerdict`] rule). At
+    /// small counts, read [`Self::wins`] against [`Self::losses`] instead.
+    pub p_value: Option<f64>,
+}
+
+/// The fewest non-tied pairs the normal-approximation Wilcoxon accepts.
+///
+/// Below this the approximation's error is material and an exact table would
+/// be needed; above it the correction terms keep it honest.
+pub const WILCOXON_MIN_PAIRS: usize = 8;
+
+impl PairedEffect {
+    /// Compute the paired comparison from the per-task drill-down.
+    ///
+    /// `None` when no `(task, seed)` pair has both sides measured — a paired
+    /// analysis of nothing is not a zero effect.
+    #[must_use]
+    pub fn from_tasks(tasks: &[AgenticTaskComparison]) -> Option<Self> {
+        let mut deltas = Vec::new();
+        let mut unmeasured_pairs = 0_usize;
+        for task in tasks {
+            for (raw, gglib) in task.raw.iter().zip(task.gglib.iter()) {
+                if raw.is_measured() && gglib.is_measured() {
+                    deltas.push(gglib.tool_match_score - raw.tool_match_score);
+                } else {
+                    unmeasured_pairs += 1;
+                }
+            }
+        }
+        if deltas.is_empty() {
+            return None;
+        }
+
+        let wins = deltas.iter().filter(|d| **d > 0.0).count();
+        let losses = deltas.iter().filter(|d| **d < 0.0).count();
+        let ties = deltas.len() - wins - losses;
+        #[allow(clippy::cast_precision_loss)]
+        let mean_delta = deltas.iter().sum::<f64>() / deltas.len() as f64;
+
+        Some(Self {
+            pairs: deltas.len(),
+            unmeasured_pairs,
+            wins,
+            losses,
+            ties,
+            mean_delta,
+            p_value: wilcoxon_one_sided(&deltas),
+        })
+    }
+}
+
+/// One-sided Wilcoxon signed-rank *p* for "the deltas are positive".
+///
+/// Textbook construction: zeros dropped, absolute deltas ranked with average
+/// ranks over ties, `W⁻` (the rank sum of the negative deltas) compared
+/// against its null distribution by normal approximation with the tie
+/// correction and a continuity correction. Small `W⁻` — losses carrying
+/// little rank weight — yields small *p*.
+///
+/// `None` when fewer than [`WILCOXON_MIN_PAIRS`] non-zero deltas remain.
+fn wilcoxon_one_sided(deltas: &[f64]) -> Option<f64> {
+    let mut nonzero: Vec<f64> = deltas.iter().copied().filter(|d| *d != 0.0).collect();
+    let n = nonzero.len();
+    if n < WILCOXON_MIN_PAIRS {
+        return None;
+    }
+    nonzero.sort_by(|a, b| a.abs().partial_cmp(&b.abs()).expect("scores are finite"));
+
+    // Average ranks over runs of tied |delta|, accumulating the tie
+    // correction term as each run closes.
+    let mut w_minus = 0.0_f64;
+    let mut tie_correction = 0.0_f64;
+    let mut index = 0;
+    while index < n {
+        let mut end = index + 1;
+        // Bitwise equality is the right tie test here: ranks tie when the
+        // stored |delta| values are literally the same number, and a margin
+        // would invent ties between distinct scores.
+        while end < n && (nonzero[end].abs() - nonzero[index].abs()).abs() == 0.0 {
+            end += 1;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let average_rank = ((index + 1 + end) as f64) / 2.0;
+        let run = end - index;
+        if run > 1 {
+            #[allow(clippy::cast_precision_loss)]
+            let t = run as f64;
+            tie_correction += (t * t).mul_add(t, -t);
+        }
+        for value in &nonzero[index..end] {
+            if *value < 0.0 {
+                w_minus += average_rank;
+            }
+        }
+        index = end;
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let nf = n as f64;
+    let mean = nf * (nf + 1.0) / 4.0;
+    let variance = nf * (nf + 1.0) * 2.0f64.mul_add(nf, 1.0) / 24.0 - tie_correction / 48.0;
+    if variance <= 0.0 {
+        // Every |delta| identical and tied: the statistic is degenerate, and
+        // the sign test the caller can read from wins/losses is the honest
+        // fallback.
+        return None;
+    }
+    // Continuity correction toward the mean; "gglib higher" means W⁻ is
+    // small, so the one-sided p is the lower tail.
+    let z = (w_minus - mean + 0.5) / variance.sqrt();
+    Some(normal_cdf(z))
+}
+
+/// Standard normal CDF via Abramowitz–Stegun 7.1.26 on `erf`, accurate to
+/// ~1.5e-7 — orders of magnitude finer than any decision read from a *p*.
+fn normal_cdf(z: f64) -> f64 {
+    let x = z / std::f64::consts::SQRT_2;
+    let t = 1.0 / 0.327_591_1f64.mul_add(x.abs(), 1.0);
+    let poly = t
+        * (0.254_829_592
+            + t * (-0.284_496_736
+                + t * (1.421_413_741 + t * (-1.453_152_027 + t * 1.061_405_429))));
+    let erf = 1.0 - poly * (-x * x).exp();
+    let signed = if x < 0.0 { -erf } else { erf };
+    0.5 * (1.0 + signed)
 }
 
 /// `raw ÷ gglib`, or `None` when either side is unmeasured or the denominator
@@ -1304,5 +1478,118 @@ mod tests {
         let config: AgenticEvalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.model_id, 3);
         assert!(config.ctx_size.is_none());
+    }
+
+    // ── PairedEffect ─────────────────────────────────────────────────────────
+
+    /// A result with a chosen match score, for paired fixtures.
+    fn scored_result(id: &str, score: f64) -> TuneTaskResult {
+        TuneTaskResult {
+            tool_match_score: score,
+            passed: score >= 1.0,
+            ..task_result(id, false)
+        }
+    }
+
+    fn paired_task(id: &str, raw_scores: &[f64], gglib_scores: &[f64]) -> AgenticTaskComparison {
+        AgenticTaskComparison {
+            task_id: id.to_owned(),
+            category: TaskCategory::SingleCall,
+            raw: raw_scores.iter().map(|s| scored_result(id, *s)).collect(),
+            gglib: gglib_scores.iter().map(|s| scored_result(id, *s)).collect(),
+        }
+    }
+
+    #[test]
+    fn paired_effect_counts_wins_losses_ties_and_means_the_deltas() {
+        let tasks = vec![
+            paired_task("a", &[0.5, 1.0], &[1.0, 1.0]), // one win, one tie
+            paired_task("b", &[1.0], &[0.5]),           // one loss
+        ];
+        let paired = PairedEffect::from_tasks(&tasks).expect("pairs exist");
+        assert_eq!(paired.pairs, 3);
+        assert_eq!((paired.wins, paired.losses, paired.ties), (1, 1, 1));
+        assert!((paired.mean_delta - 0.0).abs() < 1e-12, "{paired:?}");
+        assert_eq!(paired.unmeasured_pairs, 0);
+        // Two non-tied pairs is far below the Wilcoxon minimum.
+        assert_eq!(paired.p_value, None);
+    }
+
+    /// A pair either side of which never reached the model is dropped and
+    /// counted, never scored — the same rule `ArmScores::unmeasured_runs`
+    /// applies arm-wide, kept at pair granularity here.
+    #[test]
+    fn paired_effect_drops_unmeasured_pairs_and_says_so() {
+        let mut task = paired_task("a", &[0.5, 0.5], &[1.0, 1.0]);
+        task.raw[1].unmeasured = Some("upstream unreachable".to_owned());
+        let paired = PairedEffect::from_tasks(&[task]).expect("one live pair");
+        assert_eq!(paired.pairs, 1);
+        assert_eq!(paired.unmeasured_pairs, 1);
+        assert_eq!(paired.wins, 1);
+    }
+
+    #[test]
+    fn paired_effect_is_none_when_nothing_was_measured() {
+        assert!(PairedEffect::from_tasks(&[]).is_none());
+        let mut task = paired_task("a", &[0.5], &[1.0]);
+        task.gglib[0].unmeasured = Some("dead".to_owned());
+        assert!(PairedEffect::from_tasks(&[task]).is_none());
+    }
+
+    /// Ten distinct all-positive deltas: W⁻ = 0, and the normal approximation
+    /// with continuity correction gives z = (0 − 27.5 + 0.5)/√96.25 ≈ −2.752,
+    /// p ≈ 0.0030. Pinned inside a band an implementation error of one rank,
+    /// one correction term, or a dropped tail would leave.
+    #[test]
+    fn wilcoxon_all_positive_deltas_is_a_strong_result() {
+        let gglib: Vec<f64> = (1..=10).map(|i| f64::from(i) * 0.05).collect();
+        let raw = vec![0.0; 10];
+        let tasks = vec![paired_task("a", &raw, &gglib)];
+        let p = PairedEffect::from_tasks(&tasks)
+            .unwrap()
+            .p_value
+            .expect("ten non-tied pairs");
+        assert!(p > 0.001 && p < 0.005, "p = {p}");
+    }
+
+    /// Symmetric wins and losses of matching magnitude: W⁻ lands on its null
+    /// mean and the one-sided p sits at chance.
+    #[test]
+    fn wilcoxon_balanced_deltas_read_as_chance() {
+        let raw = vec![0.5; 10];
+        let gglib = vec![0.6, 0.4, 0.7, 0.3, 0.8, 0.2, 0.9, 0.1, 1.0, 0.0];
+        let tasks = vec![paired_task("a", &raw, &gglib)];
+        let p = PairedEffect::from_tasks(&tasks)
+            .unwrap()
+            .p_value
+            .expect("ten non-tied pairs");
+        assert!(p > 0.4 && p < 0.6, "p = {p}");
+    }
+
+    /// Below the minimum the statistic says nothing — ties do not count
+    /// toward the minimum, because zeros are dropped before ranking.
+    #[test]
+    fn wilcoxon_says_nothing_below_the_minimum() {
+        let raw = vec![0.5; 10];
+        let mut gglib = vec![0.5; 10]; // ties everywhere...
+        for (i, value) in gglib.iter_mut().enumerate().take(7) {
+            *value = 0.01f64.mul_add(f64::from(u8::try_from(i).unwrap()), 0.6);
+        }
+        let tasks = vec![paired_task("a", &raw, &gglib)];
+        let paired = PairedEffect::from_tasks(&tasks).unwrap();
+        assert_eq!(paired.pairs, 10);
+        assert_eq!(paired.wins, 7);
+        assert_eq!(paired.p_value, None);
+    }
+
+    /// The report derives it from the drill-down it already stores, so a
+    /// legacy report gains the paired view retroactively.
+    #[test]
+    fn a_report_derives_its_paired_effect_from_tasks() {
+        let mut report = report_with(None, 0.7);
+        assert!(report.paired_effect().is_none(), "no drill-down stored");
+        report.tasks = vec![paired_task("a", &[0.5], &[1.0])];
+        let paired = report.paired_effect().expect("one pair");
+        assert_eq!((paired.pairs, paired.wins), (1, 1));
     }
 }

--- a/crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs
@@ -726,6 +726,9 @@ mod tests {
             }),
             raw_replicate: Some(arm(0.780, None)),
             replicate_seeds: replicate_seeds(&DEFAULT_SEEDS),
+            raw_replicates: vec![arm(0.780, None)],
+            replicate_seed_sets: vec![replicate_seeds(&DEFAULT_SEEDS)],
+            paired: None,
         }
     }
 

--- a/src/components/Benchmark/Agentic/AgenticReportVerdicts.tsx
+++ b/src/components/Benchmark/Agentic/AgenticReportVerdicts.tsx
@@ -57,7 +57,36 @@ const NoiseBlock: FC<{ report: AgenticEvalReport }> = ({ report }) => {
       </p>
       <p className="text-xs text-text-muted m-0">
         A sanity ratio, not a significance test — more seeds strengthen it, a bigger factor does not.
+        {verdict.pairs > 1 && ` Drift is the mean of ${verdict.pairs} pairwise gaps.`}
       </p>
+    </div>
+  );
+};
+
+/** The paired per-(task, seed) view, when the report carries one. */
+const PairedBlock: FC<{ report: AgenticEvalReport }> = ({ report }) => {
+  const paired = report.paired;
+  if (paired == null) return null;
+  const p =
+    paired.p_value == null
+      ? 'too few non-tied pairs for a p — read wins against losses'
+      : `Wilcoxon one-sided p = ${paired.p_value.toFixed(4)}`;
+  return (
+    <div className="flex flex-col gap-xs">
+      <p className="text-sm text-text m-0">
+        Paired
+        <span className="font-mono tabular-nums text-text-secondary">
+          {' '}
+          — {paired.wins}W–{paired.losses}L–{paired.ties}T over {paired.pairs} pairs, mean Δ{' '}
+          {paired.mean_delta >= 0 ? '+' : ''}
+          {paired.mean_delta.toFixed(3)}; {p}
+        </span>
+      </p>
+      {paired.unmeasured_pairs > 0 && (
+        <p className="text-xs text-warning m-0">
+          {paired.unmeasured_pairs} pairs dropped: at least one side never reached the model.
+        </p>
+      )}
     </div>
   );
 };
@@ -149,6 +178,7 @@ export const AgenticReportVerdicts: FC<{ report: AgenticEvalReport }> = ({ repor
     <section className="flex flex-col gap-xs">
       <h3 className="m-0 text-sm font-semibold text-text">Drift (A/A)</h3>
       <NoiseBlock report={report} />
+      <PairedBlock report={report} />
     </section>
     <section className="flex flex-col gap-xs">
       <h3 className="m-0 text-sm font-semibold text-text">Positive control</h3>

--- a/src/components/Benchmark/Agentic/verdicts.ts
+++ b/src/components/Benchmark/Agentic/verdicts.ts
@@ -27,8 +27,8 @@ export type ControlVerdict =
   | { kind: 'wrong_direction'; gap: number };
 
 export type EffectVerdict =
-  | { kind: 'exceeds_noise'; effect: number; noise: number }
-  | { kind: 'within_noise'; effect: number; noise: number };
+  | { kind: 'exceeds_noise'; effect: number; noise: number; pairs: number }
+  | { kind: 'within_noise'; effect: number; noise: number; pairs: number };
 
 /** What the positive control demonstrated, or `null` when it did not run. */
 export function controlVerdict(report: AgenticEvalReport): ControlVerdict | null {
@@ -40,11 +40,37 @@ export function controlVerdict(report: AgenticEvalReport): ControlVerdict | null
   return { kind: 'wrong_direction', gap: -gap };
 }
 
-/** The eval's own drift: how far two identical raw arms landed apart. `null` when the A/A arm did not run. */
+/**
+ * The eval's own drift: the mean pairwise composite gap over every run of the
+ * identical raw configuration — the primary plus each A/A pair. With one pair
+ * this is the old single gap; `null` when no A/A arm ran.
+ */
 export function noiseFloor(report: AgenticEvalReport): number | null {
-  const replicate = report.raw_replicate;
-  if (replicate == null) return null;
-  return Math.abs(report.raw.composite - replicate.composite);
+  const gaps = driftGaps(report);
+  if (gaps.length === 0) return null;
+  return gaps.reduce((sum, gap) => sum + gap, 0) / gaps.length;
+}
+
+/** How many pairwise gaps stand behind the noise floor. */
+export function noisePairs(report: AgenticEvalReport): number {
+  return driftGaps(report).length;
+}
+
+function driftGaps(report: AgenticEvalReport): number[] {
+  const composites = [report.raw.composite];
+  const replicates = report.raw_replicates ?? [];
+  if (replicates.length > 0) {
+    composites.push(...replicates.map((r) => r.composite));
+  } else if (report.raw_replicate != null) {
+    composites.push(report.raw_replicate.composite);
+  }
+  const gaps: number[] = [];
+  for (let i = 0; i < composites.length; i += 1) {
+    for (let j = i + 1; j < composites.length; j += 1) {
+      gaps.push(Math.abs(composites[i] - composites[j]));
+    }
+  }
+  return gaps;
 }
 
 /**
@@ -55,11 +81,12 @@ export function noiseFloor(report: AgenticEvalReport): number | null {
 export function effectVerdict(report: AgenticEvalReport): EffectVerdict | null {
   const noise = noiseFloor(report);
   if (noise == null) return null;
+  const pairs = noisePairs(report);
   const effect = report.delta.composite;
   if (Math.abs(effect) > 0 && Math.abs(effect) >= EFFECT_NOISE_RATIO * noise) {
-    return { kind: 'exceeds_noise', effect, noise };
+    return { kind: 'exceeds_noise', effect, noise, pairs };
   }
-  return { kind: 'within_noise', effect, noise };
+  return { kind: 'within_noise', effect, noise, pairs };
 }
 
 /** Per-arm pass counts for one task, in (raw, gglib) order. */

--- a/src/types/benchmark.ts
+++ b/src/types/benchmark.ts
@@ -322,6 +322,11 @@ export interface AgenticEvalConfig {
   include_control?: boolean;
   /** Server default true — re-run the raw arm on disjoint seeds (the A/A drift floor). */
   replicate_raw?: boolean;
+  /**
+   * Server default 1. Each extra pair re-runs the raw arm on another derived
+   * seed set, and the drift floor becomes the mean over every pairwise gap.
+   */
+  replicate_pairs?: number;
   /** Server default 1; clamped into 1..=seeds.len() server-side. */
   control_seeds?: number;
 }
@@ -424,6 +429,47 @@ export interface AgenticEvalReport {
   raw_replicate?: ArmScores | null;
   /** The seeds the A/A arm used. Empty when it did not run. */
   replicate_seeds?: number[];
+  /**
+   * Every A/A pair's scores when more than one ran. `raw_replicate` stays
+   * populated with the first pair, so single-pair reports read unchanged;
+   * the drift becomes the mean pairwise gap over all runs of the raw
+   * configuration when this is non-empty.
+   */
+  raw_replicates?: ArmScores[];
+  /** The seed set behind each entry of `raw_replicates`. */
+  replicate_seed_sets?: number[][];
+  /**
+   * The paired per-(task, seed) comparison, computed server-side at report
+   * assembly. Stored rather than re-derived here because it carries a rank
+   * test (Wilcoxon signed-rank) nobody should maintain twice; `null` or
+   * absent on reports written before the field existed.
+   */
+  paired?: PairedEffect | null;
+}
+
+/**
+ * The paired view of raw-versus-gglib: every matched (task, seed) cell
+ * compared directly, which removes the eval's identical-arm spread from the
+ * comparison. Mirrors `gglib_core::domain::benchmark::agentic::PairedEffect`.
+ */
+export interface PairedEffect {
+  /** Matched pairs in which both arms produced a real observation. */
+  pairs: number;
+  /** Pairs dropped because at least one side never reached the model. */
+  unmeasured_pairs: number;
+  /** Pairs the gglib arm scored strictly higher. */
+  wins: number;
+  /** Pairs the raw arm scored strictly higher. */
+  losses: number;
+  /** Pairs with identical scores. */
+  ties: number;
+  /** Mean of gglib − raw over the measured pairs. */
+  mean_delta: number;
+  /**
+   * One-sided Wilcoxon signed-rank p for "gglib scores higher". `null` below
+   * eight non-tied pairs — read wins against losses instead.
+   */
+  p_value: number | null;
 }
 
 // ─── API Response Shapes ─────────────────────────────────────────────────────


### PR DESCRIPTION
> **Stacked on #780** (which stacks on #779). Base is `feat(core,db)/measured-defaults-origin`; retarget as the stack merges.

Third PR of the closed-loop arc, and the gate everything after it depends on: nothing may ever auto-apply a tuning decision the eval cannot resolve from its own noise. Two strengthenings, both prescribed by the instrument's own documentation.

## 1. Paired per-seed statistics — from data the report already stores

The two real arms run the same seeds on the same tasks, and the report's drill-down stores every `(task, seed)` cell — but the only comparison ever made was arm mean against arm mean. Pairing is what removes the eval's identical-arm spread from the comparison: the ceiling experiment (ADR 0004's postscript) resolved a +0.067 effect through noise wider than that *only* because it paired per run. The A/B eval now gets the same treatment.

`PairedEffect` carries matched-pair counts (unmeasured pairs dropped **and reported** — the `unmeasured_runs` rule at pair granularity), wins/losses/ties on `tool_match_score`, the mean paired delta, and a one-sided Wilcoxon signed-rank *p* — textbook construction: zeros dropped, average ranks with the tie correction, continuity-corrected normal approximation, and a refusal to speak below eight non-tied pairs rather than rendering a statistic the design cannot support (`EffectVerdict`'s own rule). Two tests pin the implementation against hand-computed bands: ten distinct all-positive deltas give W⁻ = 0 and p ≈ 0.0030 — an error of one rank, one correction term, or a dropped tail leaves the band — and magnitude-balanced deltas land on the null mean at chance.

**Stored, not derived** — a deliberate exception to the verdicts' derive-only pattern, because the verdicts re-derive from two floats in any language while this carries a rank test nobody should maintain twice (the GUI hand-mirrors the verdict math in `verdicts.ts`, and a TS Wilcoxon twin is exactly the drift-prone duplication the mirror comment warns about). `paired_effect()` still re-derives from the drill-down, so legacy reports gain the paired view retroactively.

## 2. Multi-pair A/A drift — the strengthening the docs always named

`EFFECT_NOISE_RATIO`'s doc has said from day one: "The honest way to strengthen this is more A/A pairs, not a bigger factor." Now there can be more pairs. `--replicate-pairs N` re-runs the raw arm on N derived disjoint seed sets; the drift floor becomes the **mean pairwise composite gap over all C(K+1, 2) pairs** among the primary and every replicate — same estimator (a gap, not an SD, so the 2.0 threshold keeps its calibration), more degrees of freedom. `EffectVerdict` now carries the pair count, because a verdict over one pair and one over six are not the same strength of claim.

Compatibility is pinned by test in both directions: pair 1's seed set is exactly the legacy derivation (a multi-pair run's first pair stays comparable with every earlier report), and a legacy report — populated `raw_replicate`, empty `raw_replicates` — reads exactly as it always did: one gap, one pair.

## Surfaces

- **CLI**: the report prints the paired line (`11W–4L–5T over 20 pairs, mean Δ +0.067; Wilcoxon one-sided p = 0.0099` — or an honest refusal below the minimum), names the gap count behind the drift, and describes a multi-pair A/A arm as what it is.
- **GUI**: the verdicts panel gains the paired block; `verdicts.ts`'s hand-mirrored `noiseFloor`/`effectVerdict` upgrade to the multi-pair mean with the pair count threaded through.
- **Types**: `AgenticEvalConfig.replicate_pairs`, `AgenticEvalReport.{raw_replicates, replicate_seed_sets, paired}` on both sides of the wire, all serde-defaulted so old configs and old reports deserialize unchanged.
- The axum handler needed nothing: it accepts `AgenticEvalConfig` as JSON, and the new field defaults server-side.

## Verification

- Full workspace `cargo test` green — 1023 tests in `gglib-core` (10 new: the Wilcoxon bands, pair accounting, unmeasured-pair drops, multi-pair drift arithmetic with hand-computed gaps, legacy single-pair equivalence, first-pair seed-set equality). `clippy --all-targets -- -D warnings` clean; fmt clean.
- TS: 816 tests green (the pinned verdict-mirror tests pass unchanged — single-pair behaviour is identical by construction), `tsc --noEmit` clean, eslint clean.

### Not verified here

A live multi-pair run (needs a model and GPU): `gglib benchmark agentic <model> --replicate-pairs 3` should print a drift floor labelled "mean over 3 pairwise gaps"… with 3 A/A arms it is 6 gaps among 4 raw runs. One eval's wall-clock worth of confirmation before merge.

## What this sets up

PR 4 (`gglib model tune --apply`) gates on exactly these numbers: a winner applies only when its margin clears the multi-pair drift and the paired comparison agrees with the direction. This PR makes those numbers exist.
