### PR TITLE
refactor(core): the defect window, and the decay policy that judges it

### DIFF
--- a/crates/gglib-core/src/domain/defects/README.md
+++ b/crates/gglib-core/src/domain/defects/README.md
@@ -1,0 +1,50 @@
+# defects
+
+![LOC](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-defects-loc.json)
+![Complexity](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-defects-complexity.json)
+
+<!-- module-docs:start -->
+
+Per-model defect counters — the Tier C signals the closed loop steers by.
+
+The proxy records defect *events* (a loop-guard trip, a tool-call repair)
+as they happen; the auto-tune scheduler reads *rates* over the traffic
+since its last look and decides whether a model has earned a targeted
+sweep. Writers never interpret and the reader never guesses: a trip is a
+fact about one request, a rate is a claim about a model, and the split
+keeps both honest.
+
+Counters are cumulative and process-lifetime (they live on the proxy
+supervisor, like the agent cache metrics, so a proxy restart does not
+zero them). Windowing is the *reader's* job: the scheduler keeps its own
+per-model baselines and rates the delta, so two readers can window
+differently without fighting over a reset button.
+
+A restart no longer zeroes the evidence. The *unacted window* per model
+is persisted and re-seeded at boot via [`ModelDefectLedger::seed`] —
+decayed by wall-clock age, and discarded outright when it was recorded
+against a different llama.cpp release.
+
+Decay and build scoping are the two answers to the staleness objection
+that originally kept this unpersisted (ADR 0001 via ADR 0005):
+yesterday's rate must not answer today's question at full weight, and
+another build's rate must not answer it at all. Interpretation still
+belongs to readers — this module stores and adds counts; nothing here
+judges. The policy that decides what a restored row is worth lives next
+door in [`decay`], kept pure and separately testable.
+
+The accepted residual: a window held by a long-lived process does not
+decay in place, because decay covers only the recorded gap between runs.
+
+<!-- module-docs:end -->
+
+<details>
+<summary><h2>Modules</h2></summary>
+
+<!-- module-table:start -->
+| Module | LOC | Complexity | Coverage |
+|--------|-----|------------|----------|
+| [`decay.rs`](decay.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-defects-decay-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-defects-decay-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-defects-decay-coverage.json) |
+<!-- module-table:end -->
+
+</details>

--- a/crates/gglib-core/src/domain/defects/decay.rs
+++ b/crates/gglib-core/src/domain/defects/decay.rs
@@ -1,0 +1,277 @@
+//! What restored defect evidence is still worth, and what should be written
+//! back.
+//!
+//! Entirely pure: every function here is a total function of its arguments,
+//! with no clock, no environment and no I/O. The caller supplies `now`, the
+//! half-life and the build string; this module only decides. That is what
+//! makes the two staleness answers — decay by age, discard by build —
+//! testable without a database or a running daemon, which is the whole
+//! reason they live here rather than beside the code that persists them.
+
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+
+use chrono::{DateTime, Utc};
+
+use super::{ModelDefectCounts, PersistedDefectWindow, delta};
+
+/// The exponential decay a gap of `gap_secs` applies: `0.5^(gap/half_life)`.
+///
+/// A non-positive gap — clock skew, or a stamp from the future — decays
+/// nothing. Evidence is at worst current; it is never *amplified* by a clock
+/// that disagrees with itself.
+#[must_use]
+pub fn decay_factor(gap_secs: f64, half_life_secs: f64) -> f64 {
+    if gap_secs <= 0.0 {
+        return 1.0;
+    }
+    0.5_f64.powf(gap_secs / half_life_secs)
+}
+
+/// Each count scaled and rounded independently.
+///
+/// A window is a bundle of counts, not a ratio, so per-field rounding noise
+/// of ±0.5 events is accepted. Documented here so nobody "fixes" it into a
+/// scheme that preserves ratios by inventing fractional events — a rate is
+/// the reader's job to compute, and it would rather divide two honest
+/// integers than two doctored ones.
+#[must_use]
+pub fn decay_counts(counts: ModelDefectCounts, factor: f64) -> ModelDefectCounts {
+    let scale = |c: u64| -> u64 {
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        {
+            ((c as f64) * factor).round() as u64
+        }
+    };
+    ModelDefectCounts {
+        requests: scale(counts.requests),
+        loop_guard_trips: scale(counts.loop_guard_trips),
+        repairs_attempted: scale(counts.repairs_attempted),
+        repairs_succeeded: scale(counts.repairs_succeeded),
+        stream_errors: scale(counts.stream_errors),
+    }
+}
+
+/// What boot does with the persisted rows: seed these, delete those.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct RestorePlan {
+    /// Rows to seed into the ledger, already decayed.
+    pub seed: Vec<(String, ModelDefectCounts)>,
+    /// Rows to delete: foreign-build evidence, and windows decayed to
+    /// nothing.
+    pub discard: Vec<String>,
+}
+
+/// Sort persisted rows into seeds and discards.
+///
+/// A row from another llama.cpp release is discarded outright — another
+/// build's rate must not answer this build's question at *any* weight, so
+/// this is a rejection rather than a heavier decay. A surviving row decays
+/// by its age; one whose decayed request count rounds below a single request
+/// has nothing left to say and is deleted rather than carried forever.
+#[must_use]
+pub fn restore_plan(
+    rows: Vec<PersistedDefectWindow>,
+    now: DateTime<Utc>,
+    llama_build: &str,
+    half_life_secs: f64,
+) -> RestorePlan {
+    let mut plan = RestorePlan::default();
+    for row in rows {
+        if row.llama_build != llama_build {
+            plan.discard.push(row.model_name);
+            continue;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let gap_secs = (now - row.updated_at).num_seconds() as f64;
+        let decayed = decay_counts(row.counts, decay_factor(gap_secs, half_life_secs));
+        if decayed.requests == 0 {
+            plan.discard.push(row.model_name);
+            continue;
+        }
+        plan.seed.push((row.model_name, decayed));
+    }
+    plan
+}
+
+/// The per-model window: current counts minus the reader's baseline.
+#[must_use]
+pub fn windowed<C: BuildHasher, B: BuildHasher>(
+    current: &HashMap<String, ModelDefectCounts, C>,
+    baselines: &HashMap<String, ModelDefectCounts, B>,
+) -> HashMap<String, ModelDefectCounts> {
+    current
+        .iter()
+        .map(|(name, counts)| {
+            let baseline = baselines.get(name).copied().unwrap_or_default();
+            (name.clone(), delta(*counts, baseline))
+        })
+        .collect()
+}
+
+/// The rows one flush writes: every window that differs from what was last
+/// persisted, stamped with `now` and the current release.
+///
+/// Skipping unchanged rows is not just economy — it preserves a stored row's
+/// `updated_at`, so evidence that sits untouched keeps decaying from its real
+/// age instead of being re-dated by every flush. Re-stamping an idle window
+/// would make it immortal.
+#[must_use]
+pub fn rows_to_flush<W: BuildHasher, L: BuildHasher>(
+    windows: &HashMap<String, ModelDefectCounts, W>,
+    last_flushed: &HashMap<String, ModelDefectCounts, L>,
+    now: DateTime<Utc>,
+    llama_build: &str,
+) -> Vec<PersistedDefectWindow> {
+    windows
+        .iter()
+        .filter(|(name, counts)| last_flushed.get(*name) != Some(counts))
+        .map(|(name, counts)| PersistedDefectWindow {
+            model_name: name.clone(),
+            counts: *counts,
+            updated_at: now,
+            llama_build: llama_build.to_owned(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HALF_LIFE: f64 = 86_400.0; // one day
+
+    fn counts(requests: u64) -> ModelDefectCounts {
+        ModelDefectCounts {
+            requests,
+            ..ModelDefectCounts::default()
+        }
+    }
+
+    fn row(name: &str, requests: u64, age_secs: i64, build: &str) -> PersistedDefectWindow {
+        PersistedDefectWindow {
+            model_name: name.to_owned(),
+            counts: counts(requests),
+            updated_at: Utc::now() - chrono::Duration::seconds(age_secs),
+            llama_build: build.to_owned(),
+        }
+    }
+
+    #[test]
+    fn one_half_life_halves_the_evidence() {
+        assert!((decay_factor(HALF_LIFE, HALF_LIFE) - 0.5).abs() < f64::EPSILON);
+        assert!((decay_factor(2.0 * HALF_LIFE, HALF_LIFE) - 0.25).abs() < f64::EPSILON);
+    }
+
+    /// Clock skew must never make evidence stronger than when it was written.
+    #[test]
+    fn a_gap_that_runs_backwards_decays_nothing() {
+        assert!((decay_factor(-500.0, HALF_LIFE) - 1.0).abs() < f64::EPSILON);
+        assert!((decay_factor(0.0, HALF_LIFE) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn every_field_decays_including_stream_errors() {
+        let full = ModelDefectCounts {
+            requests: 100,
+            loop_guard_trips: 10,
+            repairs_attempted: 8,
+            repairs_succeeded: 4,
+            stream_errors: 6,
+        };
+        let halved = decay_counts(full, 0.5);
+        assert_eq!(halved.requests, 50);
+        assert_eq!(halved.loop_guard_trips, 5);
+        assert_eq!(halved.repairs_attempted, 4);
+        assert_eq!(halved.repairs_succeeded, 2);
+        assert_eq!(halved.stream_errors, 3);
+    }
+
+    /// A foreign build is rejected outright, not merely discounted — the
+    /// distinction the whole build-scoping argument rests on.
+    #[test]
+    fn another_builds_evidence_is_discarded_however_fresh() {
+        let plan = restore_plan(
+            vec![row("m", 10_000, 0, "b10000")],
+            Utc::now(),
+            "b10327",
+            HALF_LIFE,
+        );
+        assert!(plan.seed.is_empty(), "no weight at all, not reduced weight");
+        assert_eq!(plan.discard, vec!["m".to_owned()]);
+    }
+
+    #[test]
+    fn fresh_same_build_evidence_survives_intact() {
+        let plan = restore_plan(
+            vec![row("m", 40, 0, "b10327")],
+            Utc::now(),
+            "b10327",
+            HALF_LIFE,
+        );
+        assert_eq!(plan.seed, vec![("m".to_owned(), counts(40))]);
+        assert!(plan.discard.is_empty());
+    }
+
+    /// Evidence too old to round to a single request is deleted rather than
+    /// carried forever as a zero row.
+    #[test]
+    fn a_window_decayed_below_one_request_is_discarded() {
+        let plan = restore_plan(
+            vec![row("m", 4, 20 * 86_400, "b10327")],
+            Utc::now(),
+            "b10327",
+            HALF_LIFE,
+        );
+        assert!(plan.seed.is_empty());
+        assert_eq!(plan.discard, vec!["m".to_owned()]);
+    }
+
+    #[test]
+    fn windowing_subtracts_the_baseline_and_treats_absent_as_zero() {
+        let current = HashMap::from([("a".to_owned(), counts(10)), ("b".to_owned(), counts(3))]);
+        let baselines = HashMap::from([("a".to_owned(), counts(4))]);
+
+        let w = windowed(&current, &baselines);
+        assert_eq!(w["a"].requests, 6);
+        assert_eq!(w["b"].requests, 3, "no baseline means the whole count");
+    }
+
+    /// The immortality guard: an unchanged window is not rewritten, so its
+    /// stored `updated_at` keeps ageing and decay keeps biting.
+    #[test]
+    fn an_unchanged_window_is_not_reflushed() {
+        let windows = HashMap::from([("a".to_owned(), counts(5)), ("b".to_owned(), counts(9))]);
+        let last = HashMap::from([("a".to_owned(), counts(5))]);
+
+        let rows = rows_to_flush(&windows, &last, Utc::now(), "b10327");
+        assert_eq!(rows.len(), 1, "only the changed window");
+        assert_eq!(rows[0].model_name, "b");
+    }
+
+    #[test]
+    fn flushed_rows_carry_the_current_build_and_stamp() {
+        let now = Utc::now();
+        let windows = HashMap::from([("a".to_owned(), counts(5))]);
+
+        let rows = rows_to_flush(&windows, &HashMap::new(), now, "b10327");
+        assert_eq!(rows[0].llama_build, "b10327");
+        assert_eq!(rows[0].updated_at, now);
+    }
+
+    /// Round-trip: what a flush writes is what a same-build restore reads
+    /// back, undecayed when no time has passed.
+    #[test]
+    fn a_flush_round_trips_through_restore_unchanged() {
+        let now = Utc::now();
+        let windows = HashMap::from([("a".to_owned(), counts(7))]);
+        let rows = rows_to_flush(&windows, &HashMap::new(), now, "b10327");
+
+        let plan = restore_plan(rows, now, "b10327", HALF_LIFE);
+        assert_eq!(plan.seed, vec![("a".to_owned(), counts(7))]);
+    }
+}

--- a/crates/gglib-core/src/domain/defects/mod.rs
+++ b/crates/gglib-core/src/domain/defects/mod.rs
@@ -1,25 +1,9 @@
-//! Per-model defect counters — the Tier C signals the closed loop steers by.
-//!
-//! The proxy records defect *events* (a loop-guard trip, a tool-call repair)
-//! as they happen; the auto-tune scheduler reads *rates* over the traffic
-//! since its last look and decides whether a model has earned a targeted
-//! sweep. Writers never interpret and the reader never guesses: a trip is a
-//! fact about one request, a rate is a claim about a model, and the split
-//! keeps both honest.
-//!
-//! Counters are cumulative and process-lifetime (they live on the proxy
-//! supervisor, like the agent cache metrics, so a proxy restart does not
-//! zero them). Windowing is the *reader's* job: the scheduler keeps its own
-//! per-model baselines and rates the delta, so two readers can window
-//! differently without fighting over a reset button.
-//!
-//! Deliberately not persisted: a defect rate is a claim about recent traffic
-//! on this build of everything, and yesterday's rate answering today's
-//! question is exactly the staleness ADR 0001 warns about. The loop reacts
-//! to what is happening, not to what once happened.
+#![doc = include_str!("README.md")]
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+
+pub mod decay;
 
 /// Cumulative defect counts for one model.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -49,6 +33,26 @@ pub struct ModelDefectCounts {
     /// Client disconnects are deliberately not in here: hanging up is a
     /// person's action, not a model defect.
     pub stream_errors: u64,
+}
+
+/// One persisted unacted window — the counts not yet acted on, stamped with
+/// when they were last true and the llama.cpp release they were observed
+/// against.
+///
+/// The stamp is what makes restored evidence honest: age decays it, a
+/// foreign build discards it. Without both, a restart would let a rate
+/// measured against different inference code answer a question about this
+/// one, at full confidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedDefectWindow {
+    /// The ledger's key — the model name requests carry, not the catalog id.
+    pub model_name: String,
+    /// The unacted counts at `updated_at`.
+    pub counts: ModelDefectCounts,
+    /// When these counts were last written — the base of the decay gap.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    /// The llama.cpp release the evidence was observed against.
+    pub llama_build: String,
 }
 
 /// Process-lifetime per-model defect counters.
@@ -81,6 +85,22 @@ impl ModelDefectLedger {
         self.with(model, |c| {
             c.requests += 1;
             c.loop_guard_trips += 1;
+        });
+    }
+
+    /// Seed `model`'s counters with restored evidence.
+    ///
+    /// Saturating adds, and additive rather than assigning: a proxy that has
+    /// already counted live traffic before the restore lands is never zeroed
+    /// by it. Overflow on counters this small is a bug shield, not a case
+    /// anyone expects to hit.
+    pub fn seed(&self, model: &str, counts: ModelDefectCounts) {
+        self.with(model, |c| {
+            c.requests = c.requests.saturating_add(counts.requests);
+            c.loop_guard_trips = c.loop_guard_trips.saturating_add(counts.loop_guard_trips);
+            c.repairs_attempted = c.repairs_attempted.saturating_add(counts.repairs_attempted);
+            c.repairs_succeeded = c.repairs_succeeded.saturating_add(counts.repairs_succeeded);
+            c.stream_errors = c.stream_errors.saturating_add(counts.stream_errors);
         });
     }
 
@@ -160,6 +180,66 @@ mod tests {
         assert_eq!(snap["a"].loop_guard_trips, 1);
         assert_eq!(snap["b"].repairs_attempted, 2);
         assert_eq!(snap["b"].repairs_succeeded, 1);
+    }
+
+    /// The restore contract: seeded counts read back through the ordinary
+    /// snapshot/delta path, so a reader needs no special case for restored
+    /// evidence.
+    #[test]
+    fn seeding_restores_counts_the_reader_windows() {
+        let ledger = ModelDefectLedger::new();
+        ledger.seed(
+            "a",
+            ModelDefectCounts {
+                requests: 40,
+                loop_guard_trips: 3,
+                repairs_attempted: 2,
+                repairs_succeeded: 1,
+                stream_errors: 4,
+            },
+        );
+        ledger.record_request("a");
+
+        let snap = ledger.snapshot()["a"];
+        assert_eq!(snap.requests, 41, "seed is additive, not assignment");
+        assert_eq!(snap.loop_guard_trips, 3);
+        assert_eq!(snap.stream_errors, 4);
+        // An empty baseline windows the whole seed.
+        assert_eq!(delta(snap, ModelDefectCounts::default()), snap);
+    }
+
+    /// Live traffic counted before a restore lands must not be erased by it.
+    #[test]
+    fn seeding_adds_to_traffic_already_counted() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_request("a");
+        ledger.record_stream_error("a");
+        ledger.seed(
+            "a",
+            ModelDefectCounts {
+                requests: 10,
+                stream_errors: 2,
+                ..Default::default()
+            },
+        );
+
+        let snap = ledger.snapshot()["a"];
+        assert_eq!(snap.requests, 11);
+        assert_eq!(snap.stream_errors, 3);
+    }
+
+    #[test]
+    fn seeding_saturates_rather_than_wrapping() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_request("a");
+        ledger.seed(
+            "a",
+            ModelDefectCounts {
+                requests: u64::MAX,
+                ..ModelDefectCounts::default()
+            },
+        );
+        assert_eq!(ledger.snapshot()["a"].requests, u64::MAX);
     }
 
     /// A stream error marks an already-forwarded request as having died; it

--- a/crates/gglib-core/src/ports/defect_windows.rs
+++ b/crates/gglib-core/src/ports/defect_windows.rs
@@ -1,0 +1,32 @@
+//! Defect-window repository port definition.
+//!
+//! Persists the *unacted* per-model defect windows so a daemon restart
+//! resumes the count instead of zeroing it. Implementations live in
+//! `gglib-db`; this trait contains only domain types.
+//!
+//! Staleness is answered at load, not at store. The store keeps whatever it
+//! was given, including rows from other llama.cpp releases; the reader
+//! decays by wall-clock age and rejects foreign builds. Keeping that policy
+//! out of the repository is what lets it be unit-tested with no database —
+//! see [`crate::domain::defects::decay`].
+
+use async_trait::async_trait;
+
+use super::RepositoryError;
+use crate::domain::defects::PersistedDefectWindow;
+
+/// Repository interface for persisted defect windows.
+#[async_trait]
+pub trait DefectWindowRepositoryPort: Send + Sync {
+    /// Every persisted window, all builds included — build filtering and
+    /// decay are the reader's policy, not the store's.
+    async fn load_all(&self) -> Result<Vec<PersistedDefectWindow>, RepositoryError>;
+
+    /// Upsert these rows in one transaction — a flush is one fact about one
+    /// moment and must not half-land.
+    async fn upsert_many(&self, rows: &[PersistedDefectWindow]) -> Result<(), RepositoryError>;
+
+    /// Delete the named rows in one transaction (stale-build discards, and
+    /// windows decayed to nothing).
+    async fn delete(&self, model_names: &[String]) -> Result<(), RepositoryError>;
+}

--- a/crates/gglib-core/src/ports/mod.rs
+++ b/crates/gglib-core/src/ports/mod.rs
@@ -2,6 +2,7 @@
 pub mod agent;
 pub mod benchmark;
 pub mod chat_history;
+pub mod defect_windows;
 pub mod download;
 pub mod download_event_emitter;
 pub mod download_manager;


### PR DESCRIPTION
First of two, re-authoring #795 onto clean `main`. **This is the pure half only** — types and rules, no store and no caller. The sqlite repository, the service and the wiring follow in a second PR.

### What moves and why

`defects.rs` becomes `defects/`, splitting *what accumulates counts* from *what decides their worth*. The ledger still only stores and adds; the policy that reads a restored row and asks whether it still means anything lives next door in `decay`.

That separation isn't tidiness. Decay-by-age and rejection-by-build are the two answers to the staleness objection that originally kept these counters unpersisted — and answers of that kind should be provable by unit test, not by running a daemon and waiting a day. So `decay` is **total and clockless**: the caller supplies `now`, the half-life and the build string, and nothing in it reads the environment or touches I/O.

### Two rules that look like details and aren't

**A foreign build is discarded outright, never merely discounted.** Another llama.cpp release's rate must not answer this build's question at *any* weight — the inference code changed underneath the measurement, so the measurement is about something else. There's a test asserting a 10,000-request row from another build contributes nothing even when perfectly fresh.

**An unchanged window is not rewritten on flush.** A stored row's `updated_at` is the base of its decay, so re-stamping an idle window on every flush would make it *immortal* and the evidence would never age out. Also tested.

### Contents

| File | What |
|---|---|
| `domain/defects/mod.rs` | ledger, counts, `PersistedDefectWindow`, `seed`, `delta` |
| `domain/defects/decay.rs` | `decay_factor`, `decay_counts`, `RestorePlan`, `restore_plan`, `windowed`, `rows_to_flush` |
| `ports/defect_windows.rs` | `DefectWindowRepositoryPort` |

`seed` is additive and saturating, so a restore landing *after* live traffic has been counted adds to it rather than replacing it.

### Notes

- Carries `stream_errors` (merged in #803) through decay and seed — the field didn't exist when #795 was written.
- `windowed` and `rows_to_flush` are generic over the hasher. They were private in `auto_tune.rs`; as public API clippy's `implicit_hasher` applies, and generalising is the honest fix rather than an `allow`.
- The new subdir README is produced by the repo's own `generate_submodule_readmes.sh`, and the `//!` block it extracts is removed rather than left duplicated — matching how every other subdir module here is documented. I reverted the 14 unrelated READMEs the generator also touched; those diffs were badge-row reordering with no information in them.

### Verification

`make pre-commit` passes in full. 13 tests across the two modules, including a flush→restore round-trip.