### PR TITLE
fix(gui): a frontend-driven sync asks the daemon before it paints

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,13 @@ gtk.workspace = true
 ksni.workspace = true
 libloading.workspace = true
 
+[dev-dependencies]
+# `test-util` for `#[tokio::test(start_paused = true)]`, and `macros` for the
+# attribute itself. The watcher's timing rules — a wake arrives, or the poll
+# interval elapses — are only testable against a clock the test controls; the
+# alternative is a suite that sleeps two seconds per assertion.
+tokio = { workspace = true, features = ["macros", "test-util"] }
+
 [features]
 # This feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!

--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -40,6 +40,10 @@ pub async fn open_url(url: String) -> Result<(), String> {
 }
 
 /// Set the currently selected model ID and sync menu state.
+///
+/// The selection lives in this process, not in the daemon, so repainting from
+/// the snapshot already in hand is correct here — nothing about the daemon
+/// changed.
 #[tauri::command]
 pub async fn set_selected_model(
     model_id: Option<i64>,
@@ -53,11 +57,32 @@ pub async fn set_selected_model(
     state_sync::sync_all_state(&app, &state).await
 }
 
-/// Sync menu state based on current application state.
+/// Sync menu state after the frontend has changed something.
+///
+/// Every caller is a fire-and-forget `syncMenuStateSilent()` after an action
+/// that changed something the menu shows: a server stopped, a model removed,
+/// llama.cpp installed. Two kinds of state are involved and they need
+/// different treatment, which is why this does both things.
+///
+/// **Ask for a poll**, because `sync_all_state` paints from
+/// `AppState::snapshot` and only `daemon::watch` writes it. Painting without
+/// asking redraws from what was true *before* the action, and it stays wrong
+/// until the next tick. The Rust-side callers were all converted to
+/// `Refresh::now` when the watcher landed; this is the frontend's equivalent
+/// and was missed.
+///
+/// **Then paint anyway**, because not everything the menu reads is in that
+/// snapshot — `llama_installed` is a filesystem check, and an install changes
+/// it without changing anything the daemon would report. The watcher would see
+/// no difference and skip the repaint.
+///
+/// So: the immediate paint catches the local state, and the poll it just asked
+/// for catches the daemon's, a moment later.
 #[tauri::command]
 pub async fn sync_menu_state(
     app: AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    state.refresh.now();
     state_sync::sync_all_state(&app, &state).await
 }

--- a/src-tauri/src/daemon/watch.rs
+++ b/src-tauri/src/daemon/watch.rs
@@ -121,3 +121,72 @@ async fn read(daemon: &Daemon) -> DaemonSnapshot {
         _ => DaemonSnapshot::default(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A clone has to reach the same waiter. `Refresh` is handed out by
+    /// cloning it off `AppState`, so a clone that notified its own private
+    /// `Notify` would make every caller's `now()` a silent no-op — and that
+    /// failure looks exactly like the stale-surface bug this handle exists to
+    /// prevent.
+    #[tokio::test(start_paused = true)]
+    async fn a_clone_wakes_the_original() {
+        let refresh = Refresh::default();
+        let clone = refresh.clone();
+
+        clone.now();
+
+        // Returns without the interval elapsing, so the wake came from `now()`.
+        tokio::time::timeout(Duration::from_millis(1), refresh.wait())
+            .await
+            .expect("a clone's notify must reach the original's waiter");
+    }
+
+    /// `notify_one` stores a permit when nobody is waiting. That is what makes
+    /// the ordering safe: an action can call `now()` before the watcher gets
+    /// back to `wait()`, which is the ordinary case for a fast action.
+    #[tokio::test(start_paused = true)]
+    async fn a_wake_that_arrives_early_is_not_lost() {
+        let refresh = Refresh::default();
+
+        refresh.now();
+
+        tokio::time::timeout(Duration::from_millis(1), refresh.wait())
+            .await
+            .expect("a notify with no waiter must be held, not dropped");
+    }
+
+    /// With nothing asking, the watcher still polls — that is what catches a
+    /// proxy the CLI started, or a daemon that died.
+    #[tokio::test(start_paused = true)]
+    async fn the_interval_wakes_it_on_its_own() {
+        let refresh = Refresh::default();
+
+        let start = tokio::time::Instant::now();
+        refresh.wait().await;
+
+        assert!(
+            start.elapsed() >= POLL_INTERVAL,
+            "an unprompted wait must run the full interval"
+        );
+    }
+
+    /// One permit, one wake. A stored notification must not satisfy the next
+    /// wait as well, or the watcher spins on a single `now()`.
+    #[tokio::test(start_paused = true)]
+    async fn one_wake_does_not_satisfy_two_waits() {
+        let refresh = Refresh::default();
+        refresh.now();
+        refresh.wait().await;
+
+        let start = tokio::time::Instant::now();
+        refresh.wait().await;
+
+        assert!(
+            start.elapsed() >= POLL_INTERVAL,
+            "the second wait must fall back to the interval"
+        );
+    }
+}


### PR DESCRIPTION
`sync_all_state` paints from `AppState::snapshot`, and only `daemon::watch` writes that. The `sync_menu_state` command never asked for a poll, so every `syncMenuStateSilent()` the frontend fires after an action — a server stopped, a model removed, llama.cpp installed — repainted the menu and tray from what was true **before** the action, and stayed wrong until the next 2 s tick.

Every Rust-side caller was converted to `Refresh::now` when the watcher landed (`proxy_actions.rs`, `tray/handlers.rs`). This path is the frontend's equivalent and was missed.

It now does both things, because two kinds of state are involved:

- **Ask for a poll** — so the daemon's state is corrected a moment later instead of up to two seconds later.
- **Still paint immediately** — because `llama_installed` is a filesystem check the daemon knows nothing about. After an install the snapshot is unchanged, so the watcher would see no difference and skip the repaint entirely.

## Tests

`Refresh` had none. It gets four, on a paused clock. The load-bearing one is `a_clone_wakes_the_original`: `Refresh` is handed out by cloning it off `AppState`, so a clone notifying its own private `Notify` would make every caller's `now()` a silent no-op — a failure that looks exactly like the bug above.

`src-tauri` gains a `[dev-dependencies]` `tokio` with `macros` + `test-util`; without a controllable clock these assertions would each sleep two seconds.

`cargo test -p gglib-app` 46 passed, `cargo clippy -p gglib-app --all-targets` clean, ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)