### PR TITLE
refactor(core,proxy): delete PipelinePass, whose second variant was unreachable

### DIFF
--- a/crates/gglib-core/src/request_pipeline/apply.rs
+++ b/crates/gglib-core/src/request_pipeline/apply.rs
@@ -60,33 +60,6 @@
 
 use serde_json::Value;
 
-/// Which trip through the pipeline this is.
-///
-/// The pipeline is otherwise stateless, so a repair re-issue would be
-/// indistinguishable from a first attempt — and stage 6 behaves differently
-/// on the two.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum PipelinePass {
-    /// A request's first trip through. Every stage runs.
-    #[default]
-    Initial,
-    /// A tool-call repair re-issue, carrying `tool_choice: "required"` so
-    /// llama.cpp installs its own schema-derived grammar.
-    ///
-    /// [`constrain`] must **not** run on this pass. It fires on
-    /// `tool_choice: "required"` for dialect models, installs gglib's own
-    /// grammar, and rewrites `tool_choice` to `"none"` — because llama-server
-    /// rejects a custom grammar combined with `tools`. On a repair that would
-    /// convert the request into one asking for no tool call at all: the repair
-    /// costs a full generation and changes nothing, silently.
-    ///
-    /// Suppressing it is not a workaround but the point. gglib's grammar
-    /// constrains the envelope, the name, and JSON well-formedness; upstream's
-    /// constrains arguments to the tool's schema. On the repair path the
-    /// stronger of the two is the one we want.
-    Repair,
-}
-
 use super::sampling::SamplingDecision;
 use super::truncation::{TruncationError, TruncationReport};
 use super::{ModelContext, SamplingLayers, constrain, messages, sampling, tools, truncation};
@@ -130,7 +103,6 @@ pub fn apply(
     ctx: &ModelContext,
     layers: &SamplingLayers,
     budget_chars: Option<usize>,
-    pass: PipelinePass,
 ) -> Result<PipelineReport, TruncationError> {
     messages::shape_messages(body, ctx);
     tools::strip_unsupported_tools(body, ctx);
@@ -142,12 +114,23 @@ pub fn apply(
 
     let sampling = sampling::resolve_sampling(body, ctx, layers);
 
-    // Stage 6 stands down on a repair pass. See [`PipelinePass::Repair`] —
-    // running it there would rewrite `tool_choice` to `"none"` and silently
-    // turn the repair into a request for no tool call at all.
-    if pass == PipelinePass::Initial {
-        constrain::constrain_tool_calls(body, ctx);
-    }
+    // Stage 6 runs unconditionally, because there is only one kind of trip
+    // through this pipeline.
+    //
+    // A `PipelinePass` parameter used to exist so this stage could stand down
+    // on a tool-call repair: `constrain` fires on `tool_choice: "required"`
+    // for dialect models, installs gglib's own grammar and rewrites
+    // `tool_choice` to `"none"` (llama-server rejects a custom grammar
+    // alongside `tools`), which on a repair would silently convert the
+    // re-issue into a request for no tool call at all.
+    //
+    // That guard was never reachable. The repair path does not call `apply`
+    // at all — it mutates the already-resolved body and sends it — so every
+    // caller here passed `Initial` and the alternative branch was dead. The
+    // reasoning still matters, but it belongs where the risk actually lives:
+    // see `gglib_proxy::repair::repair_body`, which must keep bypassing this
+    // pipeline for exactly the reason above.
+    constrain::constrain_tool_calls(body, ctx);
     Ok(PipelineReport {
         truncation,
         sampling,
@@ -178,8 +161,7 @@ mod live_shape_probe {
             ..ModelContext::passthrough()
         };
         let layers = SamplingLayers::default();
-        let report =
-            apply(&mut body, &ctx, &layers, None, PipelinePass::Initial).expect("pipeline applies");
+        let report = apply(&mut body, &ctx, &layers, None).expect("pipeline applies");
         assert!(report.sampling.applied);
 
         let obj = body.as_object().unwrap();
@@ -232,7 +214,6 @@ mod tests {
             &strict_turn_ctx(),
             &SamplingLayers::default(),
             None,
-            PipelinePass::Initial,
         )
         .unwrap();
 
@@ -249,7 +230,6 @@ mod tests {
             &strict_turn_ctx(),
             &SamplingLayers::default(),
             Some(100_000),
-            PipelinePass::Initial,
         )
         .unwrap();
 
@@ -281,7 +261,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             None,
-            PipelinePass::Initial,
         )
         .unwrap();
 
@@ -312,7 +291,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             Some(20_000),
-            PipelinePass::Initial,
         )
         .unwrap();
 
@@ -330,7 +308,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             None,
-            PipelinePass::Initial,
         )
         .unwrap();
 
@@ -353,7 +330,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             Some(200),
-            PipelinePass::Initial,
         )
         .unwrap_err();
 

--- a/crates/gglib-core/src/request_pipeline/mod.rs
+++ b/crates/gglib-core/src/request_pipeline/mod.rs
@@ -10,7 +10,7 @@ pub mod tools;
 pub mod truncation;
 pub mod validate;
 
-pub use apply::{PipelinePass, PipelineReport, apply};
+pub use apply::{PipelineReport, apply};
 pub use constrain::{DISABLE_GRAMMAR_ENV, constrain_tool_calls};
 pub use messages::shape_messages;
 pub use model_context::ModelContext;

--- a/crates/gglib-proxy/src/forward.rs
+++ b/crates/gglib-proxy/src/forward.rs
@@ -76,8 +76,7 @@ use gglib_core::LlmStreamEvent;
 use gglib_core::domain::DialectSpec;
 use gglib_core::normalize::{NormalizingStream, get_parser};
 use gglib_core::request_pipeline::{
-    self, ModelContext, PipelinePass, SamplingDecision, SamplingLayers, TruncationError,
-    TruncationReport,
+    self, ModelContext, SamplingDecision, SamplingLayers, TruncationError, TruncationReport,
 };
 use gglib_core::sse::{DONE_SENTINEL, SseEncoder, SseStreamDecoder};
 
@@ -402,7 +401,6 @@ fn shape_request_body(
     ctx: &ModelContext,
     layers: &SamplingLayers,
     budget_chars: Option<usize>,
-    pass: PipelinePass,
 ) -> Result<ShapedRequest, TruncationError> {
     let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
         return Ok(ShapedRequest {
@@ -416,7 +414,7 @@ fn shape_request_body(
     // The constrain stage never engages over a client-sent grammar, so
     // before-absent + after-present is exactly "the pipeline originated one".
     let grammar_before = value.get("grammar").is_some();
-    let report = request_pipeline::apply(&mut value, ctx, layers, budget_chars, pass)?;
+    let report = request_pipeline::apply(&mut value, ctx, layers, budget_chars)?;
     let grammar_enforced = !grammar_before && value.get("grammar").is_some();
 
     match serde_json::to_vec(&value) {
@@ -507,12 +505,6 @@ pub(crate) struct ForwardRequest<'a> {
     /// Cache-hit telemetry sink, fed from both the streaming and
     /// non-streaming response paths.
     pub cache_metrics: Arc<CacheMetricsStore>,
-    /// Which trip through the request pipeline this is.
-    ///
-    /// [`PipelinePass::Repair`] on a tool-call repair re-issue, which
-    /// suppresses the grammar stage so llama.cpp's own schema-derived grammar
-    /// is the one that fires. See [`gglib_core::request_pipeline::PipelinePass`].
-    pub pass: PipelinePass,
     /// Whether a tool call failing schema validation is re-issued with
     /// `tool_choice: "required"`.
     ///
@@ -577,7 +569,6 @@ pub(crate) async fn forward_chat_completion(
         calibration,
         calibration_session_id,
         cache_metrics,
-        pass,
         repair_enabled,
         sampling_audit,
     } = req;
@@ -610,7 +601,7 @@ pub(crate) async fn forward_chat_completion(
     );
     let budget_chars = Some((effective_ctx as f64 * chars_per_token) as usize);
 
-    let shaped = match shape_request_body(body, &context, &sampling, budget_chars, pass) {
+    let shaped = match shape_request_body(body, &context, &sampling, budget_chars) {
         Ok(shaped) => shaped,
         Err(e) => {
             // Hard abort: the conversation cannot be trimmed to fit. Record a
@@ -1686,7 +1677,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             None,
-            PipelinePass::Initial,
         )
         .expect("no budget, so nothing to reject");
         assert!(!grammar_enforced, "passthrough context never constrains");
@@ -1719,14 +1709,8 @@ mod tests {
             body: out,
             grammar_enforced,
             ..
-        } = shape_request_body(
-            body,
-            &ctx,
-            &SamplingLayers::default(),
-            None,
-            PipelinePass::Initial,
-        )
-        .expect("nothing to reject");
+        } = shape_request_body(body, &ctx, &SamplingLayers::default(), None)
+            .expect("nothing to reject");
 
         assert!(grammar_enforced);
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
@@ -1746,7 +1730,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             Some(10),
-            PipelinePass::Initial,
         )
         .expect("a body we cannot read is forwarded, not rejected");
 
@@ -1765,7 +1748,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             Some(20_000),
-            PipelinePass::Initial,
         )
         .expect("trimming the one oversized tool result is enough");
 
@@ -1781,7 +1763,6 @@ mod tests {
             &ModelContext::passthrough(),
             &SamplingLayers::default(),
             Some(200),
-            PipelinePass::Initial,
         )
         .expect_err("nothing left to trim, still over");
 

--- a/crates/gglib-proxy/src/repair.rs
+++ b/crates/gglib-proxy/src/repair.rs
@@ -16,15 +16,23 @@
 //! — but "ask upstream to use the one it already has". The repair request is
 //! the original with `tool_choice` forced to `"required"`, which is enough.
 //!
-//! # Why the pass marker exists
+//! # Why the repair body bypasses the request pipeline
 //!
-//! [`PipelinePass::Repair`] suppresses the pipeline's grammar stage. That
-//! stage fires on `tool_choice: "required"` for dialect models and rewrites
-//! `tool_choice` to `"none"`, because llama-server rejects a custom grammar
-//! combined with `tools`. Left to run on a repair it would convert the
-//! re-issue into a request for no tool call at all: a full generation spent,
-//! nothing changed, no error anywhere. Pinned by
-//! [`the_repair_body_survives_the_pipeline_with_required_intact`].
+//! [`repair_body`] mutates the already-resolved body and sends it. It must
+//! never hand that body back to `request_pipeline::apply`.
+//!
+//! The pipeline's grammar stage fires on `tool_choice: "required"` for
+//! dialect models and rewrites `tool_choice` to `"none"`, because
+//! llama-server rejects a custom grammar combined with `tools`. Run on a
+//! repair it would convert the re-issue into a request for no tool call at
+//! all: a full generation spent, nothing changed, no error anywhere.
+//!
+//! A `PipelinePass` marker used to encode this, suppressing the stage on a
+//! repair pass. It was removed because the case never arose — the repair path
+//! does not call `apply`, so every caller passed `Initial` and the other
+//! branch was unreachable. The hazard is real but structural, and is pinned
+//! by [`the_pipeline_would_destroy_a_repair_body_which_is_why_it_bypasses_it`]
+//! rather than by a flag nobody sets.
 //!
 //! [ADR 0001]: https://github.com/mmogr/gglib/blob/main/docs/adr/0001-runtime-capability-tiers.md
 //! [ADR 0002]: https://github.com/mmogr/gglib/blob/main/docs/adr/0002-defer-tool-call-constraint-to-llama-cpp.md
@@ -314,7 +322,7 @@ pub fn choose(request_body: &[u8], original: Bytes, repaired: Bytes) -> (Bytes, 
 mod tests {
     use super::*;
     use gglib_core::domain::{DialectSpec, ModelCapabilities};
-    use gglib_core::request_pipeline::{ModelContext, PipelinePass, SamplingLayers};
+    use gglib_core::request_pipeline::{ModelContext, SamplingLayers};
     use serde_json::json;
 
     fn request(tool_choice: Value) -> Vec<u8> {
@@ -603,13 +611,22 @@ mod tests {
         assert_eq!(chosen, original);
     }
 
-    /// The interaction that would silently disable the whole feature: stage 6
-    /// fires on `tool_choice: "required"` for a dialect model and rewrites it
-    /// to `"none"`. On a repair pass it must stand down, or the re-issue asks
-    /// for no tool call at all — a full generation spent, nothing changed, no
-    /// error anywhere.
+    /// Why a repair body must never be sent back through the request
+    /// pipeline.
+    ///
+    /// Stage 6 fires on `tool_choice: "required"` for a dialect model,
+    /// installs gglib's own grammar and rewrites `tool_choice` to `"none"` —
+    /// llama-server rejects a custom grammar alongside `tools`. Applied to a
+    /// repair that silently converts the re-issue into a request for no tool
+    /// call at all: a full generation spent, nothing changed, no error
+    /// anywhere.
+    ///
+    /// `repair_body` avoids this by construction — it mutates the
+    /// already-resolved body and sends it, never calling `apply`. This test
+    /// demonstrates the damage that bypass prevents, so the reason survives
+    /// as something executable rather than as a comment nobody re-derives.
     #[test]
-    fn the_repair_body_survives_the_pipeline_with_required_intact() {
+    fn the_pipeline_would_destroy_a_repair_body_which_is_why_it_bypasses_it() {
         let ctx = ModelContext {
             capabilities: ModelCapabilities::SUPPORTS_TOOL_CALLS,
             catalog_resolved: true,
@@ -625,38 +642,31 @@ mod tests {
             panic!("expected a re-issue");
         };
 
-        let mut initial: Value = serde_json::from_slice(&body).unwrap();
-        let mut repair: Value = serde_json::from_slice(&body).unwrap();
-
-        gglib_core::request_pipeline::apply(
-            &mut initial,
-            &ctx,
-            &SamplingLayers::default(),
-            None,
-            PipelinePass::Initial,
-        )
-        .unwrap();
-        gglib_core::request_pipeline::apply(
-            &mut repair,
-            &ctx,
-            &SamplingLayers::default(),
-            None,
-            PipelinePass::Repair,
-        )
-        .unwrap();
-
+        // What `repair_body` actually produces, and sends as-is.
+        let as_sent: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(
-            initial["tool_choice"], "none",
-            "stage 6 rewrites tool_choice on an initial pass — if this ever \
-             stops being true the repair pass no longer needs suppressing"
-        );
-        assert_eq!(
-            repair["tool_choice"], "required",
-            "a repair pass must reach llama-server still demanding a call"
+            as_sent["tool_choice"], "required",
+            "the re-issue must reach llama-server still demanding a call"
         );
         assert!(
-            repair.get("grammar").is_none(),
+            as_sent.get("grammar").is_none(),
             "gglib must not install its own weaker grammar on the repair path"
+        );
+
+        // The same body put through the pipeline — the thing that must not
+        // happen. If this ever stops rewriting `tool_choice`, the bypass is
+        // no longer load-bearing and this test should be revisited.
+        let mut through_pipeline: Value = serde_json::from_slice(&body).unwrap();
+        gglib_core::request_pipeline::apply(
+            &mut through_pipeline,
+            &ctx,
+            &SamplingLayers::default(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            through_pipeline["tool_choice"], "none",
+            "stage 6 would ask for no tool call at all — hence the bypass"
         );
     }
 }

--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -1008,7 +1008,6 @@ async fn chat_completions(
     // cache-branching below — see `ForwardRequest` docs.
     let req = ForwardRequest {
         repair_enabled: settings.tool_call_repair != Some(false),
-        pass: gglib_core::request_pipeline::PipelinePass::Initial,
         client: &state.client,
         upstream_url: &upstream_url,
         headers: &headers,
@@ -1144,7 +1143,6 @@ async fn chat_completions(
 
             let retry_req = ForwardRequest {
                 repair_enabled: settings.tool_call_repair != Some(false),
-                pass: gglib_core::request_pipeline::PipelinePass::Initial,
                 client: &state.client,
                 upstream_url: &retry_url,
                 headers: &headers,

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -12,7 +12,7 @@ use gglib_core::{
     domain::InferenceConfig,
     domain::agent::{AgentMessage, LlmStreamEvent, ToolDefinition},
     ports::{LlmCompletionPort, RetryObserver, UsageSink},
-    request_pipeline::{self, ModelContext, PipelinePass, SamplingLayers},
+    request_pipeline::{self, ModelContext, SamplingLayers},
     retry::RetryPolicy,
 };
 
@@ -349,9 +349,6 @@ impl LlmCompletionAdapter {
                 ..Default::default()
             },
             self.model_context.context_budget_chars(),
-            // The in-process agent path never repairs: it owns its own loop and
-            // handles a bad tool call by re-prompting, not by re-issuing.
-            PipelinePass::Initial,
         )
         .map_err(|e| anyhow!("conversation exceeds the model's context budget: {e}"))?;
 


### PR DESCRIPTION
§11.3 of the transition plan: `PipelinePass::Repair` is dead, and leaving it is the exact dormant remnant the standing rules forbid.

### What it was for

The hazard is real. Stage 6 fires on `tool_choice: "required"` for dialect models, installs gglib's own grammar, and rewrites `tool_choice` to `"none"` — llama-server rejects a custom grammar alongside `tools`. Applied to a repair, that silently converts the re-issue into a request for **no tool call at all**: a full generation spent, nothing changed, no error anywhere.

### Why it never fired

**The repair path does not call the pipeline.** `repair_body` mutates the already-resolved body and sends it. So every production caller passed `Initial` (`server.rs:1011`, `server.rs:1147`, `llm_completion/mod.rs:354`), the `Repair` branch existed only in a test, and the enum was a two-state type with one reachable state.

With the variant gone the parameter carries no information, so it goes too — out of `apply`, out of `shape_request_body`, and out of `ForwardRequest`, where it was a field every construction site set identically.

**−112 lines, +74.**

### The knowledge is kept, and strengthened

Moved to where the risk actually lives:

- `repair.rs`'s module doc now states that the repair body must bypass the pipeline, and why.
- The test that used to compare the two passes now demonstrates **the damage the bypass prevents**: it runs a real repair body through `apply` and asserts `tool_choice` comes out `"none"`.

That's a stronger guard than the flag was. It fails if anyone routes a repair through the pipeline at all — whereas the flag only helped if they also remembered to set it.

### Verification

`make pre-commit` passes in full. No `PipelinePass` references remain in `crates/` or `docs/`.
