### PR TITLE
feat(daemon): idle-time auto-tune — the system-pressed button

### DIFF
--- a/crates/gglib-app-services/src/benchmark/README.md
+++ b/crates/gglib-app-services/src/benchmark/README.md
@@ -17,6 +17,9 @@ benchmark/
   perf.rs    — llama-bench process spawning + VRAM drain logic
   mapper.rs  — raw serde_json::Value → domain type transforms
   guard.rs   — BenchmarkTaskGuard (DropCancels pattern for HTTP layer)
+  auto_tune.rs — the idle-time scheduler: opt-in, warm-model-respecting,
+               preemptible gated tuning of untuned models (see its module
+               docs for the full rule set)
 ```
 
 # VRAM Contention Prevention

--- a/crates/gglib-app-services/src/benchmark/auto_tune.rs
+++ b/crates/gglib-app-services/src/benchmark/auto_tune.rs
@@ -50,13 +50,34 @@ use gglib_core::domain::{DefaultsOrigin, Model};
 
 use super::BenchmarkOps;
 
-/// How often the scheduler wakes to look at the world.
-const TICK: Duration = Duration::from_secs(60);
+/// How often the scheduler wakes to look at the world, in seconds.
+/// `GGLIB_AUTO_TUNE_TICK_SECS` overrides it — an operator knob, and what
+/// makes the end-to-end path testable in seconds rather than tens of
+/// minutes.
+const TICK_SECS: u64 = 60;
 
 /// Consecutive fully-idle ticks required before a run may start — 10 minutes
-/// at [`TICK`]. Long enough that a person pausing between requests is not
-/// mistaken for an empty evening.
+/// at the default tick. Long enough that a person pausing between requests
+/// is not mistaken for an empty evening. `GGLIB_AUTO_TUNE_IDLE_TICKS`
+/// overrides it.
 const IDLE_TICKS_REQUIRED: u32 = 10;
+
+/// The tick interval, after any environment override.
+fn tick_interval() -> Duration {
+    Duration::from_secs(env_override("GGLIB_AUTO_TUNE_TICK_SECS", TICK_SECS))
+}
+
+/// The idle-tick threshold, after any environment override.
+fn idle_ticks_required() -> u32 {
+    env_override("GGLIB_AUTO_TUNE_IDLE_TICKS", IDLE_TICKS_REQUIRED)
+}
+
+fn env_override<T: std::str::FromStr + Copy>(key: &str, default: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
 
 /// How often the preemption watcher checks the queue while a run is live.
 const PREEMPT_POLL: Duration = Duration::from_secs(2);
@@ -77,7 +98,7 @@ pub async fn run_loop(ops: Arc<BenchmarkOps>, shutdown: CancellationToken) {
     loop {
         tokio::select! {
             () = shutdown.cancelled() => return,
-            () = tokio::time::sleep(TICK) => {}
+            () = tokio::time::sleep(tick_interval()) => {}
         }
         match tick(&ops, &mut idle_ticks, &shutdown).await {
             Ok(()) => {}
@@ -109,18 +130,29 @@ async fn tick(
     // A run somebody started — through any surface — owns the GPU story.
     let runs = deps.bench_repo.list_runs(RUN_SCAN_LIMIT, 0).await?;
     if runs.iter().any(|r| r.status == BenchmarkRunStatus::Running) {
+        debug!("auto-tune: a benchmark run is live — standing down");
         *idle_ticks = 0;
         return Ok(());
     }
 
     let snapshot = deps.runtime.admission_snapshot();
     if snapshot.inflight() > 0 || snapshot.waiting() > 0 {
+        debug!(
+            inflight = snapshot.inflight(),
+            waiting = snapshot.waiting(),
+            "auto-tune: the GPU is busy — idle window reset"
+        );
         *idle_ticks = 0;
         return Ok(());
     }
 
     *idle_ticks += 1;
-    if *idle_ticks < IDLE_TICKS_REQUIRED {
+    let required = idle_ticks_required();
+    debug!(
+        idle_ticks = *idle_ticks,
+        required, "auto-tune: idle tick banked"
+    );
+    if *idle_ticks < required {
         return Ok(());
     }
 
@@ -139,7 +171,7 @@ async fn tick(
 
     info!(
         model_id = target,
-        "auto-tune: GPU idle for {IDLE_TICKS_REQUIRED} ticks — starting a gated tune"
+        "auto-tune: GPU idle past the threshold — starting a gated tune"
     );
     *idle_ticks = 0;
     run_one(ops, target, shutdown).await

--- a/crates/gglib-app-services/src/benchmark/auto_tune.rs
+++ b/crates/gglib-app-services/src/benchmark/auto_tune.rs
@@ -1,0 +1,396 @@
+//! The idle-time auto-tune scheduler: the closed loop's system-pressed
+//! button.
+//!
+//! Runs inside the daemon — the one process that owns llama-server — and
+//! does nothing unless `Settings.auto_tune` is deliberately on. When the GPU
+//! has been fully idle for a sustained window it picks one untuned model,
+//! runs the bounded presets-versus-incumbent tune, and applies the winner
+//! **only through the apply gate** (`tune::apply`). Every rule below exists
+//! to make the autonomy boring:
+//!
+//! - **Opt-in.** `auto_tune` defaults to off; the loop re-reads it every
+//!   tick, so switching it off takes effect within one tick and cancels
+//!   nothing that is not running.
+//! - **Idle means idle.** Zero in-flight requests *and* zero waiters,
+//!   sustained for [`IDLE_TICKS_REQUIRED`] consecutive ticks — a burst that
+//!   ends 9 minutes into the window resets it.
+//! - **A warm model is never evicted.** If the resident model is itself
+//!   untuned, it is tuned in place (no swap, no cache loss). If a *tuned*
+//!   model is resident, the scheduler stands down entirely: evicting a warm
+//!   model invalidates its KV cache and hands the next real request a cold
+//!   prefill, which is a price an idle-time nicety may not charge. Only a
+//!   fully cold GPU tunes from the catalog at large.
+//! - **A person's work is never the target.** User-set defaults are
+//!   excluded outright — the same principle that ranks `Measured` below
+//!   global settings — and measured models are excluded because re-checks
+//!   are a deliberately deferred decision (PR 6's signal triggers), not a
+//!   timer's.
+//! - **Any real request preempts.** While a run is in flight the scheduler
+//!   watches the admission queue; the moment anything is waiting, the run
+//!   is cancelled and the GPU handed over. The next attempt starts from a
+//!   fresh idle window.
+//! - **One attempt per model per [`RETUNE_INTERVAL`].** A refusal
+//!   (IncumbentStands, WithinDrift, …) is an answer, and answers do not
+//!   expire in an afternoon; without this the scheduler would re-ask every
+//!   idle window forever.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use gglib_core::domain::benchmark::run::{BenchmarkRun, BenchmarkRunStatus};
+use gglib_core::domain::benchmark::tune::config::{ScoreWeights, SweepSpec, TuneConfig};
+use gglib_core::domain::benchmark::tune::task::TaskSuite;
+use gglib_core::domain::benchmark::{BenchmarkEvent, BenchmarkRunType};
+use gglib_core::domain::{DefaultsOrigin, Model};
+
+use super::BenchmarkOps;
+
+/// How often the scheduler wakes to look at the world.
+const TICK: Duration = Duration::from_secs(60);
+
+/// Consecutive fully-idle ticks required before a run may start — 10 minutes
+/// at [`TICK`]. Long enough that a person pausing between requests is not
+/// mistaken for an empty evening.
+const IDLE_TICKS_REQUIRED: u32 = 10;
+
+/// How often the preemption watcher checks the queue while a run is live.
+const PREEMPT_POLL: Duration = Duration::from_secs(2);
+
+/// The least time between tune attempts on one model, however they ended.
+/// A refusal is an answer; the next question should wait for new evidence
+/// (a different build, new tasks) or PR 6's signal triggers.
+const RETUNE_INTERVAL: chrono::Duration = chrono::Duration::days(7);
+
+/// How many recent runs the target selector scans for the interval rule.
+/// Generous against the interval: even a daemon tuning one model per idle
+/// window cannot produce 200 tune runs in seven days.
+const RUN_SCAN_LIMIT: i64 = 200;
+
+/// Drive the scheduler until the daemon shuts down.
+pub async fn run_loop(ops: Arc<BenchmarkOps>, shutdown: CancellationToken) {
+    let mut idle_ticks: u32 = 0;
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => return,
+            () = tokio::time::sleep(TICK) => {}
+        }
+        match tick(&ops, &mut idle_ticks, &shutdown).await {
+            Ok(()) => {}
+            Err(e) => {
+                // The loop must survive anything a tick can throw — a failed
+                // settings read tonight must not cost the tuning the daemon
+                // would have done tomorrow.
+                warn!("auto-tune: tick failed: {e}");
+                idle_ticks = 0;
+            }
+        }
+    }
+}
+
+/// One observation of the world, and at most one run.
+async fn tick(
+    ops: &BenchmarkOps,
+    idle_ticks: &mut u32,
+    shutdown: &CancellationToken,
+) -> anyhow::Result<()> {
+    let deps = &ops.deps;
+
+    let settings = deps.settings_repo.load().await?;
+    if settings.auto_tune != Some(true) {
+        *idle_ticks = 0;
+        return Ok(());
+    }
+
+    // A run somebody started — through any surface — owns the GPU story.
+    let runs = deps.bench_repo.list_runs(RUN_SCAN_LIMIT, 0).await?;
+    if runs.iter().any(|r| r.status == BenchmarkRunStatus::Running) {
+        *idle_ticks = 0;
+        return Ok(());
+    }
+
+    let snapshot = deps.runtime.admission_snapshot();
+    if snapshot.inflight() > 0 || snapshot.waiting() > 0 {
+        *idle_ticks = 0;
+        return Ok(());
+    }
+
+    *idle_ticks += 1;
+    if *idle_ticks < IDLE_TICKS_REQUIRED {
+        return Ok(());
+    }
+
+    let models = deps.model_repo.list().await?;
+    let resident: Vec<i64> = snapshot
+        .slots
+        .iter()
+        .map(|s| i64::from(s.model_id))
+        .collect();
+    let Some(target) = select_target(&models, &runs, &resident, Utc::now()) else {
+        debug!("auto-tune: idle, but nothing eligible to tune");
+        // Idle stays banked: eligibility can change (a new model lands, the
+        // interval lapses) without the GPU having been touched in between.
+        return Ok(());
+    };
+
+    info!(
+        model_id = target,
+        "auto-tune: GPU idle for {IDLE_TICKS_REQUIRED} ticks — starting a gated tune"
+    );
+    *idle_ticks = 0;
+    run_one(ops, target, shutdown).await
+}
+
+/// Run one gated tune, preempting on any queue activity.
+async fn run_one(
+    ops: &BenchmarkOps,
+    model_id: i64,
+    shutdown: &CancellationToken,
+) -> anyhow::Result<()> {
+    let config = TuneConfig {
+        model_id,
+        task_suite: TaskSuite::Default,
+        // No swept dimensions: the run asks only whether the known candidate
+        // recipes — GGUF author defaults, family presets — beat the
+        // incumbent, judged by the calibration pair. Bounded, predictable,
+        // and exactly the question an unattended tuner is entitled to ask.
+        // Signal-driven dimension picks are PR 6's job.
+        sweep: SweepSpec::default(),
+        seed_from_gguf: true,
+        seed_from_family_presets: true,
+        weights: ScoreWeights::default(),
+        // Nothing is pruned: the candidate set is a handful, and only a
+        // full-suite candidate can win the gate.
+        prune_fraction: 0.0,
+        ctx_size: None,
+    };
+
+    let cancel = CancellationToken::new();
+    let (tx, mut rx) = mpsc::channel::<BenchmarkEvent>(256);
+
+    let run_handle = {
+        let ops = ops.clone_for_task();
+        let cancel = cancel.clone();
+        tokio::spawn(async move { ops.run_tune(config, tx, cancel).await })
+    };
+
+    // Consume events (capturing the run id) while watching for rivals. The
+    // watcher cancels rather than pauses: a half-yielded GPU serves nobody,
+    // and the next idle window restarts cleanly.
+    let mut completed_run: Option<i64> = None;
+    let mut preempted = false;
+    loop {
+        tokio::select! {
+            event = rx.recv() => match event {
+                Some(BenchmarkEvent::RunComplete { run_id }) => completed_run = Some(run_id),
+                Some(BenchmarkEvent::RunFailed { error }) => {
+                    info!("auto-tune: run failed: {error}");
+                }
+                Some(_) => {}
+                None => break,
+            },
+            () = tokio::time::sleep(PREEMPT_POLL) => {
+                if ops.deps.runtime.admission_snapshot().waiting() > 0 {
+                    info!("auto-tune: a request is waiting — preempting the run");
+                    preempted = true;
+                    cancel.cancel();
+                }
+            }
+            () = shutdown.cancelled() => {
+                cancel.cancel();
+            }
+        }
+    }
+    run_handle.await??;
+
+    if preempted {
+        return Ok(());
+    }
+    let Some(run_id) = completed_run else {
+        return Ok(());
+    };
+
+    let outcome = ops.apply_tune_run(run_id).await?;
+    info!(
+        run_id,
+        model_id = outcome.model_id,
+        applied = outcome.applied,
+        "auto-tune: {}",
+        summarize(&outcome.verdict)
+    );
+    Ok(())
+}
+
+/// One log line per verdict — the unattended twin of the CLI's rendering.
+fn summarize(verdict: &gglib_core::domain::benchmark::tune::apply::ApplyVerdict) -> String {
+    use gglib_core::domain::benchmark::tune::apply::ApplyVerdict as V;
+    match verdict {
+        V::Apply { margin, drift, .. } => {
+            format!("applied as measured defaults (margin {margin:+.3} against drift {drift:.3})")
+        }
+        V::IncumbentStands { incumbent_mean } => {
+            format!("incumbent stands at {incumbent_mean:.3} — nothing applied")
+        }
+        V::WithinDrift { margin, drift } => {
+            format!("not applied: margin {margin:+.3} inside drift {drift:.3}")
+        }
+        V::PairedDisagrees { wins, losses } => {
+            format!("not applied: pairs disagree ({wins}W-{losses}L)")
+        }
+        V::Uncalibrated => "not applied: run carried no calibration pair".to_owned(),
+        V::Contaminated { unmeasured_runs } => {
+            format!("not applied: {unmeasured_runs} run(s) never reached the model")
+        }
+    }
+}
+
+/// Choose the model an idle GPU should spend itself on, or `None`.
+///
+/// Pure, so the policy is testable without a daemon: eligibility (no
+/// measured or user-set defaults), the warm-model rule, the retune
+/// interval, and oldest-import-first ordering all live here.
+fn select_target(
+    models: &[Model],
+    runs: &[BenchmarkRun],
+    resident_ids: &[i64],
+    now: DateTime<Utc>,
+) -> Option<i64> {
+    let recently_tuned = |id: i64| {
+        runs.iter().any(|r| {
+            r.run_type == BenchmarkRunType::Tune
+                && r.model_ids.contains(&id)
+                && now.signed_duration_since(r.created_at) < RETUNE_INTERVAL
+        })
+    };
+    let untuned = |m: &&Model| {
+        !matches!(
+            m.defaults_origin,
+            Some(DefaultsOrigin::User | DefaultsOrigin::Measured)
+        ) && !recently_tuned(m.id)
+    };
+
+    // A resident model that needs tuning is tuned in place — no eviction.
+    if let Some(resident) = models
+        .iter()
+        .filter(|m| resident_ids.contains(&m.id))
+        .find(untuned)
+    {
+        return Some(resident.id);
+    }
+    // A resident model that does *not* need tuning is left warm: its KV
+    // cache is worth more than an idle-time nicety.
+    if !resident_ids.is_empty() {
+        return None;
+    }
+
+    models
+        .iter()
+        .filter(untuned)
+        .min_by_key(|m| m.added_at)
+        .map(|m| m.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(id: i64, origin: Option<DefaultsOrigin>, added_days_ago: i64) -> Model {
+        Model {
+            id,
+            name: format!("m{id}"),
+            model_key: format!("key{id}"),
+            file_path: std::path::PathBuf::from("/dev/null"),
+            param_count_b: 4.0,
+            architecture: None,
+            quantization: None,
+            context_length: None,
+            expert_count: None,
+            expert_used_count: None,
+            expert_shared_count: None,
+            metadata: std::collections::HashMap::new(),
+            added_at: Utc::now() - chrono::Duration::days(added_days_ago),
+            hf_repo_id: None,
+            hf_commit_sha: None,
+            hf_filename: None,
+            download_date: None,
+            last_update_check: None,
+            tags: Vec::new(),
+            capabilities: gglib_core::domain::ModelCapabilities::default(),
+            inference_defaults: None,
+            defaults_origin: origin,
+            server_defaults: None,
+            dialect_spec: None,
+            benchmark_summary: None,
+        }
+    }
+
+    fn tune_run(model_id: i64, days_ago: i64) -> BenchmarkRun {
+        BenchmarkRun {
+            id: 1,
+            run_type: BenchmarkRunType::Tune,
+            status: BenchmarkRunStatus::Complete,
+            model_ids: vec![model_id],
+            prompt_text: None,
+            system_prompt: None,
+            config_json: None,
+            applied_json: None,
+            error: None,
+            created_at: Utc::now() - chrono::Duration::days(days_ago),
+            completed_at: None,
+        }
+    }
+
+    #[test]
+    fn a_persons_work_and_a_measurement_are_never_targets() {
+        let models = vec![
+            model(1, Some(DefaultsOrigin::User), 10),
+            model(2, Some(DefaultsOrigin::Measured), 10),
+        ];
+        assert_eq!(select_target(&models, &[], &[], Utc::now()), None);
+    }
+
+    #[test]
+    fn the_oldest_untuned_model_goes_first_on_a_cold_gpu() {
+        let models = vec![
+            model(1, Some(DefaultsOrigin::AutoDetected), 3),
+            model(2, None, 30),
+            model(3, Some(DefaultsOrigin::Published), 10),
+        ];
+        assert_eq!(select_target(&models, &[], &[], Utc::now()), Some(2));
+    }
+
+    #[test]
+    fn a_resident_untuned_model_is_tuned_in_place() {
+        let models = vec![
+            model(1, Some(DefaultsOrigin::AutoDetected), 30),
+            model(2, Some(DefaultsOrigin::AutoDetected), 3),
+        ];
+        // Model 2 is warm; it wins despite being newer — no eviction.
+        assert_eq!(select_target(&models, &[], &[2], Utc::now()), Some(2));
+    }
+
+    #[test]
+    fn a_resident_tuned_model_stands_the_scheduler_down() {
+        let models = vec![
+            model(1, Some(DefaultsOrigin::AutoDetected), 30),
+            model(2, Some(DefaultsOrigin::Measured), 3),
+        ];
+        // Model 2 is warm and already measured: nothing runs, because
+        // tuning model 1 would evict a warm model's cache.
+        assert_eq!(select_target(&models, &[], &[2], Utc::now()), None);
+    }
+
+    #[test]
+    fn a_recent_tune_run_parks_the_model_for_the_interval() {
+        let models = vec![model(1, Some(DefaultsOrigin::AutoDetected), 30)];
+        let runs = vec![tune_run(1, 2)];
+        assert_eq!(select_target(&models, &runs, &[], Utc::now()), None);
+
+        let stale = vec![tune_run(1, 8)];
+        assert_eq!(select_target(&models, &stale, &[], Utc::now()), Some(1));
+    }
+}

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -14,6 +14,7 @@ use gglib_core::ports::{
 };
 
 mod agentic;
+pub mod auto_tune;
 mod compare;
 pub mod guard;
 pub mod mapper;
@@ -38,6 +39,7 @@ pub mod tune;
 ///     .timeout(Duration::from_secs(600))
 ///     .build()?;
 /// ```
+#[derive(Clone)]
 pub struct BenchmarkDeps {
     /// Model catalog for name and file-path lookups.
     pub model_repo: Arc<dyn ModelRepository>,
@@ -156,5 +158,14 @@ impl BenchmarkOps {
     /// `tune::apply_run`.
     pub async fn apply_tune_run(&self, run_id: i64) -> Result<tune::apply_run::ApplyOutcome> {
         tune::apply_run::apply_tune_run(&self.deps, run_id).await
+    }
+
+    /// A second handle for a spawned task. Every dependency is an `Arc` or a
+    /// cheaply-cloneable client, so this is reference-counting, not copying.
+    #[must_use]
+    pub fn clone_for_task(&self) -> Self {
+        Self {
+            deps: self.deps.clone(),
+        }
     }
 }

--- a/crates/gglib-app-services/src/settings.rs
+++ b/crates/gglib-app-services/src/settings.rs
@@ -282,6 +282,7 @@ mod tests {
             proxy_loop_detection: None,
             tool_call_repair: None,
             agentic_sampling: Some(false),
+            auto_tune: Some(true),
             proxy_autostart: None,
             close_to_tray: None,
             start_at_login: None,

--- a/crates/gglib-app-services/src/types.rs
+++ b/crates/gglib-app-services/src/types.rs
@@ -552,6 +552,8 @@ pub struct AppSettings {
     /// write-only until the GUI grew a toggle — a toggle that saves but
     /// cannot read back silently resets on every reopen.
     pub agentic_sampling: Option<bool>,
+    /// Idle-time auto-tune; opt-in, `None` means off (see `gglib_core::Settings`)
+    pub auto_tune: Option<bool>,
     // Always-on proxy, desktop app only (see `gglib_core::Settings`)
     pub proxy_autostart: Option<bool>,
     pub close_to_tray: Option<bool>,
@@ -581,6 +583,7 @@ impl From<gglib_core::Settings> for AppSettings {
             proxy_loop_detection: settings.proxy_loop_detection,
             tool_call_repair: settings.tool_call_repair,
             agentic_sampling: settings.agentic_sampling,
+            auto_tune: settings.auto_tune,
             proxy_autostart: settings.proxy_autostart,
             close_to_tray: settings.close_to_tray,
             start_at_login: settings.start_at_login,
@@ -650,6 +653,9 @@ pub struct UpdateSettingsRequest {
         with = "serde_with::rust::double_option"
     )]
     pub agentic_sampling: Option<Option<bool>>,
+    // Idle-time auto-tune; opt-in (see `gglib_core::Settings`)
+    #[serde(default, with = "serde_with::rust::double_option")]
+    pub auto_tune: Option<Option<bool>>,
     // Always-on proxy, desktop app only (see `gglib_core::Settings`)
     #[serde(default, with = "serde_with::rust::double_option")]
     pub proxy_autostart: Option<Option<bool>>,
@@ -682,6 +688,7 @@ impl From<UpdateSettingsRequest> for gglib_core::SettingsUpdate {
             proxy_loop_detection: request.proxy_loop_detection,
             tool_call_repair: request.tool_call_repair,
             agentic_sampling: request.agentic_sampling,
+            auto_tune: request.auto_tune,
             proxy_autostart: request.proxy_autostart,
             close_to_tray: request.close_to_tray,
             start_at_login: request.start_at_login,

--- a/crates/gglib-axum/src/daemon/mod.rs
+++ b/crates/gglib-axum/src/daemon/mod.rs
@@ -141,6 +141,16 @@ pub async fn run_daemon(opts: DaemonOptions) -> Result<()> {
         None => crate::routes::create_router(Arc::clone(&state), &opts.cors, access),
     };
 
+    // The idle-time auto-tune scheduler — inert until `Settings.auto_tune`
+    // is deliberately on, and stopped by the same token that stops the
+    // daemon. Spawned here because this is the one process that owns
+    // llama-server: a scheduler anywhere else would fight the daemon for
+    // the GPU it is trying to be polite about.
+    tokio::spawn(gglib_app_services::benchmark::auto_tune::run_loop(
+        Arc::clone(&state.benchmark),
+        shutdown_token.clone(),
+    ));
+
     let addr = format!("{}:{}", opts.host, DAEMON_PORT);
     let listener = tokio::net::TcpListener::bind(&addr)
         .await

--- a/crates/gglib-axum/src/routes.rs
+++ b/crates/gglib-axum/src/routes.rs
@@ -464,6 +464,9 @@ pub(crate) async fn health_check() -> Json<Value> {
         "service": "gglib-daemon",
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
+        // See `debug_switches::build_fingerprint`: version alone cannot tell
+        // two dev builds apart, and the probe warns on a mismatch.
+        "fingerprint": gglib_core::debug_switches::build_fingerprint(),
         // Which `GGLIB_DISABLE_*` switches this daemon actually has in effect.
         //
         // Reported because the daemon is the process that reads them, and a

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -257,6 +257,14 @@ pub enum SettingsCommand {
         /// auto-detected recipe or the floor). Anything you set stands.
         #[arg(long)]
         agentic_sampling: Option<bool>,
+        /// Let the daemon tune untuned models on its own during idle GPU
+        /// time. Off by default — autonomy on hardware is opt-in. When on,
+        /// a sustained-idle GPU triggers a bounded presets-versus-incumbent
+        /// tune of the oldest model without measured defaults (never one a
+        /// person configured); the winner applies only through the gate,
+        /// and any arriving request preempts the run
+        #[arg(long)]
+        auto_tune: Option<bool>,
         /// Start the OpenAI-compatible proxy as soon as the desktop app
         /// launches, instead of waiting for it to be switched on. Combined
         /// with --start-at-login and --close-to-tray this keeps the endpoint

--- a/crates/gglib-cli/src/daemon_client/mod.rs
+++ b/crates/gglib-cli/src/daemon_client/mod.rs
@@ -46,6 +46,7 @@ pub async fn probe(client: &reqwest::Client) -> DaemonProbe {
     match response.json::<serde_json::Value>().await {
         Ok(body) if body.get("service").and_then(|s| s.as_str()) == Some("gglib-daemon") => {
             warn_on_switch_mismatch(&body);
+            warn_on_build_mismatch(&body);
             DaemonProbe::Running
         }
         _ => DaemonProbe::ForeignServer,
@@ -78,6 +79,29 @@ fn warn_on_switch_mismatch(health: &serde_json::Value) {
     if let Some(message) = gglib_core::debug_switches::describe_mismatch(&here, &daemon) {
         eprintln!("  warning: {message}");
     }
+}
+
+/// Say so when the running daemon was built from different code than this
+/// CLI.
+///
+/// `CARGO_PKG_VERSION` cannot catch this: measured live, a CLI carrying new
+/// daemon routes used a same-version installed daemon and got an opaque 405.
+/// Printed rather than fatal, like the switch mismatch above — minor skew is
+/// routine in a dev tree — but it names the one action that resolves real
+/// skew, because "405 Method Not Allowed" never will. A daemon predating the
+/// fingerprint reports none, which is itself a mismatch worth naming.
+fn warn_on_build_mismatch(body: &serde_json::Value) {
+    let mine = gglib_core::debug_switches::build_fingerprint();
+    let theirs = body.get("fingerprint").and_then(|f| f.as_str());
+    if theirs == Some(mine) {
+        return;
+    }
+    eprintln!(
+        "  note: the running daemon is a different build ({}) than this CLI ({mine}) — \
+         if a command fails oddly, `gglib daemon stop` and re-run to respawn it from \
+         this binary",
+        theirs.unwrap_or("no fingerprint: an older build"),
+    );
 }
 
 /// A connected daemon: the shared HTTP client plus the base URL.

--- a/crates/gglib-cli/src/handlers/config/settings/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/settings/mod.rs
@@ -157,6 +157,7 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             trust_client_sampling,
             proxy_loop_detection,
             agentic_sampling,
+            auto_tune,
             proxy_autostart,
             close_to_tray,
             start_at_login,
@@ -205,6 +206,9 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             if agentic_sampling.is_some() {
                 changed.insert("agentic-sampling");
             }
+            if auto_tune.is_some() {
+                changed.insert("auto-tune");
+            }
             if proxy_autostart.is_some() {
                 changed.insert("proxy-autostart");
             }
@@ -241,6 +245,7 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
                 proxy_loop_detection: proxy_loop_detection.map(Some),
                 tool_call_repair: None,
                 agentic_sampling: agentic_sampling.map(Some),
+                auto_tune: auto_tune.map(Some),
                 proxy_autostart: proxy_autostart.map(Some),
                 close_to_tray: close_to_tray.map(Some),
                 start_at_login: start_at_login.map(Some),
@@ -290,6 +295,9 @@ pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Resu
             }
             if let Some(Some(v)) = update.agentic_sampling {
                 prospective.agentic_sampling = Some(v);
+            }
+            if let Some(Some(v)) = update.auto_tune {
+                prospective.auto_tune = Some(v);
             }
             if let Some(Some(v)) = update.proxy_autostart {
                 prospective.proxy_autostart = Some(v);

--- a/crates/gglib-core/build.rs
+++ b/crates/gglib-core/build.rs
@@ -36,5 +36,43 @@ fn main() {
     // Process README for rustdoc (uses shared build_common.rs)
     process_readme_for_rustdoc(&manifest_dir);
 
+    // Build fingerprint: the git commit this binary was built from, with a
+    // -dirty suffix for an unclean tree. Two binaries reporting the same
+    // CARGO_PKG_VERSION can still be different code — measured live: a CLI
+    // carrying new daemon routes silently used an installed daemon of the
+    // same version and got an opaque 405. The fingerprint is what lets the
+    // probe say "different build" instead. Falls back to "unknown" outside a
+    // git checkout (a release tarball), where version comparison is the best
+    // available and skew is far less likely than in a dev tree.
+    let fingerprint = git_fingerprint(&repo_root).unwrap_or_else(|| "unknown".to_owned());
+    println!("cargo:rustc-env=GGLIB_BUILD_FINGERPRINT={fingerprint}");
+    // HEAD moves on commit/checkout; index/packed-refs cover branch updates.
+    println!(
+        "cargo:rerun-if-changed={}/.git/HEAD",
+        repo_root.to_string_lossy()
+    );
+
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn git_fingerprint(repo_root: &Path) -> Option<String> {
+    let head = std::process::Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+    if !head.status.success() {
+        return None;
+    }
+    let hash = String::from_utf8_lossy(&head.stdout).trim().to_owned();
+    if hash.is_empty() {
+        return None;
+    }
+    let dirty = std::process::Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .current_dir(repo_root)
+        .output()
+        .ok()
+        .is_some_and(|out| out.status.success() && !out.stdout.is_empty());
+    Some(if dirty { format!("{hash}-dirty") } else { hash })
 }

--- a/crates/gglib-core/src/debug_switches.rs
+++ b/crates/gglib-core/src/debug_switches.rs
@@ -123,6 +123,19 @@ pub fn describe_mismatch(here: &[&str], daemon: &[String]) -> Option<String> {
     Some(out)
 }
 
+/// The git commit this binary was built from (`-dirty` when the tree was
+/// unclean), or `"unknown"` outside a git checkout.
+///
+/// Exists because `CARGO_PKG_VERSION` cannot tell two dev builds apart:
+/// a CLI carrying new daemon routes once silently used a same-version
+/// installed daemon and got an opaque 405 where "the daemon is a different
+/// build — restart it" was the real story. The daemon reports this from
+/// `/health`; the probe compares it against its own.
+#[must_use]
+pub const fn build_fingerprint() -> &'static str {
+    env!("GGLIB_BUILD_FINGERPRINT")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gglib-core/src/settings.rs
+++ b/crates/gglib-core/src/settings.rs
@@ -193,6 +193,27 @@ pub struct Settings {
     #[serde(alias = "tool_call_floor")]
     pub agentic_sampling: Option<bool>,
 
+    // ── Idle-time auto-tune ─────────────────────────────────────────
+    /// Whether the daemon tunes untuned models on its own during idle GPU
+    /// time.
+    ///
+    /// **Opt-in — `None` means off**, the opposite polarity of the guards
+    /// above, deliberately: those protect the endpoint by default, while
+    /// this one *spends the GPU* on the daemon's initiative, and autonomy
+    /// on hardware is a thing an operator turns on, never a thing that
+    /// happens to them.
+    ///
+    /// When on, the daemon watches the admission queue; after the GPU has
+    /// been fully idle for a sustained window it picks the oldest model
+    /// that has no measured defaults yet — never one whose defaults a
+    /// person set — runs the bounded presets-versus-incumbent tune, and
+    /// applies the winner only through the apply gate
+    /// (`benchmark::tune::apply`). Any request arriving mid-run preempts
+    /// it: the run is cancelled and the GPU handed over. Every applied
+    /// change is recorded on the run row and reversible per model with
+    /// `gglib model update` or the GUI.
+    pub auto_tune: Option<bool>,
+
     // ── Always-on proxy (desktop app) ───────────────────────────────
     /// Whether the desktop app starts the OpenAI-compatible proxy as soon as
     /// it launches, rather than waiting for the user to switch it on.
@@ -241,6 +262,7 @@ impl Settings {
             #[allow(clippy::cast_possible_truncation)]
             max_stagnation_steps: Some(crate::domain::agent::DEFAULT_MAX_STAGNATION_STEPS as u32),
             agentic_sampling: None,
+            auto_tune: None,
             default_model_id: None,
             inference_defaults: None,
             inference_profiles: None,
@@ -338,6 +360,9 @@ impl Settings {
         if let Some(ref v) = other.agentic_sampling {
             self.agentic_sampling = *v;
         }
+        if let Some(ref v) = other.auto_tune {
+            self.auto_tune = *v;
+        }
         if let Some(ref v) = other.proxy_autostart {
             self.proxy_autostart = *v;
         }
@@ -379,6 +404,8 @@ pub struct SettingsUpdate {
     pub tool_call_repair: Option<Option<bool>>,
     /// See [`Settings::agentic_sampling`].
     pub agentic_sampling: Option<Option<bool>>,
+    /// See [`Settings::auto_tune`].
+    pub auto_tune: Option<Option<bool>>,
     pub proxy_autostart: Option<Option<bool>>,
     pub close_to_tray: Option<Option<bool>>,
     pub start_at_login: Option<Option<bool>>,

--- a/src/components/SettingsModal/fields/AdvancedSettings.tsx
+++ b/src/components/SettingsModal/fields/AdvancedSettings.tsx
@@ -157,6 +157,20 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
           value nobody deliberately chose. Anything set by a person stands.
         </ToggleField>
 
+        <ToggleField
+          id="auto-tune-input"
+          label="Idle-time auto-tune"
+          checked={agentGuards.autoTune}
+          onChange={(value) => setAgentGuardSetting('autoTune', value)}
+          disabled={saving}
+        >
+          Off by default — this one spends the GPU. When on, a sustained-idle GPU
+          triggers a bounded tune of the oldest model without measured defaults
+          (never one you configured yourself, and never by evicting a warm model);
+          the winner applies only through the drift gate, and any arriving request
+          preempts the run.
+        </ToggleField>
+
         <NumberSettingField
           id="max-stagnation-steps-input"
           label="Max Stagnation Steps"

--- a/src/components/SettingsModal/useAgentGuardSettings.ts
+++ b/src/components/SettingsModal/useAgentGuardSettings.ts
@@ -13,12 +13,15 @@ import type { AppSettings, UpdateSettingsRequest } from '../../types';
 export interface AgentGuardSettingsValues {
   /** Inverse polarity on the wire: unset means enabled. */
   agenticSampling: boolean;
+  autoTune: boolean;
   /** Raw input string; blank = server default. */
   maxStagnationSteps: string;
 }
 
 const DEFAULTS: AgentGuardSettingsValues = {
   agenticSampling: true,
+  // Opt-in, unlike its siblings: this one spends the GPU.
+  autoTune: false,
   maxStagnationSteps: '',
 };
 
@@ -30,7 +33,7 @@ export interface UseAgentGuardSettingsResult {
     key: K,
     value: AgentGuardSettingsValues[K],
   ) => void;
-  updates: Pick<UpdateSettingsRequest, 'agenticSampling' | 'maxStagnationSteps'>;
+  updates: Pick<UpdateSettingsRequest, 'agenticSampling' | 'autoTune' | 'maxStagnationSteps'>;
 }
 
 /** Track the agent-guard fields, seeded from persisted settings. */
@@ -42,6 +45,9 @@ export function useAgentGuardSettings(settings: AppSettings | null): UseAgentGua
       setValues({
         // Unset means enabled, like proxyLoopDetection.
         agenticSampling: settings.agenticSampling !== false,
+        // Inverse polarity of the line above: autoTune is opt-in, so only an
+        // explicit true switches it on.
+        autoTune: settings.autoTune === true,
         maxStagnationSteps: settings.maxStagnationSteps?.toString() ?? '',
       });
     }
@@ -64,6 +70,7 @@ export function useAgentGuardSettings(settings: AppSettings | null): UseAgentGua
     reset,
     updates: {
       agenticSampling: values.agenticSampling,
+      autoTune: values.autoTune,
       maxStagnationSteps: Number.isFinite(parsed) ? parsed : null,
     },
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -449,6 +449,14 @@ export interface AppSettings {
    * human chose one. Unset/true = active; anything set by a person stands.
    */
   agenticSampling?: boolean | null;
+  /**
+   * Idle-time auto-tune. Opt-in — unset/false = off: the daemon spends the
+   * GPU on its own initiative only when this is deliberately on. When on,
+   * a sustained-idle GPU triggers a bounded tune of the oldest model
+   * without measured defaults, applied only through the gate; any arriving
+   * request preempts the run.
+   */
+  autoTune?: boolean | null;
 }
 
 export interface UpdateSettingsRequest {
@@ -493,6 +501,8 @@ export interface UpdateSettingsRequest {
   shareLan?: boolean | null | undefined;
   /** See `AppSettings.agenticSampling`. */
   agenticSampling?: boolean | null | undefined;
+  /** See `AppSettings.autoTune`. */
+  autoTune?: boolean | null | undefined;
 }
 
 // ============================================================================


### PR DESCRIPTION
> **Stacked on #783** (→ #782 → #780 → #779). Base is `feat(benchmark)/tune-apply`; retarget as the stack merges.

Fifth PR of the closed-loop arc: the system-pressed button. The daemon now tunes untuned models on its own during idle GPU time — through exactly the gate #783 proved live, under rules designed to make the autonomy boring. Shaped by the project decisions of 2026-08-12 (opt-in; untuned-models-oldest-first; gated auto-apply, no per-apply confirm) and by two findings only the live hardware runs could have produced.

## The rules

- **Opt-in.** `Settings.auto_tune` defaults to off — the opposite polarity of the endpoint guards beside it, deliberately: those protect the endpoint by default, while this one *spends the GPU* on the daemon's initiative. The loop re-reads the setting every tick.
- **Idle means idle.** Zero in-flight requests and zero waiters, sustained ten consecutive one-minute ticks. Any activity — including a benchmark run somebody started through any surface — resets the window.
- **A warm model is never evicted.** A resident untuned model is tuned in place (no swap, no KV-cache loss). A resident *tuned* model stands the scheduler down entirely: handing the next real request a cold prefill is a price an idle-time nicety may not charge. Only a fully cold GPU tunes from the catalog at large, oldest import first.
- **A person's work is never the target.** User-set defaults are excluded by the same principle that ranks `Measured` below global settings. Measured models are excluded too — re-checks are PR 6's deliberate signal-driven decision, not a timer's.
- **Any real request preempts.** While a run is live the scheduler polls the admission queue every 2s; the moment anything waits, the run is cancelled and the GPU handed over.
- **One attempt per model per seven days**, however the last attempt ended. A refusal (`IncumbentStands`, `WithinDrift`, …) is an answer, and answers do not expire in an afternoon.

The run itself is the bounded presets-versus-incumbent question: no swept dimensions, nothing pruned, judged by the seeded calibration pair and applied only through the gate, verdict logged in the CLI's own terms. Signal-driven dimension selection is PR 6.

## The two live-learned foundations, landed first

1. **The build fingerprint.** During the stack's hardware verification, a CLI carrying the new apply route silently used a same-version installed daemon and got an opaque 405 — and the run executed in the wrong build against the wrong database. gglib-core's build script now stamps the git commit (with `-dirty`); the daemon reports it from `/health` and the probe prints the one action that resolves real skew. First in this PR because the scheduler puts tune runs inside the daemon on a timer — version skew between the binary that schedules and the binary that judges would be exactly that incident, unattended.
2. **Seeded calibration** (landed on #783): the twins must sample real decode variance or the drift gate degenerates. The scheduler leans on that gate; it had to be real first.

## Surfaces

- `Settings.auto_tune` through `SettingsUpdate`, the wire DTOs, `gglib config settings set --auto-tune`, and the GUI Advanced Settings toggle beside its sibling guards (with the inverse-polarity read — only an explicit `true` enables — called out where it differs from them).
- The scheduler: `benchmark::auto_tune`, spawned by `run_daemon`, stopped by the daemon's own shutdown token.
- Target selection is a pure function with five tests: the eviction rule in both directions, the person/measurement exclusions, the seven-day interval, and oldest-first ordering.

## Verification

- Full workspace `cargo test` green; clippy `-D warnings` clean; fmt clean; 816 TS tests green, `tsc` and eslint clean.
- Fingerprint verified live: `/health` reports `09148c625c82-dirty` from the branch build.
- **Live unattended run — the loop closed with nobody pressing anything.** The daemon, left idle with `auto_tune` on (fast-tick overrides for the test), banked its idle window, refused twice for the right reason — the target was parked by the seven-day retune interval, first by the session's own runs and then by the ceiling-experiment runs in the test DB — and once an eligible target existed: chose it, launched llama-server, executed run #40 through the seeded calibration pair, and logged the gate's verdict in the CLI's own terms:

  ```
  auto-tune: GPU idle past the threshold — starting a gated tune model_id=1
  auto-tune: incumbent stands at 0.664 — nothing applied run_id=40 applied=false
  ```

  An honest refusal as the first unattended act: the model's auto-detected recipe beat every preset candidate, and the scheduler declined to churn — consistent with the manual seeded run (#39, `PairedDisagrees`) and with the ceiling experiment's own finding that this model's recipe is genuinely good. The apparently-stuck forty minutes before the observability fix were the interval policy being right invisibly, which is why every guard now says why it stood down.

## What this deliberately does not do

No stale re-checks (a measured model is never revisited by the timer), no swept dimensions, no signal-driven triggers — all PR 6, where the Tier C counters pick both the model and the dimension. The scheduler here is the smallest autonomy the gate can safely carry.
