### PR TITLE
refactor(core): one spelling of "truthy", and a guard that keeps it that way

### DIFF
--- a/crates/gglib-core/src/debug_switches.rs
+++ b/crates/gglib-core/src/debug_switches.rs
@@ -60,13 +60,25 @@ pub const ALL: &[&str] = &[
 /// Whether an environment value reads as "on".
 ///
 /// The spelling every switch in the tree already accepts, gathered here so a
-/// ninth one cannot quietly accept a different set.
+/// ninth one cannot quietly accept a different set. That claim used to be
+/// false: five sites had their own copy of this `matches!`, two of them in
+/// this very crate, and this one had no callers outside its own module.
 #[must_use]
 pub fn is_truthy(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),
         "1" | "true" | "yes" | "on"
     )
+}
+
+/// Whether the named environment switch is set to a truthy value **now**.
+///
+/// Reads the live environment on every call rather than caching. A switch
+/// consulted once at startup would ignore a `.env` loaded later, and the tests
+/// that set one per case would leak into each other.
+#[must_use]
+pub fn enabled(var: &str) -> bool {
+    std::env::var(var).ok().is_some_and(|v| is_truthy(&v))
 }
 
 /// The switches set truthy **in this process**.
@@ -76,10 +88,7 @@ pub fn is_truthy(value: &str) -> bool {
 /// point — see the module docs.
 #[must_use]
 pub fn active() -> Vec<&'static str> {
-    ALL.iter()
-        .copied()
-        .filter(|name| std::env::var(name).ok().is_some_and(|v| is_truthy(&v)))
-        .collect()
+    ALL.iter().copied().filter(|name| enabled(name)).collect()
 }
 
 /// What the CLI should say when its switches differ from the daemon's.
@@ -137,121 +146,5 @@ pub const fn build_fingerprint() -> &'static str {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn truthy_values_are_the_ones_the_tree_already_accepted() {
-        for v in ["1", "true", "yes", "on", "TRUE", " On "] {
-            assert!(is_truthy(v), "{v:?} should be truthy");
-        }
-        for v in ["0", "false", "no", "off", "", "maybe"] {
-            assert!(!is_truthy(v), "{v:?} should not be truthy");
-        }
-    }
-
-    /// [`ALL`] must name every `GGLIB_DISABLE_*` the tree reads, in both
-    /// directions.
-    ///
-    /// A hand-written roster of strings that other crates own is precisely the
-    /// shape that rotted in `AUTO_TAG_NAMES`: a switch missing here is
-    /// invisible to the mismatch warning forever, and one listed here that
-    /// nothing reads reports a difference that cannot matter. So the source
-    /// tree is the reference, read at test time — the same trick
-    /// `sampler_wire_semantics.py` uses on the floor and
-    /// `settingsBounds.test.ts` uses on the bounds.
-    #[test]
-    fn all_lists_every_switch_the_tree_reads() {
-        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .expect("crates/")
-            .to_path_buf();
-
-        let mut found: Vec<String> = Vec::new();
-        let mut stack = vec![root];
-        while let Some(dir) = stack.pop() {
-            let Ok(entries) = std::fs::read_dir(&dir) else {
-                continue;
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    stack.push(path);
-                } else if path.extension().is_some_and(|e| e == "rs") {
-                    // This file is the roster itself; its own list is not
-                    // evidence that anything reads the switch.
-                    if path.ends_with("debug_switches.rs") {
-                        continue;
-                    }
-                    let Ok(text) = std::fs::read_to_string(&path) else {
-                        continue;
-                    };
-                    for (i, _) in text.match_indices("GGLIB_DISABLE_") {
-                        let tail: String = text[i..]
-                            .chars()
-                            .take_while(|c| c.is_ascii_uppercase() || *c == '_')
-                            .collect();
-                        if tail.len() > "GGLIB_DISABLE_".len() && !found.contains(&tail) {
-                            found.push(tail);
-                        }
-                    }
-                }
-            }
-        }
-
-        assert!(
-            !found.is_empty(),
-            "the scan found no switches at all — it is not reading the tree, so its \
-             agreement below would mean nothing"
-        );
-
-        for name in &found {
-            assert!(
-                ALL.contains(&name.as_str()),
-                "{name} is read somewhere in the tree but missing from ALL, so a command \
-                 setting it against a running daemon gets no warning"
-            );
-        }
-        for name in ALL {
-            assert!(
-                found.iter().any(|f| f == name),
-                "ALL lists {name}, which nothing in the tree reads"
-            );
-        }
-    }
-
-    #[test]
-    fn agreeing_switch_sets_produce_no_warning() {
-        assert!(describe_mismatch(&[], &[]).is_none());
-        assert!(
-            describe_mismatch(
-                &["GGLIB_DISABLE_GRAMMAR"],
-                &["GGLIB_DISABLE_GRAMMAR".to_string()]
-            )
-            .is_none()
-        );
-    }
-
-    /// The case that cost an hour: set on the CLI, absent in the daemon.
-    #[test]
-    fn a_switch_the_daemon_never_saw_is_named_as_ignored() {
-        let msg = describe_mismatch(&["GGLIB_DISABLE_AGENTIC_SAMPLING"], &[])
-            .expect("a mismatch must be reported");
-
-        assert!(msg.contains("GGLIB_DISABLE_AGENTIC_SAMPLING"), "{msg}");
-        assert!(msg.contains("being ignored"), "{msg}");
-        assert!(msg.contains("gglib daemon stop"), "{msg}");
-    }
-
-    /// The reverse: a daemon started with a switch the current command does
-    /// not set. Equally worth saying — the run is not the vanilla one the
-    /// operator thinks they are getting.
-    #[test]
-    fn a_switch_only_the_daemon_has_is_also_reported() {
-        let msg = describe_mismatch(&[], &["GGLIB_DISABLE_TOOL_REPAIR".to_string()])
-            .expect("a mismatch must be reported");
-
-        assert!(msg.contains("GGLIB_DISABLE_TOOL_REPAIR"), "{msg}");
-        assert!(msg.contains("in effect in the daemon"), "{msg}");
-    }
-}
+#[path = "debug_switches_tests.rs"]
+mod tests;

--- a/crates/gglib-core/src/debug_switches_tests.rs
+++ b/crates/gglib-core/src/debug_switches_tests.rs
@@ -1,0 +1,169 @@
+//! Tests for [`super`] — the debug-switch registry.
+//!
+//! Their own file, the way `models_tests.rs` is: the module is a short list of
+//! constants and three small functions, and the tests are longer than all of
+//! it, because one of them walks the crate tree.
+
+use super::*;
+
+#[test]
+fn truthy_values_are_the_ones_the_tree_already_accepted() {
+    for v in ["1", "true", "yes", "on", "TRUE", " On "] {
+        assert!(is_truthy(v), "{v:?} should be truthy");
+    }
+    for v in ["0", "false", "no", "off", "", "maybe"] {
+        assert!(!is_truthy(v), "{v:?} should not be truthy");
+    }
+}
+
+/// [`ALL`] must name every `GGLIB_DISABLE_*` the tree reads, in both
+/// directions.
+///
+/// A hand-written roster of strings that other crates own is precisely the
+/// shape that rotted in `AUTO_TAG_NAMES`: a switch missing here is
+/// invisible to the mismatch warning forever, and one listed here that
+/// nothing reads reports a difference that cannot matter. So the source
+/// tree is the reference, read at test time — the same trick
+/// `sampler_wire_semantics.py` uses on the floor and
+/// `settingsBounds.test.ts` uses on the bounds.
+#[test]
+fn all_lists_every_switch_the_tree_reads() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .to_path_buf();
+
+    let mut found: Vec<String> = Vec::new();
+    let mut stack = vec![root];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                // This file is the roster itself; its own list is not
+                // evidence that anything reads the switch.
+                if path.ends_with("debug_switches.rs") {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                for (i, _) in text.match_indices("GGLIB_DISABLE_") {
+                    let tail: String = text[i..]
+                        .chars()
+                        .take_while(|c| c.is_ascii_uppercase() || *c == '_')
+                        .collect();
+                    if tail.len() > "GGLIB_DISABLE_".len() && !found.contains(&tail) {
+                        found.push(tail);
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        !found.is_empty(),
+        "the scan found no switches at all — it is not reading the tree, so its \
+         agreement below would mean nothing"
+    );
+
+    for name in &found {
+        assert!(
+            ALL.contains(&name.as_str()),
+            "{name} is read somewhere in the tree but missing from ALL, so a command \
+             setting it against a running daemon gets no warning"
+        );
+    }
+    for name in ALL {
+        assert!(
+            found.iter().any(|f| f == name),
+            "ALL lists {name}, which nothing in the tree reads"
+        );
+    }
+}
+
+#[test]
+fn agreeing_switch_sets_produce_no_warning() {
+    assert!(describe_mismatch(&[], &[]).is_none());
+    assert!(
+        describe_mismatch(
+            &["GGLIB_DISABLE_GRAMMAR"],
+            &["GGLIB_DISABLE_GRAMMAR".to_string()]
+        )
+        .is_none()
+    );
+}
+
+/// The case that cost an hour: set on the CLI, absent in the daemon.
+#[test]
+fn a_switch_the_daemon_never_saw_is_named_as_ignored() {
+    let msg = describe_mismatch(&["GGLIB_DISABLE_AGENTIC_SAMPLING"], &[])
+        .expect("a mismatch must be reported");
+
+    assert!(msg.contains("GGLIB_DISABLE_AGENTIC_SAMPLING"), "{msg}");
+    assert!(msg.contains("being ignored"), "{msg}");
+    assert!(msg.contains("gglib daemon stop"), "{msg}");
+}
+
+/// The reverse: a daemon started with a switch the current command does
+/// not set. Equally worth saying — the run is not the vanilla one the
+/// operator thinks they are getting.
+#[test]
+fn a_switch_only_the_daemon_has_is_also_reported() {
+    let msg = describe_mismatch(&[], &["GGLIB_DISABLE_TOOL_REPAIR".to_string()])
+        .expect("a mismatch must be reported");
+
+    assert!(msg.contains("GGLIB_DISABLE_TOOL_REPAIR"), "{msg}");
+    assert!(msg.contains("in effect in the daemon"), "{msg}");
+}
+
+/// The claim in `is_truthy`'s doc — that this is the spelling every switch
+/// accepts — is only true if nobody writes their own. Five sites did, two
+/// of them in this crate, and nothing failed when they diverged because
+/// each one was locally correct.
+///
+/// So this greps the tree. A unit test cannot see a copy that has not been
+/// written yet; a search for the literal can.
+#[test]
+fn nothing_else_spells_out_the_truthy_set() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .to_path_buf();
+
+    let mut offenders = Vec::new();
+    let mut stack = vec![root];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "target") {
+                    continue;
+                }
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                // Built from parts so this test's own source does not match.
+                let needle = format!("{:?} | {:?} | {:?} | {:?}", "1", "true", "yes", "on");
+                if text.contains(&needle) && !path.ends_with("gglib-core/src/debug_switches.rs") {
+                    offenders.push(path);
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "the truthy set is spelled out outside debug_switches: {offenders:#?}\n\
+         Call `debug_switches::is_truthy` (or `enabled`) instead."
+    );
+}

--- a/crates/gglib-core/src/request_pipeline/constrain.rs
+++ b/crates/gglib-core/src/request_pipeline/constrain.rs
@@ -89,12 +89,7 @@ pub const DISABLE_GRAMMAR_ENV: &str = "GGLIB_DISABLE_GRAMMAR";
 
 /// Whether [`DISABLE_GRAMMAR_ENV`] is set to a truthy value.
 fn grammar_disabled_via_env() -> bool {
-    std::env::var(DISABLE_GRAMMAR_ENV).ok().is_some_and(|v| {
-        matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    crate::debug_switches::enabled(DISABLE_GRAMMAR_ENV)
 }
 
 /// Originate a decode-time grammar for a demanded dialect tool call.

--- a/crates/gglib-core/src/request_pipeline/sampling.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling.rs
@@ -170,14 +170,7 @@ pub const DISABLE_AGENTIC_SAMPLING_ENV: &str = "GGLIB_DISABLE_AGENTIC_SAMPLING";
 
 /// Whether [`DISABLE_AGENTIC_SAMPLING_ENV`] is set to a truthy value.
 fn agentic_sampling_disabled_via_env() -> bool {
-    std::env::var(DISABLE_AGENTIC_SAMPLING_ENV)
-        .ok()
-        .is_some_and(|v| {
-            matches!(
-                v.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
+    crate::debug_switches::enabled(DISABLE_AGENTIC_SAMPLING_ENV)
 }
 
 /// Resolve the sampling hierarchy into `body`, then pin `cache_prompt`.

--- a/crates/gglib-proxy/src/canonicalization.rs
+++ b/crates/gglib-proxy/src/canonicalization.rs
@@ -44,14 +44,7 @@ pub const DISABLE_CANONICALIZATION_ENV: &str = "GGLIB_DISABLE_PROMPT_CANONICALIZ
 
 /// Whether [`DISABLE_CANONICALIZATION_ENV`] is set to a truthy value.
 fn canonicalization_disabled_via_env() -> bool {
-    std::env::var(DISABLE_CANONICALIZATION_ENV)
-        .ok()
-        .is_some_and(|v| {
-            matches!(
-                v.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
+    gglib_core::debug_switches::enabled(DISABLE_CANONICALIZATION_ENV)
 }
 
 /// Matches dynamic IDE-injected lines at the start of a line (multiline mode).

--- a/crates/gglib-proxy/src/repair.rs
+++ b/crates/gglib-proxy/src/repair.rs
@@ -51,12 +51,7 @@ pub const DISABLE_REPAIR_ENV: &str = "GGLIB_DISABLE_TOOL_REPAIR";
 
 /// Whether [`DISABLE_REPAIR_ENV`] is set to a truthy value.
 fn repair_disabled_via_env() -> bool {
-    std::env::var(DISABLE_REPAIR_ENV).ok().is_some_and(|v| {
-        matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    gglib_core::debug_switches::enabled(DISABLE_REPAIR_ENV)
 }
 
 /// Why a response was not repaired, for the record.

--- a/crates/gglib-runtime/src/system/mod.rs
+++ b/crates/gglib-runtime/src/system/mod.rs
@@ -148,12 +148,11 @@ fn detect_free_vram_source() -> FreeVramSource {
 /// Parse a string as a truthy on/off flag (case- and whitespace-insensitive).
 ///
 /// Used by `GGLIB_DISABLE_<FEATURE>` environment variable checks throughout
-/// the crate. Truthy values: `1`, `true`, `yes`, `on`.
+/// the crate. Delegates rather than repeating the spelling: every switch in
+/// the tree has to accept the same set, and this crate's copy is how they
+/// would drift.
 pub(crate) fn is_truthy_flag(v: &str) -> bool {
-    matches!(
-        v.trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    gglib_core::debug_switches::is_truthy(v)
 }
 
 /// Identify the running distribution from `/etc/os-release`.


### PR DESCRIPTION
`debug_switches::is_truthy` documents itself as *"the spelling every switch in the tree already accepts, gathered here so a ninth one cannot quietly accept a different set."*

That was false. **Five** other sites spelled out the same `matches!` — two of them in this very crate — and `is_truthy` itself had no caller outside its own module:

- `request_pipeline/constrain.rs`
- `request_pipeline/sampling.rs`
- `gglib-proxy/src/canonicalization.rs`
- `gglib-proxy/src/repair.rs` (added by the pivot work)
- `gglib-runtime/src/system/mod.rs`

Nothing failed while they agreed, because each copy was locally correct. The cost only arrives when one of them changes.

## The fix

The four `GGLIB_DISABLE_*` readers now call a new `debug_switches::enabled(var)`, which collapses each to one line. It reads the live environment on every call: caching would ignore a `.env` loaded after startup, and would leak between tests that set one switch per case.

`gglib-runtime`'s `is_truthy_flag` keeps its name — it is that crate's vocabulary — and delegates.

## The guard

A unit test cannot see a copy nobody has written yet, so this one is a grep: it walks the crate tree for the literal set and fails on any occurrence outside `debug_switches`. **Verified by adding a copy back**, which failed it with the offending path.

Tests move to `debug_switches_tests.rs` per the `models_tests.rs` convention — the module is a list of constants and three small functions, and the tests are now longer than all of it.

## Verification

`cargo test --workspace` clean, `cargo clippy --workspace --all-targets` clean, `make enforce` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)