### PR TITLE
refactor(core,cli): one source for what a tune verdict means

### DIFF
--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -324,62 +324,22 @@ async fn apply_gated(run_id: i64) -> Result<()> {
         .await
         .context("apply response unreadable")?;
 
-    match outcome.verdict {
-        ApplyVerdict::Apply {
-            winner_composite,
-            incumbent_mean,
-            margin,
-            drift,
-            paired,
-        } => {
-            println!(
-                "{SUCCESS}\u{2713} applied as measured defaults{RESET}: winner \
-                 {winner_composite:.3} over incumbent {incumbent_mean:.3}, margin \
-                 {margin:+.3} against drift {drift:.3}",
-                SUCCESS = style::SUCCESS,
-                RESET = style::RESET,
-            );
-            if let Some(p) = paired {
-                println!(
-                    "  paired: {}W-{}L-{}T over {} tasks",
-                    p.wins, p.losses, p.ties, p.pairs
-                );
-            }
-        }
-        ApplyVerdict::IncumbentStands { incumbent_mean } => println!(
-            "{}incumbent stands{} at {incumbent_mean:.3}: no candidate beat the model's \
-             current defaults. The run answered its question, and the answer is \
-             'change nothing'.",
-            style::WARNING,
-            style::RESET,
-        ),
-        ApplyVerdict::WithinDrift { margin, drift } => println!(
-            "{}not applied{}: the winner's {margin:+.3} margin is inside the run's own \
-             {drift:.3} drift. Unresolved, not absent; more tasks or a re-run resolves \
-             it, a smaller threshold never does.",
-            style::WARNING,
-            style::RESET,
-        ),
-        ApplyVerdict::PairedDisagrees { wins, losses } => println!(
-            "{}not applied{}: the winner's mean rests on a minority of tasks \
-             ({wins}W-{losses}L against the incumbent), the lucky-outlier shape, \
-             refused by the pairs.",
-            style::WARNING,
-            style::RESET,
-        ),
-        ApplyVerdict::Uncalibrated => println!(
-            "{}not applied{}: this run has no incumbent calibration pair, so nothing \
-             measures its drift. Re-run the tune; every new run carries the pair.",
-            style::WARNING,
-            style::RESET,
-        ),
-        ApplyVerdict::Contaminated { unmeasured_runs } => println!(
-            "{}not applied{}: {unmeasured_runs} task run(s) never reached the model, so \
-             the compared scores are contaminated. A zero from a dead upstream is not a \
-             low score.",
-            style::WARNING,
-            style::RESET,
-        ),
+    let applied = outcome.verdict.applies();
+    let colour = if applied {
+        style::SUCCESS
+    } else {
+        style::WARNING
+    };
+    println!("{colour}{}{RESET}", outcome.verdict, RESET = style::RESET,);
+    println!("  {}", outcome.verdict.rationale());
+    if let ApplyVerdict::Apply {
+        paired: Some(p), ..
+    } = &outcome.verdict
+    {
+        println!(
+            "  paired: {}W-{}L-{}T over {} tasks",
+            p.wins, p.losses, p.ties, p.pairs
+        );
     }
     Ok(())
 }
@@ -1169,34 +1129,15 @@ async fn cmd_list(ctx: &CliContext, limit: i64) -> Result<()> {
 /// Refusals leave records too, so this reads as the activity line it is:
 /// what the gate decided, with its headline number.
 fn run_outcome(run: &gglib_core::domain::benchmark::run::BenchmarkRun) -> String {
-    use gglib_core::domain::benchmark::tune::apply::ApplyVerdict;
-
     let Some(record) = run.applied_json.as_deref().and_then(|json| {
         serde_json::from_str::<gglib_core::domain::benchmark::tune::apply::ApplyRecord>(json).ok()
     }) else {
         return "—".to_owned();
     };
-    match record.verdict {
-        ApplyVerdict::Apply { margin, drift, .. } => {
-            format!(
-                "{}applied{} (margin {margin:+.3} vs drift {drift:.3})",
-                style::SUCCESS,
-                style::RESET
-            )
-        }
-        ApplyVerdict::IncumbentStands { incumbent_mean } => {
-            format!("refused: incumbent stands at {incumbent_mean:.3}")
-        }
-        ApplyVerdict::WithinDrift { margin, drift } => {
-            format!("refused: margin {margin:+.3} within drift {drift:.3}")
-        }
-        ApplyVerdict::PairedDisagrees { wins, losses } => {
-            format!("refused: pairs disagree ({wins}W-{losses}L)")
-        }
-        ApplyVerdict::Uncalibrated => "refused: uncalibrated run".to_owned(),
-        ApplyVerdict::Contaminated { unmeasured_runs } => {
-            format!("refused: {unmeasured_runs} unmeasured run(s)")
-        }
+    if record.verdict.applies() {
+        format!("{}{}{}", style::SUCCESS, record.verdict, style::RESET)
+    } else {
+        record.verdict.to_string()
     }
 }
 

--- a/crates/gglib-core/src/domain/benchmark/tune/apply.rs
+++ b/crates/gglib-core/src/domain/benchmark/tune/apply.rs
@@ -90,6 +90,81 @@ impl ApplyVerdict {
     pub const fn applies(&self) -> bool {
         matches!(self, Self::Apply { .. })
     }
+
+    /// Why the gate decided this, in one sentence.
+    ///
+    /// Split from [`Display`] because the two surfaces want different
+    /// amounts: a table column wants the numbers, a detail view wants the
+    /// numbers *and* the reasoning. Keeping them apart lets both read from
+    /// one source instead of each restating the gate's rules in its own
+    /// words — which is how three renderers came to disagree about what a
+    /// refusal meant.
+    ///
+    /// Every sentence here says what would resolve the refusal, because a
+    /// gate that only says "no" teaches nobody anything.
+    #[must_use]
+    pub const fn rationale(&self) -> &'static str {
+        match self {
+            Self::Apply { .. } => "The margin cleared the run's own drift and the pairs agreed.",
+            Self::IncumbentStands { .. } => {
+                "No candidate beat the model's current defaults. The run answered its \
+                 question, and the answer is 'change nothing'."
+            }
+            Self::WithinDrift { .. } => {
+                "The winner's margin is inside the run's own drift. Unresolved, not \
+                 absent; more tasks or a re-run resolves it, a smaller threshold never \
+                 does."
+            }
+            Self::PairedDisagrees { .. } => {
+                "The winner's mean rests on a minority of tasks — the lucky-outlier \
+                 shape, refused by the pairs."
+            }
+            Self::Uncalibrated => {
+                "This run has no incumbent calibration pair, so nothing measures its \
+                 drift. Re-run the tune; every new run carries the pair."
+            }
+            Self::Contaminated { .. } => {
+                "Some task runs never reached the model, so the compared scores are \
+                 contaminated. A zero from a dead upstream is not a low score."
+            }
+        }
+    }
+}
+
+/// The verdict's headline: what happened, with the numbers that decided it.
+///
+/// Deliberately unstyled and single-line so every surface can wrap it in its
+/// own presentation. Pair with [`ApplyVerdict::rationale`] where there is
+/// room to explain.
+impl std::fmt::Display for ApplyVerdict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Apply {
+                winner_composite,
+                incumbent_mean,
+                margin,
+                drift,
+                ..
+            } => write!(
+                f,
+                "applied: winner {winner_composite:.3} over incumbent \
+                 {incumbent_mean:.3}, margin {margin:+.3} against drift {drift:.3}"
+            ),
+            Self::IncumbentStands { incumbent_mean } => {
+                write!(f, "refused: incumbent stands at {incumbent_mean:.3}")
+            }
+            Self::WithinDrift { margin, drift } => {
+                write!(f, "refused: margin {margin:+.3} within drift {drift:.3}")
+            }
+            Self::PairedDisagrees { wins, losses } => {
+                write!(f, "refused: pairs disagree ({wins}W-{losses}L)")
+            }
+            Self::Uncalibrated => write!(f, "refused: uncalibrated run"),
+            Self::Contaminated { unmeasured_runs } => {
+                write!(f, "refused: {unmeasured_runs} unmeasured run(s)")
+            }
+        }
+    }
 }
 
 /// Evaluate a completed tune run's candidates against the apply gate.


### PR DESCRIPTION
§2.4 found three copies of the apply gate's verdict rendering; §11.3 found a fourth. One of the four died with the scheduler in #810 — this collapses the two remaining Rust ones onto a single source.

### The drift was already there

- `apply_gated` (detail view after an apply) **explained what would resolve a refusal**
- `run_outcome` (run-list column) **named the numbers and stopped**

Neither was wrong, but nothing tied them together — so a change to the gate's *meaning* had to be found in three places by someone who remembered they existed.

### The fix

`ApplyVerdict` now renders itself, in two parts:

| | |
|---|---|
| `Display` | the headline — what happened, with the numbers that decided it |
| `rationale()` | the sentence explaining it |

**Split rather than merged**, because the two surfaces genuinely want different amounts: a table column has room for numbers, a detail view has room to teach. Both now read from one place.

`Display` is deliberately **unstyled and single-line**, so each surface wraps it in its own presentation. The CLI picks its colour from `applies()`, which it already had.

Every `rationale` sentence says **what would resolve the refusal** — because a gate that only says "no" teaches nobody anything, which was the original reason refusals were made first-class outcomes rather than errors.

### What isn't collapsed

The GUI card keeps its own `describeVerdict`. It's TypeScript and can't read this one. **Two renderers in two languages is the floor** without introducing a code generator, and the drift that actually mattered was between the two Rust ones.

### Verification

`make pre-commit` passes in full.
