### PR TITLE
fix(db): applied_json — created on fresh schemas, selected on both read paths

### DIFF
--- a/crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs
@@ -456,7 +456,7 @@ impl BenchmarkRepositoryPort for SqliteBenchmarkRepository {
     ) -> Result<Vec<BenchmarkRun>, RepositoryError> {
         let rows = sqlx::query(
             "SELECT id, run_type, status, model_ids, prompt_text, system_prompt,
-                    config_json, error, created_at, completed_at
+                    config_json, applied_json, error, created_at, completed_at
              FROM benchmark_runs
              ORDER BY created_at DESC
              LIMIT ? OFFSET ?",
@@ -473,7 +473,7 @@ impl BenchmarkRepositoryPort for SqliteBenchmarkRepository {
     async fn get_run(&self, run_id: i64) -> Result<Option<BenchmarkRun>, RepositoryError> {
         let row = sqlx::query(
             "SELECT id, run_type, status, model_ids, prompt_text, system_prompt,
-                    config_json, error, created_at, completed_at
+                    config_json, applied_json, error, created_at, completed_at
              FROM benchmark_runs WHERE id = ?",
         )
         .bind(run_id)
@@ -775,6 +775,37 @@ mod tests {
         .await
         .expect("seed model");
         SqliteBenchmarkRepository::new(pool)
+    }
+
+    /// The apply record must survive both read paths. The row mapper reads
+    /// `applied_json` with a forgiving `try_get(..).ok()`, so a SELECT that
+    /// omits the column does not error — it silently reads back `None`, and
+    /// every Outcome surface renders an em-dash. This is the regression
+    /// test that makes that omission loud.
+    #[tokio::test]
+    async fn applied_json_survives_both_read_paths() {
+        let repo = repo().await;
+        let run_id = repo
+            .create_run(BenchmarkRunType::Tune, &[1], None, None, None)
+            .await
+            .expect("create run");
+        repo.mark_run_applied(run_id, r#"{"verdict":{"verdict":"uncalibrated"}}"#)
+            .await
+            .expect("mark applied");
+
+        let listed = repo.list_runs(10, 0).await.expect("list");
+        assert_eq!(
+            listed[0].applied_json.as_deref(),
+            Some(r#"{"verdict":{"verdict":"uncalibrated"}}"#),
+            "list_runs must select applied_json — the activity surfaces read it from here"
+        );
+
+        let fetched = repo.get_run(run_id).await.expect("get").expect("exists");
+        assert_eq!(
+            fetched.applied_json.as_deref(),
+            Some(r#"{"verdict":{"verdict":"uncalibrated"}}"#),
+            "get_run must select applied_json — the revert path reads it from here"
+        );
     }
 
     /// The report is stored whole, so every field a leaderboard reads back —

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -160,16 +160,6 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
     // `gglib_core::domain::DialectSpec`). No backfill: rows without a spec
     // fall back to their `format:*` tag at context-resolution time, and
     // `gglib model retag` re-derives the spec from persisted metadata.
-    // Migration: add applied_json to benchmark_runs — the JSON-serialized
-    // apply record (`tune::apply::ApplyRecord`) written when a tune run's
-    // winner is stored as a model's Measured defaults, so the provenance a
-    // model reports can always be traced back to the gate numbers that
-    // licensed it. NULL on every run that was never applied.
-    let _ = sqlx::query(r#"ALTER TABLE benchmark_runs ADD COLUMN applied_json TEXT"#)
-        .execute(pool)
-        .await;
-    // Ignore error if column already exists
-
     let _ = sqlx::query(r#"ALTER TABLE models ADD COLUMN dialect_spec TEXT"#)
         .execute(pool)
         .await;
@@ -391,6 +381,7 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
             prompt_text  TEXT,
             system_prompt TEXT,
             config_json  TEXT,
+            applied_json TEXT,
             error        TEXT,
             created_at   TEXT    NOT NULL,
             completed_at TEXT
@@ -398,6 +389,22 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
     )
     .execute(pool)
     .await?;
+
+    // Migration: add applied_json to benchmark_runs — the JSON-serialized
+    // apply record (`tune::apply::ApplyRecord`) written when a tune run's
+    // winner is stored as a model's Measured defaults, so the provenance a
+    // model reports can always be traced back to the gate numbers that
+    // licensed it. NULL on every run that was never applied.
+    //
+    // This ALTER must run *after* the CREATE above: it originally sat in
+    // the models migration block, before benchmark_runs existed on a fresh
+    // database — where "no such table" was silently swallowed and the CREATE
+    // (which then lacked the column) left every fresh install unable to
+    // store an apply record until a second boot re-ran the migration.
+    let _ = sqlx::query(r#"ALTER TABLE benchmark_runs ADD COLUMN applied_json TEXT"#)
+        .execute(pool)
+        .await;
+    // Ignore error if column already exists
 
     // Per-model compare results: real inference quality + real-world timing.
     // Timing fields are nullable — llama-server may omit the timings object.


### PR DESCRIPTION
## What

Two halves of one invisible failure, caught by the live smoke test for #794/#795 when a freshly-refused tune run's Outcome rendered as an em-dash.

1. **Verdicts were written but unreadable everywhere.** Neither `list_runs` nor `get_run` selected `applied_json`, and `row_to_benchmark_run` reads it with a forgiving `try_get(..).ok().flatten()` — so the omission never errored, it just read back `None`. Every surface that shows what the gate decided reads through these two queries: the CLI `benchmark list` Outcome column, the GUI Auto-Tune Activity feed (#790), and the revert path (`prior_defaults` lives in the same record). All of them have been verdict-blind since the column landed.
2. **Fresh installs couldn't write the record at all** — found by this PR's own regression test. The `ALTER TABLE benchmark_runs ADD COLUMN applied_json` sat in the *models* migration block, before `benchmark_runs` exists on a fresh database; the 'no such table' error is swallowed by design, and the CREATE that then made the table lacked the column. Result: on a single-boot fresh database, `mark_run_applied` fails with 'no such column'. (The smoke only survived because its daemon restarted between schema runs, letting the second boot's migration land.)

## The fix

- `applied_json` added to the `CREATE TABLE benchmark_runs` statement itself.
- The migration ALTER moved after the CREATE, with a comment recording the trap.
- Both SELECTs now return the column.
- Regression test `applied_json_survives_both_read_paths` holds both queries open — it fails loudly on either regression, where the mapper's forgiving read used to keep them silent.

## Verified

All 58 gglib-db tests green; full `make pre-commit` green. Live proof against the smoke database from #795's verification: the same run that rendered `—` now renders

```
1  tune  2026-08-12 05:25:42  complete  auto (signal:repair-rate)  refused: margin +0.026 within drift 0.053
```

Independent of the #794/#795 stack (different file regions; merges cleanly in any order).