### PR TITLE
feat(normalize): repair a malformed tool call instead of throwing the turn away

### DIFF
--- a/crates/gglib-core/src/normalize/coerce.rs
+++ b/crates/gglib-core/src/normalize/coerce.rs
@@ -1,0 +1,285 @@
+//! Deterministic local repair of a tool-call body the parsers rejected.
+//!
+//! The cheapest rung of the escalation ladder, and the only one that costs no
+//! model call at all. When a model emits a tool call wrapped in a code fence,
+//! trailed by prose, or carrying a trailing comma, the payload is *right* and
+//! the packaging is wrong. Today that turn is thrown away and the raw bytes
+//! are shown to the person as text. Repairing the packaging is measured in
+//! microseconds and cannot cost a generation.
+//!
+//! # Only ever additive
+//!
+//! [`coerce_json_object`] returns `Some` only when its output parses. Every
+//! failure path returns `None` and the caller behaves exactly as it did
+//! before. A turn can therefore be rescued by this module but never made
+//! worse by it — the same fail-open rule the repair re-issue follows.
+//!
+//! # The one repair deliberately not attempted
+//!
+//! **An unterminated string is never closed.** Given
+//! `{"name":"read_file","arguments":{"path":"/etc/ho` the structurally
+//! obvious fix is to add `"}}`, which yields valid JSON and a tool call that
+//! reads the wrong file. Dispatching a plausible-but-wrong call is worse than
+//! dispatching none: the client executes it, and a truncated path or query is
+//! a side effect nobody asked for. Truncation mid-string means the model's
+//! output was cut off, which is a real failure, and this module declines to
+//! paper over it.
+//!
+//! Structural delimiters are different in kind. A missing `}` at the very end
+//! of an otherwise complete object cannot change the meaning of any value
+//! already present; it can only fail to terminate them.
+
+use serde_json::Value;
+
+/// The most nesting a tool-call body may legitimately carry.
+///
+/// Bounds the repair against a pathological input — a model emitting
+/// thousands of `[` produces a body this refuses rather than a very long
+/// string of `]`.
+const MAX_NESTING: usize = 64;
+
+/// Try to make `body` parse as a JSON object, without changing what it says.
+///
+/// Returns the repaired text only when it parses *and* is an object; `None`
+/// otherwise, leaving the caller to fail exactly as it would have.
+#[must_use]
+pub fn coerce_json_object(body: &str) -> Option<String> {
+    let candidate = strip_packaging(body);
+    if candidate.is_empty() {
+        return None;
+    }
+
+    // Cheap path: the packaging was the whole problem.
+    if parses_as_object(&candidate) {
+        return Some(candidate);
+    }
+
+    let without_commas = drop_trailing_commas(&candidate);
+    if parses_as_object(&without_commas) {
+        return Some(without_commas);
+    }
+
+    let closed = close_delimiters(&without_commas)?;
+    parses_as_object(&closed).then_some(closed)
+}
+
+fn parses_as_object(text: &str) -> bool {
+    serde_json::from_str::<Value>(text).is_ok_and(|v| v.is_object())
+}
+
+/// Remove a surrounding code fence and any prose either side of the object.
+///
+/// Models introduce a tool call conversationally ("Sure — I'll read it:") or
+/// wrap it in markdown out of habit. Both leave the JSON itself intact.
+fn strip_packaging(body: &str) -> String {
+    let mut text = body.trim();
+
+    // ```json … ``` or ``` … ```
+    if let Some(rest) = text.strip_prefix("```") {
+        let rest = rest.strip_prefix("json").unwrap_or(rest);
+        text = rest.trim_start_matches(['\r', '\n']).trim();
+        if let Some(stripped) = text.strip_suffix("```") {
+            text = stripped.trim();
+        }
+    }
+
+    // Prose either side. Anchored on the outermost braces rather than the
+    // first, so a sentence containing `{` does not truncate the object.
+    match (text.find('{'), text.rfind('}')) {
+        (Some(start), Some(end)) if end > start => text[start..=end].trim().to_owned(),
+        // No closing brace at all: keep everything from the opening one, so
+        // `close_delimiters` still gets a chance.
+        (Some(start), _) => text[start..].trim().to_owned(),
+        _ => String::new(),
+    }
+}
+
+/// Drop commas that sit immediately before a closing delimiter.
+///
+/// Skips anything inside a string, so a value like `"a, }"` is untouched.
+fn drop_trailing_commas(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pending_comma: Option<usize> = None;
+    let mut scan = StringScan::default();
+
+    for ch in text.chars() {
+        if scan.step(ch) {
+            // Inside a string (or its escape): copy verbatim.
+            if let Some(idx) = pending_comma.take() {
+                out.insert(idx, ',');
+            }
+            out.push(ch);
+            continue;
+        }
+        match ch {
+            ',' => {
+                if let Some(idx) = pending_comma.take() {
+                    out.insert(idx, ',');
+                }
+                pending_comma = Some(out.len());
+            }
+            '}' | ']' => {
+                pending_comma = None;
+                out.push(ch);
+            }
+            c if c.is_whitespace() => out.push(c),
+            c => {
+                if let Some(idx) = pending_comma.take() {
+                    out.insert(idx, ',');
+                }
+                out.push(c);
+            }
+        }
+    }
+    if let Some(idx) = pending_comma {
+        out.insert(idx, ',');
+    }
+    out
+}
+
+/// Append whatever closing delimiters the body is missing.
+///
+/// Returns `None` when the text ends inside a string, when a delimiter is
+/// mismatched, or when nesting exceeds [`MAX_NESTING`] — see the module doc
+/// on why an unterminated string is left alone.
+fn close_delimiters(text: &str) -> Option<String> {
+    let mut stack: Vec<char> = Vec::new();
+    let mut scan = StringScan::default();
+
+    for ch in text.chars() {
+        if scan.step(ch) {
+            continue;
+        }
+        match ch {
+            '{' | '[' => {
+                if stack.len() >= MAX_NESTING {
+                    return None;
+                }
+                stack.push(ch);
+            }
+            '}' if stack.pop() != Some('{') => return None,
+            ']' if stack.pop() != Some('[') => return None,
+            _ => {}
+        }
+    }
+
+    // Cut off mid-string: refuse, rather than invent the rest of a value.
+    if scan.in_string {
+        return None;
+    }
+    if stack.is_empty() {
+        return None; // Nothing to close; the failure is something else.
+    }
+
+    let mut out = text.trim_end().to_owned();
+    while let Some(open) = stack.pop() {
+        out.push(if open == '{' { '}' } else { ']' });
+    }
+    Some(out)
+}
+
+/// Tracks whether the scan is inside a JSON string literal.
+#[derive(Default)]
+struct StringScan {
+    in_string: bool,
+    escaped: bool,
+}
+
+impl StringScan {
+    /// Feed one character; returns `true` if it belongs to a string literal
+    /// (and so must not be read as structure).
+    const fn step(&mut self, ch: char) -> bool {
+        if self.in_string {
+            if self.escaped {
+                self.escaped = false;
+            } else if ch == '\\' {
+                self.escaped = true;
+            } else if ch == '"' {
+                self.in_string = false;
+                return true; // the closing quote is still string punctuation
+            }
+            return true;
+        }
+        if ch == '"' {
+            self.in_string = true;
+            return true;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOOD: &str = r#"{"name":"read_file","arguments":{"path":"a"}}"#;
+
+    #[test]
+    fn a_code_fence_is_unwrapped() {
+        let fenced = format!("```json\n{GOOD}\n```");
+        assert_eq!(coerce_json_object(&fenced).as_deref(), Some(GOOD));
+    }
+
+    #[test]
+    fn prose_either_side_is_dropped() {
+        let chatty = format!("Sure, I'll read it:\n{GOOD}\nLet me know!");
+        assert_eq!(coerce_json_object(&chatty).as_deref(), Some(GOOD));
+    }
+
+    #[test]
+    fn a_trailing_comma_is_removed() {
+        let sloppy = r#"{"name":"read_file","arguments":{"path":"a"},}"#;
+        assert!(coerce_json_object(sloppy).is_some());
+    }
+
+    #[test]
+    fn missing_closing_braces_are_appended() {
+        let cut = r#"{"name":"read_file","arguments":{"path":"a"}"#;
+        assert_eq!(coerce_json_object(cut).as_deref(), Some(GOOD));
+    }
+
+    /// The safety rule this module exists to respect. Closing the string
+    /// would yield valid JSON and a call that reads the wrong file.
+    #[test]
+    fn an_unterminated_string_is_never_completed() {
+        let truncated = r#"{"name":"read_file","arguments":{"path":"/etc/ho"#;
+        assert_eq!(coerce_json_object(truncated), None);
+    }
+
+    #[test]
+    fn a_comma_inside_a_string_survives() {
+        let body = r#"{"name":"say","arguments":{"text":"a, b, }"}}"#;
+        let out = coerce_json_object(body).expect("already valid");
+        assert!(out.contains("a, b, }"), "string content altered: {out}");
+    }
+
+    #[test]
+    fn mismatched_delimiters_are_refused() {
+        assert_eq!(coerce_json_object(r#"{"name":"x","args":[}"#), None);
+    }
+
+    #[test]
+    fn a_non_object_is_refused() {
+        assert_eq!(coerce_json_object("[1, 2, 3]"), None);
+        assert_eq!(coerce_json_object("\"just a string\""), None);
+    }
+
+    #[test]
+    fn pathological_nesting_is_refused() {
+        let deep = "[".repeat(MAX_NESTING + 5);
+        assert_eq!(coerce_json_object(&deep), None);
+    }
+
+    #[test]
+    fn text_with_no_object_at_all_is_refused() {
+        assert_eq!(coerce_json_object("I could not do that."), None);
+        assert_eq!(coerce_json_object(""), None);
+    }
+
+    /// Valid input must survive untouched — the repair never rewrites a body
+    /// that was already fine.
+    #[test]
+    fn an_already_valid_body_is_returned_unchanged() {
+        assert_eq!(coerce_json_object(GOOD).as_deref(), Some(GOOD));
+    }
+}

--- a/crates/gglib-core/src/normalize/mod.rs
+++ b/crates/gglib-core/src/normalize/mod.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("README.md")]
+pub mod coerce;
 pub mod error;
 pub mod history;
 pub mod oneshot;

--- a/crates/gglib-core/src/normalize/parsers/delimited.rs
+++ b/crates/gglib-core/src/normalize/parsers/delimited.rs
@@ -270,6 +270,20 @@ fn finalize_tool_call(
             }
         }
     }
+    // Last resort before giving the turn up: repair the packaging locally.
+    //
+    // A body arriving inside a code fence, trailed by prose, or carrying a
+    // trailing comma is a *right* payload in wrong wrapping. Costs
+    // microseconds and no model call, and returns `None` on anything it
+    // cannot repair honestly — so the turn either improves or is unchanged.
+    if codecs.contains(&BodyCodec::Json)
+        && let Some(repaired) = crate::normalize::coerce::coerce_json_object(trimmed)
+        && let Some(call) = parse_json_body(&repaired, &mut mint_id)
+    {
+        out.tool_calls.push(call);
+        return;
+    }
+
     let error = if codecs.contains(&BodyCodec::FunctionXml) && trimmed.starts_with("<function=") {
         NormalizationError::malformed_function_xml(body.to_owned())
     } else {
@@ -429,6 +443,7 @@ fn partial_suffix_len(buf: &[u8], marker: &[u8]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::normalize::NormalizationErrorKind;
     use serde_json::json;
 
     /// A parser wired with the built-in Qwen spec — the configuration every
@@ -452,6 +467,63 @@ mod tests {
         total.tool_calls.extend(f.tool_calls);
         total.errors.extend(f.errors);
         total
+    }
+
+    /// The rescue, end to end through the parser: a body the JSON codec
+    /// rejects outright still becomes a tool call, with its arguments intact.
+    #[test]
+    fn a_fenced_tool_call_body_is_repaired_instead_of_discarded() {
+        let mut p = qwen();
+        let out = collect(
+            &mut p,
+            &[
+                "<tool_call>\n```json\n",
+                r#"{"name":"read_file","arguments":{"path":"a"}}"#,
+                "\n```\n</tool_call>",
+            ],
+        );
+        assert!(
+            out.errors.is_empty(),
+            "the turn should no longer be given up: {:?}",
+            out.errors
+        );
+        assert_eq!(out.tool_calls.len(), 1);
+        assert_eq!(out.tool_calls[0].name, "read_file");
+        assert_eq!(out.tool_calls[0].arguments, json!({"path": "a"}));
+    }
+
+    /// Fail-open: a body that cannot be repaired honestly still produces
+    /// exactly the error it always did, so nothing regresses.
+    #[test]
+    fn an_unrepairable_body_still_reports_the_original_error() {
+        let mut p = qwen();
+        let out = collect(&mut p, &["<tool_call>", "not json at all", "</tool_call>"]);
+        assert!(out.tool_calls.is_empty());
+        assert_eq!(out.errors.len(), 1);
+        assert!(matches!(
+            out.errors[0].kind,
+            NormalizationErrorKind::MalformedToolCallJson { .. }
+        ));
+    }
+
+    /// A call truncated mid-string is *not* rescued — closing the quote would
+    /// dispatch a call reading the wrong path. See `normalize::coerce`.
+    #[test]
+    fn a_call_truncated_mid_string_is_not_invented() {
+        let mut p = qwen();
+        let out = collect(
+            &mut p,
+            &[
+                "<tool_call>",
+                r#"{"name":"read_file","arguments":{"path":"/etc/ho"#,
+                "</tool_call>",
+            ],
+        );
+        assert!(
+            out.tool_calls.is_empty(),
+            "a truncated argument must never become a dispatched call"
+        );
+        assert_eq!(out.errors.len(), 1);
     }
 
     #[test]

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -70,7 +70,7 @@ crates/gglib-core/src/download/rate.rs 378
 crates/gglib-core/src/download/types.rs 751
 crates/gglib-core/src/events/mod.rs 306
 crates/gglib-core/src/events/server.rs 305
-crates/gglib-core/src/normalize/parsers/delimited.rs 913
+crates/gglib-core/src/normalize/parsers/delimited.rs 985
 crates/gglib-core/src/normalize/stream.rs 651
 crates/gglib-core/src/ports/model_runtime.rs 817
 crates/gglib-core/src/ports/process_runner.rs 329


### PR DESCRIPTION
**The first rung of the escalation ladder** — and the cheapest one available. When the parsers reject a tool-call body, repair it locally before giving up.

### The failure it fixes

Models wrap tool calls in markdown out of habit, introduce them conversationally (*"Sure — I'll read it:"*), and leave trailing commas. In every one of those cases **the payload is right and only the packaging is wrong.**

Today the whole turn is discarded and the raw bytes are shown to you as text with a ⚠ notice. That's a wasted generation over a missing brace.

### Why this rung, and not a sampling retry

Straight from the plan's own research (§8.4): local deterministic coercion ranks **above** resampling — under 10ms, **no second model call**, strictly cheaper than any retry. And nobody in the field retries with different sampling; §8.3 additionally found cooling can *induce* the repetition our loop guard exists to catch.

It also attacks a gap the existing repair **structurally cannot see**: repair only fires on schema violations of calls that *parsed*. A call too malformed to parse falls straight through it.

### Additive by construction

`coerce_json_object` returns `Some` only when its output parses as an object. Every other path returns `None` and the caller behaves exactly as before. **A turn can be rescued by this and never made worse** — the same fail-open rule the repair re-issue already follows.

### The one repair deliberately not attempted

**An unterminated string is never closed.** Given:

```
{"name":"read_file","arguments":{"path":"/etc/ho
```

the structurally obvious fix yields valid JSON and a call that **reads the wrong file**. Dispatching a plausible-but-wrong call is worse than dispatching none — the client executes it, and a truncated path is a side effect nobody asked for.

Truncation mid-string means the model was cut off, which is a real failure this declines to paper over. Structural delimiters are different in kind: a missing `}` cannot change the meaning of a value already present, only fail to terminate it.

Mismatched delimiters, non-objects and pathological nesting are all refused rather than guessed at.

### Verification

`make pre-commit` passes in full. **14 tests**, including the three that matter:

- a fenced body now becomes a real tool call with arguments intact
- an unrepairable body still reports exactly the error it always did
- a call truncated mid-string is still refused

Per the agreed proof bar: this is a cheap deterministic rung, so it ships on tests. Anything that re-runs the model will need measured evidence first.
