### PR TITLE
fix(core,db,cli): one canonical path rule, a migration for the rows that predate it, and model add --force

### DIFF
--- a/crates/gglib-app-services/src/models.rs
+++ b/crates/gglib-app-services/src/models.rs
@@ -147,12 +147,21 @@ impl ModelOps {
     pub async fn add(&self, request: AddModelRequest) -> Result<GuiModel, GuiError> {
         let path = PathBuf::from(&request.file_path);
 
-        // Delegate to shared core logic for model import with full metadata extraction
+        // Delegate to shared core logic for model import with full metadata
+        // extraction. Always `Fresh`: the HTTP surface has no way to ask for
+        // the destructive re-import, so a duplicate is always a 409 here. The
+        // refresh workflow is `gglib model add --force`, which is explicit
+        // about overwriting a row the caller already has.
         let model = self
             .deps
             .core
             .models()
-            .import_from_file(&path, self.deps.gguf_parser.as_ref(), None)
+            .import_from_file(
+                &path,
+                self.deps.gguf_parser.as_ref(),
+                None,
+                gglib_core::services::ImportMode::Fresh,
+            )
             .await
             .map_err(|e| match e {
                 gglib_core::ports::CoreError::Validation(msg) => GuiError::ValidationFailed(msg),
@@ -203,7 +212,11 @@ impl ModelOps {
             .await
             .map_err(|e| GuiError::Internal(format!("Failed to update model: {e}")))?;
 
-        Ok(GuiModel::from_domain(model))
+        // Answer with the row as stored, not as sent. `update` canonicalises
+        // `file_path` on write, so echoing the in-memory copy would hand back
+        // the caller's spelling and disagree with the very next GET.
+        let stored = crate::helpers::resolve_model(self.deps.core.models(), id).await?;
+        Ok(GuiModel::from_domain(stored))
     }
 
     /// Remove a model from the database.
@@ -549,6 +562,175 @@ mod tests {
         let models = ops.list().await.unwrap();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, added.id);
+    }
+
+    /// **The link production actually crosses.** The duplicate leaves the core
+    /// as `CoreError::Repository(AlreadyExists)`, and `add` intercepts it here
+    /// before the blanket `CoreError -> HttpError` conversion ever sees it. A
+    /// test that exercises only that blanket conversion leaves this arm
+    /// unpinned: reverting it to `GuiError::Internal` turns the duplicate back
+    /// into a 500 with every error-mapping test still green.
+    #[tokio::test]
+    async fn adding_a_file_already_in_the_library_is_a_conflict() {
+        let core = test_core().await;
+        let ops = make_ops(core);
+
+        let dir = tempdir().unwrap();
+        let gguf_path = dir.path().join("model.gguf");
+        fs::write(&gguf_path, b"placeholder").await.unwrap();
+        let file_path = gguf_path.to_str().unwrap().to_string();
+
+        ops.add(AddModelRequest {
+            file_path: file_path.clone(),
+        })
+        .await
+        .expect("first add should succeed");
+
+        let result = ops.add(AddModelRequest { file_path }).await;
+        assert!(
+            matches!(result, Err(GuiError::Conflict(_))),
+            "expected Conflict, got {result:?}"
+        );
+    }
+
+    /// **The duplicate `--force` used to create.** A downloaded model is keyed
+    /// `hf:<repo>@<sha>#<file>`, but re-importing its file computes a
+    /// `local:<hash>` key. Nothing conflicted, `file_path` carries no unique
+    /// index, and the refresh appended a *second* row for one file — the exact
+    /// failure this change exists to prevent, reintroduced by the flag added
+    /// to serve it.
+    ///
+    /// This has to run against the real repository. `MockRepo` upserts on
+    /// `file_path` while `SqliteModelRepository` upserts on `model_key`, so the
+    /// core-level double reports "one row, id kept" for input the product
+    /// duplicates — it cannot observe this bug at all.
+    #[tokio::test]
+    async fn forcing_a_downloaded_model_refreshes_it_rather_than_duplicating_it() {
+        use gglib_core::domain::NewModel;
+        use gglib_core::ports::NoopGgufParser;
+        use gglib_core::services::ImportMode;
+
+        let core = test_core().await;
+
+        let dir = tempdir().unwrap();
+        let gguf_path = dir.path().join("Qwen3-8B-Q4_K_M.gguf");
+        fs::write(&gguf_path, b"placeholder").await.unwrap();
+
+        // Registered the way a completed download registers it: with HF
+        // provenance, and therefore an `hf:` model key.
+        let mut downloaded = NewModel::new(
+            "Qwen3-8B".to_string(),
+            gguf_path.clone(),
+            8.0,
+            chrono::Utc::now(),
+        );
+        downloaded.hf_repo_id = Some("Qwen/Qwen3-8B-GGUF".to_string());
+        downloaded.hf_commit_sha = Some("abc123".to_string());
+        downloaded.hf_filename = Some("Qwen3-8B-Q4_K_M.gguf".to_string());
+        let original = core
+            .models()
+            .add(downloaded)
+            .await
+            .expect("registering a download should succeed");
+
+        let refreshed = core
+            .models()
+            .import_from_file(&gguf_path, &NoopGgufParser, None, ImportMode::Refresh)
+            .await
+            .expect("--force must refresh rather than fail");
+
+        assert_eq!(
+            refreshed.id, original.id,
+            "the refresh must land on the downloaded row, not create a new one"
+        );
+        assert_eq!(
+            core.models().list().await.unwrap().len(),
+            1,
+            "one file is one model"
+        );
+    }
+
+    /// **A refresh must not repoint a sharded model at the wrong file.**
+    ///
+    /// `find_by_path` matches a sharded model through its sibling paths, so
+    /// `--force` on shard 2 finds the row keyed to shard 1. Landing on it and
+    /// assigning `file_path = excluded.file_path` would repoint the model at
+    /// the shard-2 file — which llama.cpp cannot open a split GGUF from, so
+    /// the model would stop launching. Appending a stray row (the behaviour
+    /// before the refresh landed on the right row) was survivable; destroying
+    /// the good row is not.
+    #[tokio::test]
+    async fn forcing_from_a_sibling_shard_refuses_rather_than_repointing() {
+        use gglib_core::domain::NewModel;
+        use gglib_core::ports::NoopGgufParser;
+        use gglib_core::services::ImportMode;
+
+        let core = test_core().await;
+
+        let dir = tempdir().unwrap();
+        let first = dir.path().join("Qwen3-30B-00001-of-00002.gguf");
+        let second = dir.path().join("Qwen3-30B-00002-of-00002.gguf");
+        fs::write(&first, b"placeholder").await.unwrap();
+        fs::write(&second, b"placeholder").await.unwrap();
+
+        // Seeded with HuggingFace provenance, because that is the only way the
+        // product ever produces a sharded row — `file_paths` is set by the
+        // download path alone. A local sharded model would give the mutation a
+        // `local:` key to collide with and demonstrate a duplicate rather than
+        // the repoint this guard exists to prevent.
+        let mut sharded = NewModel::new(
+            "Qwen3-30B".to_string(),
+            first.clone(),
+            30.0,
+            chrono::Utc::now(),
+        );
+        sharded.file_paths = Some(vec![first.clone(), second.clone()]);
+        sharded.hf_repo_id = Some("Qwen/Qwen3-30B-GGUF".to_string());
+        sharded.hf_commit_sha = Some("abc123".to_string());
+        sharded.hf_filename = Some("Qwen3-30B-00001-of-00002.gguf".to_string());
+        let original = core.models().add(sharded).await.expect("register");
+
+        let err = core
+            .models()
+            .import_from_file(&second, &NoopGgufParser, None, ImportMode::Refresh)
+            .await
+            .expect_err("refreshing from shard 2 must be refused");
+        assert!(
+            matches!(err, gglib_core::ports::CoreError::Validation(_)),
+            "got {err:?}"
+        );
+
+        let still = core
+            .models()
+            .get_by_id(original.id)
+            .await
+            .unwrap()
+            .expect("the row must still be there");
+        assert_eq!(
+            still.file_path,
+            std::fs::canonicalize(&first).unwrap(),
+            "the model must still point at its first shard"
+        );
+        assert_eq!(core.models().list().await.unwrap().len(), 1);
+
+        // The other half of the guard: refreshing the model by its *own*
+        // first shard is the documented workflow and must be accepted —
+        // including when the caller spells that path indirectly. A guard that
+        // compared the stored column without resolving it would refuse this
+        // and print the same path on both sides of the message.
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let respelled = dir
+            .path()
+            .join("sub")
+            .join("..")
+            .join(first.file_name().expect("the shard has a file name"));
+        let refreshed = core
+            .models()
+            .import_from_file(&respelled, &NoopGgufParser, None, ImportMode::Refresh)
+            .await
+            .expect("refreshing by the model's own first shard must be accepted");
+        assert_eq!(refreshed.id, original.id);
+        assert_eq!(core.models().list().await.unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/gglib-axum/src/error.rs
+++ b/crates/gglib-axum/src/error.rs
@@ -187,8 +187,11 @@ mod tests {
     /// that a future rearrangement of these `From` impls cannot quietly send a
     /// duplicate back as a 500 again.
     ///
-    /// Both routes in, because the GUI path arrives wrapped in `CoreError` and
-    /// the repository path does not.
+    /// All three routes in. The `POST /api/models` path is the `GuiError` one
+    /// — `ModelOps::add` catches the duplicate and re-raises it as
+    /// `GuiError::Conflict`, so the blanket `CoreError` conversion below never
+    /// sees it on that route. Pinning only the other two left the arm the
+    /// product actually uses untested.
     #[test]
     fn already_exists_reaches_the_client_as_409() {
         let direct: HttpError = RepositoryError::AlreadyExists("dup".to_string()).into();
@@ -197,6 +200,9 @@ mod tests {
         let wrapped: HttpError =
             CoreError::Repository(RepositoryError::AlreadyExists("dup".to_string())).into();
         assert_eq!(wrapped.into_response().status(), StatusCode::CONFLICT);
+
+        let from_gui: HttpError = GuiError::Conflict("dup".to_string()).into();
+        assert_eq!(from_gui.into_response().status(), StatusCode::CONFLICT);
     }
 
     /// The neighbouring repository errors must not also become 409 — a

--- a/crates/gglib-bootstrap/README.md
+++ b/crates/gglib-bootstrap/README.md
@@ -49,8 +49,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 ## What it wires
 
 1. `SQLite` database pool + repository set
-2. `LlamaServerRunner` (process runner)
-3. `GgufParser` + `ModelFilesRepository` + `ModelRegistrar`
+2. `GgufParser` + `ModelFilesRepository` + `ModelRegistrar`
+3. `HfClient` (`HuggingFace` HTTP client)
 4. Download manager (using the injected `AppEventEmitter`)
 5. `DownloadTriggerAdapter` (bridges `DownloadManagerPort` → `DownloadTriggerPort`)
 6. `ModelVerificationService` + fully configured `AppCore`

--- a/crates/gglib-bootstrap/src/lib.rs
+++ b/crates/gglib-bootstrap/src/lib.rs
@@ -7,8 +7,8 @@
 //! adapter (CLI, Axum, Tauri) needs:
 //!
 //! 1. Database pool + repository set
-//! 2. Process runner (`LlamaServerRunner`)
-//! 3. GGUF parser + model-files repository + model registrar
+//! 2. GGUF parser + model-files repository + model registrar
+//! 3. `HuggingFace` HTTP client
 //! 4. Download manager (accepting an injected event emitter)
 //! 5. `DownloadTriggerAdapter` (bridges `DownloadManagerPort` → `DownloadTriggerPort`)
 //! 6. `ModelVerificationService` + fully wired `AppCore`

--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -296,6 +296,10 @@ gglib config default 1
 # Add a local model
 gglib model add ~/models/llama-2-7b.Q4_K_M.gguf
 
+# Re-import one already in the library, refreshing its derived metadata
+# (capabilities, quantization, context length, expert counts, tags, spec)
+gglib model add --force ~/models/llama-2-7b.Q4_K_M.gguf
+
 # List all models
 gglib model list
 

--- a/crates/gglib-cli/src/handlers/model/add.rs
+++ b/crates/gglib-cli/src/handlers/model/add.rs
@@ -11,6 +11,7 @@ use crate::presentation::{ModelSummaryOpts, display_model_summary};
 use crate::utils::input;
 
 use gglib_core::domain::{NameSource, resolve_model_name};
+use gglib_core::services::ImportMode;
 use gglib_core::utils::validation;
 
 /// Execute the add command.
@@ -22,6 +23,7 @@ use gglib_core::utils::validation;
 ///
 /// * `ctx` - The CLI context providing access to AppCore and parser
 /// * `file_path` - Path to the GGUF file to add
+/// * `force` - Re-import a file already in the library, overwriting its row
 ///
 /// # Returns
 ///
@@ -32,13 +34,29 @@ use gglib_core::utils::validation;
 /// This function will return an error if:
 /// - File validation fails
 /// - GGUF metadata extraction fails
+/// - The file is already in the library and `force` was not passed
 /// - Database operations fail
-pub(crate) async fn execute(ctx: &CliContext, file_path: &str) -> Result<()> {
+pub(crate) async fn execute(ctx: &CliContext, file_path: &str, force: bool) -> Result<()> {
     let path = PathBuf::from(file_path);
 
     // Validate the GGUF file and extract metadata for CLI preview
     let gguf_metadata = validation::validate_and_parse_gguf(ctx.gguf_parser.as_ref(), file_path)?;
     println!("File validation and metadata extraction successful.");
+
+    // Refuse a duplicate here rather than after the prompts below. The core
+    // import checks too — that is the guard that actually protects the
+    // database — but reaching it costs the user a parameter-count prompt
+    // first, and answering questions about a model only to be told it was
+    // already there reads as a bug even though the refusal is correct.
+    if !force && let Some(existing) = ctx.app.models().find_by_path(&path).await? {
+        anyhow::bail!(
+            "'{}' is already in the library as \"{}\" (id {}).\n\
+             Pass --force to re-import it and refresh its derived metadata.",
+            path.display(),
+            existing.name,
+            existing.id
+        );
+    }
 
     // Display extracted metadata to the user
     println!("\nExtracted metadata:");
@@ -57,8 +75,19 @@ pub(crate) async fn execute(ctx: &CliContext, file_path: &str) -> Result<()> {
         println!("  Context Length: {context}");
     }
 
-    // Prompt for parameter count override (CLI-specific interactive UX)
-    let param_count_override = if let Some(params) = gguf_metadata.param_count_b {
+    // Prompt for parameter count override (CLI-specific interactive UX).
+    //
+    // Skipped entirely under --force. `param_count_b` is not among the columns
+    // the upsert refreshes, so on this path the answer could only be collected
+    // and then thrown away — the very thing moving the duplicate check above
+    // the prompts was meant to stop.
+    let param_count_override = if force {
+        println!(
+            "\nSkipping the parameter-count prompt: --force refreshes derived \
+             metadata only and leaves the stored parameter count alone."
+        );
+        None
+    } else if let Some(params) = gguf_metadata.param_count_b {
         let user_input =
             input::prompt_float_with_default("Parameter count (in billions)", Some(params))?;
         if user_input == 0.0 {
@@ -71,17 +100,36 @@ pub(crate) async fn execute(ctx: &CliContext, file_path: &str) -> Result<()> {
     };
 
     // Delegate to shared core logic for model import
+    let mode = if force {
+        ImportMode::Refresh
+    } else {
+        ImportMode::Fresh
+    };
     let saved_model = ctx
         .app
         .models()
-        .import_from_file(&path, ctx.gguf_parser.as_ref(), param_count_override)
+        .import_from_file(&path, ctx.gguf_parser.as_ref(), param_count_override, mode)
         .await?;
 
     // Display clean summary using shared presentation
-    println!("\nModel successfully created:");
+    if force {
+        println!("\nRe-derived from file:");
+    } else {
+        println!("\nModel successfully created:");
+    }
     display_model_summary(&saved_model, ModelSummaryOpts::with_title(""));
 
-    println!("Model successfully added to database!");
+    if force {
+        // Be precise about what moved. The row is re-read after the upsert, so
+        // the name shown above is the stored one — announcing a blanket
+        // "refreshed" over it would tell the user something the database did
+        // not do.
+        println!("Replaced: tags, capabilities, dialect spec.");
+        println!("Updated where newly detected: quantization, context length, expert counts.");
+        println!("Unchanged: name, parameter count, architecture.");
+    } else {
+        println!("Model successfully added to database!");
+    }
     Ok(())
 }
 

--- a/crates/gglib-cli/src/handlers/model/mod.rs
+++ b/crates/gglib-cli/src/handlers/model/mod.rs
@@ -19,8 +19,8 @@ use crate::model_commands::ModelCommand;
 /// Dispatch a `model` subcommand to its handler.
 pub(crate) async fn dispatch(ctx: &CliContext, command: ModelCommand) -> Result<()> {
     match command {
-        ModelCommand::Add { file_path } => {
-            add::execute(ctx, &file_path).await?;
+        ModelCommand::Add { file_path, force } => {
+            add::execute(ctx, &file_path, force).await?;
         }
         ModelCommand::List {
             sort,

--- a/crates/gglib-cli/src/model_commands.rs
+++ b/crates/gglib-cli/src/model_commands.rs
@@ -96,6 +96,21 @@ pub enum ModelCommand {
     Add {
         /// Path to GGUF file to add
         file_path: String,
+
+        /// Re-import a file already in the library, re-deriving its detected
+        /// metadata from the file
+        ///
+        /// Replaces tags, capabilities and the dialect spec — including with
+        /// nothing, so these can be cleared. Updates quantization, context
+        /// length and the expert counts only where a value is newly detected;
+        /// a stored one is never emptied. `gglib model retag` rebuilds only
+        /// tags and the dialect spec, so this is the wider of the two.
+        ///
+        /// The model keeps its id, and its name, parameter count and
+        /// architecture are left exactly as stored — those columns are not
+        /// part of the upsert at all.
+        #[arg(long)]
+        force: bool,
     },
 
     /// List GGUF models in the database

--- a/crates/gglib-core/src/paths/mod.rs
+++ b/crates/gglib-core/src/paths/mod.rs
@@ -32,7 +32,10 @@ pub use llama::{
 // Models directory
 #[cfg(not(target_os = "windows"))]
 pub use models::DEFAULT_MODELS_DIR_RELATIVE;
-pub use models::{ModelsDirResolution, ModelsDirSource, default_models_dir, resolve_models_dir};
+pub use models::{
+    ModelsDirResolution, ModelsDirSource, canonical_model_path, canonical_model_path_string,
+    default_models_dir, resolve_models_dir,
+};
 
 // PID tracking
 pub use pids::pids_dir;

--- a/crates/gglib-core/src/paths/models.rs
+++ b/crates/gglib-core/src/paths/models.rs
@@ -1,10 +1,12 @@
-//! Models directory resolution.
+//! Models directory resolution, and the canonical form of a model file path.
 //!
 //! Provides utilities for resolving the models directory from explicit paths,
-//! environment variables, or platform defaults.
+//! environment variables, or platform defaults, plus the single definition of
+//! what makes two paths "the same model file" — see
+//! [`canonical_model_path`].
 
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::error::PathError;
 use super::platform::normalize_user_path;
@@ -80,6 +82,50 @@ pub fn resolve_models_dir(explicit: Option<&str>) -> Result<ModelsDirResolution,
     })
 }
 
+/// Resolve `path` to the one form the library identifies a model file by.
+///
+/// Three separate places have to agree about what "the same file" means: the
+/// `file_path` column a model is stored under, the `model_key` that decides
+/// whether an insert is really an update, and the duplicate lookup an
+/// explicit add performs before inserting. While they disagreed, the failure
+/// was silent and destructive — two *different* files sharing a relative name
+/// (`model.gguf` in two directories) hashed to one key, the duplicate check
+/// compared resolved paths and saw no match, and the UPSERT merged them into
+/// a single row carrying the first file's name and the second file's path.
+///
+/// Everything that needs that answer resolves it here, so the three cannot
+/// drift apart again.
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] when the path cannot be
+/// resolved — most often because no file exists there.
+///
+/// Fallible on purpose. The infallible "canonicalise, or keep the literal
+/// path" shape reads as the convenient one and is precisely the shape of the
+/// bug: a caller asking *is this file already in the library?* gets a literal
+/// path back, compares it against a stored canonical one, matches nothing,
+/// and reports "no duplicate" for a file that is plainly there. Callers for
+/// which this genuinely cannot fail have already established that the file
+/// exists; they should say so by propagating rather than by swallowing.
+pub fn canonical_model_path(path: &Path) -> std::io::Result<PathBuf> {
+    std::fs::canonicalize(path)
+}
+
+/// The canonical path as the string the `file_path` column stores.
+///
+/// Falls back to the literal path when the file cannot be resolved, because a
+/// row whose file has since been deleted still has to round-trip through the
+/// database. Reach for [`canonical_model_path`] anywhere a failure to resolve
+/// should be visible to the caller rather than papered over.
+#[must_use]
+pub fn canonical_model_path_string(path: &Path) -> String {
+    canonical_model_path(path).map_or_else(
+        |_| path.to_string_lossy().into_owned(),
+        |resolved| resolved.to_string_lossy().into_owned(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,5 +172,44 @@ mod tests {
         let resolved = resolve_models_dir(None).unwrap();
         assert_eq!(resolved.source, ModelsDirSource::EnvVar);
         assert!(resolved.path.ends_with("from-env"));
+    }
+
+    /// Two spellings of one file resolve to one answer. This is the property
+    /// the model key, the stored column and the duplicate lookup all lean on;
+    /// if it stops holding, a re-add silently merges two models into one row.
+    #[test]
+    fn canonical_model_path_agrees_across_spellings_of_one_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Model.gguf");
+        std::fs::File::create(&file).unwrap();
+
+        let direct = canonical_model_path(&file).unwrap();
+        let indirect = canonical_model_path(&dir.path().join(".").join("Model.gguf")).unwrap();
+
+        assert_eq!(direct, indirect);
+    }
+
+    /// The fallible form reports a path it cannot resolve instead of handing
+    /// back the literal one. A caller that treats "cannot resolve" as "not a
+    /// duplicate" reinstates the silent overwrite, so the error has to be
+    /// reachable.
+    #[test]
+    fn canonical_model_path_reports_a_path_that_does_not_resolve() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(canonical_model_path(&dir.path().join("Absent.gguf")).is_err());
+    }
+
+    /// The string form is the one the database column stores, and it keeps
+    /// the literal path when the file is gone so an existing row still
+    /// round-trips.
+    #[test]
+    fn canonical_model_path_string_falls_back_to_the_literal_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let absent = dir.path().join("Absent.gguf");
+
+        assert_eq!(
+            canonical_model_path_string(&absent),
+            absent.to_string_lossy()
+        );
     }
 }

--- a/crates/gglib-core/src/ports/README.md
+++ b/crates/gglib-core/src/ports/README.md
@@ -12,7 +12,7 @@ They contain no implementation details and use only domain types.
 - No `sqlx` types in any signature
 - No process/filesystem implementation details
 - Traits are minimal and CRUD-focused for repositories
-- Intent-based methods for process runner (not implementation-leaking)
+- Intent-based methods throughout (not implementation-leaking)
 
 <!-- module-docs:end -->
 

--- a/crates/gglib-core/src/ports/model_repository.rs
+++ b/crates/gglib-core/src/ports/model_repository.rs
@@ -58,30 +58,29 @@ pub trait ModelRepository: Send + Sync {
 
     /// Find the model registered under `path`, if there is one.
     ///
-    /// Both sides are canonicalised before comparing, falling back to the
-    /// literal path when canonicalisation fails (a deleted file, a broken
-    /// symlink). Doing it on both sides rather than trusting the stored form
-    /// is what makes this agree with every implementation: the `SQLite`
-    /// repository canonicalises on write, test doubles store what they are
-    /// given, and on macOS a `tempfile` directory differs from its resolved
-    /// path by a `/private` prefix — so a one-sided comparison finds nothing
-    /// and reports "no duplicate" for a file that is plainly already there.
+    /// `path` is matched against the form the implementation stores.
     ///
-    /// Provided rather than required so implementors and test doubles inherit
-    /// it automatically. The scan is over the whole library, which is a table
-    /// of tens to hundreds of rows and is read once per explicit add.
-    async fn find_by_path(&self, path: &Path) -> Result<Option<Model>, RepositoryError> {
-        fn resolved(path: &Path) -> std::path::PathBuf {
-            std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-        }
-
-        let target = resolved(path);
-        Ok(self
-            .list()
-            .await?
-            .into_iter()
-            .find(|model| resolved(&model.file_path) == target))
-    }
+    /// An implementation that also stores a model's sibling shard paths must
+    /// match those too: adding shard 2 of a group already in the library is
+    /// the same duplicate as adding shard 1, and only shard 1's path lives in
+    /// the primary path field. `SqliteModelRepository` in `gglib-db` does
+    /// this; the test doubles in this workspace store no siblings and so match
+    /// on the single path alone, which means a sharded duplicate is only
+    /// observable in tests that use the real repository.
+    ///
+    /// Callers pass a path already resolved by
+    /// [`canonical_model_path`](crate::paths::canonical_model_path); this
+    /// method does not resolve it for them. That is the whole point of the
+    /// split: resolution can fail, and a failure has to reach the caller as
+    /// an error rather than decay into `Ok(None)`, which reads as "no
+    /// duplicate" and silently reinstates the overwrite this lookup exists to
+    /// prevent.
+    ///
+    /// Required rather than provided. A default body here would have to touch
+    /// the filesystem, which `ports/` does not do (see the design rules in
+    /// this module's README), and would scan the entire table per call in a
+    /// trait that every test double inherits.
+    async fn find_by_path(&self, path: &Path) -> Result<Option<Model>, RepositoryError>;
 
     /// Update an existing model.
     ///
@@ -193,6 +192,14 @@ mod tests {
             } else {
                 Err(RepositoryError::NotFound(format!("name={name}")))
             }
+        }
+
+        async fn find_by_path(&self, path: &Path) -> Result<Option<Model>, RepositoryError> {
+            Ok(self
+                .list()
+                .await?
+                .into_iter()
+                .find(|m| m.file_path.as_path() == path))
         }
 
         async fn insert(&self, _model: &NewModel) -> Result<Model, RepositoryError> {

--- a/crates/gglib-core/src/ports/process_runner.rs
+++ b/crates/gglib-core/src/ports/process_runner.rs
@@ -1,10 +1,17 @@
 //! The two value types a model-server launch is described and tracked by.
 //!
 //! [`ServerConfig`] is what a caller asks for; [`ProcessHandle`] is what it
-//! gets back. The `ProcessRunner` trait this file is named after is gone —
-//! nothing ever implemented it, and `ModelRuntimePort` is the port that
-//! actually carries launches. The file keeps its name only because these two
-//! types are reached as `ports::{ServerConfig, ProcessHandle}` regardless.
+//! gets back. The `ProcessRunner` trait this file is named after is gone, and
+//! `ModelRuntimePort` is the port that actually carries launches. The file
+//! keeps its name only because these two types are reached as
+//! `ports::{ServerConfig, ProcessHandle}` regardless.
+//!
+//! It had implementors, contrary to what this comment said until now: four at
+//! `4a6fcf4b^`, including the production `LlamaServerRunner` in
+//! `gglib-runtime/src/runner.rs`. That runner went in #708 and the other three
+//! were test doubles, which is what left the trait with nothing implementing
+//! it by the time #849 removed it — a different and much less interesting
+//! claim than "nothing ever did".
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/crates/gglib-core/src/services/app_core.rs
+++ b/crates/gglib-core/src/services/app_core.rs
@@ -100,6 +100,15 @@ mod tests {
         async fn get_by_name(&self, name: &str) -> Result<Model, RepositoryError> {
             Err(RepositoryError::NotFound(format!("name={name}")))
         }
+        async fn find_by_path(
+            &self,
+            _path: &std::path::Path,
+        ) -> Result<Option<Model>, RepositoryError> {
+            // `unimplemented!()` like its siblings, not `Ok(None)`. `Ok(None)`
+            // reads as "no duplicate found", which is a specific and wrong
+            // answer for a double that stores nothing.
+            unimplemented!()
+        }
         async fn insert(&self, _model: &NewModel) -> Result<Model, RepositoryError> {
             unimplemented!()
         }

--- a/crates/gglib-core/src/services/mod.rs
+++ b/crates/gglib-core/src/services/mod.rs
@@ -13,7 +13,7 @@ pub use model_import::{
     HfOrigin, MAX_GENERATION_CONFIG_LOOKUPS, ModelOrigin, build_new_model, fetch_published_sampling,
 };
 pub use model_registrar::{ModelFilesRepositoryPort, ModelRegistrar};
-pub use model_service::{ModelService, RetagDiff};
+pub use model_service::{ImportMode, ModelService, RetagDiff};
 pub use model_verification::{
     DownloadTriggerPort, ModelFilesReaderPort, ModelVerificationService, OverallHealth,
     ShardHealth, ShardHealthReport, ShardProgress, UpdateCheckResult, UpdateDetails,

--- a/crates/gglib-core/src/services/model_registrar.rs
+++ b/crates/gglib-core/src/services/model_registrar.rs
@@ -200,6 +200,19 @@ mod tests {
                 .ok_or_else(|| RepositoryError::NotFound(format!("name={name}")))
         }
 
+        async fn find_by_path(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Option<Model>, RepositoryError> {
+            Ok(self
+                .models
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|m| m.file_path.as_path() == path)
+                .cloned())
+        }
+
         async fn insert(&self, model: &NewModel) -> Result<Model, RepositoryError> {
             let mut id = self.next_id.lock().unwrap();
             let persisted = Model {
@@ -229,9 +242,26 @@ mod tests {
                 server_defaults: model.server_defaults.clone(),
                 benchmark_summary: None,
             };
+            // Mirror the `SQLite` repository: a repeat registration of the
+            // same file updates that row and keeps its id. This double models
+            // registration-after-download, which is the very path the trait
+            // doc cites as the reason `insert` upserts — a double that appends
+            // contradicts the contract it exists to stand in for.
+            let mut models = self.models.lock().unwrap();
+            if let Some(index) = models
+                .iter()
+                .position(|m| m.file_path == persisted.file_path)
+            {
+                let mut updated = persisted.clone();
+                updated.id = models[index].id;
+                models[index] = updated.clone();
+                drop(models);
+                return Ok(updated);
+            }
             *id += 1;
             drop(id);
-            self.models.lock().unwrap().push(persisted.clone());
+            models.push(persisted.clone());
+            drop(models);
             Ok(persisted)
         }
 

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -6,6 +6,44 @@ use crate::ports::{CoreError, GgufParserPort, ModelRepository, RepositoryError};
 use std::path::Path;
 use std::sync::Arc;
 
+/// Whether an explicit import may overwrite a model already in the library.
+///
+/// Named rather than a bare `bool` because the call sites read very
+/// differently — `ImportMode::Refresh` says what it does, `true` does not,
+/// and the wrong value here silently rewrites a row's tags and capabilities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ImportMode {
+    /// Refuse when the file is already registered, reporting
+    /// [`RepositoryError::AlreadyExists`].
+    ///
+    /// The default, and what an "add this file to my library" means: a
+    /// duplicate is a conflict the caller should hear about, not an
+    /// overwrite performed on their behalf.
+    #[default]
+    Fresh,
+    /// Re-derive the model's *detected* metadata from the file, updating the
+    /// stored row in place and keeping its database id.
+    ///
+    /// This is what `gglib model add --force` asks for, and what re-importing
+    /// did unconditionally before [`ModelService::import_from_file`] began
+    /// guarding it. It refreshes tags, capabilities, quantization, context
+    /// length, the expert counts and the dialect spec — wider than `model
+    /// retag`, which rebuilds only tags and the dialect spec.
+    ///
+    /// It is narrower than "overwrite the row", and the six columns do not all
+    /// behave alike:
+    ///
+    /// - `tags`, `capabilities` and `dialect_spec` are **assigned**. A refresh
+    ///   replaces them with whatever was just derived, including with nothing
+    ///   — these can be cleared.
+    /// - `quantization`, `context_length` and the expert counts are
+    ///   **coalesced**. A detector that now reads no value leaves the stored
+    ///   one standing rather than emptying it.
+    /// - `name`, `param_count_b` and `architecture` are **absent** from the
+    ///   upsert entirely, so a name the user chose survives untouched.
+    Refresh,
+}
+
 /// The diff produced by [`ModelService::retag_model`] when at least one tag
 /// or the dialect spec changed.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,7 +121,14 @@ impl ModelService {
             .ok_or_else(|| CoreError::Validation(format!("Model not found: {identifier}")))
     }
 
-    /// Add a new model.
+    /// Add a new model from an already-built row.
+    ///
+    /// This is the raw registration door: it inherits
+    /// [`ModelRepository::insert`]'s upsert, so a row whose key already exists
+    /// is overwritten rather than reported. That is right for
+    /// registration-after-download, which has to be safe to retry, and wrong
+    /// for "add this file to my library" — which is
+    /// [`Self::import_from_file`], the door that checks first.
     pub async fn add(&self, model: NewModel) -> Result<Model, CoreError> {
         self.repo.insert(&model).await.map_err(CoreError::from)
     }
@@ -98,10 +143,20 @@ impl ModelService {
     /// * `file_path` - Absolute path to the GGUF file
     /// * `gguf_parser` - Parser implementation for metadata extraction
     /// * `param_count_override` - Optional user override for parameter count
+    /// * `mode` - Whether a file already in the library is a conflict
+    ///   ([`ImportMode::Fresh`]) or should be re-derived in place
+    ///   ([`ImportMode::Refresh`])
     ///
     /// # Returns
     ///
     /// Returns the registered `Model` with full metadata, or validation error.
+    ///
+    /// # Errors
+    ///
+    /// [`CoreError::Validation`] if the file is missing, is not a readable
+    /// GGUF, or cannot be resolved to a canonical path;
+    /// [`RepositoryError::AlreadyExists`] under [`ImportMode::Fresh`] when the
+    /// file is already registered.
     ///
     /// # Design
     ///
@@ -109,11 +164,31 @@ impl ModelService {
     /// naming, capability detection, and tag generation to
     /// [`build_new_model`] — the construction path shared with the
     /// `HuggingFace` download path — before persisting the result.
+    ///
+    /// The path is resolved once here, immediately after validation has
+    /// established that the file exists, and the resolved form is what every
+    /// later step sees: the duplicate lookup, the row that gets built, and
+    /// the `model_key` derived from it. Normalising at the entry point rather
+    /// than at each consumer is what keeps those three from disagreeing about
+    /// which file is which.
+    ///
+    /// # Concurrency
+    ///
+    /// The duplicate check and the insert are separate statements with no
+    /// transaction around them, and `file_path` carries no unique index — only
+    /// `model_key` does. Two simultaneous adds of one file can therefore both
+    /// pass the check; the `ON CONFLICT(model_key)` clause still collapses
+    /// them onto a single row, so the library stays correct, but the loser is
+    /// told it added a model that in fact already existed rather than
+    /// receiving a conflict. Closing that would take a unique index on the
+    /// path or a transaction spanning both statements, and is not something
+    /// this guard attempts.
     pub async fn import_from_file(
         &self,
         file_path: &Path,
         gguf_parser: &dyn GgufParserPort,
         param_count_override: Option<f64>,
+        mode: ImportMode,
     ) -> Result<Model, CoreError> {
         // 1. Validate and parse GGUF file
         let gguf_metadata = crate::utils::validation::validate_and_parse_gguf(
@@ -124,18 +199,36 @@ impl ModelService {
         )
         .map_err(|e| CoreError::Validation(format!("GGUF validation failed: {e}")))?;
 
-        // 2. A file already in the library is a conflict, not a silent
+        // 2. Resolve the path exactly once, now that validation has
+        //    established the file is there. Everything downstream uses the
+        //    resolved form, so no later step has to re-resolve — and none can
+        //    quietly disagree about what "the same file" means.
+        let resolved = crate::paths::canonical_model_path(file_path).map_err(|e| {
+            CoreError::Validation(format!(
+                "Cannot resolve '{}' to a canonical path: {e}",
+                file_path.display()
+            ))
+        })?;
+
+        // 3. A file already in the library is a conflict, not a silent
         //    overwrite. `insert` upserts so that registration after a download
         //    can be retried; an explicit "add this file" is the opposite
         //    intent, and without this check the caller gets a success response
         //    for a model it did not add, with the existing row's tags and
         //    capabilities rewritten underneath it.
         //
-        if let Some(existing) = self
+        //    `ImportMode::Refresh` is the caller stating that the overwrite is
+        //    what they came for — re-deriving a model's spec from the file
+        //    with newer detection logic. It is opt-in because it is
+        //    destructive, and unreachable by accident.
+        let existing = self
             .repo
-            .find_by_path(file_path)
+            .find_by_path(&resolved)
             .await
-            .map_err(CoreError::from)?
+            .map_err(CoreError::from)?;
+
+        if mode == ImportMode::Fresh
+            && let Some(existing) = &existing
         {
             return Err(CoreError::Repository(RepositoryError::AlreadyExists(
                 format!(
@@ -146,12 +239,52 @@ impl ModelService {
             )));
         }
 
-        // 3. Build the model row via the naming/capability/tag policy shared
+        // A refresh has to be asked for by the model's *own* primary file.
+        //
+        // `find_by_path` also matches a sharded model through its sibling
+        // paths, and the row it hands back is the one keyed to shard 1. Left
+        // unchecked, refreshing from shard 2 would land on that row and
+        // `file_path = excluded.file_path` would repoint it at the shard-2
+        // file — which llama.cpp cannot open a split GGUF from, so the model
+        // would stop launching. Appending a stray row (the old behaviour) was
+        // survivable; destroying the good row is not.
+        //
+        // Both sides are resolved before comparing. Comparing the stored
+        // column directly would make this guard assume the column is already
+        // canonical — the very assumption that produced the bug this change
+        // exists to fix. A row still holding an unresolved path would then
+        // refuse a refresh of its *own* first shard, and say so by printing
+        // the same path twice.
+        if let Some(existing) = &existing {
+            let existing_primary = crate::paths::canonical_model_path_string(&existing.file_path);
+            if existing_primary != resolved.to_string_lossy() {
+                return Err(CoreError::Validation(format!(
+                    "'{}' belongs to \"{}\", which is registered under '{}'. \
+                     Re-import that path instead — refreshing a sharded model from \
+                     anything but its first shard would repoint it at a file it \
+                     cannot be loaded from.",
+                    file_path.display(),
+                    existing.name,
+                    existing_primary
+                )));
+            }
+        }
+
+        // 4. Build the model row via the naming/capability/tag policy shared
         //    with the HuggingFace download path.
+        //
+        //    Built from the path the caller gave, not the resolved one. The
+        //    derived name falls back to the file stem, so building from the
+        //    resolved path would silently rename a symlinked model to its
+        //    target's stem — `current.gguf -> Qwen3-8B.gguf` would stop being
+        //    "current" — and would disagree with the preview the CLI printed
+        //    from the path the user typed. Only the *stored* path is
+        //    canonical; the *derived* name still comes from what was asked
+        //    for.
         let origin = ModelOrigin::LocalFile {
             param_count_override,
         };
-        let new_model = build_new_model(
+        let mut new_model = build_new_model(
             file_path,
             Some(&gguf_metadata),
             gguf_parser,
@@ -159,8 +292,54 @@ impl ModelService {
             chrono::Utc::now(),
         );
 
-        // 4. Persist to repository
+        // 5. Store and key the row by the resolved path, whatever spelling
+        //    was used to reach it.
+        new_model.file_path = resolved;
+
+        // 6. A refresh has to land on the row it is refreshing.
+        //
+        //    `build_new_model` was handed `ModelOrigin::LocalFile`, so it
+        //    carries no HuggingFace metadata and the row would be keyed
+        //    `local:<hash>`. A downloaded model is keyed `hf:<repo>@<sha>#<file>`.
+        //    Nothing would conflict, `file_path` carries no unique index, and
+        //    `--force` on a downloaded model would append a *second* row for
+        //    one file — the precise outcome this whole change exists to
+        //    prevent, reintroduced by the flag added to serve it.
+        //
+        //    Carrying the stored provenance forward keeps the computed key
+        //    equal to the existing row's, so the upsert updates it.
+        if let Some(existing) = &existing {
+            new_model.hf_repo_id.clone_from(&existing.hf_repo_id);
+            new_model.hf_commit_sha.clone_from(&existing.hf_commit_sha);
+            new_model.hf_filename.clone_from(&existing.hf_filename);
+        }
+
+        // 7. Persist to repository
         self.repo.insert(&new_model).await.map_err(CoreError::from)
+    }
+
+    /// Look up the model registered under `file_path`, if any.
+    ///
+    /// Resolves the path the same way [`Self::import_from_file`] does, so a
+    /// caller can ask "is this already here?" before doing expensive or
+    /// interactive work and get the same answer the import would.
+    ///
+    /// # Errors
+    ///
+    /// [`CoreError::Validation`] if the path cannot be resolved, and
+    /// [`CoreError::Repository`] if the lookup itself fails. Neither is
+    /// reported as "no duplicate".
+    pub async fn find_by_path(&self, file_path: &Path) -> Result<Option<Model>, CoreError> {
+        let resolved = crate::paths::canonical_model_path(file_path).map_err(|e| {
+            CoreError::Validation(format!(
+                "Cannot resolve '{}' to a canonical path: {e}",
+                file_path.display()
+            ))
+        })?;
+        self.repo
+            .find_by_path(&resolved)
+            .await
+            .map_err(CoreError::from)
     }
 
     /// Update a model.
@@ -513,10 +692,36 @@ mod tests {
                 .ok_or_else(|| RepositoryError::NotFound(format!("name={name}")))
         }
 
+        async fn find_by_path(&self, path: &Path) -> Result<Option<Model>, RepositoryError> {
+            Ok(self
+                .models
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|m| m.file_path.as_path() == path)
+                .cloned())
+        }
+
         #[allow(clippy::cast_possible_wrap, clippy::significant_drop_tightening)]
         async fn insert(&self, model: &NewModel) -> Result<Model, RepositoryError> {
             let mut models = self.models.lock().unwrap();
-            let id = models.len() as i64 + 1;
+            // NOTE: this double keys on `file_path`; `SqliteModelRepository`
+            // keys on `model_key`. They agree for a plain local add and
+            // diverge whenever the key is derived from something else — a
+            // downloaded model keyed `hf:<repo>@<sha>#<file>`, most of all. A
+            // test written here will therefore report "one row, id kept" for
+            // input the real repository would have duplicated, so anything
+            // turning on key identity belongs in a test against the real
+            // repository (see `gglib-app-services`'s
+            // `forcing_a_downloaded_model_refreshes_it_rather_than_duplicating_it`).
+            //
+            // Mirror the `SQLite` repository: registering the same file twice
+            // updates that row and keeps its id rather than appending a second
+            // one. A double that appends contradicts the trait doc and makes
+            // the silent-overwrite bug this guard exists for invisible to
+            // every test written against it.
+            let existing = models.iter().position(|m| m.file_path == model.file_path);
+            let id = existing.map_or(models.len() as i64 + 1, |i| models[i].id);
             let created = Model {
                 dialect_spec: model.dialect_spec.clone(),
                 id,
@@ -544,7 +749,11 @@ mod tests {
                 server_defaults: model.server_defaults.clone(),
                 benchmark_summary: None,
             };
-            models.push(created.clone());
+            if let Some(index) = existing {
+                models[index] = created.clone();
+            } else {
+                models.push(created.clone());
+            }
             Ok(created)
         }
 
@@ -581,7 +790,12 @@ mod tests {
         std::fs::File::create(&path).unwrap();
 
         let model = service
-            .import_from_file(&path, &crate::ports::NoopGgufParser, None)
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Fresh,
+            )
             .await
             .unwrap();
 
@@ -605,12 +819,22 @@ mod tests {
         std::fs::File::create(&path).unwrap();
 
         service
-            .import_from_file(&path, &crate::ports::NoopGgufParser, None)
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Fresh,
+            )
             .await
             .expect("first add succeeds");
 
         let err = service
-            .import_from_file(&path, &crate::ports::NoopGgufParser, None)
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Fresh,
+            )
             .await
             .expect_err("second add is a conflict");
 
@@ -621,6 +845,217 @@ mod tests {
             ),
             "expected AlreadyExists, got {err:?}"
         );
+    }
+
+    /// `--force` is the documented way to refresh a model's derived columns
+    /// from the file. The guard above blocks the workflow `docs/tags.md`
+    /// describes, so `Refresh` has to restore it: same file, same row, no
+    /// conflict.
+    #[tokio::test]
+    async fn refresh_re_imports_a_file_already_in_the_library() {
+        let repo = Arc::new(MockRepo::new());
+        let service = ModelService::new(repo);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Qwen3-8B-Q4_K_M.gguf");
+        std::fs::File::create(&path).unwrap();
+
+        let first = service
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Fresh,
+            )
+            .await
+            .expect("first add succeeds");
+
+        let refreshed = service
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Refresh,
+            )
+            .await
+            .expect("--force re-imports rather than refusing");
+
+        assert_eq!(
+            refreshed.id, first.id,
+            "a refresh updates the row in place; it does not create a second"
+        );
+        assert_eq!(service.list().await.unwrap().len(), 1);
+    }
+
+    /// The lookup a caller can run before doing expensive or interactive work
+    /// has to agree with the guard inside the import, or the CLI would refuse
+    /// files the import would accept and vice versa.
+    #[tokio::test]
+    async fn find_by_path_agrees_with_the_import_guard() {
+        let repo = Arc::new(MockRepo::new());
+        let service = ModelService::new(repo);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Qwen3-8B-Q4_K_M.gguf");
+        std::fs::File::create(&path).unwrap();
+
+        assert!(
+            service.find_by_path(&path).await.unwrap().is_none(),
+            "nothing is registered yet"
+        );
+
+        service
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Fresh,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            service.find_by_path(&path).await.unwrap().is_some(),
+            "the file the import just refused to duplicate must be findable"
+        );
+    }
+
+    /// An unresolvable path is an error, never `Ok(None)`. `Ok(None)` reads
+    /// as "no duplicate" and silently reinstates the overwrite the guard
+    /// exists to prevent.
+    #[tokio::test]
+    async fn find_by_path_reports_an_unresolvable_path_instead_of_no_duplicate() {
+        let repo = Arc::new(MockRepo::new());
+        let service = ModelService::new(repo);
+
+        let dir = tempfile::tempdir().unwrap();
+        let err = service
+            .find_by_path(&dir.path().join("Absent.gguf"))
+            .await
+            .expect_err("a path that does not resolve is not 'no duplicate'");
+
+        assert!(matches!(err, CoreError::Validation(_)), "got {err:?}");
+    }
+
+    /// A repository that matches any path, standing in for the sibling-shard
+    /// arm of the real `find_by_path` — the one case where the row handed back
+    /// is *not* the row the queried path is the primary file of.
+    struct SiblingMatchRepo(MockRepo);
+
+    #[async_trait]
+    impl ModelRepository for SiblingMatchRepo {
+        async fn list(&self) -> Result<Vec<Model>, RepositoryError> {
+            self.0.list().await
+        }
+        async fn get_by_id(&self, id: i64) -> Result<Model, RepositoryError> {
+            self.0.get_by_id(id).await
+        }
+        async fn get_by_name(&self, name: &str) -> Result<Model, RepositoryError> {
+            self.0.get_by_name(name).await
+        }
+        async fn find_by_path(&self, _path: &Path) -> Result<Option<Model>, RepositoryError> {
+            Ok(self.0.list().await?.into_iter().next())
+        }
+        async fn insert(&self, model: &NewModel) -> Result<Model, RepositoryError> {
+            self.0.insert(model).await
+        }
+        async fn update(&self, model: &Model) -> Result<(), RepositoryError> {
+            self.0.update(model).await
+        }
+        async fn delete(&self, id: i64) -> Result<(), RepositoryError> {
+            self.0.delete(id).await
+        }
+    }
+
+    /// The refusal resolves both sides, so a row whose stored path is spelled
+    /// differently from the caller's — while naming the same file — is still
+    /// recognised as that caller's own model and refreshed.
+    ///
+    /// That state is reachable: `canonical_model_path_string` falls back to
+    /// the literal path when the file cannot be resolved, so a row registered
+    /// while its file was missing keeps whatever spelling it was given.
+    /// Comparing the stored column directly would refuse a refresh of the
+    /// model's own file and print the same path on both sides of the error.
+    #[tokio::test]
+    async fn a_refresh_is_accepted_when_the_stored_path_is_only_spelled_differently() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Solo.gguf");
+        std::fs::File::create(&file).unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let respelled = dir.path().join("sub").join("..").join("Solo.gguf");
+
+        // Seed the row under the indirect spelling, as a registration made
+        // while the file was unresolvable would have.
+        let inner = MockRepo::new();
+        inner
+            .insert(&NewModel::new(
+                "Solo".to_string(),
+                respelled,
+                7.0,
+                Utc::now(),
+            ))
+            .await
+            .unwrap();
+
+        let service = ModelService::new(Arc::new(SiblingMatchRepo(inner)));
+        let outcome = service
+            .import_from_file(
+                &file,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Refresh,
+            )
+            .await;
+
+        // Only that the guard *lets it through* is asserted here. Which row it
+        // then lands on turns on key identity, and `MockRepo` upserts on
+        // `file_path` while the real repository upserts on `model_key` — the
+        // divergence noted above. Under this double the two spellings look
+        // like two rows; under the real repository both resolve to one key.
+        // The landing is covered against the real repository by
+        // gglib-app-services' `forcing_from_a_sibling_shard_refuses_rather_than_repointing`.
+        assert!(
+            outcome.is_ok(),
+            "the row names this very file, however it was spelled: {:?}",
+            outcome.err()
+        );
+    }
+
+    /// The other side of the same guard: when the located row names a
+    /// genuinely different file — the sharded case, where the sibling arm
+    /// returns the shard-1 row — the refresh is refused rather than
+    /// repointing it.
+    #[tokio::test]
+    async fn a_refresh_is_refused_when_the_located_row_names_another_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("m-00001-of-00002.gguf");
+        let second = dir.path().join("m-00002-of-00002.gguf");
+        std::fs::File::create(&first).unwrap();
+        std::fs::File::create(&second).unwrap();
+
+        let inner = MockRepo::new();
+        inner
+            .insert(&NewModel::new(
+                "Sharded".to_string(),
+                first,
+                7.0,
+                Utc::now(),
+            ))
+            .await
+            .unwrap();
+
+        let service = ModelService::new(Arc::new(SiblingMatchRepo(inner)));
+        let err = service
+            .import_from_file(
+                &second,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Refresh,
+            )
+            .await
+            .expect_err("shard 2 must not repoint the shard-1 row");
+
+        assert!(matches!(err, CoreError::Validation(_)), "got {err:?}");
     }
 
     /// A second *different* file must still go in — the check keys on the
@@ -635,7 +1070,12 @@ mod tests {
             let path = dir.path().join(name);
             std::fs::File::create(&path).unwrap();
             service
-                .import_from_file(&path, &crate::ports::NoopGgufParser, None)
+                .import_from_file(
+                    &path,
+                    &crate::ports::NoopGgufParser,
+                    None,
+                    ImportMode::Fresh,
+                )
                 .await
                 .unwrap_or_else(|e| panic!("{name} should import: {e:?}"));
         }
@@ -651,6 +1091,7 @@ mod tests {
                 Path::new("/nonexistent/model.gguf"),
                 &crate::ports::NoopGgufParser,
                 None,
+                ImportMode::Fresh,
             )
             .await
             .unwrap_err();
@@ -667,7 +1108,12 @@ mod tests {
         std::fs::File::create(&path).unwrap();
 
         let err = service
-            .import_from_file(&path, &crate::ports::NoopGgufParser, None)
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                None,
+                ImportMode::Fresh,
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, CoreError::Validation(_)));
@@ -683,7 +1129,12 @@ mod tests {
         std::fs::File::create(&path).unwrap();
 
         let model = service
-            .import_from_file(&path, &crate::ports::NoopGgufParser, Some(13.0))
+            .import_from_file(
+                &path,
+                &crate::ports::NoopGgufParser,
+                Some(13.0),
+                ImportMode::Fresh,
+            )
             .await
             .unwrap();
 

--- a/crates/gglib-db/src/repositories/mod.rs
+++ b/crates/gglib-db/src/repositories/mod.rs
@@ -5,7 +5,7 @@ mod sqlite_benchmark_repository;
 mod sqlite_chat_history_repository;
 mod sqlite_download_state_repository;
 mod sqlite_mcp_repository;
-mod sqlite_model_repository;
+pub(crate) mod sqlite_model_repository;
 mod sqlite_settings_repository;
 
 pub use model_files_repository::ModelFilesRepository;

--- a/crates/gglib-db/src/repositories/row_mappers.rs
+++ b/crates/gglib-db/src/repositories/row_mappers.rs
@@ -209,10 +209,12 @@ fn try_read_summary(row: &sqlx::sqlite::SqliteRow) -> Option<ModelBenchmarkSumma
 }
 
 /// Normalizes a file path to a canonical string representation.
+///
+/// Delegates so that the stored column, the `model_key` derived from it and
+/// the duplicate lookup that reads it all share one definition of "the same
+/// file"; see [`gglib_core::paths::canonical_model_path`].
 pub fn normalized_file_path_string(path: &Path) -> String {
-    std::fs::canonicalize(path)
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| path.to_string_lossy().to_string())
+    gglib_core::paths::canonical_model_path_string(path)
 }
 
 /// Parse a database row into a ModelFile.

--- a/crates/gglib-db/src/repositories/sqlite_model_repository.rs
+++ b/crates/gglib-db/src/repositories/sqlite_model_repository.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use sqlx::SqlitePool;
+use std::path::Path;
 
 use gglib_core::utils::shard_filename::base_shard_filename;
 use gglib_core::{Model, ModelRepository, NewModel, RepositoryError};
@@ -17,21 +18,59 @@ use super::row_mappers::{
 ///
 /// The filename is normalized to remove shard suffixes, ensuring all shards
 /// in a group compute the same model_key for proper UPSERT deduplication.
-fn compute_model_key(model: &NewModel) -> String {
+///
+/// The local key hashes the *canonical* path — the very value bound to the
+/// `file_path` column a few lines below — rather than the raw path it was
+/// handed. Hashing the raw path made the key disagree with the column:
+/// `gglib model add model.gguf`, run in two different directories over two
+/// genuinely different files, produced one key and two stored paths. The
+/// `ON CONFLICT(model_key)` clause then merged them, and because `name`,
+/// `param_count_b` and `architecture` are absent from its `DO UPDATE SET`
+/// list while `file_path` is present, the surviving row wore the first
+/// model's identity over the second model's file.
+///
+/// It hashes a [`Path`], not the `String`, and that is load-bearing rather
+/// than stylistic. `Path`'s `Hash` is defined over components while `str`'s
+/// is defined over bytes, so the two disagree for a path they both consider
+/// identical. Hashing the string would therefore have moved the key of *every*
+/// local row already in a user's library, rather than only the rows this rule
+/// genuinely re-keys — the ones registered under a spelling that was not
+/// already canonical.
+///
+/// Those rows do move, and they are migrated rather than stranded:
+/// `setup::backfill_local_model_keys` recomputes each `local:` key from the
+/// stored `file_path` column on open. That column has been canonical on every
+/// build that ever wrote it, so it is a sound source. The migration matters
+/// most on Windows, where `canonicalize` returns an extended-length `\\?\`
+/// path that no pre-change caller ever produced — so *no* Windows row was
+/// "already canonical" and every one of them needs re-keying.
+///
+/// `canonical_path` is the already-resolved string the caller is about to bind
+/// to `file_path`, passed in rather than recomputed. Resolving is a blocking
+/// syscall and this runs inside an async `insert`; taking it as an argument
+/// also makes it impossible for the key and the column to be derived from two
+/// different resolutions of the same path.
+fn compute_model_key(model: &NewModel, canonical_path: &str) -> String {
     match (&model.hf_repo_id, &model.hf_commit_sha, &model.hf_filename) {
         (Some(repo), Some(sha), Some(filename)) => {
             let base = base_shard_filename(filename);
             format!("hf:{}@{}#{}", repo, sha, base)
         }
-        _ => {
-            // For local models without HF metadata, use file path
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::{Hash, Hasher};
-            let mut hasher = DefaultHasher::new();
-            model.file_path.hash(&mut hasher);
-            format!("local:{:x}", hasher.finish())
-        }
+        _ => local_model_key_for(canonical_path),
     }
+}
+
+/// The `local:` key for an already-canonical path string.
+///
+/// Split out so the startup backfill in `setup.rs` can recompute a stored
+/// row's key from its `file_path` column using exactly this function, rather
+/// than a second copy of the rule that could drift from it.
+pub(crate) fn local_model_key_for(canonical_path: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    Path::new(canonical_path).hash(&mut hasher);
+    format!("local:{:x}", hasher.finish())
 }
 
 /// `SQLite` implementation of the `ModelRepository` trait.
@@ -107,6 +146,40 @@ impl ModelRepository for SqliteModelRepository {
         row_to_model(&row)
     }
 
+    async fn find_by_path(&self, path: &Path) -> Result<Option<Model>, RepositoryError> {
+        // `path` arrives already resolved, and `file_path` was normalised
+        // through the same function on write, so this is a plain equality
+        // test rather than a scan that re-resolves every row. That matters
+        // twice over: it keeps a blocking `canonicalize` syscall per library
+        // row out of an async fn, and it removes the fallback that used to
+        // turn an unresolvable path into "no duplicate found".
+        //
+        // The `json_each` arm catches sharded models: shard 2 of a group
+        // already registered is the same duplicate as shard 1, but only
+        // shard 1's path lives in `file_path` — the rest are in
+        // `file_paths_json`. `json_valid` guards a column written before that
+        // serialisation existed, since `json_each` errors on malformed input
+        // rather than returning no rows.
+        let query = format!(
+            "SELECT {} FROM models \
+             WHERE models.file_path = ?1 \
+                OR (models.file_paths_json IS NOT NULL \
+                    AND json_valid(models.file_paths_json) \
+                    AND EXISTS (SELECT 1 FROM json_each(models.file_paths_json) \
+                                WHERE json_each.value = ?1)) \
+             ORDER BY models.id LIMIT 1",
+            MODEL_SELECT_COLUMNS
+        );
+
+        let row = sqlx::query(&query)
+            .bind(path.to_string_lossy().as_ref())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| RepositoryError::Storage(e.to_string()))?;
+
+        row.as_ref().map(row_to_model).transpose()
+    }
+
     async fn insert(&self, model: &NewModel) -> Result<Model, RepositoryError> {
         let metadata_json = serde_json::to_string(&model.metadata)
             .map_err(|e| RepositoryError::Serialization(e.to_string()))?;
@@ -137,13 +210,20 @@ impl ModelRepository for SqliteModelRepository {
             .and_then(|spec| serde_json::to_string(spec).ok());
 
         // Compute model key for deduplication
-        let model_key = compute_model_key(model);
+        let model_key = compute_model_key(model, &file_path_string);
 
-        // Serialize file_paths if present
-        let file_paths_json = model
-            .file_paths
-            .as_ref()
-            .and_then(|paths| serde_json::to_string(paths).ok());
+        // Serialize file_paths if present, normalised the same way as
+        // `file_path` above. `find_by_path`'s sibling arm compares a resolved
+        // query path against these entries, so storing them as handed in
+        // would make that arm match only when the caller happened to pass
+        // already-resolved siblings — which the download path does not.
+        let file_paths_json = model.file_paths.as_ref().and_then(|paths| {
+            let normalized: Vec<String> = paths
+                .iter()
+                .map(|path| normalized_file_path_string(path))
+                .collect();
+            serde_json::to_string(&normalized).ok()
+        });
 
         // Use UPSERT to make registration idempotent
         let _result = sqlx::query(
@@ -155,14 +235,24 @@ impl ModelRepository for SqliteModelRepository {
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(model_key) DO UPDATE SET
                 file_path = excluded.file_path,
-                file_paths_json = excluded.file_paths_json,
+                -- Coalesced, not assigned. A re-registration that carries no
+                -- shard list is a local re-import, which never populates one;
+                -- assigning would erase the sibling paths a download recorded
+                -- and silently disable the sharded-duplicate lookup for that
+                -- model. A download always supplies the list, so it still
+                -- wins when there is one.
+                file_paths_json = COALESCE(excluded.file_paths_json, models.file_paths_json),
                 quantization = COALESCE(excluded.quantization, models.quantization),
                 context_length = COALESCE(excluded.context_length, models.context_length),
                 expert_count = COALESCE(excluded.expert_count, models.expert_count),
                 expert_used_count = COALESCE(excluded.expert_used_count, models.expert_used_count),
                 expert_shared_count = COALESCE(excluded.expert_shared_count, models.expert_shared_count),
-                download_date = excluded.download_date,
-                last_update_check = excluded.last_update_check,
+                -- Coalesced for the same reason: a local re-import sets
+                -- neither, and erasing them would make a downloaded model
+                -- read as never-downloaded and never-update-checked, which
+                -- the update-check workflow keys on.
+                download_date = COALESCE(excluded.download_date, models.download_date),
+                last_update_check = COALESCE(excluded.last_update_check, models.last_update_check),
                 tags = excluded.tags,
                 capabilities = excluded.capabilities,
                 dialect_spec = excluded.dialect_spec,
@@ -239,7 +329,12 @@ impl ModelRepository for SqliteModelRepository {
             "UPDATE models SET name = ?, file_path = ?, param_count_b = ?, architecture = ?, quantization = ?, context_length = ?, metadata = ?, hf_repo_id = ?, hf_commit_sha = ?, hf_filename = ?, download_date = ?, last_update_check = ?, tags = ?, capabilities = ?, inference_defaults = ?, defaults_origin = ?, server_defaults = ?, dialect_spec = ? WHERE id = ?"
         )
             .bind(&model.name)
-            .bind(model.file_path.to_string_lossy().as_ref())
+            // Normalised exactly as `insert` does. `find_by_path` is a plain
+            // equality test against this column, so a writer that stores an
+            // unresolved path here silently makes the row unfindable — and
+            // `PATCH /api/models/{id}` reaches this with a caller-supplied
+            // `file_path`.
+            .bind(normalized_file_path_string(&model.file_path))
             .bind(model.param_count_b)
             .bind(&model.architecture)
             .bind(&model.quantization)
@@ -365,12 +460,12 @@ mod tests {
         );
     }
 
-    /// The repository canonicalises on write, so a caller holding the path it
-    /// was handed must still match. On macOS a `tempfile` path resolves
-    /// through `/private`, which is exactly the mismatch that would make a
-    /// duplicate look like a new model.
+    /// The repository canonicalises on write, and callers resolve before
+    /// asking, so a real file on disk round-trips. On macOS a `tempfile`
+    /// directory resolves through `/private`, which is exactly the mismatch
+    /// that would make a duplicate look like a new model.
     #[tokio::test]
-    async fn find_by_path_matches_across_canonicalisation() {
+    async fn find_by_path_matches_the_stored_canonical_path() {
         let repo = repo().await;
 
         let dir = tempfile::tempdir().unwrap();
@@ -387,11 +482,285 @@ mod tests {
             .await
             .unwrap();
 
+        let resolved = std::fs::canonicalize(&path).expect("the file exists");
         let found = repo
-            .find_by_path(&path)
+            .find_by_path(&resolved)
             .await
             .unwrap()
-            .expect("the uncanonicalised path must still find it");
+            .expect("the resolved path must find the row stored under it");
+        assert_eq!(found.id, inserted.id);
+    }
+
+    /// **Upgrade safety.** The key a previous build computed for an
+    /// already-canonical path must not move.
+    ///
+    /// Nothing backfills `model_key` — it appears in `setup.rs` only as a
+    /// column and a unique index. If this value shifts, every local row in
+    /// every existing library becomes unreachable by `ON CONFLICT(model_key)`
+    /// and the next registration of that file silently appends a second row,
+    /// which is the exact failure this PR exists to prevent.
+    ///
+    /// The expectation is recomputed the old way rather than hardcoded,
+    /// because `DefaultHasher`'s output is explicitly not guaranteed stable
+    /// across Rust releases. What is pinned is the relationship: hashing the
+    /// canonical path must agree with hashing the `PathBuf` a previous build
+    /// hashed.
+    #[test]
+    fn the_local_key_for_a_canonical_path_survives_the_upgrade() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        // A real file, resolved: the point is that a genuine canonicalisation
+        // runs and still lands on the previous value. A path that does not
+        // exist would take the literal fallback, so no canonicalisation would
+        // happen and the assertion would prove nothing about it — and would
+        // break on any machine where that path did exist behind a symlink.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Qwen3-8B-Q4_K_M.gguf");
+        std::fs::File::create(&file).unwrap();
+        let path = std::fs::canonicalize(&file).expect("the file exists");
+        assert_eq!(
+            std::fs::canonicalize(&path).unwrap(),
+            path,
+            "the fixture must already be canonical"
+        );
+
+        // What builds up to and including c825c69d computed.
+        let previous = {
+            let mut hasher = DefaultHasher::new();
+            path.hash(&mut hasher);
+            format!("local:{:x}", hasher.finish())
+        };
+
+        let model = NewModel::new("Qwen3-8B-Q4_K_M".to_string(), path, 7.0, Utc::now());
+        assert_eq!(
+            compute_model_key(&model, &normalized_file_path_string(&model.file_path)),
+            previous,
+            "changing the local key strands every existing local row"
+        );
+    }
+
+    /// **The asymmetry this follow-up exists for.** One file is one model,
+    /// however its path was spelled on the way in.
+    ///
+    /// The local `model_key` hashes the path. While it hashed the *raw* path
+    /// and the `file_path` column stored the *resolved* one, the two
+    /// disagreed about identity: two spellings of a single file produced two
+    /// keys and therefore two rows for one model on disk, and — the
+    /// destructive direction — one raw spelling reaching two different files
+    /// produced a single key, so `ON CONFLICT(model_key)` merged them. Because
+    /// `name`, `param_count_b` and `architecture` are absent from the
+    /// `DO UPDATE SET` list while `file_path` is present, that survivor wore
+    /// the first model's identity over the second model's file.
+    ///
+    /// Hashing the stored string closes both directions at once. This test
+    /// pins the spelling direction, which is the one reachable without
+    /// changing the process working directory; it fails if the key goes back
+    /// to hashing the path it was handed.
+    ///
+    /// The respelling uses `..` deliberately. `Path`'s `Eq` and `Hash` are
+    /// defined over *components*, so a `.` or a doubled separator is already
+    /// normalised away before any hashing happens and cannot demonstrate the
+    /// difference. `..` survives as a real component — the filesystem is the
+    /// only thing that can resolve it — which is exactly the gap between
+    /// "the path as written" and "the file it names".
+    #[tokio::test]
+    async fn two_spellings_of_one_path_are_one_model() {
+        let repo = repo().await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Solo.gguf");
+        std::fs::File::create(&path).unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        // Same file, a path only the filesystem can equate: `dir/sub/../Solo.gguf`.
+        let respelled = dir.path().join("sub").join("..").join("Solo.gguf");
+        assert_ne!(path, respelled, "the two spellings must differ literally");
+
+        let first = repo
+            .insert(&NewModel::new("Solo".to_string(), path, 7.0, Utc::now()))
+            .await
+            .unwrap();
+        let second = repo
+            .insert(&NewModel::new(
+                "Solo".to_string(),
+                respelled,
+                7.0,
+                Utc::now(),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first.id, second.id,
+            "one file must be one model whichever way its path was written"
+        );
+        assert_eq!(repo.list().await.unwrap().len(), 1);
+    }
+
+    /// Two genuinely different files that share a basename are two models.
+    ///
+    /// Companion to the test above, pinning the opposite direction: this one
+    /// holds under either key rule, and exists so that a future "fix" which
+    /// over-normalises — hashing only the filename, say — is caught.
+    #[tokio::test]
+    async fn two_files_sharing_a_basename_stay_two_models() {
+        let repo = repo().await;
+
+        let root = tempfile::tempdir().unwrap();
+        let alpha_path = root.path().join("projA").join("model.gguf");
+        let beta_path = root.path().join("projB").join("model.gguf");
+        for path in [&alpha_path, &beta_path] {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::File::create(path).unwrap();
+        }
+
+        let alpha = repo
+            .insert(&NewModel::new(
+                "ALPHA".to_string(),
+                alpha_path.clone(),
+                7.0,
+                Utc::now(),
+            ))
+            .await
+            .unwrap();
+        let beta = repo
+            .insert(&NewModel::new(
+                "BETA".to_string(),
+                beta_path.clone(),
+                7.0,
+                Utc::now(),
+            ))
+            .await
+            .unwrap();
+
+        assert_ne!(
+            alpha.id, beta.id,
+            "two different files must not collapse into one row"
+        );
+        assert_eq!(repo.list().await.unwrap().len(), 2);
+
+        let at_beta = repo
+            .find_by_path(&std::fs::canonicalize(&beta_path).unwrap())
+            .await
+            .unwrap()
+            .expect("a row at B's path");
+        assert_eq!(
+            at_beta.name, "BETA",
+            "the row standing at B's path must be B's model, not A's identity"
+        );
+    }
+
+    /// A refresh must not erase what only a download knows.
+    ///
+    /// `file_paths_json`, `download_date` and `last_update_check` were plain
+    /// assignments in `DO UPDATE SET`, and a local re-import populates none of
+    /// them — so `--force` on a downloaded model wiped its shard list (taking
+    /// the sibling lookup with it) and made it read as never-downloaded and
+    /// never-update-checked, which the update-check workflow keys on.
+    #[tokio::test]
+    async fn a_refresh_keeps_the_shard_list_and_download_provenance() {
+        let repo = repo().await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("m-00001-of-00002.gguf");
+        let second = dir.path().join("m-00002-of-00002.gguf");
+        std::fs::File::create(&first).unwrap();
+        std::fs::File::create(&second).unwrap();
+
+        let mut downloaded = NewModel::new("Sharded".to_string(), first.clone(), 7.0, Utc::now());
+        downloaded.file_paths = Some(vec![first.clone(), second.clone()]);
+        downloaded.download_date = Some(Utc::now());
+        downloaded.last_update_check = Some(Utc::now());
+        let original = repo.insert(&downloaded).await.unwrap();
+
+        // A local re-import of the same file: no shard list, no dates.
+        let reimport = NewModel::new("Sharded".to_string(), first.clone(), 7.0, Utc::now());
+        let refreshed = repo.insert(&reimport).await.unwrap();
+
+        assert_eq!(refreshed.id, original.id, "same row");
+        assert!(
+            refreshed.download_date.is_some(),
+            "a refresh must not erase download_date"
+        );
+        assert!(
+            refreshed.last_update_check.is_some(),
+            "a refresh must not erase last_update_check"
+        );
+        assert!(
+            repo.find_by_path(&std::fs::canonicalize(&second).unwrap())
+                .await
+                .unwrap()
+                .is_some(),
+            "the shard list must survive a refresh, or the sibling lookup dies with it"
+        );
+    }
+
+    /// Adding shard 2 of a group already registered is the same duplicate as
+    /// adding shard 1. Only the first shard's path reaches `file_path`; the
+    /// siblings live in `file_paths_json`, so a lookup that reads only the
+    /// column would wave the rest through.
+    #[tokio::test]
+    async fn find_by_path_matches_a_sharded_sibling() {
+        let repo = repo().await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("model-00001-of-00002.gguf");
+        let second = dir.path().join("model-00002-of-00002.gguf");
+        std::fs::File::create(&first).unwrap();
+        std::fs::File::create(&second).unwrap();
+
+        // Handed in exactly as the download path hands them in: unresolved.
+        // Canonicalising these here would have the test normalise on the
+        // repository's behalf and pass whether or not `insert` does its job —
+        // on macOS a tempdir sits behind `/private`, so raw and resolved
+        // genuinely differ and the sibling arm would never match in
+        // production.
+        let mut model = NewModel::new("Sharded".to_string(), first.clone(), 7.0, Utc::now());
+        model.file_paths = Some(vec![first.clone(), second.clone()]);
+        let inserted = repo.insert(&model).await.unwrap();
+
+        let found = repo
+            .find_by_path(&std::fs::canonicalize(&second).unwrap())
+            .await
+            .unwrap()
+            .expect("the sibling shard belongs to a model already present");
+        assert_eq!(found.id, inserted.id);
+    }
+
+    /// `update` writes `file_path` too, and `find_by_path` is a plain equality
+    /// test against that column. A writer that stores an unresolved path makes
+    /// the row unfindable — and `PATCH /api/models/{id}` reaches this with a
+    /// caller-supplied path.
+    #[tokio::test]
+    async fn update_stores_a_canonical_path_so_the_row_stays_findable() {
+        let repo = repo().await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Updatable.gguf");
+        std::fs::File::create(&path).unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+
+        let inserted = repo
+            .insert(&NewModel::new(
+                "Updatable".to_string(),
+                path.clone(),
+                7.0,
+                Utc::now(),
+            ))
+            .await
+            .unwrap();
+
+        // Write the same file back under a spelling only the filesystem can
+        // equate, as an API caller might.
+        let mut edited = inserted.clone();
+        edited.file_path = dir.path().join("sub").join("..").join("Updatable.gguf");
+        repo.update(&edited).await.unwrap();
+
+        let found = repo
+            .find_by_path(&std::fs::canonicalize(&path).unwrap())
+            .await
+            .unwrap()
+            .expect("an updated row must still be findable by its real path");
         assert_eq!(found.id, inserted.id);
     }
 

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -754,10 +754,13 @@ mod tests {
     /// `ON CONFLICT(model_key)` and the next registration of that file
     /// silently appends a second row.
     ///
-    /// The tempdir path is the realistic case rather than a contrived one: on
-    /// macOS it sits under `/var`, which resolves through `/private/var`, so
-    /// the spelling the user passes and the column the row stores genuinely
-    /// differ.
+    /// The non-canonical spelling is built with `..` rather than borrowed from
+    /// the platform. A `tempfile` directory is non-canonical on macOS, where
+    /// `/var` resolves through `/private/var`, and already canonical on Linux
+    /// — so leaning on it wrote a test that passed on the machine it was
+    /// written on and failed in CI. `..` survives as a real path component
+    /// everywhere, which is what makes the two spellings differ on every
+    /// platform.
     #[tokio::test]
     async fn backfill_rekeys_a_row_stored_under_a_non_canonical_spelling() {
         use crate::repositories::sqlite_model_repository::local_model_key_for;
@@ -767,9 +770,12 @@ mod tests {
         let pool = setup_test_database().await.unwrap();
 
         let dir = tempfile::tempdir().unwrap();
-        let spelled = dir.path().join("Legacy.gguf");
-        std::fs::File::create(&spelled).unwrap();
-        let canonical = std::fs::canonicalize(&spelled).unwrap();
+        let file = dir.path().join("Legacy.gguf");
+        std::fs::File::create(&file).unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+
+        let spelled = dir.path().join("sub").join("..").join("Legacy.gguf");
+        let canonical = std::fs::canonicalize(&file).unwrap();
         assert_ne!(
             spelled, canonical,
             "this test needs the two spellings to differ"

--- a/crates/gglib-db/src/setup.rs
+++ b/crates/gglib-db/src/setup.rs
@@ -12,6 +12,26 @@ use sqlx::{
 use std::path::Path;
 use std::time::Duration;
 
+/// `PRAGMA user_version` once the canonical-path backfills have run.
+///
+/// Databases predating this carry `0`, SQLite's default. The first version
+/// this project has assigned; anything later must take a higher number and
+/// leave this one meaning what it means now.
+const CANONICAL_PATH_SCHEMA_VERSION: i64 = 1;
+
+/// Whether a `SQLite` error is a unique-index violation.
+///
+/// Used to tell the one failure the path backfill deliberately tolerates —
+/// two rows resolving onto one key — apart from a locked or full database,
+/// which must surface rather than be counted as a tidy skip.
+fn is_unique_violation(error: &sqlx::Error) -> bool {
+    matches!(
+        error,
+        sqlx::Error::Database(db) if db.code().as_deref() == Some("2067")
+            || db.code().as_deref() == Some("1555")
+    )
+}
+
 /// Sets up the `SQLite` database connection and ensures the schema exists.
 ///
 /// This function:
@@ -186,6 +206,32 @@ async fn create_schema(pool: &SqlitePool) -> Result<()> {
     sqlx::query("CREATE UNIQUE INDEX IF NOT EXISTS idx_models_model_key ON models(model_key)")
         .execute(pool)
         .await?;
+
+    // The path/key backfills below resolve every stored path, which is a
+    // blocking syscall per row and per shard entry — on Windows that opens a
+    // handle to each file, so an ungated pass would stall launch on a model
+    // living on a sleeping drive or a dead mount. Gated on `user_version` so
+    // the cost is paid once per library.
+    //
+    // The gate makes the repair one-shot, which is a real trade and not merely
+    // an optimisation: once stamped, a row written under the old key rule
+    // afterwards is never repaired. That needs an older binary writing to an
+    // already-migrated database — mixed-version writers are out of scope, the
+    // usual bargain for a version-stamped migration. The passes themselves
+    // stay idempotent, so a crash before the stamp simply re-runs them.
+    let schema_version: i64 = sqlx::query_scalar("PRAGMA user_version")
+        .fetch_one(pool)
+        .await?;
+    if schema_version < CANONICAL_PATH_SCHEMA_VERSION {
+        backfill_local_model_keys(pool).await?;
+        backfill_shard_path_lists(pool).await?;
+        // Not bindable as a parameter: SQLite requires a literal here.
+        sqlx::query(&format!(
+            "PRAGMA user_version = {CANONICAL_PATH_SCHEMA_VERSION}"
+        ))
+        .execute(pool)
+        .await?;
+    }
 
     // Index on model name for faster LIKE queries
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_models_name ON models(name)")
@@ -559,9 +605,284 @@ async fn init_settings_table(pool: &SqlitePool) -> Result<()> {
     Ok(())
 }
 
+/// Migration: put local models' paths and keys onto the canonical rule.
+///
+/// A `local:` key is a hash of the model's path. Until recently the hash was
+/// taken over the path *as the caller spelled it* — `gglib model add
+/// ./model.gguf` hashed `./model.gguf` — while `file_path` was normalised on
+/// insert. Rows added through a relative path, a symlinked models directory,
+/// or a macOS temp path (`/var` → `/private/var`) therefore carry a key no
+/// current build will ever recompute.
+///
+/// The consequence is silent and bad: `ON CONFLICT(model_key)` misses the row,
+/// `file_path` carries no unique index, and re-registering that file appends a
+/// second one — which is exactly the duplicate this whole area exists to
+/// prevent, arriving by way of the upgrade rather than by way of a bug.
+///
+/// **The stored column cannot simply be trusted.** `insert` normalised it, but
+/// `update` did not until this change, so any row that went through
+/// `PATCH /api/models/{id}` holds whatever spelling the caller sent; and
+/// `insert`'s normalisation falls back to the literal path when the file is
+/// missing. Re-keying from the column verbatim would therefore compute a key
+/// from a non-canonical string, leaving the row exactly as unreachable as
+/// before while reporting success. So each path is resolved here first, the
+/// column rewritten when it moves, and the key derived from the resolved form
+/// — the same value `insert` would compute for that file today.
+///
+/// Idempotent: once a row is normalised the recomputed values equal the stored
+/// ones and no write happens. A row whose new key would collide with another
+/// row's is left alone rather than failing the unique index — that collision
+/// means two rows genuinely name one file, which is a merge a startup
+/// migration has no business performing silently. Any other database error is
+/// propagated rather than counted as a skip.
+async fn backfill_local_model_keys(pool: &SqlitePool) -> Result<()> {
+    use crate::repositories::sqlite_model_repository::local_model_key_for;
+    use gglib_core::paths::canonical_model_path_string;
+    use sqlx::Row;
+    use std::path::Path;
+
+    let rows =
+        sqlx::query("SELECT id, file_path, model_key FROM models WHERE model_key LIKE 'local:%'")
+            .fetch_all(pool)
+            .await?;
+
+    let mut rekeyed = 0_usize;
+    let mut skipped = 0_usize;
+    for row in &rows {
+        let id: i64 = row.try_get("id")?;
+        let file_path: String = row.try_get("file_path")?;
+        let stored_key: String = row.try_get("model_key")?;
+
+        let canonical = canonical_model_path_string(Path::new(&file_path));
+        let expected = local_model_key_for(&canonical);
+        if expected == stored_key && canonical == file_path {
+            continue;
+        }
+
+        match sqlx::query("UPDATE models SET model_key = ?, file_path = ? WHERE id = ?")
+            .bind(&expected)
+            .bind(&canonical)
+            .bind(id)
+            .execute(pool)
+            .await
+        {
+            Ok(_) => rekeyed += 1,
+            // Only the collision described above is absorbed. A locked or
+            // full database must not be reported as a tidy "skipped".
+            Err(e) if is_unique_violation(&e) => skipped += 1,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    if rekeyed > 0 || skipped > 0 {
+        tracing::info!(
+            rekeyed,
+            skipped,
+            "re-keyed local models onto the canonical-path rule"
+        );
+    }
+    Ok(())
+}
+
+/// Migration: canonicalise the stored shard path lists.
+///
+/// Companion to [`backfill_local_model_keys`], and needed for the same reason:
+/// `file_paths_json` used to be written exactly as the download handed it over
+/// — absolute, but never symlink-resolved — while the duplicate lookup
+/// compares those entries against a resolved path.
+///
+/// Left alone, `gglib model add <shard-2>` against a sharded model already in
+/// the library matches nothing, so the add proceeds and appends a second row
+/// for a model that is already there. Unlike the key backfill this needs no
+/// `--force` to reach: it is the plain add path.
+///
+/// Applies to every row with a shard list, not only `local:` ones — a
+/// downloaded sharded model keeps its `hf:` key but had its paths written the
+/// same raw way. Idempotent: once resolved, re-resolving is the identity.
+async fn backfill_shard_path_lists(pool: &SqlitePool) -> Result<()> {
+    use gglib_core::paths::canonical_model_path_string;
+    use sqlx::Row;
+    use std::path::Path;
+
+    let rows =
+        sqlx::query("SELECT id, file_paths_json FROM models WHERE file_paths_json IS NOT NULL")
+            .fetch_all(pool)
+            .await?;
+
+    let mut rewritten = 0_usize;
+    for row in &rows {
+        let id: i64 = row.try_get("id")?;
+        let stored: String = row.try_get("file_paths_json")?;
+
+        // A column written before this serialisation existed, or by hand, is
+        // left exactly as found rather than guessed at.
+        let Ok(paths) = serde_json::from_str::<Vec<String>>(&stored) else {
+            continue;
+        };
+
+        let resolved: Vec<String> = paths
+            .iter()
+            .map(|p| canonical_model_path_string(Path::new(p)))
+            .collect();
+        if resolved == paths {
+            continue;
+        }
+
+        let Ok(encoded) = serde_json::to_string(&resolved) else {
+            continue;
+        };
+        sqlx::query("UPDATE models SET file_paths_json = ? WHERE id = ?")
+            .bind(&encoded)
+            .bind(id)
+            .execute(pool)
+            .await?;
+        rewritten += 1;
+    }
+
+    if rewritten > 0 {
+        tracing::info!(rewritten, "canonicalised stored shard path lists");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A row written by a build that hashed the path as the user spelled it
+    /// must be re-keyed onto the canonical rule, or it stays unreachable by
+    /// `ON CONFLICT(model_key)` and the next registration of that file
+    /// silently appends a second row.
+    ///
+    /// The tempdir path is the realistic case rather than a contrived one: on
+    /// macOS it sits under `/var`, which resolves through `/private/var`, so
+    /// the spelling the user passes and the column the row stores genuinely
+    /// differ.
+    #[tokio::test]
+    async fn backfill_rekeys_a_row_stored_under_a_non_canonical_spelling() {
+        use crate::repositories::sqlite_model_repository::local_model_key_for;
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let pool = setup_test_database().await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let spelled = dir.path().join("Legacy.gguf");
+        std::fs::File::create(&spelled).unwrap();
+        let canonical = std::fs::canonicalize(&spelled).unwrap();
+        assert_ne!(
+            spelled, canonical,
+            "this test needs the two spellings to differ"
+        );
+
+        // Exactly what a previous build wrote: canonical column, key hashed
+        // from the path it was handed.
+        let legacy_key = {
+            let mut hasher = DefaultHasher::new();
+            spelled.hash(&mut hasher);
+            format!("local:{:x}", hasher.finish())
+        };
+        sqlx::query(
+            "INSERT INTO models (name, file_path, param_count_b, added_at, model_key) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("Legacy")
+        .bind(canonical.to_string_lossy().as_ref())
+        .bind(7.0_f64)
+        .bind(chrono::Utc::now().to_string())
+        .bind(&legacy_key)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        backfill_local_model_keys(&pool).await.unwrap();
+
+        let key: String = sqlx::query_scalar("SELECT model_key FROM models WHERE name = 'Legacy'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            key,
+            local_model_key_for(canonical.to_string_lossy().as_ref()),
+            "the stranded row must be re-keyed onto the rule this build computes"
+        );
+        assert_ne!(key, legacy_key, "the key must actually have moved");
+
+        // Idempotent: a second pass is a no-op.
+        backfill_local_model_keys(&pool).await.unwrap();
+        let again: String =
+            sqlx::query_scalar("SELECT model_key FROM models WHERE name = 'Legacy'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(again, key);
+    }
+
+    /// A row whose stored `file_path` is itself non-canonical must be repaired,
+    /// not merely re-keyed from the bad value.
+    ///
+    /// `insert` normalised the column but `update` did not, so any row that
+    /// went through `PATCH /api/models/{id}` holds whatever spelling the caller
+    /// sent — and `insert`'s own normalisation falls back to the literal path
+    /// when the file is missing. Hashing the column verbatim would compute a
+    /// key from that non-canonical string and leave the row exactly as
+    /// unreachable as before, while reporting success.
+    #[tokio::test]
+    async fn backfill_repairs_a_row_whose_stored_path_is_not_canonical() {
+        use crate::repositories::sqlite_model_repository::local_model_key_for;
+
+        let pool = setup_test_database().await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Patched.gguf");
+        std::fs::File::create(&file).unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+
+        // What pre-fix `update` left behind: a spelling only the filesystem
+        // can equate with the real path.
+        let non_canonical = dir.path().join("sub").join("..").join("Patched.gguf");
+        let canonical = std::fs::canonicalize(&file).unwrap();
+        assert_ne!(
+            non_canonical.to_string_lossy(),
+            canonical.to_string_lossy(),
+            "the fixture must actually be non-canonical"
+        );
+
+        sqlx::query(
+            "INSERT INTO models (name, file_path, param_count_b, added_at, model_key) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("Patched")
+        .bind(non_canonical.to_string_lossy().as_ref())
+        .bind(7.0_f64)
+        .bind(chrono::Utc::now().to_string())
+        .bind(local_model_key_for(
+            non_canonical.to_string_lossy().as_ref(),
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        backfill_local_model_keys(&pool).await.unwrap();
+
+        let (stored_path, stored_key): (String, String) =
+            sqlx::query_as("SELECT file_path, model_key FROM models WHERE name = 'Patched'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            stored_path,
+            canonical.to_string_lossy(),
+            "the column itself must be repaired, or find_by_path still misses it"
+        );
+        assert_eq!(
+            stored_key,
+            local_model_key_for(canonical.to_string_lossy().as_ref()),
+            "the key must be the one a fresh `model add` of this file computes"
+        );
+    }
 
     #[tokio::test]
     async fn test_setup_test_database() {

--- a/crates/gglib-integration-tests/tests/integration_model_naming.rs
+++ b/crates/gglib-integration-tests/tests/integration_model_naming.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use common::{setup_test_pool, write_gguf_fixture};
 
-use gglib_core::services::ModelService;
+use gglib_core::services::{ImportMode, ModelService};
 use gglib_core::{CompletedDownload, ModelRegistrarPort, ModelRepository, Quantization};
 use gglib_db::{CoreFactory, SqliteModelRepository};
 use gglib_gguf::GgufParser;
@@ -24,7 +24,7 @@ async fn import_locally(file_path: &Path) -> gglib_core::Model {
     let repo = Arc::new(SqliteModelRepository::new(pool));
     let service = ModelService::new(repo);
     service
-        .import_from_file(file_path, &GgufParser::new(), None)
+        .import_from_file(file_path, &GgufParser::new(), None, ImportMode::Fresh)
         .await
         .unwrap()
 }

--- a/crates/gglib-integration-tests/tests/integration_model_quantization.rs
+++ b/crates/gglib-integration-tests/tests/integration_model_quantization.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use common::{setup_test_pool, write_gguf_fixture};
 
-use gglib_core::services::ModelService;
+use gglib_core::services::{ImportMode, ModelService};
 use gglib_db::SqliteModelRepository;
 use gglib_gguf::GgufParser;
 
@@ -28,7 +28,7 @@ async fn local_import_resolves_unsloth_dynamic_quantization_from_filename() {
     write_gguf_fixture(&path, &[("general.architecture", "qwen3")]);
 
     let model = service
-        .import_from_file(&path, &GgufParser::new(), None)
+        .import_from_file(&path, &GgufParser::new(), None, ImportMode::Fresh)
         .await
         .unwrap();
 

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -17,12 +17,16 @@ the runtime feel smarter than llama.cpp on its own.
 This crate is in the **Infrastructure Layer** — it manages external processes and provides system information.
 
 ```text
-gglib-core (ports)          gglib-runtime                   External
-┌──────────────────┐        ┌──────────────────┐        ┌──────────────────┐
-│  ProcessManager  │◄───────│  LlamaRunner     │───────►│  llama-server    │
-│  SystemProbe     │        │  ProxyManager    │        │  llama-cli       │
-│  HealthCheck     │        │  HealthChecker   │        └──────────────────┘
-└──────────────────┘        └──────────────────┘
+gglib-core (ports)          gglib-runtime                       External
+┌──────────────────────┐    ┌──────────────────────┐    ┌──────────────────┐
+│ ModelRuntimePort     │◄───│ RuntimePortImpl      │───►│  llama-server    │
+│ ModelCatalogPort     │    │ CatalogPortImpl      │    │  llama-cli       │
+│ LlmCompletionPort    │    │ LlmCompletionAdapter │    └──────────────────┘
+│ SystemProbePort      │    │ DefaultSystemProbe   │
+│ ServerLogSinkPort    │    │ NoopLogSink,         │
+│                      │    │ LogManagerSink       │
+│ AdmissionRelease     │    │ AdmissionQueue       │
+└──────────────────────┘    └──────────────────────┘
                                      │
                                      ▼
                             ┌──────────────────┐
@@ -41,9 +45,9 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 ├─────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                     │
 │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │
-│  │  runner.rs  │     │   llama/    │     │   proxy/    │     │  process/   │        │
-│  │ High-level  │ ──► │ llama-server│     │  OpenAI API │     │  Lifecycle  │        │
-│  │   facade    │     │  llama-cli  │     │   routing   │     │  management │        │
+│  │ ports_impl/ │     │   llama/    │     │   proxy/    │     │  process/   │        │
+│  │ Port trait  │ ──► │ llama-server│     │  OpenAI API │     │  Lifecycle  │        │
+│  │   impls     │     │  llama-cli  │     │   routing   │     │  management │        │
 │  └─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘        │
 │                                                                                     │
 │  ┌─────────────┐     ┌─────────────┐                                                │
@@ -53,8 +57,8 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 │  └─────────────┘     └─────────────┘                                                │
 │                                                                                     │
 │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐                            │
-│  │ command.rs  │     │process_core │     │ compose.rs  │                            │
-│  │ Cmd builder │     │ Core types  │     │ Agent loop  │                            │
+│  │ command.rs  │     │server_config│     │ compose.rs  │                            │
+│  │ Cmd builder │     │ Launch args │     │ Agent loop  │                            │
 │  └─────────────┘     └─────────────┘     │ composition │                            │
 │                                          └─────────────┘                            │
 │                                                                                     │
@@ -95,9 +99,10 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 - **`command.rs`** — Command builder for llama processes
 - **`health_monitor.rs`** — Continuous health monitoring for processes
 - **`health.rs`** — Health check endpoint polling
-- **`process_core.rs`** — Core process types and abstractions
 - **`compose.rs`** — Agent loop composition root (wires LLM adapter + tool executors)
-- **`runner.rs`** — High-level runner facade for llama operations
+- **`launch_narration.rs`** — Human-readable account of how a launch was configured
+- **`server_config.rs`** / **`unified_server_config.rs`** — Launch argument resolution
+- **`pidfile/`** — PID file writing and cleanup for spawned servers
 - **`llama/`** — llama-server and llama-cli process management
 - **`proxy/`** — Proxy supervisor and routing logic
 - **`process/`** — Generic process lifecycle (start, stop, signal)
@@ -203,24 +208,20 @@ while still allowing runtime flags to win when explicitly provided.
 ## Usage
 
 ```rust,ignore
-use gglib_runtime::LlamaServerRunner;
-use gglib_core::ports::ProcessRunner;
-use gglib_core::domain::ServerConfig;
+use gglib_runtime::GuiProcessCore;
+use gglib_core::ports::ServerConfig;
 
-// Create a runner
-let runner = LlamaServerRunner::new(8080, "/path/to/llama-server", 4);
+// Create a process core, given a base port to allocate from
+let mut core = GuiProcessCore::new(8080, "/path/to/llama-server");
 
-// Start a server for a model
-let handle = runner.start(ServerConfig {
-    model_id: 1,
-    model_name: "llama-3.2".to_string(),
-    model_path: "/path/to/model.gguf".into(),
-    context_size: Some(4096),
-    ..Default::default()
-}).await?;
+// Start a server for a model; the allocated port comes back
+let port = core.spawn(
+    ServerConfig::new(1, "llama-3.2".to_string(), "/path/to/model.gguf".into(), 8080)
+        .with_context_size(4096),
+).await?;
 
-// Stop the server
-runner.stop(&handle).await?;
+// Stop the server, by model id
+core.kill(1).await?;
 ```
 
 ## Design Decisions

--- a/crates/gglib-runtime/src/lib.rs
+++ b/crates/gglib-runtime/src/lib.rs
@@ -22,8 +22,6 @@ pub(crate) mod server_config;
 pub mod system;
 pub mod unified_server_config;
 
-// Re-export the main ProcessRunner implementation
-
 // Re-export health utilities for direct use if needed
 pub use health::check_http_health;
 

--- a/crates/gglib-runtime/src/ports_impl/model_catalog.rs
+++ b/crates/gglib-runtime/src/ports_impl/model_catalog.rs
@@ -205,6 +205,17 @@ mod tests {
             }
         }
 
+        async fn find_by_path(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Option<Model>, RepositoryError> {
+            Ok(self
+                .list()
+                .await?
+                .into_iter()
+                .find(|m| m.file_path.as_path() == path))
+        }
+
         async fn insert(&self, _m: &NewModel) -> Result<Model, RepositoryError> {
             unimplemented!("not exercised by these tests")
         }

--- a/crates/gglib-runtime/src/process/README.md
+++ b/crates/gglib-runtime/src/process/README.md
@@ -50,11 +50,13 @@ template  ⊕  per-call overrides  ⊕  this request's context chain
 so a flag added to `ServerConfigOptions` reaches llama-server through this path
 with no change here at all.
 
-# Distinction from `ProcessCore`
+# On the `Gui` prefix
 
-This module's `GuiProcessCore` is distinct from the port-aligned `ProcessCore`
-in `process_core.rs`. The port version implements `ProcessRunner` for CLI use
-with `i64` model IDs and no log/event infrastructure.
+`GuiProcessCore` was named against a second, port-aligned `ProcessCore` in
+`process_core.rs`, which implemented a `ProcessRunner` trait for CLI use with
+no log or event infrastructure. `process_core.rs` went in #708; the trait
+outlived it and went in #849, once it had no implementor left. This is now the
+only process core and serves every caller — the prefix is vestigial.
 
 <!-- module-docs:end -->
 

--- a/crates/gglib-runtime/src/process/core.rs
+++ b/crates/gglib-runtime/src/process/core.rs
@@ -1,10 +1,14 @@
 //! GUI-oriented process lifecycle management.
 //!
 //! This module provides process spawning, tracking, and management with
-//! integrated log streaming and event broadcasting for GUI use cases.
+//! integrated log streaming and event broadcasting.
 //!
-//! Note: This is distinct from the port-aligned `ProcessCore` in `process_core.rs`
-//! which implements the `ProcessRunner` port for CLI use cases.
+//! [`GuiProcessCore`] keeps its `Gui` prefix from a time when a second,
+//! port-aligned `ProcessCore` sat beside it in `process_core.rs` and
+//! implemented a `ProcessRunner` trait for the CLI. Both are gone, though not
+//! together: `process_core.rs` went in #708, and the trait outlived it until
+//! #849, by which point nothing implemented it. This is now the only process
+//! core, serving every caller rather than only the GUI.
 
 use super::ports::{allocate_port, is_port_available};
 use super::shutdown::shutdown_child;
@@ -25,7 +29,8 @@ use tracing::{debug, warn};
 /// integrated log streaming for GUI applications. Uses `u32` model IDs
 /// for frontend compatibility.
 ///
-/// For CLI/port-based process management, see `ProcessCore` in `process_core.rs`.
+/// The only process core. See the module docs above for why the name still
+/// carries a `Gui` prefix.
 pub struct GuiProcessCore {
     /// Running processes keyed by `model_id`
     processes: HashMap<u32, RunningProcess>,
@@ -159,7 +164,7 @@ impl GuiProcessCore {
 
     /// List all running processes
     pub fn list_all(&self) -> Vec<&ServerInfo> {
-        debug!(process_count = %self.processes.len(), "ProcessCore: list_all called");
+        debug!(process_count = %self.processes.len(), "GuiProcessCore: list_all called");
         self.processes.values().map(|p| &p.info).collect()
     }
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -191,8 +191,34 @@ gglib model retag --all --full
 gglib model retag qwen3-30b
 ```
 
-Re-registering a model (re-import or re-download) also re-derives the spec,
-overwriting the stored one — the same semantics as `--full`.
+Re-registering a model also re-derives the spec, overwriting the stored one —
+the same semantics as `--full`. Re-downloading does this implicitly;
+re-importing a file already in the library needs `--force`, because adding a
+file that is already there is otherwise a conflict rather than a silent
+overwrite:
+
+```bash
+# Re-derive the detected metadata: tags and dialect spec, plus the columns
+# `retag` does not touch — capabilities, quantization, context length,
+# expert counts
+gglib model add --force ~/models/qwen3-30b.gguf
+```
+
+Without `--force` the command reports the model already present and changes
+nothing.
+
+`--force` refreshes what was *detected*, not the whole row, and the columns it
+touches do not all behave alike:
+
+| Column | On refresh |
+|---|---|
+| `tags`, `capabilities`, `dialect_spec` | Replaced — including with nothing, so these **can** be cleared |
+| `quantization`, `context_length`, expert counts | Replaced only when newly detected; a stored value is never emptied |
+| `name`, parameter count, `architecture` | Untouched — a name you chose yourself survives |
+
+This is a CLI-only workflow. The GUI's *Add Model* and `POST /api/models` have
+no equivalent — adding a file already in the library is a `409` there, with no
+way to ask for the overwrite.
 
 End-to-end round-trip coverage lives in
 [`crates/gglib-proxy/tests/integration_proxy_pipeline.rs`](../crates/gglib-proxy/tests/integration_proxy_pipeline.rs).

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -93,7 +93,7 @@ crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs 438
 crates/gglib-db/src/repositories/sqlite_download_state_repository.rs 361
 crates/gglib-db/src/repositories/sqlite_mcp_repository.rs 564
 crates/gglib-db/src/repositories/sqlite_model_repository.rs 995
-crates/gglib-db/src/setup.rs 907
+crates/gglib-db/src/setup.rs 913
 crates/gglib-download/src/cli_emitter.rs 528
 crates/gglib-download/src/cli_exec/api.rs 369
 crates/gglib-download/src/cli_exec/exec/progress.rs 330

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -10,7 +10,7 @@ crates/gglib-app-services/src/benchmark/tune/scoring.rs 352
 crates/gglib-app-services/src/downloads.rs 375
 crates/gglib-app-services/src/launch_options.rs 326
 crates/gglib-app-services/src/mcp.rs 397
-crates/gglib-app-services/src/models.rs 928
+crates/gglib-app-services/src/models.rs 1110
 crates/gglib-app-services/src/proxy.rs 455
 crates/gglib-app-services/src/sampling_explain.rs 924
 crates/gglib-app-services/src/servers.rs 970
@@ -34,7 +34,7 @@ crates/gglib-cli/src/handlers/model/download/interactive.rs 426
 crates/gglib-cli/src/handlers/model/update.rs 712
 crates/gglib-cli/src/handlers/proxy_dashboard/render_tests.rs 624
 crates/gglib-cli/src/handlers/proxy_dashboard/render.rs 440
-crates/gglib-cli/src/model_commands.rs 440
+crates/gglib-cli/src/model_commands.rs 455
 crates/gglib-cli/src/presentation/explain_display.rs 735
 crates/gglib-cli/src/presentation/inspect_display.rs 405
 crates/gglib-cli/src/shared_args.rs 312
@@ -69,6 +69,7 @@ crates/gglib-core/src/events/mod.rs 303
 crates/gglib-core/src/normalize/parsers/delimited.rs 985
 crates/gglib-core/src/normalize/stream.rs 651
 crates/gglib-core/src/ports/model_runtime.rs 817
+crates/gglib-core/src/ports/process_runner.rs 307
 crates/gglib-core/src/request_pipeline/apply.rs 343
 crates/gglib-core/src/request_pipeline/constrain.rs 509
 crates/gglib-core/src/request_pipeline/sampling.rs 1747
@@ -77,8 +78,8 @@ crates/gglib-core/src/request_pipeline/truncation.rs 350
 crates/gglib-core/src/request_pipeline/validate.rs 790
 crates/gglib-core/src/server_config.rs 620
 crates/gglib-core/src/services/model_import.rs 687
-crates/gglib-core/src/services/model_registrar.rs 305
-crates/gglib-core/src/services/model_service.rs 1056
+crates/gglib-core/src/services/model_registrar.rs 335
+crates/gglib-core/src/services/model_service.rs 1507
 crates/gglib-core/src/services/model_verification.rs 797
 crates/gglib-core/src/settings.rs 1012
 crates/gglib-core/src/sse/decoder.rs 334
@@ -86,13 +87,13 @@ crates/gglib-core/src/sse/encoder.rs 460
 crates/gglib-core/src/sse/parser.rs 781
 crates/gglib-core/src/utils/system/packages.rs 591
 crates/gglib-db/src/factory.rs 303
-crates/gglib-db/src/repositories/row_mappers.rs 307
+crates/gglib-db/src/repositories/row_mappers.rs 309
 crates/gglib-db/src/repositories/sqlite_benchmark_repository.rs 830
 crates/gglib-db/src/repositories/sqlite_chat_history_repository.rs 438
 crates/gglib-db/src/repositories/sqlite_download_state_repository.rs 361
 crates/gglib-db/src/repositories/sqlite_mcp_repository.rs 564
-crates/gglib-db/src/repositories/sqlite_model_repository.rs 626
-crates/gglib-db/src/setup.rs 586
+crates/gglib-db/src/repositories/sqlite_model_repository.rs 995
+crates/gglib-db/src/setup.rs 907
 crates/gglib-download/src/cli_emitter.rs 528
 crates/gglib-download/src/cli_exec/api.rs 369
 crates/gglib-download/src/cli_exec/exec/progress.rs 330


### PR DESCRIPTION
Follow-up to #849, fixing defects an adversarial review found in it — plus the two the review then found in the fixes, and so on for five rounds.

## The bug

`compute_model_key` hashed the path **as it was handed over**, while the `file_path` column stored the **resolved** one. Identity was decided two different ways, and both directions were destructive:

- Two spellings of one file → two keys → two rows for one model on disk.
- One raw spelling naming two *different* files → one key → `ON CONFLICT(model_key)` merged them. Since `name`, `param_count_b` and `architecture` are absent from that clause's `DO UPDATE SET` list while `file_path` is present, the surviving row wore model A's identity over model B's file.

## The fix

One canonicalisation rule (`canonical_model_path`), applied at the entry point *and* at the storage boundary — belt and braces, as agreed. `import_from_file` resolves once, immediately after validation; the key hashes that same resolved form; `find_by_path` becomes a required trait method backed by real SQL instead of a provided body that called `std::fs::canonicalize` from `ports/` (which the module's own design rules forbid) and scanned the whole table per call.

The key hashes a `Path`, not the `String`. That is load-bearing: `Path`'s `Hash` is component-based and `str`'s is byte-based, so hashing the string would have moved the key of **every** local row rather than only the rows the new rule genuinely re-keys.

### `gglib model add --force`

Restores the re-import workflow `docs/tags.md` documents, which the duplicate guard had blocked with nothing to replace it — `model retag` rebuilds only tags and the dialect spec, leaving capabilities, quantization, context length and the expert columns refreshable by no command at all.

The docs now describe what the upsert actually does, which is three different things:

| Columns | On refresh |
|---|---|
| `tags`, `capabilities`, `dialect_spec` | Assigned — **can** be cleared |
| `quantization`, `context_length`, expert counts | Coalesced — a stored value is never emptied |
| `name`, `param_count_b`, `architecture` | Absent from the clause — a name you chose survives |

### Migration (`migration-required`)

Rows added under a relative path, a symlinked models directory, or a macOS temp path carry a key no current build recomputes. **On Windows this is every local row**: `canonicalize` there returns an extended-length `\\?\` path that no previous caller ever produced.

Two idempotent startup passes, gated on `PRAGMA user_version` so the cost is paid once per library: one re-keys local models, one canonicalises stored shard path lists. The second matters without `--force` at all — adding shard 2 of an already-registered sharded model was matching nothing and appending a row.

The stored column is **not** itself trusted, which was the trap: `update` wrote it raw until this PR, and normalisation falls back to the literal path when a file is missing. Each path is resolved first, the column rewritten when it moves, and the key derived from the resolved form.

## Review

Three adversarial reviewers in isolated worktrees, five rounds, distinct lenses (correctness · build/features/cross-platform · contracts/docs). Every finding fixed at the root. The most consequential:

- **The migration was not optional.** Two reviewers independently proved the key change stranded every local row on Windows.
- **Three regressions were introduced by an earlier fix in this same PR** — making `--force` land on the right row meant it began *overwriting* things a stray insert had previously left alone: repointing a sharded model at a shard `llama.cpp` cannot load, and erasing shard lists and download provenance.
- **The migration's own premise was disproved by a commit two earlier in this PR**, found through a documentation claim.
- **Several of my tests passed for the wrong reason** and were rewritten — `Path` equality is component-based, so a `.` spelling can't discriminate; a shard test hand-canonicalised what the repository was supposed to do; a key-stability test used a path that never resolved.

Every new guard is mutation-verified: the fix is reverted and the test confirmed to fail.

## Verification

`cargo fmt` · `cargo clippy --all-targets --all-features -- -D warnings` (zero, all 18 crates including `gglib-app`) · **2975 tests, 0 failures** · `cargo doc --document-private-items` (272 warnings, none in changed files) · complexity ratchet · README and boundary checks. Cross-checked for `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-gnu` with zero new warnings in changed files.

`ports/` is filesystem-free again.

## Known limitations, stated rather than hidden

- The duplicate guard is **advisory under concurrency** — the check and the insert are separate statements and `file_path` carries no unique index. `ON CONFLICT` still collapses the race so the library stays correct, but the loser is told it added a model that already existed. Closing it needs a unique index or a spanning transaction.
- The `user_version` gate makes the repair **one-shot**. A row written by an *older binary* after the stamp is never repaired — the standard bargain of a version-stamped migration, now stated in the code rather than implied.
- Also corrected here: `ports/process_runner.rs` claimed the trait it is named after was one "nothing ever implemented". Four things did, including the production `LlamaServerRunner`. That was the correction owed from #849's review.
