### PR TITLE
docs(cli,repo): commands as they are, not as they were

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -294,10 +294,10 @@
 			"type": "shell",
 			"command": "cargo",
 			"args": [
-				"install",
-				"--path",
-				".",
-				"--force"
+				"build",
+				"--release",
+				"--package",
+				"gglib-cli"
 			],
 			"group": "none",
 			"problemMatcher": [
@@ -402,8 +402,8 @@
 			"label": "🚢 Full CI Pipeline",
 			"dependsOn": [
 				"🔍 Check Formatting",
-				"� Check Boundaries",
-				"�📎 Clippy (Strict)",
+				"🔒 Check Boundaries",
+				"📎 Clippy (Strict)",
 				"🧪 Run All Tests",				"🧪 Run Frontend Tests",				"🚀 Build (Release)"
 			],
 			"dependsOrder": "sequence",
@@ -539,12 +539,8 @@
 				"--package",
 				"gglib-cli",
 				"--",
-				"web",
-				"--api-only",
-				"--port",
-				"9887",
-				"--base-port",
-				"9000"
+				"daemon",
+				"run"
 			],
 			"isBackground": true,
 			"group": "none",
@@ -575,13 +571,7 @@
 				"--package",
 				"gglib-cli",
 				"--",
-				"web",
-				"--port",
-				"9887",
-				"--base-port",
-				"9000",
-				"--static-dir",
-				"./web_ui"
+				"web"
 			],
 			"isBackground": true,
 			"group": "none",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,8 @@ Concrete examples of established patterns:
 
 | Domain | Event type | CLI consumer | Axum consumer | Tauri consumer |
 |---|---|---|---|---|
-| Agent loop | `AgentEvent` | spinner + streaming print | SSE at `/api/agent/stream` | `agent-event` Tauri event |
-| llama install | `LlamaProgressEvent` | progress bar | SSE at `/api/llama/install` | `llama-install-progress` |
+| Agent loop | `AgentEvent` | spinner + streaming print | SSE at `POST /api/agent/chat` | same SSE stream — no Tauri event |
+| llama install | `LlamaProgressEvent` | progress bar | SSE at `POST /api/config/system/install-llama` | `llama-install-progress` |
 | llama build | `BuildEvent` | spinner + progress bar | SSE at `/api/config/system/build-llama-from-source` | `llama-build-progress` |
 
 When adding a new long-running operation:
@@ -393,7 +393,7 @@ Download progress events for the pre-built binary pipeline.
 | Consumer | Output                                        |
 |----------|-----------------------------------------------|
 | CLI      | `indicatif` progress bar                      |
-| Axum     | SSE stream at `GET /api/llama/install`        |
+| Axum     | SSE stream at `POST /api/config/system/install-llama` |
 | Tauri    | `llama-install-progress` event to WebView     |
 
 <!-- module-docs:end -->
@@ -612,7 +612,8 @@ make lint
 # Build and open Rustdoc locally
 make doc
 
-# Run all pre-commit checks in sequence: fmt + lint + check + test
+# Run all pre-commit checks in sequence: fmt, lint, check, test, lint-web,
+# typecheck-web, test-web, boundaries, enforce
 make pre-commit
 ```
 
@@ -648,12 +649,13 @@ Every PR must pass the following gates in order. They are not advisory.
 |---|---|---|
 | **Format** | `cargo fmt --all -- --check` | Consistent code style |
 | **Boundaries** | `./scripts/check_boundaries.sh` | Layer dependency rules |
-| **Architecture** | `./scripts/check-tauri-commands.sh`, `check-frontend-ipc.sh`, `check_transport_branching.sh` | Tauri policy; no IPC in product routes; no frontend transport branching |
+| **Architecture** | `./scripts/check-tauri-commands.sh`, `check-frontend-ipc.sh`, `check_transport_branching.sh`, `check_param_source_exhaustive.sh`, `check_settings_surfaces.sh`, `check_rust_complexity.sh`, `check_file_complexity.sh` | Tauri policy; no IPC in product routes; no frontend transport branching; no catch-all over `ParamSource`; every setting reachable; the two file-size ratchets |
 | **Clippy** | `cargo clippy --all-targets --all-features -- -D warnings` | No warnings, ever |
 | **Rust tests** | `cargo test` (aggregate + per-crate) | Correctness |
 | **Doc tests** | `cargo test --doc --verbose` | Doc examples compile and run |
 | **Frontend tests** | `npm run test:run` | TypeScript correctness |
-| **Cross-OS check** | `cargo check` on Linux/macOS/Windows | No platform-specific breakage |
+| **Lint & typecheck** | `npm run lint -- --max-warnings 0`, `npm run typecheck`, `./scripts/check_workflow_yaml.sh` | Design-system guardrails; TS correctness; parseable workflows |
+| **Cross-OS check** | `cargo test -p gglib-cli --no-run` on Linux/macOS/Windows | No platform-specific breakage |
 
 After each successful CI run, `badges.yml` downloads the test/boundary/coverage artifacts and pushes updated badge JSON files to the `badges` branch. Shields.io badges in crate READMEs resolve from there.
 
@@ -693,7 +695,7 @@ In practice: if your PR closes a fully-labelled issue, you'll rarely touch label
 
 Before requesting review, confirm each item:
 
-- [ ] `make pre-commit` passes locally (`fmt` + `lint` + `check` + `test`).
+- [ ] `make pre-commit` passes locally — everything CI requires, including the frontend gates and the architecture checks.
 - [ ] `cargo test --doc` passes.
 - [ ] Any new public type or enum has `///` doc comments on all items.
 - [ ] Any architectural change is documented in `//!` module-level Rustdoc. ASCII architecture diagrams belong in crate READMEs; prose API documentation does not.

--- a/crates/gglib-axum/README.md
+++ b/crates/gglib-axum/README.md
@@ -98,8 +98,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `GET` | `/api/models` | List all models |
 | `POST` | `/api/models` | Add a new model |
 | `DELETE` | `/api/models/:id` | Remove a model |
-| `POST` | `/api/serve/:id` | Start llama-server |
-| `DELETE` | `/api/serve/:id` | Stop llama-server |
+| `POST` | `/api/servers/start` | Start llama-server (id in the body) |
+| `POST` | `/api/servers/stop` | Stop llama-server (id in the body) |
 | `POST` | `/api/models/hf/search` | Search HuggingFace |
 | `POST` | `/api/models/downloads/queue` | Queue a download |
 | `GET` | `/api/models/downloads` | Get download status |
@@ -113,12 +113,15 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 
 ## Usage
 
-```bash
-# Start the API server
-gglib-axum --port 9887
+This crate is a library — it has no binary target. The daemon that mounts it
+is `gglib daemon run`, on a fixed loopback port:
 
-# Or run from the workspace
-cargo run --package gglib-axum -- --port 9887
+```bash
+# Start the daemon (this crate's router is what answers)
+gglib daemon run
+
+# Or have any command that needs it start one for you
+gglib up
 ```
 
 ```rust,ignore

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -117,7 +117,7 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `chat <id>` | Start interactive llama-cli chat |
 | `chat <id> --continue <N>` | Resume a previous conversation by ID |
 | `question <text>` | Ask a question (with optional piped context) |
-| `question --agent <text>` | Agentic question with filesystem tools |
+| `question <text>` | Ask a question; filesystem tools are on unless `--no-tools` |
 | `chat history` | List past conversations with message counts |
 | `proxy` | Start the OpenAI-compatible proxy (context defaults to settings `default_context_size`) |
 | `proxy dashboard [--host HOST] [--port PORT]` | Live terminal view of a running proxy's active connections, slot context usage, prompt-cache health and reuse, and request history |
@@ -169,7 +169,7 @@ This is a simple redraw-in-place view (via `crossterm` cursor moves), not a full
 
 | Command | Description |
 |---|---|
-| `gglib proxy start --cache --slot-dir <path>` | Start proxy with KV cache session persistence enabled |
+| `gglib proxy --cache --slot-dir <path>` | Start proxy with KV cache session persistence enabled |
 | `gglib proxy cache-clear` | Clear KV cache for a session or all sessions on an already-running proxy |
 
 Proxy cache-clear options:
@@ -220,10 +220,10 @@ gglib q --verbose --file CODE.rs "Explain this"
 gglib q -Q "What is 2+2?"
 
 # Agentic mode: multi-step exploration with filesystem tools
-gglib q --agent "How is error handling structured in this project?"
+gglib q "How is error handling structured in this project?"
 
 # Agentic mode with piped context
-git diff | gglib q --agent "Review these changes for potential issues"
+git diff | gglib q "Review these changes for potential issues"
 ```
 
 ### Rendering Modes
@@ -311,11 +311,11 @@ gglib serve 1 --cache --slot-dir ~/.gglib/slots
 gglib model search "llama 3 GGUF"
 
 # Download from HuggingFace
-gglib model download TheBloke/Llama-2-7B-GGUF --quant Q4_K_M
+gglib model download TheBloke/Llama-2-7B-GGUF --quantization Q4_K_M
 
 # Download an Unsloth Dynamic ("UD-") quant -- distinct from the plain quant
 # of the same suffix, e.g. "UD-Q6_K" vs "Q6_K"
-gglib model download unsloth/Qwen3-Coder-Next-GGUF --quant UD-Q6_K
+gglib model download unsloth/Qwen3-Coder-Next-GGUF --quantization UD-Q6_K
 ```
 
 ## Design Decisions

--- a/crates/gglib-cli/src/handlers/README.md
+++ b/crates/gglib-cli/src/handlers/README.md
@@ -57,69 +57,28 @@ This module contains the **handler functions** that implement the actual logic f
 
 ## Handler Organization
 
-### Model Management
-- **`add.rs`** - Add new models to catalog
-  - Parse model paths or HuggingFace IDs
-  - Validate model files
-  - Call `ModelService::add_model`
-  - Display confirmation
+Handlers are grouped by the command they serve, one directory per family. The
+list below is the directory tree, not a summary of it — an earlier version of
+this section described `add.rs`, `list.rs`, `download/{start,pause,resume}.rs`
+and `question.rs` at this level, none of which have been here since the
+handlers were grouped.
 
-- **`list.rs`** - List all models
-  - Call `ModelService::list_models`
-  - Format as table using `../presentation/tables`
-  - Filter and sort options
+| Path | Serves |
+|------|--------|
+| `model/` | `gglib model …` — add, list, inspect, explain, remove, capabilities, and `download/` |
+| `inference/` | `serve`, `proxy`, `chat`, and `agent_question` (`gglib q`) |
+| `config/` | `gglib config …` — `settings/`, `paths.rs`, `llama*.rs`, `check_deps/`, `fast_downloads.rs` |
+| `agent_chat/` | The interactive agent REPL behind `gglib chat` |
+| `daemon/` | `gglib daemon run / status / stop` |
+| `up/` | `gglib up` — the one-command setup path |
+| `proxy_dashboard/` | `gglib proxy dashboard` — the live terminal view |
+| `benchmark.rs` | `gglib benchmark …`, including `tune` |
+| `mcp_cli.rs` | `gglib mcp …` |
+| `history.rs`, `web.rs`, `gui.rs`, `completions.rs`, `proxy_cache_clear.rs` | One command each |
 
-- **`remove.rs`** - Remove models from catalog
-  - Confirm deletion
-  - Call `ModelService::remove_model`
-  - Handle errors if model in use
+Each directory carries its own README with the detail; this table exists so a
+newcomer can find the right one, and so it stays true by being short.
 
-- **`inference/serve.rs`** - Start the proxy pinned to a single model
-  - Validate model exists
-  - Call `start_proxy_standalone` (unified proxy stack)
-  - Display server URL and status
-
-- **`update.rs`** - Update model metadata
-  - Parse update parameters
-  - Call `ModelService::update_model`
-  - Display changes
-
-### Download Management
-- **`download/`** - Download command handlers
-  - `start.rs` - Start new download
-  - `list.rs` - List active downloads
-  - `pause.rs` - Pause download
-  - `resume.rs` - Resume paused download
-  - `cancel.rs` - Cancel download
-
-### Configuration
-- **`config.rs`** - Configuration management
-  - Get/set configuration values
-  - Validate configuration
-  - Display current settings
-
-- **`paths.rs`** - Display path information
-  - Show data directories
-  - Show model paths
-  - Show log locations
-
-### System
-- **`check_deps/`** - Dependency checking
-  - `check.rs` - Check system dependencies
-  - `install.rs` - Install missing dependencies
-
-### Agentic
-- **`agent_chat/`** - Interactive multi-turn agent REPL (`gglib chat --agent`)
-  - Drives the agentic loop via `AgentLoopPort`
-  - Streams tool-call and text events to the terminal
-
-- **`agent_question.rs`** - Single-turn agentic question (`gglib q --agent`)
-  - Sandboxes filesystem tools to the current working directory
-  - Runs one agent turn, drains events, and exits
-
-### Question
-- **`question.rs`** - Shared argument types for the question command
-  - `QuestionArgs` struct used by both standard and agentic question handlers
 
 ## Handler Pattern
 

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -1,4 +1,4 @@
-//! Async REPL loop for `gglib chat --agent`.
+//! Async REPL loop for `gglib chat`.
 //!
 //! # Design choices
 //!

--- a/crates/gglib-proxy/README.md
+++ b/crates/gglib-proxy/README.md
@@ -216,7 +216,7 @@ resume from prior context without re-computation.
 
 CLI usage:
 ```bash
-gglib proxy start --cache --slot-dir ~/.cache/gglib/slots --cache-disk-gb 100
+gglib proxy --cache --slot-dir ~/.cache/gglib/slots --cache-disk-gb 100
 gglib proxy cache-clear --host 127.0.0.1 --port 8080 --session-id my-session
 ```
 

--- a/crates/gglib-proxy/src/repair.rs
+++ b/crates/gglib-proxy/src/repair.rs
@@ -37,7 +37,7 @@
 //! [ADR 0001]: https://github.com/mmogr/gglib/blob/main/docs/adr/0001-runtime-capability-tiers.md
 //! [ADR 0002]: https://github.com/mmogr/gglib/blob/main/docs/adr/0002-defer-tool-call-constraint-to-llama-cpp.md
 //! [`docs/tool-call-repair.md`]: https://github.com/mmogr/gglib/blob/main/docs/tool-call-repair.md
-//! [`the_repair_body_survives_the_pipeline_with_required_intact`]: tests::the_repair_body_survives_the_pipeline_with_required_intact
+//! [`the_pipeline_would_destroy_a_repair_body_which_is_why_it_bypasses_it`]: tests::the_pipeline_would_destroy_a_repair_body_which_is_why_it_bypasses_it
 
 use bytes::Bytes;
 use gglib_core::LlmStreamEvent;

--- a/docs/adr/0006-recover-dont-predict.md
+++ b/docs/adr/0006-recover-dont-predict.md
@@ -98,6 +98,31 @@ that should be chosen from measured failure rates, not from a candidate list;
 the counters exist for exactly that, and the plan's own analysis killed three
 of four originally-proposed rungs before any data was collected.
 
+## Postscript, 2026-08-13 — decision 2 names three channels, and they are not peers
+
+The decision above lists the GGUF's `general.sampling.*` keys, the publisher's
+`generation_config.json` and the curated task-regime table as one mechanism.
+Read against the code they are three different things, and only one of them
+writes a model's stored defaults:
+
+- **`generation_config.json` is the one that does.** It produces the
+  `Published` origin, and only for HuggingFace imports —
+  `services/model_import.rs` returns `None` for `ModelOrigin::LocalFile`, so a
+  local GGUF never gets one however good its metadata.
+- **The GGUF keys feed observability, not defaults.**
+  `ModelSamplingDefaults::from_metadata` is read by `props.rs`, the sampling
+  audit and `model explain`. llama.cpp applies those keys server-side, which
+  the `/props` probe confirmed — so "the defaults come from the GGUF" is a true
+  claim about llama.cpp and not about gglib.
+- **The task-regime table seeds tune candidates.** It reaches a model's
+  defaults only if a person runs a tune and the gate approves the winner. With
+  the scheduler gone that is a manual, hours-long path.
+
+None of this changes the decision — sending explicit values from a claim about
+the model still beats predicting them from traffic. It corrects the sentence,
+which reads as though three automatic channels are all writing defaults when
+one is.
+
 ## Notes
 
 The scheduler's removal was mechanical but wide: 45 references across the Rust

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -20,7 +20,7 @@ default, it drops out of the hierarchy entirely except for `max_tokens`.
 
 "Per-model defaults" isn't always one rung: it sits *above* global settings when a person set
 it, and *below* global settings when gglib auto-detected it — see [Reasoning model
-auto-defaults](#reasoning-model-auto-defaults) and [Where a model's defaults came
+auto-defaults](#2-the-reasoning-tag-guess-fallback) and [Where a model's defaults came
 from](#where-a-models-defaults-came-from) below.
 
 The full set of configurable parameters:
@@ -469,7 +469,7 @@ real candidate meaning "off", so one run compares disabled against two
 strengths on your own model and task suite:
 
 ```bash
-gglib benchmark tune <model> --sweep dry_multiplier=0,0.4,0.8
+gglib benchmark tune --model <model> --sweep dry_multiplier=0,0.4,0.8
 ```
 
 `dry_base`, `dry_allowed_length` and `dry_penalty_last_n` have no floor value.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -134,7 +134,7 @@ from GGUF metadata, which drive automatic flag selection at serve time:
 | Tag | Detection trigger | Effect |
 |-----|-------------------|--------|
 | `agent` | Chat template contains tool-calling syntax | `--jinja` auto-enabled |
-| `reasoning` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled; pre-tuned sampling defaults written (see [docs/sampling.md](sampling.md#reasoning-model-auto-defaults)) |
+| `reasoning` | Chat template contains `<think>` / DeepSeek reasoning tokens | `--reasoning-format deepseek` auto-enabled; pre-tuned sampling defaults written (see [docs/sampling.md](sampling.md#2-the-reasoning-tag-guess-fallback)) |
 | `mtp` | `{arch}.nextn_predict_layers > 0` in GGUF metadata | `--spec-type draft-mtp --spec-draft-n-max 2 --spec-draft-p-min 0.75` auto-enabled |
 | `embedding` | Non-none `{arch}.pooling_type`, or an encoder-only `general.architecture` | `--embeddings` auto-enabled; the server refuses chat completions and serves `/v1/embeddings` |
 
@@ -163,10 +163,12 @@ GGLIB_DISABLE_MTP=1 gglib proxy
 
 ## System-tag protection
 
-Auto-detected tags are protected as system tags: `gglib model remove-tag` will
-reject any attempt to remove a `format:*` tag (use the `_force` service path
-for admin operations). User-curated tags outside the auto-generated namespace
-are never touched by detection or retagging.
+Auto-detected tags are protected as system tags: the tag-removal service path
+rejects any attempt to remove a `format:*` tag, and admin operations go through
+its `_force` variant. There is no CLI subcommand for removing a tag — tags are
+edited through the model inspector in the GUI and the HTTP API
+(`DELETE /api/models/{id}/tags/{tag}`). User-curated tags outside the
+auto-generated namespace are never touched by detection or retagging.
 
 ## Retagging an existing catalog
 

--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -231,7 +231,7 @@ if (isTauri()) {
 **Manual verification checklist:**
 
 1. **Run Tauri desktop**: `npm run tauri:dev`
-2. **Run Axum WebUI**: `cargo run --package gglib-cli -- web --api-only --port 9887` + `npm run dev`
+2. **Run the daemon**: `cargo run --package gglib-cli -- daemon run` + `npm run dev`
 3. **Test UI features**:
    - Button styles and interactions (hover, active, disabled)
    - Modal dialogs (open, close, backdrop click)


### PR DESCRIPTION
Every command and flag named in the docs, checked against the clap definitions. The ones that did not survive:

| Documented | Reality |
|---|---|
| `gglib proxy start` | `ProxyCommand` is `Dashboard`/`CacheClear`/`Stop`; `gglib proxy` starts it directly |
| `--agent` on `chat` / `q` | Tools are on by default; the opt-out is `--no-tools` |
| `--quant` | The flag is `--quantization` / `-q` |
| `benchmark tune <model>` | It takes `--model`, not a positional |
| `gglib model remove-tag` | No such subcommand — tags are edited in the GUI inspector and over HTTP |
| `gglib web --api-only --port --base-port` | None of those exist |

## Two commands that cannot run

`gglib-axum`'s README opened with `gglib-axum --port 9887` and `cargo run --package gglib-axum`. The crate declares `[lib]` only — both fail. It now points at `gglib daemon run`. Its endpoint table listed `POST`/`DELETE /api/serve/:id`; the routes are `/api/servers/start` and `/stop`, id in the body.

## A file layout that has not existed for some time

`crates/gglib-cli/src/handlers/README.md` described `add.rs`, `download/{start,pause,resume}.rs` and `question.rs` at the top level — none present since the handlers were grouped — and omitted `daemon/`, `up/`, `benchmark.rs` and `proxy_dashboard/`. Replaced with the actual directory tree, kept short enough to stay true.

## CONTRIBUTING

`/api/agent/stream` → `/api/agent/chat`; the `agent-event` Tauri event does not exist; `/api/llama/install` → `/api/config/system/install-llama`; `make pre-commit` has run nine targets rather than four for some time; the CI gate table named three architecture scripts where that job runs **seven**, and credited cross-OS with `cargo check`.

## Links

Two dead anchors, both pointing at a heading renamed in `sampling.md`. One broken rustdoc link in `repair.rs`, whose link *definition* named a test that does not exist while the test that does had none — broken in both directions.

## .vscode/tasks.json

Two tasks invoked flags that never existed. "Install Binary" ran `cargo install --path .` against a virtual manifest. And the Full CI Pipeline's `dependsOn` carried **U+FFFD replacement characters**, so it could not resolve either task it named. Every `dependsOn` now resolves — checked programmatically against the label set.

## ADR 0006 gets a postscript, not an edit

Its decision 2 lists three channels as one mechanism. Only `generation_config.json` writes a model's defaults, and only for HF imports; the GGUF keys feed observability (llama.cpp applies them server-side), and the regime table seeds tune candidates behind a manual run plus gate approval. The decision stands — the sentence overstated it. Recorded as a postscript per this repo's "record retractions, do not delete them" rule.

## Verification

`cargo check --workspace --all-targets`, `cargo test -p gglib-proxy --lib` (376), 816 frontend tests, `make enforce`, README and boundary gates all green. `.vscode/tasks.json` validated as JSON with every task reference resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)