### PR TITLE
fix(core,proxy,agent): stop fabricating a finish reason the upstream never gave

### DIFF
--- a/crates/gglib-agent/src/agent_loop.rs
+++ b/crates/gglib-agent/src/agent_loop.rs
@@ -393,7 +393,10 @@ impl AgentLoopPort for AgentLoop {
                 content_len = response.content.len(),
                 reasoning_len = response.reasoning_content.len(),
                 tool_call_count = response.tool_calls.len(),
-                finish_reason = %response.finish_reason,
+                finish_reason = response
+                    .finish_reason
+                    .as_deref()
+                    .unwrap_or("<none reported>"),
                 "LLM response received"
             );
 

--- a/crates/gglib-agent/src/stream_collector.rs
+++ b/crates/gglib-agent/src/stream_collector.rs
@@ -85,8 +85,14 @@ pub struct CollectedResponse {
     pub reasoning_content: String,
     /// Tool calls requested by the model (empty when the model answered directly).
     pub tool_calls: Vec<ToolCall>,
-    /// The `finish_reason` from the [`LlmStreamEvent::Done`] terminus event.
-    pub finish_reason: String,
+    /// The `finish_reason` from the [`LlmStreamEvent::Done`] terminus event,
+    /// or `None` when the upstream never reported one.
+    ///
+    /// Kept optional rather than defaulted so a stream that ended abnormally
+    /// stays distinguishable from one that stopped cleanly — a `"length"`
+    /// truncation and a died-mid-generation turn are different facts, and
+    /// collapsing the unknown case into `"stop"` erases both.
+    pub finish_reason: Option<String>,
     /// Tool-call deltas dropped because their `index` reached
     /// [`MAX_TOOL_CALL_INDEX`].
     ///
@@ -173,7 +179,7 @@ pub async fn collect_stream(
     let mut got_any_event = false;
     // Set at `Done`; the loop keeps draining afterwards because the OpenAI
     // usage chunk legitimately trails `Done` (before the byte stream closes).
-    let mut finished: Option<(String, Vec<ToolCall>)> = None;
+    let mut finished: Option<(Option<String>, Vec<ToolCall>)> = None;
     let mut completion_tokens: Option<u32> = None;
 
     while let Some(event) = stream.next().await {

--- a/crates/gglib-agent/tests/common/mock_llm.rs
+++ b/crates/gglib-agent/tests/common/mock_llm.rs
@@ -104,7 +104,7 @@ impl MockLlmResponse {
             });
         }
         events.push(LlmStreamEvent::Done {
-            finish_reason: self.finish_reason,
+            finish_reason: Some(self.finish_reason),
         });
         events
     }

--- a/crates/gglib-agent/tests/unit_stream_collector.rs
+++ b/crates/gglib-agent/tests/unit_stream_collector.rs
@@ -43,13 +43,13 @@ async fn text_delta_forwarded_and_accumulated() {
             content: "world!".into(),
         },
         LlmStreamEvent::Done {
-            finish_reason: "stop".into(),
+            finish_reason: Some("stop".into()),
         },
     ]);
 
     let response = collect_stream(stream, &tx).await.unwrap();
     assert_eq!(response.content, "Hello, world!");
-    assert_eq!(response.finish_reason, "stop");
+    assert_eq!(response.finish_reason.as_deref(), Some("stop"));
     assert!(response.tool_calls.is_empty());
 
     // Both text deltas should have been forwarded to the channel.
@@ -73,7 +73,7 @@ async fn reasoning_delta_forwarded_and_accumulated_separately() {
             content: "Answer.".into(),
         },
         LlmStreamEvent::Done {
-            finish_reason: "stop".into(),
+            finish_reason: Some("stop".into()),
         },
     ]);
 
@@ -109,7 +109,7 @@ async fn tool_call_deltas_assembled_into_tool_calls() {
             arguments: Some("h\": \"/tmp\"}".into()),
         },
         LlmStreamEvent::Done {
-            finish_reason: "tool_calls".into(),
+            finish_reason: Some("tool_calls".into()),
         },
     ]);
 
@@ -138,7 +138,7 @@ async fn multiple_tool_calls_assembled_by_index() {
             arguments: Some("{}".into()),
         },
         LlmStreamEvent::Done {
-            finish_reason: "tool_calls".into(),
+            finish_reason: Some("tool_calls".into()),
         },
     ]);
 
@@ -192,7 +192,7 @@ async fn malformed_json_arguments_emit_error_and_fail() {
             arguments: Some("{ NOT VALID JSON ".into()),
         },
         LlmStreamEvent::Done {
-            finish_reason: "tool_calls".into(),
+            finish_reason: Some("tool_calls".into()),
         },
     ]);
 
@@ -237,7 +237,7 @@ async fn oversized_tool_call_index_is_dropped_without_losing_the_turn() {
             arguments: Some("{}".into()),
         },
         LlmStreamEvent::Done {
-            finish_reason: "tool_calls".into(),
+            finish_reason: Some("tool_calls".into()),
         },
     ]);
 
@@ -248,7 +248,7 @@ async fn oversized_tool_call_index_is_dropped_without_losing_the_turn() {
     assert_eq!(r.tool_calls_truncated, 1, "the drop is counted, not silent");
     assert_eq!(r.tool_calls.len(), 1, "the in-range call survives");
     assert_eq!(r.tool_calls[0].name, "do_thing");
-    assert_eq!(r.finish_reason, "tool_calls");
+    assert_eq!(r.finish_reason.as_deref(), Some("tool_calls"));
 }
 
 /// The Vec bound the guard exists for still holds: a wild index allocates
@@ -264,7 +264,7 @@ async fn a_wild_tool_call_index_drives_no_allocation() {
             arguments: Some("{}".into()),
         },
         LlmStreamEvent::Done {
-            finish_reason: "tool_calls".into(),
+            finish_reason: Some("tool_calls".into()),
         },
     ]);
 
@@ -285,7 +285,7 @@ async fn a_normal_stream_reports_no_truncation() {
             arguments: Some("{}".into()),
         },
         LlmStreamEvent::Done {
-            finish_reason: "tool_calls".into(),
+            finish_reason: Some("tool_calls".into()),
         },
     ]);
 

--- a/crates/gglib-core/src/domain/agent/events.rs
+++ b/crates/gglib-core/src/domain/agent/events.rs
@@ -225,8 +225,16 @@ pub enum LlmStreamEvent {
     /// Every conforming stream must end with exactly one `Done` item.
     Done {
         /// The OpenAI-compatible finish reason (e.g. `"stop"`, `"tool_calls"`,
-        /// `"length"`).
-        finish_reason: String,
+        /// `"length"`), or `None` when the upstream never reported one.
+        ///
+        /// `None` is load-bearing and must not be collapsed to `"stop"`. A
+        /// stream that ends without a finish reason ended *abnormally* — the
+        /// process died, the connection broke, the sentinel arrived with no
+        /// terminating chunk. Reporting that as a clean stop relabels a
+        /// truncation as a complete answer, which is exactly the fact any
+        /// truncation counter needs to see. `null` is the spec-legal way to
+        /// say "not known"; inventing a value is not.
+        finish_reason: Option<String>,
     },
 
     /// An upstream error reported inline, mid-stream.

--- a/crates/gglib-core/src/normalize/stream.rs
+++ b/crates/gglib-core/src/normalize/stream.rs
@@ -203,11 +203,15 @@ impl NormalizingStream {
                 // the required `"tool_calls"`.  Clients such as Zed check
                 // finish_reason to decide whether to dispatch tool results;
                 // a wrong value causes the conversation to hang.
-                let finish_reason = if finish_reason == "stop" && self.next_index > 0 {
-                    "tool_calls".to_owned()
-                } else {
-                    finish_reason
-                };
+                // Only an explicitly reported "stop" is corrected. An absent
+                // reason stays absent: the upstream never claimed the turn
+                // ended, so there is no wrong claim here to repair.
+                let finish_reason =
+                    if finish_reason.as_deref() == Some("stop") && self.next_index > 0 {
+                        Some("tool_calls".to_owned())
+                    } else {
+                        finish_reason
+                    };
                 self.queued
                     .push_back(LlmStreamEvent::Done { finish_reason });
                 // Deliberately *not* `self.terminated = true` here — see the
@@ -324,7 +328,7 @@ mod tests {
                 content: "hello".into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events.clone(), false));
@@ -344,7 +348,7 @@ mod tests {
                 cached_tokens: None,
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events.clone(), false));
@@ -362,7 +366,7 @@ mod tests {
                 content: "hello".into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
             LlmStreamEvent::Usage {
                 prompt_tokens: 10,
@@ -384,7 +388,7 @@ mod tests {
         // or resurrect already-finalised parser state; simply dropped.
         let events = vec![
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
             LlmStreamEvent::TextDelta {
                 content: "should be dropped".into(),
@@ -401,7 +405,7 @@ mod tests {
             out,
             vec![
                 LlmStreamEvent::Done {
-                    finish_reason: "stop".into(),
+                    finish_reason: Some("stop".into()),
                 },
                 LlmStreamEvent::Usage {
                     prompt_tokens: 1,
@@ -422,7 +426,7 @@ mod tests {
                     .into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "tool_calls".into(),
+                finish_reason: Some("tool_calls".into()),
             },
         ];
         let out = drain(wrap(events, true));
@@ -456,7 +460,7 @@ mod tests {
                 content: r#"think <tool_call>{"name":"foo","arguments":{}}</tool_call> end"#.into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "tool_calls".into(),
+                finish_reason: Some("tool_calls".into()),
             },
         ];
         let out = drain(wrap(events, true));
@@ -482,7 +486,7 @@ mod tests {
                 content: r#"<tool_call>{"name":"foo","arguments":{}}</tool_call>"#.into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events, true));
@@ -505,7 +509,7 @@ mod tests {
                 content: r#"<tool_call>{"name":"foo""#.into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events, true));
@@ -546,14 +550,14 @@ mod tests {
                 arguments: Some(r#"{"path":"/tmp/x"}"#.into()),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(), // wrong — model bug
+                finish_reason: Some("stop".into()), // wrong — model bug
             },
         ];
         let out = drain(wrap(events, false));
         assert_eq!(out.len(), 2);
         match &out[1] {
             LlmStreamEvent::Done { finish_reason } => {
-                assert_eq!(finish_reason, "tool_calls");
+                assert_eq!(finish_reason.as_deref(), Some("tool_calls"));
             }
             other => panic!("expected Done, got {other:?}"),
         }
@@ -568,13 +572,13 @@ mod tests {
                 content: "hello".into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events, false));
         match &out[1] {
             LlmStreamEvent::Done { finish_reason } => {
-                assert_eq!(finish_reason, "stop");
+                assert_eq!(finish_reason.as_deref(), Some("stop"));
             }
             other => panic!("expected Done, got {other:?}"),
         }
@@ -592,7 +596,7 @@ mod tests {
                 content: "actual answer".into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events, false));
@@ -623,7 +627,7 @@ mod tests {
                 content: "<think>spurious</think>real text".into(),
             },
             LlmStreamEvent::Done {
-                finish_reason: "stop".into(),
+                finish_reason: Some("stop".into()),
             },
         ];
         let out = drain(wrap(events, false));

--- a/crates/gglib-core/src/sse/decoder.rs
+++ b/crates/gglib-core/src/sse/decoder.rs
@@ -72,10 +72,13 @@ impl SseStreamDecoder {
                     if !self.done_sent {
                         debug!(
                             "LLM stream ended with [DONE] but no prior finish_reason \
-                             — emitting fallback Done"
+                             — emitting fallback Done with an unknown reason"
                         );
+                        // Deliberately not "stop": the upstream never said the
+                        // turn finished cleanly, and claiming it did would
+                        // relabel a truncation as a complete answer.
                         events.push(Ok(LlmStreamEvent::Done {
-                            finish_reason: "stop".to_owned(),
+                            finish_reason: None,
                         }));
                     }
                     self.done_sent = true;
@@ -124,9 +127,14 @@ impl SseStreamDecoder {
         if self.done_sent {
             None
         } else {
-            debug!("LLM byte-stream ended without [DONE] sentinel — emitting fallback Done");
+            debug!(
+                "LLM byte-stream ended without [DONE] sentinel — emitting fallback Done \
+                 with an unknown reason"
+            );
+            // A byte stream that simply stopped is the strongest case for not
+            // fabricating: nothing upstream ever claimed the turn was over.
             Some(LlmStreamEvent::Done {
-                finish_reason: "stop".to_owned(),
+                finish_reason: None,
             })
         }
     }
@@ -204,6 +212,53 @@ mod tests {
             dec.finish().is_none(),
             "finish() must return None after a [DONE] sentinel — done_sent must be set"
         );
+    }
+
+    /// The relabelling this fix exists to stop. A `[DONE]` arriving with no
+    /// prior finish chunk means the upstream never said how the turn ended;
+    /// synthesising `"stop"` there reported a truncation as a clean answer,
+    /// and made `finish_reason == "length"` unusable as a truncation signal
+    /// because the abnormal cases were hiding inside `"stop"`.
+    #[test]
+    fn a_synthesised_done_reports_an_unknown_reason_not_stop() {
+        let mut dec = SseStreamDecoder::default();
+        let (events, _) = collect_all(&mut dec, done_frame());
+        let done = events
+            .iter()
+            .find_map(|e| match e {
+                LlmStreamEvent::Done { finish_reason } => Some(finish_reason),
+                _ => None,
+            })
+            .expect("a fallback Done is still emitted");
+        assert_eq!(*done, None, "must not claim the turn stopped cleanly");
+    }
+
+    #[test]
+    fn a_byte_stream_that_just_stops_reports_an_unknown_reason() {
+        let mut dec = SseStreamDecoder::default();
+        let _ = collect_all(&mut dec, &text_delta_frame("partial"));
+        match dec.finish() {
+            Some(LlmStreamEvent::Done { finish_reason }) => {
+                assert_eq!(finish_reason, None);
+            }
+            other => panic!("expected a fallback Done, got {other:?}"),
+        }
+    }
+
+    /// A reason the upstream actually reported is passed through untouched —
+    /// the fix must not lose real information while refusing to invent it.
+    #[test]
+    fn a_reported_finish_reason_survives_intact() {
+        let mut dec = SseStreamDecoder::default();
+        let (events, _) = collect_all(&mut dec, &finish_reason_frame());
+        let done = events
+            .iter()
+            .find_map(|e| match e {
+                LlmStreamEvent::Done { finish_reason } => Some(finish_reason),
+                _ => None,
+            })
+            .expect("Done from the reported finish_reason");
+        assert!(done.is_some(), "a real reason must not be discarded");
     }
 
     #[test]

--- a/crates/gglib-core/src/sse/encoder.rs
+++ b/crates/gglib-core/src/sse/encoder.rs
@@ -327,7 +327,7 @@ mod tests {
     fn done_event_emits_only_finish_chunk_no_sentinel() {
         let out = enc()
             .encode(&LlmStreamEvent::Done {
-                finish_reason: "stop".to_owned(),
+                finish_reason: Some("stop".to_owned()),
             })
             .expect("frame");
         // Exactly one SSE frame -- [DONE] is the caller's responsibility now

--- a/crates/gglib-core/src/sse/parser.rs
+++ b/crates/gglib-core/src/sse/parser.rs
@@ -247,7 +247,7 @@ pub fn parse_sse_frame(data: &str) -> Result<SseParseResult> {
         && !finish_reason.is_empty()
     {
         events.push(LlmStreamEvent::Done {
-            finish_reason: finish_reason.to_owned(),
+            finish_reason: Some(finish_reason.to_owned()),
         });
     }
 
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(
             &events[0],
-            LlmStreamEvent::Done { finish_reason } if finish_reason == "stop"
+            LlmStreamEvent::Done { finish_reason } if finish_reason.as_deref() == Some("stop")
         ));
     }
 
@@ -688,7 +688,7 @@ mod tests {
         ));
         assert!(matches!(
             &events[1],
-            LlmStreamEvent::Done { finish_reason } if finish_reason == "tool_calls"
+            LlmStreamEvent::Done { finish_reason } if finish_reason.as_deref() == Some("tool_calls")
         ));
     }
 
@@ -707,7 +707,7 @@ mod tests {
         assert!(matches!(&events[0], LlmStreamEvent::Usage { .. }));
         assert!(matches!(
             &events[1],
-            LlmStreamEvent::Done { finish_reason } if finish_reason == "stop"
+            LlmStreamEvent::Done { finish_reason } if finish_reason.as_deref() == Some("stop")
         ));
     }
 

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -1025,7 +1025,7 @@ pub(crate) async fn stream_response_to_channel(
                 }
                 LlmStreamEvent::Done { finish_reason } => {
                     connection.mark_generating();
-                    outcome.finish_reason = Some(finish_reason.clone());
+                    outcome.finish_reason = finish_reason.clone();
 
                     // The turn's tool calls are complete exactly here, so this
                     // is the only point at which a repair can be judged. The

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/stream.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/stream.rs
@@ -158,7 +158,7 @@ mod tests {
                 },
                 usage(1_000, Some(900)),
                 LlmStreamEvent::Done {
-                    finish_reason: "stop".to_owned(),
+                    finish_reason: Some("stop".to_owned()),
                 },
             ]),
             sink.clone(),
@@ -188,7 +188,7 @@ mod tests {
         let sink = Arc::new(FakeSink::default());
         drain(tap_usage(
             events(vec![LlmStreamEvent::Done {
-                finish_reason: "stop".to_owned(),
+                finish_reason: Some("stop".to_owned()),
             }]),
             sink.clone(),
         ))


### PR DESCRIPTION
A stream that ended without a finish reason was reported as `finish_reason: "stop"` — a clean, complete answer. Two paths did it:

- a `[DONE]` sentinel arriving with no prior finish chunk (`sse/decoder.rs`)
- a byte stream that simply stopped, so `finish()` synthesised a terminator

**Neither is a clean stop.** They are how a truncation, a crashed model server and a severed connection all look from the decoder, and labelling them `"stop"` erased that distinction at the only point where it was still visible.

It also quietly disarmed the counter that comes next. `truncated_generations` keys on `finish_reason == "length"`, and is worthless while abnormal endings hide inside `"stop"` instead of standing out as unknown.

### The fix

`LlmStreamEvent::Done.finish_reason` becomes `Option<String>`; both synthesis sites emit `None`.

**`null`, not a sentinel string** — per your call, and it's the right one. This value reaches Copilot. The OpenAI schema permits `null` and enumerates the legal strings, so `"incomplete"` would put an unrecognised value in front of every downstream client. Two things made this cheap:

- The encoder needed **no change** — `serde_json` already renders `None` as `null`.
- gglib always appends exactly one `[DONE]` sentinel after stream exhaustion, and *that* is what terminates the stream for an OpenAI client — not this field. So a `null` here doesn't leave anyone waiting.

### Correctness details

- **A reported reason still passes through untouched.** Refusing to invent one must not mean discarding a real one; there's a test in each direction.
- **The normalizer's Qwen correction is narrowed** to an *explicitly reported* `"stop"`. Qwen3.5 emits tool calls but finishes with `"stop"` instead of `"tool_calls"`, and that correction still fires — but an absent reason carries no wrong claim to repair, so it's left alone.
- **`CollectedResponse.finish_reason`** on the agent path follows the same shape rather than defaulting, so an abnormally-ended turn stays distinguishable there too.

### Correction to the earlier survey

I previously reported that the transition plan had missed two fabrication sites in `gglib-runtime/src/ports_impl/llm_completion/stream.rs`. **That was wrong** — those two lines are test fixtures, not production code. There are exactly two real fabrication sites, both in `sse/decoder.rs`, as the plan said.

### Verification

`make pre-commit` passes in full. Three new decoder tests: synthesised-`Done`-is-`None` on both paths, and a reported reason surviving intact.