### PR TITLE
chore(repo): keep local assistant tooling out of the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,15 @@ tarpaulin-report.html
 boundary-status.json
 .vscode/settings.json
 logs/
+
+# Local AI/assistant tooling — never tracked.
+# These directories are scratch space for coding assistants (session state,
+# worktrees, handoff notes). They are machine-local and must not enter history.
+.claude/
+.cursor/
+.aider*
+.continue/
+.codeium/
+.github/copilot-instructions.md
+CLAUDE.md
+AGENTS.md


### PR DESCRIPTION
Adds `.claude/` and sibling assistant-tool paths to `.gitignore`.

`.claude/` already existed untracked (worktrees, scratch state) but was **not** ignored, so a `git add -A` could sweep it into a commit. This closes that gap.

**The tracked tree is already clean.** I audited it one term at a time, with a positive control, rather than trusting a compound grep:

| term | tracked files |
|---|---|
| `claude` | **0** |
| `anthropic` | **0** |
| `co-authored-by` | **0** |
| `copilot` | 32 — all product refs (VS Code Copilot BYOK is a motivating use case) |
| `cursor` | 43 — all `crossterm` terminal-cursor refs |
| `aider` | 1 — the README listing Aider as a supported client |
| `llama` *(control)* | 432 |

`CLAUDE.md` and `AGENTS.md` are listed pre-emptively; neither exists.

Note this covers the working tree only. Existing **history** is a separate question — see the discussion on the handoff.