### PR TITLE
fix(proxy): the recycle watchdog counts upstream deaths and abstains on hang-ups

### DIFF
--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -86,7 +86,7 @@ use crate::metrics::{ContextMetricsStore, ContextSnapshot};
 use crate::models::ErrorResponse;
 use crate::sampling_audit::SamplingAuditStore;
 use crate::token_calibration::TokenCalibration;
-use crate::upstream_health::UpstreamHealth;
+use crate::upstream_health::{StreamVerdict, UpstreamHealth};
 use gglib_core::cache_metrics::CacheMetricsStore;
 
 /// Signals that the upstream llama-server was unreachable (connection refused
@@ -113,8 +113,13 @@ pub(crate) struct StreamOutcome {
     /// in `reasoning_content` renders as an empty response in every client that
     /// treats reasoning as a collapsed side-channel (notably the VS Code LLM
     /// Gateway), so scoring it as output made a hard failure indistinguishable
-    /// from success — and, via [`crate::upstream_health`], reset the strike
-    /// counter that arms the recycle watchdog. See [`Self::saw_reasoning`].
+    /// from success. See [`Self::saw_reasoning`].
+    ///
+    /// This answers "did the client see anything?", and *only* that — it is
+    /// what decides whether the turn needs a diagnostic notice appended. It is
+    /// deliberately not the upstream-health verdict: an error frame is
+    /// renderable but is the opposite of healthy. [`Self::health_verdict`]
+    /// draws that second distinction.
     pub saw_visible_output: bool,
     /// `true` if at least one `ReasoningDelta` was emitted.
     ///
@@ -144,6 +149,45 @@ pub(crate) struct StreamOutcome {
     /// normalization, if any (see `gglib_core::normalize::residue`). The
     /// spawning task back-patches the request's metrics snapshot with it.
     pub dialect_residue: Option<String>,
+    /// The turn died on an *upstream* failure: the model server emitted an
+    /// error event mid-generation, or the byte stream itself broke. The
+    /// client's turn simply fails — the failure a person actually feels.
+    ///
+    /// Client disconnects never set this; hanging up is not a model defect.
+    pub upstream_errored: bool,
+    /// The client went away mid-turn, so the drain loop stopped forwarding.
+    ///
+    /// Kept because a turn the client abandoned is not evidence about the
+    /// upstream — see [`StreamVerdict::ClientAborted`].
+    pub client_aborted: bool,
+}
+
+impl StreamOutcome {
+    /// Reduce the turn to the one claim it makes about the upstream's health.
+    ///
+    /// The precedence is the whole content of this function, so it is stated
+    /// once here rather than at the call site:
+    ///
+    /// 1. **Died upstream** wins outright. A turn that broke mid-generation
+    ///    indicts the server even if it had already emitted good text.
+    /// 2. **Visible output** beats a client disconnect. If the upstream
+    ///    demonstrably produced, that is positive evidence of health and the
+    ///    client leaving afterwards does not retract it.
+    /// 3. **Client abort** with nothing produced is genuinely unknowable — the
+    ///    model may have been mid-prefill — so it abstains.
+    /// 4. Otherwise the turn produced nothing and nobody left: an empty
+    ///    response, the degradation this watchdog was built for.
+    pub(crate) fn health_verdict(&self) -> StreamVerdict {
+        if self.upstream_errored {
+            StreamVerdict::UpstreamError
+        } else if self.saw_visible_output {
+            StreamVerdict::Healthy
+        } else if self.client_aborted {
+            StreamVerdict::ClientAborted
+        } else {
+            StreamVerdict::Empty
+        }
+    }
 }
 
 /// Headers that should NOT be forwarded (hop-by-hop headers).
@@ -955,9 +999,20 @@ pub(crate) async fn stream_response_to_channel(
                     // Withheld, not dropped — flushed or discarded at `Done`.
                     None
                 }
-                LlmStreamEvent::ToolCallDelta { .. } | LlmStreamEvent::UpstreamError { .. } => {
+                LlmStreamEvent::ToolCallDelta { .. } => {
                     connection.mark_generating();
                     outcome.saw_visible_output = true;
+                    encoder.encode(&ev).map(Bytes::from)
+                }
+                LlmStreamEvent::UpstreamError { .. } => {
+                    connection.mark_generating();
+                    // Renderable, so the turn does not also need the empty-turn
+                    // notice — but the opposite of healthy, so the watchdog
+                    // hears about it separately. Folding these two facts into
+                    // one flag is what let a server dying on every request
+                    // report itself as producing output.
+                    outcome.saw_visible_output = true;
+                    outcome.upstream_errored = true;
                     encoder.encode(&ev).map(Bytes::from)
                 }
                 LlmStreamEvent::Done { finish_reason } => {
@@ -981,6 +1036,7 @@ pub(crate) async fn stream_response_to_channel(
                         for frame in flush {
                             if tx.send(Ok(frame)).await.is_err() {
                                 client_connected = false;
+                                outcome.client_aborted = true;
                                 break;
                             }
                         }
@@ -1004,6 +1060,10 @@ pub(crate) async fn stream_response_to_channel(
             Err(e) => {
                 error!("proxy stream error: {e}");
                 outcome.saw_visible_output = true;
+                // The upstream byte stream broke mid-generation (a crashed
+                // llama-server, a severed connection) — the same
+                // turn-died-upstream fact as an explicit error event.
+                outcome.upstream_errored = true;
                 let payload = serde_json::json!({
                     "error": {
                         "message": e.to_string(),
@@ -1020,8 +1080,11 @@ pub(crate) async fn stream_response_to_channel(
         if let Some(bytes) = frame
             && tx.send(Ok(bytes)).await.is_err()
         {
-            // Client disconnected; stop draining the upstream.
+            // Client disconnected; stop draining the upstream. Recorded so the
+            // watchdog can abstain rather than score a person's hang-up as an
+            // upstream defect.
             client_connected = false;
+            outcome.client_aborted = true;
             break;
         }
     }
@@ -1295,6 +1358,71 @@ fn normalize_non_streaming_body(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A turn that died upstream indicts the server even though its error
+    /// frame was renderable — the conflation that kept the recycle watchdog
+    /// from ever firing against a server failing every request.
+    #[test]
+    fn a_turn_that_died_upstream_is_not_healthy_however_renderable_it_was() {
+        let outcome = StreamOutcome {
+            saw_visible_output: true,
+            upstream_errored: true,
+            ..Default::default()
+        };
+        assert_eq!(outcome.health_verdict(), StreamVerdict::UpstreamError);
+    }
+
+    /// Dying outranks leaving: if both happened, the server is still at fault.
+    #[test]
+    fn dying_upstream_outranks_a_client_that_also_left() {
+        let outcome = StreamOutcome {
+            upstream_errored: true,
+            client_aborted: true,
+            ..Default::default()
+        };
+        assert_eq!(outcome.health_verdict(), StreamVerdict::UpstreamError);
+    }
+
+    /// Positive evidence of production is not retracted by the client leaving
+    /// afterwards — otherwise every cancelled long generation would abstain.
+    #[test]
+    fn output_already_produced_outranks_a_later_client_hangup() {
+        let outcome = StreamOutcome {
+            saw_visible_output: true,
+            client_aborted: true,
+            ..Default::default()
+        };
+        assert_eq!(outcome.health_verdict(), StreamVerdict::Healthy);
+    }
+
+    /// The hang-up case that used to be scored as an empty response.
+    #[test]
+    fn a_client_leaving_before_any_output_abstains() {
+        let outcome = StreamOutcome {
+            client_aborted: true,
+            ..Default::default()
+        };
+        assert_eq!(outcome.health_verdict(), StreamVerdict::ClientAborted);
+    }
+
+    #[test]
+    fn a_turn_nobody_abandoned_that_produced_nothing_is_empty() {
+        assert_eq!(
+            StreamOutcome::default().health_verdict(),
+            StreamVerdict::Empty
+        );
+    }
+
+    /// Reasoning is not renderable output, so a reasoning-only turn stays a
+    /// strike. Guards the distinction `saw_reasoning` was introduced for.
+    #[test]
+    fn a_reasoning_only_turn_is_still_empty() {
+        let outcome = StreamOutcome {
+            saw_reasoning: true,
+            ..Default::default()
+        };
+        assert_eq!(outcome.health_verdict(), StreamVerdict::Empty);
+    }
 
     #[test]
     fn session_aware_budget_falls_back_to_live_ratio_without_a_session_id() {

--- a/crates/gglib-proxy/src/sse_stream.rs
+++ b/crates/gglib-proxy/src/sse_stream.rs
@@ -209,14 +209,11 @@ pub fn spawn_and_return(
                     // has finished, by which time the snapshot already exists.
                     context_metrics.flag_tool_repair(snapshot_seq, outcome.repair_succeeded);
                 }
-                // Feed the terminal outcome to the watchdog: an empty
-                // response is a strike, visible output resets the streak.
-                //
-                // Deliberately `saw_visible_output`, not "produced any frame":
-                // a reasoning-only turn is a failed turn from the client's
-                // point of view, and counting it as success reset this streak
-                // on every retry, so the recycle watchdog never fired.
-                upstream_health.record_stream_outcome(outcome.saw_visible_output);
+                // Feed the terminal outcome to the watchdog. The precedence
+                // between "produced output", "died upstream" and "the client
+                // left" lives in `health_verdict`, so this stays one line and
+                // the rule stays in one place.
+                upstream_health.record_stream_outcome(outcome.health_verdict());
                 // Drift alarm: dialect markup survived normalization into
                 // client-visible output. Log it and back-patch this
                 // request's dashboard snapshot.

--- a/crates/gglib-proxy/src/upstream_health.rs
+++ b/crates/gglib-proxy/src/upstream_health.rs
@@ -2,17 +2,24 @@
 //!
 //! The `/health` fast-path check in `gglib_runtime`'s process manager catches
 //! a llama-server that has *crashed or wedged hard* (its `/health` endpoint
-//! stops returning `200`). It does **not** catch the subtler failure mode this
+//! stops returning `200`). It does **not** catch the subtler failure modes this
 //! module targets: a server whose `/health` is still green but which has
-//! degraded to the point of producing **empty responses** or never returning
-//! the first token. That manifests to the client as an unexplained "empty
-//! response".
+//! degraded to the point of producing **empty responses**, **dying
+//! mid-generation**, or never returning the first token. Each manifests to the
+//! client as a turn that simply failed.
 //!
 //! [`UpstreamHealth`] accumulates such degraded outcomes across requests. When
 //! [`STRIKE_THRESHOLD`] consecutive strikes occur it raises a one-shot
 //! "recycle requested" flag; the chat handler consumes that flag before the
 //! next request and proactively stops the current model, forcing a fresh
 //! respawn — the same cure a human applies by restarting the proxy, automated.
+//!
+//! ## What may cast a vote
+//!
+//! Every recorded outcome is a claim about the *upstream*. Outcomes the client
+//! caused — chiefly hanging up mid-turn — are counted for observability and
+//! then abstain, because they are evidence about a person, not a server. See
+//! [`StreamVerdict`], whose variants exist precisely to keep those two apart.
 //!
 //! ## Concurrency design
 //!
@@ -30,6 +37,44 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 /// is worth the cost of a recycle.
 pub const STRIKE_THRESHOLD: u32 = 2;
 
+/// What one streamed turn revealed about the upstream's health.
+///
+/// Deliberately four states rather than a bool. The two that a bool collapses
+/// are the ones that made the watchdog read the world backwards:
+///
+/// * [`Self::UpstreamError`] — the turn *died upstream*. Under a bool this
+///   arrived as "healthy", because the error frame is renderable and the drain
+///   loop marks renderable frames as visible output. A server dying mid-stream
+///   on every single request therefore reset the streak every time and the
+///   recycle watchdog could never fire — the failure most deserving of a
+///   recycle was the one that guaranteed none.
+/// * [`Self::ClientAborted`] — the person hung up. Under a bool this arrived as
+///   "empty", because no visible output was produced. Nothing was learned about
+///   the upstream, but a strike was recorded anyway; with
+///   [`STRIKE_THRESHOLD`] at two, cancelling two generations in a row was
+///   enough to recycle a perfectly healthy model server.
+///
+/// A verdict is about the *upstream*, never about the client. When the client's
+/// behaviour is what ended the turn, the right answer is to abstain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamVerdict {
+    /// Client-renderable model output reached the client. The upstream is
+    /// producing; the streak resets.
+    Healthy,
+    /// The turn produced nothing a client can render — no content, no tool
+    /// call, not even recovered normalization text. The original degradation
+    /// this watchdog was built for.
+    Empty,
+    /// The turn died upstream mid-generation: the model server emitted an
+    /// error event, or the byte stream itself broke. Strictly stronger
+    /// evidence of upstream sickness than an empty turn.
+    UpstreamError,
+    /// The client disconnected before the turn produced anything. Says nothing
+    /// about the upstream, so it is recorded as nothing at all — neither a
+    /// strike nor a reset.
+    ClientAborted,
+}
+
 /// Serializable, point-in-time view of the watchdog's cumulative counters.
 ///
 /// Surfaced in the proxy dashboard so the degradation this crate guards
@@ -40,8 +85,22 @@ pub struct UpstreamHealthSnapshot {
     pub consecutive_strikes: u32,
     /// Total empty responses observed since the proxy started.
     pub total_empty_responses: u64,
+    /// Total turns that died upstream mid-generation since the proxy started.
+    ///
+    /// Separate from [`Self::total_empty_responses`] because the two are
+    /// different illnesses: an empty turn is a model that produced nothing, a
+    /// stream error is a model server that fell over. Both strike, but folding
+    /// them together would report a crashing server as a quiet one.
+    pub total_upstream_errors: u64,
     /// Total first-byte deadline expiries since the proxy started.
     pub total_first_byte_timeouts: u64,
+    /// Total client disconnects that ended a turn before any output, since the
+    /// proxy started.
+    ///
+    /// Recorded for observability only — these deliberately do not strike. A
+    /// rising count next to a flat strike count is the signal that people are
+    /// cancelling, not that the upstream is sick.
+    pub total_client_aborts: u64,
     /// Total proactive recycles triggered since the proxy started.
     pub total_recycles: u64,
 }
@@ -58,7 +117,9 @@ pub struct UpstreamHealth {
     recycle_requested: AtomicBool,
     /// Cumulative counters for observability (never reset).
     total_empty_responses: AtomicU64,
+    total_upstream_errors: AtomicU64,
     total_first_byte_timeouts: AtomicU64,
+    total_client_aborts: AtomicU64,
     total_recycles: AtomicU64,
 }
 
@@ -71,24 +132,36 @@ impl UpstreamHealth {
 
     /// Record the terminal outcome of a streamed response.
     ///
-    /// `saw_visible_output == true` resets the strike counter (the upstream is
-    /// producing output and is considered healthy); `false` counts as a
-    /// strike.
+    /// Only [`StreamVerdict::Healthy`] resets the streak, and only a verdict
+    /// that actually indicts the upstream strikes it. See [`StreamVerdict`] for
+    /// why the two non-obvious states exist.
     ///
-    /// "Visible" is load-bearing: callers must pass
-    /// [`StreamOutcome::saw_visible_output`], not "the upstream emitted some
-    /// frame". A turn whose entire output arrived as `reasoning_content`
-    /// renders as an empty response in clients that collapse reasoning, so
-    /// counting it healthy resets this streak on every retry and the recycle
-    /// threshold is never reached.
+    /// "Renderable model output" is load-bearing for `Healthy`: a turn whose
+    /// entire output arrived as `reasoning_content` renders as an empty
+    /// response in clients that collapse reasoning, so counting it healthy
+    /// resets this streak on every retry and the recycle threshold is never
+    /// reached. Callers derive the verdict from
+    /// [`StreamOutcome::health_verdict`], which encodes that precedence once.
     ///
-    /// [`StreamOutcome::saw_visible_output`]: crate::forward::StreamOutcome
-    pub fn record_stream_outcome(&self, saw_visible_output: bool) {
-        if saw_visible_output {
-            self.consecutive_strikes.store(0, Ordering::Relaxed);
-        } else {
-            self.total_empty_responses.fetch_add(1, Ordering::Relaxed);
-            self.record_strike();
+    /// [`StreamOutcome::health_verdict`]: crate::forward::StreamOutcome
+    pub fn record_stream_outcome(&self, verdict: StreamVerdict) {
+        match verdict {
+            StreamVerdict::Healthy => {
+                self.consecutive_strikes.store(0, Ordering::Relaxed);
+            }
+            StreamVerdict::Empty => {
+                self.total_empty_responses.fetch_add(1, Ordering::Relaxed);
+                self.record_strike();
+            }
+            StreamVerdict::UpstreamError => {
+                self.total_upstream_errors.fetch_add(1, Ordering::Relaxed);
+                self.record_strike();
+            }
+            // Abstain: the client ended the turn, so it carries no evidence
+            // either way. Counted for observability, never scored.
+            StreamVerdict::ClientAborted => {
+                self.total_client_aborts.fetch_add(1, Ordering::Relaxed);
+            }
         }
     }
 
@@ -133,7 +206,9 @@ impl UpstreamHealth {
         UpstreamHealthSnapshot {
             consecutive_strikes: self.consecutive_strikes.load(Ordering::Relaxed),
             total_empty_responses: self.total_empty_responses.load(Ordering::Relaxed),
+            total_upstream_errors: self.total_upstream_errors.load(Ordering::Relaxed),
             total_first_byte_timeouts: self.total_first_byte_timeouts.load(Ordering::Relaxed),
+            total_client_aborts: self.total_client_aborts.load(Ordering::Relaxed),
             total_recycles: self.total_recycles.load(Ordering::Relaxed),
         }
     }
@@ -146,8 +221,8 @@ mod tests {
     #[test]
     fn healthy_outcome_keeps_strikes_zero() {
         let h = UpstreamHealth::new();
-        h.record_stream_outcome(true);
-        h.record_stream_outcome(true);
+        h.record_stream_outcome(StreamVerdict::Healthy);
+        h.record_stream_outcome(StreamVerdict::Healthy);
         assert_eq!(h.strikes(), 0);
         assert!(!h.take_recycle_request());
     }
@@ -155,7 +230,7 @@ mod tests {
     #[test]
     fn single_strike_does_not_trip_recycle() {
         let h = UpstreamHealth::new();
-        h.record_stream_outcome(false);
+        h.record_stream_outcome(StreamVerdict::Empty);
         assert_eq!(h.strikes(), 1);
         assert!(!h.take_recycle_request());
     }
@@ -163,7 +238,7 @@ mod tests {
     #[test]
     fn two_consecutive_strikes_trip_recycle_once() {
         let h = UpstreamHealth::new();
-        h.record_stream_outcome(false);
+        h.record_stream_outcome(StreamVerdict::Empty);
         h.record_timeout();
         assert!(h.take_recycle_request());
         // One-shot: a second consume returns false and the counter is reset.
@@ -174,9 +249,9 @@ mod tests {
     #[test]
     fn a_healthy_outcome_resets_the_strike_streak() {
         let h = UpstreamHealth::new();
-        h.record_stream_outcome(false);
-        h.record_stream_outcome(true);
-        h.record_stream_outcome(false);
+        h.record_stream_outcome(StreamVerdict::Empty);
+        h.record_stream_outcome(StreamVerdict::Healthy);
+        h.record_stream_outcome(StreamVerdict::Empty);
         // Only one strike since the reset — threshold not reached.
         assert!(!h.take_recycle_request());
         assert_eq!(h.strikes(), 1);
@@ -185,7 +260,7 @@ mod tests {
     #[test]
     fn cumulative_counters_track_events() {
         let h = UpstreamHealth::new();
-        h.record_stream_outcome(false); // empty #1, strike #1
+        h.record_stream_outcome(StreamVerdict::Empty); // empty #1, strike #1
         h.record_timeout(); // timeout #1, strike #2 → recycle armed
         assert!(h.take_recycle_request()); // recycle #1
         let snap = h.snapshot();
@@ -193,5 +268,48 @@ mod tests {
         assert_eq!(snap.total_first_byte_timeouts, 1);
         assert_eq!(snap.total_recycles, 1);
         assert_eq!(snap.consecutive_strikes, 0);
+    }
+
+    /// The regression this module's four-state verdict exists for: a server
+    /// dying mid-stream used to arrive as "healthy", because the error frame
+    /// it emitted was renderable. Every request failing therefore held the
+    /// streak at zero and the recycle never fired.
+    #[test]
+    fn a_stream_that_dies_upstream_strikes_instead_of_resetting() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(StreamVerdict::UpstreamError);
+        assert_eq!(h.strikes(), 1);
+        h.record_stream_outcome(StreamVerdict::UpstreamError);
+        assert!(h.take_recycle_request());
+        let snap = h.snapshot();
+        assert_eq!(snap.total_upstream_errors, 2);
+        // Not folded into the empty-response count — a crashing server and a
+        // silent one are different illnesses.
+        assert_eq!(snap.total_empty_responses, 0);
+    }
+
+    /// The other half: hanging up is a person's action. Two cancellations in a
+    /// row used to be indistinguishable from two empty responses, which at
+    /// `STRIKE_THRESHOLD == 2` was enough to recycle a healthy model server.
+    #[test]
+    fn a_client_hangup_neither_strikes_nor_resets() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(StreamVerdict::Empty);
+        h.record_stream_outcome(StreamVerdict::ClientAborted);
+        h.record_stream_outcome(StreamVerdict::ClientAborted);
+        // The one real strike still stands — abstaining is not forgiving.
+        assert_eq!(h.strikes(), 1);
+        assert!(!h.take_recycle_request());
+        assert_eq!(h.snapshot().total_client_aborts, 2);
+    }
+
+    #[test]
+    fn client_aborts_alone_never_trip_a_recycle() {
+        let h = UpstreamHealth::new();
+        for _ in 0..STRIKE_THRESHOLD + 5 {
+            h.record_stream_outcome(StreamVerdict::ClientAborted);
+        }
+        assert_eq!(h.strikes(), 0);
+        assert!(!h.take_recycle_request());
     }
 }


### PR DESCRIPTION
One boolean was answering two different questions, and had one of them backwards in both directions.

`saw_visible_output` means *"the client saw a renderable frame"* — that is what decides whether a turn needs a diagnostic notice appended. It was also being handed to the recycle watchdog as *"the upstream is healthy"*. Those two coincide for content and tool calls, and diverge exactly where it matters most.

### The two bugs

**A server dying mid-stream read as healthy.** An `UpstreamError` event or a broken byte stream forwards an error frame. That frame is renderable, so it set `saw_visible_output`, so `record_stream_outcome(true)` **reset the strike streak**. A server failing every single request held the streak at zero forever — the watchdog whose entire purpose is to recycle a degraded server was structurally guaranteed never to fire against the degradation most deserving of it.

**A client hanging up read as a model defect.** A disconnect produces no visible output, which scored as an empty response and struck the streak. Nothing had actually been learned about the upstream — the model may have been mid-prefill. With `STRIKE_THRESHOLD == 2`, cancelling two generations in a row was enough to recycle a perfectly healthy model server.

### The fix

`record_stream_outcome` now takes a four-state `StreamVerdict` rather than a bool:

| Verdict | Effect |
|---|---|
| `Healthy` | resets the streak |
| `Empty` | strikes |
| `UpstreamError` | strikes, counted separately from `Empty` |
| `ClientAborted` | counted for observability, **abstains** |

Upstream errors are counted apart from empty responses because a crashing server and a silent one are different illnesses; folding them together reports the first as the second. Client aborts are counted but never scored — a rising abort count beside a flat strike count is the signal that people are cancelling, not that the upstream is sick.

Precedence lives in one place, `StreamOutcome::health_verdict`, so the call site stays a single line:

1. **Died upstream** wins outright — a turn that broke mid-generation indicts the server even if it had already emitted good text.
2. **Visible output** beats a client disconnect — positive evidence of production is not retracted by the client leaving afterwards.
3. **Client abort** with nothing produced abstains — genuinely unknowable.
4. Otherwise: an empty response, the degradation this watchdog was built for.

### Notes

- `saw_visible_output` keeps its original meaning and its original job (gating the empty-turn notice); it simply no longer moonlights as the health verdict.
- `UpstreamHealthSnapshot` gains `total_upstream_errors` and `total_client_aborts`. It has no TS mirror and is embedded wholesale in the dashboard payload, so the addition is purely additive.
- This is a prerequisite for the adaptive-inference work: while a mid-stream death reads as health and a hang-up reads as a defect, every defect rate derived from these counters is contaminated.

### Verification

`make pre-commit` passes in full. Ten new tests: six covering `health_verdict` precedence, four covering the watchdog's scoring — including the two named regressions (`a_stream_that_dies_upstream_strikes_instead_of_resetting`, `a_client_hangup_neither_strikes_nor_resets`).