### PR TITLE
fix(proxy): a recycle that could not happen no longer spends the watchdog's case

### DIFF
--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -831,7 +831,17 @@ async fn chat_completions(
     // honored by the next request that arrives while the upstream is idle.
     if state.dashboard.connections.is_empty() && state.upstream_health.take_recycle_request() {
         warn!("upstream watchdog: recycling degraded model before next request");
-        let _ = state.runtime_port.stop_current().await;
+        // Taking the request already cleared the flag and zeroed the streak, so
+        // a swallowed failure here spends the watchdog's entire case against a
+        // server that is still sick. Put it back instead, the way the cache
+        // clear path above already reports its own recycle failures.
+        if let Err(e) = state.runtime_port.stop_current().await {
+            warn!(
+                error = %e,
+                "upstream watchdog: recycle failed; re-arming for the next idle request"
+            );
+            state.upstream_health.rearm_recycle();
+        }
     }
 
     // The one catalog round-trip this request pays for. Resolved here rather

--- a/crates/gglib-proxy/src/upstream_health.rs
+++ b/crates/gglib-proxy/src/upstream_health.rs
@@ -103,6 +103,13 @@ pub struct UpstreamHealthSnapshot {
     pub total_client_aborts: u64,
     /// Total proactive recycles triggered since the proxy started.
     pub total_recycles: u64,
+    /// Of those, how many could not actually be carried out because stopping
+    /// the model server failed.
+    ///
+    /// A non-zero value here means the watchdog is firing and being ignored —
+    /// a different problem from a healthy upstream, and one that is otherwise
+    /// invisible because the request that triggered it proceeds regardless.
+    pub total_recycle_failures: u64,
 }
 
 /// Lock-free tracker of consecutive degraded upstream responses.
@@ -121,6 +128,7 @@ pub struct UpstreamHealth {
     total_first_byte_timeouts: AtomicU64,
     total_client_aborts: AtomicU64,
     total_recycles: AtomicU64,
+    total_recycle_failures: AtomicU64,
 }
 
 impl UpstreamHealth {
@@ -194,6 +202,23 @@ impl UpstreamHealth {
         requested
     }
 
+    /// Put back a recycle request that was consumed but could not be carried
+    /// out.
+    ///
+    /// [`Self::take_recycle_request`] clears the flag *and* zeroes the streak,
+    /// on the assumption that the caller is about to act on it. When the stop
+    /// then fails, the upstream is still degraded but the evidence for that has
+    /// just been discarded — so without this the watchdog has to accumulate
+    /// [`STRIKE_THRESHOLD`] fresh strikes before it will try again, against a
+    /// server already known to be sick.
+    ///
+    /// Deliberately does not touch `total_recycles`: that counts recycles
+    /// *triggered*, which this one was. The failure is counted separately.
+    pub fn rearm_recycle(&self) {
+        self.total_recycle_failures.fetch_add(1, Ordering::Relaxed);
+        self.recycle_requested.store(true, Ordering::Relaxed);
+    }
+
     /// Current consecutive-strike count (for observability/tests).
     #[must_use]
     pub fn strikes(&self) -> u32 {
@@ -210,6 +235,7 @@ impl UpstreamHealth {
             total_first_byte_timeouts: self.total_first_byte_timeouts.load(Ordering::Relaxed),
             total_client_aborts: self.total_client_aborts.load(Ordering::Relaxed),
             total_recycles: self.total_recycles.load(Ordering::Relaxed),
+            total_recycle_failures: self.total_recycle_failures.load(Ordering::Relaxed),
         }
     }
 }
@@ -301,6 +327,41 @@ mod tests {
         assert_eq!(h.strikes(), 1);
         assert!(!h.take_recycle_request());
         assert_eq!(h.snapshot().total_client_aborts, 2);
+    }
+
+    /// A recycle that could not be carried out must not spend the watchdog's
+    /// case. Before this, a failed stop left the flag cleared and the streak
+    /// zeroed, so a server that was still sick got a clean slate and needed
+    /// two fresh strikes before anyone tried again.
+    #[test]
+    fn a_failed_recycle_rearms_instead_of_spending_the_request() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(StreamVerdict::Empty);
+        h.record_stream_outcome(StreamVerdict::Empty);
+        assert!(h.take_recycle_request(), "threshold reached");
+
+        // The stop failed, so the request goes back.
+        h.rearm_recycle();
+        assert!(
+            h.take_recycle_request(),
+            "the re-armed request is available to the next idle caller"
+        );
+
+        let snap = h.snapshot();
+        assert_eq!(snap.total_recycle_failures, 1);
+        // Both takes count as triggered — the failure is tracked separately
+        // rather than by rewriting a cumulative counter.
+        assert_eq!(snap.total_recycles, 2);
+    }
+
+    #[test]
+    fn rearming_is_not_needed_on_the_happy_path() {
+        let h = UpstreamHealth::new();
+        h.record_stream_outcome(StreamVerdict::Empty);
+        h.record_stream_outcome(StreamVerdict::Empty);
+        assert!(h.take_recycle_request());
+        assert!(!h.take_recycle_request(), "still one-shot when it succeeds");
+        assert_eq!(h.snapshot().total_recycle_failures, 0);
     }
 
     #[test]


### PR DESCRIPTION
> Stacked on #800 (sibling of #801 — different files, no interdependency). Base retargets to `main` once #800 lands.

`take_recycle_request()` is a one-shot. It clears the flag, zeroes the consecutive-strike streak, and counts a recycle — all on the assumption that the caller is about to act on it. The watchdog's caller then discarded the result of doing so:

```rust
let _ = state.runtime_port.stop_current().await;
```

### What that costs

When `stop_current()` failed, the upstream stayed exactly as degraded as it was, but every piece of evidence for that had just been thrown away. The next request met a clean slate and had to accumulate two fresh strikes — two more failed turns for the person using it — before anything tried again, against a server already known to be sick.

If stopping kept failing, the cycle repeated indefinitely and the watchdog was in effect switched off, silently.

### The fix

Handle it the way the cache-clear path in this same file (`server.rs:610-616`) already handles its own recycle failures: log it, and put the request back so the next idle caller retries.

`total_recycles` deliberately keeps counting *triggers* rather than successes — rewriting a cumulative counter to mean something else would break its meaning across a restart. Failures get their own counter instead, so "the watchdog is firing and being ignored" stops being invisible. That's a different fault from a healthy upstream, and it now reads differently on the dashboard.

### Verification

`make pre-commit` passes in full. Two new tests: one drives the threshold, fails the stop, and asserts the re-armed request is available to the next caller; one asserts the flag is still one-shot on the happy path.

### Why now

§9.3.4 of the transition plan. Grouped with the other "bugs that contaminate every rate" — while the watchdog can be silently disarmed, no defect rate derived from it is trustworthy.