### PR TITLE
fix(frontend): the settings test's missing autoTune, which reddened main

### DIFF
--- a/tests/ts/components/SettingsFields.test.tsx
+++ b/tests/ts/components/SettingsFields.test.tsx
@@ -61,7 +61,11 @@ const renderAdvanced = (
       setTrustClientSampling={noop}
       proxyLoopDetection
       setProxyLoopDetection={noop}
-      agentGuards={{ agenticSampling: true, maxStagnationSteps: overrides.stagnation ?? '' }}
+      agentGuards={{
+        agenticSampling: true,
+        autoTune: false,
+        maxStagnationSteps: overrides.stagnation ?? '',
+      }}
       setAgentGuardSetting={(key, value) => {
         if (target === 'stagnation' && key === 'maxStagnationSteps') onChange(value as string);
       }}


### PR DESCRIPTION
Based on `main`. Not part of the closed-loop arc — this is the one-property fix that un-reddens it.

## What broke

#785 made `autoTune` a required member of `AgentGuardSettingsValues`, but `SettingsFields.test.tsx`'s render helper still built its `agentGuards` literal with two fields. `tsc -b` rejects it:

```
tests/ts/components/SettingsFields.test.tsx(64,7): error TS2741:
  Property 'autoTune' is missing in type '{ agenticSampling: true; maxStagnationSteps: string; }'
  but required in type 'AgentGuardSettingsValues'.
```

#785 merged with that failure already red, so `main` has been red since 01:21 UTC.

## Why one property took out four PRs

Both the **Lint & Typecheck** job and the **Clippy** job run `npm run build` before their real work — Clippy needs the web UI built before it compiles the Rust that embeds it. So a single missing property failed two jobs, and **clippy never ran at all**, on `main` or on any open PR: the job died at the build step every time.

Every branch in the closed-loop stack (#786, #787, #788, #789) descends from the broken commit, so all four fail typecheck on code they do not touch — including the docs-only ADR PR. The fix belongs on `main` rather than in any one of them: one property, once, instead of four copies that would conflict on merge.

`false` matches the `DEFAULTS` in `useAgentGuardSettings` — the toggle is opt-in because it spends the GPU — and this file covers the numeric fields, so the neutral value keeps it about them.

## Verification

Run locally at the versions CI uses:

- `npm run build` — passes (was the failing step).
- `npm run lint -- --max-warnings 0` — clean.
- `npm run typecheck` — clean.
- `npx vitest run tests/ts/components/SettingsFields.test.tsx` — 36/36 pass.
- `cargo clippy --all-targets --all-features -- -D warnings` — **clean**, and this is its first actual run since #785; the concern that a second failure was hiding behind the build step turns out to be unfounded.

## One thing this does not fix

**Label Check** fails independently on every open PR, including this one: it requires a label from each of `component:`, `priority:`, and `size:`, and `priority:`/`size:` are human judgements the bot will not apply. Labels applied by hand alongside this PR.