### PR TITLE
feat(proxy,benchmark): signal-driven sweeps — the counters pick the model and the dimension

### DIFF
--- a/crates/gglib-app-services/src/benchmark/auto_tune.rs
+++ b/crates/gglib-app-services/src/benchmark/auto_tune.rs
@@ -46,6 +46,7 @@ use gglib_core::domain::benchmark::run::{BenchmarkRun, BenchmarkRunStatus};
 use gglib_core::domain::benchmark::tune::config::{ScoreWeights, SweepSpec, TuneConfig};
 use gglib_core::domain::benchmark::tune::task::TaskSuite;
 use gglib_core::domain::benchmark::{BenchmarkEvent, BenchmarkRunType};
+use gglib_core::domain::defects::{self, ModelDefectCounts};
 use gglib_core::domain::{DefaultsOrigin, Model};
 
 use super::BenchmarkOps;
@@ -87,6 +88,21 @@ const PREEMPT_POLL: Duration = Duration::from_secs(2);
 /// (a different build, new tasks) or PR 6's signal triggers.
 const RETUNE_INTERVAL: chrono::Duration = chrono::Duration::days(7);
 
+/// The fewest windowed requests before a defect rate means anything.
+///
+/// A rate over a handful of requests is a coin flip wearing a percentage;
+/// fifty is enough that a 5% threshold needs three real events, not one
+/// unlucky turn.
+const MIN_SIGNAL_SAMPLE: u64 = 50;
+
+/// The loop-guard trip rate that earns a model a signal-driven DRY sweep.
+///
+/// The ceiling experiment measured healthy traffic tripping at roughly 2%
+/// per task under deliberately hot sampling; a sustained 5% of *production*
+/// requests is qualitatively different traffic, and DRY is the dimension
+/// built for exactly that failure shape.
+const LOOP_TRIP_RATE_THRESHOLD: f64 = 0.05;
+
 /// How many recent runs the target selector scans for the interval rule.
 /// Generous against the interval: even a daemon tuning one model per idle
 /// window cannot produce 200 tune runs in seven days.
@@ -95,12 +111,17 @@ const RUN_SCAN_LIMIT: i64 = 200;
 /// Drive the scheduler until the daemon shuts down.
 pub async fn run_loop(ops: Arc<BenchmarkOps>, shutdown: CancellationToken) {
     let mut idle_ticks: u32 = 0;
+    // Per-model baselines for the defect windows. The scheduler rates the
+    // delta since its own last look, so acting on a signal advances the
+    // baseline and the same events can never fire twice.
+    let mut baselines: std::collections::HashMap<String, ModelDefectCounts> =
+        std::collections::HashMap::new();
     loop {
         tokio::select! {
             () = shutdown.cancelled() => return,
             () = tokio::time::sleep(tick_interval()) => {}
         }
-        match tick(&ops, &mut idle_ticks, &shutdown).await {
+        match tick(&ops, &mut idle_ticks, &mut baselines, &shutdown).await {
             Ok(()) => {}
             Err(e) => {
                 // The loop must survive anything a tick can throw — a failed
@@ -117,6 +138,7 @@ pub async fn run_loop(ops: Arc<BenchmarkOps>, shutdown: CancellationToken) {
 async fn tick(
     ops: &BenchmarkOps,
     idle_ticks: &mut u32,
+    baselines: &mut std::collections::HashMap<String, ModelDefectCounts>,
     shutdown: &CancellationToken,
 ) -> anyhow::Result<()> {
     let deps = &ops.deps;
@@ -162,6 +184,28 @@ async fn tick(
         .iter()
         .map(|s| i64::from(s.model_id))
         .collect();
+
+    // Signals outrank the untuned queue: a model demonstrably failing in
+    // production is a sharper reason to spend the GPU than one that has
+    // simply never been measured.
+    let ledger = deps.defects.snapshot();
+    let windows = windowed(&ledger, baselines);
+    if let Some((target, signal)) = select_signal_target(&models, &windows, &resident) {
+        info!(
+            model_id = target.id,
+            model = %target.name,
+            signal = %signal,
+            "auto-tune: a production defect rate crossed its threshold — starting a targeted sweep"
+        );
+        // Advance the baseline before running, so the events that earned
+        // this sweep can never earn a second one.
+        let current = ledger.get(&target.name).copied().unwrap_or_default();
+        baselines.insert(target.name.clone(), current);
+        let id = target.id;
+        *idle_ticks = 0;
+        return run_one(ops, id, signal.sweep(), shutdown).await;
+    }
+
     let Some(target) = select_target(&models, &runs, &resident, Utc::now()) else {
         debug!("auto-tune: idle, but nothing eligible to tune");
         // Idle stays banked: eligibility can change (a new model lands, the
@@ -174,24 +218,38 @@ async fn tick(
         "auto-tune: GPU idle past the threshold — starting a gated tune"
     );
     *idle_ticks = 0;
-    run_one(ops, target, shutdown).await
+    run_one(ops, target, SweepSpec::default(), shutdown).await
+}
+
+/// The counts accumulated since the scheduler's last acted-on baseline.
+fn windowed(
+    current: &std::collections::HashMap<String, ModelDefectCounts>,
+    baselines: &std::collections::HashMap<String, ModelDefectCounts>,
+) -> std::collections::HashMap<String, ModelDefectCounts> {
+    current
+        .iter()
+        .map(|(name, counts)| {
+            let baseline = baselines.get(name).copied().unwrap_or_default();
+            (name.clone(), defects::delta(*counts, baseline))
+        })
+        .collect()
 }
 
 /// Run one gated tune, preempting on any queue activity.
 async fn run_one(
     ops: &BenchmarkOps,
     model_id: i64,
+    sweep: SweepSpec,
     shutdown: &CancellationToken,
 ) -> anyhow::Result<()> {
     let config = TuneConfig {
         model_id,
         task_suite: TaskSuite::Default,
-        // No swept dimensions: the run asks only whether the known candidate
-        // recipes — GGUF author defaults, family presets — beat the
-        // incumbent, judged by the calibration pair. Bounded, predictable,
-        // and exactly the question an unattended tuner is entitled to ask.
-        // Signal-driven dimension picks are PR 6's job.
-        sweep: SweepSpec::default(),
+        // The untuned path sweeps nothing — it asks only whether the known
+        // candidate recipes beat the incumbent. A signal-driven run sweeps
+        // the one dimension its signal names, and nothing else: the sweep
+        // is the treatment for a diagnosed failure shape, not a search.
+        sweep,
         seed_from_gguf: true,
         seed_from_family_presets: true,
         weights: ScoreWeights::default(),
@@ -278,6 +336,83 @@ fn summarize(verdict: &gglib_core::domain::benchmark::tune::apply::ApplyVerdict)
             format!("not applied: {unmeasured_runs} run(s) never reached the model")
         }
     }
+}
+
+/// A production failure shape the counters can diagnose, and the one
+/// dimension that treats it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalKind {
+    /// The loop/stagnation guard is rejecting this model's traffic —
+    /// verbatim-sequence repetition, which is the failure DRY exists for.
+    LoopGuard,
+}
+
+impl SignalKind {
+    /// The sweep this signal prescribes. One dimension, off included, so
+    /// the run compares disabled against two strengths and the gate can
+    /// still say "change nothing".
+    #[must_use]
+    pub fn sweep(self) -> SweepSpec {
+        match self {
+            Self::LoopGuard => SweepSpec {
+                dry_multiplier: vec![0.0, 0.4, 0.8],
+                ..SweepSpec::default()
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for SignalKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LoopGuard => write!(f, "loop-guard trip rate"),
+        }
+    }
+}
+
+/// The model whose production defect rate has earned a targeted sweep, with
+/// the signal that earned it.
+///
+/// Signals deliberately bypass two of the untuned path's rules and honour
+/// the others. Bypassed: the untuned-only filter (a measured model failing
+/// in production is *exactly* the re-check case) and the retune interval (a
+/// defect rate is new evidence, not the old question re-asked — and the
+/// baseline advance makes one burst of events good for at most one sweep).
+/// Honoured: a person's defaults are still never touched, and the
+/// warm-model rule still applies — though in practice a model with traffic
+/// enough to signal *is* the resident one, and is tuned in place.
+fn select_signal_target<'m>(
+    models: &'m [Model],
+    windows: &std::collections::HashMap<String, ModelDefectCounts>,
+    resident_ids: &[i64],
+) -> Option<(&'m Model, SignalKind)> {
+    let mut candidates: Vec<(&Model, SignalKind, f64)> = Vec::new();
+    for model in models {
+        if matches!(model.defaults_origin, Some(DefaultsOrigin::User)) {
+            continue;
+        }
+        // The warm-model rule, unchanged: never evict, tune in place.
+        if !resident_ids.is_empty() && !resident_ids.contains(&model.id) {
+            continue;
+        }
+        let Some(window) = windows.get(&model.name) else {
+            continue;
+        };
+        if window.requests < MIN_SIGNAL_SAMPLE {
+            continue;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let trip_rate = window.loop_guard_trips as f64 / window.requests as f64;
+        if trip_rate >= LOOP_TRIP_RATE_THRESHOLD {
+            candidates.push((model, SignalKind::LoopGuard, trip_rate));
+        }
+    }
+    // The worst rate first: one sweep per idle window, spent where the
+    // evidence is loudest.
+    candidates
+        .into_iter()
+        .max_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(model, signal, _)| (model, signal))
 }
 
 /// Choose the model an idle GPU should spend itself on, or `None`.
@@ -374,6 +509,88 @@ mod tests {
             created_at: Utc::now() - chrono::Duration::days(days_ago),
             completed_at: None,
         }
+    }
+
+    fn window(requests: u64, trips: u64) -> ModelDefectCounts {
+        ModelDefectCounts {
+            requests,
+            loop_guard_trips: trips,
+            ..ModelDefectCounts::default()
+        }
+    }
+
+    fn windows_for(
+        entries: &[(&str, ModelDefectCounts)],
+    ) -> std::collections::HashMap<String, ModelDefectCounts> {
+        entries
+            .iter()
+            .map(|(name, counts)| ((*name).to_owned(), *counts))
+            .collect()
+    }
+
+    /// The headline signal: a sustained trip rate over enough traffic earns
+    /// the sweep — and a measured model is eligible, because production
+    /// failure is exactly the re-check case.
+    #[test]
+    fn a_loud_loop_rate_earns_a_measured_model_a_dry_sweep() {
+        let models = vec![model(1, Some(DefaultsOrigin::Measured), 10)];
+        // model() names them m{id}; 100 requests, 8 trips = 8%.
+        let windows = windows_for(&[("m1", window(100, 8))]);
+        let (target, signal) = select_signal_target(&models, &windows, &[]).expect("signal fires");
+        assert_eq!(target.id, 1);
+        assert_eq!(signal, SignalKind::LoopGuard);
+        assert_eq!(signal.sweep().dry_multiplier, vec![0.0, 0.4, 0.8]);
+    }
+
+    /// A rate over a handful of requests is a coin flip wearing a
+    /// percentage: below the sample floor nothing fires, however loud.
+    #[test]
+    fn a_thin_sample_never_signals() {
+        let models = vec![model(1, Some(DefaultsOrigin::AutoDetected), 10)];
+        let windows = windows_for(&[("m1", window(10, 5))]); // 50%!
+        assert!(select_signal_target(&models, &windows, &[]).is_none());
+    }
+
+    /// Below the rate threshold, healthy-ish traffic is left alone.
+    #[test]
+    fn a_quiet_rate_never_signals() {
+        let models = vec![model(1, Some(DefaultsOrigin::AutoDetected), 10)];
+        let windows = windows_for(&[("m1", window(200, 4))]); // 2%
+        assert!(select_signal_target(&models, &windows, &[]).is_none());
+    }
+
+    /// The two rules signals do NOT bypass: a person's defaults, and the
+    /// warm model.
+    #[test]
+    fn signals_honour_the_person_and_the_warm_model() {
+        let user = vec![model(1, Some(DefaultsOrigin::User), 10)];
+        let windows = windows_for(&[("m1", window(100, 20))]);
+        assert!(select_signal_target(&user, &windows, &[]).is_none());
+
+        // Model 1 signals, but model 2 is resident: no eviction, no run.
+        let models = vec![
+            model(1, Some(DefaultsOrigin::AutoDetected), 10),
+            model(2, Some(DefaultsOrigin::Measured), 5),
+        ];
+        assert!(select_signal_target(&models, &windows, &[2]).is_none());
+        // The signalling model resident itself: tuned in place.
+        let hit = select_signal_target(&models, &windows, &[1]);
+        assert_eq!(hit.map(|(m, _)| m.id), Some(1));
+    }
+
+    /// One sweep per window, spent where the evidence is loudest.
+    #[test]
+    fn the_worst_rate_wins_the_window() {
+        let models = vec![
+            model(1, Some(DefaultsOrigin::AutoDetected), 10),
+            model(2, Some(DefaultsOrigin::AutoDetected), 5),
+        ];
+        let windows = windows_for(&[
+            ("m1", window(100, 6)),  // 6%
+            ("m2", window(100, 12)), // 12%
+        ]);
+        let hit = select_signal_target(&models, &windows, &[]);
+        assert_eq!(hit.map(|(m, _)| m.id), Some(2));
     }
 
     #[test]

--- a/crates/gglib-app-services/src/benchmark/mod.rs
+++ b/crates/gglib-app-services/src/benchmark/mod.rs
@@ -56,6 +56,10 @@ pub struct BenchmarkDeps {
     /// `inference_defaults` at the start of each compare run — mirrors the
     /// same per-request settings read the proxy performs.
     pub settings_repo: Arc<dyn SettingsRepository>,
+    /// Per-model defect counters, shared with the proxy supervisor that
+    /// writes them. The auto-tune scheduler windows these to decide whether
+    /// a model has earned a signal-driven sweep.
+    pub defects: Arc<gglib_core::domain::defects::ModelDefectLedger>,
 }
 
 impl BenchmarkDeps {

--- a/crates/gglib-app-services/src/benchmark/tune/apply_run.rs
+++ b/crates/gglib-app-services/src/benchmark/tune/apply_run.rs
@@ -78,6 +78,8 @@ pub async fn apply_tune_run(deps: &BenchmarkDeps, run_id: i64) -> Result<ApplyOu
         .get_by_id(model_id)
         .await
         .with_context(|| format!("model {model_id} not found"))?;
+    let prior_defaults = model.inference_defaults.clone();
+    let prior_origin = model.defaults_origin;
     model.inference_defaults = Some(winner.config.clone());
     model.defaults_origin = Some(DefaultsOrigin::Measured);
     deps.model_repo
@@ -91,6 +93,8 @@ pub async fn apply_tune_run(deps: &BenchmarkDeps, run_id: i64) -> Result<ApplyOu
     let record = ApplyRecord {
         verdict: verdict.clone(),
         applied_config: winner.config.clone(),
+        prior_defaults: Some(prior_defaults),
+        prior_origin: Some(prior_origin),
     };
     if let Ok(json) = serde_json::to_string(&record) {
         deps.bench_repo.mark_run_applied(run_id, &json).await.ok();

--- a/crates/gglib-app-services/src/service_graph.rs
+++ b/crates/gglib-app-services/src/service_graph.rs
@@ -235,6 +235,8 @@ pub async fn build_service_graph(params: ServiceGraphParams) -> anyhow::Result<A
         bench_repo,
         http_client: BenchmarkDeps::build_http_client()?,
         settings_repo: repos.settings.clone(),
+        // The same ledger the proxy writes: one Arc, two ends of the loop.
+        defects: proxy_supervisor.defects(),
     }));
 
     let setup = Arc::new(SetupOps::new(SetupDeps {

--- a/crates/gglib-core/src/domain/benchmark/tune/apply.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/apply.rs
@@ -212,6 +212,18 @@ pub struct ApplyRecord {
     pub verdict: ApplyVerdict,
     /// The applied sampling overlay, exactly as stored on the model.
     pub applied_config: crate::domain::InferenceConfig,
+    /// The defaults the apply displaced, exactly as they were stored.
+    ///
+    /// What makes an apply reversible without archaeology: a signal-driven
+    /// sweep that made things worse can be undone from the run row alone.
+    /// `None` on records written before the field existed, and a real
+    /// `Some(None)`-shaped absence is representable — a model that had no
+    /// stored defaults restores to having none.
+    #[serde(default)]
+    pub prior_defaults: Option<Option<crate::domain::InferenceConfig>>,
+    /// The origin the displaced defaults carried.
+    #[serde(default)]
+    pub prior_origin: Option<Option<crate::domain::DefaultsOrigin>>,
 }
 
 #[cfg(test)]

--- a/crates/gglib-core/src/domain/defects.rs
+++ b/crates/gglib-core/src/domain/defects.rs
@@ -1,0 +1,152 @@
+//! Per-model defect counters — the Tier C signals the closed loop steers by.
+//!
+//! The proxy records defect *events* (a loop-guard trip, a tool-call repair)
+//! as they happen; the auto-tune scheduler reads *rates* over the traffic
+//! since its last look and decides whether a model has earned a targeted
+//! sweep. Writers never interpret and the reader never guesses: a trip is a
+//! fact about one request, a rate is a claim about a model, and the split
+//! keeps both honest.
+//!
+//! Counters are cumulative and process-lifetime (they live on the proxy
+//! supervisor, like the agent cache metrics, so a proxy restart does not
+//! zero them). Windowing is the *reader's* job: the scheduler keeps its own
+//! per-model baselines and rates the delta, so two readers can window
+//! differently without fighting over a reset button.
+//!
+//! Deliberately not persisted: a defect rate is a claim about recent traffic
+//! on this build of everything, and yesterday's rate answering today's
+//! question is exactly the staleness ADR 0001 warns about. The loop reacts
+//! to what is happening, not to what once happened.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Cumulative defect counts for one model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ModelDefectCounts {
+    /// Requests the proxy forwarded (or would have, but for a guard) for
+    /// this model — every rate's denominator.
+    pub requests: u64,
+    /// Requests the loop/stagnation guard rejected before dispatch.
+    pub loop_guard_trips: u64,
+    /// Turns whose tool call failed schema validation and was re-issued
+    /// with `tool_choice: "required"`.
+    pub repairs_attempted: u64,
+    /// Of those, the re-issues that produced a conformant call.
+    pub repairs_succeeded: u64,
+}
+
+/// Process-lifetime per-model defect counters.
+///
+/// A synchronous mutex over a small map: every operation is a couple of
+/// integer bumps under the lock, on paths that already do far heavier work.
+#[derive(Debug, Default)]
+pub struct ModelDefectLedger {
+    counts: Mutex<HashMap<String, ModelDefectCounts>>,
+}
+
+impl ModelDefectLedger {
+    /// Create an empty ledger.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Count one request for `model`.
+    pub fn record_request(&self, model: &str) {
+        self.with(model, |c| c.requests += 1);
+    }
+
+    /// Count one loop-guard rejection for `model`.
+    ///
+    /// Also counts the request itself: the guard fires *instead of* a
+    /// forward, and a trip outside its own denominator would overstate
+    /// every rate computed from these numbers.
+    pub fn record_loop_guard_trip(&self, model: &str) {
+        self.with(model, |c| {
+            c.requests += 1;
+            c.loop_guard_trips += 1;
+        });
+    }
+
+    /// Count one tool-call repair attempt for `model`.
+    pub fn record_repair(&self, model: &str, succeeded: bool) {
+        self.with(model, |c| {
+            c.repairs_attempted += 1;
+            if succeeded {
+                c.repairs_succeeded += 1;
+            }
+        });
+    }
+
+    /// The current counts for every model that has any.
+    #[must_use]
+    pub fn snapshot(&self) -> HashMap<String, ModelDefectCounts> {
+        self.counts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn with(&self, model: &str, update: impl FnOnce(&mut ModelDefectCounts)) {
+        let mut counts = self
+            .counts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        update(counts.entry(model.to_owned()).or_default());
+    }
+}
+
+/// The counts accumulated between two snapshots — what a windowing reader
+/// actually rates.
+#[must_use]
+pub const fn delta(current: ModelDefectCounts, baseline: ModelDefectCounts) -> ModelDefectCounts {
+    ModelDefectCounts {
+        requests: current.requests.saturating_sub(baseline.requests),
+        loop_guard_trips: current
+            .loop_guard_trips
+            .saturating_sub(baseline.loop_guard_trips),
+        repairs_attempted: current
+            .repairs_attempted
+            .saturating_sub(baseline.repairs_attempted),
+        repairs_succeeded: current
+            .repairs_succeeded
+            .saturating_sub(baseline.repairs_succeeded),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn events_accumulate_per_model() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_request("a");
+        ledger.record_request("a");
+        ledger.record_loop_guard_trip("a");
+        ledger.record_repair("b", true);
+        ledger.record_repair("b", false);
+
+        let snap = ledger.snapshot();
+        assert_eq!(snap["a"].requests, 3); // a trip counts its own request
+        assert_eq!(snap["a"].loop_guard_trips, 1);
+        assert_eq!(snap["b"].repairs_attempted, 2);
+        assert_eq!(snap["b"].repairs_succeeded, 1);
+    }
+
+    #[test]
+    fn a_windowing_reader_rates_the_delta() {
+        let ledger = ModelDefectLedger::new();
+        for _ in 0..10 {
+            ledger.record_request("a");
+        }
+        let baseline = ledger.snapshot()["a"];
+        ledger.record_loop_guard_trip("a");
+        ledger.record_request("a");
+
+        let window = delta(ledger.snapshot()["a"], baseline);
+        assert_eq!(window.requests, 2);
+        assert_eq!(window.loop_guard_trips, 1);
+    }
+}

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -6,6 +6,7 @@ pub mod cache_budget;
 pub mod capabilities;
 pub mod capability_tags;
 pub mod chat;
+pub mod defects;
 pub mod dialect;
 pub mod generation_config;
 pub mod gguf;

--- a/crates/gglib-proxy/src/metrics.rs
+++ b/crates/gglib-proxy/src/metrics.rs
@@ -109,6 +109,14 @@ pub struct ContextMetricsStore {
     /// what this model gets wrong, which is a different problem from an
     /// unconstrained `auto` path.
     tool_repairs_succeeded: AtomicU64,
+    /// The process-lifetime per-model defect ledger, when one was injected.
+    ///
+    /// Every signal the ledger wants already passes through this store with
+    /// the model name attached — `record` sees each request and the loop
+    /// guard's trips, `flag_tool_repair` sees each repair — so forwarding
+    /// from here reaches all of them with zero call-site changes. `None` in
+    /// tests and in any embedding that has no scheduler to read it.
+    ledger: Option<std::sync::Arc<gglib_core::domain::defects::ModelDefectLedger>>,
 }
 
 impl ContextMetricsStore {
@@ -121,7 +129,18 @@ impl ContextMetricsStore {
             dialect_residue_total: AtomicU64::new(0),
             tool_repairs_attempted: AtomicU64::new(0),
             tool_repairs_succeeded: AtomicU64::new(0),
+            ledger: None,
         }
+    }
+
+    /// Attach the process-lifetime defect ledger; see the field docs.
+    #[must_use]
+    pub fn with_ledger(
+        mut self,
+        ledger: std::sync::Arc<gglib_core::domain::defects::ModelDefectLedger>,
+    ) -> Self {
+        self.ledger = Some(ledger);
+        self
     }
 
     /// Record a new snapshot.
@@ -140,6 +159,14 @@ impl ContextMetricsStore {
     pub fn record(&self, mut snapshot: ContextSnapshot) -> u64 {
         let seq = self.total_requests.fetch_add(1, Ordering::Relaxed);
         snapshot.seq = seq;
+
+        if let Some(ledger) = &self.ledger {
+            if snapshot.loop_guard_tripped {
+                ledger.record_loop_guard_trip(&snapshot.model_name);
+            } else {
+                ledger.record_request(&snapshot.model_name);
+            }
+        }
 
         let mut guard = self.snapshots.lock().unwrap_or_else(|e| e.into_inner());
         guard.push_back(snapshot);
@@ -183,6 +210,13 @@ impl ContextMetricsStore {
         let mut guard = self.snapshots.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(snapshot) = guard.iter_mut().find(|s| s.seq == seq) {
             snapshot.tool_repaired = succeeded;
+            // The ring row still knows its model; a repair whose snapshot
+            // was already evicted keeps the fleet counter above but is lost
+            // to the per-model ledger — a bounded, bias-free undercount on
+            // exactly the busiest traffic, noted in the ledger's docs.
+            if let Some(ledger) = &self.ledger {
+                ledger.record_repair(&snapshot.model_name, succeeded);
+            }
         }
     }
 

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -198,6 +198,11 @@ pub async fn serve(
     // single proxy run. Exposed on the dashboard as `agent_usage`, alongside
     // the proxied figure.
     agent_metrics: Arc<CacheMetricsStore>,
+    // Per-model defect counters, supervisor-owned for the same reason as
+    // `agent_metrics`: the auto-tune scheduler windows them across proxy
+    // restarts. Fed by the context-metrics store, which sees every signal
+    // with the model name attached.
+    defects: Arc<gglib_core::domain::defects::ModelDefectLedger>,
     // Who may reach this endpoint: the CORS policy, the optional bearer token,
     // and the Host allowlist. Carries the `CorsConfig` it replaced rather than
     // sitting beside it — `serve` was already at fifteen parameters, and access
@@ -282,7 +287,7 @@ pub async fn serve(
     let dashboard = Arc::new(DashboardState::new(
         connections,
         slots_cache,
-        Arc::new(ContextMetricsStore::new()),
+        Arc::new(ContextMetricsStore::new().with_ledger(defects)),
         Arc::clone(&upstream_health),
         Arc::new(CacheStatusCache::new()),
         Arc::new(CacheMetricsStore::new()),

--- a/crates/gglib-proxy/tests/fixtures/common.rs
+++ b/crates/gglib-proxy/tests/fixtures/common.rs
@@ -1054,6 +1054,7 @@ pub async fn spawn_proxy_with_settings(
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await
@@ -1106,6 +1107,7 @@ pub async fn spawn_proxy_with_cache_for_model(
             Some(slot_dir),
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-proxy/tests/integration_auth.rs
+++ b/crates/gglib-proxy/tests/integration_auth.rs
@@ -60,6 +60,7 @@ async fn spawn_proxy(access: ProxyAccessConfig) -> (String, u16, CancellationTok
             None,  // slot_dir
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &access,
         )
         .await

--- a/crates/gglib-proxy/tests/integration_cache_clear.rs
+++ b/crates/gglib-proxy/tests/integration_cache_clear.rs
@@ -82,6 +82,7 @@ async fn spawn_proxy(
             slot_dir,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-proxy/tests/integration_cors.rs
+++ b/crates/gglib-proxy/tests/integration_cors.rs
@@ -53,6 +53,7 @@ async fn spawn_proxy() -> (String, CancellationToken) {
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-proxy/tests/integration_inference_profiles.rs
+++ b/crates/gglib-proxy/tests/integration_inference_profiles.rs
@@ -251,6 +251,7 @@ async fn spawn(
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-proxy/tests/integration_mcp_gateway.rs
+++ b/crates/gglib-proxy/tests/integration_mcp_gateway.rs
@@ -42,6 +42,7 @@ async fn start_proxy() -> (String, CancellationToken) {
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             std::sync::Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-proxy/tests/integration_pinned_models.rs
+++ b/crates/gglib-proxy/tests/integration_pinned_models.rs
@@ -59,6 +59,7 @@ async fn spawn(
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-proxy/tests/integration_shutdown.rs
+++ b/crates/gglib-proxy/tests/integration_shutdown.rs
@@ -55,6 +55,7 @@ async fn spawn_proxy() -> (String, CancellationToken, JoinHandle<()>) {
             None,
             gglib_proxy::slot_eviction::DiskBudget::Auto,
             Arc::new(gglib_core::cache_metrics::CacheMetricsStore::new()),
+            Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
             &gglib_core::ProxyAccessConfig::default(),
         )
         .await

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -237,6 +237,11 @@ pub struct ProxySupervisor {
     /// the embedded axum server (GUI chat, via [`Self::agent_metrics`]) reach —
     /// so a single population survives proxy restarts within one process.
     agent_metrics: Arc<CacheMetricsStore>,
+    /// Per-model defect counters (loop-guard trips, repairs), owned here for
+    /// the same reason `agent_metrics` is: they must outlive any single
+    /// proxy run, because their reader — the auto-tune scheduler — windows
+    /// them across restarts.
+    defects: Arc<gglib_core::domain::defects::ModelDefectLedger>,
 }
 
 impl Default for ProxySupervisor {
@@ -254,6 +259,7 @@ impl ProxySupervisor {
             handle: Mutex::new(None),
             exit_tx,
             agent_metrics: Arc::new(CacheMetricsStore::new()),
+            defects: Arc::new(gglib_core::domain::defects::ModelDefectLedger::new()),
         }
     }
 
@@ -265,6 +271,13 @@ impl ProxySupervisor {
     #[must_use]
     pub fn agent_metrics(&self) -> Arc<CacheMetricsStore> {
         Arc::clone(&self.agent_metrics)
+    }
+
+    /// The per-model defect ledger — the Tier C signals the auto-tune
+    /// scheduler steers by.
+    #[must_use]
+    pub fn defects(&self) -> Arc<gglib_core::domain::defects::ModelDefectLedger> {
+        Arc::clone(&self.defects)
     }
 
     /// Get a watch receiver for proxy exit notifications.
@@ -356,6 +369,7 @@ impl ProxySupervisor {
         let disk_budget = config.disk_budget;
         let inference_override = config.inference_override;
         let agent_metrics = Arc::clone(&self.agent_metrics);
+        let defects = Arc::clone(&self.defects);
         let exit_tx = self.exit_tx.clone();
 
         // Spawn the proxy task - calls real gglib_proxy::serve
@@ -380,6 +394,7 @@ impl ProxySupervisor {
                 slot_dir,
                 disk_budget,
                 agent_metrics,
+                defects,
                 &access,
             )
             .await;


### PR DESCRIPTION
Based on `main` (the full stack merged). Sixth PR of the closed-loop arc: the counters now pick both the model **and** the dimension — the "dynamic" in dynamic optimisation, kept honest by triggering only on defect events, never on request content (ADR 0004's ban).

## The ledger (the write half)

`ModelDefectLedger` (gglib-core, std-only): cumulative per-model counts of requests, loop-guard trips, and tool-call repair attempts/successes. The proxy has counted these fleet-wide since the dashboard existed, but a fleet rate cannot name a model, and the scheduler's whole question is *which model has earned a sweep*.

Wiring cost is one line: the context-metrics store already sees every signal with the model name attached, so `with_ledger()` at store construction forwards everything — zero call-site changes. Supervisor-owned like the agent cache metrics and for the same reason (readers window across proxy restarts); deliberately **not persisted** — a defect rate is a claim about recent traffic on this build of everything, and yesterday's rate answering today's question is exactly the staleness ADR 0001 warns about. A trip counts its own request, or every derived rate would be overstated.

Windowing is the reader's job: the scheduler keeps its own per-model baselines and rates the delta, so nobody fights over a reset button.

## The signal (the read half)

One ships, deliberately: **loop-guard trip rate ≥ 5% over ≥ 50 windowed requests → a DRY sweep** (`0.0/0.4/0.8` — off included, so the gate can still answer "change nothing"). The thresholds carry their reasoning: fifty requests is where a rate stops being a coin flip wearing a percentage, and the ceiling experiment measured healthy-hot traffic tripping ~2% — a sustained 5% of production requests is qualitatively different, and DRY is the dimension built for verbatim-sequence repetition. Repair-rate counters are recorded but not yet acted on — they are PR 7's signal (grammar engagement, not a sampling sweep), and the drift alarm's treatment is dialect work, not tuning.

Signals bypass exactly two of the untuned path's rules, and the bypasses are the point:
- **the untuned-only filter** — a measured model failing in production is precisely the re-check case PR 5 deferred to signals;
- **the seven-day interval** — a defect rate is new evidence, not the old question re-asked; the baseline advance before each run makes one burst of events good for at most one sweep.

Still honoured: a person's defaults are never touched, and the warm-model rule stands (in practice a model with traffic enough to signal *is* the resident one, tuned in place). One sweep per idle window, spent where the rate is loudest. Everything downstream is unchanged PR 5 machinery: same idle detection, same preemption, same gate.

## The revert trail

`ApplyRecord` gains `prior_defaults` and `prior_origin` (serde-defaulted; old records read as absent, and "the model had no defaults" is representable distinctly). Any apply — manual or signal-driven — is now reversible from the run row alone with one `gglib model update`, no archaeology. Automated revert-on-regression is deliberately **not** included: an unattended revert loop can oscillate, and the ledger plus logged verdicts give the operator the evidence; if a revert policy is wanted it should be its own reviewed decision.

## Verification

- Full workspace `cargo test` green; clippy `-D warnings` clean; fmt clean; 816 TS tests green (no TS surface changed).
- Ledger: 2 tests (per-model accumulation with the trip-counts-its-request rule; delta windowing).
- Scheduler policy: 10 tests — the 5 new ones cover the signal firing on a measured model, the sample floor, the rate floor, the person/warm-model rules holding under signals, and worst-rate-wins.
- 9 proxy integration-test fixtures updated for the new `serve()` parameter.

### Not verified here

A live signal firing needs sustained looping production traffic (≥50 requests at ≥5% trip rate), which cannot be decently simulated against a real model in a test window. The pure selection policy is what the live path consumes, and it is fully unit-covered; the ledger's live write path rides the same `metrics.record()` calls the dashboard has exercised in production since #536.
