### PR TITLE
feat(proxy,core): the counted-only instruments, so rungs are chosen from measurements

### DIFF
--- a/crates/gglib-core/src/domain/defects.rs
+++ b/crates/gglib-core/src/domain/defects.rs
@@ -64,6 +64,38 @@ pub struct ModelDefectCounts {
     /// Client disconnects are deliberately not in here: hanging up is a
     /// person's action, not a model defect.
     pub stream_errors: u64,
+    /// Turns the model server cut off at the token ceiling
+    /// (`finish_reason == "length"`).
+    ///
+    /// Not a model defect in the same sense as the others — a long answer is
+    /// allowed to be long — but a *rising* rate is how a runaway generation
+    /// looks before anything else notices, and it is the cheapest evidence
+    /// that a context budget is mis-sized.
+    pub truncated_generations: u64,
+    /// Turns that produced nothing a client can render.
+    pub empty_responses: u64,
+    /// Of those, the ones that produced reasoning and nothing else.
+    ///
+    /// Counted inside [`Self::empty_responses`] rather than beside it: the
+    /// turn was empty from the client's point of view either way, and the
+    /// distinction is *why*. A model stranding its whole answer in
+    /// `reasoning_content` is a prompt/template problem; one producing
+    /// nothing at all is not.
+    pub reasoning_only: u64,
+    /// Turns where dialect markup survived normalization into client-visible
+    /// output — the drift alarm, per model rather than fleet-wide.
+    pub dialect_residue: u64,
+    /// Turns whose tool call could not be validated at all, so repair never
+    /// had an opinion to act on.
+    ///
+    /// The blind spot this makes visible: a client whose tools all use
+    /// `anyOf` gets zero repair coverage *and*, until now, zero evidence of
+    /// that fact. A high rate here means the repair rate below it is
+    /// measuring a much smaller slice of traffic than it appears to.
+    pub unvalidatable_schemas: u64,
+    /// Turns whose normalization discarded a malformed dialect tool call and
+    /// surfaced the raw body as visible text instead.
+    pub normalization_errors: u64,
 }
 
 /// Process-lifetime per-model defect counters.
@@ -120,6 +152,40 @@ impl ModelDefectLedger {
         self.with(model, |c| c.stream_errors += 1);
     }
 
+    /// Count one generation cut off at the token ceiling for `model`.
+    pub fn record_truncated_generation(&self, model: &str) {
+        self.with(model, |c| c.truncated_generations += 1);
+    }
+
+    /// Count one turn that produced nothing client-renderable for `model`.
+    ///
+    /// `reasoning_only` says whether the model produced reasoning and nothing
+    /// else. It is counted *within* the empty total, not beside it — the turn
+    /// was empty either way, and this records why.
+    pub fn record_empty_response(&self, model: &str, reasoning_only: bool) {
+        self.with(model, |c| {
+            c.empty_responses += 1;
+            if reasoning_only {
+                c.reasoning_only += 1;
+            }
+        });
+    }
+
+    /// Count one turn where dialect markup reached client-visible output.
+    pub fn record_dialect_residue(&self, model: &str) {
+        self.with(model, |c| c.dialect_residue += 1);
+    }
+
+    /// Count one turn whose tool call could not be validated at all.
+    pub fn record_unvalidatable_schema(&self, model: &str) {
+        self.with(model, |c| c.unvalidatable_schemas += 1);
+    }
+
+    /// Count one turn whose normalization discarded a malformed tool call.
+    pub fn record_normalization_error(&self, model: &str) {
+        self.with(model, |c| c.normalization_errors += 1);
+    }
+
     /// The current counts for every model that has any.
     #[must_use]
     pub fn snapshot(&self) -> HashMap<String, ModelDefectCounts> {
@@ -154,6 +220,24 @@ pub const fn delta(current: ModelDefectCounts, baseline: ModelDefectCounts) -> M
             .repairs_succeeded
             .saturating_sub(baseline.repairs_succeeded),
         stream_errors: current.stream_errors.saturating_sub(baseline.stream_errors),
+        truncated_generations: current
+            .truncated_generations
+            .saturating_sub(baseline.truncated_generations),
+        empty_responses: current
+            .empty_responses
+            .saturating_sub(baseline.empty_responses),
+        reasoning_only: current
+            .reasoning_only
+            .saturating_sub(baseline.reasoning_only),
+        dialect_residue: current
+            .dialect_residue
+            .saturating_sub(baseline.dialect_residue),
+        unvalidatable_schemas: current
+            .unvalidatable_schemas
+            .saturating_sub(baseline.unvalidatable_schemas),
+        normalization_errors: current
+            .normalization_errors
+            .saturating_sub(baseline.normalization_errors),
     }
 }
 
@@ -189,6 +273,67 @@ mod tests {
         let snap = ledger.snapshot()["a"];
         assert_eq!(snap.requests, 1, "the turn was counted when forwarded");
         assert_eq!(snap.stream_errors, 1);
+    }
+
+    /// `reasoning_only` is a subset of `empty_responses`, not a sibling. A
+    /// reader wanting "empty but not reasoning-only" subtracts; one wanting
+    /// the empty rate uses the total without having to add two fields.
+    #[test]
+    fn reasoning_only_turns_are_counted_within_the_empty_total() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_empty_response("a", true);
+        ledger.record_empty_response("a", false);
+
+        let snap = ledger.snapshot()["a"];
+        assert_eq!(snap.empty_responses, 2, "both turns were empty");
+        assert_eq!(snap.reasoning_only, 1, "one of them had reasoning");
+    }
+
+    /// None of the counted-only instruments touch `requests`. They describe
+    /// turns that were already counted when forwarded, so bumping the
+    /// denominator here would deflate every rate computed from it.
+    #[test]
+    fn counted_only_instruments_leave_the_denominator_alone() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_request("a");
+        ledger.record_truncated_generation("a");
+        ledger.record_empty_response("a", false);
+        ledger.record_dialect_residue("a");
+        ledger.record_unvalidatable_schema("a");
+        ledger.record_normalization_error("a");
+        ledger.record_stream_error("a");
+
+        let snap = ledger.snapshot()["a"];
+        assert_eq!(snap.requests, 1, "one request, however many faults it had");
+        assert_eq!(snap.truncated_generations, 1);
+        assert_eq!(snap.dialect_residue, 1);
+        assert_eq!(snap.unvalidatable_schemas, 1);
+        assert_eq!(snap.normalization_errors, 1);
+    }
+
+    /// Every new field must window like the old ones, or a reader silently
+    /// rates a cumulative total against a windowed denominator.
+    #[test]
+    fn every_counter_windows_against_its_baseline() {
+        let ledger = ModelDefectLedger::new();
+        ledger.record_truncated_generation("a");
+        ledger.record_empty_response("a", true);
+        ledger.record_dialect_residue("a");
+        let baseline = ledger.snapshot()["a"];
+
+        ledger.record_truncated_generation("a");
+        ledger.record_empty_response("a", true);
+        ledger.record_dialect_residue("a");
+        ledger.record_unvalidatable_schema("a");
+        ledger.record_normalization_error("a");
+
+        let window = delta(ledger.snapshot()["a"], baseline);
+        assert_eq!(window.truncated_generations, 1);
+        assert_eq!(window.empty_responses, 1);
+        assert_eq!(window.reasoning_only, 1);
+        assert_eq!(window.dialect_residue, 1);
+        assert_eq!(window.unvalidatable_schemas, 1);
+        assert_eq!(window.normalization_errors, 1);
     }
 
     #[test]

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -155,6 +155,16 @@ pub(crate) struct StreamOutcome {
     ///
     /// Client disconnects never set this; hanging up is not a model defect.
     pub upstream_errored: bool,
+    /// Normalization discarded a malformed dialect tool call and surfaced the
+    /// raw body as visible text instead.
+    ///
+    /// A pure model defect, and one the existing repair never sees: repair
+    /// fires on schema violations of *parsed* calls, so a call too malformed
+    /// to parse falls outside it entirely.
+    pub normalization_errored: bool,
+    /// The turn's tool call could not be validated, so repair never had an
+    /// opinion to act on. See [`crate::repair::Skipped::Unvalidatable`].
+    pub unvalidatable_schema: bool,
     /// The client went away mid-turn, so the drain loop stopped forwarding.
     ///
     /// Kept because a turn the client abandoned is not evidence about the
@@ -963,6 +973,7 @@ pub(crate) async fn stream_response_to_channel(
                     // empty response when the whole turn was one bad tool call).
                     warn!(?kind, raw = %raw, "proxy: surfacing normalization issue as visible content");
                     outcome.saw_visible_output = true;
+                    outcome.normalization_errored = true;
                     let recovered = LlmStreamEvent::TextDelta {
                         content: format!("{NORMALIZATION_NOTICE_PREFIX}{raw}"),
                     };
@@ -1205,6 +1216,17 @@ async fn resolve_held_tool_calls(
     };
 
     let decision = crate::repair::decide(&ctx.request_body, &assembled_bytes, ctx.enabled);
+    // A call the validator could not judge at all leaves repair with no
+    // opinion to act on. Recorded before the early return, because a client
+    // whose tools all use `anyOf` gets zero repair coverage and, without
+    // this, zero evidence that the repair rate beside it is measuring a much
+    // smaller slice of traffic than it appears to.
+    if matches!(
+        decision,
+        crate::repair::Decision::Forward(crate::repair::Skipped::Unvalidatable)
+    ) {
+        outcome.unvalidatable_schema = true;
+    }
     let crate::repair::Decision::Reissue { body, violations } = decision else {
         return original_frames;
     };

--- a/crates/gglib-proxy/src/metrics.rs
+++ b/crates/gglib-proxy/src/metrics.rs
@@ -189,6 +189,13 @@ impl ContextMetricsStore {
         let mut guard = self.snapshots.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(snapshot) = guard.iter_mut().find(|s| s.seq == seq) {
             snapshot.dialect_residue = true;
+            // Also per model. This was the one flag of the three that never
+            // reached the ledger, so drift was visible fleet-wide but could
+            // not be attributed — and attribution is the whole point, since
+            // residue is a property of one model's dialect, not of traffic.
+            if let Some(ledger) = &self.ledger {
+                ledger.record_dialect_residue(&snapshot.model_name);
+            }
         }
     }
 
@@ -238,6 +245,56 @@ impl ContextMetricsStore {
             && let Some(ledger) = &self.ledger
         {
             ledger.record_stream_error(&snapshot.model_name);
+        }
+    }
+
+    /// Count one generation cut off at the token ceiling against `seq`'s model.
+    pub fn flag_truncated_generation(&self, seq: u64) {
+        self.with_model(seq, |ledger, model| {
+            ledger.record_truncated_generation(model);
+        });
+    }
+
+    /// Count one turn that produced nothing client-renderable.
+    ///
+    /// `reasoning_only` distinguishes a model that stranded its whole answer
+    /// in `reasoning_content` from one that produced nothing at all.
+    pub fn flag_empty_response(&self, seq: u64, reasoning_only: bool) {
+        self.with_model(seq, |ledger, model| {
+            ledger.record_empty_response(model, reasoning_only);
+        });
+    }
+
+    /// Count one turn whose tool call could not be validated at all.
+    pub fn flag_unvalidatable_schema(&self, seq: u64) {
+        self.with_model(seq, |ledger, model| {
+            ledger.record_unvalidatable_schema(model);
+        });
+    }
+
+    /// Count one turn whose normalization discarded a malformed tool call.
+    pub fn flag_normalization_error(&self, seq: u64) {
+        self.with_model(seq, |ledger, model| {
+            ledger.record_normalization_error(model);
+        });
+    }
+
+    /// Look up `seq`'s model name and hand it to the ledger.
+    ///
+    /// The ring row is consulted only for its model name, so an event whose
+    /// snapshot was already evicted is lost to the per-model ledger — the
+    /// same bounded, bias-free undercount [`Self::flag_tool_repair`] accepts,
+    /// falling on exactly the busiest traffic.
+    fn with_model(
+        &self,
+        seq: u64,
+        record: impl FnOnce(&gglib_core::domain::defects::ModelDefectLedger, &str),
+    ) {
+        let guard = self.snapshots.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(snapshot) = guard.iter().find(|s| s.seq == seq)
+            && let Some(ledger) = &self.ledger
+        {
+            record(ledger, &snapshot.model_name);
         }
     }
 

--- a/crates/gglib-proxy/src/sse_stream.rs
+++ b/crates/gglib-proxy/src/sse_stream.rs
@@ -219,6 +219,27 @@ pub fn spawn_and_return(
                     // snapshot already exists.
                     context_metrics.flag_stream_error(snapshot_seq);
                 }
+                // The counted-only instruments. None of these change what the
+                // client receives — they exist so the escalation ladder is
+                // built against measured failure rates rather than guesses
+                // about which failures are common.
+                if outcome.finish_reason.as_deref() == Some("length") {
+                    context_metrics.flag_truncated_generation(snapshot_seq);
+                }
+                if !outcome.saw_visible_output {
+                    warn!(
+                        model = %model_name_owned,
+                        reasoning_only = outcome.saw_reasoning,
+                        "turn produced no client-renderable output"
+                    );
+                    context_metrics.flag_empty_response(snapshot_seq, outcome.saw_reasoning);
+                }
+                if outcome.normalization_errored {
+                    context_metrics.flag_normalization_error(snapshot_seq);
+                }
+                if outcome.unvalidatable_schema {
+                    context_metrics.flag_unvalidatable_schema(snapshot_seq);
+                }
                 // Feed the terminal outcome to the watchdog. The precedence
                 // between "produced output", "died upstream" and "the client
                 // left" lives in `health_verdict`, so this stays one line and


### PR DESCRIPTION
Six per-model counters, **none of which change what a client receives**. They exist so the escalation ladder is built against measured failure rates rather than a guess about which failures are common — §9.7's "let the counters run for a window, then choose rungs from measurements".

| Counter | What it sees |
|---|---|
| `truncated_generations` | `finish_reason == "length"` |
| `empty_responses` | nothing client-renderable was produced |
| `reasoning_only` | of those, the answer was stranded in `reasoning_content` |
| `dialect_residue` | dialect markup survived normalization, **per model** |
| `unvalidatable_schemas` | repair had no opinion to act on |
| `normalization_errors` | a tool call too malformed to parse |

### The two that were already broken

**`dialect_residue` had a counter and no ledger call.** Of the three flags that back-patch through the metrics ring, this was the only one that never reached the per-model ledger — so drift was visible fleet-wide but could not be attributed. Attribution is the entire point: residue is a property of one model's dialect, not of traffic.

**`unvalidatable_schemas` had no evidence at all.** A client whose tools all use `anyOf` gets zero repair coverage, and until now zero indication of that fact. A high rate here means the repair rate beside it is measuring a much smaller slice of traffic than it appears to — which would otherwise read as "repair rarely fires, so the model is fine."

### Design notes

**`reasoning_only` is counted *within* `empty_responses`, not beside it.** The turn was empty from the client's point of view either way; what differs is *why*. A reader wanting the empty rate uses one field; one wanting "empty and not reasoning-only" subtracts.

**`truncated_generations` only became meaningful after #806.** The value was already captured in `StreamOutcome` and never inspected, while the benchmark path had mapped the same field to `was_truncated` all along — the cleanest asymmetry in the failure report. It was unusable while the decoder fabricated `"stop"` for abnormal endings.

**The invariant across all six: none touch `requests`.** They describe turns already counted when forwarded, so bumping the denominator would deflate every rate computed from it. `record_loop_guard_trip` remains the sole exception, because it fires *instead of* a forward rather than after one.

### Verification

`make pre-commit` passes in full. Three new ledger tests pin the parts easiest to get wrong later: that `reasoning_only` nests inside the empty total, that no counted-only instrument inflates the denominator, and that every new field windows against a baseline (a field that doesn't would silently rate a cumulative total against a windowed denominator).
