### PR TITLE
refactor(gui): one name per formatter, and labels that match the maths

### DIFF
--- a/scripts/ts-complexity-baseline.txt
+++ b/scripts/ts-complexity-baseline.txt
@@ -8,7 +8,6 @@ src/components/ModelInspectorPanel/ModelInspectorPanel.tsx 352
 src/components/ProxyControl.tsx 345
 src/components/ProxySamplingPanel.tsx 373
 src/components/SettingsModal.tsx 373
-src/components/SettingsModal/SystemSettings.tsx 312
 src/components/SetupWizard/SetupWizard.tsx 721
 src/components/VerificationModal.tsx 454
 src/hooks/useDownloadManager.ts 451

--- a/src/components/ConsoleInfoPanel/TelemetrySections.tsx
+++ b/src/components/ConsoleInfoPanel/TelemetrySections.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { Readout, Sparkline, Stack } from '../primitives';
 import { useMetricHistory } from '../../hooks/useMetricHistory';
-import { formatRate } from '../../utils/formatRate';
+import { formatPerSecond } from '../../utils/formatPerSecond';
 import type { ServerMetrics } from './useServerMetrics';
 
 interface TelemetryProps {
@@ -87,7 +87,7 @@ export const StatisticsSection: FC<Omit<TelemetryProps, 'contextLength'>> = ({
       <h3 className="m-0 text-sm font-semibold text-text">Statistics</h3>
       <Readout
         label="Generation"
-        value={genRate.latest != null ? formatRate(genRate.latest) : '—'}
+        value={genRate.latest != null ? formatPerSecond(genRate.latest) : '—'}
         unit="tok/s"
         trend={
           <Sparkline

--- a/src/components/ProxyAdmissionPanel.tsx
+++ b/src/components/ProxyAdmissionPanel.tsx
@@ -29,15 +29,11 @@ import type {
   ResidentSlotSnapshot,
   SecondarySlotState,
 } from '../services/transport/types/dashboard';
+import { formatCount } from '../utils/format';
 
 export interface ProxyAdmissionPanelProps {
   /** `null`/`undefined` on a proxy that predates admission control. */
   admission?: AdmissionSnapshot | null;
-}
-
-/** Thousands-separated count, matching the cache panel's type scale. */
-function formatCount(value: number): string {
-  return value.toLocaleString();
 }
 
 /** Whole seconds, or a coarse minutes figure once a wait gets long. */

--- a/src/components/ProxyCachePanel.tsx
+++ b/src/components/ProxyCachePanel.tsx
@@ -21,15 +21,11 @@ import type { FC } from 'react';
 import { Banner } from './ui/Banner';
 import { Readout } from './primitives';
 import type { CacheStatus, CacheUsage } from '../services/transport/types/dashboard';
+import { formatCount } from '../utils/format';
 
 export interface ProxyCachePanelProps {
   /** `null`/`undefined` before the first request resolves a model. */
   cache?: CacheStatus | null;
-}
-
-/** Thousands-separated count, so six-figure token totals stay readable. */
-function formatCount(value: number): string {
-  return value.toLocaleString();
 }
 
 /** One label/value row, matching the modal's existing type scale. */

--- a/src/components/ProxyLaunchPanel.tsx
+++ b/src/components/ProxyLaunchPanel.tsx
@@ -25,8 +25,8 @@ export interface ProxyLaunchPanelProps {
 }
 
 /** Bytes as GiB with one decimal, matching the backend's `format_gib`. */
-export function formatWeights(bytes: number): string {
-  return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+function formatWeights(bytes: number): string {
+  return `${(bytes / 1_073_741_824).toFixed(1)} GiB`;
 }
 
 /**

--- a/src/components/SettingsModal/LabelledValue.tsx
+++ b/src/components/SettingsModal/LabelledValue.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react';
+
+/**
+ * One label/value row. Values are mono so paths and hashes line up.
+ *
+ * Deliberately not called `Row`. It was, inside `SystemSettings.tsx`, which
+ * also imports `Stack` from `components/primitives` — where `Row` is a flex
+ * container. Two different ideas under one name, one import away from being
+ * confused for each other.
+ */
+export const LabelledValue: FC<{ label: string; value: string; mono?: boolean }> = ({
+  label,
+  value,
+  mono = true,
+}) => (
+  <div className="flex items-baseline justify-between gap-md">
+    <span className="text-xs text-text-muted shrink-0">{label}</span>
+    <span
+      className={`text-xs text-text-secondary text-right break-all ${mono ? 'font-mono tabular-nums' : ''}`}
+    >
+      {value}
+    </span>
+  </div>
+);

--- a/src/components/SettingsModal/SystemSettings.tsx
+++ b/src/components/SettingsModal/SystemSettings.tsx
@@ -15,22 +15,7 @@ import { getTransport } from '../../services/transport';
 import { useSystemSettings } from './useSystemSettings';
 import { DiagnosticsPanel } from './DiagnosticsPanel';
 import type { LlamaStatus } from '../../types/setup';
-
-/** One label/value row. Values are mono so paths and hashes line up. */
-const Row: FC<{ label: string; value: string; mono?: boolean }> = ({
-  label,
-  value,
-  mono = true,
-}) => (
-  <div className="flex items-baseline justify-between gap-md">
-    <span className="text-xs text-text-muted shrink-0">{label}</span>
-    <span
-      className={`text-xs text-text-secondary text-right break-all ${mono ? 'font-mono tabular-nums' : ''}`}
-    >
-      {value}
-    </span>
-  </div>
-);
+import { LabelledValue } from './LabelledValue';
 
 /** Installed / degraded / absent, as a dot and a word. */
 const InstallState: FC<{ status: LlamaStatus }> = ({ status }) => {
@@ -150,15 +135,15 @@ export const SystemSettings: FC = () => {
 
         {status && (
           <Stack gap="xs">
-            <Row label="Binary" value={status.binaryPath} />
+            <LabelledValue label="Binary" value={status.binaryPath} />
             {status.build ? (
               <>
-                <Row label="Built from" value={status.build.version} />
-                <Row label="Acceleration" value={status.build.acceleration} mono={false} />
-                <Row label="Built" value={status.build.buildDate.split('T')[0]} />
+                <LabelledValue label="Built from" value={status.build.version} />
+                <LabelledValue label="Acceleration" value={status.build.acceleration} mono={false} />
+                <LabelledValue label="Built" value={status.build.buildDate.split('T')[0]} />
               </>
             ) : (
-              <Row
+              <LabelledValue
                 label="Build record"
                 value={
                   status.buildError ??
@@ -168,7 +153,7 @@ export const SystemSettings: FC = () => {
               />
             )}
             {status.runtime && (
-              <Row
+              <LabelledValue
                 label="Binary reports"
                 value={
                   status.runtime.build

--- a/src/components/proxy/RequestThroughput.tsx
+++ b/src/components/proxy/RequestThroughput.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { Readout, Sparkline } from '../primitives';
 import { useMetricHistory } from '../../hooks/useMetricHistory';
-import { formatRate } from '../../utils/formatRate';
+import { formatPerSecond } from '../../utils/formatPerSecond';
 import type { DashboardSnapshot } from '../../services/transport/types/dashboard';
 
 interface RequestThroughputProps {
@@ -27,7 +27,7 @@ export const RequestThroughput: FC<RequestThroughputProps> = ({ snapshot }) => {
       <Readout
         size="sm"
         label="Throughput"
-        value={rate.latest != null ? formatRate(rate.latest) : '—'}
+        value={rate.latest != null ? formatPerSecond(rate.latest) : '—'}
         unit="req/s"
       />
       <Sparkline

--- a/src/components/proxy/SlotCard.tsx
+++ b/src/components/proxy/SlotCard.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { ContextUsageDonut } from '../ContextUsageDonut';
 import { Readout, Sparkline } from '../primitives';
 import { useMetricHistory } from '../../hooks/useMetricHistory';
-import { formatRate } from '../../utils/formatRate';
+import { formatPerSecond } from '../../utils/formatPerSecond';
 import { tokensInUse, type SlotSnapshot } from '../../services/transport/types/dashboard';
 
 interface SlotCardProps {
@@ -44,7 +44,7 @@ export const SlotCard: FC<SlotCardProps> = ({ slot, size = 80, tick, resetKey })
         size="sm"
         align="center"
         label={`Slot ${slot.id}${slot.is_processing ? ' · active' : ''}`}
-        value={genRate.latest != null ? formatRate(genRate.latest) : '—'}
+        value={genRate.latest != null ? formatPerSecond(genRate.latest) : '—'}
         unit="tok/s"
         trend={
           <Sparkline

--- a/src/hooks/useSystemMemory.ts
+++ b/src/hooks/useSystemMemory.ts
@@ -45,15 +45,21 @@ export function determineFitStatus(requiredBytes: number, availableBytes: number
 }
 
 /**
- * Format bytes to a human-readable string.
+ * Format a memory size, in binary units.
+ *
+ * The divisors were always 1024-based — the same convention `gglib up` and the
+ * fit indicators use, and the reason those three agree. The *labels* said `GB`,
+ * `MB`, `KB`, so a 21 GiB figure was printed as "21 GB", which is a different
+ * number. Fixed on the label rather than the maths: changing the divisors would
+ * have made this disagree with every fit calculation it sits beside.
  */
 export function formatMemorySize(bytes: number): string {
   if (bytes >= 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
   } else if (bytes >= 1024 * 1024) {
-    return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+    return `${(bytes / (1024 * 1024)).toFixed(0)} MiB`;
   } else {
-    return `${(bytes / 1024).toFixed(0)} KB`;
+    return `${(bytes / 1024).toFixed(0)} KiB`;
   }
 }
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -134,3 +134,11 @@ export const getHuggingFaceUrl = (
 export const getHuggingFaceModelUrl = (modelId: string): string => {
   return `https://huggingface.co/${modelId}`;
 };
+
+/**
+ * Thousands-separated count, so six-figure token totals stay readable.
+ *
+ * Trivial enough that two panels each grew their own copy; here so a third
+ * does not, and so a future change of mind about separators lands once.
+ */
+export const formatCount = (value: number): string => value.toLocaleString();

--- a/src/utils/formatPerSecond.ts
+++ b/src/utils/formatPerSecond.ts
@@ -1,0 +1,12 @@
+/**
+ * Compact per-second count: sub-10 keeps one decimal, larger values round whole.
+ *
+ * A bare figure with no unit — the caller supplies "tok/s", "req/s" or
+ * whatever it is counting. Named `formatRate` until a second `formatRate` in
+ * `utils/format.ts` turned out to format *bytes* per second, complete with a
+ * "MB/s" suffix. Two functions, one name, incompatible units, chosen by import
+ * path: a one-character typo silently changed what a number meant.
+ */
+export function formatPerSecond(perSecond: number): string {
+  return perSecond < 10 ? perSecond.toFixed(1) : String(Math.round(perSecond));
+}

--- a/src/utils/formatRate.ts
+++ b/src/utils/formatRate.ts
@@ -1,4 +1,0 @@
-/** Compact per-second rate figure: sub-10 keeps one decimal, larger values round whole. */
-export function formatRate(perSecond: number): string {
-  return perSecond < 10 ? perSecond.toFixed(1) : String(Math.round(perSecond));
-}

--- a/tests/ts/components/RecommendedModel.test.tsx
+++ b/tests/ts/components/RecommendedModel.test.tsx
@@ -23,7 +23,7 @@ const rec: ModelRecommendation = {
   repo: 'unsloth/Qwen3-30B-A3B-GGUF',
   quantization: 'Q4_K_M',
   rationale: 'mixture-of-experts: 30B of knowledge, ~3B active per token',
-  // Binary GB, matching formatMemorySize: 21 GiB and 32 GiB exactly.
+  // Binary, matching formatMemorySize: 21 GiB and 32 GiB exactly.
   requiredBytes: 21 * 1024 ** 3,
   budgetBytes: 32 * 1024 ** 3,
   budgetSource: 'unifiedMemory',
@@ -41,8 +41,8 @@ describe('RecommendedModel', () => {
 
     expect(await screen.findByText('unsloth/Qwen3-30B-A3B-GGUF')).toBeInTheDocument();
     // Binary units, the same convention as the fit indicators and `gglib up`.
-    expect(screen.getByText('21.0 GB')).toBeInTheDocument();
-    expect(screen.getByText('32.0 GB')).toBeInTheDocument();
+    expect(screen.getByText('21.0 GiB')).toBeInTheDocument();
+    expect(screen.getByText('32.0 GiB')).toBeInTheDocument();
     expect(screen.getByText(/unified memory/)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Two functions called `formatRate`

One formats **bytes** per second and appends `"MB/s"`; the other formats a bare **count** and appends nothing. They were chosen by import path, so a one-character difference silently changed what a number meant. The count one is now `formatPerSecond`, which is what it does.

## Two formatters divided by 1024 and labelled the result `GB`

`formatMemorySize` and `formatWeights` both did binary maths under decimal labels — a 21 GiB figure printed as **"21 GB"**, which is a different number.

Fixed on the **label**, not the maths: changing the divisors would have made these disagree with the fit indicators and `gglib up`, which are binary and correct.

The drift was already written down. `RecommendedModel.test.tsx` carries the comment *"Binary GB, matching formatMemorySize: 21 GiB and 32 GiB exactly"* — and then asserts `'21.0 GB'`. The author knew.

## Two identical `formatCount`

Defined separately in two adjacent panels. One definition now, in `utils/format`, so a third panel does not grow a fourth.

## Two different `Row`

`SystemSettings.tsx` declared a local `Row` (a label/value pair) while importing `Stack` from `components/primitives` — where `Row` is a flex container. Two ideas under one name, one import away from being confused.

It is `LabelledValue` now, in its own file. **The new TypeScript ratchet caught the doc comment growing an over-budget file** — the ratchet working on the commit after the one that added it — so extracting was the answer rather than shortening the comment. `SystemSettings.tsx` drops from 312 to under budget, and leaves the baseline.

## Verification

`make typecheck-web`, `make lint-web`, 816 frontend tests, both file-size ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)