### PR TITLE
feat(proxy,core): stream_errors — the counter that sees dead, not just sick

### DIFF
--- a/crates/gglib-core/src/domain/defects.rs
+++ b/crates/gglib-core/src/domain/defects.rs
@@ -34,6 +34,21 @@ pub struct ModelDefectCounts {
     pub repairs_attempted: u64,
     /// Of those, the re-issues that produced a conformant call.
     pub repairs_succeeded: u64,
+    /// Streaming turns that died on an *upstream* mid-stream failure — an
+    /// error event the model server emitted mid-generation, or the byte
+    /// stream itself breaking.
+    ///
+    /// The catastrophic sibling of the repair signal. Both of the counters
+    /// above require a model coherent enough to produce structured output:
+    /// one counts verbatim repetition, the other a tool call that was
+    /// attempted and malformed. A model whose sampling has collapsed
+    /// produces neither — it emits output so far outside the expected shape
+    /// that the model server kills the stream, and the person's turn simply
+    /// fails, invisibly to every other counter here.
+    ///
+    /// Client disconnects are deliberately not in here: hanging up is a
+    /// person's action, not a model defect.
+    pub stream_errors: u64,
 }
 
 /// Process-lifetime per-model defect counters.
@@ -79,6 +94,17 @@ impl ModelDefectLedger {
         });
     }
 
+    /// Count one upstream mid-stream failure for `model`.
+    ///
+    /// Deliberately does *not* bump `requests`, unlike
+    /// [`Self::record_loop_guard_trip`]. The guard fires *instead of* a
+    /// forward, so it has to count its own denominator; a stream error
+    /// happens after the request was forwarded and already counted. Bumping
+    /// here would count the same request twice and deflate every rate.
+    pub fn record_stream_error(&self, model: &str) {
+        self.with(model, |c| c.stream_errors += 1);
+    }
+
     /// The current counts for every model that has any.
     #[must_use]
     pub fn snapshot(&self) -> HashMap<String, ModelDefectCounts> {
@@ -112,6 +138,7 @@ pub const fn delta(current: ModelDefectCounts, baseline: ModelDefectCounts) -> M
         repairs_succeeded: current
             .repairs_succeeded
             .saturating_sub(baseline.repairs_succeeded),
+        stream_errors: current.stream_errors.saturating_sub(baseline.stream_errors),
     }
 }
 
@@ -133,6 +160,20 @@ mod tests {
         assert_eq!(snap["a"].loop_guard_trips, 1);
         assert_eq!(snap["b"].repairs_attempted, 2);
         assert_eq!(snap["b"].repairs_succeeded, 1);
+    }
+
+    /// A stream error marks an already-forwarded request as having died; it
+    /// must not also count a request, or the rate it feeds is deflated by
+    /// its own denominator.
+    #[test]
+    fn a_stream_error_does_not_bump_its_own_denominator() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_request("a");
+        ledger.record_stream_error("a");
+
+        let snap = ledger.snapshot()["a"];
+        assert_eq!(snap.requests, 1, "the turn was counted when forwarded");
+        assert_eq!(snap.stream_errors, 1);
     }
 
     #[test]

--- a/crates/gglib-proxy/src/metrics.rs
+++ b/crates/gglib-proxy/src/metrics.rs
@@ -220,6 +220,27 @@ impl ContextMetricsStore {
         }
     }
 
+    /// Count one upstream mid-stream failure against `seq`'s model.
+    ///
+    /// Unlike its two siblings above this keeps no fleet-wide total, because
+    /// one already exists: `UpstreamHealth` counts every upstream death for
+    /// the dashboard. What is missing there, and supplied here, is *which
+    /// model* died — a fleet counter cannot tell a single sick model from a
+    /// sick server.
+    ///
+    /// The ring row is consulted only for its model name, so an event whose
+    /// snapshot was already evicted is lost to the per-model ledger. That is
+    /// the same bounded, bias-free undercount [`Self::flag_tool_repair`]
+    /// accepts, on exactly the busiest traffic.
+    pub fn flag_stream_error(&self, seq: u64) {
+        let guard = self.snapshots.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(snapshot) = guard.iter().find(|s| s.seq == seq)
+            && let Some(ledger) = &self.ledger
+        {
+            ledger.record_stream_error(&snapshot.model_name);
+        }
+    }
+
     /// Total tool-call repairs attempted, eviction-safe.
     pub fn tool_repairs_attempted(&self) -> u64 {
         self.tool_repairs_attempted.load(Ordering::Relaxed)

--- a/crates/gglib-proxy/src/sse_stream.rs
+++ b/crates/gglib-proxy/src/sse_stream.rs
@@ -209,6 +209,16 @@ pub fn spawn_and_return(
                     // has finished, by which time the snapshot already exists.
                     context_metrics.flag_tool_repair(snapshot_seq, outcome.repair_succeeded);
                 }
+                if outcome.upstream_errored {
+                    warn!(
+                        model = %model_name_owned,
+                        "turn died on an upstream mid-stream failure"
+                    );
+                    // Back-patched like the repair flag: the fact is only
+                    // known once the stream has ended, by which time the
+                    // snapshot already exists.
+                    context_metrics.flag_stream_error(snapshot_seq);
+                }
                 // Feed the terminal outcome to the watchdog. The precedence
                 // between "produced output", "died upstream" and "the client
                 // left" lives in `health_verdict`, so this stays one line and


### PR DESCRIPTION
Re-authored from #798's proxy half onto clean `main`. Supersedes #798, which will be closed.

### The blind spot

The loop guard and the repair loop both require a model coherent enough to produce structured output — one counts verbatim repetition, the other counts a tool call that was attempted and malformed. **A model whose sampling has collapsed produces neither.** It emits output so far outside the expected shape that the model server kills the stream, and the person's turn simply fails.

That failure was invisible to every counter we had. It was mapped by deliberately sabotaging a model's recipe and watching a real chat die with nothing recorded anywhere.

`stream_errors` counts exactly that, **per model**.

### Why this is small now

#800 already landed the two facts this needs: `StreamOutcome::upstream_errored`, set at the two sites in the drain loop that know, and the `UpstreamError`/`ToolCallDelta` match-arm split. So what remains is the counter itself plus wiring — the same back-patch through the metrics ring that the repair flag already uses, for the same reason: the outcome is only known once the stream ends, by which time the snapshot exists.

### Two deliberate asymmetries

Both would be bugs if copied from the wrong sibling, so they're stated in the code:

**No fleet-wide total**, unlike `flag_dialect_residue` and `flag_tool_repair`. One already exists — `UpstreamHealth::total_upstream_errors` counts every upstream death for the dashboard. What a fleet counter *cannot* do is tell one sick model apart from a sick server, and that is the entire reason for a per-model ledger.

**Does not bump `requests`**, unlike `record_loop_guard_trip`. The guard fires *instead of* a forward, so it must count its own denominator. A stream error happens *after* the request was forwarded and already counted — bumping here would count one request twice and deflate every rate derived from it. There's a test pinning this.

### Scope

Deliberately **excluded** from this branch:

- The `ALTER TABLE defect_windows ADD COLUMN stream_errors` from #798's `setup.rs`. It hard-depends on #795 creating that table, so it folds into #795 and the column gets created correctly the first time rather than added by migration.
- #798's `auto_tune.rs` (+116) and `benchmark.rs` changes — scheduler wiring for a scheduler being removed.
- #798's ADR 0005 edits — ADR 0005 is being superseded by 0006, not amended.

Also note: #798 filed this under "the proxy half", but the ledger lives in `gglib-core/src/domain/defects.rs`, not `gglib-proxy` — hence the `(proxy,core)` scope.

### Verification

`make pre-commit` passes in full. One new test asserting a stream error doesn't inflate its own denominator.