### PR TITLE
docs(core): record which paths use the retry engine, and which deliberately do not

### DIFF
--- a/crates/gglib-core/src/retry/README.md
+++ b/crates/gglib-core/src/retry/README.md
@@ -63,6 +63,36 @@ were only tightening it.
 resolves to — asked for by name rather than by knowing that `max_attempts: 1`
 means "off".
 
+# Who uses this, and who deliberately does not
+
+gglib is periodically observed to have "five retry implementations with only
+one using the shared engine". The count is right and the conclusion is not:
+those five are three different shapes, and only one shape is what this module
+models.
+
+**Backoff sequences** — retry *the same operation* after a delay. This module
+is for these.
+
+| Site | Uses this engine | Why |
+|---|---|---|
+| `gglib-runtime` `llm_completion/retry/execute.rs` | **yes** | Many clients can collide on one model's startup; decorrelating them is exactly what full jitter is for. |
+| `gglib-proxy` `slots.rs` | no | A single-writer disk save. Jitter exists to decorrelate competing callers and there are none, so exponential growth would only make the second attempt slower for no benefit. |
+| `gglib-proxy` `sse_stream.rs` | no | Its "retry" is a `select!` arm over a first-byte deadline and client keepalives, and it fires on *deadline expiry with no other active connection* — a queue-position judgement, not a transient error. Different control structure, different trigger. |
+
+**One-shot recovery with different configuration** — not retries at all. These
+re-issue *changed* work exactly once, so a backoff policy has nothing to say
+about them.
+
+- `gglib-proxy` `server.rs`, on `ForwardError::UpstreamDead`: relaunches the
+  model, then issues one attempt against a **fresh admission, lease and
+  settings snapshot**.
+- `gglib-proxy` `forward.rs`, the tool-call repair: one attempt with a
+  **different request body** (`tool_choice: "required"`), bounded by its own
+  timeout because it runs while the client is receiving nothing.
+
+Unifying either of those under a backoff policy would be a category error:
+repeating identical work is the one thing neither of them does.
+
 <!-- module-docs:end -->
 
 <details>


### PR DESCRIPTION
§11.3 flagged *"five retry implementations, one shared policy engine used by exactly one of them"* as duplication to consolidate. I went to do it, read all five, and concluded **it shouldn't be done** — so this records why instead.

The count is right. The conclusion isn't: those five are **three different shapes**, and only one shape is what the retry module models.

### Backoff sequences — retry *the same operation* after a delay

| Site | Uses the engine | Why |
|---|---|---|
| `llm_completion/retry/execute.rs` | **yes** | Many clients collide on one model's startup — exactly what full jitter decorrelates. |
| `proxy/slots.rs` | no, correctly | Single-writer disk save. Nothing to decorrelate, and exponential growth would only make its second attempt *slower* for no benefit. |
| `proxy/sse_stream.rs` | no, correctly | Its "retry" is a `select!` arm over a first-byte deadline and client keepalives, fired by a **queue-position judgement**, not a transient error. Different control structure, different trigger. |

### Not retries at all

- `server.rs` on `UpstreamDead`: relaunches the model, then one attempt against a **fresh admission, lease and settings snapshot**.
- `forward.rs` tool-call repair: one attempt with a **different request body**.

Unifying either under a backoff policy would be a category error — repeating *identical* work is the one thing neither does.

### Why not just do it anyway

Converting `slots.rs` or `sse_stream.rs` would change live retry behaviour on paths I can't load-test, for a tidiness win the code doesn't want. And the pressure that made it look urgent is gone: the ladder's first rung (#815) repairs malformed tool calls locally and **adds no retry at all**, so there is no sixth implementation coming.

### Verification

`make pre-commit` passes, with one **pre-existing, unrelated** exception noted below.

---

⚠️ **Unrelated pre-existing test flake, reported not fixed.** `daemon::watchdog::tests::a_healthy_daemon_passes_the_probe` fails under whole-workspace parallel load. I confirmed it is **not** caused by any of today's work — it reproduces on clean `main` with my changes stashed. Narrowed so far: passes **47/47 single-threaded**, fails only under full-workspace load, no stray daemon or port contention involved. A separate PR removes one genuine startup race in its helper, but that is not the root cause and the flake persists. Filed rather than papered over.
