### PR TITLE
chore(deps): sync lockfile version with package.json 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gglib-gui",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gglib-gui",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assistant-ui/react": "^0.11.48",


### PR DESCRIPTION
## What

Syncs the two root `version` fields in `package-lock.json` from `0.12.2` to `0.13.0`. That is the entire diff — no dependency tree changes.

## Why

The bump in #773 touched `package.json` only. `package-lock.json` was still gitignored at that point, so nobody regenerated it. #774 then committed the lockfile for the first time — but the copy that landed had been generated before the bump, so it has carried `0.12.2` ever since.

`npm install` mirrors `package.json`'s version into the lock, so `make setup` (which runs `npm install`, Makefile:163) rewrites the file on every run and leaves the working tree permanently dirty. That's how this surfaced.

## Impact

Nothing was broken. `npm ci` tolerates a root-version mismatch — it only hard-fails when the actual dependency tree diverges — and it was verified to install cleanly against the stale lockfile, so CI has been green throughout.

## Follow-up worth considering

Version bumps should update both files atomically. `npm version <x.y.z>` does that; hand-editing `package.json` (as in #773) reintroduces this drift every release.
