### PR TITLE
feat(benchmark): tune --apply — the drift-gated winner write

### DIFF
--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -149,4 +149,12 @@ impl BenchmarkOps {
     ) -> Result<()> {
         agentic::run_agentic_eval(&self.deps, config, tx, cancel).await
     }
+
+    /// Evaluate a completed tune run against the apply gate and, when the
+    /// verdict licenses it, store the winner as the model's `Measured`
+    /// defaults. Refusals return as verdicts, never as errors — see
+    /// `tune::apply_run`.
+    pub async fn apply_tune_run(&self, run_id: i64) -> Result<tune::apply_run::ApplyOutcome> {
+        tune::apply_run::apply_tune_run(&self.deps, run_id).await
+    }
 }

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -18,7 +18,7 @@ mod compare;
 pub mod guard;
 pub mod mapper;
 mod perf;
-mod tune;
+pub mod tune;
 
 // ────────────────────────────────────────────────────────────────────────────
 // Dependency bundle

--- a/crates/gglib-app-services/src/benchmark/tune/apply_run.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/apply_run.rs
@@ -1,0 +1,104 @@
+//! Applying a tune run's winner as a model's `Measured` defaults, through
+//! the gate.
+//!
+//! This is the write half of the closed loop's first cycle: the gate
+//! (`gglib_core::domain::benchmark::tune::apply`) judges the stored run, and
+//! only an [`ApplyVerdict::Apply`] licenses touching the model. Every other
+//! verdict is returned to the caller as itself — a refusal that names its
+//! evidence, never an error.
+
+use anyhow::{Context as _, Result, anyhow};
+use gglib_core::domain::DefaultsOrigin;
+use gglib_core::domain::benchmark::BenchmarkRunType;
+use gglib_core::domain::benchmark::tune::apply::{
+    ApplyRecord, ApplyVerdict, evaluate_apply, winning_candidate,
+};
+use serde::{Deserialize, Serialize};
+
+use super::super::BenchmarkDeps;
+
+/// What an apply attempt returned to its caller.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApplyOutcome {
+    /// The gate's decision, with its numbers.
+    pub verdict: ApplyVerdict,
+    /// The model the run tuned.
+    pub model_id: i64,
+    /// Whether the model was actually written — `verdict.applies()`, echoed
+    /// so a wire consumer does not have to know the enum's variants to ask
+    /// the one question that matters.
+    pub applied: bool,
+}
+
+/// Evaluate a completed tune run against the apply gate and, if it passes,
+/// store the winner as the model's `Measured` defaults.
+///
+/// The write is the whole of what changes: `inference_defaults` becomes the
+/// winner's sparse overlay (unswept dimensions stay `None` and keep
+/// resolving through the chain, exactly as they did during the run), and
+/// `defaults_origin` becomes [`DefaultsOrigin::Measured`] — below global
+/// settings, exempt from the agentic ceiling, per its own docs. The run row
+/// records the [`ApplyRecord`] so the model's provenance stays traceable to
+/// the numbers that licensed it.
+pub async fn apply_tune_run(deps: &BenchmarkDeps, run_id: i64) -> Result<ApplyOutcome> {
+    let run = deps
+        .bench_repo
+        .get_run(run_id)
+        .await
+        .context("failed to load run")?
+        .ok_or_else(|| anyhow!("run {run_id} not found"))?;
+    if run.run_type != BenchmarkRunType::Tune {
+        return Err(anyhow!("run {run_id} is not a tune run"));
+    }
+    let model_id = *run
+        .model_ids
+        .first()
+        .ok_or_else(|| anyhow!("run {run_id} names no model"))?;
+
+    let candidates = deps
+        .bench_repo
+        .get_tune_results(run_id)
+        .await
+        .context("failed to load tune results")?;
+
+    let verdict = evaluate_apply(&candidates);
+    if !verdict.applies() {
+        return Ok(ApplyOutcome {
+            verdict,
+            model_id,
+            applied: false,
+        });
+    }
+
+    let winner = winning_candidate(&candidates)
+        .expect("a verdict of Apply implies a winning candidate exists");
+
+    let mut model = deps
+        .model_repo
+        .get_by_id(model_id)
+        .await
+        .with_context(|| format!("model {model_id} not found"))?;
+    model.inference_defaults = Some(winner.config.clone());
+    model.defaults_origin = Some(DefaultsOrigin::Measured);
+    deps.model_repo
+        .update(&model)
+        .await
+        .context("failed to store the measured defaults")?;
+
+    // Recorded after the model write: a record naming an apply that never
+    // happened misleads; an apply missing its record is recoverable from the
+    // model's origin alone.
+    let record = ApplyRecord {
+        verdict: verdict.clone(),
+        applied_config: winner.config.clone(),
+    };
+    if let Ok(json) = serde_json::to_string(&record) {
+        deps.bench_repo.mark_run_applied(run_id, &json).await.ok();
+    }
+
+    Ok(ApplyOutcome {
+        verdict,
+        model_id,
+        applied: true,
+    })
+}

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -14,7 +14,7 @@ use gglib_core::domain::benchmark::tune::config::{ScoreWeights, SweepSpec, TuneC
 use gglib_core::domain::benchmark::tune::result::{
     CandidateSource, TuneCandidateResult, TuneTaskResult,
 };
-use gglib_core::domain::benchmark::tune::task::{TaskCategory, TaskSuite, TuneTask};
+use gglib_core::domain::benchmark::tune::task::{TaskCategory, TuneTask};
 use gglib_core::domain::benchmark::{BenchmarkEvent, BenchmarkRunType};
 use gglib_core::domain::{InferenceConfig, Model};
 use gglib_core::ports::{LlmCompletionPort, RunningTarget, ToolExecutorPort, UsageSink};
@@ -844,6 +844,7 @@ pub(crate) fn axis_scores(results: &[TuneTaskResult]) -> Option<AxisScores> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gglib_core::domain::benchmark::tune::task::TaskSuite;
 
     // ── Task seeding (the calibration instrument's integrity) ───────────────
 

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -25,6 +25,7 @@ use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
+pub mod apply_run;
 pub mod executor;
 pub mod pruning;
 pub mod scoring;
@@ -197,7 +198,14 @@ pub async fn run_tune(
             return Ok(());
         }
 
-        let is_survivor = survivors.contains(&idx);
+        // The incumbent pair always runs the full suite: pruning either twin
+        // would leave the run uncalibrated, and a pre-screen composite is
+        // not comparable with the full-suite scores the gate reads.
+        let is_survivor = survivors.contains(&idx)
+            || matches!(
+                source,
+                CandidateSource::Incumbent | CandidateSource::IncumbentCalibration
+            );
         let mut task_results = std::mem::take(&mut prescreen_results[idx]);
 
         if is_survivor {
@@ -342,6 +350,18 @@ fn build_candidates(
             candidates.push((preset, CandidateSource::FamilyPreset { family }));
         }
     }
+
+    // The incumbent pair, always: an all-None overlay resolves through the
+    // normal chain and is therefore exactly what the model does today, and
+    // the gap between the identical twins is the run's own drift — the
+    // number the apply gate divides every margin by. Two extra candidates
+    // is the price of a run that can calibrate itself; a run without them
+    // is Uncalibrated and nothing may be applied from it.
+    candidates.push((InferenceConfig::default(), CandidateSource::Incumbent));
+    candidates.push((
+        InferenceConfig::default(),
+        CandidateSource::IncumbentCalibration,
+    ));
 
     candidates
 }

--- a/crates/gglib-app-services/src/benchmark/tune/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/mod.rs
@@ -9,11 +9,12 @@ use std::time::Instant;
 use anyhow::{Context as _, Result};
 use gglib_agent::AgentLoop;
 use gglib_core::domain::agent::{AgentConfig, AgentEvent, AgentMessage};
+use gglib_core::domain::benchmark::agentic::REPLICATE_SEED_OFFSET;
 use gglib_core::domain::benchmark::tune::config::{ScoreWeights, SweepSpec, TuneConfig};
 use gglib_core::domain::benchmark::tune::result::{
     CandidateSource, TuneCandidateResult, TuneTaskResult,
 };
-use gglib_core::domain::benchmark::tune::task::{TaskCategory, TuneTask};
+use gglib_core::domain::benchmark::tune::task::{TaskCategory, TaskSuite, TuneTask};
 use gglib_core::domain::benchmark::{BenchmarkEvent, BenchmarkRunType};
 use gglib_core::domain::{InferenceConfig, Model};
 use gglib_core::ports::{LlmCompletionPort, RunningTarget, ToolExecutorPort, UsageSink};
@@ -142,7 +143,7 @@ pub async fn run_tune(
     let model_context = model_context_for(&model);
     let mut prescreen_results: Vec<Vec<TuneTaskResult>> = Vec::with_capacity(total);
 
-    for (idx, (candidate_config, _)) in candidates.iter().enumerate() {
+    for (idx, (candidate_config, source)) in candidates.iter().enumerate() {
         if cancel.is_cancelled() {
             deps.bench_repo
                 .fail_run(run_id, "Aborted by user")
@@ -166,7 +167,7 @@ pub async fn run_tune(
                 target,
                 &model,
                 &model_context,
-                candidate_config,
+                &seeded(candidate_config, task, source),
                 task,
             )
             .await;
@@ -215,7 +216,7 @@ pub async fn run_tune(
                     target,
                     &model,
                     &model_context,
-                    &candidate_config,
+                    &seeded(&candidate_config, task, &source),
                     task,
                 )
                 .await;
@@ -494,6 +495,57 @@ fn family_presets(model: &Model) -> Vec<(String, InferenceConfig)> {
     }
 
     presets
+}
+
+/// The seed a candidate runs `task` under.
+///
+/// # Why tune tasks are seeded at all
+///
+/// Measured on the first live gated apply: unseeded, the incumbent twins
+/// scored *identically*, so the run's drift read 0.000 — and at zero drift
+/// the ratio gate passes any positive margin, leaving the paired check as
+/// the only guard. A calibration instrument that reads zero because nothing
+/// was pinned is the inert-organ trap in one more costume.
+///
+/// # The design, mirrored from the agentic eval
+///
+/// Every candidate runs task `T` under the **same** derived seed — common
+/// random numbers, so candidate-versus-candidate comparisons stay tightly
+/// paired. The calibration twin alone runs offset seeds
+/// ([`REPLICATE_SEED_OFFSET`], the same constant and rationale as the A/A
+/// arm's): its gap from the incumbent then genuinely samples seed-to-seed
+/// variance under the incumbent's own configuration, which is exactly the
+/// noise the apply gate's question is about — would this margin replicate
+/// under different draws?
+///
+/// Derived from the task *id*, not its position, so the seed survives suite
+/// reordering and additions; derived rather than drawn so a surprising score
+/// can be re-run and reproduced instead of chased.
+fn tune_task_seed(task_id: &str, calibration_twin: bool) -> u32 {
+    // djb2 over the id bytes: stable, dependency-free, and well-spread
+    // enough for a decode seed — this is reproducibility, not cryptography.
+    let mut hash: u32 = 5381;
+    for byte in task_id.as_bytes() {
+        hash = hash.wrapping_mul(33) ^ u32::from(*byte);
+    }
+    if calibration_twin {
+        hash = hash.wrapping_add(REPLICATE_SEED_OFFSET);
+    }
+    hash
+}
+
+/// A candidate's config with the per-task seed stamped in.
+fn seeded(
+    candidate: &InferenceConfig,
+    task: &TuneTask,
+    source: &CandidateSource,
+) -> InferenceConfig {
+    let mut config = candidate.clone();
+    config.seed = Some(tune_task_seed(
+        &task.id,
+        matches!(source, CandidateSource::IncumbentCalibration),
+    ));
+    config
 }
 
 /// Run one task against one candidate's sampling settings through the real
@@ -792,6 +844,59 @@ pub(crate) fn axis_scores(results: &[TuneTaskResult]) -> Option<AxisScores> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Task seeding (the calibration instrument's integrity) ───────────────
+
+    /// Common random numbers: every non-calibration candidate runs a task
+    /// under the same seed, so candidate comparisons stay paired.
+    #[test]
+    fn every_candidate_runs_a_task_under_the_same_seed() {
+        assert_eq!(
+            tune_task_seed("single_call_weather", false),
+            tune_task_seed("single_call_weather", false),
+        );
+    }
+
+    /// The calibration twin alone runs offset seeds — its gap from the
+    /// incumbent samples seed-to-seed variance, which is what makes the
+    /// drift a reading instead of the 0.000 the first live run measured.
+    #[test]
+    fn the_calibration_twin_runs_different_seeds() {
+        let primary = tune_task_seed("single_call_weather", false);
+        let twin = tune_task_seed("single_call_weather", true);
+        assert_ne!(primary, twin);
+        assert_eq!(twin, primary.wrapping_add(REPLICATE_SEED_OFFSET));
+    }
+
+    /// Seeds derive from the task id, not its position: distinct tasks get
+    /// distinct seeds, and reordering the suite changes nothing.
+    #[test]
+    fn distinct_tasks_get_distinct_seeds() {
+        let suite = TaskSuite::Default.resolve().expect("suite resolves");
+        let mut seeds: Vec<u32> = suite.iter().map(|t| tune_task_seed(&t.id, false)).collect();
+        let total = seeds.len();
+        seeds.sort_unstable();
+        seeds.dedup();
+        assert_eq!(seeds.len(), total, "seed collision in the default suite");
+    }
+
+    /// The stamp lands on the config the task actually runs under, and the
+    /// candidate's own fields survive it.
+    #[test]
+    fn seeded_stamps_the_seed_and_keeps_the_candidate() {
+        let suite = TaskSuite::Default.resolve().expect("suite resolves");
+        let task = &suite[0];
+        let candidate = InferenceConfig {
+            temperature: Some(0.7),
+            ..Default::default()
+        };
+        let stamped = seeded(&candidate, task, &CandidateSource::UserGrid);
+        assert_eq!(stamped.temperature, Some(0.7));
+        assert_eq!(stamped.seed, Some(tune_task_seed(&task.id, false)));
+
+        let twin = seeded(&candidate, task, &CandidateSource::IncumbentCalibration);
+        assert_eq!(twin.seed, Some(tune_task_seed(&task.id, true)));
+    }
 
     /// A loop-eligible result by default (`iterations` at the threshold), so
     /// scoring fixtures exercise the loop axis rather than skipping it.

--- a/crates/gglib-axum/src/handlers/benchmark/tune.rs
+++ b/crates/gglib-axum/src/handlers/benchmark/tune.rs
@@ -22,7 +22,7 @@ use std::convert::Infallible;
 use std::time::Duration;
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use futures_core::Stream;
 use futures_util::StreamExt as _;
@@ -31,6 +31,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 use gglib_app_services::benchmark::guard::BenchmarkTaskGuard;
+use gglib_app_services::benchmark::tune::apply_run::ApplyOutcome;
 use gglib_core::domain::benchmark::BenchmarkEvent;
 use gglib_core::domain::benchmark::tune::config::TuneConfig;
 
@@ -97,4 +98,24 @@ pub async fn tune_sse(
             .interval(Duration::from_secs(15))
             .text("ping"),
     ))
+}
+
+/// `POST /api/benchmark/tune/{run_id}/apply` — judge a completed tune run
+/// against the apply gate and, when the verdict licenses it, store the
+/// winner as the model's `Measured` defaults.
+///
+/// The response is always `200` with an
+/// [`ApplyOutcome`]: a refusal is a first-class verdict naming its evidence,
+/// not an error. Errors are reserved for a run that does not exist, is not a
+/// tune run, or storage failing.
+pub async fn tune_apply(
+    State(state): State<AppState>,
+    Path(run_id): Path<i64>,
+) -> Result<Json<ApplyOutcome>, HttpError> {
+    state
+        .benchmark
+        .apply_tune_run(run_id)
+        .await
+        .map(Json)
+        .map_err(|e| HttpError::Internal(e.to_string()))
 }

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -142,6 +142,12 @@ pub(crate) fn api_routes() -> Router<AppState> {
             "/benchmark/tune",
             post(handlers::benchmark::tune::tune_sse).layer(DefaultBodyLimit::max(5 * 1024 * 1024)),
         )
+        // Benchmark — gated apply of a completed tune run's winner. Plain
+        // JSON, not SSE: the gate judges stored results, no model runs.
+        .route(
+            "/benchmark/tune/{run_id}/apply",
+            post(handlers::benchmark::tune::tune_apply),
+        )
         // Benchmark — raw-vs-gglib A/B agentic eval SSE stream. Same body
         // limit as tune: a custom task_suite can embed long_context tasks.
         .route(

--- a/crates/gglib-cli/src/benchmark_commands.rs
+++ b/crates/gglib-cli/src/benchmark_commands.rs
@@ -153,12 +153,14 @@ pub enum BenchmarkCommand {
         #[arg(long)]
         ctx_size: Option<u64>,
 
-        /// After the run completes, write the highest-scoring candidate's
-        /// sampling settings to this model's `inference_defaults` — the
-        /// same effect as `gglib model update <id> --temperature ...`,
-        /// applied automatically
-        #[arg(long)]
-        apply_best: bool,
+        /// After the run completes, apply the winner as this model's
+        /// *measured* defaults — through the gate: the winner must clear the
+        /// incumbent pair's mean by twice the run's own drift, with the
+        /// per-task pairs agreeing. A refusal prints its evidence and
+        /// changes nothing. (`--apply-best` is the old name for the ungated
+        /// version of this and is kept as an alias.)
+        #[arg(long = "apply", alias = "apply-best")]
+        apply: bool,
     },
 
     /// Measure what the gglib pipeline buys: run the agentic task suite

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -10,7 +10,6 @@ use anyhow::{Context as _, Result, anyhow};
 
 use gglib_core::domain::InferenceConfig;
 use gglib_core::domain::benchmark::tune::config::{ScoreWeights, SweepSpec, TuneConfig};
-use gglib_core::domain::benchmark::tune::result::TuneCandidateResult;
 use gglib_core::domain::benchmark::tune::task::{TaskSuite, TuneTask};
 use gglib_core::domain::benchmark::{
     AgenticEvalConfig, AgenticEvalReport, ArmScores, BenchmarkEvent, BenchmarkModelResult,
@@ -67,7 +66,7 @@ pub async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
             weight_task_completion,
             weight_speed,
             ctx_size,
-            apply_best,
+            apply,
         } => {
             cmd_tune(
                 ctx,
@@ -82,7 +81,7 @@ pub async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
                 weight_task_completion,
                 weight_speed,
                 ctx_size,
-                apply_best,
+                apply,
             )
             .await
         }
@@ -246,7 +245,7 @@ async fn cmd_tune(
     weight_task_completion: Option<f32>,
     weight_speed: Option<f32>,
     ctx_size: Option<u64>,
-    apply_best: bool,
+    apply: bool,
 ) -> Result<()> {
     let model_id = resolve_model_ids(ctx, std::slice::from_ref(&model))
         .await?
@@ -281,31 +280,109 @@ async fn cmd_tune(
     eprintln!("  Suite : {task_suite}");
     style::print_banner_close();
 
-    let mut best: Option<TuneCandidateResult> = None;
+    let mut completed_run: Option<i64> = None;
     run_on_daemon("/api/benchmark/tune", &config, |event| {
-        if let BenchmarkEvent::TuneCandidateComplete { result } = event
-            && !result.pruned
-            && best
-                .as_ref()
-                .is_none_or(|b| result.composite_score > b.composite_score)
-        {
-            best = Some(result.clone());
+        if let BenchmarkEvent::RunComplete { run_id } = event {
+            completed_run = Some(*run_id);
         }
         render_event(event);
     })
     .await?;
 
-    if apply_best {
-        match best {
-            Some(winner) => apply_best_config(ctx, model_id, &winner).await?,
+    if apply {
+        match completed_run {
+            Some(run_id) => apply_gated(run_id).await?,
             None => eprintln!(
-                "{}note:{} no surviving candidate to apply (run may have been aborted)",
+                "{}note:{} the run did not complete, so there is nothing to judge",
                 style::WARNING,
                 style::RESET
             ),
         }
     }
 
+    Ok(())
+}
+
+/// Ask the daemon to judge the run against the apply gate and render the
+/// verdict — a refusal is an outcome with evidence, not an error.
+async fn apply_gated(run_id: i64) -> Result<()> {
+    use gglib_app_services::benchmark::tune::apply_run::ApplyOutcome;
+    use gglib_core::domain::benchmark::tune::apply::ApplyVerdict;
+
+    let handle = daemon_client::ensure_daemon().await?;
+    let url = format!(
+        "{}/api/benchmark/tune/{run_id}/apply",
+        daemon_client::base_url()
+    );
+    let outcome: ApplyOutcome = handle
+        .client
+        .post(&url)
+        .send()
+        .await
+        .context("apply request failed")?
+        .error_for_status()
+        .context("apply request rejected")?
+        .json()
+        .await
+        .context("apply response unreadable")?;
+
+    match outcome.verdict {
+        ApplyVerdict::Apply {
+            winner_composite,
+            incumbent_mean,
+            margin,
+            drift,
+            paired,
+        } => {
+            println!(
+                "{SUCCESS}\u{2713} applied as measured defaults{RESET}: winner \
+                 {winner_composite:.3} over incumbent {incumbent_mean:.3}, margin \
+                 {margin:+.3} against drift {drift:.3}",
+                SUCCESS = style::SUCCESS,
+                RESET = style::RESET,
+            );
+            if let Some(p) = paired {
+                println!(
+                    "  paired: {}W-{}L-{}T over {} tasks",
+                    p.wins, p.losses, p.ties, p.pairs
+                );
+            }
+        }
+        ApplyVerdict::IncumbentStands { incumbent_mean } => println!(
+            "{}incumbent stands{} at {incumbent_mean:.3}: no candidate beat the model's \
+             current defaults. The run answered its question, and the answer is \
+             'change nothing'.",
+            style::WARNING,
+            style::RESET,
+        ),
+        ApplyVerdict::WithinDrift { margin, drift } => println!(
+            "{}not applied{}: the winner's {margin:+.3} margin is inside the run's own \
+             {drift:.3} drift. Unresolved, not absent; more tasks or a re-run resolves \
+             it, a smaller threshold never does.",
+            style::WARNING,
+            style::RESET,
+        ),
+        ApplyVerdict::PairedDisagrees { wins, losses } => println!(
+            "{}not applied{}: the winner's mean rests on a minority of tasks \
+             ({wins}W-{losses}L against the incumbent), the lucky-outlier shape, \
+             refused by the pairs.",
+            style::WARNING,
+            style::RESET,
+        ),
+        ApplyVerdict::Uncalibrated => println!(
+            "{}not applied{}: this run has no incumbent calibration pair, so nothing \
+             measures its drift. Re-run the tune; every new run carries the pair.",
+            style::WARNING,
+            style::RESET,
+        ),
+        ApplyVerdict::Contaminated { unmeasured_runs } => println!(
+            "{}not applied{}: {unmeasured_runs} task run(s) never reached the model, so \
+             the compared scores are contaminated. A zero from a dead upstream is not a \
+             low score.",
+            style::WARNING,
+            style::RESET,
+        ),
+    }
     Ok(())
 }
 
@@ -1046,33 +1123,6 @@ fn load_task_suite(spec: &str) -> Result<TaskSuite> {
     let tasks: Vec<TuneTask> = serde_json::from_str(&content)
         .with_context(|| format!("failed to parse '{spec}' as a JSON array of task definitions"))?;
     Ok(TaskSuite::Custom { tasks })
-}
-
-/// Write the winning candidate's sampling settings to the model's
-/// `inference_defaults`, mirroring `gglib model update <id> --temperature ...`.
-async fn apply_best_config(
-    ctx: &CliContext,
-    model_id: i64,
-    winner: &TuneCandidateResult,
-) -> Result<()> {
-    let mut model = ctx
-        .model_repo
-        .get_by_id(model_id)
-        .await
-        .with_context(|| format!("failed to load model {model_id} to apply tune result"))?;
-    model.inference_defaults = Some(winner.config.clone());
-    ctx.model_repo
-        .update(&model)
-        .await
-        .context("failed to save tuned inference defaults")?;
-
-    println!(
-        "{SUCCESS}\u{2713} Applied best config (score {:.3}) to model {model_id}'s inference_defaults{RESET}",
-        winner.composite_score,
-        SUCCESS = style::SUCCESS,
-        RESET = style::RESET
-    );
-    Ok(())
 }
 
 // ─── benchmark list ───────────────────────────────────────────────────────────

--- a/crates/gglib-core/src/domain/benchmark/agentic.rs
+++ b/crates/gglib-core/src/domain/benchmark/agentic.rs
@@ -908,6 +908,39 @@ impl PairedEffect {
                 }
             }
         }
+        Self::from_deltas(&deltas, unmeasured_pairs)
+    }
+
+    /// The paired comparison between two runs of the same task list, paired
+    /// by `task_id` — the first argument's score minus the second's, so
+    /// `wins` counts pairs the *first* run took.
+    ///
+    /// Built for the tune apply gate (winner versus incumbent), where the
+    /// two sides are candidates rather than eval arms. A task present in one
+    /// run and absent from the other is skipped, not counted: an unpaired
+    /// task has nothing to compare.
+    #[must_use]
+    pub fn from_paired_runs(a: &[TuneTaskResult], b: &[TuneTaskResult]) -> Option<Self> {
+        let b_by_id: std::collections::HashMap<&str, &TuneTaskResult> =
+            b.iter().map(|r| (r.task_id.as_str(), r)).collect();
+        let mut deltas = Vec::new();
+        let mut unmeasured_pairs = 0_usize;
+        for left in a {
+            let Some(right) = b_by_id.get(left.task_id.as_str()) else {
+                continue;
+            };
+            if left.is_measured() && right.is_measured() {
+                deltas.push(left.tool_match_score - right.tool_match_score);
+            } else {
+                unmeasured_pairs += 1;
+            }
+        }
+        Self::from_deltas(&deltas, unmeasured_pairs)
+    }
+
+    /// Aggregate a delta list into the paired record. `None` on no deltas —
+    /// a paired analysis of nothing is not a zero effect.
+    fn from_deltas(deltas: &[f64], unmeasured_pairs: usize) -> Option<Self> {
         if deltas.is_empty() {
             return None;
         }
@@ -925,7 +958,7 @@ impl PairedEffect {
             losses,
             ties,
             mean_delta,
-            p_value: wilcoxon_one_sided(&deltas),
+            p_value: wilcoxon_one_sided(deltas),
         })
     }
 }

--- a/crates/gglib-core/src/domain/benchmark/run.rs
+++ b/crates/gglib-core/src/domain/benchmark/run.rs
@@ -49,6 +49,12 @@ pub struct BenchmarkRun {
     /// Serialised run configuration (`CompareConfig`, `PerfConfig`, or
     /// `TuneConfig` JSON).
     pub config_json: Option<String>,
+    /// The apply record written when this tune run's winner became a model's
+    /// Measured defaults (JSON-serialized `tune::apply::ApplyRecord`).
+    /// `None` on every run that was never applied — which is every run of
+    /// every other type, and most tune runs.
+    #[serde(default)]
+    pub applied_json: Option<String>,
     /// Error message if the run failed.
     pub error: Option<String>,
     /// UTC timestamp when the run was created.

--- a/crates/gglib-core/src/domain/benchmark/tune/apply.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/apply.rs
@@ -1,0 +1,356 @@
+//! The apply gate: whether a tune run's winner may become a model's
+//! [`Measured`](crate::domain::DefaultsOrigin::Measured) defaults.
+//!
+//! The gate exists because an auto-tuner without one optimises noise: it
+//! ratchets whichever candidate a lucky draw favoured into the catalog and
+//! reports improvement while doing it. Every rule here is the codified form
+//! of a failure this repo has already measured — a +0.082 that did not
+//! replicate, a control that could not degrade, an arm of 45 zeros that
+//! rendered as a score (ADR 0004).
+//!
+//! ## The in-run calibration pair
+//!
+//! A tune run has no A/A arm the way the agentic eval does, so the drift
+//! estimate is built into the candidate list instead: the **incumbent** — an
+//! all-`None` overlay, which resolves through the normal chain and is
+//! therefore exactly what the model does today — runs twice. The gap between
+//! the twins is the run's own noise, measured under the same tasks, the same
+//! server, the same everything. A winner must clear the incumbent's mean by
+//! [`EFFECT_NOISE_RATIO`] times that gap before the gate calls it a winner.
+
+use serde::{Deserialize, Serialize};
+
+use super::result::{CandidateSource, TuneCandidateResult};
+use crate::domain::benchmark::agentic::{EFFECT_NOISE_RATIO, PairedEffect};
+
+/// What an apply attempt decided, and the numbers it decided on.
+///
+/// Refusals are first-class outcomes, not errors: each names the evidence
+/// that was missing or contrary, because "the gate said no" is only useful
+/// if it says what would have changed the answer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "verdict", rename_all = "snake_case")]
+pub enum ApplyVerdict {
+    /// The winner cleared every gate and may be stored as this model's
+    /// measured defaults.
+    Apply {
+        /// The winning candidate's composite.
+        winner_composite: f64,
+        /// Mean composite of the incumbent pair.
+        incumbent_mean: f64,
+        /// `winner_composite − incumbent_mean`.
+        margin: f64,
+        /// The calibration pair's gap — the run's own drift.
+        drift: f64,
+        /// The winner-versus-incumbent paired comparison.
+        paired: Option<PairedEffect>,
+    },
+    /// The best candidate *is* the incumbent: the model's current defaults
+    /// beat every swept candidate, and there is nothing to apply. Not a
+    /// failure — the run answered its question.
+    IncumbentStands {
+        /// The incumbent pair's mean composite.
+        incumbent_mean: f64,
+    },
+    /// The winner's margin over the incumbent is inside the run's own drift.
+    /// Unresolved, not absent — the fix is more tasks or a re-run, never a
+    /// smaller threshold.
+    WithinDrift {
+        /// `winner_composite − incumbent_mean`.
+        margin: f64,
+        /// The calibration pair's gap.
+        drift: f64,
+    },
+    /// The margin clears the drift, but the per-task paired comparison runs
+    /// the other way — the winner's mean rests on a minority of tasks. A
+    /// mean and its pairs disagreeing is exactly the shape a lucky outlier
+    /// task produces.
+    PairedDisagrees {
+        /// Pairs the winner took.
+        wins: usize,
+        /// Pairs the incumbent took.
+        losses: usize,
+    },
+    /// The run carries no incumbent pair, so nothing calibrates it — a run
+    /// from before the calibration pair existed, or one whose incumbents
+    /// never completed. Nothing can be applied from it.
+    Uncalibrated,
+    /// The winner or an incumbent has runs that never reached the model, so
+    /// their composites are contaminated by a knowable amount and the
+    /// comparison is not trustworthy.
+    Contaminated {
+        /// Unmeasured runs across the compared candidates.
+        unmeasured_runs: usize,
+    },
+}
+
+impl ApplyVerdict {
+    /// Whether this verdict licenses writing the winner.
+    #[must_use]
+    pub const fn applies(&self) -> bool {
+        matches!(self, Self::Apply { .. })
+    }
+}
+
+/// Evaluate a completed tune run's candidates against the apply gate.
+///
+/// `candidates` is the run's full stored list. The winner is the highest
+/// composite among full-suite, measured, non-calibration candidates; the
+/// incumbent pair is found by [`CandidateSource`].
+#[must_use]
+pub fn evaluate_apply(candidates: &[TuneCandidateResult]) -> ApplyVerdict {
+    let incumbents: Vec<&TuneCandidateResult> = candidates
+        .iter()
+        .filter(|c| {
+            matches!(
+                c.source,
+                CandidateSource::Incumbent | CandidateSource::IncumbentCalibration
+            ) && !c.pruned
+        })
+        .collect();
+    let [first, second] = incumbents.as_slice() else {
+        return ApplyVerdict::Uncalibrated;
+    };
+
+    let Some(winner) = candidates
+        .iter()
+        .filter(|c| {
+            !c.pruned
+                && !matches!(
+                    c.source,
+                    CandidateSource::Incumbent | CandidateSource::IncumbentCalibration
+                )
+        })
+        .max_by(|a, b| {
+            a.composite_score
+                .partial_cmp(&b.composite_score)
+                .expect("composites are finite")
+        })
+    else {
+        // Only the incumbent pair survived: the sweep produced nothing to
+        // compare, which is the incumbent standing by default.
+        return ApplyVerdict::IncumbentStands {
+            incumbent_mean: f64::midpoint(first.composite_score, second.composite_score),
+        };
+    };
+
+    let unmeasured_runs = unmeasured(winner) + unmeasured(first) + unmeasured(second);
+    if unmeasured_runs > 0 {
+        return ApplyVerdict::Contaminated { unmeasured_runs };
+    }
+
+    let incumbent_mean = f64::midpoint(first.composite_score, second.composite_score);
+    let drift = (first.composite_score - second.composite_score).abs();
+    let margin = winner.composite_score - incumbent_mean;
+
+    if margin <= 0.0 {
+        return ApplyVerdict::IncumbentStands { incumbent_mean };
+    }
+    if margin < EFFECT_NOISE_RATIO * drift {
+        return ApplyVerdict::WithinDrift { margin, drift };
+    }
+
+    // Direction check: the winner's mean must not rest on a minority of
+    // tasks. Compared against the first incumbent twin — either would do,
+    // and mixing both would double the incumbent's task list against the
+    // winner's single one.
+    let paired = PairedEffect::from_paired_runs(&winner.task_results, &first.task_results);
+    if let Some(p) = &paired
+        && p.losses > p.wins
+    {
+        return ApplyVerdict::PairedDisagrees {
+            wins: p.wins,
+            losses: p.losses,
+        };
+    }
+
+    ApplyVerdict::Apply {
+        winner_composite: winner.composite_score,
+        incumbent_mean,
+        margin,
+        drift,
+        paired,
+    }
+}
+
+/// The winner a verdict of [`ApplyVerdict::Apply`] refers to.
+///
+/// Re-derived by the same rule `evaluate_apply` uses, so the applier and the
+/// gate cannot disagree about which candidate won.
+#[must_use]
+pub fn winning_candidate(candidates: &[TuneCandidateResult]) -> Option<&TuneCandidateResult> {
+    candidates
+        .iter()
+        .filter(|c| {
+            !c.pruned
+                && !matches!(
+                    c.source,
+                    CandidateSource::Incumbent | CandidateSource::IncumbentCalibration
+                )
+        })
+        .max_by(|a, b| {
+            a.composite_score
+                .partial_cmp(&b.composite_score)
+                .expect("composites are finite")
+        })
+}
+
+fn unmeasured(candidate: &TuneCandidateResult) -> usize {
+    candidate
+        .task_results
+        .iter()
+        .filter(|r| !r.is_measured())
+        .count()
+}
+
+/// The durable record of an apply, stored on the run row so
+/// `gglib model explain`'s "measured by a tune sweep" can be traced to the
+/// numbers that licensed it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApplyRecord {
+    /// The verdict that licensed the write, with its numbers.
+    pub verdict: ApplyVerdict,
+    /// The applied sampling overlay, exactly as stored on the model.
+    pub applied_config: crate::domain::InferenceConfig,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::InferenceConfig;
+    use crate::domain::benchmark::tune::result::TuneTaskResult;
+    use crate::domain::benchmark::tune::task::TaskCategory;
+
+    fn task(id: &str, score: f64) -> TuneTaskResult {
+        TuneTaskResult {
+            task_id: id.to_owned(),
+            category: TaskCategory::SingleCall,
+            passed: score >= 1.0,
+            tool_match_score: score,
+            loop_detected: false,
+            stagnation_detected: false,
+            iterations: 1,
+            latency_ms: 10,
+            completion_tokens: Some(100),
+            time_to_first_tool_call_ms: Some(5),
+            detail: None,
+            unmeasured: None,
+        }
+    }
+
+    fn candidate(source: CandidateSource, scores: &[f64]) -> TuneCandidateResult {
+        #[allow(clippy::cast_precision_loss)]
+        let composite = scores.iter().sum::<f64>() / scores.len() as f64;
+        TuneCandidateResult {
+            config: InferenceConfig::default(),
+            source,
+            task_results: scores
+                .iter()
+                .enumerate()
+                .map(|(i, s)| task(&format!("t{i}"), *s))
+                .collect(),
+            composite_score: composite,
+            pruned: false,
+            tg_tps: None,
+        }
+    }
+
+    fn incumbent_pair(scores: &[f64], twin_scores: &[f64]) -> Vec<TuneCandidateResult> {
+        vec![
+            candidate(CandidateSource::Incumbent, scores),
+            candidate(CandidateSource::IncumbentCalibration, twin_scores),
+        ]
+    }
+
+    /// The headline path: a winner clearly above the incumbent pair, with
+    /// the pairs agreeing, applies.
+    #[test]
+    fn a_clear_winner_applies() {
+        let mut candidates = incumbent_pair(&[0.5, 0.5, 0.5], &[0.52, 0.5, 0.5]);
+        candidates.push(candidate(CandidateSource::UserGrid, &[0.9, 0.9, 0.9]));
+        let verdict = evaluate_apply(&candidates);
+        assert!(verdict.applies(), "{verdict:?}");
+    }
+
+    /// The gate's core rule: a margin inside the run's own drift is
+    /// unresolved, and unresolved never applies.
+    #[test]
+    fn a_margin_within_drift_is_refused() {
+        // Incumbent twins 0.3 apart: the run is very noisy.
+        let mut candidates = incumbent_pair(&[0.5, 0.5, 0.6], &[0.8, 0.8, 0.9]);
+        // The winner beats the incumbent mean by less than 2× that gap.
+        candidates.push(candidate(CandidateSource::UserGrid, &[0.9, 0.8, 0.9]));
+        match evaluate_apply(&candidates) {
+            ApplyVerdict::WithinDrift { margin, drift } => {
+                assert!(margin < EFFECT_NOISE_RATIO * drift, "{margin} vs {drift}");
+            }
+            other => panic!("expected WithinDrift, got {other:?}"),
+        }
+    }
+
+    /// A run without the calibration pair — every run recorded before the
+    /// pair existed — cannot be applied from, whatever its scores say.
+    #[test]
+    fn a_run_without_the_incumbent_pair_is_uncalibrated() {
+        let candidates = vec![candidate(CandidateSource::UserGrid, &[1.0, 1.0, 1.0])];
+        assert_eq!(evaluate_apply(&candidates), ApplyVerdict::Uncalibrated);
+    }
+
+    /// A winner that does not beat the incumbent is the incumbent standing —
+    /// a successful run whose answer is "change nothing".
+    #[test]
+    fn an_unbeaten_incumbent_stands() {
+        let mut candidates = incumbent_pair(&[0.9, 0.9, 0.9], &[0.9, 0.9, 0.9]);
+        candidates.push(candidate(CandidateSource::UserGrid, &[0.5, 0.5, 0.5]));
+        assert!(matches!(
+            evaluate_apply(&candidates),
+            ApplyVerdict::IncumbentStands { .. }
+        ));
+    }
+
+    /// Unmeasured runs in either side of the comparison poison it: a zero
+    /// from a dead upstream is not a low score (the 45-zeros lesson,
+    /// ADR 0004).
+    #[test]
+    fn contaminated_candidates_are_refused() {
+        let mut candidates = incumbent_pair(&[0.5, 0.5, 0.5], &[0.5, 0.5, 0.5]);
+        let mut winner = candidate(CandidateSource::UserGrid, &[0.9, 0.9, 0.9]);
+        winner.task_results[1].unmeasured = Some("upstream died".to_owned());
+        candidates.push(winner);
+        assert!(matches!(
+            evaluate_apply(&candidates),
+            ApplyVerdict::Contaminated { unmeasured_runs: 1 }
+        ));
+    }
+
+    /// A mean carried by one outlier task while the incumbent wins the rest
+    /// is refused: the pairs outvote the mean.
+    #[test]
+    fn a_minority_winner_is_refused_by_the_pairs() {
+        // The winner's mean (0.55) clears the incumbent mean (0.5) and the
+        // twins' zero drift — but it rests entirely on one outlier task
+        // while the incumbent takes the other three.
+        let mut candidates = incumbent_pair(&[0.5, 0.5, 0.5, 0.5], &[0.5, 0.5, 0.5, 0.5]);
+        candidates.push(candidate(CandidateSource::UserGrid, &[1.0, 0.4, 0.4, 0.4]));
+        match evaluate_apply(&candidates) {
+            ApplyVerdict::PairedDisagrees { wins, losses } => {
+                assert_eq!((wins, losses), (1, 3));
+            }
+            other => panic!("expected PairedDisagrees, got {other:?}"),
+        }
+    }
+
+    /// A pruned candidate never wins: its composite covers only the
+    /// pre-screen tasks and is not comparable with a full-suite score.
+    #[test]
+    fn a_pruned_candidate_cannot_win() {
+        let mut candidates = incumbent_pair(&[0.5, 0.5, 0.5], &[0.5, 0.5, 0.5]);
+        let mut pruned = candidate(CandidateSource::UserGrid, &[1.0, 1.0, 1.0]);
+        pruned.pruned = true;
+        candidates.push(pruned);
+        assert!(matches!(
+            evaluate_apply(&candidates),
+            ApplyVerdict::IncumbentStands { .. }
+        ));
+    }
+}

--- a/crates/gglib-core/src/domain/benchmark/tune/mod.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/mod.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("README.md")]
 
+pub mod apply;
 pub mod config;
 pub mod result;
 pub mod task;

--- a/crates/gglib-core/src/domain/benchmark/tune/result.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/result.rs
@@ -21,6 +21,16 @@ pub enum CandidateSource {
         /// Display name of the matched family/preset (e.g. `"qwen-coding"`).
         family: String,
     },
+    /// The model's current behaviour: an all-`None` overlay, which resolves
+    /// through the normal chain and is therefore exactly what an untouched
+    /// request gets today. Always included, never pruned — a winner that
+    /// never raced the incumbent has not beaten it.
+    Incumbent,
+    /// The incumbent again, identically. The gap between the twins is the
+    /// run's own drift — the in-run calibration the apply gate divides every
+    /// margin by (see `tune::apply`). Excluded from the leaderboard's notion
+    /// of "winner": it is an instrument, not a contender.
+    IncumbentCalibration,
 }
 
 #[cfg(test)]

--- a/crates/gglib-core/src/ports/benchmark.rs
+++ b/crates/gglib-core/src/ports/benchmark.rs
@@ -118,6 +118,22 @@ pub trait BenchmarkRepositoryPort: Send + Sync {
         limit: i64,
     ) -> Result<Vec<TuneCandidateResult>, RepositoryError>;
 
+    /// Every candidate of one tune run, in insertion order — the input the
+    /// apply gate (`tune::apply::evaluate_apply`) judges.
+    async fn get_tune_results(
+        &self,
+        run_id: i64,
+    ) -> Result<Vec<TuneCandidateResult>, RepositoryError>;
+
+    /// Record the apply decision taken from this run — a JSON-serialized
+    /// `tune::apply::ApplyRecord`, stored so "measured by a tune sweep" on
+    /// the model can always be traced to the numbers that licensed it.
+    async fn mark_run_applied(
+        &self,
+        run_id: i64,
+        applied_json: &str,
+    ) -> Result<(), RepositoryError>;
+
     /// Persist one raw-vs-gglib A/B report.
     ///
     /// Like tune results, this does not upsert `model_benchmark_summaries`:

--- a/crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs
@@ -116,6 +116,7 @@ fn row_to_benchmark_run(row: &sqlx::sqlite::SqliteRow) -> Result<BenchmarkRun, R
         prompt_text: row.try_get("prompt_text").ok().flatten(),
         system_prompt: row.try_get("system_prompt").ok().flatten(),
         config_json: row.try_get("config_json").ok().flatten(),
+        applied_json: row.try_get("applied_json").ok().flatten(),
         error: row.try_get("error").ok().flatten(),
         created_at: parse_datetime(created_at_str).unwrap_or_else(Utc::now),
         completed_at: parse_datetime(completed_at_str),
@@ -605,6 +606,38 @@ impl BenchmarkRepositoryPort for SqliteBenchmarkRepository {
         .map_err(|e| RepositoryError::Storage(e.to_string()))?;
 
         rows.iter().map(row_to_tune_result).collect()
+    }
+
+    async fn get_tune_results(
+        &self,
+        run_id: i64,
+    ) -> Result<Vec<TuneCandidateResult>, RepositoryError> {
+        let rows = sqlx::query(
+            "SELECT config_json, source_json, composite_score, pruned, tg_tps, task_results_json
+             FROM benchmark_tune_results
+             WHERE run_id = ?
+             ORDER BY id ASC",
+        )
+        .bind(run_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| RepositoryError::Storage(e.to_string()))?;
+
+        rows.iter().map(row_to_tune_result).collect()
+    }
+
+    async fn mark_run_applied(
+        &self,
+        run_id: i64,
+        applied_json: &str,
+    ) -> Result<(), RepositoryError> {
+        sqlx::query("UPDATE benchmark_runs SET applied_json = ? WHERE id = ?")
+            .bind(applied_json)
+            .bind(run_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| RepositoryError::Storage(e.to_string()))?;
+        Ok(())
     }
 
     async fn save_agentic_result(

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -160,6 +160,16 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
     // `gglib_core::domain::DialectSpec`). No backfill: rows without a spec
     // fall back to their `format:*` tag at context-resolution time, and
     // `gglib model retag` re-derives the spec from persisted metadata.
+    // Migration: add applied_json to benchmark_runs — the JSON-serialized
+    // apply record (`tune::apply::ApplyRecord`) written when a tune run's
+    // winner is stored as a model's Measured defaults, so the provenance a
+    // model reports can always be traced back to the gate numbers that
+    // licensed it. NULL on every run that was never applied.
+    let _ = sqlx::query(r#"ALTER TABLE benchmark_runs ADD COLUMN applied_json TEXT"#)
+        .execute(pool)
+        .await;
+    // Ignore error if column already exists
+
     let _ = sqlx::query(r#"ALTER TABLE models ADD COLUMN dialect_spec TEXT"#)
         .execute(pool)
         .await;

--- a/src/components/Benchmark/Tune/TuneConfigForm.tsx
+++ b/src/components/Benchmark/Tune/TuneConfigForm.tsx
@@ -283,7 +283,7 @@ export const TuneConfigForm: FC<TuneConfigFormProps> = ({ models, disabled, onSu
           checked={applyBest}
           disabled={disabled}
           onChange={e => setApplyBest(e.target.checked)}
-          label="Apply best config to model when complete"
+          label="Apply the winner as measured defaults when complete (gated: must beat the incumbent beyond the run's own drift)"
         />
 
       <Button

--- a/src/components/Benchmark/Tune/TuneLeaderboard.tsx
+++ b/src/components/Benchmark/Tune/TuneLeaderboard.tsx
@@ -27,6 +27,10 @@ function sourceLabel(source: TuneCandidateResult['source']): string {
       return 'gguf default';
     case 'family_preset':
       return source.family;
+    case 'incumbent':
+      return 'incumbent';
+    case 'incumbent_calibration':
+      return 'incumbent (A/A)';
     default:
       return '—';
   }

--- a/src/components/Benchmark/Tune/TuneTab.tsx
+++ b/src/components/Benchmark/Tune/TuneTab.tsx
@@ -19,8 +19,13 @@ import { AlertTriangle, Target } from 'lucide-react';
 import { EmptyState } from '../../primitives';
 import { Icon } from '../../ui/Icon';
 import type { GgufModel } from '../../../types';
-import type { BenchmarkEvent, TuneCandidateResult, TuneConfig } from '../../../types/benchmark';
-import { startTuneRun } from '../../../services/clients/benchmark';
+import type {
+  ApplyVerdict,
+  BenchmarkEvent,
+  TuneCandidateResult,
+  TuneConfig,
+} from '../../../types/benchmark';
+import { applyTuneRun, startTuneRun } from '../../../services/clients/benchmark';
 import { TuneConfigForm } from './TuneConfigForm';
 import { TuneLiveProgress, TuneTaskLogEntry, TunePrunedEntry } from './TuneLiveProgress';
 import { TuneLeaderboard } from './TuneLeaderboard';
@@ -49,6 +54,48 @@ const INITIAL_STATE: TuneRunState = {
   prunedLog: [],
   results: [],
 };
+
+/** One line per verdict, evidence included — refusals must read as refusals. */
+function describeApplyVerdict(verdict: ApplyVerdict): string {
+  switch (verdict.verdict) {
+    case 'apply': {
+      const paired = verdict.paired
+        ? `; paired ${verdict.paired.wins}W-${verdict.paired.losses}L-${verdict.paired.ties}T`
+        : '';
+      return (
+        `Applied as measured defaults: winner ${verdict.winner_composite.toFixed(3)} over ` +
+        `incumbent ${verdict.incumbent_mean.toFixed(3)}, margin ` +
+        `${verdict.margin >= 0 ? '+' : ''}${verdict.margin.toFixed(3)} against drift ` +
+        `${verdict.drift.toFixed(3)}${paired}.`
+      );
+    }
+    case 'incumbent_stands':
+      return (
+        `Incumbent stands at ${verdict.incumbent_mean.toFixed(3)}: no candidate beat the ` +
+        `model's current defaults — the run's answer is "change nothing".`
+      );
+    case 'within_drift':
+      return (
+        `Not applied: the winner's ${verdict.margin >= 0 ? '+' : ''}` +
+        `${verdict.margin.toFixed(3)} margin is inside the run's own ` +
+        `${verdict.drift.toFixed(3)} drift — unresolved, not absent.`
+      );
+    case 'paired_disagrees':
+      return (
+        `Not applied: the winner's mean rests on a minority of tasks ` +
+        `(${verdict.wins}W-${verdict.losses}L against the incumbent) — refused by the pairs.`
+      );
+    case 'uncalibrated':
+      return 'Not applied: this run has no incumbent calibration pair; re-run the tune.';
+    case 'contaminated':
+      return (
+        `Not applied: ${verdict.unmeasured_runs} task run(s) never reached the model, ` +
+        `so the compared scores are contaminated.`
+      );
+    default:
+      return 'Not applied: unrecognised verdict.';
+  }
+}
 
 export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
   const [runState, setRunState] = useState<TuneRunState>(INITIAL_STATE);
@@ -116,6 +163,7 @@ export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
           break;
 
         case 'run_complete':
+          completedRunIdRef.current = event.run_id;
           setRunState(prev => ({ ...prev, status: 'complete' }));
           onRunComplete?.();
           break;
@@ -131,6 +179,14 @@ export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
     [scheduleFlush, onRunComplete],
   );
 
+  const completedRunIdRef = useRef<number | null>(null);
+
+  /**
+   * The per-row apply: a person picked this exact candidate, which is a
+   * deliberate choice — it writes as user-set defaults, the same as typing
+   * the values into `gglib model update`. The gate governs the *automatic*
+   * path below, not this one.
+   */
   const handleApply = useCallback(async (result: TuneCandidateResult, modelId: number) => {
     setApplyMessage(null);
     try {
@@ -140,6 +196,22 @@ export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
       );
     } catch (err) {
       setApplyMessage(`Failed to apply config: ${(err as Error).message}`);
+    }
+  }, []);
+
+  /**
+   * The automatic apply, through the gate: the daemon judges the stored run
+   * (winner vs the incumbent calibration pair) and only an `apply` verdict
+   * writes the model — as *measured* defaults. Every refusal renders with
+   * its evidence.
+   */
+  const handleGatedApply = useCallback(async (runId: number) => {
+    setApplyMessage(null);
+    try {
+      const outcome = await applyTuneRun(runId);
+      setApplyMessage(describeApplyVerdict(outcome.verdict));
+    } catch (err) {
+      setApplyMessage(`Apply failed: ${(err as Error).message}`);
     }
   }, []);
 
@@ -161,11 +233,9 @@ export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
       .then(() => {
         setRunState(prev => {
           if (applyBest && prev.status !== 'failed') {
-            const best = [...prev.results]
-              .filter(r => !r.pruned)
-              .sort((a, b) => b.composite_score - a.composite_score)[0];
-            if (best) {
-              void handleApply(best, config.model_id);
+            const runId = completedRunIdRef.current;
+            if (runId != null) {
+              void handleGatedApply(runId);
             }
           }
           return prev;
@@ -176,7 +246,7 @@ export const TuneTab: FC<TuneTabProps> = ({ models, onRunComplete }) => {
           setRunState(prev => ({ ...prev, status: 'failed', error: (err as Error).message }));
         }
       });
-  }, [handleEvent, handleApply]);
+  }, [handleEvent, handleGatedApply]);
 
   const isRunning = runState.status === 'running';
 

--- a/src/services/clients/benchmark.ts
+++ b/src/services/clients/benchmark.ts
@@ -14,6 +14,7 @@ import { get, getAuthenticatedFetchConfig } from '../transport/api/client';
 import type {
   AgenticEvalConfig,
   AgenticEvalReport,
+  ApplyOutcome,
   BenchmarkEvent,
   BenchmarkRun,
   CompareConfig,
@@ -271,4 +272,24 @@ export async function startAgenticRun(
   }
 
   await consumeSseStream(response, onEvent);
+}
+
+/**
+ * POST /api/benchmark/tune/{runId}/apply — judge a completed tune run
+ * against the apply gate; only an `apply` verdict has written the model.
+ * Refusals come back as verdicts, never as HTTP errors.
+ */
+export async function applyTuneRun(runId: number): Promise<ApplyOutcome> {
+  const { baseUrl, headers } = await getAuthenticatedFetchConfig();
+  const response = await fetch(`${baseUrl}/api/benchmark/tune/${runId}/apply`, {
+    method: 'POST',
+    headers: headers as Record<string, string>,
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: string }).error ?? `apply failed: ${response.status}`,
+    );
+  }
+  return (await response.json()) as ApplyOutcome;
 }

--- a/src/types/benchmark.ts
+++ b/src/types/benchmark.ts
@@ -221,7 +221,9 @@ export interface TuneConfig {
 export type CandidateSource =
   | { kind: 'user_grid' }
   | { kind: 'gguf_author_default' }
-  | { kind: 'family_preset'; family: string };
+  | { kind: 'family_preset'; family: string }
+  | { kind: 'incumbent' }
+  | { kind: 'incumbent_calibration' };
 
 /** Result of evaluating one task against one candidate's sampling settings. */
 export interface TuneTaskResult {
@@ -470,6 +472,35 @@ export interface PairedEffect {
    * eight non-tied pairs — read wins against losses instead.
    */
   p_value: number | null;
+}
+
+/**
+ * The apply gate's decision on one completed tune run. Mirrors
+ * `gglib_core::domain::benchmark::tune::apply::ApplyVerdict`
+ * (`#[serde(tag = "verdict", rename_all = "snake_case")]`). Refusals are
+ * first-class outcomes carrying the evidence that was missing or contrary.
+ */
+export type ApplyVerdict =
+  | {
+      verdict: 'apply';
+      winner_composite: number;
+      incumbent_mean: number;
+      margin: number;
+      drift: number;
+      paired?: PairedEffect | null;
+    }
+  | { verdict: 'incumbent_stands'; incumbent_mean: number }
+  | { verdict: 'within_drift'; margin: number; drift: number }
+  | { verdict: 'paired_disagrees'; wins: number; losses: number }
+  | { verdict: 'uncalibrated' }
+  | { verdict: 'contaminated'; unmeasured_runs: number };
+
+/** Response of `POST /api/benchmark/tune/{run_id}/apply`. */
+export interface ApplyOutcome {
+  verdict: ApplyVerdict;
+  model_id: number;
+  /** Whether the model was actually written. */
+  applied: boolean;
 }
 
 // ─── API Response Shapes ─────────────────────────────────────────────────────


### PR DESCRIPTION
> **Stacked on #782** (→ #780 → #779). Base is `feat(benchmark)/eval-gates`; retarget as the stack merges.

Fourth PR of the closed-loop arc: the loop's write half, with a human still pressing the button. A tune run's winner can now become a model's `Measured` defaults — but only through a gate whose every rule is the codified form of a failure this repo has already measured.

## The problem this replaces

Both existing apply paths were ungated. The CLI's `--apply-best` and the GUI's "apply best config" checkbox wrote the top composite straight into the model's defaults — no drift check, no incumbent comparison, and without touching `defaults_origin` (leaving an auto-detected model's origin claiming a recipe that no longer matched it). That is precisely the noise-ratchet an auto-tuner becomes without a gate: it stores whichever candidate a lucky draw favoured and reports improvement while doing it.

## The in-run calibration pair

A tune run has no A/A arm, so the drift estimate is built into the candidate list: every run now carries the **incumbent** twice. The incumbent is an all-`None` overlay — it resolves through the normal chain, so it is *exactly what the model does today* — and the gap between the identical twins is the run's own noise, measured under the same tasks, server, and everything else. Both twins always run the full suite, exempt from pruning (a pruned twin leaves the run uncalibrated, and a pre-screen composite is not comparable with full-suite scores). Two extra candidates is the price of a run that can calibrate itself.

## The gate

`evaluate_apply` refuses with a first-class verdict naming its evidence — never an error:

| verdict | rule | the failure it codifies |
|---|---|---|
| `Apply` | margin ≥ `EFFECT_NOISE_RATIO` × the twins' gap, pairs agree | — |
| `IncumbentStands` | no candidate beat the current defaults | a successful run whose answer is "change nothing" |
| `WithinDrift` | margin inside the run's own noise | the +0.082 that did not replicate |
| `PairedDisagrees` | the winner's mean rests on a minority of per-task pairs | the lucky-outlier shape |
| `Uncalibrated` | no incumbent pair (any pre-existing run) | a comparison in which nothing could vary |
| `Contaminated` | unmeasured task runs in the compared candidates | the arm of 45 zeros that rendered as a score |

The direction check reuses PR 3's `PairedEffect` (new `from_paired_runs`, pairing two candidates' task lists by `task_id`) rather than reinventing paired comparison.

## The write, and its trail

An `Apply` verdict stores the winner's **sparse overlay** as `inference_defaults` (unswept dimensions stay `None` and keep resolving through the chain, exactly as they did during the run) with `defaults_origin = Measured` — below global, ceiling-exempt, per #780. The run row records an `ApplyRecord` (verdict numbers + the applied overlay) in a new nullable `applied_json` column — the metadata trail #780 deferred to the apply's own schema — written *after* the model, deliberately: a record naming an apply that never happened misleads, while an apply missing its record is recoverable from the model's origin alone.

## Surfaces

- **HTTP**: `POST /api/benchmark/tune/{run_id}/apply` → `ApplyOutcome` JSON. Always 200 for a verdict; errors are reserved for a missing run, a non-tune run, or storage failing.
- **CLI**: `--apply` (alias `--apply-best` kept for scripts) captures the run id from `RunComplete` and renders every verdict with its numbers.
- **GUI**: the "apply best" checkbox becomes the gated path with verdict messages; the incumbent rows are labelled on the leaderboard (`incumbent` / `incumbent (A/A)`). The **per-row apply deliberately stays ungated**: a person picking one exact candidate is a deliberate choice and writes as user-set defaults, the same as typing the values into `gglib model update` — the gate governs the automatic path, not the person. The distinction is documented on both handlers.

## Verification

- Full workspace `cargo test` green (1033 in `gglib-core`; 7 new gate tests covering every verdict, including a pruned candidate never winning). Clippy `-D warnings` clean, fmt clean, `check_boundaries.sh` passes.
- TS: 816 tests green, `tsc --noEmit` clean, eslint clean.
- Schema: one nullable `ALTER TABLE benchmark_runs ADD COLUMN applied_json` following the repo's ignore-if-exists migration pattern; `BenchmarkRun` deserializes legacy rows via serde default.

### Not verified here

A live gated apply end-to-end (needs a model): `gglib benchmark tune -m <model> --sweep temperature=0.7,1.0 --apply` should show the two incumbent rows in the run, then either an apply with margin-vs-drift numbers or a refusal with evidence, and `gglib model explain` should afterwards say `measured by a tune sweep` on an applied model.

## What this sets up

PR 5 puts this exact call on the daemon's idle-time schedule — the system-pressed button. Nothing about the gate changes there; that is the point of landing it here first.
