### PR TITLE
refactor(core,services,axum): one shape per concept — collapse DefaultsOriginDto

### DIFF
--- a/crates/gglib-app-services/src/sampling_explain.rs
+++ b/crates/gglib-app-services/src/sampling_explain.rs
@@ -68,8 +68,12 @@ pub struct SamplingExplanationDto {
     /// [`ParamProvenanceDto::layer`] alone cannot name its own source. Without
     /// this, a recipe fetched from the model author renders as gglib's
     /// reasoning-tag guess.
+    ///
+    /// The domain enum itself, not a re-spelling of it: the library list
+    /// reports this same column, and a wire form that differed from it in
+    /// casing alone meant one stored value reached a client under two names.
     #[serde(default)]
-    pub defaults_origin: Option<DefaultsOriginDto>,
+    pub defaults_origin: Option<DefaultsOrigin>,
     /// The `reasoning_effort` this model's template would ignore, when the
     /// stored configuration resolves one it does not read.
     ///
@@ -109,34 +113,6 @@ pub struct SuppressedEffortDto {
     /// floor names an effort.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layer: Option<SamplingLayerDto>,
-}
-
-/// The wire form of [`DefaultsOrigin`](gglib_core::domain::DefaultsOrigin).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum DefaultsOriginDto {
-    /// Set by a person. Outranks global settings.
-    User,
-    /// gglib's own `reasoning`-tag guess. Ranks below global settings.
-    AutoDetected,
-    /// Read from the model author's `generation_config.json` at import.
-    /// Ranks below global settings, exactly where `AutoDetected` does.
-    Published,
-    /// A tune sweep's winner, measured on this installation. Ranks below
-    /// global settings like the other two — and unlike them, the agentic
-    /// ceiling never caps it.
-    Measured,
-}
-
-impl From<DefaultsOrigin> for DefaultsOriginDto {
-    fn from(origin: DefaultsOrigin) -> Self {
-        match origin {
-            DefaultsOrigin::User => Self::User,
-            DefaultsOrigin::AutoDetected => Self::AutoDetected,
-            DefaultsOrigin::Published => Self::Published,
-            DefaultsOrigin::Measured => Self::Measured,
-        }
-    }
 }
 
 /// What gglib does with one field's published recommendation.
@@ -425,7 +401,7 @@ pub(crate) fn explain(
         is_reasoning: model_ctx.is_reasoning,
         trust_client_sampling: settings.trust_client_sampling.unwrap_or(false),
         published,
-        defaults_origin: model.defaults_origin.map(DefaultsOriginDto::from),
+        defaults_origin: model.defaults_origin,
         effort_suppressed,
     }
 }

--- a/crates/gglib-app-services/src/sampling_explain_tests.rs
+++ b/crates/gglib-app-services/src/sampling_explain_tests.rs
@@ -339,6 +339,69 @@ fn auto_detected_model_defaults_rank_below_global_settings() {
     );
 }
 
+/// Every surface that reports this column spells its values the same way.
+///
+/// `Model.defaults_origin` is one value in one database column, and three
+/// separately-declared DTOs serialize it across four routes: [`GuiModel`] for
+/// the library list, [`ModelDetailDto`] for the inspector, and
+/// [`SamplingExplanationDto`] here. The last used to re-spell it through a DTO
+/// that differed from the domain enum in nothing but its casing, so a client
+/// holding two replies for the same stored model read `auto_detected` from one
+/// and `autoDetected` from the other, and could not compare them without first
+/// knowing which route each had come from.
+///
+/// Each surface is checked against the domain enum's own [`Display`], not
+/// against the other surfaces. Comparing them to each other looks equivalent
+/// and is not: `Value::Index` yields `Null` for a key that is absent, so
+/// mutual comparison holds just as well when *every* surface has dropped the
+/// field as when they agree on it — and it pins no spelling at all, leaving a
+/// change that re-camelCased all three green.
+///
+/// [`Display`]: std::fmt::Display
+#[test]
+fn every_surface_spells_an_origin_the_same_way() {
+    for origin in [
+        DefaultsOrigin::User,
+        DefaultsOrigin::AutoDetected,
+        DefaultsOrigin::Published,
+        DefaultsOrigin::Measured,
+    ] {
+        let stored = Model {
+            dialect_spec: None,
+            defaults_origin: Some(origin),
+            ..model()
+        };
+        let expected = serde_json::Value::String(origin.to_string());
+
+        let surfaces = [
+            (
+                "the explain endpoint",
+                serde_json::to_value(explain(&stored, &Settings::with_defaults(), None)).unwrap(),
+            ),
+            (
+                "the library list",
+                serde_json::to_value(crate::types::GuiModel::from_domain(stored.clone())).unwrap(),
+            ),
+            (
+                "the model inspector",
+                serde_json::to_value(crate::types::ModelDetailDto::from_model(
+                    stored.clone(),
+                    false,
+                    None,
+                ))
+                .unwrap(),
+            ),
+        ];
+
+        for (surface, payload) in surfaces {
+            assert_eq!(
+                payload["defaultsOrigin"], expected,
+                "{surface} does not spell {origin:?} the way the domain enum does"
+            );
+        }
+    }
+}
+
 /// The tag changes both the flag the client renders and the floor the
 /// coupled set falls back to.
 #[test]

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -13,8 +13,8 @@ crates/gglib-app-services/src/mcp.rs 396
 crates/gglib-app-services/src/models_tests.rs 886
 crates/gglib-app-services/src/models.rs 576
 crates/gglib-app-services/src/proxy.rs 455
-crates/gglib-app-services/src/sampling_explain_tests.rs 694
-crates/gglib-app-services/src/sampling_explain.rs 477
+crates/gglib-app-services/src/sampling_explain_tests.rs 757
+crates/gglib-app-services/src/sampling_explain.rs 453
 crates/gglib-app-services/src/servers.rs 965
 crates/gglib-app-services/src/settings.rs 404
 crates/gglib-app-services/src/setup.rs 351

--- a/scripts/ts-complexity-baseline.txt
+++ b/scripts/ts-complexity-baseline.txt
@@ -20,4 +20,4 @@ src/services/transport/events/sse.ts 342
 src/services/transport/types/dashboard.ts 559
 src/styles/tailwind.css 402
 src/types/benchmark.ts 539
-src/types/index.ts 851
+src/types/index.ts 855

--- a/src/components/InferenceParametersForm/fallbackCaption.ts
+++ b/src/components/InferenceParametersForm/fallbackCaption.ts
@@ -166,6 +166,11 @@ export function fallbackCaption(
   const source = describeSource(usable.entry, {
     profile: explanation.profile,
     isReasoning: explanation.isReasoning,
+    // Three origins share the auto-detected rung, and this is the only thing
+    // that separates them. Omitting it does not make the caption vaguer — it
+    // makes it name the reasoning-tag guess for all three, which is this
+    // module working something out for itself.
+    defaultsOrigin: explanation.defaultsOrigin,
   });
   const value = explanation.resolved[field];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -380,12 +380,12 @@ export interface GgufModel {
   // Inference defaults
   inferenceDefaults?: InferenceConfig;
   /**
-   * Whether `inferenceDefaults` was set by the user or auto-detected at
-   * import time from the model's `reasoning` tag. Auto-detected values rank
-   * below the global inference defaults in the resolution hierarchy — see
-   * the `InferenceConfig` doc comment above.
+   * Where `inferenceDefaults` came from — see {@link DefaultsOriginName}.
+   *
+   * Everything but `user` ranks below the global inference defaults in the
+   * resolution hierarchy; see the `InferenceConfig` doc comment above.
    */
-  defaultsOrigin?: 'user' | 'auto_detected' | null;
+  defaultsOrigin?: DefaultsOriginName | null;
   // Per-model server defaults (overrides global settings for launch params)
   serverDefaults?: ServerConfig;
   // Benchmark summary (cached from benchmark_summaries table)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -268,7 +268,7 @@ export interface SamplingExplanation {
   /**
    * Where the model's stored defaults came from.
    *
-   * `published` and `autoDetected` share a ladder rung — both are unreviewed,
+   * `published` and `auto_detected` share a ladder rung — both are unreviewed,
    * so both rank below global settings — which means `ParamProvenance.layer`
    * alone cannot name its own source. Without this, a recipe fetched from the
    * model author renders as gglib's reasoning-tag guess.
@@ -295,11 +295,15 @@ export interface SamplingExplanation {
  * Where a model's stored `inferenceDefaults` came from.
  *
  * - `user` — set by a person. Outranks global settings.
- * - `autoDetected` — gglib's `reasoning`-tag guess. Ranks below.
+ * - `auto_detected` — gglib's `reasoning`-tag guess. Ranks below.
  * - `published` — the author's `generation_config.json`, read at import. Ranks
- *   exactly where `autoDetected` does; what differs is the evidence.
+ *   exactly where `auto_detected` does; what differs is the evidence.
+ * - `measured` — a tune sweep's winner on this hardware, ranked with those two.
+ *
+ * Snake_case: this mirrors `gglib_core::domain::DefaultsOrigin` itself, which
+ * is the one spelling every endpoint reporting the column now uses.
  */
-export type DefaultsOriginName = 'user' | 'autoDetected' | 'published' | 'measured';
+export type DefaultsOriginName = 'user' | 'auto_detected' | 'published' | 'measured';
 
 /**
  * What gglib does with one field's published recommendation.

--- a/tests/ts/components/fallbackCaption.test.ts
+++ b/tests/ts/components/fallbackCaption.test.ts
@@ -1,0 +1,80 @@
+/**
+ * What the inference form says under an empty field.
+ *
+ * The module's rule is that it formats what `GET /api/models/:id/explain`
+ * returns and never works anything out for itself. These pin the place that
+ * rule is easiest to break: the auto-detected rung, where three different
+ * origins share one layer name and only `defaultsOrigin` tells them apart.
+ *
+ * Three, not four: `user` is the one origin that cannot reach this rung.
+ * Resolution picks `modelUserSet` for it and `modelAutoDetected` for the other
+ * three, so a fixture pairing `user` with this layer would describe a state
+ * the backend does not produce, and would pin wording nobody ever sees.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  fallbackCaption,
+  type InferenceFallback,
+} from '../../../src/components/InferenceParametersForm/fallbackCaption';
+import type { DefaultsOriginName, SamplingExplanation } from '../../../src/types';
+
+/**
+ * An explanation attributing temperature to the auto-detected rung.
+ *
+ * `ownLayer` is `modelUserSet` — the rung `ModelEditForm` edits, and so the
+ * surface this caption actually appears on. It differs from the entry's own
+ * layer, which is what keeps `usableEntry` from reading the entry as one the
+ * form is in the middle of clearing.
+ */
+const explaining = (defaultsOrigin?: DefaultsOriginName | null): InferenceFallback => ({
+  kind: 'resolved',
+  ownLayer: 'modelUserSet',
+  resolution: {
+    isLoading: false,
+    hasError: false,
+    explanation: {
+      resolved: { temperature: 1.2 },
+      sources: [{ param: 'temperature', kind: 'layer', layer: 'modelAutoDetected' }],
+      profile: null,
+      isReasoning: false,
+      trustClientSampling: false,
+      defaultsOrigin,
+    } satisfies SamplingExplanation,
+  },
+});
+
+describe('fallbackCaption on the auto-detected rung', () => {
+  it("names the model author when the origin is the author's own recipe", () => {
+    expect(fallbackCaption('temperature', explaining('published'))).toContain(
+      'per-model defaults (published by the model author)',
+    );
+  });
+
+  it('names the sweep when the origin was measured', () => {
+    expect(fallbackCaption('temperature', explaining('measured'))).toContain(
+      'per-model defaults (measured by a tune sweep)',
+    );
+  });
+
+  it('names the tag guess when that is what it actually was', () => {
+    expect(fallbackCaption('temperature', explaining('auto_detected'))).toContain(
+      'per-model defaults (auto-detected: reasoning tag)',
+    );
+  });
+
+  /**
+   * A backend too old to send the field, or a model with no origin stored.
+   * The tag guess is the pre-existing wording for that case and stays.
+   */
+  it('keeps the old wording when the backend sent no origin at all', () => {
+    expect(fallbackCaption('temperature', explaining(undefined))).toContain(
+      'per-model defaults (auto-detected: reasoning tag)',
+    );
+  });
+
+  it('still reports the resolved value beside the source', () => {
+    expect(fallbackCaption('temperature', explaining('measured'))).toMatch(/^Resolves to 1\.2/);
+  });
+});


### PR DESCRIPTION
Second of the Phase 2 stack, based on #869 rather than on `main`, so the diff below is this PR's own work. **Merge #869 first**; this retargets to `main` when it lands.

`Model.defaults_origin` is one value in one database column. Three separately declared DTOs serialize it across four routes, and they did not agree with each other.

## One concept, two spellings

`GuiModel` (the library list) and `ModelDetailDto` (the inspector) carried the domain enum straight through, snake_case. `SamplingExplanationDto` sent it through `DefaultsOriginDto` — a type naming the same four variants, converted one-for-one, differing from the domain enum in nothing but `rename_all`. A client holding two replies for the same model read `auto_detected` from one and `autoDetected` from the other, and could not compare them without first knowing which route each had come from.

The DTO and its `From` impl are gone. The wire changes deliberately: `autoDetected` → `auto_detected` on the explain endpoint, with TypeScript moving in the same commit. Nothing in the frontend compares against that literal — `describeSource` reads only `published` and `measured`, both single words that spell identically either way.

The test asserts the invariant rather than the fix: all four origins, through all three surfaces, each checked against the domain enum's own `Display`. Watched to fail first, on `AutoDetected`.

Checked against `Display` rather than against each other, which looks equivalent and is not: `Value::Index` yields `Null` for an absent key, so mutual comparison holds just as well when *every* surface has dropped the field as when they agree — and pins no spelling at all. Verified by mutation: with the origins removed, the `Display` form fails and the mutual form passes.

## Two defects found behind it

**The model endpoints admitted two of four variants.** `GgufModel.defaultsOrigin` declared `'user' | 'auto_detected'`. The Rust has emitted `published` and `measured` since the published-recipe import and the tune sweep landed. Nothing broke, because nothing reads the field — the fetches are unchecked casts, so the value arrives and sits there unread. That is the reason to fix it now rather than the reason not to: the first reader would have been written against a union missing half its cases, with the compiler agreeing. It now shares `DefaultsOriginName` with the explain mirror, so the two surfaces reporting this column name one type between them.

**The inference form credited gglib for the model author's numbers.** `describeSource` needs `defaultsOrigin` to tell three origins apart, because they share one rung — a published recipe, a measured sweep, and gglib's own reasoning-tag guess all arrive as `modelAutoDetected`. The inspector's provenance table passes it; `fallbackCaption.ts` built its context from `profile` and `isReasoning` and stopped. There is no vaguer fallback to land in: that arm ends with the tag-guess wording unconditionally, so every empty field on the form read "per-model defaults (auto-detected: reasoning tag)" — including on a model configured from its author's own `generation_config.json`. The caption did not decline to name a source; it named the wrong one. The value was already in scope, one property from the same `explanation` the two lines above it read.

Both `published` and `measured` arms of `describeSource` had no test coverage at all before this. The new tests cover the three origins that can reach this rung plus the absent case; `user` is excluded because resolution picks `modelUserSet` for it, so pairing it with this layer would describe a state the backend does not produce.

## Two planned items dropped, both on measurement

The plan called for restructuring `PublishedDefaultDto.state` and for making ~50 `pub(crate)` axum wire types `pub` so ts-rs could export them. Probes disproved both premises.

ts-rs 12 expresses the `flatten`-of-internally-tagged-enum shape correctly, so the working wire stays untouched — that was the PR's riskiest item.

And ts-rs needs no particular visibility: it exports a `pub(crate)` type, one nested inside another, and a fully module-private `struct` — correct casing, doc comments carried through, cross-type imports resolved — with `#![deny(unreachable_pub)]` active. `#[ts(export)]`'s generated test is a sibling of the type, so visibility never enters into it.

Done on assumption, that item would have reversed a deliberate documented decision: `gglib-axum/src/lib.rs:32` keeps all ten modules `pub(crate)` and re-exports a seven-item surface precisely so the 35 `pub mod` under `handlers` stay auditable rather than reachable from anywhere in the workspace. `unreachable_pub` would have fired on every type anyway.

## Deliberately not done

No contract test pinning the TS union against the Rust enum. The `tests/ts/contracts/` helper reads structs and functions, not enums, and the extractor that gap needs would be deleted three PRs from now when PR 4 generates these types from Rust directly. The DRY-ness is the guard in the meantime: one declaration, both users.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `npx tsc -b`, `npm run lint`, `npm run test:run` (897), and the `enforcement` script suite — all green locally, exit codes read directly rather than through a pipe.
