### PR TITLE
feat(setup): the auto-tune consent — asked at setup, on both surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,6 +369,9 @@ setup: check-deps build-gui build-tauri install ## Full setup (check deps + buil
 	@# without a terminal and reports a failed provision as a skipped step —
 	@# but setup must not break over an optional extra, so belt and braces.
 	@./target/release/gglib config fast-downloads prompt || true
+	@# Idle-time auto-tune is opt-in by design; setup is where the question
+	@# is asked, so the feature does not ship dark. Same belt and braces.
+	@./target/release/gglib config auto-tune prompt || true
 	@echo "✓ Core setup complete!"
 	@$(MAKE) llama-install-auto
 

--- a/crates/gglib-cli/src/config_commands.rs
+++ b/crates/gglib-cli/src/config_commands.rs
@@ -55,6 +55,20 @@ pub enum ConfigCommand {
     },
     /// Show resolved paths for all gglib directories
     Paths,
+    /// Inspect or enable the idle-time auto-tune scheduler
+    AutoTune {
+        #[command(subcommand)]
+        command: Option<AutoTuneCommand>,
+    },
+}
+
+/// Idle-time auto-tune command variants.
+#[derive(Subcommand)]
+pub enum AutoTuneCommand {
+    /// Show whether idle-time auto-tune is enabled (default)
+    Status,
+    /// Offer to enable it, interactively. Skips silently without a terminal
+    Prompt,
 }
 
 /// Fast-download accelerator command variants.

--- a/crates/gglib-cli/src/handlers/config/auto_tune.rs
+++ b/crates/gglib-cli/src/handlers/config/auto_tune.rs
@@ -1,0 +1,87 @@
+//! `gglib config auto-tune` — status and the setup-time consent prompt.
+//!
+//! The idle-time auto-tune scheduler is opt-in by project decision:
+//! autonomy that spends the GPU is a thing an operator turns on. This
+//! command is how the question gets *asked* — `make setup` runs the prompt
+//! beside the models-directory and fast-downloads prompts, so every CLI
+//! install sees the offer once, with yes as the recommended answer, instead
+//! of the feature shipping dark.
+
+use std::io::IsTerminal as _;
+use std::io::Write as _;
+
+use anyhow::Result;
+use gglib_core::SettingsUpdate;
+
+use crate::bootstrap::CliContext;
+use crate::config_commands::AutoTuneCommand;
+use crate::presentation::style::{INFO, RESET, SUCCESS};
+
+/// Route an `auto-tune` subcommand.
+pub async fn dispatch(ctx: &CliContext, command: Option<AutoTuneCommand>) -> Result<()> {
+    match command.unwrap_or(AutoTuneCommand::Status) {
+        AutoTuneCommand::Status => status(ctx).await,
+        AutoTuneCommand::Prompt => prompt(ctx).await,
+    }
+}
+
+async fn status(ctx: &CliContext) -> Result<()> {
+    let enabled = ctx.app.settings().get().await?.auto_tune == Some(true);
+    if enabled {
+        println!("{SUCCESS}✓ Idle-time auto-tune is enabled{RESET}");
+    } else {
+        println!(
+            "{INFO}Idle-time auto-tune is off. Enable with:{RESET} \
+             gglib config settings set --auto-tune true"
+        );
+    }
+    Ok(())
+}
+
+/// Offer to enable auto-tune, interactively. Skips without a terminal.
+async fn prompt(ctx: &CliContext) -> Result<()> {
+    if ctx.app.settings().get().await?.auto_tune == Some(true) {
+        println!("{SUCCESS}✓ Idle-time auto-tune is already enabled{RESET}");
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        // No terminal is not an answer. Say what did not happen and how to
+        // do it later, rather than assuming either way on the user's behalf.
+        println!(
+            "{INFO}Idle-time auto-tune stays off. To let gglib tune models \
+             during idle GPU time:{RESET} gglib config settings set --auto-tune true"
+        );
+        return Ok(());
+    }
+
+    println!("Let gglib tune your models during idle GPU time? (recommended)");
+    println!("  When the GPU has been idle a while, gglib measures untuned models and");
+    println!("  applies better sampling defaults — only when the evidence clears a");
+    println!("  statistical gate. Warm models are never evicted, your own settings are");
+    println!("  never touched, and any request preempts the run instantly.");
+    print!("Enable idle-time auto-tune? [Y/n] ");
+    std::io::stdout().flush().ok();
+
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer).ok();
+    let declined = matches!(answer.trim().to_lowercase().as_str(), "n" | "no");
+
+    if declined {
+        println!(
+            "{INFO}Leaving it off. Enable later with:{RESET} \
+             gglib config settings set --auto-tune true"
+        );
+        return Ok(());
+    }
+
+    ctx.app
+        .settings()
+        .update(SettingsUpdate {
+            auto_tune: Some(Some(true)),
+            ..Default::default()
+        })
+        .await?;
+    println!("{SUCCESS}✓ Idle-time auto-tune enabled{RESET}");
+    Ok(())
+}

--- a/crates/gglib-cli/src/handlers/config/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/mod.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("README.md")]
+pub mod auto_tune;
 pub mod check_deps;
 pub mod fast_downloads;
 pub mod llama;
@@ -29,6 +30,7 @@ pub async fn dispatch(ctx: &CliContext, command: ConfigCommand) -> Result<()> {
             check_deps::execute(&probe, setup_fast_downloads).await
         }
         ConfigCommand::FastDownloads { command } => fast_downloads::dispatch(command).await,
+        ConfigCommand::AutoTune { command } => auto_tune::dispatch(ctx, command).await,
         ConfigCommand::Paths => paths::execute(),
     }
 }

--- a/src/components/SetupWizard/SetupWizard.tsx
+++ b/src/components/SetupWizard/SetupWizard.tsx
@@ -28,6 +28,7 @@ import type { LucideIcon } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Banner } from '../ui/Banner';
 import { Icon } from '../ui/Icon';
+import { Checkbox } from '../ui/Checkbox';
 import { cn } from '../../utils/cn';
 import { formatBytes } from '../../utils/format';
 import type { SetupStatus, LlamaInstallProgress } from '../../types/setup';
@@ -90,15 +91,20 @@ export const SetupWizard: FC<SetupWizardProps> = ({ onComplete }) => {
     }
   }, []);
 
+  // Pre-checked as the recommended answer: this is the consent moment the
+  // opt-in design routes through, so the feature does not ship dark. An
+  // unchecked box writes nothing — off stays the absence it already is.
+  const [autoTune, setAutoTune] = useState(true);
+
   const handleComplete = useCallback(async () => {
     try {
-      await updateSettings({ setupCompleted: true });
+      await updateSettings({ setupCompleted: true, ...(autoTune ? { autoTune: true } : {}) });
       onComplete();
     } catch {
       // Even if saving fails, let user through
       onComplete();
     }
-  }, [onComplete]);
+  }, [onComplete, autoTune]);
 
   const steps: readonly WizardStep[] = WIZARD_STEPS;
   const currentIndex = steps.indexOf(step);
@@ -172,7 +178,12 @@ export const SetupWizard: FC<SetupWizardProps> = ({ onComplete }) => {
           />
         )}
         {step === 'complete' && (
-          <CompleteStep status={status} onFinish={handleComplete} />
+          <CompleteStep
+            status={status}
+            autoTune={autoTune}
+            onAutoTuneChange={setAutoTune}
+            onFinish={handleComplete}
+          />
         )}
       </div>
     </WizardShell>
@@ -622,7 +633,12 @@ const PythonSetupStep: FC<{
 // Step: Complete
 // ============================================================================
 
-const CompleteStep: FC<{ status: SetupStatus; onFinish: () => void }> = ({ status, onFinish }) => (
+const CompleteStep: FC<{
+  status: SetupStatus;
+  autoTune: boolean;
+  onAutoTuneChange: (value: boolean) => void;
+  onFinish: () => void;
+}> = ({ status, autoTune, onAutoTuneChange, onFinish }) => (
   <div className="flex flex-col gap-6">
     <div className="text-center py-4">
       <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-success-subtle mb-4">
@@ -642,6 +658,23 @@ const CompleteStep: FC<{ status: SetupStatus; onFinish: () => void }> = ({ statu
       {/* Always ok: downloads work either way, so an absent accelerator is a
           choice of transport, not a failure to flag. */}
       <SummaryRow label="Downloads" ok value={status.fastDownloadReady ? 'Accelerated (hf_xet)' : 'Direct'} />
+    </div>
+
+    {/* The auto-tune consent — the one setup question that changes what
+        gglib does on its own. Off is a real choice, so it is a checkbox
+        here rather than a default nobody saw. */}
+    <div className="bg-background-secondary rounded-md p-4">
+      <Checkbox
+        checked={autoTune}
+        onChange={(e) => onAutoTuneChange(e.target.checked)}
+        label={
+          <>
+            Tune models automatically during idle time
+            <span className="ml-2 text-xs font-normal text-primary">Recommended</span>
+          </>
+        }
+        description="When the GPU is idle, gglib measures untuned models and applies better sampling defaults — only when the evidence clears a statistical gate. Warm models are never evicted, your own settings are never touched, and any request preempts the run instantly. Change anytime in Settings."
+      />
     </div>
 
     <div className="flex justify-center pt-4">


### PR DESCRIPTION
Follow-up to the closed-loop arc, per the project decision on defaults: idle-time auto-tune **stays opt-in** (autonomy that spends the GPU is a thing an operator turns on), but an opt-in nobody sees ships the feature dark — so setup is where the question gets asked, once, with yes as the recommended answer. The power/battery gate was considered and explicitly vetoed by the project lead.

## CLI / `make setup`

New `gglib config auto-tune {status, prompt}`, following the `fast-downloads` prompt pattern exactly:
- already enabled → short-circuit with a ✓;
- no terminal → no assumption either way — say what did not happen and how to enable later;
- interactive → the offer with the honest fine print, `[Y/n]` with bare-Enter accepting the recommendation.

`make setup` runs it beside the models-dir and fast-downloads prompts (same `|| true` belt and braces).

## GUI setup wizard

The completion step gains the consent checkbox — pre-checked as **Recommended**, design-system `Checkbox` with label + description — stating exactly what the user is agreeing to: measured-gate applies only, warm models never evicted, their own settings untouchable, instant preemption, changeable in Settings. An unchecked box **writes nothing**: off stays the absence it already is, so a future default change isn't blocked by a stored false nobody meant.

## Verification

- `cargo test` (gglib-cli 180 green), clippy `-D warnings` clean, fmt clean; 816 TS tests, `tsc` and eslint clean (the native-checkbox lint caught the first draft and the design-system `Checkbox` replaced it).
- CLI smoke-tested live: `status` renders the off-state with the enable command; a piped (non-terminal) `prompt` correctly declines to assume and prints the later-enable path.
- Not verified: the interactive Y-path needs a real TTY (it is a four-line branch through the same settings service the `--auto-tune` flag exercises), and the wizard step is visual — one `make setup` run and one fresh-install wizard pass worth eyeballing before merge.

## Deliberately not included

The auto-tune **activity feed** (dashboard card of applies *and* refusals) — the other half of making the autonomy visible — remains a separate, purely-presentational follow-up.