### PR TITLE
fix(runtime): make an explicit "jinja off" actually turn jinja off

### DIFF
--- a/crates/gglib-core/src/lib.rs
+++ b/crates/gglib-core/src/lib.rs
@@ -49,10 +49,10 @@ pub use ports::{
     DownloadManagerConfig, DownloadManagerPort, DownloadRequest, DownloadStateRepositoryPort,
     EmptyToolExecutor, FilteredToolExecutor, GgufCapabilities, GgufMetadata, GgufParseError,
     GgufParserPort, HfClientPort, HfFileInfo, HfPortError, HfQuantInfo, HfRepoInfo,
-    HfSearchOptions, HfSearchResult, LlmCompletionPort, McpRepositoryError, McpServerRepository,
-    McpServiceError, ModelRegistrarPort, ModelRepository, NoopDownloadEmitter, NoopEmitter,
-    NoopGgufParser, ProcessHandle, QuantizationResolver, Repos, RepositoryError, Resolution,
-    ResolvedFile, ServerConfig, SettingsRepository, ToolExecutorPort, UsageSink,
+    HfSearchOptions, HfSearchResult, JinjaMode, LlmCompletionPort, McpRepositoryError,
+    McpServerRepository, McpServiceError, ModelRegistrarPort, ModelRepository, NoopDownloadEmitter,
+    NoopEmitter, NoopGgufParser, ProcessHandle, QuantizationResolver, Repos, RepositoryError,
+    Resolution, ResolvedFile, ServerConfig, SettingsRepository, ToolExecutorPort, UsageSink,
 };
 pub use services::{ChatHistoryService, ModelRegistrar};
 pub use settings::{

--- a/crates/gglib-core/src/ports/mod.rs
+++ b/crates/gglib-core/src/ports/mod.rs
@@ -61,7 +61,7 @@ pub use model_runtime::{
     Admission, AdmissionLease, AdmissionRelease, LaunchOverrides, ModelRuntimeError,
     ModelRuntimePort, NoopModelRuntime, PinnedSpec, RunningTarget, RuntimeErrorEnvelope,
 };
-pub use process_runner::{ProcessHandle, ServerConfig};
+pub use process_runner::{JinjaMode, ProcessHandle, ServerConfig};
 pub use retry_observer::RetryObserver;
 pub use server_health::ServerHealthStatus;
 pub use server_log_sink::ServerLogSinkPort;

--- a/crates/gglib-core/src/ports/process_runner.rs
+++ b/crates/gglib-core/src/ports/process_runner.rs
@@ -18,6 +18,39 @@ use std::path::PathBuf;
 
 use crate::domain::InferenceConfig;
 
+/// What position a launch takes on Jinja chat templating.
+///
+/// Three states rather than a bool because llama-server's default is jinja
+/// **on**: `use_jinja` initialises to `true` (`common/common.h:621`) and
+/// `common/arg.cpp:1394-1399` flips it off only for the completion and mtmd
+/// examples — never for the server. So "gglib emits no flag" and "gglib turns
+/// jinja off" are two different launches, and a bool could only ever name one
+/// of them. It named the wrong one: `false` meant *emit nothing*, so a user who
+/// explicitly disabled Jinja got a server running with it anyway, silently.
+///
+/// The distinction is in the type rather than in a convention because both
+/// falsy cases are reachable and they must not be conflated — see
+/// [`Self::Defer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JinjaMode {
+    /// Emit no jinja flag at all and let llama-server decide.
+    ///
+    /// The default, and what an untagged model with no override resolves to.
+    /// Against this pinned llama.cpp that means jinja is **on** — deferring is
+    /// not the same as turning it off, and gglib does not pretend otherwise.
+    #[default]
+    Defer,
+    /// Emit `--jinja`.
+    On,
+    /// Emit `--no-jinja`.
+    ///
+    /// Reached only from an explicit caller override. Nothing tag-derived
+    /// produces this: taking jinja away removes tool-call templating and
+    /// template kwargs, which is a decision only the user gets to make.
+    Off,
+}
+
 /// Configuration for starting a model server.
 ///
 /// This is an intent-based configuration — it expresses what the caller
@@ -40,8 +73,11 @@ pub struct ServerConfig {
     pub context_size: Option<u64>,
     /// Number of GPU layers to offload (if None, use default).
     pub gpu_layers: Option<i32>,
-    /// Enable Jinja templating for chat formats.
-    pub jinja: bool,
+    /// What this launch says about Jinja templating for chat formats.
+    ///
+    /// See [`JinjaMode`] — [`JinjaMode::Defer`] emits nothing, which leaves
+    /// llama-server's own (on) default in place rather than turning jinja off.
+    pub jinja: JinjaMode,
     /// Reasoning format override (e.g., `"deepseek"`, `"none"`).
     pub reasoning_format: Option<String>,
     /// Number of MTP draft tokens to speculate ahead (`--spec-draft-n-max`).
@@ -131,7 +167,7 @@ impl ServerConfig {
             base_port,
             context_size: None,
             gpu_layers: None,
-            jinja: false,
+            jinja: JinjaMode::Defer,
             reasoning_format: None,
             spec_draft_n_max: None,
             spec_draft_p_min: None,
@@ -168,10 +204,14 @@ impl ServerConfig {
         self
     }
 
-    /// Enable Jinja templating.
+    /// State this launch's position on Jinja templating.
+    ///
+    /// Takes the mode rather than defaulting to "on" because the caller that
+    /// has resolved it is the only one that knows which of the two falsy
+    /// answers it holds — see [`JinjaMode`].
     #[must_use]
-    pub const fn with_jinja(mut self) -> Self {
-        self.jinja = true;
+    pub const fn with_jinja_mode(mut self, mode: JinjaMode) -> Self {
+        self.jinja = mode;
         self
     }
 

--- a/crates/gglib-core/src/server_config.rs
+++ b/crates/gglib-core/src/server_config.rs
@@ -102,9 +102,12 @@ pub struct ServerConfigOptions {
     pub port: Option<u16>,
 
     /// Override Jinja template support.
-    /// - `None` → auto-detect: enabled when the model has the `"agent"` tag.
-    /// - `Some(true)` → force enable regardless of tags.
-    /// - `Some(false)` → force disable regardless of tags.
+    /// - `None` → auto-detect: `--jinja` when the model has the `"agent"` tag,
+    ///   and otherwise **no flag at all**, which leaves llama-server's own
+    ///   default (jinja on) in place rather than disabling it.
+    /// - `Some(true)` → `--jinja` regardless of tags.
+    /// - `Some(false)` → `--no-jinja` regardless of tags. The only route to
+    ///   actually turning jinja off; see [`crate::ports::JinjaMode`].
     pub jinja: Option<bool>,
 
     /// Override the reasoning format passed to llama-server.

--- a/crates/gglib-runtime/README.md
+++ b/crates/gglib-runtime/README.md
@@ -185,9 +185,20 @@ let config = build_server_config(
 
 | Feature | Explicit override wins over… | Tag-based default |
 |---------|------------------------------|-------------------|
-| Jinja templates | `opts.jinja = Some(true/false)` | `"agent"` tag → enabled |
+| Jinja templates | `opts.jinja = Some(true)` → `--jinja`, `Some(false)` → `--no-jinja` | `"agent"` tag → `--jinja`; otherwise **no flag**, leaving llama-server's own default (jinja on) |
 | Reasoning format | `opts.reasoning_format = Some(…)` | model tags |
 | MTP speculative decoding | `opts.mtp_draft_n_max = Some(0)` (off) or `Some(n)` (on) | `"mtp"` tag → `n=2, p_min=0.75` |
+
+The jinja row is the one where gglib's silence is not a "no". llama-server
+initialises `use_jinja = true` and the server example never clears it, so a
+launch that emits no flag runs *with* jinja. That is why the flag is emitted in
+both directions: `--no-jinja` is the only thing gglib can send that turns jinja
+off, and nothing tag-derived reaches it — taking tool-call templating and
+template kwargs away from every non-agent model is a choice only the user gets
+to make. One caveat: llama.cpp also reads `LLAMA_ARG_JINJA` from the
+environment, which gglib does not sanitise, so an exported `LLAMA_ARG_JINJA=0`
+turns jinja off on a deferred launch. It cannot beat `--no-jinja`, since
+arguments are applied after the environment.
 
 ### Context size resolution
 

--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -6,7 +6,7 @@
 use crate::llama::{LlamaServerError, resolve_llama_server};
 use crate::process::spawn_stream_reader;
 use crate::system::is_truthy_flag;
-use gglib_core::ports::{ServerConfig, ServerLogSinkPort};
+use gglib_core::ports::{JinjaMode, ServerConfig, ServerLogSinkPort};
 use gglib_core::utils::process::cmd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -208,9 +208,21 @@ fn build_command(validated_path: &Path, config: &ServerConfig, port: u16) -> std
         cmd.arg("-ngl").arg(layers.to_string());
     }
 
-    // Add jinja if enabled
-    if config.jinja {
-        cmd.arg("--jinja");
+    // Jinja. Both flags are emitted, and the third state emits neither.
+    //
+    // `--no-jinja` is not redundant with saying nothing: llama-server starts
+    // with `use_jinja = true` (`common/common.h:621`) and the server example
+    // never clears it, so a launch that omits the flag runs *with* jinja. Only
+    // an explicit `--no-jinja` turns it off. `JinjaMode::Defer` therefore means
+    // "gglib takes no position", not "off" — see `llama::args::jinja`.
+    match config.jinja {
+        JinjaMode::On => {
+            cmd.arg("--jinja");
+        }
+        JinjaMode::Off => {
+            cmd.arg("--no-jinja");
+        }
+        JinjaMode::Defer => {}
     }
 
     // Embedding mode. Not additive — llama-server reads `--embeddings` as
@@ -370,7 +382,7 @@ mod tests {
             port: None,
             context_size: None,
             gpu_layers: None,
-            jinja: false,
+            jinja: JinjaMode::Defer,
             reasoning_format: None,
             spec_draft_n_max: None,
             spec_draft_p_min: None,
@@ -410,6 +422,58 @@ mod tests {
             .position(|a| a == "--parallel")
             .expect("--parallel is always emitted");
         assert_eq!(args[idx + 1], SERVER_PARALLEL.to_string());
+    }
+
+    /// The bug: an explicit jinja-off used to emit nothing, and llama-server
+    /// starts with `use_jinja = true`, so the user's "off" produced a server
+    /// running with jinja and no sign that anything had been ignored.
+    #[test]
+    fn an_explicit_jinja_off_emits_no_jinja() {
+        let config = ServerConfig {
+            jinja: JinjaMode::Off,
+            ..minimal_config()
+        };
+        let args = args_of(&build_command(
+            Path::new("/fake/llama-server"),
+            &config,
+            5500,
+        ));
+        assert!(args.contains(&"--no-jinja".to_string()), "got {args:?}");
+        assert!(!args.contains(&"--jinja".to_string()), "got {args:?}");
+    }
+
+    #[test]
+    fn an_explicit_jinja_on_emits_jinja() {
+        let config = ServerConfig {
+            jinja: JinjaMode::On,
+            ..minimal_config()
+        };
+        let args = args_of(&build_command(
+            Path::new("/fake/llama-server"),
+            &config,
+            5500,
+        ));
+        assert!(args.contains(&"--jinja".to_string()), "got {args:?}");
+        assert!(!args.contains(&"--no-jinja".to_string()), "got {args:?}");
+    }
+
+    /// Pinned deliberately, not incidentally. `Defer` is what an untagged
+    /// model with no override resolves to, and against this llama.cpp the
+    /// flagless launch runs *with* jinja. Emitting `--no-jinja` here would
+    /// newly strip tool-call templating and template kwargs from every
+    /// non-agent model — a real behaviour change, and this test is what makes
+    /// it visible if anyone tries.
+    #[test]
+    fn a_deferred_jinja_emits_neither_flag() {
+        let config = minimal_config();
+        assert_eq!(config.jinja, JinjaMode::Defer);
+        let args = args_of(&build_command(
+            Path::new("/fake/llama-server"),
+            &config,
+            5500,
+        ));
+        assert!(!args.contains(&"--jinja".to_string()), "got {args:?}");
+        assert!(!args.contains(&"--no-jinja".to_string()), "got {args:?}");
     }
 
     #[test]
@@ -583,7 +647,7 @@ mod tests {
             port: Some(8080),
             context_size: None,
             gpu_layers: None,
-            jinja: false,
+            jinja: JinjaMode::Defer,
             reasoning_format: None,
             spec_draft_n_max: None,
             spec_draft_p_min: None,

--- a/crates/gglib-runtime/src/launch_narration.rs
+++ b/crates/gglib-runtime/src/launch_narration.rs
@@ -18,12 +18,13 @@ use gglib_core::domain::{
     format_mib_as_gib, kv_bytes_per_token,
 };
 use gglib_core::normalize::tags::FORMAT_QWEN_XML;
-use gglib_core::ports::ModelLaunchSpec;
+use gglib_core::ports::{JinjaMode, ModelLaunchSpec};
 use gglib_core::server_config::ContextSizeSource;
 
 use crate::llama::args::{
-    CacheRamResolution, CacheRamSource, JinjaResolutionSource, KvCacheTypeResolution,
-    KvCacheTypeSource, MtpResolutionSource, ReasoningFormatSource, SlotRestoreResolution,
+    CacheRamResolution, CacheRamSource, JinjaResolution, JinjaResolutionSource,
+    KvCacheTypeResolution, KvCacheTypeSource, MtpResolutionSource, ReasoningFormatSource,
+    SlotRestoreResolution,
 };
 use crate::server_config::ResolvedCapabilities;
 
@@ -240,6 +241,30 @@ fn mtp_decision(inputs: &NarrationInputs<'_>) -> Option<LaunchDecision> {
     ))
 }
 
+/// How one launch's jinja decision reads on the flags line.
+///
+/// Both directions get a line. A user who turned jinja off has no other way to
+/// tell that it took effect — and until `--no-jinja` was actually emitted it
+/// did not, which is exactly the failure a silent narration would hide again.
+/// [`JinjaMode::Defer`] gets nothing, because gglib genuinely did not decide:
+/// llama-server's own default stands, and claiming a flag would misreport the
+/// command line.
+fn jinja_flag(res: JinjaResolution) -> Option<String> {
+    let why = match res.source {
+        JinjaResolutionSource::AgentTag => "agent tag",
+        JinjaResolutionSource::ExplicitTrue | JinjaResolutionSource::ExplicitFalse => "explicit",
+        // Only ever pairs with `Defer`, which yields `None` below — matched
+        // rather than wildcarded so a new source cannot render as the wrong
+        // reason.
+        JinjaResolutionSource::Default => "default",
+    };
+    match res.mode {
+        JinjaMode::On => Some(format!("--jinja ({why})")),
+        JinjaMode::Off => Some(format!("--no-jinja ({why})")),
+        JinjaMode::Defer => None,
+    }
+}
+
 /// The llama-server flags gglib chose on the user's behalf.
 ///
 /// Each flag carries its own provenance inline, so the line reads
@@ -250,15 +275,8 @@ fn flags_decision(inputs: &NarrationInputs<'_>) -> Option<LaunchDecision> {
     let caps = inputs.capabilities;
     let mut parts: Vec<String> = Vec::new();
 
-    if caps.jinja.enabled {
-        let why = match caps.jinja.source {
-            JinjaResolutionSource::AgentTag => "agent tag",
-            JinjaResolutionSource::ExplicitTrue => "explicit",
-            // Not reachable while `enabled` is true, but matched exhaustively
-            // so a new source cannot silently render as the wrong reason.
-            JinjaResolutionSource::ExplicitFalse | JinjaResolutionSource::Default => "default",
-        };
-        parts.push(format!("--jinja ({why})"));
+    if let Some(jinja) = jinja_flag(caps.jinja) {
+        parts.push(jinja);
     }
 
     if let Some(format) = &caps.reasoning.format {
@@ -324,9 +342,7 @@ mod tests {
     use gglib_core::domain::KvElemsPerToken;
     use std::path::PathBuf;
 
-    use crate::llama::args::{
-        JinjaResolution, MtpResolution, ReasoningFormatResolution, SlotRestoreSource,
-    };
+    use crate::llama::args::{MtpResolution, ReasoningFormatResolution, SlotRestoreSource};
 
     fn spec(tags: &[&str]) -> ModelLaunchSpec {
         ModelLaunchSpec {
@@ -348,7 +364,7 @@ mod tests {
     fn caps() -> ResolvedCapabilities {
         ResolvedCapabilities {
             jinja: JinjaResolution {
-                enabled: false,
+                mode: JinjaMode::Defer,
                 source: JinjaResolutionSource::Default,
             },
             reasoning: ReasoningFormatResolution {
@@ -548,7 +564,7 @@ mod tests {
         let (s, r) = (spec(&[]), cache_ram(Some(6144), CacheRamSource::Auto));
         let mut c = caps();
         c.jinja = JinjaResolution {
-            enabled: true,
+            mode: JinjaMode::On,
             source: JinjaResolutionSource::AgentTag,
         };
         c.reasoning = ReasoningFormatResolution {
@@ -560,6 +576,34 @@ mod tests {
             n.decision("flags").unwrap().value,
             "--jinja (agent tag) \u{b7} --reasoning-format deepseek (reasoning tag)"
         );
+    }
+
+    /// Turning jinja off is at least as worth narrating as turning it on: it
+    /// is the case a user chose deliberately, and the case that until now did
+    /// not take effect at all.
+    #[test]
+    fn flags_line_names_an_explicitly_disabled_jinja() {
+        let (s, r) = (spec(&[]), cache_ram(Some(6144), CacheRamSource::Auto));
+        let mut c = caps();
+        c.jinja = JinjaResolution {
+            mode: JinjaMode::Off,
+            source: JinjaResolutionSource::ExplicitFalse,
+        };
+        let n = narrate(&inputs(&s, &c, &r));
+        assert_eq!(n.decision("flags").unwrap().value, "--no-jinja (explicit)");
+    }
+
+    /// Deferring is not a flag, so it is not a line. Claiming one would
+    /// misreport the command line gglib actually built.
+    #[test]
+    fn flags_line_stays_silent_when_jinja_is_deferred() {
+        let (s, c, r) = (
+            spec(&[]),
+            caps(),
+            cache_ram(Some(6144), CacheRamSource::Auto),
+        );
+        assert_eq!(c.jinja.mode, JinjaMode::Defer);
+        assert!(narrate(&inputs(&s, &c, &r)).decision("flags").is_none());
     }
 
     /// The one flag that takes chat completions away has to be visible in the
@@ -628,7 +672,7 @@ mod tests {
         );
         let mut c = caps();
         c.jinja = JinjaResolution {
-            enabled: true,
+            mode: JinjaMode::On,
             source: JinjaResolutionSource::AgentTag,
         };
         c.reasoning = ReasoningFormatResolution {

--- a/crates/gglib-runtime/src/llama/args/jinja.rs
+++ b/crates/gglib-runtime/src/llama/args/jinja.rs
@@ -1,4 +1,30 @@
 //! Jinja template flag resolution for llama.cpp launches.
+//!
+//! # Why the result is not a bool
+//!
+//! llama-server's own default is jinja **on** — `use_jinja` initialises to
+//! `true` in `common/common.h:621`, and `common/arg.cpp:1394-1399` flips it
+//! false only for the completion and mtmd examples, never for the server. So
+//! there are two distinct ways for this resolver to answer "not on", and they
+//! call for opposite launches:
+//!
+//! - the user explicitly turned jinja off, which needs `--no-jinja` to be
+//!   emitted or the server runs with jinja regardless;
+//! - gglib has no opinion — no `agent` tag, no override — which needs *no*
+//!   flag, leaving upstream's default in place.
+//!
+//! This used to be one `enabled: bool`, where `false` meant "emit nothing".
+//! That silently discarded the first case: an explicit jinja-off produced a
+//! server running with jinja, and nothing said so. [`JinjaMode`] names the
+//! three answers so the emitter cannot conflate them again.
+//!
+//! Note the consequence for the second case: an untagged model with no
+//! override gets jinja from upstream. gglib does not take that away — doing so
+//! would newly break tool-call templating and template kwargs for every
+//! non-agent model.
+
+use gglib_core::domain::capability_tags;
+use gglib_core::ports::JinjaMode;
 
 /// Indicates how the Jinja flag was resolved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6,45 +32,121 @@ pub enum JinjaResolutionSource {
     /// User explicitly forced Jinja on via CLI/UI flag.
     ExplicitTrue,
     /// User explicitly disabled Jinja even if tags would auto-enable it.
+    ///
+    /// The only source that yields [`JinjaMode::Off`], and therefore the only
+    /// one that puts `--no-jinja` on the command line.
     ExplicitFalse,
-    /// Auto-enabled because the model has the "agent" tag.
+    /// Auto-enabled because the model has the
+    /// [`AGENT`](capability_tags::AGENT) tag.
     AgentTag,
-    /// Not enabled (default).
+    /// No tag and no override, so gglib takes no position.
+    ///
+    /// Not the same as "off": this yields [`JinjaMode::Defer`], gglib emits no
+    /// flag, and llama-server's own default (jinja on) applies.
     Default,
 }
 
-/// Result of resolving whether to enable Jinja templates.
+/// Result of resolving what a launch says about Jinja templates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JinjaResolution {
-    /// Whether the `--jinja` flag should be forwarded to llama.cpp.
-    pub enabled: bool,
+    /// Which jinja flag, if any, should be forwarded to llama.cpp.
+    pub mode: JinjaMode,
     /// Source of the decision, used for UX/logging.
     pub source: JinjaResolutionSource,
 }
 
-/// Determine whether to enable Jinja templates for llama-server launches.
+/// Determine what a llama-server launch says about Jinja templates.
+///
+/// See the module docs for why the three outcomes are not two.
+#[must_use]
 pub fn resolve_jinja_flag(explicit: Option<bool>, tags: &[String]) -> JinjaResolution {
     match explicit {
         Some(true) => JinjaResolution {
-            enabled: true,
+            mode: JinjaMode::On,
             source: JinjaResolutionSource::ExplicitTrue,
         },
         Some(false) => JinjaResolution {
-            enabled: false,
+            mode: JinjaMode::Off,
             source: JinjaResolutionSource::ExplicitFalse,
         },
         None => {
-            if tags.iter().any(|tag| tag.eq_ignore_ascii_case("agent")) {
+            if capability_tags::has(tags, capability_tags::AGENT) {
                 JinjaResolution {
-                    enabled: true,
+                    mode: JinjaMode::On,
                     source: JinjaResolutionSource::AgentTag,
                 }
             } else {
                 JinjaResolution {
-                    enabled: false,
+                    mode: JinjaMode::Defer,
                     source: JinjaResolutionSource::Default,
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// The bug this module was rewritten for: an explicit false used to
+    /// resolve to `enabled: false`, which emitted nothing, which left the
+    /// server running with upstream's jinja-on default.
+    #[test]
+    fn an_explicit_false_resolves_to_off_not_to_silence() {
+        let r = resolve_jinja_flag(Some(false), &tags(&["agent"]));
+        assert_eq!(r.mode, JinjaMode::Off);
+        assert_eq!(r.source, JinjaResolutionSource::ExplicitFalse);
+    }
+
+    #[test]
+    fn an_explicit_true_resolves_to_on() {
+        let r = resolve_jinja_flag(Some(true), &[]);
+        assert_eq!(r.mode, JinjaMode::On);
+        assert_eq!(r.source, JinjaResolutionSource::ExplicitTrue);
+    }
+
+    #[test]
+    fn the_agent_tag_resolves_to_on() {
+        let r = resolve_jinja_flag(None, &tags(&["reasoning", "agent"]));
+        assert_eq!(r.mode, JinjaMode::On);
+        assert_eq!(r.source, JinjaResolutionSource::AgentTag);
+    }
+
+    /// Tags reach the catalog from GGUF detection, `HuggingFace` metadata and
+    /// hand edits, and only the first is guaranteed lowercase. Preserved from
+    /// the hand-rolled `eq_ignore_ascii_case` this now delegates to
+    /// [`capability_tags::has`].
+    #[test]
+    fn the_agent_tag_match_is_case_insensitive() {
+        assert_eq!(
+            resolve_jinja_flag(None, &tags(&["Agent"])).mode,
+            JinjaMode::On
+        );
+    }
+
+    /// Untagged and un-overridden is a *deferral*, not an off. Turning jinja
+    /// off here would take tool-call templating and template kwargs away from
+    /// every non-agent model — a behaviour change this resolver deliberately
+    /// does not make.
+    #[test]
+    fn an_untagged_model_defers_rather_than_disabling() {
+        let r = resolve_jinja_flag(None, &tags(&["reasoning", "code"]));
+        assert_eq!(r.mode, JinjaMode::Defer);
+        assert_eq!(r.source, JinjaResolutionSource::Default);
+    }
+
+    /// An explicit false beats the tag that would otherwise auto-enable —
+    /// the whole point of an override.
+    #[test]
+    fn an_explicit_false_overrides_the_agent_tag() {
+        assert_eq!(
+            resolve_jinja_flag(Some(false), &tags(&["agent", "mtp"])).mode,
+            JinjaMode::Off
+        );
     }
 }

--- a/crates/gglib-runtime/src/server_config.rs
+++ b/crates/gglib-runtime/src/server_config.rs
@@ -23,10 +23,27 @@
 //!
 //! | Feature | Explicit override wins over… | Tag-based default |
 //! |---------|------------------------------|-------------------|
-//! | Jinja templates | `opts.jinja = Some(…)` | `"agent"` tag → enabled |
+//! | Jinja templates | `opts.jinja = Some(true)` → `--jinja`, `Some(false)` → `--no-jinja` | `"agent"` tag → `--jinja`; otherwise **no flag**, and llama-server's own default (jinja on) stands |
 //! | Reasoning format | `opts.reasoning_format = Some(…)` | model tags |
 //! | MTP speculative decoding | `opts.mtp_draft_n_max = Some(0)` (off) or `Some(n)` (on) | `"mtp"` tag → enabled |
 //! | Embedding mode | *(no override — see below)* | `"embedding"` tag → enabled |
+//!
+//! The jinja row is the one where gglib's silence is not a "no". llama-server
+//! starts with `use_jinja = true` and the server example never clears it, so an
+//! untagged model launches *with* jinja unless something outside gglib says
+//! otherwise. That is why the flag is emitted in both directions: `--jinja`
+//! states a decision gglib already agreed with, and `--no-jinja` is the only
+//! thing gglib can send that takes jinja away. Nothing tag-derived emits
+//! `--no-jinja` — removing tool-call templating and template kwargs from every
+//! non-agent model is not a default anyone asked for, so only an explicit
+//! override reaches it.
+//!
+//! The "outside gglib" caveat is real: llama.cpp registers `LLAMA_ARG_JINJA`
+//! as an env alias for the same option, and gglib does not sanitise the
+//! spawned process's environment. An exported `LLAMA_ARG_JINJA=0` therefore
+//! turns jinja off under the deferred arm. It cannot override the explicit
+//! arm — command-line arguments are applied after the environment — so
+//! `--no-jinja` still means what it says.
 //!
 //! Embedding mode is the one row with no override column. `--embeddings`
 //! restricts llama-server to serving embeddings, so the flag is a statement
@@ -77,7 +94,8 @@ use crate::llama::args::{
 /// resolution that drifted would narrate a launch that never happened.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ResolvedCapabilities {
-    /// Whether `--jinja` was emitted, and why.
+    /// Which jinja flag was emitted — `--jinja`, `--no-jinja`, or neither —
+    /// and why.
     pub jinja: JinjaResolution,
     /// The `--reasoning-format` decision, and why.
     pub reasoning: ReasoningFormatResolution,
@@ -147,11 +165,12 @@ pub(crate) fn build_server_config_narrated(
     }
 
     // --- Jinja templates -------------------------------------------------------
+    // Carried through as a mode, unconditionally: the "no flag" outcome is a
+    // decision in its own right here (see the module docs), so there is nothing
+    // to branch on.
     let jinja = resolve_jinja_flag(opts.jinja, tags);
-    if jinja.enabled {
-        debug!(source = ?jinja.source, "enabling --jinja for model");
-        config = config.with_jinja();
-    }
+    debug!(mode = ?jinja.mode, source = ?jinja.source, "resolved jinja mode for model");
+    config = config.with_jinja_mode(jinja.mode);
 
     // --- Reasoning format ------------------------------------------------------
     let reasoning = match opts.reasoning_format.as_deref() {

--- a/crates/gglib-runtime/src/server_config_tests.rs
+++ b/crates/gglib-runtime/src/server_config_tests.rs
@@ -5,6 +5,7 @@
 use super::*;
 use crate::unified_server_config::{GlobalDefaults, UnifiedServerConfig};
 use gglib_core::domain::InferenceConfig;
+use gglib_core::ports::JinjaMode;
 
 const BASE_PORT: u16 = 9000;
 
@@ -79,7 +80,7 @@ fn cascade_reaches_the_built_config_with_fully_specified_options() {
 
     assert_eq!(config.context_size, Some(32_768));
     assert_eq!(config.port, Some(5501));
-    assert!(config.jinja);
+    assert_eq!(config.jinja, JinjaMode::On);
     assert_eq!(config.reasoning_format.as_deref(), Some("deepseek"));
     assert_eq!(config.spec_draft_n_max, Some(4));
     assert_eq!(config.cache_ram_mb, Some(4096));
@@ -104,7 +105,11 @@ fn cascade_preserves_tag_driven_detection() {
         },
     );
 
-    assert!(config.jinja, "agent tag should auto-enable jinja");
+    assert_eq!(
+        config.jinja,
+        JinjaMode::On,
+        "agent tag should auto-enable jinja"
+    );
     assert!(
         config.reasoning_format.is_some(),
         "reasoning tag should auto-detect a reasoning format"
@@ -117,6 +122,36 @@ fn cascade_preserves_tag_driven_detection() {
         !config.embeddings,
         "a chat model's tags must never reach --embeddings"
     );
+}
+
+/// An explicit jinja-off has to survive the cascade as an *off*, not decay
+/// into the deferral an untagged model produces — those emit opposite command
+/// lines, and only one of them actually disables jinja.
+#[test]
+fn cascade_carries_an_explicit_jinja_off_through_as_off() {
+    let config = build_via_cascade(
+        &["agent".to_string()],
+        ServerConfigOptions {
+            jinja: Some(false),
+            ..Default::default()
+        },
+        GlobalDefaults::default(),
+    );
+    assert_eq!(config.jinja, JinjaMode::Off);
+}
+
+/// Pinned as a deliberate behaviour: gglib takes no position on jinja for a
+/// model with neither the tag nor an override, so llama-server's own default
+/// (jinja on) stands. Flipping this to `Off` would silently strip tool-call
+/// templating and template kwargs from every non-agent model.
+#[test]
+fn cascade_leaves_an_untagged_model_deferring_to_upstream() {
+    let config = build_via_cascade(
+        &["reasoning".to_string()],
+        ServerConfigOptions::default(),
+        GlobalDefaults::default(),
+    );
+    assert_eq!(config.jinja, JinjaMode::Defer);
 }
 
 /// The embedding tag is the only route to `--embeddings`; there is no

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -67,14 +67,14 @@ crates/gglib-core/src/download/types.rs 745
 crates/gglib-core/src/normalize/parsers/delimited.rs 985
 crates/gglib-core/src/normalize/stream.rs 651
 crates/gglib-core/src/ports/model_runtime.rs 817
-crates/gglib-core/src/ports/process_runner.rs 307
+crates/gglib-core/src/ports/process_runner.rs 347
 crates/gglib-core/src/request_pipeline/constrain.rs 509
 crates/gglib-core/src/request_pipeline/sampling_tests.rs 1755
 crates/gglib-core/src/request_pipeline/sampling.rs 733
 crates/gglib-core/src/request_pipeline/truncation_tests.rs 443
 crates/gglib-core/src/request_pipeline/truncation.rs 350
 crates/gglib-core/src/request_pipeline/validate.rs 790
-crates/gglib-core/src/server_config.rs 620
+crates/gglib-core/src/server_config.rs 623
 crates/gglib-core/src/services/model_import.rs 687
 crates/gglib-core/src/services/model_registrar.rs 336
 crates/gglib-core/src/services/model_service.rs 1508
@@ -150,8 +150,8 @@ crates/gglib-proxy/tests/integration_mcp_gateway.rs 476
 crates/gglib-proxy/tests/integration_pinned_models.rs 309
 crates/gglib-proxy/tests/integration_proxy_pipeline.rs 645
 crates/gglib-proxy/tests/integration_slot_roundtrip.rs 615
-crates/gglib-runtime/src/command.rs 673
-crates/gglib-runtime/src/launch_narration.rs 651
+crates/gglib-runtime/src/command.rs 737
+crates/gglib-runtime/src/launch_narration.rs 695
 crates/gglib-runtime/src/llama/args/cache_ram.rs 344
 crates/gglib-runtime/src/llama/build/mod.rs 418
 crates/gglib-runtime/src/llama/detect/cuda.rs 304


### PR DESCRIPTION
## What

PR 4 of the reasoning-controls arc (stacked on #864). A self-contained bug fix: `JinjaResolutionSource::ExplicitFalse` was documented as "user explicitly disabled Jinja" and produced a launch that **ran with jinja anyway**.

llama-server initialises `use_jinja = true` (`common/common.h:621`) and its server example never clears it (`common/arg.cpp:1400`), while gglib only ever emitted `--jinja` and never `--no-jinja`. So the one setting whose purpose is to turn the feature off did nothing — and nothing narrated it, because the narration covered only the enabled case.

| Case | Before | After |
|---|---|---|
| Explicit off | emitted nothing → **ran with jinja** (the bug) | `--no-jinja` → actually off |
| Explicit on | `--jinja` | `--jinja` |
| `agent` tag, no override | `--jinja` | `--jinja` |
| **Untagged, no override** | emitted nothing → ran with jinja | **emitted nothing → runs with jinja (unchanged, pinned by test)** |

## The real bug was a bool carrying three meanings

gglib's resolver returned `false` both for *"the user turned this off"* and *"this model has no agent tag"* — indistinguishable at the emission site, even though upstream treats them oppositely: the first must send a flag, the second must send nothing and inherit jinja.

The resolution now carries a **`JinjaMode` of `Off` / `On` / `Defer`**, and `ServerConfig::with_jinja` (which could only ever say "on") becomes `with_jinja_mode`. The type change reaches gglib-core because that is where the port's `ServerConfig` lives — launch intent, not a persisted shape.

**Nothing tag-derived reaches `Off`.** Emitting `--no-jinja` for every untagged model would newly strip tool-call templating and template kwargs from all of them. The deferred arm emits no flag and behaves exactly as before, pinned by `a_deferred_jinja_emits_neither_flag`, written to fail if that changes.

## Docs corrected

The precedence table's jinja row implied gglib's silence meant *off*. It now states that silence means llama-server's own default, which is *on*. Both module docs note the one thing that can still contradict that: llama.cpp registers `LLAMA_ARG_JINJA` as an env alias and gglib does not sanitise the spawned environment, so an exported `LLAMA_ARG_JINJA=0` turns jinja off on a **deferred** launch. It cannot beat `--no-jinja` — arguments are applied after the environment.

`jinja.rs` also stops hardcoding the literal `"agent"` and asks `capability_tags::AGENT`, which is precisely the hazard that module's docs were written about (case-insensitive match preserved, pinned by test).

## ⚠️ User-visible behaviour change shipping here

The GUI already produces an explicit `false`: `ServeModal.tsx:71` sends `jinjaOverride` through to the start request. So **unchecking "Jinja Templates" now does what it says** — previously it emitted nothing and was identical to leaving it alone.

Consequence for PR 5 (tracked, not lost): `ServeModal.tsx:208-212` labels the *deferred* case "Disabled" and `:220-221` advises "Leave off for plain chat models" — both now false, since a deferred launch runs *with* jinja. PR 5 must reconcile `JinjaMode`'s three states into that two-state checkbox. Also carried: `shared_args.rs`'s `--jinja` is a bare `bool` that can only force-on, so `--no-jinja` is currently unreachable from the CLI.

## Verification

- `make pre-commit` green.
- Adversarial review: two lenses (behaviour — especially the untagged non-regression; docs/conventions) — **zero blockers**.
- Flag string verified against the real binary's `--help`.
- Note: `gglib-runtime`'s retry timing tests (`execute_tests.rs`) are load-flaky and unrelated to this diff — a full-suite run may show red there; re-running the module passes.
