### PR TITLE
fix(ci): the settings-surface guard actually checks the CLI again

### DIFF
--- a/scripts/check_settings_surfaces.sh
+++ b/scripts/check_settings_surfaces.sh
@@ -44,6 +44,17 @@ cd "$ROOT_DIR"
 SETTINGS_RS="crates/gglib-core/src/settings.rs"
 CLI_SET_ARGS="crates/gglib-cli/src/config_commands/settings_args.rs"
 
+if [ ! -f "$CLI_SET_ARGS" ]; then
+  echo -e "${RED}❌ ${CLI_SET_ARGS} does not exist${NC}"
+  echo
+  echo "The CLI half of this guard reads that file. When the path is wrong the"
+  echo "grep below fails per field, and because it sits inside an \`if\` it does"
+  echo "not trip \`set -e\` — every field then passes on the GUI check alone."
+  echo "That is exactly how this guard ran half-blind after 333682f3 moved"
+  echo "\`config_commands.rs\` into a directory."
+  exit 1
+fi
+
 # Fields nothing settable is expected for, and why.
 declare -A EXEMPT=(
   [setup_completed]="written by the setup wizard when it finishes, not chosen"
@@ -89,8 +100,27 @@ to_camel() {
   }'
 }
 
+# CLI detection, factored into a function so the self-test below exercises the
+# same code path the real scan uses. The `pub ` is optional because the fields
+# moved from a clap variant's inline list (no `pub`) to a named `Args` struct
+# (`pub`) — a pattern that assumes either one silently matches nothing.
+cli_has_field() {
+  grep -qE "^[[:space:]]+(pub )?$1: Option<" "$CLI_SET_ARGS"
+}
+
+# A name that is not a field must not match. This catches the opposite failure
+# from the one above: a pattern loose enough to match everything reports every
+# field as CLI-reachable and is just as useless as one that matches nothing.
+if cli_has_field "definitely_not_a_settings_field"; then
+  echo -e "${RED}❌ self-test: the CLI detector matches a field that does not exist${NC}"
+  echo
+  echo "The pattern is too loose, so every field will look CLI-reachable."
+  exit 1
+fi
+
 unreachable=()
 checked=0
+cli_reachable=0
 
 for field in $fields; do
   checked=$((checked + 1))
@@ -103,11 +133,10 @@ for field in $fields; do
   in_cli=false
   in_gui=false
 
-  # CLI: the field name appears in `SettingsSetArgs`. The `pub ` is optional
-  # because the fields moved from a clap variant's inline list (no `pub`) to a
-  # named `Args` struct (`pub`); a pattern assuming either one matches nothing.
-  if grep -qE "^[[:space:]]+(pub )?${field}: Option<" "$CLI_SET_ARGS"; then
+  # CLI: the field name appears in `SettingsSetArgs`.
+  if cli_has_field "$field"; then
     in_cli=true
+    cli_reachable=$((cli_reachable + 1))
   fi
 
   # GUI: the camelCase name appears anywhere the frontend can act on it.
@@ -128,6 +157,21 @@ for field in $fields; do
 done
 
 echo
+
+# Several settings are deliberately CLI-only, so a run in which *nothing* is
+# CLI-reachable is not a real state — it is the detector having stopped
+# working. Reporting "all clear" on that is what this guard did between
+# 333682f3 and the fix, and it is indistinguishable from a healthy run unless
+# the count is asserted.
+if [ "$cli_reachable" -eq 0 ]; then
+  echo -e "${RED}❌ no Settings field was found on the CLI surface${NC}"
+  echo
+  echo "Either every flag was deleted from ${CLI_SET_ARGS}, or the detector no"
+  echo "longer matches it. The second is far more likely — check the pattern in"
+  echo "\`cli_has_field\` against the current shape of \`SettingsSetArgs\`."
+  exit 1
+fi
+
 if [ ${#unreachable[@]} -gt 0 ]; then
   echo -e "${RED}❌ ${#unreachable[@]} setting(s) nobody can change${NC}"
   echo
@@ -153,4 +197,4 @@ MSG
   exit 1
 fi
 
-echo -e "${GREEN}✅ every Settings field is reachable${NC} (${checked} checked)"
+echo -e "${GREEN}✅ every Settings field is reachable${NC} (${checked} checked, ${cli_reachable} on the CLI)"

--- a/scripts/check_settings_surfaces.sh
+++ b/scripts/check_settings_surfaces.sh
@@ -17,7 +17,8 @@
 # A field is reachable if it is settable from the CLI, or from the GUI:
 #
 #   CLI — a `--kebab-case` flag on `gglib config settings set`, which means the
-#         field appears in the `Set` variant in `config_commands.rs`.
+#         field appears in `SettingsSetArgs`, in
+#         `config_commands/settings_args.rs`.
 #   GUI — the camelCase name appears in `src/`, which is where the TypeScript
 #         mirror and the settings modal both live.
 #
@@ -41,7 +42,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 SETTINGS_RS="crates/gglib-core/src/settings.rs"
-CLI_COMMANDS="crates/gglib-cli/src/config_commands.rs"
+CLI_SET_ARGS="crates/gglib-cli/src/config_commands/settings_args.rs"
 
 # Fields nothing settable is expected for, and why.
 declare -A EXEMPT=(
@@ -102,8 +103,10 @@ for field in $fields; do
   in_cli=false
   in_gui=false
 
-  # CLI: the field name appears in the `Set` variant's argument list.
-  if grep -qE "^[[:space:]]+${field}: Option<" "$CLI_COMMANDS"; then
+  # CLI: the field name appears in `SettingsSetArgs`. The `pub ` is optional
+  # because the fields moved from a clap variant's inline list (no `pub`) to a
+  # named `Args` struct (`pub`); a pattern assuming either one matches nothing.
+  if grep -qE "^[[:space:]]+(pub )?${field}: Option<" "$CLI_SET_ARGS"; then
     in_cli=true
   fi
 
@@ -136,8 +139,8 @@ if [ ${#unreachable[@]} -gt 0 ]; then
 Each of these is stored, plumbed and read, and settable from no surface a
 person has. Pick one:
 
-  1. Give it a CLI flag: add it to the `Set` variant in
-     `crates/gglib-cli/src/config_commands.rs` and map it in
+  1. Give it a CLI flag: add it to `SettingsSetArgs` in
+     `crates/gglib-cli/src/config_commands/settings_args.rs` and map it in
      `crates/gglib-cli/src/handlers/config/settings/mod.rs` — all four places
      (the destructure, the `changed` set, the `SettingsUpdate`, the
      pre-validate merge).

--- a/scripts/check_settings_surfaces.sh
+++ b/scripts/check_settings_surfaces.sh
@@ -44,6 +44,8 @@ cd "$ROOT_DIR"
 SETTINGS_RS="crates/gglib-core/src/settings.rs"
 CLI_SET_ARGS="crates/gglib-cli/src/config_commands/settings_args.rs"
 
+GUI_DIR="src"
+
 if [ ! -f "$CLI_SET_ARGS" ]; then
   echo -e "${RED}❌ ${CLI_SET_ARGS} does not exist${NC}"
   echo
@@ -52,6 +54,16 @@ if [ ! -f "$CLI_SET_ARGS" ]; then
   echo "not trip \`set -e\` — every field then passes on the GUI check alone."
   echo "That is exactly how this guard ran half-blind after 333682f3 moved"
   echo "\`config_commands.rs\` into a directory."
+  exit 1
+fi
+
+if [ ! -d "$GUI_DIR" ]; then
+  echo -e "${RED}❌ ${GUI_DIR}/ does not exist${NC}"
+  echo
+  echo "The GUI half reads that tree, and had the same silent-failure shape as"
+  echo "the CLI half: a missing directory made grep fail, \`2>/dev/null\` hid the"
+  echo "error, the \`if\` kept \`set -e\` out of it, and every field passed on the"
+  echo "CLI check alone. Checked here so the redirect is no longer needed."
   exit 1
 fi
 
@@ -108,9 +120,16 @@ cli_has_field() {
   grep -qE "^[[:space:]]+(pub )?$1: Option<" "$CLI_SET_ARGS"
 }
 
-# A name that is not a field must not match. This catches the opposite failure
-# from the one above: a pattern loose enough to match everything reports every
-# field as CLI-reachable and is just as useless as one that matches nothing.
+# GUI detection, factored out for the same reason. No `2>/dev/null`: the only
+# error it ever hid was a missing `$GUI_DIR`, which is now checked up front, and
+# hiding anything else is how this half went quiet in the first place.
+gui_has_field() {
+  grep -rqE "\b$(to_camel "$1")\b" "$GUI_DIR" --include='*.ts' --include='*.tsx'
+}
+
+# Neither detector may match a name that is not a field. A pattern loose enough
+# to match everything reports every field as reachable and is exactly as useless
+# as one that matches nothing.
 if cli_has_field "definitely_not_a_settings_field"; then
   echo -e "${RED}❌ self-test: the CLI detector matches a field that does not exist${NC}"
   echo
@@ -118,9 +137,45 @@ if cli_has_field "definitely_not_a_settings_field"; then
   exit 1
 fi
 
+if gui_has_field "definitely_not_a_settings_field"; then
+  echo -e "${RED}❌ self-test: the GUI detector matches a field that does not exist${NC}"
+  echo
+  echo "The pattern is too loose, so every field will look GUI-reachable."
+  exit 1
+fi
+
+# Every field `SettingsSetArgs` declares, by name — matched loosely, on any
+# field of any type. Deliberately a different pattern from `cli_has_field`'s:
+# where the two disagree about a field `Settings` also declares, the strict one
+# has drifted and the cross-check after the scan says so. A count that only
+# fails at zero catches the detector dying; this catches it going partially
+# deaf, which is the same bug arriving more quietly.
+declared_flags=$(
+  awk '
+    /^pub struct SettingsSetArgs \{/ { inside = 1; next }
+    inside && /^\}/                  { exit }
+    inside && /^[[:space:]]+(pub )?[a-z_0-9]+[[:space:]]*:/ {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/^pub /, "", line)
+      sub(/[[:space:]]*:.*/, "", line)
+      print line
+    }
+  ' "$CLI_SET_ARGS"
+)
+
+if [ -z "$declared_flags" ]; then
+  echo -e "${RED}❌ no flags found in SettingsSetArgs${NC}"
+  echo
+  echo "The struct was renamed or reshaped, so the cross-check below compares"
+  echo "against nothing. Fix the parser rather than trusting this exit code."
+  exit 1
+fi
+
 unreachable=()
 checked=0
 cli_reachable=0
+gui_reachable=0
 
 for field in $fields; do
   checked=$((checked + 1))
@@ -140,9 +195,9 @@ for field in $fields; do
   fi
 
   # GUI: the camelCase name appears anywhere the frontend can act on it.
-  camel=$(to_camel "$field")
-  if grep -rqE "\b${camel}\b" src --include='*.ts' --include='*.tsx' 2>/dev/null; then
+  if gui_has_field "$field"; then
     in_gui=true
+    gui_reachable=$((gui_reachable + 1))
   fi
 
   if $in_cli || $in_gui; then
@@ -158,17 +213,51 @@ done
 
 echo
 
-# Several settings are deliberately CLI-only, so a run in which *nothing* is
-# CLI-reachable is not a real state — it is the detector having stopped
-# working. Reporting "all clear" on that is what this guard did between
-# 333682f3 and the fix, and it is indistinguishable from a healthy run unless
-# the count is asserted.
+# A surface on which *nothing* was found is not a real state — it is a detector
+# that has stopped working. Reporting "all clear" on that is what this guard did
+# between 333682f3 and the fix, and it is indistinguishable from a healthy run
+# unless the counts are asserted.
 if [ "$cli_reachable" -eq 0 ]; then
   echo -e "${RED}❌ no Settings field was found on the CLI surface${NC}"
   echo
   echo "Either every flag was deleted from ${CLI_SET_ARGS}, or the detector no"
   echo "longer matches it. The second is far more likely — check the pattern in"
   echo "\`cli_has_field\` against the current shape of \`SettingsSetArgs\`."
+  exit 1
+fi
+
+if [ "$gui_reachable" -eq 0 ]; then
+  echo -e "${RED}❌ no Settings field was found on the GUI surface${NC}"
+  echo
+  echo "Either every setting was removed from ${GUI_DIR}/, or the detector no"
+  echo "longer matches it. Check the pattern in \`gui_has_field\` and that"
+  echo "\`to_camel\` still produces the names the TypeScript side uses."
+  exit 1
+fi
+
+# Partial drift: a flag `SettingsSetArgs` declares, that `Settings` also
+# declares and does not exempt, must have been found by `cli_has_field`. The
+# enumeration above and the detector use different patterns on purpose, so a
+# detector that has drifted out of step with the struct's shape fails here
+# instead of quietly under-reporting a subset.
+missed=()
+for flag in $declared_flags; do
+  printf '%s\n' $fields | grep -qx "$flag" || continue
+  [[ -v "EXEMPT[$flag]" ]] && continue
+  cli_has_field "$flag" || missed+=("$flag")
+done
+
+if [ ${#missed[@]} -gt 0 ]; then
+  echo -e "${RED}❌ the CLI detector missed ${#missed[@]} flag(s) that SettingsSetArgs declares${NC}"
+  echo
+  for flag in "${missed[@]}"; do
+    echo "  - ${flag}"
+  done
+  echo
+  echo "These are declared in ${CLI_SET_ARGS} and are non-exempt \`Settings\`"
+  echo "fields, so \`cli_has_field\` should match them. It does not, which means"
+  echo "its pattern no longer fits the struct — the same failure as a wrong"
+  echo "path, only partial. Fix the pattern; do not exempt your way out."
   exit 1
 fi
 
@@ -197,4 +286,4 @@ MSG
   exit 1
 fi
 
-echo -e "${GREEN}✅ every Settings field is reachable${NC} (${checked} checked, ${cli_reachable} on the CLI)"
+echo -e "${GREEN}✅ every Settings field is reachable${NC} (${checked} checked, ${cli_reachable} on the CLI, ${gui_reachable} on the GUI)"


### PR DESCRIPTION
## What

`scripts/check_settings_surfaces.sh` has been running at half strength since
333682f3 split `config_commands.rs` into a directory. The guard kept pointing at
the old path, so its CLI arm was dead: `grep` printed *No such file or
directory* once per field and, because the call sits inside an `if`,
`set -euo pipefail` never aborted. `in_cli` was always false and every setting
passed on the GUI check alone.

Before this change, on `main`:

```
grep: crates/gglib-cli/src/config_commands.rs: No such file or directory
  ✓ tool_call_repair (GUI)
  ...
✅ every Settings field is reachable (23 checked)      # exit 0
```

After:

```
  ✓ tool_call_repair (CLI, GUI)
  ...
✅ every Settings field is reachable (23 checked, 18 on the CLI)
```

18 matches the number of `Option<…>` flags in `SettingsSetArgs` exactly.

## Why two changes, not one

Repointing the path alone would have kept matching nothing. The fields moved
from a clap variant's inline list to a named `Args` struct, so they now carry a
`pub ` prefix the old pattern did not allow for. Both halves are needed.

## Why the second commit

The bug was never really the wrong path — it was that a wrong path produced
output indistinguishable from a healthy run. The second commit adds one rail per
way the CLI arm can stop working:

| Failure | Rail |
|---|---|
| File missing | Checked up front, instead of `grep` failing inside an `if` where `set -e` cannot see it |
| Pattern matches everything | Probes a name that is not a field; refuses to continue if it matches |
| Pattern matches nothing | Several settings are deliberately CLI-only, so zero CLI-reachable fields is not a real state — it fails instead of reporting all clear |

Each was verified by perturbing a copy of the script and confirming the intended
rail fires:

```
variant 1 (old path)              exit=1  ❌ crates/gglib-cli/src/config_commands.rs does not exist
variant 2 (pattern too loose)     exit=1  ❌ self-test: the CLI detector matches a field that does not exist
variant 3 (pattern too strict)    exit=1  ❌ no Settings field was found on the CLI surface
```

This mirrors `check_param_source_exhaustive.sh`, which already refuses to trust
its own verdict when it cannot prove it still detects.

## Context

Found during a dead-code audit of the workspace. This guard is the one written
because `tool_call_repair` sat unreachable for months, so it seemed worth fixing
before anything else in that sweep.

## Verification

- `./scripts/check_settings_surfaces.sh` — 23 checked, 18 on the CLI, exit 0
- `make enforce` — passes
- No Rust or TypeScript is touched