### PR TITLE
fix(proxy,docs): the upstream-dead retry honours the settings it re-read

### DIFF
--- a/crates/gglib-proxy/src/server.rs
+++ b/crates/gglib-proxy/src/server.rs
@@ -1142,7 +1142,10 @@ async fn chat_completions(
             };
 
             let retry_req = ForwardRequest {
-                repair_enabled: settings.tool_call_repair != Some(false),
+                // `retry_settings`, not `settings` — the sibling sampling
+                // layers above already read the fresh snapshot this block
+                // deliberately took, and this one was still on the stale one.
+                repair_enabled: retry_settings.tool_call_repair != Some(false),
                 client: &state.client,
                 upstream_url: &retry_url,
                 headers: &headers,

--- a/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
+++ b/crates/gglib-runtime/src/ports_impl/llm_completion/mod.rs
@@ -189,7 +189,7 @@ impl LlmCompletionAdapter {
     }
 
     /// Override the send-phase timeout (connect through first response
-    /// headers).  The default is [`DEFAULT_SEND_TIMEOUT_SECS`] (120 s).
+    /// headers).  The default is [`DEFAULT_SEND_TIMEOUT_SECS`].
     #[must_use]
     pub fn with_send_timeout(mut self, secs: u64) -> Self {
         self.send_timeout_secs = secs;

--- a/docs/tool-call-repair.md
+++ b/docs/tool-call-repair.md
@@ -1,6 +1,10 @@
 # Tool-call repair
 
-**Status:** implemented. Streaming and non-streaming both route through the hold-back.
+**Status:** implemented, **streaming only**. The hold-back and the re-issue
+live on the SSE path; the non-streaming branch has no repair at all.
+`RepairContext` is constructed in exactly one place (`sse_stream.rs`), so a
+non-streaming request carries none and a malformed tool call on that path
+reaches the client unaltered.
 **Decided by:** [ADR 0002](adr/0002-defer-tool-call-constraint-to-llama-cpp.md), findings 4–5.
 
 ## What this solves

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -139,7 +139,7 @@ crates/gglib-proxy/src/profiles.rs 495
 crates/gglib-proxy/src/props.rs 995
 crates/gglib-proxy/src/repair.rs 672
 crates/gglib-proxy/src/sampling_audit.rs 1487
-crates/gglib-proxy/src/server.rs 1319
+crates/gglib-proxy/src/server.rs 1322
 crates/gglib-proxy/src/slots_poller.rs 795
 crates/gglib-proxy/src/slots.rs 1250
 crates/gglib-proxy/src/sse_stream.rs 371


### PR DESCRIPTION
Three corrections from §11.3 and §10.4, all of the same kind: something said one thing and did another.

### 1. The live bug

When an upstream dies mid-turn the proxy relaunches the model and retries. That block **deliberately re-reads the settings snapshot** — its own comment says why: *"the model was just relaunched, so this is a fresh point in time"* — and the retry's sampling layers use `retry_settings`.

Its `repair_enabled` did not. That one field still read the **pre-relaunch** snapshot:

```rust
repair_enabled: settings.tool_call_repair != Some(false),   // stale
global: retry_settings.inference_defaults.clone(),          // fresh
```

So a repair setting changed during the recycle was honoured by the sampling and ignored by the repair, on the same request.

### 2. A doc naming a number it doesn't own

`with_send_timeout`'s doc claimed a default of **120 s**. The constant is **600**. Rather than correct it to a second place it can drift from, the doc now just points at the constant.

### 3. A doc asserting coverage that doesn't exist

`docs/tool-call-repair.md` opened with *"Streaming and non-streaming both route through the hold-back."* **Only streaming does.** `RepairContext` is built in exactly one place — the SSE path — so a non-streaming request carries none, and a malformed tool call there reaches the client unaltered.

That's a real gap worth knowing about. A document asserting it's already handled is worse than one that says nothing.

### On the baseline bump

The new comment grew `server.rs` by three lines, and the ratchet added in #813 **refused it**. I tightened the comment twice, and any comment at all still tripped it — the ratchet allows zero growth by design.

So this uses `--update`, which is exactly what that flag is for. The growth is now a single visible line in the diff rather than something nobody would ever have noticed. That's the mechanism working, not failing — and it's worth seeing it exercised once on a real change.

### Verification

`make pre-commit` passes in full.
