### PR TITLE
chore(cli,tauri): close the module tree in the two crates nothing imports

### DIFF
--- a/crates/gglib-cli/Cargo.toml
+++ b/crates/gglib-cli/Cargo.toml
@@ -60,3 +60,15 @@ tokio-test = { workspace = true }
 
 [lints.rust]
 unsafe_code = "deny"
+# Locks in the visibility this crate was just given: every `pub` here must be
+# reachable from outside, and the only things outside are `main.rs` and
+# `tests/`, so in practice it must be in `lib.rs`'s re-export list.
+#
+# Declared per-crate rather than switching this section to `[lints] workspace
+# = true`, which is the usual way to pick up `[workspace.lints]`. Cargo does
+# not let a manifest do both: `workspace = true` must be the only key in
+# `[lints]`, so adopting it here would also switch on the workspace's clippy
+# `pedantic` and `nursery` sets, which this crate has never been held to —
+# 559 warnings, which is its own piece of work rather than a line in a
+# visibility PR.
+unreachable_pub = "deny"

--- a/crates/gglib-cli/src/bootstrap.rs
+++ b/crates/gglib-cli/src/bootstrap.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use gglib_bootstrap::{BootstrapConfig, BuiltCore, CoreBootstrap};
 use gglib_core::ports::{
     AppEventEmitter, DownloadManagerPort, GgufParserPort, ModelCatalogPort, ModelRegistrarPort,
-    ModelRepository, NoopEmitter, Repos, SettingsRepository,
+    ModelRepository, NoopEmitter, SettingsRepository,
 };
 use gglib_core::services::AppCore;
 use gglib_db::SqliteBenchmarkRepository;
@@ -154,46 +154,3 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
     })
 }
 
-/// Bootstrap with custom repos (for testing).
-///
-/// Note: callers provide their own download manager (typically a stub that
-/// does nothing). This path bypasses [`CoreBootstrap::build`] entirely.
-pub fn bootstrap_with(
-    repos: Repos,
-    downloads: Arc<dyn DownloadManagerPort>,
-    gguf_parser: Arc<dyn GgufParserPort>,
-    model_registrar: Arc<dyn ModelRegistrarPort>,
-    llama_server_path: PathBuf,
-) -> CliContext {
-    let model_repo = repos.models.clone();
-    let app = Arc::new(AppCore::new(repos.clone()));
-    let mcp = Arc::new(McpService::new(
-        repos.mcp_servers.clone(),
-        Arc::new(NoopEmitter),
-    ));
-    CliContext {
-        app,
-        mcp,
-        downloads,
-        gguf_parser,
-        catalog: Arc::new(CatalogPortImpl::new(Arc::clone(&model_repo))),
-        model_repo,
-        model_registrar,
-        llama_server_path,
-        base_port: 9000,
-        http_client: reqwest::Client::new(),
-        bench_repo: Arc::new(SqliteBenchmarkRepository::new_in_memory_blocking()),
-        settings_repo: repos.settings.clone(),
-        download_emitter: Arc::new(CliDownloadEventEmitter::new()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_config_with_defaults() {
-        // with_defaults can fail if paths don't exist, so just test the method exists
-        // In real tests, we'd use bootstrap_with() with mocks
-    }
-}

--- a/crates/gglib-cli/src/bootstrap.rs
+++ b/crates/gglib-cli/src/bootstrap.rs
@@ -153,4 +153,3 @@ pub async fn bootstrap(config: CliConfig) -> Result<CliContext> {
         download_emitter,
     })
 }
-

--- a/crates/gglib-cli/src/config_commands/mod.rs
+++ b/crates/gglib-cli/src/config_commands/mod.rs
@@ -8,7 +8,7 @@ use clap::Subcommand;
 
 mod settings_args;
 
-pub use settings_args::SettingsSetArgs;
+pub(crate) use settings_args::SettingsSetArgs;
 
 use crate::llama_commands::LlamaCommand;
 

--- a/crates/gglib-cli/src/daemon_client/mod.rs
+++ b/crates/gglib-cli/src/daemon_client/mod.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("README.md")]
 
-pub mod sse;
+pub(crate) mod sse;
 
 use std::time::Duration;
 
@@ -22,17 +22,17 @@ const LAUNCH_WAIT: Duration = Duration::from_secs(10);
 /// The daemon's base URL. The port is a compile-time constant by design —
 /// see `gglib_core::DAEMON_PORT`.
 #[must_use]
-pub fn base_url() -> String {
+pub(crate) fn base_url() -> String {
     format!("http://127.0.0.1:{DAEMON_PORT}")
 }
 
 /// Every daemon path this CLI calls, defined in shared vocabulary so the
 /// daemon's own suite can pin them — see `gglib_core::contracts::http::daemon`.
-pub use gglib_core::contracts::http::daemon as paths;
+pub(crate) use gglib_core::contracts::http::daemon as paths;
 
 /// What answered (or didn't) on the daemon port.
 #[derive(Debug)]
-pub enum DaemonProbe {
+pub(crate) enum DaemonProbe {
     /// A gglib daemon answered with its identity marker.
     Running,
     /// Nothing is listening.
@@ -42,7 +42,7 @@ pub enum DaemonProbe {
 }
 
 /// Identity-check the daemon port.
-pub async fn probe(client: &reqwest::Client) -> DaemonProbe {
+pub(crate) async fn probe(client: &reqwest::Client) -> DaemonProbe {
     let url = format!("{}{}", base_url(), paths::HEALTH_PATH);
     let response = match client.get(&url).timeout(PROBE_TIMEOUT).send().await {
         Ok(r) => r,
@@ -110,7 +110,7 @@ fn warn_on_build_mismatch(body: &serde_json::Value) {
 }
 
 /// A connected daemon: the shared HTTP client plus the base URL.
-pub struct DaemonHandle {
+pub(crate) struct DaemonHandle {
     /// Client for talking to the daemon. No global timeout — long calls
     /// (model start) set their own.
     pub client: reqwest::Client,
@@ -128,7 +128,7 @@ pub struct DaemonHandle {
 /// - the daemon binary cannot be spawned,
 /// - the launched daemon does not become healthy within the wait window
 ///   (the log file path is named in the error).
-pub async fn ensure_daemon() -> Result<DaemonHandle> {
+pub(crate) async fn ensure_daemon() -> Result<DaemonHandle> {
     let client = reqwest::Client::new();
 
     match probe(&client).await {
@@ -199,7 +199,7 @@ fn spawn_daemon() -> Result<std::path::PathBuf> {
 /// Body for `POST /api/proxy/start` — the daemon-side twin of
 /// `gglib_axum::handlers::proxy::StartProxyConfig`.
 #[derive(Debug, Clone, Default, Serialize)]
-pub struct StartProxyBody {
+pub(crate) struct StartProxyBody {
     pub host: Option<String>,
     pub port: Option<u16>,
     pub default_context: Option<u64>,
@@ -215,7 +215,7 @@ pub struct StartProxyBody {
 
 /// `GET /api/proxy/status` / start / stop response.
 #[derive(Debug, Clone, Deserialize)]
-pub struct ProxyStatusDto {
+pub(crate) struct ProxyStatusDto {
     pub running: bool,
     pub port: Option<u16>,
     #[serde(default)]
@@ -224,25 +224,16 @@ pub struct ProxyStatusDto {
 
 /// `POST /api/servers/start` response.
 #[derive(Debug, Clone, Deserialize)]
-pub struct StartServerDto {
+pub(crate) struct StartServerDto {
     pub port: u16,
 }
 
 /// `POST /api/models/downloads/queue` request body.
 #[derive(Debug, Clone, Serialize)]
-pub struct QueueDownloadBody {
+pub(crate) struct QueueDownloadBody {
     pub model_id: String,
     /// `None` leaves the quantization choice to the daemon.
     pub quant: Option<String>,
-}
-
-/// `POST /api/models/downloads/queue` response.
-#[derive(Debug, Clone, Deserialize)]
-pub struct QueueDownloadDto {
-    /// Position in the queue; 0 means it started immediately.
-    pub position: usize,
-    /// Shards queued: 1 for a single file, N for a sharded model.
-    pub shard_count: usize,
 }
 
 impl DaemonHandle {
@@ -268,7 +259,7 @@ impl DaemonHandle {
     }
 
     /// Start the proxy (idempotent on the daemon side).
-    pub async fn start_proxy(&self, body: &StartProxyBody) -> Result<ProxyStatusDto> {
+    pub(crate) async fn start_proxy(&self, body: &StartProxyBody) -> Result<ProxyStatusDto> {
         let response = self
             .client
             .post(self.url(paths::PROXY_START_PATH))
@@ -280,7 +271,7 @@ impl DaemonHandle {
     }
 
     /// Stop the proxy (idempotent on the daemon side).
-    pub async fn stop_proxy(&self) -> Result<ProxyStatusDto> {
+    pub(crate) async fn stop_proxy(&self) -> Result<ProxyStatusDto> {
         let response = self
             .client
             .post(self.url(paths::PROXY_STOP_PATH))
@@ -292,7 +283,7 @@ impl DaemonHandle {
     }
 
     /// Current proxy status.
-    pub async fn proxy_status(&self) -> Result<ProxyStatusDto> {
+    pub(crate) async fn proxy_status(&self) -> Result<ProxyStatusDto> {
         let response = self
             .client
             .get(self.url(paths::PROXY_STATUS_PATH))
@@ -305,7 +296,7 @@ impl DaemonHandle {
     /// Start (or reuse) a llama-server for a model, returning its port.
     ///
     /// Long timeout: the daemon holds the request open while the model loads.
-    pub async fn start_model_server(
+    pub(crate) async fn start_model_server(
         &self,
         model_id: i64,
         context_length: Option<u64>,
@@ -324,7 +315,11 @@ impl DaemonHandle {
     ///
     /// Long timeout: the daemon resolves the repo and its shard list against
     /// HuggingFace before answering.
-    pub async fn queue_download(&self, body: &QueueDownloadBody) -> Result<QueueDownloadDto> {
+    /// The response body carries a queue position and shard count. Nothing
+    /// reads them — the caller goes straight to watching the queue — so this
+    /// checks the status and discards the body rather than deserializing a
+    /// shape no one inspects.
+    pub(crate) async fn queue_download(&self, body: &QueueDownloadBody) -> Result<()> {
         let response = self
             .client
             .post(self.url(paths::DOWNLOADS_QUEUE_PATH))
@@ -332,7 +327,8 @@ impl DaemonHandle {
             .timeout(Duration::from_secs(30))
             .send()
             .await?;
-        Ok(Self::expect_ok(response).await?.json().await?)
+        Self::expect_ok(response).await?;
+        Ok(())
     }
 
     /// The daemon's download queue snapshot — what the dashboard renders.
@@ -342,7 +338,7 @@ impl DaemonHandle {
     /// mount was retired as unused (#834) the CLI was still polling it. The bare
     /// path then fell through to `/api/models/{id}`, whose `i64` extractor
     /// answers `400 text/plain` — which the poller tried to parse as JSON.
-    pub async fn download_queue(&self) -> Result<QueueSnapshot> {
+    pub(crate) async fn download_queue(&self) -> Result<QueueSnapshot> {
         let response = self
             .client
             .get(self.url(paths::DOWNLOADS_QUEUE_PATH))
@@ -354,7 +350,7 @@ impl DaemonHandle {
 
     /// Ask the daemon to shut down. `Ok(true)` when a shutdown was accepted,
     /// `Ok(false)` when the server said it is not running as a daemon.
-    pub async fn shutdown_daemon(&self) -> Result<bool> {
+    pub(crate) async fn shutdown_daemon(&self) -> Result<bool> {
         let response = self
             .client
             .post(self.url(paths::DAEMON_SHUTDOWN_PATH))

--- a/crates/gglib-cli/src/daemon_client/sse.rs
+++ b/crates/gglib-cli/src/daemon_client/sse.rs
@@ -16,7 +16,7 @@ use futures_util::StreamExt as _;
 /// lines (leading `:`, used for SSE keep-alives) and events with no `data:`
 /// line are silently skipped. Any trailing partial event is left in `buffer`
 /// for the next call once more bytes arrive.
-pub fn drain_events(buffer: &mut String) -> Vec<String> {
+pub(crate) fn drain_events(buffer: &mut String) -> Vec<String> {
     let mut payloads = Vec::new();
     while let Some(idx) = buffer.find("\n\n") {
         let event: String = buffer.drain(..idx + 2).collect();
@@ -38,7 +38,7 @@ pub fn drain_events(buffer: &mut String) -> Vec<String> {
 /// Runs until the server closes the stream. Dropping the future (Ctrl-C on
 /// the caller) drops the response, which is exactly the disconnect signal
 /// the daemon's benchmark guard cancels on.
-pub async fn stream_json<T, B>(
+pub(crate) async fn stream_json<T, B>(
     client: &reqwest::Client,
     url: &str,
     body: &B,

--- a/crates/gglib-cli/src/handlers/agent_chat/config.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/config.rs
@@ -33,7 +33,7 @@ use crate::presentation::style;
 /// single-turn question) can compose the agent loop without constructing a
 /// full `ChatArgs`.
 #[derive(Debug, Clone)]
-pub struct AgentSessionParams {
+pub(crate) struct AgentSessionParams {
     /// Model name or ID used to start llama-server.
     pub model_identifier: String,
     /// Optional context-size override (numeric string or `"max"`).
@@ -54,7 +54,7 @@ pub struct AgentSessionParams {
 /// Callers populate this with whatever session context they have so that
 /// `resolve_port` can render a richer startup message.
 #[derive(Debug, Clone, Default)]
-pub struct BannerInfo {
+pub(crate) struct BannerInfo {
     /// Suppress the banner entirely (e.g. `gglib q -Q`).
     pub quiet: bool,
     /// Sampling overrides to display (only non-default values are shown).
@@ -95,7 +95,7 @@ impl From<&ChatArgs> for AgentSessionParams {
 ///
 /// When `sandbox_root` is `Some`, filesystem tools are restricted to that
 /// directory.  Pass `None` for an unsandboxed session.
-pub async fn compose(
+pub(crate) async fn compose(
     ctx: &CliContext,
     params: &AgentSessionParams,
     sandbox_root: Option<PathBuf>,

--- a/crates/gglib-cli/src/handlers/agent_chat/drain.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/drain.rs
@@ -40,7 +40,7 @@ use super::thinking_dispatch::{
 ///
 /// The caller **must** gate any history update on the return value: history
 /// from a failed or incomplete turn must not replace the previous context.
-pub async fn drain_event_stream(
+pub(crate) async fn drain_event_stream(
     rx: &mut mpsc::Receiver<AgentEvent>,
     verbose: bool,
     quiet: bool,

--- a/crates/gglib-cli/src/handlers/agent_chat/mod.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/mod.rs
@@ -1,10 +1,10 @@
 #![doc = include_str!("README.md")]
-pub mod config;
-pub mod drain;
+pub(crate) mod config;
+pub(crate) mod drain;
 mod markdown;
-pub mod persistence;
-pub mod renderer;
-pub mod repl;
+pub(crate) mod persistence;
+pub(crate) mod renderer;
+pub(crate) mod repl;
 mod thinking_dispatch;
 mod tool_format;
 
@@ -26,7 +26,7 @@ use self::persistence::Conversation;
 /// When `args.continue_id` is set, loads a previous conversation and resumes
 /// with the original session parameters (saved settings fill in any CLI args
 /// the user didn't explicitly provide).
-pub async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
+pub(crate) async fn run(ctx: &CliContext, args: &ChatArgs) -> Result<()> {
     // 1. If resuming, load the conversation first and merge saved settings
     //    into args so the agent is composed with the correct parameters.
     let mut args = args.clone();

--- a/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/persistence.rs
@@ -12,7 +12,7 @@ use gglib_core::services::ChatHistoryService;
 
 /// Tracks a persisted conversation and the number of messages already saved,
 /// so subsequent calls to [`Conversation::save_new`] only write the delta.
-pub struct Conversation<'a> {
+pub(crate) struct Conversation<'a> {
     service: &'a ChatHistoryService,
     pub id: i64,
     saved: usize,
@@ -20,7 +20,7 @@ pub struct Conversation<'a> {
 
 impl<'a> Conversation<'a> {
     /// Create a new conversation with a timestamp-based title.
-    pub async fn create(
+    pub(crate) async fn create(
         service: &'a ChatHistoryService,
         system_prompt: Option<String>,
         model_id: Option<i64>,
@@ -45,7 +45,7 @@ impl<'a> Conversation<'a> {
     /// Resume an existing conversation for continued persistence.
     ///
     /// Loads the existing message count so [`save_new`] only persists the delta.
-    pub async fn resume(
+    pub(crate) async fn resume(
         service: &'a ChatHistoryService,
         id: i64,
         existing_message_count: usize,
@@ -66,7 +66,7 @@ impl<'a> Conversation<'a> {
     ///
     /// Errors are logged as warnings and swallowed — persistence must never
     /// break the interactive session.
-    pub async fn save_new(&mut self, messages: &[AgentMessage]) {
+    pub(crate) async fn save_new(&mut self, messages: &[AgentMessage]) {
         for msg in messages.iter().skip(self.saved) {
             if matches!(msg, AgentMessage::System { .. }) {
                 continue;

--- a/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/renderer.rs
@@ -50,7 +50,7 @@ use super::tool_format::format_tool_result;
 /// was rendered before this call.  When `false`, [`AgentEvent::FinalAnswer`]
 /// will print `content` to stdout — a defensive fallback for non-streaming
 /// invocations where the model returns its answer in a single chunk.
-pub fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_delta: bool) {
+pub(crate) fn render_event(event: &AgentEvent, verbose: bool, quiet: bool, had_text_delta: bool) {
     match event {
         AgentEvent::ReasoningDelta { content } => {
             if !quiet {

--- a/crates/gglib-cli/src/handlers/agent_chat/repl.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/repl.rs
@@ -16,7 +16,7 @@
 //! ## Ctrl+C cancellation
 //!
 //! A Ctrl+C **during an agent response** is handled via a `tokio::select!` in
-//! `run_repl`: the agent-loop task is aborted, the event channel is drained,
+//! `run_repl_with_history`: the agent-loop task is aborted, the channel drained,
 //! and the REPL returns to the prompt — the `handle.abort()` side effect is
 //! explicit at the call site, not hidden inside `collect_events`.
 //!
@@ -57,26 +57,17 @@ const REPL_HELP: &str = "\
 // Public entry point
 // =============================================================================
 
-/// Run the interactive agent REPL until the user quits or reaches EOF.
+/// Run the interactive agent REPL until the user quits or reaches EOF, with
+/// optional prior messages from a resumed conversation.
 ///
 /// Takes the agent loop as `Arc<dyn AgentLoopPort>` so the REPL can cheaply
 /// clone the reference for each spawned per-turn task without requiring
 /// [`AgentLoop`] to implement [`Clone`].
-pub async fn run_repl(
-    agent_loop: Arc<dyn AgentLoopPort>,
-    args: &ChatArgs,
-    persistence: Option<Conversation<'_>>,
-) -> Result<()> {
-    run_repl_with_prior(agent_loop, args, persistence, Vec::new()).await
-}
-
-/// Run the interactive agent REPL with optional prior messages from a resumed
-/// conversation.
 ///
 /// When `prior_messages` is non-empty, the REPL begins with those messages
 /// already in the history (no system prompt is prepended — it is already
-/// in the prior messages). When empty, behaves identically to [`run_repl`].
-pub async fn run_repl_with_prior(
+/// in the prior messages). Pass an empty vector to start fresh.
+pub(crate) async fn run_repl_with_prior(
     agent_loop: Arc<dyn AgentLoopPort>,
     args: &ChatArgs,
     persistence: Option<Conversation<'_>>,
@@ -114,12 +105,12 @@ pub async fn run_repl_with_prior(
 
 /// Run the interactive agent REPL with a pre-populated conversation history.
 ///
-/// This is the core REPL implementation.  [`run_repl`] delegates here after
-/// building the initial message list and config from [`ChatArgs`].  It is
+/// This is the core REPL implementation.  [`run_repl_with_prior`] delegates
+/// here after building the message list and config from [`ChatArgs`].  It is
 /// also called directly by `gglib q --agent` to transition from a single-turn
 /// question into an interactive session, carrying the full conversation
 /// history forward.
-pub async fn run_repl_with_history(
+pub(crate) async fn run_repl_with_history(
     agent_loop: Arc<dyn AgentLoopPort>,
     mut messages: Vec<AgentMessage>,
     config: AgentConfig,

--- a/crates/gglib-cli/src/handlers/agent_chat/thinking_dispatch.rs
+++ b/crates/gglib-cli/src/handlers/agent_chat/thinking_dispatch.rs
@@ -35,7 +35,7 @@ pub(super) struct RenderContext {
 }
 
 impl RenderContext {
-    pub fn new(rich: bool, stderr_tty: bool, quiet: bool) -> Self {
+    pub(super) fn new(rich: bool, stderr_tty: bool, quiet: bool) -> Self {
         Self {
             buf: String::new(),
             in_thinking: false,

--- a/crates/gglib-cli/src/handlers/benchmark.rs
+++ b/crates/gglib-cli/src/handlers/benchmark.rs
@@ -25,7 +25,7 @@ use crate::presentation::style;
 // ─── Public entry point ──────────────────────────────────────────────────────
 
 /// Route a `BenchmarkCommand` to its handler.
-pub async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
+pub(crate) async fn dispatch(ctx: &CliContext, cmd: BenchmarkCommand) -> Result<()> {
     match cmd {
         BenchmarkCommand::Compare {
             prompt,

--- a/crates/gglib-cli/src/handlers/completions.rs
+++ b/crates/gglib-cli/src/handlers/completions.rs
@@ -23,7 +23,7 @@ use crate::parser::Cli;
 /// The script is buffered in memory before writing so that a broken pipe
 /// (e.g. the caller piping to `head`) is handled gracefully rather than
 /// causing a panic from within `clap_complete`.
-pub fn execute(shell: Shell) -> Result<()> {
+pub(crate) fn execute(shell: Shell) -> Result<()> {
     let mut cmd = Cli::command();
     let bin_name = cmd.get_name().to_string();
     let mut buf: Vec<u8> = Vec::new();

--- a/crates/gglib-cli/src/handlers/config/check_deps/README.md
+++ b/crates/gglib-cli/src/handlers/config/check_deps/README.md
@@ -105,7 +105,7 @@ Missing dependencies trigger platform-specific installation instructions.
 ## Usage Pattern
 
 ```rust,ignore
-use gglib_cli::handlers::check_deps;
+use crate::handlers::check_deps;
 use gglib_core::ports::SystemProbePort;
 
 pub async fn handle_check_deps_command(

--- a/crates/gglib-cli/src/handlers/config/check_deps/display.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/display.rs
@@ -6,7 +6,7 @@ use gglib_core::utils::system::{Dependency, DependencyStatus};
 use crate::presentation::style::{BOLD, DANGER, RESET, SUCCESS, WARNING};
 
 /// Print a single dependency row in the status table.
-pub fn print_dependency(dep: &Dependency) {
+pub(super) fn print_dependency(dep: &Dependency) {
     let status_str = match &dep.status {
         DependencyStatus::Present { version } => {
             if version.is_empty() {
@@ -40,7 +40,7 @@ pub fn print_dependency(dep: &Dependency) {
 }
 
 /// Print GPU detection status and recommendations.
-pub fn print_gpu_status(probe: &dyn SystemProbePort) {
+pub(super) fn print_gpu_status(probe: &dyn SystemProbePort) {
     let gpu_info = probe.detect_gpu_info();
 
     println!("\n{}GPU Detection:{}", BOLD, RESET);

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/common.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/common.rs
@@ -2,10 +2,10 @@
 
 // Re-export from the centralised style module so sibling instruction files
 // can continue to use `super::common::{BOLD, RESET}`.
-pub use crate::presentation::style::{BOLD, INFO, RESET};
+pub(super) use crate::presentation::style::{BOLD, INFO, RESET};
 
 /// Print a section header for installation instructions.
-pub fn print_header(title: &str) {
+pub(super) fn print_header(title: &str) {
     println!(
         "\n{}{}Installation Instructions ({}):{}",
         BOLD, INFO, title, RESET
@@ -14,11 +14,11 @@ pub fn print_header(title: &str) {
 }
 
 /// Print a command with proper formatting.
-pub fn print_command(cmd: &str) {
+pub(super) fn print_command(cmd: &str) {
     println!("  {}$ {}{}", INFO, cmd, RESET);
 }
 
 /// Print a subsection header.
-pub fn print_subsection(title: &str) {
+pub(super) fn print_subsection(title: &str) {
     println!("\n{}{}:{}", BOLD, title, RESET);
 }

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/linux.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/linux.rs
@@ -4,7 +4,7 @@ use super::common::{BOLD, RESET, print_command, print_header, print_subsection};
 use gglib_core::utils::system::{Dependency, LinuxDistro, packages_for};
 
 /// Print Linux-specific installation instructions.
-pub fn print_instructions(missing: &[&Dependency], distro: LinuxDistro) {
+pub(super) fn print_instructions(missing: &[&Dependency], distro: LinuxDistro) {
     print_header(distro.label());
 
     print_package_instructions(missing, distro);

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/macos.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/macos.rs
@@ -4,7 +4,7 @@ use super::common::{print_command, print_header, print_subsection};
 use gglib_core::utils::system::Dependency;
 
 /// Print macOS-specific installation instructions.
-pub fn print_instructions(missing: &[&Dependency]) {
+pub(super) fn print_instructions(missing: &[&Dependency]) {
     print_header("macOS");
 
     // Check if Homebrew is needed

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/mod.rs
@@ -14,7 +14,7 @@ use crate::handlers::config::check_deps::platform::{Os, detect_linux_distro, det
 use gglib_core::utils::system::Dependency;
 
 /// Print installation instructions for missing dependencies.
-pub fn print_installation_instructions(missing: &[&Dependency]) {
+pub(super) fn print_installation_instructions(missing: &[&Dependency]) {
     match detect_os() {
         Os::MacOS => macos::print_instructions(missing),
         Os::Windows => windows::print_instructions(missing),

--- a/crates/gglib-cli/src/handlers/config/check_deps/instructions/windows.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/instructions/windows.rs
@@ -4,7 +4,7 @@ use super::common::{BOLD, RESET, print_command, print_header, print_subsection};
 use gglib_core::utils::system::Dependency;
 
 /// Print Windows-specific installation instructions.
-pub fn print_instructions(missing: &[&Dependency]) {
+pub(super) fn print_instructions(missing: &[&Dependency]) {
     print_header("Windows");
 
     // Check for winget/choco packages

--- a/crates/gglib-cli/src/handlers/config/check_deps/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/mod.rs
@@ -38,7 +38,7 @@ use crate::presentation::style::{BOLD, DANGER, INFO, RESET, SUCCESS};
 ///
 /// Returns `Ok(())` if all required dependencies are present.
 /// Returns an error if any required dependencies are missing.
-pub async fn execute(probe: &dyn SystemProbePort, setup_fast_downloads: bool) -> Result<()> {
+pub(crate) async fn execute(probe: &dyn SystemProbePort, setup_fast_downloads: bool) -> Result<()> {
     println!("{}{}Checking system dependencies...{}\n", BOLD, INFO, RESET);
 
     let dependencies = probe.check_all_dependencies();

--- a/crates/gglib-cli/src/handlers/config/check_deps/platform.rs
+++ b/crates/gglib-cli/src/handlers/config/check_deps/platform.rs
@@ -2,14 +2,14 @@
 
 /// Operating system detection result.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Os {
+pub(super) enum Os {
     MacOS,
     Windows,
     Linux,
 }
 
 /// Detect the current operating system.
-pub fn detect_os() -> Os {
+pub(super) fn detect_os() -> Os {
     if cfg!(target_os = "macos") {
         Os::MacOS
     } else if cfg!(target_os = "windows") {
@@ -26,7 +26,7 @@ pub fn detect_os() -> Os {
 /// distribution names — which meant a `HOME_URL` containing "research" was read
 /// as Arch Linux, and the CLI could recommend different packages than the
 /// dependency check did on the very same machine.
-pub use gglib_runtime::system::detect_linux_distro;
+pub(super) use gglib_runtime::system::detect_linux_distro;
 
 #[cfg(test)]
 mod tests {

--- a/crates/gglib-cli/src/handlers/config/fast_downloads.rs
+++ b/crates/gglib-cli/src/handlers/config/fast_downloads.rs
@@ -31,7 +31,7 @@ use crate::utils::input::prompt_confirmation_default_yes;
 const PRESEED_ENV: &str = "GGLIB_FAST_DOWNLOADS";
 
 /// Dispatch a `config fast-downloads` subcommand.
-pub async fn dispatch(command: Option<FastDownloadsCommand>) -> Result<()> {
+pub(crate) async fn dispatch(command: Option<FastDownloadsCommand>) -> Result<()> {
     match command.unwrap_or(FastDownloadsCommand::Status) {
         FastDownloadsCommand::Status => status(),
         FastDownloadsCommand::Enable { python } => enable(python.as_deref()).await,

--- a/crates/gglib-cli/src/handlers/config/llama.rs
+++ b/crates/gglib-cli/src/handlers/config/llama.rs
@@ -12,7 +12,7 @@ use super::llama_detect;
 use super::llama_install;
 
 /// Dispatch a `llama` sub-command to the appropriate `gglib_runtime` handler.
-pub async fn dispatch(command: LlamaCommand) -> Result<()> {
+pub(crate) async fn dispatch(command: LlamaCommand) -> Result<()> {
     use gglib_runtime::llama::{
         handle_check_updates, handle_status, handle_uninstall, handle_update,
     };

--- a/crates/gglib-cli/src/handlers/config/llama_detect.rs
+++ b/crates/gglib-cli/src/handlers/config/llama_detect.rs
@@ -14,7 +14,7 @@ use gglib_runtime::llama::{Acceleration, detect_optimal_acceleration, vulkan_sta
 /// Returns `Ok(())` when all build dependencies for the detected
 /// acceleration are present. Returns `Err` (non-zero exit) when
 /// dependencies are missing.
-pub fn execute(json: bool) -> Result<()> {
+pub(crate) fn execute(json: bool) -> Result<()> {
     let accel = detect_optimal_acceleration();
     let vk = vulkan_status();
 

--- a/crates/gglib-cli/src/handlers/config/llama_install.rs
+++ b/crates/gglib-cli/src/handlers/config/llama_install.rs
@@ -28,7 +28,7 @@ fn path_err<T>(r: Result<T, gglib_core::paths::PathError>) -> Result<T> {
 /// - Running from source repo: Build from source (existing behavior)
 /// - Pre-built binary + macOS/Windows: Download pre-built binaries
 /// - Pre-built binary + Linux: Build from source (CUDA requires compilation)
-pub async fn handle_install(
+pub(crate) async fn handle_install(
     cuda: bool,
     metal: bool,
     vulkan: bool,

--- a/crates/gglib-cli/src/handlers/config/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/mod.rs
@@ -1,11 +1,11 @@
 #![doc = include_str!("README.md")]
-pub mod check_deps;
-pub mod fast_downloads;
-pub mod llama;
-pub mod llama_detect;
-pub mod llama_install;
-pub mod paths;
-pub mod settings;
+pub(crate) mod check_deps;
+pub(crate) mod fast_downloads;
+pub(crate) mod llama;
+pub(crate) mod llama_detect;
+pub(crate) mod llama_install;
+pub(crate) mod paths;
+pub(crate) mod settings;
 
 use anyhow::Result;
 
@@ -13,7 +13,7 @@ use crate::bootstrap::CliContext;
 use crate::config_commands::ConfigCommand;
 
 /// Dispatch a `config` subcommand to its handler.
-pub async fn dispatch(ctx: &CliContext, command: ConfigCommand) -> Result<()> {
+pub(crate) async fn dispatch(ctx: &CliContext, command: ConfigCommand) -> Result<()> {
     match command {
         ConfigCommand::Default { identifier, clear } => {
             settings::handle_default_model(ctx, identifier, clear).await

--- a/crates/gglib-cli/src/handlers/config/paths.rs
+++ b/crates/gglib-cli/src/handlers/config/paths.rs
@@ -16,7 +16,7 @@ use gglib_core::paths::ResolvedPaths;
 /// # Returns
 ///
 /// Returns `Result<()>` indicating the success or failure of the operation.
-pub fn execute() -> Result<()> {
+pub(crate) fn execute() -> Result<()> {
     let paths = ResolvedPaths::resolve()?;
     println!("{paths}");
     Ok(())

--- a/crates/gglib-cli/src/handlers/config/settings/mod.rs
+++ b/crates/gglib-cli/src/handlers/config/settings/mod.rs
@@ -16,7 +16,7 @@ use gglib_core::{Settings, SettingsUpdate};
 
 use settings_display::{print_sections, settings_display_rows, settings_to_sections};
 
-pub use profiles::handle_profile;
+pub(crate) use profiles::handle_profile;
 
 /// Resolve the display string for `default-model-id`, performing a DB lookup when set.
 ///
@@ -36,7 +36,7 @@ async fn resolve_model_display(ctx: &CliContext, settings: &Settings) -> Result<
 /// - No args: show current default
 /// - With identifier: set as default
 /// - With --clear: remove default
-pub async fn handle_default_model(
+pub(crate) async fn handle_default_model(
     ctx: &CliContext,
     identifier: Option<String>,
     clear: bool,
@@ -85,7 +85,7 @@ pub async fn handle_default_model(
     Ok(())
 }
 
-pub fn handle_models_dir(command: ModelsDirCommand) -> Result<()> {
+pub(crate) fn handle_models_dir(command: ModelsDirCommand) -> Result<()> {
     match command {
         ModelsDirCommand::Show => {
             let resolved = resolve_models_dir(None)?;
@@ -129,7 +129,7 @@ pub fn handle_models_dir(command: ModelsDirCommand) -> Result<()> {
     }
 }
 
-pub async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<()> {
+pub(crate) async fn handle_settings(ctx: &CliContext, command: SettingsCommand) -> Result<()> {
     match command {
         SettingsCommand::Show => {
             let settings = ctx.app.settings().get().await?;

--- a/crates/gglib-cli/src/handlers/config/settings/profiles.rs
+++ b/crates/gglib-cli/src/handlers/config/settings/profiles.rs
@@ -19,7 +19,7 @@ use crate::bootstrap::CliContext;
 use crate::config_commands::ProfileCommand;
 
 /// Dispatch a `config profile` subcommand.
-pub async fn handle_profile(ctx: &CliContext, command: ProfileCommand) -> Result<()> {
+pub(crate) async fn handle_profile(ctx: &CliContext, command: ProfileCommand) -> Result<()> {
     match command {
         ProfileCommand::List => list(ctx).await,
         ProfileCommand::Show { name } => show(ctx, &name).await,

--- a/crates/gglib-cli/src/handlers/daemon/mdns.rs
+++ b/crates/gglib-cli/src/handlers/daemon/mdns.rs
@@ -40,7 +40,7 @@ const HOSTNAME: &str = "gglib.local.";
 pub(crate) const LAN_HOSTNAME: &str = "gglib.local";
 
 /// An active mDNS registration, unregistered on [`shutdown`](Self::shutdown).
-pub struct MdnsAdvertiser {
+pub(super) struct MdnsAdvertiser {
     daemon: ServiceDaemon,
     fullname: String,
 }
@@ -55,7 +55,7 @@ impl MdnsAdvertiser {
     /// discover the machine's interface addresses and keep the record current
     /// as they change. A specific `host` is advertised verbatim, so a server
     /// narrowed to one interface does not advertise the others.
-    pub fn start(host: &str, port: u16) -> Option<Self> {
+    pub(super) fn start(host: &str, port: u16) -> Option<Self> {
         let daemon = match ServiceDaemon::new() {
             Ok(daemon) => daemon,
             Err(e) => {
@@ -101,7 +101,7 @@ impl MdnsAdvertiser {
     /// Awaits the unregister acknowledgement before shutting the daemon down —
     /// dropping it immediately would leave the goodbye packet unsent and the
     /// stale record cached by every resolver on the network.
-    pub async fn shutdown(self) {
+    pub(super) async fn shutdown(self) {
         match self.daemon.unregister(&self.fullname) {
             Ok(rx) => {
                 if let Err(e) = rx.recv_async().await {

--- a/crates/gglib-cli/src/handlers/daemon/mod.rs
+++ b/crates/gglib-cli/src/handlers/daemon/mod.rs
@@ -10,7 +10,7 @@ use gglib_axum::daemon::{DaemonLock, DaemonOptions, run_daemon};
 use gglib_core::{CorsConfig, DAEMON_PORT};
 
 /// Execute `gglib daemon run`: host the daemon in the foreground.
-pub async fn run(share_lan: bool, allowed_hosts: Vec<String>) -> Result<()> {
+pub(crate) async fn run(share_lan: bool, allowed_hosts: Vec<String>) -> Result<()> {
     let opts = if share_lan {
         print_share_lan_warning();
         // The mDNS name is advertised below, so it is plainly a name this
@@ -48,7 +48,7 @@ pub async fn run(share_lan: bool, allowed_hosts: Vec<String>) -> Result<()> {
 }
 
 /// Execute `gglib daemon status`.
-pub async fn status() -> Result<()> {
+pub(crate) async fn status() -> Result<()> {
     let client = reqwest::Client::new();
 
     style::print_info_banner("Daemon", "\u{2139}\u{fe0f}");
@@ -90,7 +90,7 @@ pub async fn status() -> Result<()> {
 }
 
 /// Execute `gglib daemon stop`: request shutdown and wait for it to land.
-pub async fn stop() -> Result<()> {
+pub(crate) async fn stop() -> Result<()> {
     let client = reqwest::Client::new();
 
     match daemon_client::probe(&client).await {

--- a/crates/gglib-cli/src/handlers/gui.rs
+++ b/crates/gglib-cli/src/handlers/gui.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 /// In development mode, prints instructions for running `cargo tauri dev`.
 /// Otherwise, locates and launches the built application bundle for the
 /// current platform.
-pub fn execute(dev: bool) -> Result<()> {
+pub(crate) fn execute(dev: bool) -> Result<()> {
     if dev {
         println!("Development mode requires running 'cargo tauri dev' directly");
         return Ok(());

--- a/crates/gglib-cli/src/handlers/history.rs
+++ b/crates/gglib-cli/src/handlers/history.rs
@@ -11,7 +11,7 @@ use crate::presentation::{format_relative_time, print_separator, truncate_string
 ///
 /// Retrieves and displays past conversations with message counts
 /// and relative timestamps for quick browsing.
-pub async fn execute(ctx: &CliContext, limit: usize) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, limit: usize) -> Result<()> {
     let conversations = ctx.app.chat_history().list_conversations().await?;
 
     if conversations.is_empty() {

--- a/crates/gglib-cli/src/handlers/inference/agent_question.rs
+++ b/crates/gglib-cli/src/handlers/inference/agent_question.rs
@@ -32,7 +32,7 @@ thoroughly. Be direct and concise.";
 
 /// Run a single-turn agentic question, with optional continuation into chat.
 #[allow(clippy::too_many_arguments)]
-pub async fn execute(
+pub(crate) async fn execute(
     ctx: &CliContext,
     question: String,
     model_arg: Option<String>,

--- a/crates/gglib-cli/src/handlers/inference/chat.rs
+++ b/crates/gglib-cli/src/handlers/inference/chat.rs
@@ -9,7 +9,7 @@ use crate::shared_args::{ContextArgs, SamplingArgs};
 
 /// Arguments for the chat command.
 #[derive(Debug, Clone)]
-pub struct ChatArgs {
+pub(crate) struct ChatArgs {
     pub identifier: String,
     pub context: ContextArgs,
     pub system_prompt: Option<String>,
@@ -42,7 +42,7 @@ pub struct ChatArgs {
 }
 
 /// Execute the chat command — always routes to the agentic REPL.
-pub async fn execute(ctx: &CliContext, args: ChatArgs) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, args: ChatArgs) -> Result<()> {
     crate::handlers::agent_chat::run(ctx, &args).await
 }
 

--- a/crates/gglib-cli/src/handlers/inference/mod.rs
+++ b/crates/gglib-cli/src/handlers/inference/mod.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("README.md")]
-pub mod agent_question;
-pub mod chat;
-pub mod proxy;
-pub mod serve;
-pub mod shared;
+pub(crate) mod agent_question;
+pub(crate) mod chat;
+pub(crate) mod proxy;
+pub(crate) mod serve;
+pub(crate) mod shared;

--- a/crates/gglib-cli/src/handlers/inference/proxy.rs
+++ b/crates/gglib-cli/src/handlers/inference/proxy.rs
@@ -18,7 +18,7 @@ use gglib_core::server_config::{ServerConfigOptions, resolve_context_size};
 /// Ensures the daemon is running, starts the proxy on it (idempotent), and
 /// attaches the dashboard until Ctrl-C.
 #[allow(clippy::too_many_arguments)]
-pub async fn execute(
+pub(crate) async fn execute(
     ctx: &CliContext,
     host: String,
     port: u16,
@@ -98,7 +98,7 @@ pub(in crate::handlers) async fn attach_dashboard(
 }
 
 /// Execute `gglib proxy stop`.
-pub async fn stop() -> Result<()> {
+pub(crate) async fn stop() -> Result<()> {
     let client = reqwest::Client::new();
     match daemon_client::probe(&client).await {
         daemon_client::DaemonProbe::Running => {}

--- a/crates/gglib-cli/src/handlers/inference/serve.rs
+++ b/crates/gglib-cli/src/handlers/inference/serve.rs
@@ -27,7 +27,7 @@ use super::shared::{log_inference_info, log_mlock_info};
 /// Resolves the model's launch options locally (the full cascade), asks the
 /// daemon to start the proxy pinned to it, and attaches the dashboard.
 #[allow(clippy::too_many_arguments)]
-pub async fn execute(
+pub(crate) async fn execute(
     ctx: &CliContext,
     id: u32,
     context: ContextArgs,

--- a/crates/gglib-cli/src/handlers/inference/shared.rs
+++ b/crates/gglib-cli/src/handlers/inference/shared.rs
@@ -20,7 +20,7 @@ use gglib_core::domain::agent::DEFAULT_MAX_ITERATIONS;
 ///
 /// `gglib model explain <id>` prints the outcome of this resolution for any
 /// model, naming the layer each parameter came from.
-pub async fn resolve_inference_config(
+pub(crate) async fn resolve_inference_config(
     ctx: &CliContext,
     config: InferenceConfig,
     model: &gglib_core::Model,
@@ -38,21 +38,21 @@ pub async fn resolve_inference_config(
 ///
 /// Merge order: CLI flag → persisted `Settings.max_tool_iterations` → `DEFAULT_MAX_ITERATIONS`.
 /// This mirrors the pattern in [`resolve_inference_config`] and keeps handler code clean.
-pub fn resolve_max_iterations(cli_override: Option<usize>, settings: &Settings) -> usize {
+pub(crate) fn resolve_max_iterations(cli_override: Option<usize>, settings: &Settings) -> usize {
     cli_override
         .or_else(|| settings.max_tool_iterations.map(|v| v as usize))
         .unwrap_or(DEFAULT_MAX_ITERATIONS)
 }
 
 /// Log mlock status to stderr.
-pub fn log_mlock_info(mlock: bool) {
+pub(crate) fn log_mlock_info(mlock: bool) {
     if mlock {
         eprintln!("  Memory lock: enabled");
     }
 }
 
 /// Log resolved inference parameters to stderr.
-pub fn log_inference_info(config: &InferenceConfig) {
+pub(crate) fn log_inference_info(config: &InferenceConfig) {
     eprintln!("  Inference parameters:");
     if let Some(temp) = config.temperature {
         eprintln!("    Temperature: {}", temp);

--- a/crates/gglib-cli/src/handlers/mcp_cli.rs
+++ b/crates/gglib-cli/src/handlers/mcp_cli.rs
@@ -12,7 +12,7 @@ use crate::presentation::{print_separator, truncate_string};
 use crate::utils::input;
 
 /// Dispatch an MCP subcommand to its handler.
-pub async fn dispatch(ctx: &CliContext, cmd: McpCommand) -> Result<()> {
+pub(crate) async fn dispatch(ctx: &CliContext, cmd: McpCommand) -> Result<()> {
     match cmd {
         McpCommand::List => list(ctx).await,
         McpCommand::Add {

--- a/crates/gglib-cli/src/handlers/mod.rs
+++ b/crates/gglib-cli/src/handlers/mod.rs
@@ -15,17 +15,17 @@
 //! - [`web`]       — Axum web-server GUI launcher
 //! - [`proxy_dashboard`] — live terminal view of a running proxy's dashboard stream
 
-pub mod agent_chat;
-pub mod benchmark;
-pub mod completions;
-pub mod config;
-pub mod daemon;
-pub mod gui;
-pub mod history;
-pub mod inference;
-pub mod mcp_cli;
-pub mod model;
-pub mod proxy_cache_clear;
-pub mod proxy_dashboard;
-pub mod up;
-pub mod web;
+pub(crate) mod agent_chat;
+pub(crate) mod benchmark;
+pub(crate) mod completions;
+pub(crate) mod config;
+pub(crate) mod daemon;
+pub(crate) mod gui;
+pub(crate) mod history;
+pub(crate) mod inference;
+pub(crate) mod mcp_cli;
+pub(crate) mod model;
+pub(crate) mod proxy_cache_clear;
+pub(crate) mod proxy_dashboard;
+pub(crate) mod up;
+pub(crate) mod web;

--- a/crates/gglib-cli/src/handlers/model/add.rs
+++ b/crates/gglib-cli/src/handlers/model/add.rs
@@ -33,7 +33,7 @@ use gglib_core::utils::validation;
 /// - File validation fails
 /// - GGUF metadata extraction fails
 /// - Database operations fail
-pub async fn execute(ctx: &CliContext, file_path: &str) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, file_path: &str) -> Result<()> {
     let path = PathBuf::from(file_path);
 
     // Validate the GGUF file and extract metadata for CLI preview

--- a/crates/gglib-cli/src/handlers/model/capabilities.rs
+++ b/crates/gglib-cli/src/handlers/model/capabilities.rs
@@ -22,7 +22,7 @@ use crate::bootstrap::CliContext;
 /// Without `--set` or `--unset` flags the command is read-only and prints the
 /// current capability state.  With flags it applies the requested overrides
 /// via [`ModelOps::set_capabilities`] and prints the updated state.
-pub async fn execute(
+pub(crate) async fn execute(
     ctx: &CliContext,
     identifier: &str,
     set: Vec<String>,

--- a/crates/gglib-cli/src/handlers/model/download/browse.rs
+++ b/crates/gglib-cli/src/handlers/model/download/browse.rs
@@ -10,7 +10,7 @@ use gglib_hf::{DefaultHfClient, HfClientConfig};
 ///
 /// Browses popular/recent/trending GGUF models on HuggingFace Hub.
 /// No database access required.
-pub async fn execute(category: String, limit: u32, size: Option<String>) -> Result<()> {
+pub(crate) async fn execute(category: String, limit: u32, size: Option<String>) -> Result<()> {
     let sort_param = match category.as_str() {
         "popular" => "downloads",
         "recent" => "created",

--- a/crates/gglib-cli/src/handlers/model/download/check_updates.rs
+++ b/crates/gglib-cli/src/handlers/model/download/check_updates.rs
@@ -10,7 +10,7 @@ use crate::handlers::model::resolver;
 /// Execute the check-updates command.
 ///
 /// Checks if locally downloaded models have updates available on HuggingFace.
-pub async fn execute(ctx: &CliContext, identifier: Option<&str>, all: bool) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, identifier: Option<&str>, all: bool) -> Result<()> {
     if all {
         println!("Checking updates for all models...");
         let models = ctx.app.models().list().await?;

--- a/crates/gglib-cli/src/handlers/model/download/exec.rs
+++ b/crates/gglib-cli/src/handlers/model/download/exec.rs
@@ -15,11 +15,10 @@ use gglib_core::paths::resolve_models_dir;
 use super::remote;
 
 /// Download command arguments passed from CLI.
-pub struct DownloadArgs<'a> {
+pub(crate) struct DownloadArgs<'a> {
     pub model_id: &'a str,
     pub quantization: Option<&'a str>,
     pub list_quants: bool,
-    pub force: bool,
     /// HuggingFace token for private models.
     ///
     /// Used only for `--list-quants`. For downloads, prefer the `HF_TOKEN`
@@ -33,7 +32,7 @@ pub struct DownloadArgs<'a> {
 /// Queues `model_id` on the daemon and watches the queue until it drains.
 /// Ctrl-C detaches; the daemon keeps downloading and registers the model
 /// itself.
-pub async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, args: DownloadArgs<'_>) -> Result<()> {
     let _ = ctx;
     let models_dir = resolve_models_dir(None)?.path;
 

--- a/crates/gglib-cli/src/handlers/model/download/interactive.rs
+++ b/crates/gglib-cli/src/handlers/model/download/interactive.rs
@@ -72,7 +72,7 @@ use gglib_download::CliDownloadEventEmitter;
 ///
 /// The calling `execute()` handler simply awaits this future — all queue
 /// interaction and progress rendering is encapsulated here.
-pub async fn run_interactive_monitor(
+pub(crate) async fn run_interactive_monitor(
     downloads: Arc<dyn DownloadManagerPort>,
     emitter: Arc<CliDownloadEventEmitter>,
 ) -> Result<()> {

--- a/crates/gglib-cli/src/handlers/model/download/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/download/mod.rs
@@ -14,12 +14,12 @@ mod remote;
 mod search;
 mod update_model;
 
-pub use browse::execute as browse;
-pub use check_updates::execute as check_updates;
-pub use exec::{DownloadArgs, execute as download};
+pub(crate) use browse::execute as browse;
+pub(crate) use check_updates::execute as check_updates;
+pub(crate) use exec::{DownloadArgs, execute as download};
 // Re-exported for `gglib up`, which queues one model and then needs exactly
 // this rendering and completion behaviour. A second monitor would be a second
 // set of progress-bar and TTY bugs.
-pub use interactive::run_interactive_monitor;
-pub use search::execute as search;
-pub use update_model::execute as update_model;
+pub(crate) use interactive::run_interactive_monitor;
+pub(crate) use search::execute as search;
+pub(crate) use update_model::execute as update_model;

--- a/crates/gglib-cli/src/handlers/model/download/remote.rs
+++ b/crates/gglib-cli/src/handlers/model/download/remote.rs
@@ -27,7 +27,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(250);
 /// Exits successfully once at least one item has been observed and the queue
 /// is empty again; a failure recorded for anything observed is reported as
 /// an error. Ctrl-C detaches — the daemon keeps downloading.
-pub async fn monitor(handle: &DaemonHandle) -> Result<()> {
+pub(super) async fn monitor(handle: &DaemonHandle) -> Result<()> {
     let watch = watch_queue(handle);
     tokio::select! {
         result = watch => result,

--- a/crates/gglib-cli/src/handlers/model/download/search.rs
+++ b/crates/gglib-cli/src/handlers/model/download/search.rs
@@ -10,7 +10,7 @@ use gglib_hf::{DefaultHfClient, HfClientConfig};
 ///
 /// Searches HuggingFace Hub for models matching the query.
 /// No database access required.
-pub async fn execute(query: String, limit: u32, sort: String, gguf_only: bool) -> Result<()> {
+pub(crate) async fn execute(query: String, limit: u32, sort: String, gguf_only: bool) -> Result<()> {
     println!("🔍 Searching HuggingFace Hub for: '{}'...", query);
 
     let client = DefaultHfClient::new(&HfClientConfig::default());

--- a/crates/gglib-cli/src/handlers/model/download/search.rs
+++ b/crates/gglib-cli/src/handlers/model/download/search.rs
@@ -10,7 +10,12 @@ use gglib_hf::{DefaultHfClient, HfClientConfig};
 ///
 /// Searches HuggingFace Hub for models matching the query.
 /// No database access required.
-pub(crate) async fn execute(query: String, limit: u32, sort: String, gguf_only: bool) -> Result<()> {
+pub(crate) async fn execute(
+    query: String,
+    limit: u32,
+    sort: String,
+    gguf_only: bool,
+) -> Result<()> {
     println!("🔍 Searching HuggingFace Hub for: '{}'...", query);
 
     let client = DefaultHfClient::new(&HfClientConfig::default());

--- a/crates/gglib-cli/src/handlers/model/download/update_model.rs
+++ b/crates/gglib-cli/src/handlers/model/download/update_model.rs
@@ -19,7 +19,7 @@ use crate::handlers::model::resolver;
 ///
 /// Upgrades a model to the latest revision from HuggingFace. `force` skips
 /// the confirmation prompt; everything else is identical to the GUI path.
-pub async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> Result<()> {
     let model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
     // `NoopModelRuntime` rather than `ctx.runner`: a one-shot CLI command has

--- a/crates/gglib-cli/src/handlers/model/explain.rs
+++ b/crates/gglib-cli/src/handlers/model/explain.rs
@@ -19,7 +19,7 @@ use crate::handlers::config::settings::profiles::not_found_message;
 use crate::presentation::explain_display::{self, ExplainContext};
 
 /// Execute `gglib model explain <id> [--profile NAME]`.
-pub async fn execute(ctx: &CliContext, identifier: &str, profile: Option<&str>) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, identifier: &str, profile: Option<&str>) -> Result<()> {
     let model = resolver::resolve_model_identifier(ctx, identifier).await?;
     let settings = ctx.app.settings().get().await?;
 

--- a/crates/gglib-cli/src/handlers/model/explain.rs
+++ b/crates/gglib-cli/src/handlers/model/explain.rs
@@ -19,7 +19,11 @@ use crate::handlers::config::settings::profiles::not_found_message;
 use crate::presentation::explain_display::{self, ExplainContext};
 
 /// Execute `gglib model explain <id> [--profile NAME]`.
-pub(crate) async fn execute(ctx: &CliContext, identifier: &str, profile: Option<&str>) -> Result<()> {
+pub(crate) async fn execute(
+    ctx: &CliContext,
+    identifier: &str,
+    profile: Option<&str>,
+) -> Result<()> {
     let model = resolver::resolve_model_identifier(ctx, identifier).await?;
     let settings = ctx.app.settings().get().await?;
 

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -21,7 +21,7 @@ use crate::bootstrap::CliContext;
 use crate::presentation::inspect_display;
 
 /// Execute `gglib model inspect <identifier> [--metadata] [--json]`.
-pub async fn execute(
+pub(crate) async fn execute(
     ctx: &CliContext,
     identifier: &str,
     show_metadata: bool,

--- a/crates/gglib-cli/src/handlers/model/list.rs
+++ b/crates/gglib-cli/src/handlers/model/list.rs
@@ -28,7 +28,7 @@ use crate::presentation::{print_separator, truncate_string};
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Arguments forwarded from the `List` CLI variant.
-pub struct ListArgs {
+pub(crate) struct ListArgs {
     pub sort: CliModelSortBy,
     pub order: CliSortOrder,
     pub min_params: Option<f64>,
@@ -39,7 +39,7 @@ pub struct ListArgs {
 }
 
 /// Execute the list command.
-pub async fn execute(ctx: &CliContext, args: ListArgs) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, args: ListArgs) -> Result<()> {
     let models = fetch_models(ctx, &args).await?;
 
     if models.is_empty() {

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -1,15 +1,15 @@
 #![doc = include_str!("README.md")]
-pub mod add;
-pub mod capabilities;
-pub mod download;
-pub mod explain;
-pub mod inspect;
-pub mod list;
-pub mod remove;
-pub mod resolver;
-pub mod retag;
-pub mod update;
-pub mod verification;
+pub(crate) mod add;
+pub(crate) mod capabilities;
+pub(crate) mod download;
+pub(crate) mod explain;
+pub(crate) mod inspect;
+pub(crate) mod list;
+pub(crate) mod remove;
+pub(crate) mod resolver;
+pub(crate) mod retag;
+pub(crate) mod update;
+pub(crate) mod verification;
 
 use anyhow::Result;
 
@@ -17,7 +17,7 @@ use crate::bootstrap::CliContext;
 use crate::model_commands::ModelCommand;
 
 /// Dispatch a `model` subcommand to its handler.
-pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
+pub(crate) async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
     match command {
         ModelCommand::Add { file_path } => {
             add::execute(ctx, &file_path).await?;
@@ -134,7 +134,12 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
             list_quants,
             skip_db,
             token,
-            force,
+            // `--force` skips a confirmation prompt, and this path has none to
+            // skip: the daemon owns the download and `exec` never asks. The
+            // flag is inert, like `--skip-db` above it but without the notice.
+            // Bound and dropped here rather than threaded into `DownloadArgs`,
+            // where it was carried three layers and read by nobody.
+            force: _,
         } => {
             // Registration happens daemon-side as a queue lifecycle phase, so
             // honouring this flag needs a protocol change. Say so rather than
@@ -153,7 +158,6 @@ pub async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
                 model_id: &model_id,
                 quantization: quantization.as_deref(),
                 list_quants,
-                force,
                 token: token.as_deref(),
             };
             download::download(ctx, args).await?;

--- a/crates/gglib-cli/src/handlers/model/remove.rs
+++ b/crates/gglib-cli/src/handlers/model/remove.rs
@@ -31,7 +31,7 @@ use crate::utils::input;
 /// - Model not found
 /// - User input fails
 /// - Database removal operation fails
-pub async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> Result<()> {
     // First, try to find the model to show it to the user
     let model = match ctx.app.models().get(identifier).await? {
         Some(m) => m,

--- a/crates/gglib-cli/src/handlers/model/resolver.rs
+++ b/crates/gglib-cli/src/handlers/model/resolver.rs
@@ -17,7 +17,7 @@ use crate::bootstrap::CliContext;
 /// Accepts either a numeric model ID or a model name.  If no model matches,
 /// returns an error with a helpful message rather than `Ok(None)`, ensuring
 /// consistent non-zero exit codes across all callers.
-pub async fn resolve_model_identifier(ctx: &CliContext, identifier: &str) -> Result<Model> {
+pub(crate) async fn resolve_model_identifier(ctx: &CliContext, identifier: &str) -> Result<Model> {
     ctx.app.models().get(identifier).await?.ok_or_else(|| {
         anyhow!(
             "No model found matching: '{identifier}'\n\

--- a/crates/gglib-cli/src/handlers/model/retag.rs
+++ b/crates/gglib-cli/src/handlers/model/retag.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result};
 use crate::bootstrap::CliContext;
 
 /// Execute the retag command.
-pub async fn execute(
+pub(crate) async fn execute(
     ctx: &CliContext,
     identifier: Option<String>,
     all: bool,

--- a/crates/gglib-cli/src/handlers/model/update.rs
+++ b/crates/gglib-cli/src/handlers/model/update.rs
@@ -15,7 +15,7 @@ use crate::bootstrap::CliContext;
 
 /// Arguments for the update command.
 #[derive(Debug, Clone)]
-pub struct UpdateArgs {
+pub(crate) struct UpdateArgs {
     pub identifier: String,
     pub name: Option<String>,
     pub param_count: Option<f64>,
@@ -58,7 +58,7 @@ pub struct UpdateArgs {
 /// # Returns
 ///
 /// Returns `Result<()>` indicating the success or failure of the operation.
-pub async fn execute(ctx: &CliContext, args: UpdateArgs) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, args: UpdateArgs) -> Result<()> {
     // Get the existing model by name or ID
     let existing_model = ctx
         .app
@@ -125,7 +125,7 @@ pub async fn execute(ctx: &CliContext, args: UpdateArgs) -> Result<()> {
 }
 
 /// Parse metadata updates from command line arguments.
-pub fn parse_metadata_updates(metadata_args: &[String]) -> Result<HashMap<String, String>> {
+pub(crate) fn parse_metadata_updates(metadata_args: &[String]) -> Result<HashMap<String, String>> {
     let mut metadata = HashMap::new();
 
     for arg in metadata_args {
@@ -143,7 +143,7 @@ pub fn parse_metadata_updates(metadata_args: &[String]) -> Result<HashMap<String
 }
 
 /// Parse metadata keys to remove.
-pub fn parse_metadata_removals(remove_arg: &Option<String>) -> Result<Vec<String>> {
+pub(crate) fn parse_metadata_removals(remove_arg: &Option<String>) -> Result<Vec<String>> {
     match remove_arg {
         Some(keys_str) => Ok(keys_str.split(',').map(|s| s.trim().to_string()).collect()),
         None => Ok(Vec::new()),
@@ -151,7 +151,7 @@ pub fn parse_metadata_removals(remove_arg: &Option<String>) -> Result<Vec<String
 }
 
 /// Create updated model with new values.
-pub fn create_updated_model(
+pub(crate) fn create_updated_model(
     existing: &Model,
     args: &UpdateArgs,
     metadata_updates: &HashMap<String, String>,

--- a/crates/gglib-cli/src/handlers/model/verification.rs
+++ b/crates/gglib-cli/src/handlers/model/verification.rs
@@ -13,7 +13,11 @@ use crate::bootstrap::CliContext;
 ///
 /// Verifies model integrity by computing SHA256 hashes and comparing against
 /// stored OIDs from HuggingFace.
-pub(crate) async fn execute_verify(ctx: &CliContext, identifier: &str, verbose: bool) -> Result<()> {
+pub(crate) async fn execute_verify(
+    ctx: &CliContext,
+    identifier: &str,
+    verbose: bool,
+) -> Result<()> {
     // Get verification service
     let verification = ctx
         .app

--- a/crates/gglib-cli/src/handlers/model/verification.rs
+++ b/crates/gglib-cli/src/handlers/model/verification.rs
@@ -13,7 +13,7 @@ use crate::bootstrap::CliContext;
 ///
 /// Verifies model integrity by computing SHA256 hashes and comparing against
 /// stored OIDs from HuggingFace.
-pub async fn execute_verify(ctx: &CliContext, identifier: &str, verbose: bool) -> Result<()> {
+pub(crate) async fn execute_verify(ctx: &CliContext, identifier: &str, verbose: bool) -> Result<()> {
     // Get verification service
     let verification = ctx
         .app
@@ -146,7 +146,7 @@ pub async fn execute_verify(ctx: &CliContext, identifier: &str, verbose: bool) -
 /// Execute the repair command.
 ///
 /// Repairs a corrupt model by deleting failed shards and re-downloading them.
-pub async fn execute_repair(
+pub(crate) async fn execute_repair(
     ctx: &CliContext,
     identifier: &str,
     shards: Option<String>,

--- a/crates/gglib-cli/src/handlers/proxy_cache_clear.rs
+++ b/crates/gglib-cli/src/handlers/proxy_cache_clear.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result};
 
 /// Clear KV cache via the proxy's `/v1/proxy/cache/clear` endpoint.
-pub async fn execute(
+pub(crate) async fn execute(
     host: &str,
     port: u16,
     session_id: Option<&str>,

--- a/crates/gglib-cli/src/handlers/proxy_dashboard/mod.rs
+++ b/crates/gglib-cli/src/handlers/proxy_dashboard/mod.rs
@@ -112,7 +112,7 @@ impl Drop for TerminalGuard {
 /// Connects to `http://{host}:{port}/v1/proxy/status/stream`, prints the
 /// hydration snapshot immediately, then redraws in place on every subsequent
 /// tick until `Ctrl+C` is pressed or the connection is closed by the server.
-pub async fn execute(host: String, port: u16, api_key: Option<&str>) -> Result<()> {
+pub(crate) async fn execute(host: String, port: u16, api_key: Option<&str>) -> Result<()> {
     let url = format!("http://{host}:{port}/v1/proxy/status/stream");
 
     let mut request = reqwest::Client::new().get(&url);

--- a/crates/gglib-cli/src/handlers/up/mod.rs
+++ b/crates/gglib-cli/src/handlers/up/mod.rs
@@ -26,7 +26,7 @@ const LABEL_WIDTH: usize = 8;
 
 /// Parsed `gglib up` flags.
 #[derive(Debug, Clone)]
-pub struct UpArgs {
+pub(crate) struct UpArgs {
     /// Proceed with the model download without asking.
     pub yes: bool,
     /// Load this model rather than the recommended (or most recent) one.
@@ -39,7 +39,7 @@ pub struct UpArgs {
 ///
 /// Blocks until Ctrl-C, like `gglib proxy` — the endpoint it just built is the
 /// point, so the command stays in the foreground serving it.
-pub async fn execute(ctx: &CliContext, args: UpArgs) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, args: UpArgs) -> Result<()> {
     println!();
     println!(
         "  {}gglib up{} \u{2014} from nothing to a working endpoint",

--- a/crates/gglib-cli/src/handlers/web.rs
+++ b/crates/gglib-cli/src/handlers/web.rs
@@ -12,7 +12,7 @@ use crate::daemon_client;
 use crate::presentation::style;
 
 /// Execute the `web` command.
-pub async fn execute(share_lan: bool) -> Result<()> {
+pub(crate) async fn execute(share_lan: bool) -> Result<()> {
     if share_lan {
         // Foreground, eyes-open LAN mode — identical to `daemon run --share-lan`.
         return super::daemon::run(true, Vec::new()).await;

--- a/crates/gglib-cli/src/lib.rs
+++ b/crates/gglib-cli/src/lib.rs
@@ -27,21 +27,26 @@ use gglib_axum as _;
 // handlers/proxy_dashboard.rs
 use gglib_proxy as _;
 
-pub mod benchmark_commands;
-pub mod bootstrap;
-pub mod commands;
-pub mod config_commands;
-pub mod daemon_client;
-pub mod dispatch;
-pub mod error;
-pub mod handlers;
-pub mod llama_commands;
-pub mod mcp_commands;
-pub mod model_commands;
-pub mod parser;
-pub mod presentation;
-pub mod shared_args;
-pub mod utils;
+// Nothing in the workspace depends on this crate: its only outside consumers
+// are its own `gglib` binary and its own `tests/`, and between them they need
+// the seven types re-exported below and nothing else. So the module tree is
+// crate-internal and the re-export list *is* the public API — which is what
+// lets `unreachable_pub` and then `dead_code` see inside `handlers/`.
+pub(crate) mod benchmark_commands;
+pub(crate) mod bootstrap;
+pub(crate) mod commands;
+pub(crate) mod config_commands;
+pub(crate) mod daemon_client;
+pub(crate) mod dispatch;
+pub(crate) mod error;
+pub(crate) mod handlers;
+pub(crate) mod llama_commands;
+pub(crate) mod mcp_commands;
+pub(crate) mod model_commands;
+pub(crate) mod parser;
+pub(crate) mod presentation;
+pub(crate) mod shared_args;
+pub(crate) mod utils;
 
 // Re-export primary types for convenient access
 pub use bootstrap::{CliConfig, CliContext, bootstrap};
@@ -50,4 +55,5 @@ pub use config_commands::{ConfigCommand, ModelsDirCommand, SettingsCommand};
 pub use dispatch::dispatch;
 pub use error::CliError;
 pub use llama_commands::LlamaCommand;
+pub use model_commands::ModelCommand;
 pub use parser::Cli;

--- a/crates/gglib-cli/src/lib.rs
+++ b/crates/gglib-cli/src/lib.rs
@@ -29,7 +29,7 @@ use gglib_proxy as _;
 
 // Nothing in the workspace depends on this crate: its only outside consumers
 // are its own `gglib` binary and its own `tests/`, and between them they need
-// the seven types re-exported below and nothing else. So the module tree is
+// the twelve names re-exported below and nothing else. So the module tree is
 // crate-internal and the re-export list *is* the public API — which is what
 // lets `unreachable_pub` and then `dead_code` see inside `handlers/`.
 pub(crate) mod benchmark_commands;

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -300,8 +300,11 @@ pub enum ModelCommand {
         /// mirroring how the GUI handles authentication.
         #[arg(long)]
         token: Option<String>,
-        /// Skip confirmation prompt
-        #[arg(short, long)]
+        /// Accepted and ignored: this path has no prompt to skip, unlike
+        /// `model remove` and `model update`.
+        // TODO: retire with the other inert flags. Hidden rather than deleted
+        // so invocations that pass it today keep working.
+        #[arg(short, long, hide = true)]
         force: bool,
     },
 

--- a/crates/gglib-cli/src/presentation/README.md
+++ b/crates/gglib-cli/src/presentation/README.md
@@ -54,15 +54,14 @@ Formats model information for terminal output.
 
 **Key Functions:**
 - `display_model_summary()` - Renders model details with metadata
-- `DisplayStyle` enum - Controls verbosity (compact, detailed)
-- `ModelSummaryOpts` - Configuration for display options
+- `ModelSummaryOpts` - Which fields to include, built by `with_title()` or `for_removal()`
 
 **Example:**
 ```rust,ignore
-use gglib_cli::presentation::model_display::{display_model_summary, DisplayStyle};
+use crate::presentation::model_display::{display_model_summary, ModelSummaryOpts};
 
 let model = /* ... */;
-display_model_summary(&model, DisplayStyle::Detailed)?;
+display_model_summary(&model, ModelSummaryOpts::with_title("Model created:"));
 ```
 
 **Output:**
@@ -82,23 +81,19 @@ Context Length: 4096
 Provides table formatting utilities and helper functions.
 
 **Key Functions:**
-- `format_optional(value: Option<T>)` - Formats optional values as "N/A" or actual value
+- `format_relative_time(datetime_str: &str)` - Renders a SQLite timestamp as "5 min ago"
 - `truncate_string(s: &str, max_len: usize)` - Safely truncates with ellipsis
-- `print_separator(char: char, width: usize)` - Prints horizontal separators
+- `print_separator(width: usize)` - Prints a horizontal separator
 
 **Example:**
 ```rust,ignore
-use gglib_cli::presentation::tables::{format_optional, print_separator};
+use crate::presentation::tables::{print_separator, truncate_string};
 
-// Optional value formatting
-let name = Some("model.gguf");
-println!("Name: {}", format_optional(name)); // "Name: model.gguf"
-
-let missing = None::<String>;
-println!("Tags: {}", format_optional(missing)); // "Tags: N/A"
+// Column-safe truncation
+println!("Name: {}", truncate_string("a-very-long-model-name.gguf", 12));
 
 // Separators
-print_separator('=', 80);
+print_separator(80);
 // ================================================================================
 ```
 
@@ -108,8 +103,8 @@ Most commands use a consistent table pattern:
 
 ```rust,ignore
 // Header
-println!("{:<15} {:<20} {:<10}", "ID", "Name", "Size");
-print_separator('-', 45);
+println!("{:<15} {:<20} {:<10}", "ID", "Name", "Added");
+print_separator(45);
 
 // Rows
 for model in models {
@@ -117,7 +112,7 @@ for model in models {
         "{:<15} {:<20} {:<10}",
         model.id,
         truncate_string(&model.name, 20),
-        format_optional(model.size_gb)
+        format_relative_time(&model.added_at)
     );
 }
 ```
@@ -178,15 +173,14 @@ Tests focus on:
 
 ```rust,ignore
 #[test]
-fn test_format_optional() {
-    assert_eq!(format_optional(Some(42)), "42");
-    assert_eq!(format_optional(None::<i32>), "N/A");
+fn relative_time_bad_parse_returns_raw() {
+    assert_eq!(format_relative_time("not-a-date"), "not-a-date");
 }
 
 #[test]
-fn test_truncate_string() {
-    let long = "This is a very long string";
-    assert_eq!(truncate_string(long, 10), "This is...");
+fn truncate_long_string_gets_ellipsis() {
+    // max_len=5: 4 chars of content + ellipsis = 5 chars total
+    assert_eq!(truncate_string("hello world", 5), "hell\u{2026}");
 }
 ```
 

--- a/crates/gglib-cli/src/presentation/explain_display.rs
+++ b/crates/gglib-cli/src/presentation/explain_display.rs
@@ -69,7 +69,7 @@ const MARK_UNKNOWN: char = '?';
 /// The wording matches `inspect_display`'s, so the two commands describe the
 /// same stored fact the same way.
 #[derive(Debug, Clone, Copy)]
-pub struct ExplainContext<'a> {
+pub(crate) struct ExplainContext<'a> {
     /// The profile that was selected, if any.
     pub profile: Option<&'a str>,
     /// Whether the model carries the `reasoning` tag, which selects the floor.
@@ -99,7 +99,7 @@ pub struct ExplainContext<'a> {
 }
 
 /// Print the resolved parameters and their provenance.
-pub fn print_explanation(
+pub(crate) fn print_explanation(
     model_name: &str,
     model_id: i64,
     resolved: &InferenceConfig,
@@ -129,7 +129,7 @@ pub fn print_explanation(
 /// Split from the printing so it can be asserted on directly — this is the
 /// part with the logic in it.
 #[must_use]
-pub fn explanation_lines(
+pub(crate) fn explanation_lines(
     resolved: &InferenceConfig,
     sources: &FieldSources,
     ctx: ExplainContext<'_>,

--- a/crates/gglib-cli/src/presentation/inspect_display.rs
+++ b/crates/gglib-cli/src/presentation/inspect_display.rs
@@ -17,7 +17,7 @@ const SEP_WIDTH: usize = 60;
 /// The `show_metadata` flag gates the raw GGUF key-value section.  Pass
 /// `true` only when the user supplies `--metadata` — the dictionary can be
 /// several hundred lines for large models.
-pub fn print_model_detail(dto: &ModelDetailDto, show_metadata: bool) {
+pub(crate) fn print_model_detail(dto: &ModelDetailDto, show_metadata: bool) {
     // ── Overview ──────────────────────────────────────────────────────────────
     print_separator(SEP_WIDTH);
     println!("  Model: {}", dto.name);

--- a/crates/gglib-cli/src/presentation/mod.rs
+++ b/crates/gglib-cli/src/presentation/mod.rs
@@ -10,12 +10,12 @@
 //! - Keep this module format-only: no domain transforms
 //! - Domain transforms belong in core services or CLI-local view-model helpers
 
-pub mod explain_display;
-pub mod inspect_display;
-pub mod model_display;
-pub mod style;
-pub mod tables;
+pub(crate) mod explain_display;
+pub(crate) mod inspect_display;
+pub(crate) mod model_display;
+pub(crate) mod style;
+pub(crate) mod tables;
 
 // Re-export commonly used items
-pub use model_display::{DisplayStyle, ModelSummaryOpts, display_model_summary};
-pub use tables::{format_optional, format_relative_time, print_separator, truncate_string};
+pub(crate) use model_display::{ModelSummaryOpts, display_model_summary};
+pub(crate) use tables::{format_relative_time, print_separator, truncate_string};

--- a/crates/gglib-cli/src/presentation/model_display.rs
+++ b/crates/gglib-cli/src/presentation/model_display.rs
@@ -2,23 +2,11 @@
 
 use gglib_core::Model;
 
-/// Style options for model display.
-#[derive(Debug, Clone, Copy, Default)]
-pub enum DisplayStyle {
-    /// Full details with all available fields.
-    #[default]
-    Default,
-    /// Compact single-line format.
-    Compact,
-}
-
 /// Options for displaying a model summary.
 #[derive(Debug, Clone, Default)]
-pub struct ModelSummaryOpts<'a> {
+pub(crate) struct ModelSummaryOpts<'a> {
     /// Optional title to display before the model details.
     pub title: Option<&'a str>,
-    /// Display style to use.
-    pub style: DisplayStyle,
     /// Whether to include the model ID.
     pub show_id: bool,
     /// Whether to include the file path.
@@ -28,8 +16,8 @@ pub struct ModelSummaryOpts<'a> {
 }
 
 impl<'a> ModelSummaryOpts<'a> {
-    /// Create options with a title and default style.
-    pub fn with_title(title: &'a str) -> Self {
+    /// Create options with a title.
+    pub(crate) fn with_title(title: &'a str) -> Self {
         Self {
             title: Some(title),
             show_file_path: true,
@@ -38,13 +26,12 @@ impl<'a> ModelSummaryOpts<'a> {
     }
 
     /// Create options for removal confirmation (includes ID and timestamp).
-    pub fn for_removal() -> Self {
+    pub(crate) fn for_removal() -> Self {
         Self {
             title: Some("Model to remove:"),
             show_id: true,
             show_file_path: true,
             show_added_at: true,
-            ..Default::default()
         }
     }
 }
@@ -54,7 +41,7 @@ impl<'a> ModelSummaryOpts<'a> {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use gglib_cli::presentation::{display_model_summary, ModelSummaryOpts};
+/// use crate::presentation::{display_model_summary, ModelSummaryOpts};
 ///
 /// // Simple usage with title
 /// display_model_summary(&model, ModelSummaryOpts::with_title("Model created:"));
@@ -62,7 +49,7 @@ impl<'a> ModelSummaryOpts<'a> {
 /// // For removal confirmation
 /// display_model_summary(&model, ModelSummaryOpts::for_removal());
 /// ```
-pub fn display_model_summary(model: &Model, opts: ModelSummaryOpts) {
+pub(crate) fn display_model_summary(model: &Model, opts: ModelSummaryOpts) {
     if let Some(title) = opts.title {
         println!("{title}");
     }

--- a/crates/gglib-cli/src/presentation/style.rs
+++ b/crates/gglib-cli/src/presentation/style.rs
@@ -10,30 +10,30 @@ use indicatif::{ProgressBar, ProgressStyle};
 use termimad::{ListItemsIndentationMode, MadSkin, StyledChar};
 
 /// Green — success states, installed dependencies, GPU detected.
-pub const SUCCESS: &str = "\x1b[32m";
+pub(crate) const SUCCESS: &str = "\x1b[32m";
 /// Red — error states, missing required dependencies. Reserved for actual
 /// failure; an idle/stopped state is not a failure — use MUTED.
-pub const DANGER: &str = "\x1b[31m";
+pub(crate) const DANGER: &str = "\x1b[31m";
 /// Yellow — warnings, optional missing items.
-pub const WARNING: &str = "\x1b[33m";
+pub(crate) const WARNING: &str = "\x1b[33m";
 /// Blue — informational labels, commands, headings.
-pub const INFO: &str = "\x1b[34m";
+pub(crate) const INFO: &str = "\x1b[34m";
 /// Grey — idle/stopped states. Mirrors --color-offline in the GUI's
 /// variables.css. Before this constant existed, idle states had nowhere
 /// to go but DANGER, which is why a stopped proxy used to print red.
-pub const MUTED: &str = "\x1b[90m";
+pub(crate) const MUTED: &str = "\x1b[90m";
 /// Bold — emphasis, table headers.
-pub const BOLD: &str = "\x1b[1m";
+pub(crate) const BOLD: &str = "\x1b[1m";
 /// Dim — reduced intensity (thinking blocks).
-pub const DIM: &str = "\x1b[2m";
+pub(crate) const DIM: &str = "\x1b[2m";
 /// Resets all attributes.
-pub const RESET: &str = "\x1b[0m";
+pub(crate) const RESET: &str = "\x1b[0m";
 
 /// Build a [`MadSkin`] tuned for dark terminal backgrounds.
 ///
 /// Headings are bold cyan, inline code is yellow, and code blocks use green
 /// foreground with a 2-column left margin.
-pub fn get_markdown_skin() -> MadSkin {
+pub(crate) fn get_markdown_skin() -> MadSkin {
     let mut skin = MadSkin::default_dark();
     skin.set_headers_fg(Color::Cyan);
     for h in &mut skin.headers {
@@ -72,7 +72,7 @@ pub fn get_markdown_skin() -> MadSkin {
 ///
 /// All output goes to **stderr** so that stdout remains clean for piped
 /// command output.
-pub fn print_info_banner(label: &str, emoji: &str) {
+pub(crate) fn print_info_banner(label: &str, emoji: &str) {
     // "  ╭─ {emoji} {label} " = fixed prefix; fill the rest with ─ up to
     // column 42 (banner width), then close with ╮.
     let prefix = format!("  \u{256d}\u{2500} {emoji} {label} ");
@@ -87,7 +87,7 @@ pub fn print_info_banner(label: &str, emoji: &str) {
 /// ```text
 ///   ╰───────────────────────────────────────╯
 /// ```
-pub fn print_banner_close() {
+pub(crate) fn print_banner_close() {
     // 39 = banner width (42) minus the 3-char "  ╰" prefix.
     let fill = "\u{2500}".repeat(39);
     eprintln!("{RESET}\n{INFO}  \u{2570}{fill}\u{256f}{RESET}");
@@ -96,7 +96,7 @@ pub fn print_banner_close() {
 /// Print the thinking-block banner and enter DIM mode on stderr.
 ///
 /// Equivalent to [`print_info_banner`] with label "Thinking" and 💭 emoji.
-pub fn print_thinking_banner() {
+pub(crate) fn print_thinking_banner() {
     print_info_banner("Thinking", "\u{1f4ad}");
 }
 
@@ -108,7 +108,7 @@ pub fn print_thinking_banner() {
 ///
 /// Used by the Rich-mode rendering path to show progress while tokens are
 /// being received.
-pub fn make_spinner() -> ProgressBar {
+pub(crate) fn make_spinner() -> ProgressBar {
     let sp = ProgressBar::new_spinner();
     sp.set_style(
         ProgressStyle::default_spinner()

--- a/crates/gglib-cli/src/presentation/tables.rs
+++ b/crates/gglib-cli/src/presentation/tables.rs
@@ -8,7 +8,7 @@ use chrono::{NaiveDateTime, Utc};
 /// or the original date if more than 30 days old.
 ///
 /// Falls back to the raw string on parse failure.
-pub fn format_relative_time(datetime_str: &str) -> String {
+pub(crate) fn format_relative_time(datetime_str: &str) -> String {
     let Ok(dt) = NaiveDateTime::parse_from_str(datetime_str, "%Y-%m-%d %H:%M:%S") else {
         return datetime_str.to_string();
     };
@@ -54,13 +54,17 @@ pub fn format_relative_time(datetime_str: &str) -> String {
 ///
 /// # Examples
 ///
-/// ```rust
-/// use gglib_cli::presentation::truncate_string;
+/// Illustrative rather than executable: this function is crate-internal, so a
+/// doctest (which compiles as its own crate) cannot name it. The two cases
+/// below are asserted for real in this module's tests.
+///
+/// ```rust,ignore
+/// use crate::presentation::truncate_string;
 ///
 /// assert_eq!(truncate_string("Hello", 10), "Hello");
 /// assert_eq!(truncate_string("Hello World", 8), "Hello W\u{2026}");
 /// ```
-pub fn truncate_string(s: &str, max_len: usize) -> String {
+pub(crate) fn truncate_string(s: &str, max_len: usize) -> String {
     if s.chars().count() <= max_len {
         // String fits — return as-is (no allocation needed beyond this clone).
         s.to_string()
@@ -73,16 +77,8 @@ pub fn truncate_string(s: &str, max_len: usize) -> String {
 }
 
 /// Print a horizontal separator line.
-pub fn print_separator(width: usize) {
+pub(crate) fn print_separator(width: usize) {
     println!("{}", "-".repeat(width));
-}
-
-/// Format an optional value for table display, returning a default if None.
-pub fn format_optional<T: std::fmt::Display>(value: &Option<T>, default: &str) -> String {
-    match value {
-        Some(v) => v.to_string(),
-        None => default.to_string(),
-    }
 }
 
 // =============================================================================

--- a/crates/gglib-cli/src/presentation/tables.rs
+++ b/crates/gglib-cli/src/presentation/tables.rs
@@ -54,15 +54,15 @@ pub(crate) fn format_relative_time(datetime_str: &str) -> String {
 ///
 /// # Examples
 ///
-/// Illustrative rather than executable: this function is crate-internal, so a
-/// doctest (which compiles as its own crate) cannot name it. The two cases
-/// below are asserted for real in this module's tests.
+/// Illustrative rather than executable: this function is crate-internal, and a
+/// doctest compiles as its own crate, so no import path can name it. Fenced as
+/// `text` rather than `ignore` so rustdoc renders it as prose instead of an
+/// untested example. The two cases below are asserted for real in this
+/// module's tests.
 ///
-/// ```rust,ignore
-/// use crate::presentation::truncate_string;
-///
-/// assert_eq!(truncate_string("Hello", 10), "Hello");
-/// assert_eq!(truncate_string("Hello World", 8), "Hello W\u{2026}");
+/// ```text
+/// truncate_string("Hello", 10)       == "Hello"
+/// truncate_string("Hello World", 8)  == "Hello W…"
 /// ```
 pub(crate) fn truncate_string(s: &str, max_len: usize) -> String {
     if s.chars().count() <= max_len {

--- a/crates/gglib-cli/src/shared_args.rs
+++ b/crates/gglib-cli/src/shared_args.rs
@@ -256,13 +256,13 @@ pub struct ServeOptions {
 /// from CLI argument groups.
 ///
 /// A single conversion point used by both `chat` and `q` handlers (DRY).
-pub struct ConversationSettingsBuilder {
+pub(crate) struct ConversationSettingsBuilder {
     settings: gglib_core::domain::chat::ConversationSettings,
 }
 
 impl ConversationSettingsBuilder {
     /// Start building settings from sampling and context args.
-    pub fn new(sampling: &SamplingArgs, context: &ContextArgs) -> Self {
+    pub(crate) fn new(sampling: &SamplingArgs, context: &ContextArgs) -> Self {
         Self {
             settings: gglib_core::domain::chat::ConversationSettings {
                 temperature: sampling.temperature,
@@ -278,13 +278,13 @@ impl ConversationSettingsBuilder {
     }
 
     /// Set the model name used for this session.
-    pub fn model_name(mut self, name: impl Into<String>) -> Self {
+    pub(crate) fn model_name(mut self, name: impl Into<String>) -> Self {
         self.settings.model_name = Some(name.into());
         self
     }
 
     /// Set tool-related configuration.
-    pub fn tools(mut self, tools: Vec<String>, no_tools: bool) -> Self {
+    pub(crate) fn tools(mut self, tools: Vec<String>, no_tools: bool) -> Self {
         self.settings.tools = tools;
         if no_tools {
             self.settings.no_tools = Some(true);
@@ -293,7 +293,7 @@ impl ConversationSettingsBuilder {
     }
 
     /// Set agent loop parameters.
-    pub fn agent_params(
+    pub(crate) fn agent_params(
         mut self,
         max_iterations: Option<usize>,
         tool_timeout_ms: Option<u64>,
@@ -306,7 +306,7 @@ impl ConversationSettingsBuilder {
     }
 
     /// Consume the builder and return the finished settings.
-    pub fn build(self) -> gglib_core::domain::chat::ConversationSettings {
+    pub(crate) fn build(self) -> gglib_core::domain::chat::ConversationSettings {
         self.settings
     }
 }

--- a/crates/gglib-cli/src/utils/README.md
+++ b/crates/gglib-cli/src/utils/README.md
@@ -47,7 +47,7 @@ Provides functions for prompting users and reading responses from the terminal.
 Displays a yes/no prompt and returns the user's choice.
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 if input::confirm("Delete this model?")? {
     // User said yes
@@ -73,7 +73,7 @@ Deleting model...
 Displays a text prompt and returns the user's input.
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 let name = input::prompt("Enter model name:")?;
 println!("You entered: {}", name);
@@ -94,7 +94,7 @@ You entered: Llama 2 7B Chat
 Prompts with a default value shown in brackets.
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 let port = input::prompt_with_default("Server port", "8080")?;
 // If user presses Enter without typing, returns "8080"
@@ -110,7 +110,7 @@ Using default: 8080
 Presents a numbered list and returns the selected index.
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 let models = vec!["Llama 2 7B", "Mistral 7B", "GPT-J 6B"];
 let choice = input::select_from_list("Select a model:", &models)?;
@@ -133,7 +133,7 @@ You selected: Mistral 7B
 Always confirm before destructive operations:
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 pub async fn execute_remove(ctx: &CliContext, id: i64, force: bool) -> Result<()> {
     if !force && !input::confirm("Remove model? This cannot be undone.")? {
@@ -151,7 +151,7 @@ pub async fn execute_remove(ctx: &CliContext, id: i64, force: bool) -> Result<()
 Use defaults for common settings:
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 let host = input::prompt_with_default("Server host", "127.0.0.1")?;
 let port = input::prompt_with_default("Server port", "8080")?;
@@ -163,7 +163,7 @@ let port_num: u16 = port.parse()
 Present choices when multiple options exist:
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 let quantizations = vec!["Q4_K_M", "Q5_K_M", "Q8_0"];
 if quantizations.len() > 1 {
@@ -184,7 +184,7 @@ All input functions return `anyhow::Result` and handle:
 - **Invalid input** - Out of range selections, malformed input
 
 ```rust,ignore
-use gglib_cli::utils::input;
+use crate::utils::input;
 
 match input::confirm("Continue?") {
     Ok(true) => { /* proceed */ },

--- a/crates/gglib-cli/src/utils/input.rs
+++ b/crates/gglib-cli/src/utils/input.rs
@@ -22,7 +22,7 @@ use std::io;
 /// # Errors
 ///
 /// Returns an error if reading from stdin fails.
-pub fn prompt_string(prompt: &str) -> Result<String> {
+pub(crate) fn prompt_string(prompt: &str) -> Result<String> {
     println!("{prompt}: ");
 
     let mut input: String = String::new();
@@ -46,7 +46,7 @@ pub fn prompt_string(prompt: &str) -> Result<String> {
 /// # Returns
 ///
 /// * `Result<String>` - The user's input or default value
-pub fn prompt_string_with_default(prompt: &str, default: Option<&str>) -> Result<String> {
+pub(crate) fn prompt_string_with_default(prompt: &str, default: Option<&str>) -> Result<String> {
     if let Some(default_val) = default {
         println!("{prompt} [{default_val}]: ");
     } else {
@@ -86,7 +86,7 @@ pub fn prompt_string_with_default(prompt: &str, default: Option<&str>) -> Result
 /// # Errors
 ///
 /// Returns an error if reading from stdin fails.
-pub fn prompt_confirmation(prompt: &str) -> Result<bool> {
+pub(crate) fn prompt_confirmation(prompt: &str) -> Result<bool> {
     loop {
         let input = prompt_string(&format!("{prompt} (y/N)"))?;
         match input.to_lowercase().as_str() {
@@ -115,7 +115,7 @@ pub fn prompt_confirmation(prompt: &str) -> Result<bool> {
 /// # Errors
 ///
 /// Returns an error if reading from stdin fails.
-pub fn prompt_confirmation_default_yes(prompt: &str) -> Result<bool> {
+pub(crate) fn prompt_confirmation_default_yes(prompt: &str) -> Result<bool> {
     loop {
         let input = prompt_string(&format!("{prompt} (Y/n)"))?;
         match input.to_lowercase().as_str() {
@@ -141,7 +141,7 @@ pub fn prompt_confirmation_default_yes(prompt: &str) -> Result<bool> {
 /// # Returns
 ///
 /// * `Result<f64>` - The user's input as a positive float
-pub fn prompt_float(prompt: &str) -> Result<f64> {
+pub(crate) fn prompt_float(prompt: &str) -> Result<f64> {
     loop {
         let input: String = prompt_string(prompt)?;
 
@@ -172,7 +172,7 @@ pub fn prompt_float(prompt: &str) -> Result<f64> {
 /// # Returns
 ///
 /// * `Result<f64>` - The user's input or default value as a positive float
-pub fn prompt_float_with_default(prompt: &str, default: Option<f64>) -> Result<f64> {
+pub(crate) fn prompt_float_with_default(prompt: &str, default: Option<f64>) -> Result<f64> {
     loop {
         let input: String = if let Some(default_val) = default {
             prompt_string(&format!("{prompt} [{default_val:.1}]"))?

--- a/crates/gglib-cli/src/utils/mod.rs
+++ b/crates/gglib-cli/src/utils/mod.rs
@@ -2,4 +2,4 @@
 
 //! CLI utility modules.
 
-pub mod input;
+pub(crate) mod input;

--- a/crates/gglib-cli/tests/cli_parity.rs
+++ b/crates/gglib-cli/tests/cli_parity.rs
@@ -257,7 +257,7 @@ fn omitted_flags_express_no_opinion() {
 /// positional.
 #[test]
 fn model_explain_parses_the_identifier_and_profile() {
-    use gglib_cli::model_commands::ModelCommand;
+    use gglib_cli::ModelCommand;
 
     let cli = Cli::try_parse_from(["gglib", "model", "explain", "3", "--profile", "coding"])
         .expect("model explain should parse");
@@ -280,7 +280,7 @@ fn model_explain_parses_the_identifier_and_profile() {
 /// must stay `None` rather than defaulting to some named profile.
 #[test]
 fn model_explain_leaves_the_profile_unset_when_omitted() {
-    use gglib_cli::model_commands::ModelCommand;
+    use gglib_cli::ModelCommand;
 
     let cli = Cli::try_parse_from(["gglib", "model", "explain", "Qwen3-30B"])
         .expect("bare model explain should parse");

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -24,7 +24,7 @@ crates/gglib-axum/src/handlers/config/setup.rs 306
 crates/gglib-axum/src/routes.rs 472
 crates/gglib-axum/tests/integration_routes.rs 1280
 crates/gglib-cli/src/commands.rs 413
-crates/gglib-cli/src/daemon_client/mod.rs 366
+crates/gglib-cli/src/daemon_client/mod.rs 362
 crates/gglib-cli/src/handlers/benchmark.rs 1499
 crates/gglib-cli/src/handlers/config/llama_install.rs 341
 crates/gglib-cli/src/handlers/config/settings/profiles.rs 508
@@ -34,7 +34,7 @@ crates/gglib-cli/src/handlers/model/download/interactive.rs 426
 crates/gglib-cli/src/handlers/model/update.rs 712
 crates/gglib-cli/src/handlers/proxy_dashboard/render_tests.rs 624
 crates/gglib-cli/src/handlers/proxy_dashboard/render.rs 440
-crates/gglib-cli/src/model_commands.rs 437
+crates/gglib-cli/src/model_commands.rs 440
 crates/gglib-cli/src/presentation/explain_display.rs 735
 crates/gglib-cli/src/presentation/inspect_display.rs 405
 crates/gglib-cli/src/shared_args.rs 312

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,3 +52,10 @@ tokio = { workspace = true, features = ["macros", "test-util"] }
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
 default = []
+
+# This crate had no `[lints]` section at all, so it inherited nothing and
+# enforced nothing. `gglib-app` is a single binary target with no lib and no
+# workspace consumer, which makes every `pub` in it reachable by nobody — the
+# state this PR just cleared. Denying the lint keeps it cleared.
+[lints.rust]
+unreachable_pub = "deny"

--- a/src-tauri/src/app/events.rs
+++ b/src-tauri/src/app/events.rs
@@ -3,4 +3,4 @@
 //! This module re-exports event helpers from gglib-tauri for use in the app crate.
 
 // Re-export from gglib-tauri to maintain existing import paths
-pub use gglib_tauri::events::{emit_or_log, names};
+pub(crate) use gglib_tauri::events::{emit_or_log, names};

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("README.md")]
-pub mod events;
-pub mod state;
+pub(crate) mod events;
+pub(crate) mod state;
 
-pub use state::AppState;
+pub(crate) use state::AppState;

--- a/src-tauri/src/app/state.rs
+++ b/src-tauri/src/app/state.rs
@@ -17,7 +17,7 @@ use crate::tray::Tray;
 ///
 /// This struct is managed by Tauri and accessible to all commands
 /// via `tauri::State<'_, AppState>`.
-pub struct AppState {
+pub(crate) struct AppState {
     /// The connection to the gglib daemon (external or hosted in-process).
     pub daemon: Arc<Daemon>,
     /// Menu state for dynamic updates (macOS application menu only)
@@ -41,7 +41,7 @@ pub struct AppState {
 
 impl AppState {
     /// Create a new application state around a connected daemon.
-    pub fn new(daemon: Arc<Daemon>) -> Self {
+    pub(crate) fn new(daemon: Arc<Daemon>) -> Self {
         Self {
             daemon,
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -22,7 +22,7 @@ use crate::{dock, tray};
 /// `std::env::args`. macOS's `LaunchAgent` writes it into the plist's
 /// `ProgramArguments` alongside the executable path, and the equivalent happens
 /// on Windows and Linux.
-pub const LOGIN_ITEM_FLAG: &str = "--from-autostart";
+pub(crate) const LOGIN_ITEM_FLAG: &str = "--from-autostart";
 
 /// Whether this process was started by the OS login item rather than by hand.
 fn launched_by_login_item() -> bool {
@@ -40,7 +40,7 @@ fn launched_by_login_item() -> bool {
 /// app with no window, no Dock icon and nothing to click: unreachable short of
 /// killing it from a terminal. Requiring a tray means the worst outcome is a
 /// window someone did not want, which they can close.
-pub const fn should_start_hidden(
+pub(crate) const fn should_start_hidden(
     launched_by_login_item: bool,
     close_to_tray: Option<bool>,
     tray_available: bool,
@@ -61,7 +61,7 @@ pub const fn should_start_hidden(
 /// immediately before calling this hook, both inside `build()`, and GTK only
 /// completes a queued map once `run()` pumps the event loop. So the window is
 /// still unmapped at this point and hiding it cancels the map outright.
-pub async fn apply_initial_visibility(app: &AppHandle, tray_available: bool) {
+pub(crate) async fn apply_initial_visibility(app: &AppHandle, tray_available: bool) {
     let state = app.state::<AppState>();
 
     let close_to_tray = match state.daemon.settings().await {
@@ -100,7 +100,7 @@ pub async fn apply_initial_visibility(app: &AppHandle, tray_available: bool) {
 /// Runs after the window exists so a slow settings read delays nothing the
 /// user is waiting on. Proxy autostart is deliberately absent: the daemon
 /// honours `proxy_autostart` itself when it starts.
-pub async fn apply(app: &AppHandle) {
+pub(crate) async fn apply(app: &AppHandle) {
     let state = app.state::<AppState>();
 
     let settings = match state.daemon.settings().await {

--- a/src-tauri/src/commands/app_logs.rs
+++ b/src-tauri/src/commands/app_logs.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 /// Matches the LogEntry interface in TypeScript.
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)] // timestamp is required for deserialization but not used in logging
-pub struct FrontendLogEntry {
+pub(crate) struct FrontendLogEntry {
     pub timestamp: String,
     pub level: String,
     pub category: String,
@@ -41,7 +41,7 @@ pub struct FrontendLogEntry {
 /// RUST_LOG=gglib=debug,gglib_frontend=debug
 /// ```
 #[tauri::command]
-pub fn log_from_frontend(entry: FrontendLogEntry) -> Result<(), String> {
+pub(crate) fn log_from_frontend(entry: FrontendLogEntry) -> Result<(), String> {
     let message = &entry.message;
     let category = &entry.category;
 

--- a/src-tauri/src/commands/llama.rs
+++ b/src-tauri/src/commands/llama.rs
@@ -13,14 +13,14 @@ use tauri::AppHandle;
 
 /// Response for check_llama_status command.
 #[derive(serde::Serialize)]
-pub struct LlamaStatus {
+pub(crate) struct LlamaStatus {
     pub installed: bool,
     pub can_download: bool,
 }
 
 /// Progress event for llama installation.
 #[derive(Clone, serde::Serialize)]
-pub struct LlamaInstallEvent {
+pub(crate) struct LlamaInstallEvent {
     pub status: String,
     pub downloaded: u64,
     pub total: u64,
@@ -30,7 +30,7 @@ pub struct LlamaInstallEvent {
 
 /// Check if llama.cpp is installed.
 #[tauri::command]
-pub fn check_llama_status() -> Result<LlamaStatus, String> {
+pub(crate) fn check_llama_status() -> Result<LlamaStatus, String> {
     let installed = check_llama_installed();
     let can_download = matches!(
         check_prebuilt_availability(),
@@ -45,7 +45,7 @@ pub fn check_llama_status() -> Result<LlamaStatus, String> {
 
 /// Install llama.cpp by downloading pre-built binaries.
 #[tauri::command]
-pub async fn install_llama(app: AppHandle) -> Result<String, String> {
+pub(crate) async fn install_llama(app: AppHandle) -> Result<String, String> {
     // Check if pre-built binaries are available
     match check_prebuilt_availability() {
         PrebuiltAvailability::Available { description, .. } => {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,4 @@
 #![doc = include_str!("README.md")]
-pub mod app_logs;
-pub mod llama;
-pub mod util;
+pub(crate) mod app_logs;
+pub(crate) mod llama;
+pub(crate) mod util;

--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -13,7 +13,7 @@ use tauri::AppHandle;
 /// daemon's fixed loopback port, which is unauthenticated — the token field
 /// went with the embedded server, having been an empty string ever since.
 #[derive(Debug, Clone, serde::Serialize)]
-pub struct ApiInfo {
+pub(crate) struct ApiInfo {
     /// Port of the daemon's management API.
     pub port: u16,
 }
@@ -22,7 +22,7 @@ pub struct ApiInfo {
 ///
 /// The frontend calls this once at startup to discover where the API lives.
 #[tauri::command]
-pub fn get_embedded_api_info() -> ApiInfo {
+pub(crate) fn get_embedded_api_info() -> ApiInfo {
     ApiInfo {
         port: gglib_core::DAEMON_PORT,
     }
@@ -32,7 +32,7 @@ pub fn get_embedded_api_info() -> ApiInfo {
 ///
 /// Used by the frontend to open external links (e.g., HuggingFace model pages).
 #[tauri::command]
-pub async fn open_url(url: String) -> Result<(), String> {
+pub(crate) async fn open_url(url: String) -> Result<(), String> {
     open::that(&url).map_err(|e| format!("Failed to open URL: {}", e))
 }
 
@@ -42,7 +42,7 @@ pub async fn open_url(url: String) -> Result<(), String> {
 /// the snapshot already in hand is correct here — nothing about the daemon
 /// changed.
 #[tauri::command]
-pub async fn set_selected_model(
+pub(crate) async fn set_selected_model(
     model_id: Option<i64>,
     app: AppHandle,
     state: tauri::State<'_, AppState>,
@@ -76,7 +76,7 @@ pub async fn set_selected_model(
 /// So: the immediate paint catches the local state, and the poll it just asked
 /// for catches the daemon's, a moment later.
 #[tauri::command]
-pub async fn sync_menu_state(
+pub(crate) async fn sync_menu_state(
     app: AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -6,8 +6,8 @@
 mod snapshot;
 mod watch;
 
-pub use snapshot::DaemonSnapshot;
-pub use watch::{Refresh, spawn as watch};
+pub(crate) use snapshot::DaemonSnapshot;
+pub(crate) use watch::{Refresh, spawn as watch};
 
 use std::time::Duration;
 
@@ -28,7 +28,7 @@ const LAUNCH_WAIT: Duration = Duration::from_secs(15);
 /// into a single "hosted" bool, which could not tell a daemon we started from
 /// one that was already serving somebody else.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Ownership {
+pub(crate) enum Ownership {
     /// Already answering when we probed. Someone else's — a CLI session's, or
     /// an earlier app instance's — so this app does not get to end it.
     Adopted,
@@ -50,13 +50,13 @@ impl Ownership {
     /// session, an earlier instance — and quitting a dashboard is no reason to
     /// take their endpoint away.
     #[must_use]
-    pub const fn ends_with_the_app(self) -> bool {
+    pub(crate) const fn ends_with_the_app(self) -> bool {
         matches!(self, Self::Launched | Self::Hosted)
     }
 }
 
 /// A connected daemon.
-pub struct Daemon {
+pub(crate) struct Daemon {
     /// Shared HTTP client for daemon calls.
     pub client: reqwest::Client,
     /// How this app came by it — see [`Ownership`].
@@ -64,7 +64,7 @@ pub struct Daemon {
 }
 
 /// The daemon's base URL — fixed loopback port by design.
-pub fn base_url() -> String {
+pub(crate) fn base_url() -> String {
     format!("http://127.0.0.1:{DAEMON_PORT}")
 }
 
@@ -102,7 +102,7 @@ impl Daemon {
     /// Every call made through this fails until a daemon answers, which is
     /// exactly what the watcher reports as unreachable.
     #[must_use]
-    pub fn disconnected() -> Self {
+    pub(crate) fn disconnected() -> Self {
         Self {
             client: reqwest::Client::new(),
             ownership: Ownership::Unresolved,
@@ -115,7 +115,7 @@ impl Daemon {
     ///
     /// Fails when the port is held by a foreign program, or when neither an
     /// external launch nor the in-process fallback becomes healthy in time.
-    pub async fn connect_or_launch() -> Result<Self, String> {
+    pub(crate) async fn connect_or_launch() -> Result<Self, String> {
         let client = reqwest::Client::new();
 
         match probe(&client).await {
@@ -177,7 +177,7 @@ impl Daemon {
     /// Fails when one is already running, when the port is held by a foreign
     /// program, when no `gglib` binary can be found, or when the launched
     /// daemon does not become healthy in time.
-    pub async fn restart(&self) -> Result<(), String> {
+    pub(crate) async fn restart(&self) -> Result<(), String> {
         match probe(&self.client).await {
             Probe::Running => return Err("the gglib daemon is already running".to_owned()),
             Probe::Foreign => {
@@ -195,7 +195,7 @@ impl Daemon {
     }
 
     /// GET a JSON value from the daemon.
-    pub async fn get_json(&self, path: &str) -> Result<serde_json::Value, String> {
+    pub(crate) async fn get_json(&self, path: &str) -> Result<serde_json::Value, String> {
         let response = self
             .client
             .get(format!("{}{path}", base_url()))
@@ -207,7 +207,7 @@ impl Daemon {
     }
 
     /// POST to the daemon, returning the JSON response.
-    pub async fn post_json(
+    pub(crate) async fn post_json(
         &self,
         path: &str,
         body: &serde_json::Value,
@@ -233,7 +233,7 @@ impl Daemon {
     }
 
     /// Read the stored settings through the daemon.
-    pub async fn settings(&self) -> Result<AppSettings, String> {
+    pub(crate) async fn settings(&self) -> Result<AppSettings, String> {
         let value = self.get_json("/api/config/settings").await?;
         serde_json::from_value(value).map_err(|e| e.to_string())
     }
@@ -244,7 +244,7 @@ impl Daemon {
     /// teardown — proxy drained, every llama-server stopped gracefully,
     /// downloads cancelled — runs after. Pair with [`Self::wait_for_exit`]
     /// when the caller needs it finished.
-    pub async fn request_shutdown(&self) {
+    pub(crate) async fn request_shutdown(&self) {
         let _ = self
             .client
             .post(format!("{}/api/daemon/shutdown", base_url()))
@@ -254,7 +254,7 @@ impl Daemon {
     }
 
     /// Wait (bounded) for the daemon to stop answering.
-    pub async fn wait_for_exit(&self, budget: Duration) {
+    pub(crate) async fn wait_for_exit(&self, budget: Duration) {
         let deadline = tokio::time::Instant::now() + budget;
         while tokio::time::Instant::now() < deadline {
             if matches!(probe(&self.client).await, Probe::NotRunning) {

--- a/src-tauri/src/daemon/snapshot.rs
+++ b/src-tauri/src/daemon/snapshot.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 /// Linux, so the watcher compares before it paints and does nothing at all when
 /// nothing has changed.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DaemonSnapshot {
+pub(crate) struct DaemonSnapshot {
     /// Whether the daemon answered at all. Everything below is meaningless
     /// when this is false.
     pub reachable: bool,
@@ -41,7 +41,7 @@ impl DaemonSnapshot {
     /// A snapshot that cannot be built is indistinguishable from an
     /// unreachable daemon, and the tray has to show something either way.
     #[must_use]
-    pub fn from_responses(proxy: &Value, servers: &Value) -> Self {
+    pub(crate) fn from_responses(proxy: &Value, servers: &Value) -> Self {
         let proxy_running = proxy
             .get("running")
             .and_then(Value::as_bool)
@@ -72,7 +72,7 @@ impl DaemonSnapshot {
     /// The question a menu bar icon is actually asked. A resident model holds
     /// VRAM whether or not the proxy is listening, so both count.
     #[must_use]
-    pub fn is_active(&self) -> bool {
+    pub(crate) fn is_active(&self) -> bool {
         self.proxy_running || !self.resident.is_empty()
     }
 
@@ -83,7 +83,7 @@ impl DaemonSnapshot {
     /// back to — and a guessed default port would hand out a dead URL, which
     /// is worse than the button doing nothing.
     #[must_use]
-    pub fn endpoint_url(&self) -> Option<String> {
+    pub(crate) fn endpoint_url(&self) -> Option<String> {
         self.proxy_port
             .map(|port| format!("http://127.0.0.1:{port}/v1"))
     }
@@ -99,7 +99,7 @@ impl DaemonSnapshot {
     /// true, so a caller disappearing on macOS still fails the build.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     #[must_use]
-    pub fn serves(&self, model_id: i64) -> bool {
+    pub(crate) fn serves(&self, model_id: i64) -> bool {
         self.resident.binary_search(&model_id).is_ok()
     }
 }

--- a/src-tauri/src/daemon/watch.rs
+++ b/src-tauri/src/daemon/watch.rs
@@ -42,14 +42,14 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// A handle for asking the watcher to poll now rather than on the next tick.
 #[derive(Clone, Default)]
-pub struct Refresh(Arc<Notify>);
+pub(crate) struct Refresh(Arc<Notify>);
 
 impl Refresh {
     /// Wake the watcher immediately.
     ///
     /// Called after this app changes something, so the tray does not sit out
     /// the poll interval showing what the user just stopped doing.
-    pub fn now(&self) {
+    pub(crate) fn now(&self) {
         self.0.notify_one();
     }
 
@@ -67,7 +67,7 @@ impl Refresh {
 /// Polls once immediately so the first paint shows the daemon's real state
 /// rather than the struct defaults — which is what used to leave a launch with
 /// `proxy_autostart` on reading "proxy stopped".
-pub fn spawn(app: &AppHandle) {
+pub(crate) fn spawn(app: &AppHandle) {
     let app = app.clone();
 
     tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/dock.rs
+++ b/src-tauri/src/dock.rs
@@ -26,7 +26,7 @@ use tauri::AppHandle;
 /// Call only once the window is hidden. The policy change is what makes the app
 /// menu bar disappear too, which would be visible as a flicker if a window were
 /// still on screen.
-pub fn hide(app: &AppHandle) {
+pub(crate) fn hide(app: &AppHandle) {
     set_policy(app, Policy::Accessory);
 }
 
@@ -35,7 +35,7 @@ pub fn hide(app: &AppHandle) {
 /// Call *before* showing and focusing the window: an `Accessory` app cannot
 /// become frontmost, so a window shown first would appear behind whatever the
 /// user was using.
-pub fn show(app: &AppHandle) {
+pub(crate) fn show(app: &AppHandle) {
     set_policy(app, Policy::Regular);
 }
 

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -38,7 +38,7 @@ static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 /// prevent the exit: preventing it once is how the cleanup gets to run at all,
 /// but preventing the second one — the exit this module itself requested —
 /// would strand the process.
-pub fn is_shutting_down() -> bool {
+pub(crate) fn is_shutting_down() -> bool {
     SHUTTING_DOWN.load(Ordering::SeqCst)
 }
 
@@ -48,7 +48,7 @@ pub fn is_shutting_down() -> bool {
 /// goes away. Allow any later one: that is [`request_shutdown`]'s own
 /// `exit(0)` coming back around, and preventing it is precisely what left the
 /// app running with a dead embedded API server.
-pub const fn should_prevent_exit(shutting_down: bool) -> bool {
+pub(crate) const fn should_prevent_exit(shutting_down: bool) -> bool {
     !shutting_down
 }
 
@@ -62,7 +62,7 @@ pub const fn should_prevent_exit(shutting_down: bool) -> bool {
 ///
 /// Spawns rather than blocks: it is called from event-loop handlers that must
 /// not stall while llama-server processes are stopped.
-pub fn request_shutdown(app: &AppHandle) {
+pub(crate) fn request_shutdown(app: &AppHandle) {
     if SHUTTING_DOWN.swap(true, Ordering::SeqCst) {
         info!("Shutdown already in progress - ignoring duplicate request");
         return;

--- a/src-tauri/src/menu/build.rs
+++ b/src-tauri/src/menu/build.rs
@@ -10,7 +10,7 @@ use tauri::{
 ///
 /// Returns both the Menu to attach to the app and the AppMenu struct
 /// containing references to stateful items for later updates.
-pub fn build_app_menu(app: &AppHandle) -> Result<(Menu<Wry>, AppMenu), tauri::Error> {
+pub(crate) fn build_app_menu(app: &AppHandle) -> Result<(Menu<Wry>, AppMenu), tauri::Error> {
     // =========================================================================
     // App Menu (GGLib) - First submenu becomes app menu on macOS
     // =========================================================================

--- a/src-tauri/src/menu/handlers.rs
+++ b/src-tauri/src/menu/handlers.rs
@@ -6,7 +6,7 @@ use tauri::AppHandle;
 use tracing::debug;
 
 /// Handle menu item click events.
-pub fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+pub(crate) fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
     let id = event.id().as_ref();
 
     debug!(menu_id = %id, "Menu event received");

--- a/src-tauri/src/menu/ids.rs
+++ b/src-tauri/src/menu/ids.rs
@@ -1,27 +1,27 @@
 //! Menu item IDs for event handling.
 
 // File menu
-pub const ADD_MODEL_FILE: &str = "add_model_file";
-pub const DOWNLOAD_MODEL: &str = "download_model";
-pub const REFRESH_MODELS: &str = "refresh_models";
+pub(crate) const ADD_MODEL_FILE: &str = "add_model_file";
+pub(crate) const DOWNLOAD_MODEL: &str = "download_model";
+pub(crate) const REFRESH_MODELS: &str = "refresh_models";
 
 // Model menu
-pub const START_SERVER: &str = "start_server";
-pub const STOP_SERVER: &str = "stop_server";
-pub const REMOVE_MODEL: &str = "remove_model";
+pub(crate) const START_SERVER: &str = "start_server";
+pub(crate) const STOP_SERVER: &str = "stop_server";
+pub(crate) const REMOVE_MODEL: &str = "remove_model";
 
 // Proxy menu
-pub const START_PROXY: &str = "start_proxy";
-pub const STOP_PROXY: &str = "stop_proxy";
-pub const COPY_PROXY_URL: &str = "copy_proxy_url";
+pub(crate) const START_PROXY: &str = "start_proxy";
+pub(crate) const STOP_PROXY: &str = "stop_proxy";
+pub(crate) const COPY_PROXY_URL: &str = "copy_proxy_url";
 
 // View menu
-pub const SHOW_CHAT: &str = "show_chat";
+pub(crate) const SHOW_CHAT: &str = "show_chat";
 
 // Help menu
-pub const INSTALL_LLAMA: &str = "install_llama";
-pub const CHECK_LLAMA_STATUS: &str = "check_llama_status";
-pub const OPEN_DOCS: &str = "open_docs";
+pub(crate) const INSTALL_LLAMA: &str = "install_llama";
+pub(crate) const CHECK_LLAMA_STATUS: &str = "check_llama_status";
+pub(crate) const OPEN_DOCS: &str = "open_docs";
 
 // App menu
-pub const PREFERENCES: &str = "preferences";
+pub(crate) const PREFERENCES: &str = "preferences";

--- a/src-tauri/src/menu/mod.rs
+++ b/src-tauri/src/menu/mod.rs
@@ -3,14 +3,14 @@
 mod build;
 
 #[cfg(target_os = "macos")]
-pub mod handlers;
+pub(crate) mod handlers;
 
 #[cfg(target_os = "macos")]
-pub mod ids;
-pub mod state_sync;
+pub(crate) mod ids;
+pub(crate) mod state_sync;
 
 #[cfg(target_os = "macos")]
-pub use build::build_app_menu;
+pub(crate) use build::build_app_menu;
 
 #[cfg(target_os = "macos")]
 use tauri::{Wry, menu::MenuItem};
@@ -23,7 +23,7 @@ use tauri::{Wry, menu::MenuItem};
 /// This struct is stored in the application state and used to
 /// enable/disable or check/uncheck menu items based on app state.
 #[cfg(target_os = "macos")]
-pub struct AppMenu {
+pub(crate) struct AppMenu {
     // Model menu items (enabled based on selection/server state)
     pub start_server: MenuItem<Wry>,
     pub stop_server: MenuItem<Wry>,
@@ -41,7 +41,7 @@ pub struct AppMenu {
 /// State used to synchronize menu item enabled/checked status
 #[cfg(target_os = "macos")]
 #[derive(Debug, Clone, Default)]
-pub struct MenuState {
+pub(crate) struct MenuState {
     pub llama_installed: bool,
     pub proxy_running: bool,
     pub model_selected: bool,
@@ -57,7 +57,7 @@ impl AppMenu {
     /// - Server starts/stops
     /// - Proxy starts/stops
     /// - llama.cpp is installed
-    pub fn sync_state(&self, state: &MenuState) -> Result<(), tauri::Error> {
+    pub(crate) fn sync_state(&self, state: &MenuState) -> Result<(), tauri::Error> {
         // Model menu items
         // Start Server: enabled if model selected AND not already running
         self.start_server

--- a/src-tauri/src/menu/state_sync.rs
+++ b/src-tauri/src/menu/state_sync.rs
@@ -23,7 +23,7 @@ use tracing::warn;
 ///
 /// The snapshot is cloned out of its lock rather than read through it: both
 /// surfaces below await, and the tray's await is a D-Bus round trip on Linux.
-pub async fn sync_all_state(
+pub(crate) async fn sync_all_state(
     app: &AppHandle,
     state: &tauri::State<'_, AppState>,
 ) -> Result<(), String> {
@@ -81,7 +81,7 @@ async fn sync_app_menu(
 /// Sync every surface, logging rather than returning any failure.
 ///
 /// For fire-and-forget callers with nowhere useful to send an error.
-pub async fn sync_all_state_logged(app: &AppHandle, state: &tauri::State<'_, AppState>) {
+pub(crate) async fn sync_all_state_logged(app: &AppHandle, state: &tauri::State<'_, AppState>) {
     if let Err(e) = sync_all_state(app, state).await {
         warn!("Failed to sync menu and tray state: {e}");
     }

--- a/src-tauri/src/proxy_actions.rs
+++ b/src-tauri/src/proxy_actions.rs
@@ -22,7 +22,7 @@ use crate::app::events::{emit_or_log, names};
 ///
 /// Idempotent: the daemon's start route treats an already-running proxy as
 /// success, and honours the saved `proxy_port` setting.
-pub async fn start(app: &AppHandle) -> Result<u16, String> {
+pub(crate) async fn start(app: &AppHandle) -> Result<u16, String> {
     let state = app.state::<AppState>();
 
     let status = state
@@ -42,7 +42,7 @@ pub async fn start(app: &AppHandle) -> Result<u16, String> {
 
 /// Stop the proxy, treating an already-stopped proxy as success (the
 /// daemon's stop route is idempotent).
-pub async fn stop(app: &AppHandle) -> Result<(), String> {
+pub(crate) async fn stop(app: &AppHandle) -> Result<(), String> {
     let state = app.state::<AppState>();
 
     state
@@ -63,7 +63,7 @@ pub async fn stop(app: &AppHandle) -> Result<(), String> {
 /// to fall back to and the snapshot is the only source of the port.
 ///
 /// Goes through the frontend because clipboard access is a webview capability.
-pub async fn copy_endpoint_url(app: &AppHandle) {
+pub(crate) async fn copy_endpoint_url(app: &AppHandle) {
     let state = app.state::<AppState>();
     let url = state.snapshot.read().await.endpoint_url();
 

--- a/src-tauri/src/tray/build.rs
+++ b/src-tauri/src/tray/build.rs
@@ -23,7 +23,7 @@ use crate::tray::{handlers, ids, window};
 ///
 /// A map rather than named fields because the item list lives in `items` now;
 /// naming them here would be a second copy of the same structure.
-pub struct TrayMenu {
+pub(super) struct TrayMenu {
     items: HashMap<&'static str, MenuItem<Wry>>,
 }
 
@@ -43,13 +43,13 @@ impl TrayMenu {
 
 /// Build the tray icon, its menu, and its click behaviour.
 /// A built tray, kept alive for as long as the icon should exist.
-pub struct Handle {
+pub(super) struct Handle {
     tray: TrayIcon,
     menu: TrayMenu,
 }
 
 /// Apply the daemon's state to the icon, tooltip and menu.
-pub async fn sync(handle: &Handle, snapshot: &DaemonSnapshot) -> Result<(), String> {
+pub(super) async fn sync(handle: &Handle, snapshot: &DaemonSnapshot) -> Result<(), String> {
     let visual = icon::derive(snapshot);
     let image =
         icon::for_state(visual.state).map_err(|e| format!("Failed to decode tray icon: {e}"))?;
@@ -70,7 +70,7 @@ pub async fn sync(handle: &Handle, snapshot: &DaemonSnapshot) -> Result<(), Stri
 }
 
 /// Build the tray icon, its menu, and its click behaviour.
-pub fn build(app: &AppHandle) -> Result<Handle, String> {
+pub(super) fn build(app: &AppHandle) -> Result<Handle, String> {
     build_inner(app).map_err(|e| format!("Failed to build system tray: {e}"))
 }
 

--- a/src-tauri/src/tray/confirm.rs
+++ b/src-tauri/src/tray/confirm.rs
@@ -18,7 +18,7 @@ use crate::daemon::DaemonSnapshot;
 /// signal not to ask at all: interrupting someone to confirm the shutdown of a
 /// daemon that is serving nothing and holding nothing is noise.
 #[must_use]
-pub fn at_stake(snap: &DaemonSnapshot) -> Option<String> {
+pub(super) fn at_stake(snap: &DaemonSnapshot) -> Option<String> {
     let proxy = snap
         .proxy_port
         .map(|port| format!("the proxy on :{port}"))
@@ -43,7 +43,7 @@ pub fn at_stake(snap: &DaemonSnapshot) -> Option<String> {
 /// Only asks when this app's exit actually takes the daemon with it. Against
 /// an adopted daemon there is nothing to warn about: it keeps serving, which
 /// is the whole reason it is left alone.
-pub fn quit(app: &AppHandle, snap: &DaemonSnapshot, ends_with_the_app: bool) -> bool {
+pub(super) fn quit(app: &AppHandle, snap: &DaemonSnapshot, ends_with_the_app: bool) -> bool {
     if !ends_with_the_app {
         return true;
     }
@@ -61,7 +61,7 @@ pub fn quit(app: &AppHandle, snap: &DaemonSnapshot, ends_with_the_app: bool) -> 
 }
 
 /// Ask before stopping the daemon from the tray.
-pub fn stop_service(app: &AppHandle, snap: &DaemonSnapshot) -> bool {
+pub(super) fn stop_service(app: &AppHandle, snap: &DaemonSnapshot) -> bool {
     let Some(at_stake) = at_stake(snap) else {
         return true;
     };
@@ -85,7 +85,7 @@ pub fn stop_service(app: &AppHandle, snap: &DaemonSnapshot) -> bool {
 /// Spawns rather than blocking, so it is safe to call from the setup hook —
 /// which runs before the event loop is pumping and would otherwise deadlock on
 /// a modal.
-pub fn report_failure(app: &AppHandle, title: &str, detail: &str) {
+pub(crate) fn report_failure(app: &AppHandle, title: &str, detail: &str) {
     let (app, title, detail) = (app.clone(), title.to_owned(), detail.to_owned());
 
     tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/tray/handlers.rs
+++ b/src-tauri/src/tray/handlers.rs
@@ -27,7 +27,7 @@ const SERVICE_STOP_WAIT: Duration = Duration::from_secs(12);
 ///
 /// The single entry point for every tray backend, so the tray reaches the same
 /// code as the WebUI and the CLI however the click arrived.
-pub fn dispatch(app: &AppHandle, id: &str) {
+pub(super) fn dispatch(app: &AppHandle, id: &str) {
     debug!(tray_id = %id, "Tray menu event received");
 
     match id {

--- a/src-tauri/src/tray/icon.rs
+++ b/src-tauri/src/tray/icon.rs
@@ -9,14 +9,14 @@ use tauri::image::Image;
 use crate::daemon::DaemonSnapshot;
 
 /// Identifier the tray registers under.
-pub const TRAY_ID: &str = "gglib";
+pub(super) const TRAY_ID: &str = "gglib";
 
 /// How much of the idle icon's opacity the offline icon keeps.
 const OFFLINE_OPACITY_PERCENT: u16 = 35;
 
 /// What the tray icon is saying.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TrayState {
+pub(super) enum TrayState {
     /// No daemon answering: gglib is not running on this machine.
     Offline,
     /// A daemon is up but consuming nothing — no proxy, no resident models.
@@ -26,12 +26,12 @@ pub enum TrayState {
 }
 
 /// Decoded idle icon: a daemon that is up and doing nothing.
-pub fn idle_icon() -> tauri::Result<Image<'static>> {
+pub(super) fn idle_icon() -> tauri::Result<Image<'static>> {
     Image::from_bytes(include_bytes!("../../icons/tray-idle.png"))
 }
 
 /// Decoded active icon: something is being served or resident.
-pub fn active_icon() -> tauri::Result<Image<'static>> {
+pub(super) fn active_icon() -> tauri::Result<Image<'static>> {
     Image::from_bytes(include_bytes!("../../icons/tray-active.png"))
 }
 
@@ -43,7 +43,7 @@ pub fn active_icon() -> tauri::Result<Image<'static>> {
 /// [`super::linux`]. Both icons carry their glyph entirely in the alpha
 /// channel, which is what macOS template mode requires, so scaling alpha is
 /// exactly "draw the same thing fainter" on every backend.
-pub fn offline_icon() -> tauri::Result<Image<'static>> {
+pub(super) fn offline_icon() -> tauri::Result<Image<'static>> {
     let idle = idle_icon()?;
     let (width, height) = (idle.width(), idle.height());
 
@@ -70,7 +70,7 @@ const fn fade(alpha: u8) -> u8 {
 }
 
 /// The icon for a state, already decoded.
-pub fn for_state(state: TrayState) -> tauri::Result<Image<'static>> {
+pub(super) fn for_state(state: TrayState) -> tauri::Result<Image<'static>> {
     match state {
         TrayState::Offline => offline_icon(),
         TrayState::Idle => idle_icon(),
@@ -80,7 +80,7 @@ pub fn for_state(state: TrayState) -> tauri::Result<Image<'static>> {
 
 /// How the tray should look for a given daemon state.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TrayVisual {
+pub(super) struct TrayVisual {
     /// Which icon to show.
     pub state: TrayState,
     /// Hover text, and the label of the menu's status item.
@@ -101,7 +101,7 @@ pub struct TrayVisual {
 /// What it reports is whether gglib is doing something to this machine right
 /// now, which is true of a resident model whether or not the proxy is up.
 #[must_use]
-pub fn derive(snap: &DaemonSnapshot) -> TrayVisual {
+pub(super) fn derive(snap: &DaemonSnapshot) -> TrayVisual {
     TrayVisual {
         state: state_of(snap),
         status: status_of(snap),

--- a/src-tauri/src/tray/ids.rs
+++ b/src-tauri/src/tray/ids.rs
@@ -2,27 +2,27 @@
 
 /// Endpoint status header. Disabled, so it never raises a menu event — it has
 /// an ID only because `MenuItem` requires one and `tray::sync` looks it up.
-pub const STATUS: &str = "tray_status";
+pub(super) const STATUS: &str = "tray_status";
 
 /// Show the live proxy panel. Also the left-click action where the platform
 /// reports one — see the module README on Linux's AppIndicator.
-pub const OPEN_PANEL: &str = "tray_open_panel";
+pub(super) const OPEN_PANEL: &str = "tray_open_panel";
 
-pub const START_PROXY: &str = "tray_start_proxy";
-pub const STOP_PROXY: &str = "tray_stop_proxy";
-pub const COPY_PROXY_URL: &str = "tray_copy_proxy_url";
+pub(super) const START_PROXY: &str = "tray_start_proxy";
+pub(super) const STOP_PROXY: &str = "tray_stop_proxy";
+pub(super) const COPY_PROXY_URL: &str = "tray_copy_proxy_url";
 
 /// Start the gglib daemon, when nothing is running.
-pub const START_SERVICE: &str = "tray_start_service";
+pub(super) const START_SERVICE: &str = "tray_start_service";
 /// Stop the gglib daemon: the proxy, every llama-server, the lot.
-pub const STOP_SERVICE: &str = "tray_stop_service";
+pub(super) const STOP_SERVICE: &str = "tray_stop_service";
 
 /// Show the main window.
-pub const OPEN_MAIN: &str = "tray_open_main";
-pub const PREFERENCES: &str = "tray_preferences";
+pub(super) const OPEN_MAIN: &str = "tray_open_main";
+pub(super) const PREFERENCES: &str = "tray_preferences";
 
 /// Quit the application.
-pub const QUIT: &str = "tray_quit";
+pub(super) const QUIT: &str = "tray_quit";
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/tray/items.rs
+++ b/src-tauri/src/tray/items.rs
@@ -13,7 +13,7 @@ use crate::tray::ids;
 
 /// One entry on the tray menu.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Item {
+pub(super) enum Item {
     /// The status header. Always disabled — a label, not a command — and the
     /// only entry whose text changes, from `icon::derive`.
     Status,
@@ -29,7 +29,7 @@ pub enum Item {
 ///
 /// Every action appears here, including the ones that also have a click
 /// gesture: the gesture is a shortcut, never the only route to a feature.
-pub const ITEMS: &[Item] = &[
+pub(super) const ITEMS: &[Item] = &[
     Item::Status,
     Item::Separator,
     Item::Action {
@@ -79,7 +79,7 @@ pub const ITEMS: &[Item] = &[
 /// The single rule both backends apply, so the two menus cannot disagree about
 /// what is greyed out. Pure, so the table below is testable without a tray.
 #[must_use]
-pub fn is_enabled(id: &str, snap: &DaemonSnapshot) -> bool {
+pub(super) fn is_enabled(id: &str, snap: &DaemonSnapshot) -> bool {
     match id {
         // A label, not a command — never clickable on any backend.
         ids::STATUS => false,

--- a/src-tauri/src/tray/layer_shell.rs
+++ b/src-tauri/src/tray/layer_shell.rs
@@ -99,7 +99,7 @@ fn api() -> Option<&'static Api> {
 ///
 /// Bottom-right matches the default panel position on KDE and most desktops.
 #[must_use]
-pub fn prepare(panel: &WebviewWindow) -> bool {
+pub(super) fn prepare(panel: &WebviewWindow) -> bool {
     let Some(api) = api() else {
         debug!("gtk-layer-shell unavailable; leaving panel placement to the compositor");
         return false;
@@ -170,7 +170,7 @@ fn margins_for(
 /// Unlike [`prepare`] this runs per activation, because it is the only moment
 /// the icon's position is known. The anchors themselves do not change — only
 /// the margins — so the surface is not re-initialised.
-pub fn anchor_at(panel: &WebviewWindow, x: i32, y: i32) {
+pub(super) fn anchor_at(panel: &WebviewWindow, x: i32, y: i32) {
     let Some(api) = api() else { return };
 
     let Ok(window) = panel.gtk_window() else {

--- a/src-tauri/src/tray/linux.rs
+++ b/src-tauri/src/tray/linux.rs
@@ -134,14 +134,14 @@ fn pixmap(state: TrayState) -> Vec<Icon> {
 }
 
 /// A registered tray, kept alive for as long as the item should exist.
-pub struct Handle(ServiceHandle<GglibTray>);
+pub(super) struct Handle(ServiceHandle<GglibTray>);
 
 /// Register the tray with the desktop's `StatusNotifierWatcher`.
 ///
 /// Fails when nothing is watching — a bare window manager with no tray host —
 /// which the caller treats exactly as it treats a failed Tauri tray: the app
 /// runs, and `autostart::should_start_hidden` refuses to hide the window.
-pub fn build(app: &AppHandle) -> Result<Handle, String> {
+pub(super) fn build(app: &AppHandle) -> Result<Handle, String> {
     let tray = GglibTray {
         app: app.clone(),
         // Nothing has been polled yet, and the default says so: the tray
@@ -163,7 +163,7 @@ pub fn build(app: &AppHandle) -> Result<Handle, String> {
 ///
 /// One `update` for all three: `ksni` rebuilds the menu from the tray's state
 /// after the closure returns, so there is nothing to keep in step by hand.
-pub async fn sync(handle: &Handle, snapshot: &DaemonSnapshot) -> Result<(), String> {
+pub(super) async fn sync(handle: &Handle, snapshot: &DaemonSnapshot) -> Result<(), String> {
     handle
         .0
         .update(|tray| tray.snapshot.clone_from(snapshot))

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -10,10 +10,10 @@ mod items;
 mod layer_shell;
 #[cfg(target_os = "linux")]
 mod linux;
-pub mod placement;
-pub mod window;
+pub(crate) mod placement;
+pub(crate) mod window;
 
-pub use confirm::report_failure;
+pub(crate) use confirm::report_failure;
 
 use tauri::{AppHandle, Manager};
 
@@ -34,7 +34,7 @@ use linux as backend;
 ///
 /// Dropping this removes the icon, so it is owned by [`AppState`] rather than
 /// left to fall out of scope at the end of setup.
-pub struct Tray(backend::Handle);
+pub(crate) struct Tray(backend::Handle);
 
 impl Tray {
     /// Build the tray and register it with the desktop.
@@ -44,7 +44,7 @@ impl Tray {
     /// When the platform refuses to give us one — no tray host on Linux, or a
     /// failed icon decode anywhere. Callers treat that as a degraded app, not
     /// a broken one.
-    pub fn build(app: &AppHandle) -> Result<Self, String> {
+    pub(crate) fn build(app: &AppHandle) -> Result<Self, String> {
         backend::build(app).map(Self)
     }
 
@@ -53,7 +53,7 @@ impl Tray {
     /// # Errors
     ///
     /// When the backend cannot update the icon, tooltip or menu.
-    pub async fn sync(&self, snapshot: &DaemonSnapshot) -> Result<(), String> {
+    pub(crate) async fn sync(&self, snapshot: &DaemonSnapshot) -> Result<(), String> {
         backend::sync(&self.0, snapshot).await
     }
 }
@@ -67,7 +67,7 @@ impl Tray {
 /// # Errors
 ///
 /// Propagates whatever the backend reports.
-pub async fn sync(app: &AppHandle, snapshot: &DaemonSnapshot) -> Result<(), String> {
+pub(crate) async fn sync(app: &AppHandle, snapshot: &DaemonSnapshot) -> Result<(), String> {
     let state = app.state::<AppState>();
     let guard = state.tray.read().await;
 

--- a/src-tauri/src/tray/placement.rs
+++ b/src-tauri/src/tray/placement.rs
@@ -12,7 +12,7 @@ use tauri::{PhysicalPosition, Rect};
 
 /// What the caller knows about where the tray icon is.
 #[derive(Debug, Clone, Copy)]
-pub enum Anchor {
+pub(crate) enum Anchor {
     /// The icon's rectangle, from a click event that carried one.
     ///
     /// Only the `muda` backend reports these; Linux's tray fires no click
@@ -54,7 +54,7 @@ pub fn prepare(panel: &WebviewWindow) -> bool {
 /// nothing to set up ahead of time.
 #[cfg(not(target_os = "linux"))]
 #[must_use]
-pub fn prepare(_panel: &WebviewWindow) -> bool {
+pub(crate) fn prepare(_panel: &WebviewWindow) -> bool {
     true
 }
 
@@ -63,7 +63,7 @@ pub fn prepare(_panel: &WebviewWindow) -> bool {
 /// On Linux the anchoring was already applied by [`prepare`] and the panel is
 /// pinned beside the tray, so there is nothing per-toggle to do. Elsewhere a
 /// known rectangle is used to drop the panel directly beneath the icon.
-pub fn place(panel: &WebviewWindow, anchor: Anchor) -> tauri::Result<()> {
+pub(crate) fn place(panel: &WebviewWindow, anchor: Anchor) -> tauri::Result<()> {
     match anchor {
         #[cfg(not(target_os = "linux"))]
         Anchor::Rect(rect) => position_near(panel, rect),

--- a/src-tauri/src/tray/placement.rs
+++ b/src-tauri/src/tray/placement.rs
@@ -44,7 +44,7 @@ pub(crate) enum Anchor {
 /// for why the timing is not incidental.
 #[cfg(target_os = "linux")]
 #[must_use]
-pub fn prepare(panel: &WebviewWindow) -> bool {
+pub(crate) fn prepare(panel: &WebviewWindow) -> bool {
     super::layer_shell::prepare(panel)
 }
 

--- a/src-tauri/src/tray/window.rs
+++ b/src-tauri/src/tray/window.rs
@@ -7,16 +7,16 @@ use crate::dock;
 use crate::tray::placement::{self, Anchor};
 
 /// Window label of the tray panel, as declared in `tauri.conf.json`.
-pub const PANEL_LABEL: &str = "tray";
+pub(crate) const PANEL_LABEL: &str = "tray";
 
 /// Window label of the main application window.
-pub const MAIN_LABEL: &str = "main";
+pub(crate) const MAIN_LABEL: &str = "main";
 
 /// Show the panel if hidden, hide it if already visible.
 ///
 /// Clicking the tray icon while the panel is open should put it away again,
 /// which is what every other menu bar item does.
-pub fn toggle_panel(app: &AppHandle, anchor: Anchor) -> tauri::Result<()> {
+pub(crate) fn toggle_panel(app: &AppHandle, anchor: Anchor) -> tauri::Result<()> {
     let Some(panel) = app.get_webview_window(PANEL_LABEL) else {
         debug!("Tray panel window not found");
         return Ok(());
@@ -37,7 +37,7 @@ pub fn toggle_panel(app: &AppHandle, anchor: Anchor) -> tauri::Result<()> {
 /// The one way back from menu-bar-only mode, shared by the tray's Open item,
 /// the tray icon's double-click and macOS's dock-reopen event — which is why
 /// the Dock icon is restored here rather than at each of those call sites.
-pub fn show_main(app: &AppHandle) -> tauri::Result<()> {
+pub(crate) fn show_main(app: &AppHandle) -> tauri::Result<()> {
     let Some(main) = app.get_webview_window(MAIN_LABEL) else {
         debug!("Main window not found");
         return Ok(());


### PR DESCRIPTION
First code-touching step of the dead-code sweep. Both crates here are leaves —
`cargo metadata` shows no workspace consumer for either — so everything `pub` in
them is reachable by nobody, which is precisely the state in which `dead_code`
stays silent: the lint has to assume some other crate might be the caller.

## The cascade, measured

The point of demoting the module tree is that it arms the next lint. That is
observable rather than theoretical:

| | `unreachable_pub` in `gglib-cli` |
|---|---|
| Before the root modules were demoted | **20** |
| After | **215** |

Same code, newly auditable. All 215 were then demoted by `cargo fix`, so each is
rustc's own suggestion — it picked `pub(super)` over `pub(crate)` wherever the
only caller is the parent module, which is tighter than I would have written.

Then `dead_code` finally spoke, and found seven things no text search had.

## What the compiler found

| Item | Why it is dead |
|---|---|
| `bootstrap_with` | A test-only composition root no test calls, plus the empty `mod tests` whose only content was a comment saying real tests would use it |
| `run_repl` | A wrapper passing `Vec::new()` to `run_repl_with_prior`; every caller already goes to the latter |
| `format_optional` | A table helper with no caller |
| `DisplayStyle` | `Compact` never constructed → a one-variant enum → held in a `style` field nothing read. Enum and field both go |
| `QueueDownloadDto` | `queue_download` deserialised a queue position and shard count its one caller discards; now checks status and returns `()` |
| `DownloadArgs::force` | Carried three layers, read by nobody |

`gglib-app` is the interesting null result: 132 items were over-public, and
**nothing in it turned out to be dead.** Its visibility was wrong; its contents
are all genuinely used.

## One thing that is not dead code, and is not fixed here

`--force` on `gglib model download` is a real advertised flag with a `-f` short
form and the help text "Skip confirmation prompt". It is inert: `exec` has no
prompt to skip, unlike its `remove` and `update` siblings, which use their
`force` properly.

The dead plumbing comes out here. The flag itself is user-facing surface, so it
is bound and dropped at the destructure with a note rather than being quietly
removed from the CLI inside a visibility change. It belongs with `--weight-speed`
and the other inert flags — I'd suggest folding it into that PR.

## Knock-on effects, stated rather than hidden

- **A doctest becomes `ignore`.** `truncate_string` is now `pub(crate)`, and a
  doctest compiles as its own crate, so no import path can name it. Its two
  assertions already exist verbatim in the module's unit tests. Doctests go from
  3 passing to 2.
- **Docs that named deleted items are updated.** Two doc comments linked
  `run_repl` and would have failed `broken_intra_doc_links`. The presentation
  module README documented `DisplayStyle` and `format_optional`; while fixing it
  I found its `display_model_summary` example was *already* wrong before this PR
   — it passed a `DisplayStyle` to a function taking `ModelSummaryOpts`, naming a
  `Detailed` variant that never existed.
- **Module READMEs no longer use `gglib_cli::` paths** in examples, since those
  modules are crate-internal now.

## Scope

`unreachable_pub` is applied via `RUSTFLAGS` for discovery only — no lint config
is added. Turning it on permanently is the last PR in this arc, once the library
crates have been through the same cascade.

Warnings this surfaced in `gglib-core`, `gglib-hf`, `gglib-runtime` and others
are deliberately untouched; they are the next two PRs.

## Verification

- `make pre-commit` — passes in full
- `cargo clippy -p gglib-cli -p gglib-app --all-targets --all-features -- -D warnings` — clean
- `cargo test -p gglib-cli -p gglib-app` — 244 tests pass
- `cargo test --doc -p gglib-cli` — passes (2, down from 3, per the note above)
- Net: 106 files, 70 lines of dead code removed, the rest visibility