### PR TITLE
fix(benchmark): an aborted tune run no longer consumes the retune interval

### DIFF
--- a/crates/gglib-app-services/src/benchmark/auto_tune.rs
+++ b/crates/gglib-app-services/src/benchmark/auto_tune.rs
@@ -92,9 +92,16 @@ fn env_override<T: std::str::FromStr + Copy>(key: &str, default: T) -> T {
 /// How often the preemption watcher checks the queue while a run is live.
 const PREEMPT_POLL: Duration = Duration::from_secs(2);
 
-/// The least time between tune attempts on one model, however they ended.
+/// The least time between *answered* tune attempts on one model.
 /// A refusal is an answer; the next question should wait for new evidence
-/// (a different build, new tasks) or the signal triggers.
+/// (a different build, new tasks) or the signal triggers. An aborted or
+/// crashed run is **not** an answer — a preempted idle tune, a daemon
+/// stopped mid-run, a launch failure — and must not park the model for a
+/// week (the first live idle tune was aborted by a daemon stop and parked
+/// its model seven days for zero information). Only completed runs
+/// consume the interval; the accepted trade is that a deterministically
+/// crashing tune retries each idle window, bounded by the idle threshold
+/// and visible in the activity feed.
 const RETUNE_INTERVAL: chrono::Duration = chrono::Duration::days(7);
 
 /// The fewest windowed requests before a defect rate means anything.
@@ -748,9 +755,17 @@ fn select_target(
     resident_ids: &[i64],
     now: DateTime<Utc>,
 ) -> Option<i64> {
+    // Only an answered question consumes the interval: completed runs
+    // (their verdict stands for a week) and runs still in flight (their
+    // answer is coming). A failed row — preempted, aborted by a daemon
+    // stop, crashed — produced no answer and holds no claim.
     let recently_tuned = |id: i64| {
         runs.iter().any(|r| {
             r.run_type == BenchmarkRunType::Tune
+                && matches!(
+                    r.status,
+                    BenchmarkRunStatus::Complete | BenchmarkRunStatus::Running
+                )
                 && r.model_ids.contains(&id)
                 && now.signed_duration_since(r.created_at) < RETUNE_INTERVAL
         })
@@ -1056,6 +1071,32 @@ mod tests {
 
         let stale = vec![tune_run(1, 8)];
         assert_eq!(select_target(&models, &stale, &[], Utc::now()), Some(1));
+    }
+
+    /// An aborted run answered nothing and holds no claim: the model stays
+    /// eligible. (The first live idle tune was aborted by a daemon stop and
+    /// wrongly parked its model for a week — this is that bug's headstone.)
+    #[test]
+    fn an_aborted_run_does_not_park_the_model() {
+        let models = vec![model(1, Some(DefaultsOrigin::AutoDetected), 30)];
+        let aborted = vec![BenchmarkRun {
+            status: BenchmarkRunStatus::Failed,
+            ..tune_run(1, 0)
+        }];
+        assert_eq!(select_target(&models, &aborted, &[], Utc::now()), Some(1));
+    }
+
+    /// A run still in flight is a question being answered — it parks the
+    /// model exactly like a completed one, so two surfaces cannot race the
+    /// same question.
+    #[test]
+    fn a_running_tune_parks_the_model() {
+        let models = vec![model(1, Some(DefaultsOrigin::AutoDetected), 30)];
+        let running = vec![BenchmarkRun {
+            status: BenchmarkRunStatus::Running,
+            ..tune_run(1, 0)
+        }];
+        assert_eq!(select_target(&models, &running, &[], Utc::now()), None);
     }
 
     // ── Persistence: decay, restore plans, flush rows ────────────────────


### PR DESCRIPTION
## What

`select_target`'s interval rule counted **any** tune run in the last seven days, whatever its status. An aborted run — preempted, crashed at launch, or killed by a daemon stop mid-flight — therefore parked its model for a week having produced no information at all.

Only an *answered* question holds a claim now: `Complete` (its verdict stands for the interval) and `Running` (its answer is coming, and two surfaces must not race the same question). `Failed` holds nothing.

## Why it matters, live

Both models on the author's machine are currently parked by aborted runs:

```
1|tune|failed|[1]|2026-08-12 04:25:14|Aborted by user
2|tune|failed|[2]|2026-08-12 07:05:01|Process terminated unexpectedly
```

Run 1 was the first-ever unattended idle tune, killed seconds in by a daemon stop. Run 2 was a recovery tune — the scheduler measuring a deliberately sabotaged recipe — killed by a daemon restart. With the daemon now fully idle and eager (44 idle ticks banked), the log reads `auto-tune: idle, but nothing eligible to tune` on every tick: the scheduler is standing down for a week on two runs that measured nothing.

## The trade, accepted and documented

A tune that crashes *deterministically* now retries each idle window rather than backing off for a week. Bounded by the idle threshold (10 sustained idle minutes per attempt) and visible in the activity feed with its initiator, so a repeating failure is loud rather than silent. The alternative — treating a crash as an answer — is what this PR removes.

## Tests

`an_aborted_run_does_not_park_the_model` and `a_running_tune_parks_the_model`, beside the existing interval test. Full `make pre-commit` green.

Stacked on #795.