### PR TITLE
feat(proxy,benchmark): the stream-error signal — the counter that sees dead, not just sick

### DIFF
--- a/crates/gglib-app-services/src/benchmark/auto_tune.rs
+++ b/crates/gglib-app-services/src/benchmark/auto_tune.rs
@@ -24,9 +24,9 @@
 //!   excluded outright — the same principle that ranks `Measured` below
 //!   global settings — and measured models are excluded from the idle
 //!   queue because re-checks belong to the signal triggers: a production
-//!   defect rate past its threshold (a loop-trip rate → a DRY sweep, a
-//!   tool-call repair rate → a temperature sweep) is the one thing that
-//!   reopens a measured recipe, not a timer.
+//!   defect rate past its threshold (a loop-trip rate → a DRY sweep; a
+//!   tool-call repair rate or a mid-stream failure rate → a temperature
+//!   sweep) is the one thing that reopens a measured recipe, not a timer.
 //! - **Any real request preempts.** While a run is in flight the scheduler
 //!   watches the admission queue; the moment anything is waiting, the run
 //!   is cancelled and the GPU handed over. The next attempt starts from a
@@ -133,6 +133,19 @@ const LOOP_TRIP_RATE_THRESHOLD: f64 = 0.05;
 /// window that crosses this threshold understates the true rate, so the
 /// signal fires late, never spuriously.
 const REPAIR_RATE_THRESHOLD: f64 = 0.05;
+
+/// The upstream mid-stream failure rate that earns a model a signal-driven
+/// temperature sweep.
+///
+/// A stream error is the failure a person actually feels: the model server
+/// killed the turn mid-generation (its native tool-call grammar rejecting
+/// the model's own output, a crash, a severed stream) and the client's
+/// request simply failed. It is also the counter that sees "dead" where
+/// the loop and repair counters only see "sick" — a model too broken to
+/// even attempt a tool call raises neither of those, but it raises this.
+/// Same sample floor and threshold as its siblings; under real breakdown
+/// the rate approaches 100%, so 5% fires almost immediately.
+const STREAM_ERROR_RATE_THRESHOLD: f64 = 0.05;
 
 /// How many recent runs the target selector scans for the interval rule.
 /// Generous against the interval: even a daemon tuning one model per idle
@@ -432,6 +445,7 @@ fn decay_counts(counts: ModelDefectCounts, factor: f64) -> ModelDefectCounts {
         loop_guard_trips: scale(counts.loop_guard_trips),
         repairs_attempted: scale(counts.repairs_attempted),
         repairs_succeeded: scale(counts.repairs_succeeded),
+        stream_errors: scale(counts.stream_errors),
     }
 }
 
@@ -619,6 +633,11 @@ pub enum SignalKind {
     /// [`REPAIR_RATE_THRESHOLD`] for why the measured rate understates
     /// the true one.
     RepairRate,
+    /// This model's turns keep dying on upstream mid-stream failures —
+    /// output so far outside the expected shape that the model server
+    /// kills the stream rather than finish it. The catastrophic sibling
+    /// of [`Self::RepairRate`], treated with the same dimension.
+    StreamError,
 }
 
 impl SignalKind {
@@ -629,6 +648,7 @@ impl SignalKind {
         match self {
             Self::LoopGuard => "signal:loop-guard",
             Self::RepairRate => "signal:repair-rate",
+            Self::StreamError => "signal:stream-error",
         }
     }
 
@@ -658,6 +678,13 @@ impl SignalKind {
                 temperature: vec![0.2, 0.5, 0.8],
                 ..SweepSpec::default()
             },
+            // The same diagnosis family as RepairRate — output too hot to
+            // hold its required shape — one step further along, so the
+            // same treatment applies.
+            Self::StreamError => SweepSpec {
+                temperature: vec![0.2, 0.5, 0.8],
+                ..SweepSpec::default()
+            },
         }
     }
 }
@@ -667,6 +694,7 @@ impl std::fmt::Display for SignalKind {
         match self {
             Self::LoopGuard => write!(f, "loop-guard trip rate"),
             Self::RepairRate => write!(f, "tool-call repair rate"),
+            Self::StreamError => write!(f, "mid-stream failure rate"),
         }
     }
 }
@@ -674,26 +702,35 @@ impl std::fmt::Display for SignalKind {
 /// The strongest signal one model's window raises, with its severity —
 /// the rate as a multiple of its threshold, so signals with different
 /// thresholds compare on how far past alarm they are rather than on raw
-/// percentages. A dead heat prefers the loop guard: verbatim repetition
-/// is the sharper failure, and the ordering must not depend on iteration
-/// accidents (`max_by` keeps the *last* maximum, so push order cannot be
-/// the tie-break). The caller has already enforced [`MIN_SIGNAL_SAMPLE`],
-/// so the denominator is never zero.
+/// percentages. A dead heat resolves by the array's order — loop guard,
+/// then stream errors, then repairs: the sharper failure first, and never
+/// by iteration accident (`max_by` keeps the *last* maximum, so the fold
+/// below keeps the first instead). The caller has already enforced
+/// [`MIN_SIGNAL_SAMPLE`], so the denominator is never zero.
 fn worst_signal(window: &ModelDefectCounts) -> Option<(SignalKind, f64)> {
     #[allow(clippy::cast_precision_loss)]
-    let requests = window.requests as f64;
-    #[allow(clippy::cast_precision_loss)]
-    let loop_severity = (window.loop_guard_trips as f64 / requests) / LOOP_TRIP_RATE_THRESHOLD;
-    #[allow(clippy::cast_precision_loss)]
-    let repair_severity = (window.repairs_attempted as f64 / requests) / REPAIR_RATE_THRESHOLD;
-    if loop_severity < 1.0 && repair_severity < 1.0 {
-        return None;
-    }
-    if loop_severity >= repair_severity {
-        Some((SignalKind::LoopGuard, loop_severity))
-    } else {
-        Some((SignalKind::RepairRate, repair_severity))
-    }
+    let rate = |count: u64, threshold: f64| (count as f64 / window.requests as f64) / threshold;
+    let severities = [
+        (
+            SignalKind::LoopGuard,
+            rate(window.loop_guard_trips, LOOP_TRIP_RATE_THRESHOLD),
+        ),
+        (
+            SignalKind::StreamError,
+            rate(window.stream_errors, STREAM_ERROR_RATE_THRESHOLD),
+        ),
+        (
+            SignalKind::RepairRate,
+            rate(window.repairs_attempted, REPAIR_RATE_THRESHOLD),
+        ),
+    ];
+    severities
+        .into_iter()
+        .filter(|&(_, severity)| severity >= 1.0)
+        .fold(None, |best, candidate| match best {
+            Some((_, best_severity)) if best_severity >= candidate.1 => best,
+            _ => Some(candidate),
+        })
 }
 
 /// The model whose production defect rate has earned a targeted sweep, with
@@ -972,6 +1009,41 @@ mod tests {
         );
     }
 
+    /// The catastrophic counter: turns dying mid-stream earn the same
+    /// temperature treatment as malformed calls — and a measured model is
+    /// eligible, because production failure is exactly the re-check case.
+    #[test]
+    fn a_dying_stream_earns_a_temperature_sweep() {
+        let models = vec![model(1, Some(DefaultsOrigin::Measured), 10)];
+        let dying = ModelDefectCounts {
+            requests: 100,
+            stream_errors: 40, // severity 8.0 — a model that is simply broken
+            ..ModelDefectCounts::default()
+        };
+        let windows = windows_for(&[("m1", dying)]);
+        let (target, signal) = select_signal_target(&models, &windows, &[]).expect("signal fires");
+        assert_eq!(target.id, 1);
+        assert_eq!(signal, SignalKind::StreamError);
+        assert_eq!(signal.initiator(), "signal:stream-error");
+        assert_eq!(signal.sweep().temperature, vec![0.2, 0.5, 0.8]);
+    }
+
+    /// Between the two temperature-treated kinds, a dead heat prefers the
+    /// stream error: a turn that died outranks a turn that was repaired.
+    #[test]
+    fn a_dead_heat_prefers_death_over_repair() {
+        let both = ModelDefectCounts {
+            requests: 100,
+            repairs_attempted: 5, // severity 1.0
+            stream_errors: 5,     // severity 1.0
+            ..ModelDefectCounts::default()
+        };
+        assert_eq!(
+            worst_signal(&both).map(|(s, _)| s),
+            Some(SignalKind::StreamError)
+        );
+    }
+
     /// A rate over a handful of requests is a coin flip wearing a
     /// percentage: below the sample floor nothing fires, however loud.
     #[test]
@@ -1111,6 +1183,7 @@ mod tests {
             loop_guard_trips: 10,
             repairs_attempted: 8,
             repairs_succeeded: 4,
+            stream_errors: 6,
         }
     }
 
@@ -1145,6 +1218,7 @@ mod tests {
                 loop_guard_trips: 5,
                 repairs_attempted: 4,
                 repairs_succeeded: 2,
+                stream_errors: 3,
             }
         );
     }

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -1144,9 +1144,9 @@ async fn cmd_list(ctx: &CliContext, limit: i64) -> Result<()> {
     }
 
     // Initiator width fits the longest slug the scheduler stamps:
-    // `auto (signal:repair-rate)` at 25 characters.
+    // `auto (signal:stream-error)` at 26 characters.
     println!(
-        "{BOLD}{:>6}  {:<8}  {:<19}  {:<9}  {:<25}  Outcome{RESET}",
+        "{BOLD}{:>6}  {:<8}  {:<19}  {:<9}  {:<26}  Outcome{RESET}",
         "ID",
         "Type",
         "Started",
@@ -1155,13 +1155,13 @@ async fn cmd_list(ctx: &CliContext, limit: i64) -> Result<()> {
         BOLD = style::BOLD,
         RESET = style::RESET,
     );
-    println!("{}", "─".repeat(99));
+    println!("{}", "─".repeat(100));
     for run in &runs {
         let run_type = format!("{:?}", run.run_type).to_lowercase();
         let started = run.created_at.format("%Y-%m-%d %H:%M:%S").to_string();
         let status = format!("{:?}", run.status).to_lowercase();
         println!(
-            "{:>6}  {:<8}  {:<19}  {:<9}  {:<25}  {}",
+            "{:>6}  {:<8}  {:<19}  {:<9}  {:<26}  {}",
             run.id,
             run_type,
             started,

--- a/crates/gglib-core/src/domain/defects.rs
+++ b/crates/gglib-core/src/domain/defects.rs
@@ -42,6 +42,12 @@ pub struct ModelDefectCounts {
     pub repairs_attempted: u64,
     /// Of those, the re-issues that produced a conformant call.
     pub repairs_succeeded: u64,
+    /// Streaming turns that died on an *upstream* mid-stream failure — an
+    /// error event the model server emitted mid-generation, or the byte
+    /// stream itself breaking. The client's turn simply fails; nothing
+    /// else counts it. Client disconnects are not in here: hanging up is
+    /// a person's action, not a model defect.
+    pub stream_errors: u64,
 }
 
 /// One persisted unacted window — the counts the scheduler had not yet
@@ -104,6 +110,7 @@ impl ModelDefectLedger {
             c.loop_guard_trips = c.loop_guard_trips.saturating_add(counts.loop_guard_trips);
             c.repairs_attempted = c.repairs_attempted.saturating_add(counts.repairs_attempted);
             c.repairs_succeeded = c.repairs_succeeded.saturating_add(counts.repairs_succeeded);
+            c.stream_errors = c.stream_errors.saturating_add(counts.stream_errors);
         });
     }
 
@@ -115,6 +122,15 @@ impl ModelDefectLedger {
                 c.repairs_succeeded += 1;
             }
         });
+    }
+
+    /// Count one upstream mid-stream failure for `model`.
+    ///
+    /// Does *not* bump `requests`: unlike a loop-guard trip, a stream
+    /// error happens after the request was forwarded and counted — this
+    /// marks an already-counted request as having died mid-generation.
+    pub fn record_stream_error(&self, model: &str) {
+        self.with(model, |c| c.stream_errors += 1);
     }
 
     /// The current counts for every model that has any.
@@ -150,6 +166,7 @@ pub const fn delta(current: ModelDefectCounts, baseline: ModelDefectCounts) -> M
         repairs_succeeded: current
             .repairs_succeeded
             .saturating_sub(baseline.repairs_succeeded),
+        stream_errors: current.stream_errors.saturating_sub(baseline.stream_errors),
     }
 }
 
@@ -185,6 +202,7 @@ mod tests {
                 loop_guard_trips: 3,
                 repairs_attempted: 2,
                 repairs_succeeded: 1,
+                stream_errors: 5,
             },
         );
         ledger.record_request("a");
@@ -192,6 +210,7 @@ mod tests {
         let snap = ledger.snapshot()["a"];
         assert_eq!(snap.requests, 41);
         assert_eq!(snap.loop_guard_trips, 3);
+        assert_eq!(snap.stream_errors, 5);
         assert_eq!(snap.repairs_attempted, 2);
         assert_eq!(snap.repairs_succeeded, 1);
         // An empty baseline (a fresh scheduler) windows the whole seed.
@@ -216,6 +235,21 @@ mod tests {
             },
         );
         assert_eq!(ledger.snapshot()["a"].requests, u64::MAX);
+    }
+
+    /// A stream error marks an already-counted request as having died —
+    /// it must never inflate the denominator it will be rated against.
+    #[test]
+    fn a_stream_error_never_bumps_its_own_denominator() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_request("a");
+        ledger.record_stream_error("a");
+
+        let snap = ledger.snapshot()["a"];
+        assert_eq!(snap.requests, 1);
+        assert_eq!(snap.stream_errors, 1);
+        let window = delta(snap, ModelDefectCounts::default());
+        assert_eq!(window.stream_errors, 1);
     }
 
     #[test]

--- a/crates/gglib-db/src/repositories/sqlite_defect_window_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_defect_window_repository.rs
@@ -40,7 +40,7 @@ impl DefectWindowRepositoryPort for SqliteDefectWindowRepository {
     async fn load_all(&self) -> Result<Vec<PersistedDefectWindow>, RepositoryError> {
         let rows = sqlx::query(
             "SELECT model_name, requests, loop_guard_trips, repairs_attempted, \
-             repairs_succeeded, updated_at, llama_build FROM defect_windows",
+             repairs_succeeded, stream_errors, updated_at, llama_build FROM defect_windows",
         )
         .fetch_all(&self.pool)
         .await
@@ -55,6 +55,7 @@ impl DefectWindowRepositoryPort for SqliteDefectWindowRepository {
                     loop_guard_trips: count_from_row(row, "loop_guard_trips"),
                     repairs_attempted: count_from_row(row, "repairs_attempted"),
                     repairs_succeeded: count_from_row(row, "repairs_succeeded"),
+                    stream_errors: count_from_row(row, "stream_errors"),
                 },
                 updated_at: parse_datetime(row.get("updated_at")).unwrap_or_else(Utc::now),
                 llama_build: row.get("llama_build"),
@@ -73,13 +74,14 @@ impl DefectWindowRepositoryPort for SqliteDefectWindowRepository {
             sqlx::query(
                 "INSERT INTO defect_windows \
                  (model_name, requests, loop_guard_trips, repairs_attempted, \
-                  repairs_succeeded, updated_at, llama_build) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?) \
+                  repairs_succeeded, stream_errors, updated_at, llama_build) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
                  ON CONFLICT(model_name) DO UPDATE SET \
                  requests = excluded.requests, \
                  loop_guard_trips = excluded.loop_guard_trips, \
                  repairs_attempted = excluded.repairs_attempted, \
                  repairs_succeeded = excluded.repairs_succeeded, \
+                 stream_errors = excluded.stream_errors, \
                  updated_at = excluded.updated_at, \
                  llama_build = excluded.llama_build",
             )
@@ -88,6 +90,7 @@ impl DefectWindowRepositoryPort for SqliteDefectWindowRepository {
             .bind(count_to_db(row.counts.loop_guard_trips))
             .bind(count_to_db(row.counts.repairs_attempted))
             .bind(count_to_db(row.counts.repairs_succeeded))
+            .bind(count_to_db(row.counts.stream_errors))
             .bind(row.updated_at.format("%Y-%m-%d %H:%M:%S").to_string())
             .bind(&row.llama_build)
             .execute(&mut *tx)
@@ -135,6 +138,7 @@ mod tests {
                 loop_guard_trips: 2,
                 repairs_attempted: 5,
                 repairs_succeeded: 3,
+                stream_errors: 4,
             },
             updated_at: Utc.with_ymd_and_hms(2026, 8, 12, 10, 0, 0).unwrap(),
             llama_build: "b10327".to_owned(),
@@ -157,6 +161,7 @@ mod tests {
         assert_eq!(rows[0].counts.loop_guard_trips, 2);
         assert_eq!(rows[0].counts.repairs_attempted, 5);
         assert_eq!(rows[0].counts.repairs_succeeded, 3);
+        assert_eq!(rows[0].counts.stream_errors, 4);
         assert_eq!(
             rows[0].updated_at,
             Utc.with_ymd_and_hms(2026, 8, 12, 10, 0, 0).unwrap()

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -542,12 +542,25 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
             loop_guard_trips  INTEGER NOT NULL DEFAULT 0,
             repairs_attempted INTEGER NOT NULL DEFAULT 0,
             repairs_succeeded INTEGER NOT NULL DEFAULT 0,
+            stream_errors     INTEGER NOT NULL DEFAULT 0,
             updated_at        TEXT    NOT NULL,
             llama_build       TEXT    NOT NULL
         )",
     )
     .execute(pool)
     .await?;
+
+    // Migration: add stream_errors to defect_windows — the upstream
+    // mid-stream failure counter, the third signal's evidence. Runs after
+    // the CREATE (the applied_json lesson: an ALTER before its table
+    // exists is silently swallowed on a fresh database). Existing rows
+    // backfill to 0: absence of evidence, honestly recorded.
+    let _ = sqlx::query(
+        r#"ALTER TABLE defect_windows ADD COLUMN stream_errors INTEGER NOT NULL DEFAULT 0"#,
+    )
+    .execute(pool)
+    .await;
+    // Ignore error if column already exists
 
     Ok(())
 }

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -144,6 +144,12 @@ pub(crate) struct StreamOutcome {
     /// normalization, if any (see `gglib_core::normalize::residue`). The
     /// spawning task back-patches the request's metrics snapshot with it.
     pub dialect_residue: Option<String>,
+    /// The turn died on an *upstream* failure: the model server emitted an
+    /// error event mid-generation, or the byte stream itself broke. The
+    /// client's turn simply fails — the failure a person actually feels —
+    /// and the spawning task feeds it to the per-model defect ledger.
+    /// Client disconnects never set this; hanging up is not a model defect.
+    pub upstream_errored: bool,
 }
 
 /// Headers that should NOT be forwarded (hop-by-hop headers).
@@ -955,9 +961,20 @@ pub(crate) async fn stream_response_to_channel(
                     // Withheld, not dropped — flushed or discarded at `Done`.
                     None
                 }
-                LlmStreamEvent::ToolCallDelta { .. } | LlmStreamEvent::UpstreamError { .. } => {
+                LlmStreamEvent::ToolCallDelta { .. } => {
                     connection.mark_generating();
                     outcome.saw_visible_output = true;
+                    encoder.encode(&ev).map(Bytes::from)
+                }
+                LlmStreamEvent::UpstreamError { .. } => {
+                    connection.mark_generating();
+                    outcome.saw_visible_output = true;
+                    // The model server reported the failure itself — e.g. its
+                    // native tool-call grammar rejecting the model's own
+                    // output mid-generation. Forwarded to the client as
+                    // before, and flagged so the defect ledger hears about
+                    // the turn that died.
+                    outcome.upstream_errored = true;
                     encoder.encode(&ev).map(Bytes::from)
                 }
                 LlmStreamEvent::Done { finish_reason } => {
@@ -1004,6 +1021,10 @@ pub(crate) async fn stream_response_to_channel(
             Err(e) => {
                 error!("proxy stream error: {e}");
                 outcome.saw_visible_output = true;
+                // The upstream byte stream broke mid-generation (a crashed
+                // llama-server, a severed connection) — the same
+                // turn-died-upstream fact as an explicit error event.
+                outcome.upstream_errored = true;
                 let payload = serde_json::json!({
                     "error": {
                         "message": e.to_string(),

--- a/crates/gglib-proxy/src/metrics.rs
+++ b/crates/gglib-proxy/src/metrics.rs
@@ -220,6 +220,21 @@ impl ContextMetricsStore {
         }
     }
 
+    /// Count one upstream mid-stream failure against `seq`'s model.
+    ///
+    /// The ring row is only consulted for its model name; like
+    /// [`Self::flag_tool_repair`], an event whose snapshot was already
+    /// evicted is lost to the per-model ledger — the same bounded,
+    /// bias-free undercount on exactly the busiest traffic.
+    pub fn flag_stream_error(&self, seq: u64) {
+        let guard = self.snapshots.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(snapshot) = guard.iter().find(|s| s.seq == seq)
+            && let Some(ledger) = &self.ledger
+        {
+            ledger.record_stream_error(&snapshot.model_name);
+        }
+    }
+
     /// Total tool-call repairs attempted, eviction-safe.
     pub fn tool_repairs_attempted(&self) -> u64 {
         self.tool_repairs_attempted.load(Ordering::Relaxed)

--- a/crates/gglib-proxy/src/sse_stream.rs
+++ b/crates/gglib-proxy/src/sse_stream.rs
@@ -209,6 +209,16 @@ pub fn spawn_and_return(
                     // has finished, by which time the snapshot already exists.
                     context_metrics.flag_tool_repair(snapshot_seq, outcome.repair_succeeded);
                 }
+                if outcome.upstream_errored {
+                    warn!(
+                        model = %model_name_owned,
+                        "turn died on an upstream mid-stream failure"
+                    );
+                    // Back-patched like the repair flag: the fact is only
+                    // known once the stream ends, by which time the
+                    // snapshot already exists.
+                    context_metrics.flag_stream_error(snapshot_seq);
+                }
                 // Feed the terminal outcome to the watchdog: an empty
                 // response is a strike, visible output resets the streak.
                 //

--- a/docs/adr/0005-autonomous-closed-loop-and-reactive-grammar.md
+++ b/docs/adr/0005-autonomous-closed-loop-and-reactive-grammar.md
@@ -66,12 +66,14 @@ not charge; **a person's work is never the target**; any waiting request
 preempts the run outright; and one attempt per model per seven days,
 because a refusal is an answer and answers do not expire in an afternoon.
 Signal-driven runs (a loop-trip rate ≥ 5% → a DRY sweep; a tool-call
-repair rate ≥ 5% → a temperature sweep, each over ≥ 50 windowed requests
-— the repair signal added 2026-08-12, consuming the counter this ADR
-noted was already flowing) bypass exactly two rules — the untuned-only
-filter and the interval, both because a production defect is *new
-evidence* — and honour the rest. When one model raises both, severity
-(the rate as a multiple of its threshold) picks the sweep.
+repair rate or an upstream mid-stream failure rate ≥ 5% → a temperature
+sweep, each over ≥ 50 windowed requests — the repair and stream-error
+signals added 2026-08-12; the latter counts the turns that die outright,
+which the other two counters cannot see, a blind spot mapped by
+deliberately sabotaging a model's recipe) bypass exactly two rules — the
+untuned-only filter and the interval, both because a production defect
+is *new evidence* — and honour the rest. When one model raises several,
+severity (the rate as a multiple of its threshold) picks the sweep.
 
 **The `Measured` defaults origin** is where an applied winner lives: below
 global settings, like `AutoDetected` and `Published`, on the ladder's


### PR DESCRIPTION
## What

A third defect counter and its signal: `stream_errors` counts turns that died on an **upstream mid-stream failure** — the model server emitting an error event mid-generation, or the byte stream itself breaking. At ≥ 5% over ≥ 50 windowed requests it raises `signal:stream-error`, treated with the same temperature sweep as the repair-rate signal.

## Why — a blind spot found by sabotage, not by argument

A model's recipe was deliberately sabotaged (temperature 2.0, top_p 1.0, top_k off) to make the existing signals fire on organic traffic. They never did. The reason is structural: **both existing counters require a model coherent enough to produce structured output.** The loop guard counts verbatim repetition; the repair loop counts a tool call that was *attempted and malformed*. A model whose sampling has collapsed produces neither — it emits output so far outside the expected shape that the model server kills the stream.

A real editor session died exactly that way, with nothing recorded:

```
Reason: Chat completion request failed: Inference server reported an error
mid-stream: The model produced output that does not match the expected
peg-native format
```

| Failure mode | Counted before | Counted now |
|---|---|---|
| Verbatim loops | ✅ loop-guard trips | ✅ |
| Malformed-but-complete tool calls | ✅ repair attempts | ✅ |
| Output so broken the stream is killed | ❌ **invisible** | ✅ stream errors |

The counters could see *sick*. They could not see *dead* — the failure a person actually feels, because their chat simply fails.

## Correctness details

- **Client disconnects never count.** Hanging up is a person's action, not a model defect. Only the two upstream-failure sites in the drain loop set the flag: an `UpstreamError` event (split out of the `ToolCallDelta` arm it shared) and the byte-stream `Err` arm.
- **The counter never bumps its own denominator.** Unlike a loop-guard trip (which fires *instead of* a forward), a stream error marks a request already counted at forward time. Test: `a_stream_error_never_bumps_its_own_denominator`.
- **Same ring-eviction undercount** as tool repairs, and the same fail-safe direction: the signal fires late, never spuriously.
- **Three-way severity** with ties resolved in array order — loop guard, then stream error, then repair — inside the fold, so ordering never depends on `max_by` keeping the last maximum.
- **The migration runs after its CREATE**, per the #796 lesson; existing `defect_windows` rows backfill to 0.

## Tests

`a_dying_stream_earns_a_temperature_sweep`, `a_dead_heat_prefers_death_over_repair`, `a_stream_error_never_bumps_its_own_denominator`, plus the persistence round-trip and decay fixtures extended with the new field. Full `make pre-commit` green.

Stacked on #797.