### PR TITLE
fix(core): KV estimate counts only the layers that hold a cache

### DIFF
--- a/crates/gglib-core/src/domain/README.md
+++ b/crates/gglib-core/src/domain/README.md
@@ -17,6 +17,12 @@ infrastructure concerns (database, filesystem, etc.).
 - `gguf` - GGUF metadata and capability types
 - `capabilities` - Model capability detection and inference
 - `thinking` - Thinking/reasoning tag parsing and streaming accumulation
+- `kv_memory` - Shape of a model's KV memory from GGUF metadata: whether it
+  keeps only part of the token history (`kv_memory_is_partial`), and how many
+  layers hold a per-token cache at all (`kv_cache_layer_count`)
+- `kv_estimate` - Per-token KV cache size, which takes that layer count from
+  `kv_memory` rather than counting every block. The dependency runs one way
+  only: `kv_memory` reads metadata and knows nothing of the estimate
 
 <!-- module-docs:end -->
 
@@ -38,6 +44,7 @@ infrastructure concerns (database, filesystem, etc.).
 | [`inference_profile.rs`](inference_profile.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-inference_profile-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-inference_profile-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-inference_profile-coverage.json) |
 | [`inference.rs`](inference.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-inference-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-inference-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-inference-coverage.json) |
 | [`kv_estimate.rs`](kv_estimate.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_estimate-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_estimate-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_estimate-coverage.json) |
+| [`kv_memory_tests.rs`](kv_memory_tests.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_memory_tests-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_memory_tests-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_memory_tests-coverage.json) |
 | [`kv_memory.rs`](kv_memory.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_memory-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_memory-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-kv_memory-coverage.json) |
 | [`launch_narration.rs`](launch_narration.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-launch_narration-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-launch_narration-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-launch_narration-coverage.json) |
 | [`model_naming.rs`](model_naming.rs) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-model_naming-loc.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-model_naming-complexity.json) | ![](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmogr/gglib/badges/gglib-core-domain-model_naming-coverage.json) |

--- a/crates/gglib-core/src/domain/kv_estimate.rs
+++ b/crates/gglib-core/src/domain/kv_estimate.rs
@@ -13,16 +13,16 @@
 //! `.gguf` file is needed. Every key is architecture-prefixed
 //! (`qwen3.block_count`, `llama.attention.head_count_kv`, …).
 //!
-//! This is deliberately an *estimate*: it models the standard transformer
-//! KV-cache layout and ignores architecture-specific extras (sliding-window
-//! layers, MLA compression, per-layer overrides). It is used only for
-//! conservative memory budgeting, never for correctness, and returns `None`
-//! rather than guessing when the metadata doesn't carry what it needs.
+//! This is deliberately an *estimate*: it counts only the layers that hold a
+//! per-token cache (see [`crate::domain::kv_memory::kv_cache_layer_count`]) and
+//! models no other architecture-specific extras (MLA compression, per-layer
+//! overrides). It is for conservative memory budgeting, never for correctness.
 
 use std::collections::HashMap;
 use std::hash::BuildHasher;
 
 use crate::cache_config::KvCacheType;
+use crate::domain::kv_memory::kv_cache_layer_count;
 
 /// Per-token K and V element counts, type-agnostic.
 ///
@@ -51,11 +51,11 @@ fn lookup<S: BuildHasher>(
 
 /// Estimate K and V element counts consumed per token of context.
 ///
-/// Formula (standard transformer KV cache):
+/// Formula, over the layers that hold a cache ([`kv_cache_layer_count`]):
 ///
 /// ```text
-/// k_elems/token = block_count × head_count_kv × key_length
-/// v_elems/token = block_count × head_count_kv × value_length
+/// k_elems/token = kv_cache_layers × head_count_kv × key_length
+/// v_elems/token = kv_cache_layers × head_count_kv × value_length
 /// ```
 ///
 /// `key_length`/`value_length` are the per-head dimensions. When absent, both
@@ -85,7 +85,7 @@ pub fn estimate_kv_elems_per_token<S: BuildHasher>(
         .or_else(|| metadata.get("general.architecture").cloned())?;
     let arch = arch.trim().to_ascii_lowercase();
 
-    let block_count = lookup(metadata, &arch, "block_count")?;
+    let cache_layers = kv_cache_layer_count(metadata, Some(&arch))?;
     let head_count = lookup(metadata, &arch, "attention.head_count");
     // Grouped-query attention shrinks the KV cache: prefer head_count_kv.
     let head_count_kv = lookup(metadata, &arch, "attention.head_count_kv").or(head_count)?;
@@ -101,11 +101,11 @@ pub fn estimate_kv_elems_per_token<S: BuildHasher>(
     let value_length =
         lookup(metadata, &arch, "attention.value_length").or_else(derived_head_dim)?;
 
-    if block_count == 0 || head_count_kv == 0 {
+    if cache_layers == 0 || head_count_kv == 0 {
         return None;
     }
 
-    let per_head = block_count.saturating_mul(head_count_kv);
+    let per_head = cache_layers.saturating_mul(head_count_kv);
     Some(KvElemsPerToken {
         k: per_head.saturating_mul(key_length),
         v: per_head.saturating_mul(value_length),

--- a/crates/gglib-core/src/domain/kv_memory.rs
+++ b/crates/gglib-core/src/domain/kv_memory.rs
@@ -1,4 +1,5 @@
-//! Detection of partial-KV-memory architectures from GGUF metadata.
+//! The shape of a model's KV memory, read from GGUF metadata: whether it
+//! retains the full token history, and how many layers hold a cache at all.
 //!
 //! Some model architectures do not retain the full token history in their KV
 //! memory: sliding-window attention (SWA) layers keep only a recent window,
@@ -28,6 +29,10 @@
 //! silently costs minutes of TTFT per restore. Some older GGUFs carry a
 //! `sliding_window` key the runtime ignores; treating them as partial is the
 //! safe direction.
+//!
+//! [`kv_cache_layer_count`] answers the quantitative half of the same
+//! question — how many layers hold a per-token cache — and is what
+//! [`crate::domain::estimate_kv_elems_per_token`] sizes its budget from.
 
 use std::collections::HashMap;
 use std::hash::BuildHasher;
@@ -52,6 +57,22 @@ fn lookup_u64<S: BuildHasher>(
     suffix: &str,
 ) -> Option<u64> {
     lookup_raw(metadata, arch, suffix).and_then(|v| v.parse::<u64>().ok())
+}
+
+/// Resolve the GGUF key prefix: the caller's architecture when it knows one,
+/// else the file's own `general.architecture`, normalised for lookup. Empty
+/// when neither is available, which is harmless — [`lookup_raw`]'s unprefixed
+/// fallback still runs.
+fn resolve_arch<S: BuildHasher>(
+    metadata: &HashMap<String, String, S>,
+    architecture: Option<&str>,
+) -> String {
+    architecture
+        .map(str::to_owned)
+        .or_else(|| metadata.get("general.architecture").cloned())
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
 }
 
 /// Whether the model's KV memory retains only part of the token history
@@ -83,11 +104,7 @@ pub fn kv_memory_is_partial<S: BuildHasher>(
     metadata: &HashMap<String, String, S>,
     architecture: Option<&str>,
 ) -> bool {
-    let arch = architecture
-        .map(str::to_owned)
-        .or_else(|| metadata.get("general.architecture").cloned())
-        .unwrap_or_default();
-    let arch = arch.trim().to_ascii_lowercase();
+    let arch = resolve_arch(metadata, architecture);
 
     if lookup_u64(metadata, &arch, "full_attention_interval").is_some_and(|v| v > 1) {
         return true;
@@ -102,110 +119,56 @@ pub fn kv_memory_is_partial<S: BuildHasher>(
     false
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// How many of the model's layers hold a per-token KV cache.
+///
+/// On a plain transformer that is every layer, so this is `{arch}.block_count`
+/// unchanged. Hybrid-attention architectures interleave two kinds of layer:
+/// `{arch}.full_attention_interval = 4` means every 4th layer is full
+/// attention, so of Qwen3.8's 64 blocks only 16 keep a KV cache.
+///
+/// The other 48 are linear/SSM layers, and they contribute **zero** here on
+/// purpose. Their state is a fixed-size summary — constant in context length,
+/// not proportional to it — so its cost belongs in a weights-side allowance,
+/// not in a per-token figure. A per-token figure is a slope: whatever it
+/// carries gets multiplied by the context size. Folding those layers in
+/// therefore over-counts them by the entire context — 256 KiB/token instead of
+/// 64, i.e. 64 GiB rather than 16 GiB at Qwen3.8's 262144-token context.
+///
+/// Division rounds **up**. When the interval does not divide the block count
+/// evenly the metadata alone cannot say which side the remainder falls on, and
+/// counting one layer too many over-states the budget — the safe direction for
+/// a figure the launcher plans memory against.
+///
+/// # Arguments
+///
+/// * `metadata` — raw GGUF key/value map (see [`crate::domain::Model::metadata`]).
+/// * `architecture` — the model's architecture, used as the key prefix. When
+///   `None`, falls back to the `general.architecture` metadata key.
+///
+/// # Returns
+///
+/// `None` when `block_count` is absent or non-numeric, so the "we don't know"
+/// signal keeps travelling rather than collapsing into a zero that would read
+/// as "KV is free" — [`crate::domain::estimate_kv_elems_per_token`] propagates
+/// it with `?`. An absent, non-numeric, or `1` interval leaves `block_count`
+/// untouched, so every full-attention model is bit-identical to before this
+/// function existed.
+#[must_use]
+pub fn kv_cache_layer_count<S: BuildHasher>(
+    metadata: &HashMap<String, String, S>,
+    architecture: Option<&str>,
+) -> Option<u64> {
+    let arch = resolve_arch(metadata, architecture);
+    let block_count = lookup_u64(metadata, &arch, "block_count")?;
 
-    /// Qwen3.6-shaped metadata: hybrid attention, every 4th layer full.
-    fn qwen36_metadata() -> HashMap<String, String> {
-        HashMap::from([
-            ("general.architecture".to_string(), "qwen35".to_string()),
-            (
-                "qwen35.full_attention_interval".to_string(),
-                "4".to_string(),
-            ),
-            ("qwen35.attention.head_count".to_string(), "24".to_string()),
-        ])
-    }
-
-    #[test]
-    fn detects_hybrid_full_attention_interval() {
-        assert!(kv_memory_is_partial(&qwen36_metadata(), Some("qwen35")));
-    }
-
-    #[test]
-    fn architecture_falls_back_to_general_architecture_key() {
-        assert!(kv_memory_is_partial(&qwen36_metadata(), None));
-    }
-
-    #[test]
-    fn architecture_lookup_is_case_insensitive() {
-        assert!(kv_memory_is_partial(&qwen36_metadata(), Some("QWEN35")));
-    }
-
-    /// Interval of 1 means every layer is full attention — not partial.
-    #[test]
-    fn interval_of_one_is_full_attention() {
-        let mut md = qwen36_metadata();
-        md.insert(
-            "qwen35.full_attention_interval".to_string(),
-            "1".to_string(),
-        );
-        assert!(!kv_memory_is_partial(&md, Some("qwen35")));
-    }
-
-    #[test]
-    fn detects_sliding_window_attention() {
-        let md = HashMap::from([
-            ("general.architecture".to_string(), "gemma3".to_string()),
-            (
-                "gemma3.attention.sliding_window".to_string(),
-                "1024".to_string(),
-            ),
-        ]);
-        assert!(kv_memory_is_partial(&md, Some("gemma3")));
-    }
-
-    /// A zero-size window means SWA is effectively disabled.
-    #[test]
-    fn zero_sliding_window_is_full_attention() {
-        let md = HashMap::from([(
-            "gemma3.attention.sliding_window".to_string(),
-            "0".to_string(),
-        )]);
-        assert!(!kv_memory_is_partial(&md, Some("gemma3")));
-    }
-
-    #[test]
-    fn detects_recurrent_ssm_state() {
-        let md = HashMap::from([
-            ("general.architecture".to_string(), "mamba".to_string()),
-            ("mamba.ssm.conv_kernel".to_string(), "4".to_string()),
-        ]);
-        assert!(kv_memory_is_partial(&md, Some("mamba")));
-    }
-
-    /// Plain full-attention transformer metadata (the Qwen3 fixture shape
-    /// from `kv_estimate`) must not trip the detector.
-    #[test]
-    fn full_attention_model_is_not_partial() {
-        let md = HashMap::from([
-            ("general.architecture".to_string(), "qwen3".to_string()),
-            ("qwen3.block_count".to_string(), "64".to_string()),
-            ("qwen3.attention.head_count".to_string(), "40".to_string()),
-            ("qwen3.attention.head_count_kv".to_string(), "8".to_string()),
-        ]);
-        assert!(!kv_memory_is_partial(&md, Some("qwen3")));
-    }
-
-    #[test]
-    fn empty_metadata_is_not_partial() {
-        assert!(!kv_memory_is_partial(&HashMap::new(), Some("llama")));
-        assert!(!kv_memory_is_partial(&HashMap::new(), None));
-    }
-
-    #[test]
-    fn unprefixed_keys_are_accepted_as_a_fallback() {
-        let md = HashMap::from([("attention.sliding_window".to_string(), "512".to_string())]);
-        assert!(kv_memory_is_partial(&md, Some("gemma2")));
-    }
-
-    #[test]
-    fn non_numeric_marker_values_are_ignored() {
-        let md = HashMap::from([(
-            "qwen35.full_attention_interval".to_string(),
-            "four".to_string(),
-        )]);
-        assert!(!kv_memory_is_partial(&md, Some("qwen35")));
+    // An interval of 1 (or none at all) means every layer is full attention,
+    // so there is nothing to divide out.
+    match lookup_u64(metadata, &arch, "full_attention_interval") {
+        Some(interval) if interval > 1 => Some(block_count.div_ceil(interval)),
+        _ => Some(block_count),
     }
 }
+
+#[cfg(test)]
+#[path = "kv_memory_tests.rs"]
+mod kv_memory_tests;

--- a/crates/gglib-core/src/domain/kv_memory_tests.rs
+++ b/crates/gglib-core/src/domain/kv_memory_tests.rs
@@ -1,0 +1,218 @@
+//! Tests for [`super::kv_memory_is_partial`] and [`super::kv_cache_layer_count`].
+//!
+//! Split out via `#[path]` so the module itself stays inside the file budget.
+
+use super::*;
+use crate::domain::{KvElemsPerToken, estimate_kv_elems_per_token};
+
+/// Qwen3.6-shaped metadata: hybrid attention, every 4th layer full.
+fn qwen36_metadata() -> HashMap<String, String> {
+    HashMap::from([
+        ("general.architecture".to_string(), "qwen35".to_string()),
+        (
+            "qwen35.full_attention_interval".to_string(),
+            "4".to_string(),
+        ),
+        ("qwen35.block_count".to_string(), "64".to_string()),
+        ("qwen35.attention.head_count".to_string(), "24".to_string()),
+    ])
+}
+
+// ── Partial-history detection ────────────────────────────────────────────────
+
+#[test]
+fn detects_hybrid_full_attention_interval() {
+    assert!(kv_memory_is_partial(&qwen36_metadata(), Some("qwen35")));
+}
+
+#[test]
+fn architecture_falls_back_to_general_architecture_key() {
+    assert!(kv_memory_is_partial(&qwen36_metadata(), None));
+}
+
+#[test]
+fn architecture_lookup_is_case_insensitive() {
+    assert!(kv_memory_is_partial(&qwen36_metadata(), Some("QWEN35")));
+}
+
+/// Interval of 1 means every layer is full attention — not partial.
+#[test]
+fn interval_of_one_is_full_attention() {
+    let mut md = qwen36_metadata();
+    md.insert(
+        "qwen35.full_attention_interval".to_string(),
+        "1".to_string(),
+    );
+    assert!(!kv_memory_is_partial(&md, Some("qwen35")));
+}
+
+#[test]
+fn detects_sliding_window_attention() {
+    let md = HashMap::from([
+        ("general.architecture".to_string(), "gemma3".to_string()),
+        (
+            "gemma3.attention.sliding_window".to_string(),
+            "1024".to_string(),
+        ),
+    ]);
+    assert!(kv_memory_is_partial(&md, Some("gemma3")));
+}
+
+/// A zero-size window means SWA is effectively disabled.
+#[test]
+fn zero_sliding_window_is_full_attention() {
+    let md = HashMap::from([(
+        "gemma3.attention.sliding_window".to_string(),
+        "0".to_string(),
+    )]);
+    assert!(!kv_memory_is_partial(&md, Some("gemma3")));
+}
+
+#[test]
+fn detects_recurrent_ssm_state() {
+    let md = HashMap::from([
+        ("general.architecture".to_string(), "mamba".to_string()),
+        ("mamba.ssm.conv_kernel".to_string(), "4".to_string()),
+    ]);
+    assert!(kv_memory_is_partial(&md, Some("mamba")));
+}
+
+/// Plain full-attention transformer metadata (the Qwen3 fixture shape
+/// from `kv_estimate`) must not trip the detector.
+#[test]
+fn full_attention_model_is_not_partial() {
+    let md = HashMap::from([
+        ("general.architecture".to_string(), "qwen3".to_string()),
+        ("qwen3.block_count".to_string(), "64".to_string()),
+        ("qwen3.attention.head_count".to_string(), "40".to_string()),
+        ("qwen3.attention.head_count_kv".to_string(), "8".to_string()),
+    ]);
+    assert!(!kv_memory_is_partial(&md, Some("qwen3")));
+}
+
+#[test]
+fn empty_metadata_is_not_partial() {
+    assert!(!kv_memory_is_partial(&HashMap::new(), Some("llama")));
+    assert!(!kv_memory_is_partial(&HashMap::new(), None));
+}
+
+#[test]
+fn unprefixed_keys_are_accepted_as_a_fallback() {
+    let md = HashMap::from([("attention.sliding_window".to_string(), "512".to_string())]);
+    assert!(kv_memory_is_partial(&md, Some("gemma2")));
+}
+
+#[test]
+fn non_numeric_marker_values_are_ignored() {
+    let md = HashMap::from([(
+        "qwen35.full_attention_interval".to_string(),
+        "four".to_string(),
+    )]);
+    assert!(!kv_memory_is_partial(&md, Some("qwen35")));
+}
+
+// ── Cache-holding layer count ────────────────────────────────────────────────
+
+/// The defect this function exists for: on a hybrid model only every
+/// `full_attention_interval`-th layer keeps a KV cache, so Qwen3.8's 64 blocks
+/// contribute 16. Counting all 64 budgets four times the KV the model needs.
+#[test]
+fn a_hybrid_interval_divides_the_block_count() {
+    let count = kv_cache_layer_count(&qwen36_metadata(), Some("qwen35"));
+    assert_eq!(count, Some(16));
+}
+
+/// The regression guard for every model gglib already serves: with no
+/// `full_attention_interval` key every block holds a cache, so the count is
+/// `block_count` untouched and the estimate is bit-identical to before.
+#[test]
+fn a_full_attention_model_counts_every_block() {
+    let md = HashMap::from([
+        ("general.architecture".to_string(), "qwen3".to_string()),
+        ("qwen3.block_count".to_string(), "64".to_string()),
+    ]);
+    assert_eq!(kv_cache_layer_count(&md, Some("qwen3")), Some(64));
+}
+
+/// `full_attention_interval = 1` says every layer is full attention. Dividing
+/// by it would be harmless arithmetic, but the `> 1` guard is what keeps the
+/// key's meaning — a *marker* of hybridity — rather than a bare divisor.
+#[test]
+fn an_interval_of_one_is_not_a_divisor() {
+    let mut md = qwen36_metadata();
+    md.insert(
+        "qwen35.full_attention_interval".to_string(),
+        "1".to_string(),
+    );
+    assert_eq!(kv_cache_layer_count(&md, Some("qwen35")), Some(64));
+}
+
+/// When the interval does not divide the block count evenly the metadata
+/// cannot say where the remainder falls, so the count rounds up: 65 blocks at
+/// interval 4 is 17, not 16. One layer of over-estimate is the safe direction
+/// for a memory budget; rounding down would promise memory that isn't there.
+#[test]
+fn an_uneven_interval_rounds_the_layer_count_up() {
+    let mut md = qwen36_metadata();
+    md.insert("qwen35.block_count".to_string(), "65".to_string());
+    assert_eq!(kv_cache_layer_count(&md, Some("qwen35")), Some(17));
+}
+
+/// A garbage interval must not poison the count. Falling back to every block
+/// over-states the budget, which is survivable; propagating `None` would
+/// discard a `block_count` the file did carry.
+#[test]
+fn a_non_numeric_interval_is_ignored_rather_than_fatal() {
+    let mut md = qwen36_metadata();
+    md.insert(
+        "qwen35.full_attention_interval".to_string(),
+        "four".to_string(),
+    );
+    assert_eq!(kv_cache_layer_count(&md, Some("qwen35")), Some(64));
+}
+
+/// `block_count` has no fallback, and [`estimate_kv_elems_per_token`]
+/// propagates its absence with `?`. Returning `None` keeps "we don't know"
+/// travelling instead of collapsing into a zero that reads as "KV is free".
+#[test]
+fn a_missing_block_count_is_unknown_rather_than_zero() {
+    let mut md = qwen36_metadata();
+    md.remove("qwen35.block_count");
+    assert_eq!(kv_cache_layer_count(&md, Some("qwen35")), None);
+}
+
+/// The seam, asserted through the public entry point rather than the helper:
+/// a Qwen3.8-shaped GGUF header must reach the estimate as 16 cache-holding
+/// layers, not 64. At f16 that is 64 KiB/token instead of 256 — 16 GiB rather
+/// than 64 GiB at the model's 262144-token context, which is the difference
+/// between a launch that fits and one the residency check refuses.
+#[test]
+fn the_estimate_counts_only_the_cache_holding_layers_of_a_hybrid_model() {
+    let md = HashMap::from([
+        ("general.architecture".to_string(), "qwen35".to_string()),
+        ("qwen35.block_count".to_string(), "64".to_string()),
+        (
+            "qwen35.full_attention_interval".to_string(),
+            "4".to_string(),
+        ),
+        ("qwen35.attention.head_count".to_string(), "32".to_string()),
+        (
+            "qwen35.attention.head_count_kv".to_string(),
+            "4".to_string(),
+        ),
+        ("qwen35.attention.key_length".to_string(), "256".to_string()),
+        (
+            "qwen35.attention.value_length".to_string(),
+            "256".to_string(),
+        ),
+    ]);
+    // 16 cache-holding layers × 4 kv heads × 256 head dim.
+    let expected = 16 * 4 * 256;
+    assert_eq!(
+        estimate_kv_elems_per_token(&md, Some("qwen35")),
+        Some(KvElemsPerToken {
+            k: expected,
+            v: expected
+        })
+    );
+}

--- a/crates/gglib-core/src/domain/mod.rs
+++ b/crates/gglib-core/src/domain/mod.rs
@@ -58,7 +58,7 @@ pub use kv_estimate::{
 };
 
 // Re-export KV memory-shape detection at the domain level for convenience
-pub use kv_memory::kv_memory_is_partial;
+pub use kv_memory::{kv_cache_layer_count, kv_memory_is_partial};
 pub use model_sampling::{
     MODEL_SAMPLING_KEYS, ModelSamplingDefault, ModelSamplingDefaults, SamplingOverride,
 };


### PR DESCRIPTION
## The bug

`estimate_kv_elems_per_token` multiplies by `block_count` — every layer. On a hybrid-attention model
only the full-attention layers hold a per-token KV cache; the linear/SSM layers carry a fixed-size
recurrent state that is constant in context length, not proportional to it.

Qwen3.5/3.6/3.8 (GGUF arch `qwen35`) are hybrid: **64 layers, of which 16 are full-attention** and 48
are linear (`qwen35.full_attention_interval = 4`, verified against the published
`ggml-org/Qwen3.8-27B-GGUF` header). So gglib has been over-estimating their KV cache by 4x — and this
is wrong for Qwen3.6 today, not only for the new model.

| At 262144 ctx, f16 | per token | total |
|---|---|---|
| estimated today | 256 KiB | **64 GiB** |
| actual | 64 KiB | **16 GiB** |

A 48 GiB phantom, and it is not inert. Three consumers read this number:

- the launch banner's `kv` line (`launch_narration.rs:161`) — printed to the terminal and shipped to the GUI
- the `--cache-ram` budget and its `CacheRamHealth` band (`llama/args/cache_ram.rs:113`) — an inflated
  KV shrinks or zeroes the prompt cache
- the secondary-VRAM-slot verdict (`residency.rs:96`, hard 2 GiB ceiling) — which can refuse to
  co-resident a model that genuinely fits

## The fix

`kv_memory.rs` already owned this concept and threw the number away: it reads
`full_attention_interval` to decide whether KV memory is *partial*, its doc comment already names
`qwen35.full_attention_interval = 4`, and its fixture was already called `qwen36_metadata()` — but it
returned only a `bool`.

It now also answers the numeric question. `kv_estimate.rs:88` takes its layer count from there instead
of from `block_count` directly. A model with no interval key resolves to `block_count` unchanged, so
**every non-hybrid model is bit-identical**. The division rounds up: over-estimating by at most one
layer is the safe direction for a memory budget.

## Ratchet arithmetic

`kv_estimate.rs` is frozen at 341 in `rust-complexity-baseline.txt` and **stays at exactly 341** — the
one-line call is paid for by rewriting the module doc's now-false claim that the estimate "ignores
architecture-specific extras (sliding-window layers, …)", which it no longer does.

`kv_memory.rs` 211 → 174 with its tests split to `kv_memory_tests.rs` (218) via `#[path]`, the pattern
`request_pipeline/truncation.rs:349` establishes. **Neither complexity baseline was modified.**

## Tests

Seven invariants in `kv_memory_tests.rs`, including the two that matter most: a full-attention model
still counts every block (the regression guard for every model already in a library), and a seam test
driving `estimate_kv_elems_per_token` over a complete `qwen35` fixture to assert `k == v == 16*4*256`.

## Tier

**Tier 1** — it changes a launch flag and an admission verdict. Parity is satisfied by construction
rather than by new surface work: the value reaches CLI, API and GUI through `ModelLaunchSpec`, and all
three already render it, so all three are corrected by this change alone.

## Follow-up, not in scope

`src/hooks/useSystemMemory.ts:11-20` carries an independent hardcoded front-end heuristic
(`0.5 GB per 1K context`) that duplicates this arithmetic in TypeScript and is wrong for every model.
