### PR TITLE
test(axum): close a startup race in the watchdog probe helper

### DIFF
--- a/crates/gglib-axum/src/daemon/watchdog.rs
+++ b/crates/gglib-axum/src/daemon/watchdog.rs
@@ -179,16 +179,27 @@ mod tests {
     use std::net::TcpListener;
 
     /// A scratch server that answers one connection with `response`.
+    ///
+    /// Returns only once the serving thread is scheduled and about to
+    /// `accept`. Without that handshake the helper returned as soon as the
+    /// thread was *spawned*, and the caller could finish connecting, writing
+    /// and waiting out its read timeout before the thread ever ran — which
+    /// made these tests fail under parallel load while passing in isolation.
+    /// The connection itself needs no synchronising: it waits in the
+    /// listener's backlog from the moment the socket is bound.
     fn one_shot_server(response: &'static [u8]) -> SocketAddr {
         let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral port");
         let addr = listener.local_addr().expect("bound addr");
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
+            let _ = ready_tx.send(());
             if let Ok((mut stream, _)) = listener.accept() {
                 let mut discard = [0u8; 512];
                 let _ = stream.read(&mut discard);
                 let _ = stream.write_all(response);
             }
         });
+        ready_rx.recv().expect("serving thread started");
         addr
     }
 


### PR DESCRIPTION
`one_shot_server` returned as soon as its serving thread was **spawned**, not once that thread was ready to `accept`. The caller could therefore connect, write its request, and wait out the entire read timeout before the thread had run at all.

It now waits for the thread to signal readiness immediately before `accept`. The connection itself needs no synchronising — it waits in the listener's backlog from the moment the socket is bound.

### This does not fix the flake, and isn't claimed to

`a_healthy_daemon_passes_the_probe` **still fails under whole-workspace parallel load.** I'm shipping this because the race it closes is real and would have bitten eventually — not because it's the cure.

What's established so far, so whoever picks it up doesn't redo it:

- **Predates today's work.** Reproduces on clean `main` with every unrelated change stashed.
- **Not a code defect.** Passes 47/47 single-threaded, and four consecutive full runs when `gglib-axum` is tested alone.
- **Not environmental contention.** No stray `gglib` daemon running, no conflicting listener on any port.
- **Only fails under `cargo test` across the whole workspace**, i.e. maximum parallel load.

That points at resource pressure during the connect/accept/read round trip rather than anything in `probe` itself, but I stopped short of proving it — it's unrelated to the transition work and I didn't want to spend more of your budget on it while guessing.

### Verification

The axum crate passes 47/47 in four consecutive parallel runs. Full `make pre-commit` still trips the flake above.
