### PR TITLE
chore(cleanup): remove the ledger accessor nobody calls, and stop degrading silently

### DIFF
--- a/crates/gglib-proxy/src/sse_stream.rs
+++ b/crates/gglib-proxy/src/sse_stream.rs
@@ -181,10 +181,24 @@ pub fn spawn_and_return(
                 );
                 // The repair re-issue needs the same endpoint, headers and
                 // body the original went out with. `try_clone` succeeds
-                // because the body is `Bytes`; a `None` here simply means no
-                // repair is possible for this turn, which is a degradation
-                // rather than a failure.
-                let repair = req_builder.try_clone().map(|builder| RepairContext {
+                // because the body is `Bytes` — the sibling call above
+                // `expect`s on that same invariant.
+                //
+                // A `None` here is therefore a should-never-happen, and it is
+                // worth saying so out loud: it silently disables repair *and*
+                // the tool-call hold-back for the whole turn, so the client's
+                // frames go out unwithheld and a malformed call reaches it
+                // unaltered. Degrading is the right behaviour; degrading
+                // without a trace is what made this hard to reason about.
+                let cloned = req_builder.try_clone();
+                if cloned.is_none() {
+                    warn!(
+                        model = %model_name_owned,
+                        "request builder could not be cloned; tool-call repair and hold-back \
+                         are disabled for this turn"
+                    );
+                }
+                let repair = cloned.map(|builder| RepairContext {
                     req_builder: builder,
                     request_body: body.clone(),
                     enabled: repair_enabled,

--- a/crates/gglib-runtime/src/proxy/supervisor.rs
+++ b/crates/gglib-runtime/src/proxy/supervisor.rs
@@ -272,15 +272,6 @@ impl ProxySupervisor {
         Arc::clone(&self.agent_metrics)
     }
 
-    /// The per-model defect ledger — the Tier C signals, kept as diagnosis.
-    ///
-    /// Nothing acts on these automatically since ADR 0006; they record what
-    /// actually fails, per model, for a person to read.
-    #[must_use]
-    pub fn defects(&self) -> Arc<gglib_core::domain::defects::ModelDefectLedger> {
-        Arc::clone(&self.defects)
-    }
-
     /// Get a watch receiver for proxy exit notifications.
     ///
     /// The receiver yields the new `ProxyStatus` whenever the proxy task exits


### PR DESCRIPTION
Two leftovers from the scheduler's removal, both found while driving real traffic through the proxy.

### 1. A public accessor nobody calls

`ProxySupervisor::defects()` has **zero callers**. Its only one was the `service_graph.rs` line #810 deleted, and the ledger reaches the proxy by a completely different route — the supervisor clones it straight into `serve` (`supervisor.rs:373,398`).

A public accessor to a field that already travels another way is exactly the dormant remnant the house rules forbid. Worse, it *reads* as though the ledger were still fetched that way, which is how I initially mis-traced the wiring.

### 2. A silent degradation

When `try_clone` on the request builder returns `None`, the turn loses tool-call repair **and** the hold-back — frames go out unwithheld and a malformed call reaches the client unaltered.

Degrading is the right behaviour. Degrading *without a trace* is not, especially since the sibling call a few lines above `expect`s on the very same invariant:

```rust
.try_clone()
.expect("streaming request body is Bytes (non-stream); try_clone always succeeds")
```

So one site asserts it cannot happen while the other quietly accommodates it happening. That inconsistency was most of what made this hard to reason about. It still degrades; it now says so.

§9.5 flagged this as *"try_clone() failure silently disables hold-back for the whole turn, no log"*.

### Verification

`cargo test` across the workspace — the **only** failure is the known pre-existing flake `daemon::watchdog::tests::a_healthy_daemon_passes_the_probe` (see #817), which reproduces on clean `main`. `gglib-axum` passes 47/47 single-threaded.

Also cleaned up out-of-tree: the scratch database and model registration I created while verifying #818 live. Nothing tracked was touched.
