### PR TITLE
feat(proxy): surface per-model defect counts, which nothing could read

### DIFF
--- a/crates/gglib-core/src/domain/defects.rs
+++ b/crates/gglib-core/src/domain/defects.rs
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 /// Cumulative defect counts for one model.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub struct ModelDefectCounts {
     /// Requests the proxy forwarded (or would have, but for a guard) for
     /// this model — every rate's denominator.

--- a/crates/gglib-proxy/src/dashboard.rs
+++ b/crates/gglib-proxy/src/dashboard.rs
@@ -317,6 +317,16 @@ pub struct DashboardSnapshot {
     /// Upstream-degradation watchdog counters (empty responses, first-byte
     /// timeouts, proactive recycles) since the proxy started.
     pub upstream_health: UpstreamHealthSnapshot,
+    /// Per-model defect counts, keyed by the model name requests carry.
+    ///
+    /// The fleet totals above answer "is something wrong"; this answers
+    /// "with which model", which is the only form the answer is actionable
+    /// in — a rate is a claim about a model, not about traffic.
+    ///
+    /// Process-lifetime and reset on restart, deliberately (ADR 0006): a
+    /// defect rate is a claim about *recent* traffic on *this* build.
+    pub per_model_defects:
+        std::collections::HashMap<String, gglib_core::domain::defects::ModelDefectCounts>,
     /// How prompt caching is configured for the running model. `None` until
     /// the first request resolves a model, since the RAM budget isn't known
     /// until something is launched.
@@ -395,6 +405,7 @@ impl DashboardSnapshot {
             tool_repairs_attempted: metrics.tool_repairs_attempted(),
             tool_repairs_succeeded: metrics.tool_repairs_succeeded(),
             upstream_health: upstream_health.snapshot(),
+            per_model_defects: metrics.defect_counts(),
             // Stored config plus live reuse totals — see `CacheStatusCache`.
             cache: cache
                 .get()

--- a/crates/gglib-proxy/src/metrics.rs
+++ b/crates/gglib-proxy/src/metrics.rs
@@ -298,6 +298,24 @@ impl ContextMetricsStore {
         }
     }
 
+    /// Per-model defect counts, for the dashboard.
+    ///
+    /// The ledger is written on every request and, until this existed, read by
+    /// nothing: the auto-tune scheduler was its only reader and went with ADR
+    /// 0006. Counters nobody can see are not diagnosis, they are a memory
+    /// leak with good intentions.
+    ///
+    /// Empty when no ledger is wired (the proxy can run without one).
+    #[must_use]
+    pub fn defect_counts(
+        &self,
+    ) -> std::collections::HashMap<String, gglib_core::domain::defects::ModelDefectCounts> {
+        self.ledger
+            .as_ref()
+            .map(|ledger| ledger.snapshot())
+            .unwrap_or_default()
+    }
+
     /// Total tool-call repairs attempted, eviction-safe.
     pub fn tool_repairs_attempted(&self) -> u64 {
         self.tool_repairs_attempted.load(Ordering::Relaxed)
@@ -357,6 +375,38 @@ mod tests {
     }
 
     // ── Basic record + retrieve ───────────────────────────────────────────────
+
+    /// The counters must be *readable*, not merely recorded.
+    ///
+    /// Until this existed the ledger's only reader was the auto-tune
+    /// scheduler, which went with ADR 0006 — leaving every per-model counter
+    /// accumulating into memory that nothing could observe. A day of traffic
+    /// would have produced evidence nobody could look at.
+    #[test]
+    fn per_model_counts_are_readable_after_recording() {
+        let ledger = std::sync::Arc::new(gglib_core::domain::defects::ModelDefectLedger::new());
+        let store = ContextMetricsStore::new().with_ledger(std::sync::Arc::clone(&ledger));
+
+        store.record(make_snapshot("qwen-27b"));
+        let seq = store.recent(1)[0].seq;
+        store.flag_stream_error(seq);
+        store.flag_truncated_generation(seq);
+        store.flag_empty_response(seq, true);
+
+        let counts = store.defect_counts();
+        let qwen = counts.get("qwen-27b").expect("the model appears by name");
+        assert_eq!(qwen.stream_errors, 1);
+        assert_eq!(qwen.truncated_generations, 1);
+        assert_eq!(qwen.empty_responses, 1);
+        assert_eq!(qwen.reasoning_only, 1, "nested inside the empty total");
+    }
+
+    #[test]
+    fn defect_counts_are_empty_without_a_ledger() {
+        let store = ContextMetricsStore::new();
+        store.record(make_snapshot("qwen-27b"));
+        assert!(store.defect_counts().is_empty());
+    }
 
     #[test]
     fn record_single_snapshot_and_retrieve() {


### PR DESCRIPTION
**The defect ledger has been write-only since the scheduler was removed.**

Every counter added over the last two days — `stream_errors`, `truncated_generations`, `empty_responses`, `reasoning_only`, `dialect_residue`, `unvalidatable_schemas`, `normalization_errors` — accumulated correctly into memory that **nothing could observe**. The auto-tune scheduler was the ledger's only reader, and it went with ADR 0006 (#810).

I found this while setting up to run traffic through the proxy: `supervisor.defects()` still exists, but its only caller was the `service_graph.rs` line the scheduler removal deleted.

### Why it matters now

The plan's next step is to run the counters against real traffic and choose escalation rungs from what actually fires. **A day of traffic would have produced evidence nobody could look at.** This is the thing standing between the instrumentation work and using it.

### The change

`DashboardSnapshot` gains `per_model_defects`, keyed by the model name requests carry — available on `GET /v1/proxy/status` and the status stream, so both the CLI dashboard and the GUI modal can read it.

The fleet totals beside it answer *"is something wrong"*; this answers *"with which model"*, which is the only form the answer is actionable in. A rate is a claim about a model, not about traffic — that split is why the ledger is per-model in the first place.

**No new plumbing.** `ContextMetricsStore` already holds the ledger, because every signal it wants passes through there with the model name attached. Reading it back is one accessor.

### Unchanged

Still process-lifetime, still reset on restart. That's the accepted consequence of culling persistence (#805), recorded in the module doc: a defect rate is a claim about *recent* traffic on *this* build.

### Verification

Two new tests: counters are readable after recording (asserting `reasoning_only` nests inside the empty total, as designed), and the accessor degrades to empty when no ledger is wired — the proxy can run without one.

`cargo test -p gglib-proxy -p gglib-core` — all 20 test binaries pass.

⚠️ Full `make pre-commit` trips **only** the known pre-existing flake `daemon::watchdog::tests::a_healthy_daemon_passes_the_probe` (see #817), which is unrelated to this change and fails on clean `main`.
