### PR TITLE
refactor(gui): one shape for every event

### DIFF
--- a/crates/gglib-core/src/domain/admission.rs
+++ b/crates/gglib-core/src/domain/admission.rs
@@ -70,6 +70,18 @@ pub struct SecondarySlotStatus {
     /// Stable machine-readable label, for styling. One of `resident`,
     /// `available`, `too_large`, `no_headroom`, `unknown_footprint`,
     /// `unknown_budget`.
+    ///
+    /// A `&'static str`, which ts-rs would render as a bare `string` — losing
+    /// the exhaustiveness the GUI's icon table and tone function are written
+    /// against. The override restates the closed set above, the same way
+    /// `gglib_proxy::dashboard::CacheSnapshot::ram_state` does; it is produced
+    /// by one exhaustive `match`, so a new arm there is the one other place
+    /// that must touch this line.
+    #[cfg_attr(
+        feature = "ts-bindings",
+        ts(type = "\"resident\" | \"available\" | \"too_large\" \
+                   | \"no_headroom\" | \"unknown_footprint\" | \"unknown_budget\"")
+    )]
     pub state: &'static str,
     /// Ready-to-render explanation. Phrased for display rather than parsing —
     /// consumers branch on [`Self::state`].

--- a/crates/gglib-core/src/domain/admission.rs
+++ b/crates/gglib-core/src/domain/admission.rs
@@ -74,9 +74,13 @@ pub struct SecondarySlotStatus {
     /// A `&'static str`, which ts-rs would render as a bare `string` — losing
     /// the exhaustiveness the GUI's icon table and tone function are written
     /// against. The override restates the closed set above, the same way
-    /// `gglib_proxy::dashboard::CacheSnapshot::ram_state` does; it is produced
-    /// by one exhaustive `match`, so a new arm there is the one other place
-    /// that must touch this line.
+    /// `gglib_proxy::dashboard::CacheSnapshot::ram_state` does.
+    ///
+    /// Three places set it, and all three must stay inside that set:
+    /// [`Self::default`] and [`Self::resident`] each write one literal, and
+    /// [`Self::from_decision`] takes `SecondarySlotDecision::label` for every
+    /// refusal. `label` also answers `"grant"`, which never reaches here —
+    /// `from_decision` maps a grant to `"available"` before consulting it.
     #[cfg_attr(
         feature = "ts-bindings",
         ts(type = "\"resident\" | \"available\" | \"too_large\" \

--- a/crates/gglib-core/src/domain/admission.rs
+++ b/crates/gglib-core/src/domain/admission.rs
@@ -74,7 +74,7 @@ pub struct SecondarySlotStatus {
     /// A `&'static str`, which ts-rs would render as a bare `string` — losing
     /// the exhaustiveness the GUI's icon table and tone function are written
     /// against. The override restates the closed set above, the same way
-    /// `gglib_proxy::dashboard::CacheSnapshot::ram_state` does.
+    /// `gglib_proxy::dashboard::CacheStatus::ram_state` does.
     ///
     /// Three places set it, and all three must stay inside that set:
     /// [`Self::default`] and [`Self::resident`] each write one literal, and

--- a/crates/gglib-core/src/download/events.rs
+++ b/crates/gglib-core/src/download/events.rs
@@ -118,8 +118,8 @@ impl DownloadStatus {
 /// download that has just started has no meaningful rate yet. Renderers must
 /// show a placeholder for the absent case rather than substituting `0`, and
 /// must never compute a rate of their own from successive `downloaded` values;
-/// the manager's `RateEstimator` is the only source. The mirrored TypeScript
-/// declaration lives in `src/services/transport/types/events.ts`.
+/// the manager's `RateEstimator` is the only source. TypeScript reads this
+/// type through its generated binding; there is no mirror to keep in step.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS), ts(export))]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -39,7 +39,7 @@ crates/gglib-cli/src/model_commands.rs 403
 crates/gglib-cli/src/presentation/explain_display_tests.rs 709
 crates/gglib-cli/src/presentation/explain_display.rs 474
 crates/gglib-cli/src/presentation/inspect_display.rs 405
-crates/gglib-core/src/domain/admission.rs 309
+crates/gglib-core/src/domain/admission.rs 321
 crates/gglib-core/src/domain/agent/config.rs 635
 crates/gglib-core/src/domain/agent/events.rs 354
 crates/gglib-core/src/domain/agent/loop_detection/tests.rs 401

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -39,7 +39,7 @@ crates/gglib-cli/src/model_commands.rs 403
 crates/gglib-cli/src/presentation/explain_display_tests.rs 709
 crates/gglib-cli/src/presentation/explain_display.rs 474
 crates/gglib-cli/src/presentation/inspect_display.rs 405
-crates/gglib-core/src/domain/admission.rs 321
+crates/gglib-core/src/domain/admission.rs 325
 crates/gglib-core/src/domain/agent/config.rs 635
 crates/gglib-core/src/domain/agent/events.rs 354
 crates/gglib-core/src/domain/agent/loop_detection/tests.rs 401

--- a/scripts/ts-complexity-baseline.txt
+++ b/scripts/ts-complexity-baseline.txt
@@ -10,14 +10,13 @@ src/components/ProxySamplingPanel.tsx 405
 src/components/SettingsModal.tsx 373
 src/components/SetupWizard/SetupWizard.tsx 721
 src/components/VerificationModal.tsx 454
-src/hooks/useDownloadManager.ts 451
+src/hooks/useDownloadManager.ts 450
 src/hooks/useGglibRuntime/streamAgentChat.ts 399
 src/pages/ChatPage.tsx 475
 src/pages/ModelControlCenterPage.tsx 326
 src/services/tools/registry.ts 432
 src/services/transport/api/client.ts 361
 src/services/transport/events/sse.ts 342
-src/services/transport/types/dashboard.ts 559
 src/styles/tailwind.css 402
-src/types/benchmark.ts 539
-src/types/index.ts 867
+src/types/benchmark.ts 538
+src/types/index.ts 555

--- a/src/components/ProxySamplingPanel.tsx
+++ b/src/components/ProxySamplingPanel.tsx
@@ -132,9 +132,8 @@ const AuditStateLine: FC<{ audit: SamplingAuditSnapshot }> = ({ audit }) => {
 
 /** The `/props` baseline check: has this build's own default table moved? */
 const BaselineRows: FC<{ baseline?: SamplingBaselineState | null }> = ({ baseline }) => {
-  // A proxy that predates the field sends nothing; a current one always sends
-  // a state, and `not_yet_read` is the honest answer only when no read has
-  // been attempted.
+  // The `!baseline` arm is defence against a malformed frame, not an old
+  // proxy: the field is unconditional. `not_yet_read` is the real case.
   if (!baseline || baseline.state === 'not_yet_read') {
     return (
       <p className="text-sm text-text-muted">
@@ -272,8 +271,9 @@ const ReasonList: FC<{ report: SamplingBaselineReport }> = ({ report }) => {
  * zero rather than being collapsed into silence.
  */
 const PublishedRows: FC<{ published?: SamplingPublishedOverrides | null }> = ({ published }) => {
-  // A proxy that predates the field sends nothing. Distinct from a current
-  // proxy reporting zero intents, which is a statement about traffic.
+  // Defensive, not a shape the wire sends: `published` is unconditional but
+  // arrives through an unchecked cast, and `.fields` off a missing one takes
+  // the panel down. Distinct from zero intents, which is about traffic.
   if (!published) {
     return null;
   }

--- a/src/components/proxy/SlotCard.tsx
+++ b/src/components/proxy/SlotCard.tsx
@@ -3,7 +3,8 @@ import { ContextUsageDonut } from '../ContextUsageDonut';
 import { Readout, Sparkline } from '../primitives';
 import { useMetricHistory } from '../../hooks/useMetricHistory';
 import { formatPerSecond } from '../../utils/formatPerSecond';
-import { tokensInUse, type SlotSnapshot } from '../../services/transport/types/dashboard';
+import { tokensInUse } from '../../services/transport/slotTokens';
+import type { SlotSnapshot } from '../../services/transport/types/dashboard';
 
 interface SlotCardProps {
   slot: SlotSnapshot;

--- a/src/hooks/useDownloadManager.ts
+++ b/src/hooks/useDownloadManager.ts
@@ -4,12 +4,13 @@ import type { DownloadQueueStatus, DownloadQueueItem, DownloadCompletionInfo, Qu
 import type { DownloadEvent, DownloadSummary, QueueRunSummary } from '../services/transport/types/events';
 import { isDesktop } from '../services/platform';
 import { getTransport } from '../services/transport';
+import { bucketQueue, queueIsBusy } from '../services/transport/downloadQueue';
 
 /**
  * Returns true if a queue snapshot indicates active work (busy state).
  */
 function snapshotIsBusy(items: DownloadSummary[]): boolean {
-  return items.some(i => i.status === 'queued' || i.status === 'downloading');
+  return queueIsBusy(items);
 }
 
 export type DownloadProgressStatus = 'started' | 'progress' | 'finalizing' | 'registering' | 'notice' | 'completed' | 'error';
@@ -79,33 +80,29 @@ interface UseDownloadManagerOptions {
   onCompleted?: (info: DownloadCompletionInfo) => void;
 }
 
+/**
+ * A wire row as the queue UI holds it.
+ *
+ * The two shapes now differ only in name — `DownloadQueueItem.status` is the
+ * same seven-member `DownloadStatus` the wire sends — so this no longer
+ * translates anything. It used to map through a `Record` of four states with
+ * a `?? 'failed'` fallback, which turned `finalizing` and `registering` into
+ * failures and `cancelled` into one too.
+ */
 function normalizeQueueItem(item: DownloadSummary): DownloadQueueItem {
-  const statusMap: Record<string, 'downloading' | 'queued' | 'completed' | 'failed'> = {
-    downloading: 'downloading',
-    queued: 'queued',
-    completed: 'completed',
-    failed: 'failed',
-    cancelled: 'failed',
-  };
-
   return {
     id: item.id,
-    display_name: (item as any).display_name ?? item.id,
-    status: statusMap[item.status] ?? 'failed',
-    position: (item as any).position ?? 0,
-    error: (item as any).error,
-    group_id: (item as any).group_id,
-    shard_info: (item as any).shard_info,
+    display_name: item.display_name,
+    status: item.status,
+    position: item.position,
+    error: item.error,
+    group_id: item.group_id,
+    shard_info: item.shard_info,
   };
 }
 
 function snapshotToQueueStatus(items: DownloadSummary[], maxSize: number): DownloadQueueStatus {
-  const normalized = items.map(normalizeQueueItem);
-  const current = normalized.find((item) => item.status === 'downloading') ?? null;
-  const pending = normalized.filter((item) => item.status === 'queued');
-  const failed = normalized.filter((item) => item.status === 'failed');
-
-  return { current, pending, failed, max_size: maxSize };
+  return bucketQueue(items.map(normalizeQueueItem), maxSize);
 }
 
 function eventToProgress(event: DownloadEvent): DownloadProgressView | null {

--- a/src/hooks/useDownloadManager.ts
+++ b/src/hooks/useDownloadManager.ts
@@ -8,6 +8,9 @@ import { bucketQueue, queueIsBusy } from '../services/transport/downloadQueue';
 
 /**
  * Returns true if a queue snapshot indicates active work (busy state).
+ *
+ * One caller, and it *clears* a stale banner when busy — widening this makes
+ * the banner go sooner, never later.
  */
 function snapshotIsBusy(items: DownloadSummary[]): boolean {
   return queueIsBusy(items);
@@ -83,11 +86,10 @@ interface UseDownloadManagerOptions {
 /**
  * A wire row as the queue UI holds it.
  *
- * The two shapes now differ only in name — `DownloadQueueItem.status` is the
- * same seven-member `DownloadStatus` the wire sends — so this no longer
- * translates anything. It used to map through a `Record` of four states with
- * a `?? 'failed'` fallback, which turned `finalizing` and `registering` into
- * failures and `cancelled` into one too.
+ * No longer translates anything: `DownloadQueueItem.status` is the same
+ * seven-member `DownloadStatus` the wire sends. The `Record` of four it used
+ * to map through narrowed a type to less than the one it assigned into —
+ * moot on the two statuses a snapshot carries, where it was the identity.
  */
 function normalizeQueueItem(item: DownloadSummary): DownloadQueueItem {
   return {

--- a/src/services/transport/api/downloads.ts
+++ b/src/services/transport/api/downloads.ts
@@ -32,9 +32,9 @@ export async function getDownloadQueue(): Promise<DownloadQueueStatus> {
   const snapshot = await get<QueueSnapshotResponse>('/api/models/downloads/queue');
   
   // Bucketed by the same function the SSE `queue_snapshot` path uses. The
-  // comment here used to claim that and it was not true: the SSE side ran
-  // every row through a status map first, so the two produced different
-  // queues from the same data depending on which answered last.
+  // comment here claimed that before it was true — this path read the raw
+  // status while the SSE side normalised first. The two agreed on every frame
+  // the server sends, so nothing was broken; they were two copies of one rule.
   return bucketQueue(snapshot.items || [], snapshot.max_size);
 }
 

--- a/src/services/transport/api/downloads.ts
+++ b/src/services/transport/api/downloads.ts
@@ -4,6 +4,7 @@
  */
 
 import { get, post, del } from './client';
+import { bucketQueue } from '../downloadQueue';
 import type { DownloadId } from '../types/ids';
 import type {
   DownloadQueueStatus,
@@ -30,18 +31,11 @@ interface QueueSnapshotResponse {
 export async function getDownloadQueue(): Promise<DownloadQueueStatus> {
   const snapshot = await get<QueueSnapshotResponse>('/api/models/downloads/queue');
   
-  // Split items by status (same logic as SSE event handler)
-  const items = snapshot.items || [];
-  const current = items.find((item) => item.status === 'downloading') ?? null;
-  const pending = items.filter((item) => item.status === 'queued');
-  const failed = items.filter((item) => item.status === 'failed');
-  
-  return {
-    current,
-    pending,
-    failed,
-    max_size: snapshot.max_size,
-  };
+  // Bucketed by the same function the SSE `queue_snapshot` path uses. The
+  // comment here used to claim that and it was not true: the SSE side ran
+  // every row through a status map first, so the two produced different
+  // queues from the same data depending on which answered last.
+  return bucketQueue(snapshot.items || [], snapshot.max_size);
 }
 
 /**

--- a/src/services/transport/downloadQueue.ts
+++ b/src/services/transport/downloadQueue.ts
@@ -1,0 +1,74 @@
+/**
+ * Sorting a flat download-queue snapshot into the three buckets the GUI reads.
+ *
+ * One module because there are two ways a snapshot arrives — the SSE
+ * `queue_snapshot` frame and `GET /api/models/downloads/queue` — and they used
+ * to sort it differently while a comment in the HTTP path claimed they were
+ * "the same logic as the SSE event handler". They were not: the SSE side ran
+ * every row through a status map that collapsed seven wire states into four,
+ * and the HTTP side used the raw status. A user could see a different queue
+ * depending on which one answered last.
+ *
+ * @module services/transport/downloadQueue
+ */
+
+import type { DownloadQueueItem, DownloadQueueStatus } from './types/downloads';
+
+/**
+ * The queue is actively working on this row.
+ *
+ * Three statuses and not one: `finalizing` and `registering` are the tail of a
+ * download — the bytes are on disk and the queue is checksumming shards and
+ * writing the library row. Treating only `downloading` as in-flight makes a
+ * download disappear from the UI for those two phases, which is precisely
+ * when `GlobalDownloadStatus` wants to say "Finalizing" and "Registering".
+ */
+export function isInFlight(item: DownloadQueueItem): boolean {
+  return (
+    item.status === 'downloading' || item.status === 'finalizing' || item.status === 'registering'
+  );
+}
+
+/** Waiting for a slot; nothing has been fetched yet. */
+export function isPending(item: DownloadQueueItem): boolean {
+  return item.status === 'queued';
+}
+
+/**
+ * Ended badly.
+ *
+ * `cancelled` is deliberately not folded in. It is its own wire status, and a
+ * download the user stopped is not one that went wrong.
+ */
+export function isFailed(item: DownloadQueueItem): boolean {
+  return item.status === 'failed';
+}
+
+/**
+ * Sort a snapshot into `{current, pending, failed}`.
+ *
+ * `current` is the first in-flight row. The queue runs one download at a time,
+ * so "first" and "only" coincide; taking the first keeps that assumption in
+ * one place rather than asserting it.
+ */
+export function bucketQueue(
+  items: DownloadQueueItem[],
+  maxSize = 0,
+): DownloadQueueStatus {
+  return {
+    current: items.find(isInFlight) ?? null,
+    pending: items.filter(isPending),
+    failed: items.filter(isFailed),
+    max_size: maxSize,
+  };
+}
+
+/**
+ * Whether a snapshot shows the queue doing anything at all.
+ *
+ * Includes the finalize and register tail, so a success banner is not cleared
+ * while the queue is still writing the row it is about to announce.
+ */
+export function queueIsBusy(items: DownloadQueueItem[]): boolean {
+  return items.some((item) => isPending(item) || isInFlight(item));
+}

--- a/src/services/transport/downloadQueue.ts
+++ b/src/services/transport/downloadQueue.ts
@@ -1,13 +1,27 @@
 /**
- * Sorting a flat download-queue snapshot into the three buckets the GUI reads.
+ * Sorting a download-queue snapshot into the three buckets the GUI reads.
  *
- * One module because there are two ways a snapshot arrives — the SSE
- * `queue_snapshot` frame and `GET /api/models/downloads/queue` — and they used
- * to sort it differently while a comment in the HTTP path claimed they were
- * "the same logic as the SSE event handler". They were not: the SSE side ran
- * every row through a status map that collapsed seven wire states into four,
- * and the HTTP side used the raw status. A user could see a different queue
- * depending on which one answered last.
+ * One module because a snapshot arrives two ways — the SSE `queue_snapshot`
+ * frame and `GET /api/models/downloads/queue` — and each used to sort it with
+ * its own copy of the rules, while a comment in the HTTP one claimed they were
+ * "the same logic as the SSE event handler". They agreed on every frame the
+ * server sends, so nothing was broken; they were two copies of one rule, which
+ * is the state a rule is in just before it stops being one.
+ *
+ * # What the snapshot can actually contain
+ *
+ * `DownloadStatus` has seven variants, and a queue snapshot carries two of
+ * them. `gglib-download` hard-codes the active row to `Downloading`
+ * (`manager/mod.rs`'s `build_active_dto`) and every pending row to `Queued`
+ * (`queue/mod.rs`), and failed rows are not in `items` at all — they go to a
+ * separate `recent_failures` the wire type does not carry. `finalizing`,
+ * `registering`, `completed`, `failed` and `cancelled` are unreachable here.
+ *
+ * The predicates below still name them, deliberately, and that is the only
+ * claim this module makes about them: the *type* admits seven, so a reader
+ * should not have to guess what a `finalizing` row would do if the queue ever
+ * reported one. They are defence, not a fix — nothing today produces the
+ * inputs they cover.
  *
  * @module services/transport/downloadQueue
  */
@@ -17,11 +31,13 @@ import type { DownloadQueueItem, DownloadQueueStatus } from './types/downloads';
 /**
  * The queue is actively working on this row.
  *
- * Three statuses and not one: `finalizing` and `registering` are the tail of a
- * download — the bytes are on disk and the queue is checksumming shards and
- * writing the library row. Treating only `downloading` as in-flight makes a
- * download disappear from the UI for those two phases, which is precisely
- * when `GlobalDownloadStatus` wants to say "Finalizing" and "Registering".
+ * `downloading` is the only one a snapshot carries today. `finalizing` and
+ * `registering` are the tail of a download — bytes on disk, shards being
+ * checksummed, the library row being written — and belong here rather than
+ * nowhere if they ever reach a snapshot: a row in that state is work in
+ * progress, and treating it as neither current nor pending would make the
+ * download vanish from the UI during the phase `GlobalDownloadStatus` has
+ * "Finalizing" and "Registering" labels for.
  */
 export function isInFlight(item: DownloadQueueItem): boolean {
   return (
@@ -37,8 +53,13 @@ export function isPending(item: DownloadQueueItem): boolean {
 /**
  * Ended badly.
  *
- * `cancelled` is deliberately not folded in. It is its own wire status, and a
- * download the user stopped is not one that went wrong.
+ * Always empty in practice — the queue keeps failures in `recent_failures`,
+ * which the snapshot wire type does not carry — and `DownloadQueueStatus.failed`
+ * has no reader. Both are kept because the field is part of the shape the two
+ * paths return, not because either does anything.
+ *
+ * `cancelled` is not folded in. It is its own wire status, and a download the
+ * user stopped is not one that went wrong.
  */
 export function isFailed(item: DownloadQueueItem): boolean {
   return item.status === 'failed';
@@ -47,14 +68,11 @@ export function isFailed(item: DownloadQueueItem): boolean {
 /**
  * Sort a snapshot into `{current, pending, failed}`.
  *
- * `current` is the first in-flight row. The queue runs one download at a time,
- * so "first" and "only" coincide; taking the first keeps that assumption in
- * one place rather than asserting it.
+ * `current` is the first in-flight row. The queue runs one download at a time
+ * and `get_queue_snapshot` puts the active item first, so "first" and "only"
+ * coincide; a second in-flight row would be dropped rather than shown.
  */
-export function bucketQueue(
-  items: DownloadQueueItem[],
-  maxSize = 0,
-): DownloadQueueStatus {
+export function bucketQueue(items: DownloadQueueItem[], maxSize = 0): DownloadQueueStatus {
   return {
     current: items.find(isInFlight) ?? null,
     pending: items.filter(isPending),
@@ -63,12 +81,7 @@ export function bucketQueue(
   };
 }
 
-/**
- * Whether a snapshot shows the queue doing anything at all.
- *
- * Includes the finalize and register tail, so a success banner is not cleared
- * while the queue is still writing the row it is about to announce.
- */
+/** Whether a snapshot shows the queue doing anything at all. */
 export function queueIsBusy(items: DownloadQueueItem[]): boolean {
   return items.some((item) => isPending(item) || isInFlight(item));
 }

--- a/src/services/transport/slotTokens.ts
+++ b/src/services/transport/slotTokens.ts
@@ -1,0 +1,60 @@
+/**
+ * How many tokens a llama-server slot is actually holding.
+ *
+ * Lives in its own module because it is the one piece of *behaviour* that grew
+ * up among the proxy dashboard's type declarations. Those declarations are
+ * being replaced by generated ones; this cannot be, so separating them first
+ * keeps a mechanical swap from having to step around live logic.
+ *
+ * # The contract this reads, and why it is a mirror rather than a shared type
+ *
+ * The frontend connects directly to an already-running proxy's own HTTP port
+ * (`http://{host}:{port}/v1/proxy/status/stream`), the same way the CLI's
+ * `gglib proxy dashboard` command does — a real HTTP client of the JSON
+ * contract, not a shared in-process type. Unknown or extra fields are ignored
+ * by TypeScript's structural typing, so a reader tolerates additive
+ * server-side changes the same way the CLI's `serde(default)` does.
+ *
+ * @module services/transport/slotTokens
+ */
+
+import type { SlotSnapshot } from './types/dashboard';
+
+/**
+ * Same additive logic as `SlotSnapshot::tokens_in_use()` (Rust) and
+ * `proxy_dashboard.rs`'s local reimplementation (CLI) — kept in sync by hand,
+ * since it's a tiny amount of logic mirrored across three consumers.
+ *
+ * Current-schema builds report prompt usage and generation progress as two
+ * separate counters — `n_prompt_tokens(_processed)` and `next_token.n_decoded`
+ * — which must be added together to get the true total (a 20k-token prompt
+ * with 89 tokens generated so far is ~20k tokens in use, not 89).
+ * `n_prompt_tokens_processed` is preferred over `n_prompt_tokens` when both
+ * are present (it tracks real progress mid-prefill) and, when present, is
+ * combined with `n_prompt_tokens_cache` (tokens reused from KV cache this
+ * round, not re-processed) — otherwise a cache-hit follow-up prompt would
+ * falsely collapse context usage down to just the tiny newly-processed
+ * delta. The grand-total `n_prompt_tokens` fallback (used only when
+ * `_processed` is absent) already includes any cached prefix, so cache is
+ * NOT added on top of it. Only when neither prompt-side field is present
+ * does this fall back to the legacy, non-additive chain: `n_past`, then
+ * `cache_tokens`, then `n_decoded` alone.
+ *
+ * `next_token` may be a single object or an array (MTP builds); element 0 is
+ * the accepted/main decode stream when it's an array.
+ */
+export function tokensInUse(slot: SlotSnapshot): number | null {
+  const nextToken = Array.isArray(slot.next_token) ? slot.next_token[0] : slot.next_token;
+  const nDecoded = nextToken?.n_decoded ?? undefined;
+
+  const promptComponent =
+    slot.n_prompt_tokens_processed != null
+      ? slot.n_prompt_tokens_processed + (slot.n_prompt_tokens_cache ?? 0)
+      : slot.n_prompt_tokens;
+
+  if (promptComponent != null) {
+    return promptComponent + (nDecoded ?? 0);
+  }
+
+  return slot.n_past ?? slot.cache_tokens ?? nDecoded ?? null;
+}

--- a/src/services/transport/types/admission.ts
+++ b/src/services/transport/types/admission.ts
@@ -1,19 +1,14 @@
 /**
  * Admission-control transport types.
  *
- * Mirrors `gglib_core::domain::admission` (Rust,
- * `crates/gglib-core/src/domain/admission.rs`) bit-for-bit — field names and
- * casing match the wire format exactly.
+ * Aliases over the bindings generated from
+ * `crates/gglib-core/src/domain/admission.rs`. It was a hand-written mirror
+ * until the generator covered these types.
  *
- * Split out of `dashboard.ts` rather than sitting alongside the rest of the
- * snapshot: these describe the runtime's VRAM residency and request queue,
- * which is a different subject from llama.cpp's inference slots and prompt
- * cache, and keeping them apart stops either file growing past the point where
- * it can be read in one sitting.
- *
- * The same local-mirror caveat applies as in `dashboard.ts`: this is a real
- * HTTP client of the JSON contract, not a shared type, and it tolerates
- * additive server-side changes by ignoring unknown fields.
+ * Kept apart from `dashboard.ts` rather than folded into it: these describe
+ * the runtime's VRAM residency and request queue, which is a different
+ * subject from llama.cpp's inference slots and prompt cache, and the snapshot
+ * re-exports them so a component reading one need not know the difference.
  */
 
 /**

--- a/src/services/transport/types/admission.ts
+++ b/src/services/transport/types/admission.ts
@@ -26,59 +26,24 @@
  * footprint that could not be estimated, or a machine whose free VRAM gglib
  * cannot read (everything but NVIDIA and Apple Silicon).
  */
-export type SecondarySlotState =
-  | 'resident'
-  | 'available'
-  | 'too_large'
-  | 'no_headroom'
-  | 'unknown_footprint'
-  | 'unknown_budget';
+import type { SecondarySlotStatus } from '../../../types/generated/SecondarySlotStatus';
 
-/** Mirrors `gglib_core::domain::SecondarySlotStatus`. */
-export interface SecondarySlotStatus {
-  /** Machine-readable label, for styling. Branch on this, not on `detail`. */
-  state: SecondarySlotState;
-  /** Ready-to-render explanation. */
-  detail: string;
-}
+export type SecondarySlotState = SecondarySlotStatus['state'];
 
-/** Mirrors `gglib_core::domain::ResidentSlotSnapshot` — one model in VRAM. */
-export interface ResidentSlotSnapshot {
-  /** Slot index; `0` is the primary. */
-  slot: number;
-  model_name: string;
-  model_id: number;
-  port: number;
-  /**
-   * Requests currently holding a lease on this slot. A slot serving anything
-   * at all is never evicted — a swap must not preempt a live generation.
-   */
-  inflight: number;
-  /** Whether this is the slot chat traffic and the `/slots` poller follow. */
-  is_primary: boolean;
-  resident_for_secs: number;
-}
+export type { SecondarySlotStatus };
 
-/** Mirrors `gglib_core::domain::QueuedModelSnapshot` — requests waiting for one model. */
-export interface QueuedModelSnapshot {
-  model_name: string;
-  waiting: number;
-  /** Age of the oldest waiter, in milliseconds. */
-  oldest_wait_ms: number;
-}
+/** One model in VRAM. */
+export type { ResidentSlotSnapshot } from '../../../types/generated/ResidentSlotSnapshot';
+
+/** Requests waiting for one model. */
+export type { QueuedModelSnapshot } from '../../../types/generated/QueuedModelSnapshot';
 
 /**
- * Mirrors `gglib_core::domain::AdmissionSnapshot` — who holds VRAM, who is
- * queued behind them, and why the second slot is or is not in use.
+ * Who holds VRAM, who is queued behind them, and why the second slot is or is
+ * not in use.
  *
  * A non-empty `queued` means traffic is being batched behind a model swap,
  * which is the queue working rather than a fault. Comparing `total_queued`
  * against `total_swaps` shows how much that batching saved.
  */
-export interface AdmissionSnapshot {
-  slots: ResidentSlotSnapshot[];
-  queued: QueuedModelSnapshot[];
-  total_queued: number;
-  total_swaps: number;
-  secondary_slot: SecondarySlotStatus;
-}
+export type { AdmissionSnapshot } from '../../../types/generated/AdmissionSnapshot';

--- a/src/services/transport/types/dashboard.ts
+++ b/src/services/transport/types/dashboard.ts
@@ -58,6 +58,8 @@ export type { ContextSnapshot } from '../../../types/generated/ContextSnapshot';
 
 export type { CacheUsage } from '../../../types/generated/CacheUsage';
 
+import type { CacheStatus } from '../../../types/generated/CacheStatus';
+
 /**
  * KV cache health.
  *
@@ -66,8 +68,19 @@ export type { CacheUsage } from '../../../types/generated/CacheUsage';
  * dashboard's switch is written against those five values and would lose
  * exhaustiveness without it.
  */
-export type { CacheStatus } from '../../../types/generated/CacheStatus';
+export type { CacheStatus };
+
 export type { KvCacheType } from '../../../types/generated/KvCacheType';
+
+/**
+ * The five values `ram_state` can hold.
+ *
+ * Kept as a name because the generator inlines the union into the field and
+ * there is no binding to import — the same reason `SecondarySlotState` exists
+ * next door. A consumer writing a `Record` or a `switch` over these needs
+ * something to name.
+ */
+export type CacheRamState = CacheStatus['ram_state'];
 
 // ============================================================================
 // Launch

--- a/src/services/transport/types/dashboard.ts
+++ b/src/services/transport/types/dashboard.ts
@@ -5,15 +5,17 @@
  * `gglib_proxy::dashboard::DashboardSnapshot` (Rust, `crates/gglib-proxy/src/dashboard.rs`)
  * bit-for-bit — field names and casing match the wire format exactly.
  *
- * This is a **local mirror, not a shared type** (there is of course no shared
- * Rust/TS type system across the wasm boundary here): the frontend connects
- * directly to an already-running proxy's own HTTP port
+ * The frontend connects directly to an already-running proxy's own HTTP port
  * (`http://{host}:{port}/v1/proxy/status/stream`), the same way the CLI's
  * `gglib proxy dashboard` command does (see
  * `crates/gglib-cli/src/handlers/proxy_dashboard.rs`) — a real HTTP client of
- * the JSON contract, not a shared in-process type. Unknown/extra fields are
- * simply ignored by TypeScript's structural typing, so this mirror tolerates
- * additive server-side changes the same way the CLI's `serde(default)` does.
+ * the JSON contract. Unknown or extra fields are ignored by TypeScript's
+ * structural typing, so a reader tolerates additive server-side changes the
+ * same way the CLI's `serde(default)` does.
+ *
+ * `tokensInUse` used to live here. It is behaviour rather than a declaration
+ * and now sits in `../slotTokens`, so that replacing these mirrors with
+ * generated types does not have to step around live logic.
  */
 
 import type { AdmissionSnapshot } from './admission';
@@ -63,44 +65,6 @@ export interface SlotSnapshot {
   next_token?: NextTokenInfo | NextTokenInfo[] | null;
 }
 
-/**
- * Same additive logic as `SlotSnapshot::tokens_in_use()` (Rust) and
- * `proxy_dashboard.rs`'s local reimplementation (CLI) — kept in sync by hand,
- * since it's a tiny amount of logic mirrored across three consumers.
- *
- * Current-schema builds report prompt usage and generation progress as two
- * separate counters — `n_prompt_tokens(_processed)` and `next_token.n_decoded`
- * — which must be added together to get the true total (a 20k-token prompt
- * with 89 tokens generated so far is ~20k tokens in use, not 89).
- * `n_prompt_tokens_processed` is preferred over `n_prompt_tokens` when both
- * are present (it tracks real progress mid-prefill) and, when present, is
- * combined with `n_prompt_tokens_cache` (tokens reused from KV cache this
- * round, not re-processed) — otherwise a cache-hit follow-up prompt would
- * falsely collapse context usage down to just the tiny newly-processed
- * delta. The grand-total `n_prompt_tokens` fallback (used only when
- * `_processed` is absent) already includes any cached prefix, so cache is
- * NOT added on top of it. Only when neither prompt-side field is present
- * does this fall back to the legacy, non-additive chain: `n_past`, then
- * `cache_tokens`, then `n_decoded` alone.
- *
- * `next_token` may be a single object or an array (MTP builds); element 0 is
- * the accepted/main decode stream when it's an array.
- */
-export function tokensInUse(slot: SlotSnapshot): number | null {
-  const nextToken = Array.isArray(slot.next_token) ? slot.next_token[0] : slot.next_token;
-  const nDecoded = nextToken?.n_decoded ?? undefined;
-
-  const promptComponent =
-    slot.n_prompt_tokens_processed != null
-      ? slot.n_prompt_tokens_processed + (slot.n_prompt_tokens_cache ?? 0)
-      : slot.n_prompt_tokens;
-
-  if (promptComponent != null) {
-    return promptComponent + (nDecoded ?? 0);
-  }
-
-  return slot.n_past ?? slot.cache_tokens ?? nDecoded ?? null;
-}
 
 export type {
   AdmissionSnapshot,

--- a/src/services/transport/types/dashboard.ts
+++ b/src/services/transport/types/dashboard.ts
@@ -1,10 +1,6 @@
 /**
  * Proxy dashboard transport types.
  *
- * These types mirror the JSON contract produced by
- * `gglib_proxy::dashboard::DashboardSnapshot` (Rust, `crates/gglib-proxy/src/dashboard.rs`)
- * bit-for-bit — field names and casing match the wire format exactly.
- *
  * The frontend connects directly to an already-running proxy's own HTTP port
  * (`http://{host}:{port}/v1/proxy/status/stream`), the same way the CLI's
  * `gglib proxy dashboard` command does (see
@@ -13,58 +9,124 @@
  * structural typing, so a reader tolerates additive server-side changes the
  * same way the CLI's `serde(default)` does.
  *
+ * These were hand-written declarations and are now aliases over
+ * `src/types/generated/`. That tolerance is what let them drift: the mirror
+ * was thirty-two fields out of step on optionality alone, and a client that
+ * only ever reads the wire never notices being wrong about what is optional.
+ *
+ * The `Sampling*` names are the GUI's own. Rust calls several of these by
+ * short names that are unambiguous inside `audit_records.rs` and are not out
+ * here — `Divergence`, `BaselineReport`, `EffortRung` — so the aliases keep
+ * the longer spellings the components use.
+ *
  * `tokensInUse` used to live here. It is behaviour rather than a declaration
  * and now sits in `../slotTokens`, so that replacing these mirrors with
- * generated types does not have to step around live logic.
+ * generated types did not have to step around live logic.
  */
 
-import type { AdmissionSnapshot } from './admission';
+// ============================================================================
+// Connections and slots
+// ============================================================================
 
-/** Mirrors `gglib_proxy::connections::ConnectionPhase` (`#[serde(rename_all = "snake_case")]`). */
-export type ConnectionPhase = 'queued' | 'processing_prompt' | 'generating';
-
-/** Mirrors `gglib_proxy::connections::ActiveConnectionSnapshot`. */
-export interface ActiveConnectionSnapshot {
-  id: string;
-  model_name: string;
-  started_at_secs: number;
-  is_streaming: boolean;
-  num_ctx?: number | null;
-  phase: ConnectionPhase;
-  prompt_processed?: number | null;
-  prompt_total?: number | null;
-  prompt_cached?: number | null;
-  prompt_time_ms?: number | null;
-}
-
-/** Mirrors `gglib_proxy::slots::NextTokenInfo` (a private-but-serialized field). */
-export interface NextTokenInfo {
-  n_decoded?: number | null;
-}
+export type { ConnectionPhase } from '../../../types/generated/ConnectionPhase';
+export type { ActiveConnectionSnapshot } from '../../../types/generated/ActiveConnectionSnapshot';
+export type { NextTokenInfo } from '../../../types/generated/NextTokenInfo';
 
 /**
- * Mirrors `gglib_proxy::slots::SlotSnapshot`, including its private-but-serialized
- * legacy fields — serde ignores Rust visibility, so `n_past`/`cache_tokens`/
- * `n_prompt_tokens(_processed)`/`next_token` all appear on the wire despite
- * being private in Rust.
+ * One llama-server slot.
  *
- * `next_token` is a single object on regular llama-server builds, but an
- * array of objects on builds with Multi-Token Prediction ("draft-mtp")
- * enabled — mirrors `gglib_proxy::slots::NextTokenField`.
+ * Gained `params` — llama-server's own parsed `temperature`, `top_p`, `top_k`,
+ * `seed` and sampler chain, serialized on every slot and absent from the
+ * mirror for its whole life. It is the only place the dashboard can show what
+ * the *server* believes it was asked for, as against what gglib believes it
+ * sent.
  */
-export interface SlotSnapshot {
-  id: number;
-  id_task?: number | null;
-  n_ctx?: number | null;
-  is_processing: boolean;
-  n_past?: number | null;
-  cache_tokens?: number | null;
-  n_prompt_tokens?: number | null;
-  n_prompt_tokens_processed?: number | null;
-  n_prompt_tokens_cache?: number | null;
-  next_token?: NextTokenInfo | NextTokenInfo[] | null;
-}
+export type { SlotSnapshot } from '../../../types/generated/SlotSnapshot';
+export type { SlotParams } from '../../../types/generated/SlotParams';
 
+// ============================================================================
+// Context and cache
+// ============================================================================
+
+/**
+ * One model's context accounting.
+ *
+ * Gained `tool_repaired`: how many tool calls this model needed re-issued
+ * after failing schema validation. The proxy has always sent it.
+ */
+export type { ContextSnapshot } from '../../../types/generated/ContextSnapshot';
+
+export type { CacheUsage } from '../../../types/generated/CacheUsage';
+
+/**
+ * KV cache health.
+ *
+ * `ram_state` is a closed union rather than a bare `string` because the Rust
+ * field is a `&'static str` carrying a `#[ts(type = …)]` override. The
+ * dashboard's switch is written against those five values and would lose
+ * exhaustiveness without it.
+ */
+export type { CacheStatus } from '../../../types/generated/CacheStatus';
+export type { KvCacheType } from '../../../types/generated/KvCacheType';
+
+// ============================================================================
+// Launch
+// ============================================================================
+
+export type { LaunchDecision } from '../../../types/generated/LaunchDecision';
+export type { LaunchNarration } from '../../../types/generated/LaunchNarration';
+
+// ============================================================================
+// Sampling audit
+// ============================================================================
+//
+// ADR 0007's record of what the proxy actually sent, as against what the
+// resolution ladder decided it should.
+
+export type { Divergence as SamplingDivergence } from '../../../types/generated/Divergence';
+export type { BaselineVerdict as SamplingBaselineVerdict } from '../../../types/generated/BaselineVerdict';
+export type { BaselineField as SamplingBaselineField } from '../../../types/generated/BaselineField';
+export type { BaselineCoverage as SamplingBaselineCoverage } from '../../../types/generated/BaselineCoverage';
+export type { BaselineReport as SamplingBaselineReport } from '../../../types/generated/BaselineReport';
+export type { BaselineState as SamplingBaselineState } from '../../../types/generated/BaselineState';
+
+/**
+ * What one model's requests actually carried.
+ *
+ * Gained `effort_suppressed` — the record ADR 0007 says nothing else in the
+ * system can reconstruct, because a `reasoning_effort` dropped by the template
+ * gate leaves no other trace. The GUI had no way to render it.
+ */
+export type { SamplingAuditSnapshot } from '../../../types/generated/SamplingAuditSnapshot';
+export type { EffortSuppressions } from '../../../types/generated/EffortSuppressions';
+export type { SuppressedEffortRecord } from '../../../types/generated/SuppressedEffortRecord';
+
+// ============================================================================
+// Reasoning readback
+// ============================================================================
+
+export type { EffortSupportState as SamplingEffortSupport } from '../../../types/generated/EffortSupportState';
+export type { EffortRung as SamplingEffortRung } from '../../../types/generated/EffortRung';
+export type { BudgetRung as SamplingBudgetRung } from '../../../types/generated/BudgetRung';
+export type { ResolvedReasoning as SamplingResolvedReasoning } from '../../../types/generated/ResolvedReasoning';
+export type { ReasoningReadback as SamplingReasoningReadback } from '../../../types/generated/ReasoningReadback';
+export type { ClientFieldTally as SamplingClientFieldTally } from '../../../types/generated/ClientFieldTally';
+export type { ClientFieldNames as SamplingClientFieldNames } from '../../../types/generated/ClientFieldNames';
+
+// ============================================================================
+// Published overrides
+// ============================================================================
+
+export type { PublishedOverrides as SamplingPublishedOverrides } from '../../../types/generated/PublishedOverrides';
+export type { PublishedOverrideField as SamplingPublishedField } from '../../../types/generated/PublishedOverrideField';
+export type { PublishedOverrideState } from '../../../types/generated/PublishedOverrideState';
+
+// ============================================================================
+// Admission
+// ============================================================================
+//
+// Re-exported rather than imported from `./admission` by each consumer: the
+// snapshot embeds them, so a component reading one reaches for it here.
 
 export type {
   AdmissionSnapshot,
@@ -74,450 +136,15 @@ export type {
   SecondarySlotStatus,
 } from './admission';
 
-/** Mirrors `gglib_proxy::metrics::ContextSnapshot`. */
-export interface ContextSnapshot {
-  model_name: string;
-  payload_chars_before: number;
-  payload_chars_after: number;
-  messages_truncated: number;
-  was_clamped: boolean;
-  /** True when the pre-dispatch loop guard rejected this request with a 400. */
-  loop_guard_tripped: boolean;
-  /** True when the proxy originated a decode-time tool-call grammar. */
-  grammar_enforced: boolean;
-  /** True when dialect markup survived normalization into this request's client-visible output. */
-  dialect_residue: boolean;
-  recorded_at_secs: number;
-}
-
-/** Health of the resolved `--cache-ram` budget. Mirrors `CacheStatus.ram_state`. */
-export type CacheRamState =
-  | 'healthy'
-  | 'low'
-  | 'disabled_insufficient_ram'
-  | 'disabled_by_user'
-  | 'llama_default';
+// ============================================================================
+// The snapshot itself
+// ============================================================================
 
 /**
- * Mirrors `gglib_core::cache_metrics::CacheUsage` — measured prompt-cache
- * reuse since the proxy started.
+ * Everything the proxy reports in one frame.
  *
- * Raw counts only. Nothing here is derived or estimated: reuse is exact, but
- * what it saved depends on a prefill that never ran, so no "time saved" figure
- * exists to display.
+ * Gained four fields the proxy has been sending all along and the mirror never
+ * declared: `tool_repairs_attempted`, `tool_repairs_succeeded`,
+ * `upstream_health` and `per_model_defects`.
  */
-export interface CacheUsage {
-  /** Completed requests whose upstream reported a cached-token count. */
-  reporting_requests: number;
-  /**
-   * Completed requests whose upstream omitted the field, excluded from every
-   * other figure here. Lets a consumer tell "no reuse" from "no data".
-   */
-  unreported_requests: number;
-  /** Total prompt tokens across `reporting_requests`. */
-  prompt_tokens: number;
-  /** Total prompt tokens served from cache. Always `<= prompt_tokens`. */
-  cached_tokens: number;
-  /** Prompt tokens in the most recent reporting request. */
-  last_prompt_tokens?: number | null;
-  /** Tokens reused from cache in the most recent reporting request. */
-  last_cached_tokens?: number | null;
-}
-
-/**
- * Mirrors `gglib_proxy::dashboard::CacheStatus` — how prompt caching is
- * configured for the running model.
- *
- * The fields directly on this interface are configuration: resolved when a
- * model launches and changing only on a model swap. Per-request measurements
- * live under `usage`.
- */
-export interface CacheStatus {
-  /** Whether disk KV slot persistence is enabled on this proxy instance. */
-  disk_enabled: boolean;
-  /**
-   * Disk layer enabled proxy-wide but suppressed for this model, whose
-   * attention keeps only part of the token history. Always `false` when
-   * `disk_enabled` is `false`.
-   */
-  disk_suppressed_for_model: boolean;
-  /** Resolved `--cache-ram` budget in MiB; `null` when llama-server's own default applies. */
-  ram_budget_mb?: number | null;
-  /** Machine-readable budget health, for styling. */
-  ram_state: CacheRamState;
-  /** Whether anything here warrants surfacing to the user. */
-  needs_attention: boolean;
-  /** Ready-to-render warning lines; empty when nothing is wrong. */
-  warnings: string[];
-  /** Measured reuse since proxy start. Unlike the fields above, moves per request. */
-  usage: CacheUsage;
-}
-
-/**
- * Mirrors `gglib_core::domain::LaunchDecision` — one resolved launch decision
- * and the reason it was chosen.
- *
- * `source` is the point of the type: a value alone says what happened, never
- * why. `null` only for decisions whose value states its own origin.
- */
-export interface LaunchDecision {
-  /** Stable key: `ctx`, `backend`, `kv`, `cache`, `mtp`, `flags`, `dialect`. */
-  label: string;
-  /** Display-ready value. */
-  value: string;
-  /** Provenance, rendered in parentheses. */
-  source?: string | null;
-}
-
-/**
- * Mirrors `gglib_core::domain::LaunchNarration` — what the runtime decided
- * when it launched the running model, and why.
- *
- * The same record the CLI banner prints at startup. `decisions` arrives in
- * display order; consumers render it as given rather than re-sorting, so the
- * GUI and the banner cannot disagree about what a launch decided.
- */
-export interface LaunchNarration {
-  model_name: string;
-  /** Quantization label (`Q4_K_M`); `null` when the catalog recorded none. */
-  quantization?: string | null;
-  /** On-disk weight size in bytes; `0` when unknown. */
-  weights_bytes: number;
-  decisions: LaunchDecision[];
-}
-
-/**
- * Mirrors `gglib_proxy::sampling_audit::AuditState`
- * (`#[serde(tag = "state", rename_all = "snake_case")]`).
- *
- * A tagged union rather than a count, deliberately. `blind` and
- * `{comparing, divergences: 0}` both mean "no divergences reported" and mean
- * opposite things: one is an instrument that cannot see, the other is one that
- * sees and finds nothing wrong. Consumers must render them differently — see
- * the Rust module docs on ADR 0002 finding 2's inert-module trap.
- */
-export type SamplingAuditState =
-  | { state: 'not_yet_observed' }
-  | { state: 'blind'; reason: string }
-  | { state: 'comparing'; comparisons: number; divergences: number };
-
-/** Mirrors `gglib_proxy::sampling_audit::Divergence`. */
-export interface SamplingDivergence {
-  /** Wire name of the parameter. */
-  field: string;
-  /** What gglib resolved and wrote into the request body. */
-  sent: number;
-  /** What llama-server reported for the request in flight. */
-  observed: number;
-  /** Ladder rung the sent value came from, or `floor`/`unset`. */
-  provenance: string;
-}
-
-/**
- * Mirrors `gglib_proxy::props::BaselineVerdict`
- * (`#[serde(tag = "verdict", rename_all = "snake_case")]`).
- *
- * `indeterminate` means the field could not be attributed — `/props` does not
- * report it, or something is masking the build's own value. It must never
- * render as agreement: that would report a tautology rather than an
- * observation. Before ADR 0003 deleted the sampler launch flags it was the
- * normal case for every field, because a flag overwrites the `/props` field it
- * names and the check was reading gglib's own value back.
- */
-export type SamplingBaselineVerdict =
-  | { verdict: 'matches' }
-  | { verdict: 'differs'; expected: number; observed: number }
-  /**
-   * The effective default came from this model's own GGUF
-   * (`general.sampling.*`), not the build. Neither agreement nor drift: the
-   * model asked for it and llama.cpp applied it, which is gglib's deferral
-   * working — it just means the build's own value is unobservable for that
-   * field on this launch. Never render it as either of the other two.
-   */
-  | { verdict: 'model_supplied'; key: string; value: number }
-  | { verdict: 'indeterminate'; reason: string };
-
-/** Mirrors `gglib_proxy::props::BaselineField`. */
-export interface SamplingBaselineField {
-  field: string;
-  verdict: SamplingBaselineVerdict;
-}
-
-/**
- * Mirrors `gglib_proxy::props::BaselineCoverage`
- * (`#[serde(tag = "coverage", rename_all = "snake_case")]`).
- *
- * Replaces a `conclusive: boolean` that was computed as "any field reached a
- * verdict", so a report covering two of seven fields claimed to be conclusive
- * and rendered as an all-clear over all seven. Only `complete` may render one.
- *
- * Orthogonal to drift: `complete` says every field was compared, not that
- * every field agreed. Check the field verdicts first.
- */
-export type SamplingBaselineCoverage =
-  | { coverage: 'complete' }
-  | {
-      coverage: 'partial';
-      checked: number;
-      /** Fields the model's own GGUF supplied, so the build's value is hidden. */
-      model_supplied: number;
-      indeterminate: number;
-    }
-  | { coverage: 'blind'; model_supplied: number; indeterminate: number };
-
-/** Mirrors `gglib_proxy::props::BaselineReport`. */
-export interface SamplingBaselineReport {
-  fields: SamplingBaselineField[];
-  coverage: SamplingBaselineCoverage;
-}
-
-/**
- * Mirrors `gglib_proxy::props::BaselineState`
- * (`#[serde(tag = "state", rename_all = "snake_case")]`).
- *
- * Three states rather than a nullable report, for `SamplingAuditState`'s
- * reason. `not_yet_read` and `unreadable` both mean "no table to show" and mean
- * opposite things: one is a poller that has not got there yet, the other is a
- * read that happened and failed. Rendering the second as the first is the same
- * blind-as-health collapse the slot half carries `blind { reason }` to avoid.
- */
-export type SamplingBaselineState =
-  | { state: 'not_yet_read' }
-  | { state: 'unreadable'; reason: string }
-  | { state: 'read'; report: SamplingBaselineReport };
-
-/**
- * Mirrors `gglib_proxy::sampling_audit::SamplingAuditSnapshot` — whether the
- * sampling gglib resolved is the sampling llama-server applied.
- */
-export interface SamplingAuditSnapshot {
-  state: SamplingAuditState;
-  /**
-   * Polls that saw busy slots but could not attribute them to one intent,
-   * because the requests in flight had resolved differently and llama-server
-   * gives no way to join a slot to the request that filled it.
-   *
-   * Beside the state, not inside it: abstaining is something a *sighted* organ
-   * does, and a large count here alongside zero comparisons is a different
-   * problem from blindness.
-   */
-  skipped_ambiguous: number;
-  /** Client sampling fields that could not be read as sent. */
-  client_fields_rejected: number;
-  /**
-   * Client sampling fields dropped by the trust gate. Expected to be large by
-   * default — `trust_client_sampling` is off, so every client-supplied value
-   * is discarded by design.
-   */
-  client_fields_discarded: number;
-  /** Most recent field-level disagreements, oldest first. */
-  recent_divergences: SamplingDivergence[];
-  /**
-   * `/props` baseline reading for the running model.
-   *
-   * Optional only so this mirror still parses a payload from a proxy that
-   * predates the field; a current proxy always sends one of the three states.
-   */
-  baseline?: SamplingBaselineState | null;
-  /**
-   * What gglib's own requests do with the running model's published sampler
-   * defaults.
-   *
-   * Optional only so this mirror still parses a payload from a proxy that
-   * predates the field.
-   */
-  published?: SamplingPublishedOverrides | null;
-  /**
-   * The two reasoning controls: what the running template says about
-   * `reasoning_effort`, what the last request resolved, and why none of it is
-   * an observation.
-   *
-   * Optional only so this mirror still parses a payload from a proxy that
-   * predates the field.
-   */
-  reasoning?: SamplingReasoningReadback | null;
-  /**
-   * Which of the client's own sampling fields were dropped, by name.
-   *
-   * `client_fields_discarded` above is the total; this is what it was made of.
-   * Optional for a proxy that predates the field.
-   */
-  client_field_names?: SamplingClientFieldNames | null;
-}
-
-/**
- * Mirrors `gglib_proxy::audit_records::EffortSupportState`.
- *
- * The tri-state ADR 0007 decision 3 requires held all the way to the pixel:
- * `not_supported` is a positive observation that a resolved effort will be
- * suppressed, and `not_yet_observed` is nobody having managed to ask. A UI that
- * renders them the same way has re-introduced the collapse the type exists to
- * prevent — so neither may render as a green tick, and `not_yet_observed` may
- * never render as `not_supported`.
- *
- * These are the states *this build* knows; a newer proxy can send a fourth over
- * the HTTP contract above. So consumers must branch on `supported`
- * affirmatively and treat anything else as unknown — a catch-all arm here would
- * cost the narrowing that makes `reason` readable, so that floor lives in the
- * consumer's `default` branch (`ProxyReasoningRows.tsx`), as it does in the CLI
- * mirror's `#[serde(other)] Unrecognised`.
- */
-export type SamplingEffortSupport =
-  | { state: 'supported' }
-  | { state: 'not_supported' }
-  | { state: 'not_yet_observed'; reason: string };
-
-/** Mirrors `gglib_proxy::audit_records::EffortRung`. */
-export interface SamplingEffortRung {
-  /** The level the ladder resolved, e.g. `high`. */
-  level: string;
-  /** The rung that supplied it — `profile`, `model`, `global`, `cli`. */
-  source: string;
-  /**
-   * Whether the effort gate deleted it before sending. Rendering the level
-   * without this marker reports a control that went nowhere as though it had
-   * worked, and no readback exists that could contradict the claim.
-   */
-  suppressed: boolean;
-}
-
-/** Mirrors `gglib_proxy::audit_records::BudgetRung`. */
-export interface SamplingBudgetRung {
-  /** The cap, in tokens. `0` is the documented "stop thinking". */
-  tokens: number;
-  /** The rung that supplied it. */
-  source: string;
-}
-
-/**
- * Mirrors `gglib_proxy::audit_records::ResolvedReasoning`.
- *
- * A record with both halves null is **not** the same as no record: it says a
- * request was resolved and named neither control, where an absent record says
- * no request has been resolved at all.
- */
-export interface SamplingResolvedReasoning {
-  effort?: SamplingEffortRung | null;
-  budget?: SamplingBudgetRung | null;
-}
-
-/**
- * Mirrors `gglib_proxy::audit_records::ReasoningReadback`.
- *
- * Structurally unlike every other field on the audit snapshot: those report a
- * comparison between what gglib sent and what llama-server echoed, and there is
- * no echo for these two. `reasoning_effort` becomes a chat-template kwarg
- * consumed at render time, and `task_params::to_json` serialises no
- * `reasoning_budget_*` field (ADR 0007 finding 7a). So this is gglib's own
- * record, and `wire_blind_reason` is the server-supplied sentence that says so.
- */
-export interface SamplingReasoningReadback {
-  effort_support: SamplingEffortSupport;
-  /** What the most recent resolved request named. `null` until one has been. */
-  latest?: SamplingResolvedReasoning | null;
-  /** Why nothing above is corroborated. Sent by the server, never paraphrased. */
-  wire_blind_reason: string;
-}
-
-/** Mirrors `gglib_proxy::audit_records::ClientFieldTally`. */
-export interface SamplingClientFieldTally {
-  /** The wire key, as gglib names it — never a client-supplied string. */
-  field: string;
-  /** Times the trust gate binned it. Large by default and not a fault. */
-  discarded: number;
-  /** Times it could not be read as sent. */
-  rejected: number;
-}
-
-/** Mirrors `gglib_proxy::audit_records::ClientFieldNames`. */
-export interface SamplingClientFieldNames {
-  /** Tracked names, most-dropped first. */
-  fields: SamplingClientFieldTally[];
-  /**
-   * Drops whose name was not tracked because the bounded table was full. Zero
-   * on every configuration gglib can currently produce, and reported anyway: a
-   * silent bound and a bound nobody hit look identical.
-   */
-  untracked: number;
-}
-
-/**
- * Published-vs-sent for the running model.
- *
- * Mirrors `gglib_proxy::sampling_audit::PublishedOverrides`. A *different*
- * question from the baseline check above, and the two report the same field
- * differently without either being wrong: `/props` says `model_supplied`
- * because the *build's* value is unobservable there, while this says
- * `overridden` because gglib's request body wins over the table `/props`
- * renders. A reader seeing only the first would reasonably conclude the model's
- * value is what the sampler uses.
- */
-export interface SamplingPublishedOverrides {
-  /**
-   * Resolved intents folded in since this model launched.
-   *
-   * **Zero means nothing has been compared, never "nothing is overridden".**
-   * `fields` is empty both when a model publishes nothing and when no request
-   * has been resolved yet, and those license opposite conclusions.
-   */
-  intents: number;
-  /** One entry per field this model publishes. Empty on almost every model. */
-  fields: SamplingPublishedField[];
-}
-
-/** One published field and what gglib's most recent intent did with it. */
-export type SamplingPublishedField = {
-  /** gglib's wire name for the parameter. */
-  field: string;
-  /** The GGUF key carrying it, e.g. `general.sampling.penalty_repeat`. */
-  key: string;
-} & (
-  | { state: 'deferred'; published: number }
-  | { state: 'restated'; published: number }
-  | { state: 'overridden'; published: number; sending: number }
-  | { state: 'unreadable' }
-);
-
-/** Mirrors `gglib_proxy::dashboard::DashboardSnapshot` — the full hydration/tick payload. */
-export interface DashboardSnapshot {
-  active_connections: ActiveConnectionSnapshot[];
-  slots_available: boolean;
-  slots: SlotSnapshot[];
-  slots_status?: string | null;
-  recent_requests: ContextSnapshot[];
-  total_requests: number;
-  /** Requests whose client-visible output carried dialect residue (drift alarm), eviction-safe. */
-  dialect_residue_total: number;
-  /**
-   * Prompt-cache configuration for the running model. `null` until the first
-   * request resolves one, since the RAM budget isn't known until launch.
-   *
-   * Replaces the former `cache_enabled` boolean, which was declared here but
-   * never read; `cache.disk_enabled` carries the same information.
-   */
-  cache?: CacheStatus | null;
-  /**
-   * Prompt-cache reuse for the in-process agent path (GUI chat),
-   * reported alongside `cache.usage` and never merged into it. Top-level and
-   * always present, since it does not depend on a resolved model; may be absent
-   * on a proxy older than this field.
-   */
-  agent_usage?: CacheUsage | null;
-  /**
-   * What the running model's launch decided, and why. `null` until a request
-   * resolves a model, and absent on a proxy older than this field.
-   */
-  launch?: LaunchNarration | null;
-  /**
-   * VRAM residency and the admission queue. Always present on a proxy that has
-   * it; optional here so this mirror still parses a payload from one that
-   * predates M9.
-   */
-  admission?: AdmissionSnapshot | null;
-  /**
-   * Whether the sampling gglib resolved reached llama-server intact, and
-   * whether anyone is in a position to know. Optional here so this mirror
-   * still parses a payload from a proxy that predates it.
-   */
-  sampling_audit?: SamplingAuditSnapshot | null;
-}
+export type { DashboardSnapshot } from '../../../types/generated/DashboardSnapshot';

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -4,7 +4,6 @@
  */
 
 import type { Unsubscribe, EventHandler } from './common';
-import type { DownloadId } from './ids';
 
 // ============================================================================
 // Server Events
@@ -105,9 +104,6 @@ export type { CompletionKind } from '../../../types/generated/CompletionKind';
 
 /**
  * Details for a single completed artifact in a queue run.
- */
-/**
- * Details for a single completed artifact in a queue run.
  *
  * `download_ids` carries the structured wire id — `{ model_id, quantization }`
  * — not the `"model_id:quantization"` string that `./ids` calls a
@@ -136,23 +132,7 @@ export interface QueueRunSummary {
   items: CompletionDetail[];
 }
 
-export type DownloadEvent =
-  | { type: 'queue_snapshot'; items: DownloadSummary[]; max_size: number }
-  | { type: 'download_started'; id: DownloadId; shard_index?: number; total_shards?: number }
-  // speed_bps / eta_seconds are omitted while the manager's rate estimator is
-  // still warming up. Absent means unknown, never zero — render a placeholder.
-  | { type: 'download_progress'; id: DownloadId; downloaded: number; total: number; speed_bps?: number; eta_seconds?: number; percentage: number }
-  | { type: 'shard_progress'; id: DownloadId; shard_index: number; total_shards: number; shard_filename: string; shard_downloaded: number; shard_total: number; aggregate_downloaded: number; aggregate_total: number; speed_bps?: number; eta_seconds?: number; percentage: number }
-  | { type: 'download_completed'; id: DownloadId; message?: string | null }
-  | { type: 'download_failed'; id: DownloadId; error: string }
-  | { type: 'download_cancelled'; id: DownloadId }
-  | { type: 'download_status_changed'; id: DownloadId; status: import('./downloads').DownloadStatus }
-  // Transient, non-persisted note about work happening for this download
-  // that produces no byte progress (e.g. first-run Python env setup for the
-  // fast downloader). Unlike download_status_changed, message is free-form
-  // text rather than a fixed status.
-  | { type: 'download_notice'; id: DownloadId; message: string }
-  | { type: 'queue_run_complete'; summary: QueueRunSummary };
+export type { DownloadEvent } from '../../../types/generated/DownloadEvent';
 
 // ============================================================================
 // Model Events
@@ -214,11 +194,7 @@ export type ProxyEvent = Extract<AppEvent, { type: `proxy_${string}` }>;
  */
 export interface AppEventMap {
   'server': ServerWireEvent;
-  // Still the hand-written wrapper. Adopting the generated arm pulls in the
-  // generated `DownloadEvent`, whose `DownloadSummary.status` carries all
-  // seven statuses the queue actually reports — the mirror knows five — and
-  // that is a behaviour change with its own commit.
-  'download': { type: 'download'; event: DownloadEvent };
+  'download': Extract<AppEvent, { type: 'download' }>;
   'model': ModelEvent;
   'verification': VerificationEvent;
   'proxy': ProxyEvent;

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -5,7 +5,6 @@
 
 import type { Unsubscribe, EventHandler } from './common';
 import type { DownloadId } from './ids';
-import type { RuntimeErrorInfo, ServerHealthStatus } from '../../../types';
 
 // ============================================================================
 // Server Events
@@ -35,25 +34,19 @@ export interface ServerSnapshotEntry {
  * registry's `ServerEvent`, which is keyed by string and speaks in
  * running/stopping/stopped/crashed. Two shapes, because there really are two.
  */
-export type ServerWireEvent =
-  | { type: 'server_started'; modelId: number; modelName: string; port: number }
-  | { type: 'server_stopped'; modelId: number; modelName: string }
-  // `modelId` is null when the runtime could not attribute the failure, and is
-  // always present — the Rust field carries no `skip_serializing_if`.
-  | { type: 'server_error'; modelId: number | null; modelName: string; error: RuntimeErrorInfo }
-  | { type: 'server_snapshot'; servers: ServerSnapshotEntry[] }
-  | {
-      type: 'server_health_changed';
-      serverId: number;
-      modelId: number;
-      // Nested, not flat: `ServerHealthStatus` is internally tagged on `status`
-      // and the field is also named `status`, so the wire reads
-      // `"status": { "status": "healthy" }`.
-      status: ServerHealthStatus;
-      detail?: string;
-      /** Unix milliseconds. */
-      timestamp: number;
-    };
+import type { AppEvent } from '../../../types/generated/AppEvent';
+
+/**
+ * The `server_*` slice of `AppEvent`.
+ *
+ * An `Extract` rather than a re-declaration, so the arms cannot drift. Note
+ * what that buys and what it does not: a new `server_*` arm added in Rust
+ * joins this type with no TypeScript error anywhere, and
+ * `normalizeServerEventFromAppEvent` will drop it in its `default:`. The
+ * compiler cannot flag that, because widening a union it consumes is not a
+ * type error. A new arm needs a normalizer case written by hand.
+ */
+export type ServerWireEvent = Extract<AppEvent, { type: `server_${string}` }>;
 
 // ============================================================================
 // Download Events
@@ -169,13 +162,7 @@ export type DownloadEvent =
  *
  * Mirrors `gglib_core::events::ModelSummary` (camelCase).
  */
-export interface ModelEventSummary {
-  id: number;
-  name: string;
-  filePath: string;
-  architecture?: string;
-  quantization?: string;
-}
+export type { ModelSummary as ModelEventSummary } from '../../../types/generated/ModelSummary';
 
 /**
  * Library changes, broadcast to every client attached to the daemon.
@@ -184,57 +171,50 @@ export interface ModelEventSummary {
  * refresh only when its own tab made the edit. A `gglib model add` in a
  * terminal is a separate process and does not reach here.
  */
-export type ModelEvent =
-  | { type: 'model_added'; model: ModelEventSummary }
-  | { type: 'model_updated'; model: ModelEventSummary }
-  | { type: 'model_removed'; modelId: number };
+export type ModelEvent = Extract<AppEvent, { type: `model_${string}` }>;
 
 // ============================================================================
 // Verification Events
 // ============================================================================
 
-export type OverallHealth = 'healthy' | 'unhealthy' | 'unverifiable';
+export type { OverallHealth } from '../../../types/generated/OverallHealth';
 
-export interface VerificationProgressEvent {
-  type: 'verification_progress';
-  modelId: number;
-  modelName: string;
-  shardName: string;
-  bytesProcessed: number;
-  totalBytes: number;
-}
-
-export interface VerificationCompleteEvent {
-  type: 'verification_complete';
-  modelId: number;
-  modelName: string;
-  overallHealth: OverallHealth;
-}
-
-export type VerificationEvent = VerificationProgressEvent | VerificationCompleteEvent;
+export type VerificationEvent = Extract<AppEvent, { type: `verification_${string}` }>;
 
 // ============================================================================
 // Proxy Events
 // ============================================================================
 
-export type ProxyEvent =
-  | { type: 'proxy_started'; port: number }
-  | { type: 'proxy_stopped' }
-  | { type: 'proxy_crashed' };
+export type ProxyEvent = Extract<AppEvent, { type: `proxy_${string}` }>;
 
 // ============================================================================
 // App Event Map
 // ============================================================================
 
 /**
- * Map of all event types to their payload types.
- * Used for type-safe event subscriptions.
+ * Each subscribable category, and the slice of `AppEvent` it delivers.
  *
- * Note: Download events arrive wrapped as { type: "download", event: DownloadEvent }
- * to preserve all details including shard progress.
+ * Every value is a named slice and never a bare `AppEvent`. That is the point
+ * of the map: a handler registered for `'proxy'` should not have to narrow
+ * against `server_started`, and typing any entry as the whole union would let
+ * a `server` handler compile while reading a `download` payload.
+ *
+ * `getEventCategory` is what actually routes a message here, and it is
+ * ordinary runtime code — so these five slices are a claim about the router,
+ * not a guarantee from it. The five together are exhaustive over `AppEvent`'s
+ * fourteen arms today, which `tests/ts/services/eventCategory.test.ts` is the
+ * place to keep true.
+ *
+ * Download events arrive wrapped as `{ type: "download", event: DownloadEvent }`
+ * to preserve shard-level detail, which is why that entry is the whole arm
+ * rather than the inner event.
  */
 export interface AppEventMap {
   'server': ServerWireEvent;
+  // Still the hand-written wrapper. Adopting the generated arm pulls in the
+  // generated `DownloadEvent`, whose `DownloadSummary.status` carries all
+  // seven statuses the queue actually reports — the mirror knows five — and
+  // that is a behaviour change with its own commit.
   'download': { type: 'download'; event: DownloadEvent };
   'model': ModelEvent;
   'verification': VerificationEvent;

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -52,20 +52,20 @@ export type ServerWireEvent = Extract<AppEvent, { type: `server_${string}` }>;
 // Download Events
 // ============================================================================
 
-export interface DownloadSummary {
-  id: DownloadId;
-  display_name: string;
-  status: 'queued' | 'downloading' | 'completed' | 'failed' | 'cancelled';
-  position: number;
-  error?: string | null;
-  group_id?: string | null;
-  shard_info?: {
-    shard_index: number;
-    total_shards: number;
-    filename: string;
-    file_size?: number | null;
-  } | null;
-}
+/**
+ * One row of the download queue.
+ *
+ * `status` carries all seven states the queue reports. The mirror knew five,
+ * so `finalizing` and `registering` fell through `normalizeQueueItem`'s
+ * `?? 'failed'` and rendered as failures.
+ *
+ * `error`, `group_id` and `shard_info` are optional and *not* nullable: each
+ * carries `skip_serializing_if`, so the key is absent rather than `null`. The
+ * mirror admitted both, which is why the normalizer reached for them through
+ * `as any` casts.
+ */
+import type { DownloadSummary } from '../../../types/generated/DownloadSummary';
+export type { DownloadSummary };
 
 /**
  * Stable artifact identity for completion tracking.
@@ -101,19 +101,22 @@ export interface AttemptCounts {
 /**
  * Result kind for a completion attempt.
  */
-export type CompletionKind = 'downloaded' | 'failed' | 'cancelled' | 'already_present';
+export type { CompletionKind } from '../../../types/generated/CompletionKind';
 
 /**
  * Details for a single completed artifact in a queue run.
  */
-export interface CompletionDetail {
-  key: CompletionKey;
-  display_name: string;
-  last_result: CompletionKind;
-  last_completed_at_ms: number;
-  download_ids: DownloadId[];
-  attempt_counts: AttemptCounts;
-}
+/**
+ * Details for a single completed artifact in a queue run.
+ *
+ * `download_ids` carries the structured wire id — `{ model_id, quantization }`
+ * — not the `"model_id:quantization"` string that `./ids` calls a
+ * `DownloadId`. Two different things share that name, so the generated one is
+ * imported under its own alias rather than shadowing the string form, which
+ * the rest of the transport still uses.
+ */
+import type { CompletionDetail } from '../../../types/generated/CompletionDetail';
+export type { CompletionDetail };
 
 /**
  * Summary of an entire queue run from start to drain.

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -118,20 +118,16 @@ export type { CompletionDetail };
 /**
  * Summary of an entire queue run from start to drain.
  * Emitted when the queue transitions from busy → idle.
+ *
+ * The last hand-written type in this file, and the only drift class it could
+ * still hide was field *addition*: `useDownloadManager` assigns the generated
+ * `DownloadEvent.summary` into state typed by this, so a removal or a type
+ * change already failed to compile, while a new Rust field simply stayed
+ * unreadable. Nothing gated it either — `check_ts_bindings.sh` and
+ * `make bindings-check` only ever look at Rust and `src/types/generated`.
  */
-export interface QueueRunSummary {
-  run_id: string;
-  started_at_ms: number;
-  completed_at_ms: number;
-  total_attempts_downloaded: number;
-  total_attempts_failed: number;
-  total_attempts_cancelled: number;
-  unique_models_downloaded: number;
-  unique_models_failed: number;
-  unique_models_cancelled: number;
-  truncated: boolean;
-  items: CompletionDetail[];
-}
+import type { QueueRunSummary } from '../../../types/generated/QueueRunSummary';
+export type { QueueRunSummary };
 
 export type { DownloadEvent } from '../../../types/generated/DownloadEvent';
 

--- a/src/services/transport/types/events.ts
+++ b/src/services/transport/types/events.ts
@@ -54,9 +54,10 @@ export type ServerWireEvent = Extract<AppEvent, { type: `server_${string}` }>;
 /**
  * One row of the download queue.
  *
- * `status` carries all seven states the queue reports. The mirror knew five,
- * so `finalizing` and `registering` fell through `normalizeQueueItem`'s
- * `?? 'failed'` and rendered as failures.
+ * `status` is the full seven-member `DownloadStatus`, where the mirror named
+ * five. A snapshot row only ever carries `downloading` or `queued` —
+ * `gglib-download` hard-codes both — so the two the mirror omitted never
+ * arrived, and nothing was misrendered. The type is simply the type.
  *
  * `error`, `group_id` and `shard_info` are optional and *not* nullable: each
  * carries `skip_serializing_if`, so the key is absent rather than `null`. The

--- a/src/services/transport/types/proxy.ts
+++ b/src/services/transport/types/proxy.ts
@@ -3,76 +3,53 @@
  * Handles multi-model proxy server management.
  */
 
-import type { InferenceConfig } from '../../../types';
 import type { StartServerRequest } from '../mappers';
 
 /**
- * Proxy server configuration — the full `StartProxyConfig` wire surface
- * (snake_case keys, matching the Rust serde form).
+ * Proxy server configuration — the body of `POST /api/proxy/start`.
+ *
+ * `Partial` over the generated shape, and the wrapper is the accurate part.
+ * ts-rs renders every field as required: an `Option<T>` becomes `T | null`,
+ * and `allowed_hosts: Vec<String>` becomes a plain `Array<string>`. The
+ * handler accepts all of them omitted — the struct derives `Default`, every
+ * non-`Option` field carries `#[serde(default)]`, and serde fills a missing
+ * `Option` with `None` on its own — so a caller sending `{}` is starting the
+ * proxy on saved settings, which is the ordinary case.
+ *
+ * One field is worth knowing before sending it: `llama_base_port` is read
+ * only by `POST /api/proxy/start-pinned`, which routes it through the launch
+ * cascade. `POST /api/proxy/start` deserializes it and never looks at it, so
+ * sending it there is accepted and silently ignored.
+ *
+ * `pinned.launch_overrides` is now the real `ServerConfigOptions` rather than
+ * the `Record<string, unknown>` this file left open pending the generator.
  */
-export interface ProxyConfig {
-  /** Omitted resolves to `127.0.0.1`. */
-  host?: string;
-  /** Omitted falls through to the saved `proxy_port`, then the built-in default. */
-  port?: number;
-  /**
-   * First port of the range spawned llama.cpp servers are allocated from.
-   *
-   * Read only by `POST /api/proxy/start-pinned`, which routes it through the
-   * launch cascade. `POST /api/proxy/start` deserializes it and then never
-   * looks at it — `to_runtime_config` does not carry it — so sending it there
-   * is accepted and silently ignored.
-   */
-  llama_base_port?: number;
-  /** Omitted resolves through the saved default context size. */
-  default_context?: number;
-  /** Master switch for disk KV-slot persistence. */
-  cache?: boolean;
-  /** Slot directory; omitted = default when cache is on. */
-  slot_dir?: string;
-  /** Byte budget (GiB) for the on-disk slot eviction sweep. */
-  cache_disk_gb?: number;
-  /** Proxy-wide sampling override (camelCase inner keys — `InferenceConfig`
-      serializes camelCase on both sides, so this passes through unmapped). */
-  inference_override?: InferenceConfig;
-  /** Require this bearer key on the OpenAI surface. */
-  api_key?: string;
-  /** Extra Host-header allowlist entries beyond loopback. */
-  allowed_hosts?: string[];
-  /**
-   * Pin this run to a single model, refusing every request for another —
-   * `gglib serve`'s guarantee, offered on the ordinary start route.
-   *
-   * The GUI reaches pinned mode through `POST /api/proxy/start-pinned`
-   * instead, which resolves the launch cascade server-side; this is the
-   * lower-level form that path delegates to.
-   */
-  pinned?: {
-    /** The name clients must address the model by. Matched exactly. */
-    name: string;
-    /**
-     * Standing launch options, already cascade-resolved by the caller.
-     *
-     * Mirrors Rust `ServerConfigOptions`, which has no TypeScript
-     * counterpart — it is a large type no frontend surface builds by hand,
-     * and PR 4's generated bindings will supply the real one. Left open
-     * rather than half-mirrored: a partial copy is the drift this file exists
-     * to stop.
-     */
-    launch_overrides?: Record<string, unknown>;
-  };
-}
+import type { StartProxyConfig } from '../../../types/generated/StartProxyConfig';
+export type ProxyConfig = Partial<StartProxyConfig>;
+
+export type { PinnedSpec } from '../../../types/generated/PinnedSpec';
+export type { ServerConfigOptions } from '../../../types/generated/ServerConfigOptions';
 
 /**
  * Request body for `POST /api/proxy/start-pinned` — the GUI counterpart of
  * `gglib serve`. The daemon runs the launch cascade server-side.
+ *
+ * `model_id` is the only required key. `options` and `proxy` both carry
+ * `#[serde(default)]`, which ts-rs does not render as optional — so the
+ * generated body demands two objects the handler is happy to construct
+ * itself, and the GUI's own pinned-start call omits `proxy` entirely.
+ *
+ * `options` keeps the local `StartServerRequest` rather than the generated
+ * one for the same reason: its fields are `Option` with defaults, and the
+ * mapper builds a sparse object.
  */
-export interface StartPinnedRequest {
-  model_id: number;
-  /** Per-model launch overrides, same camelCase shape as `/api/servers/start`. */
-  options?: StartServerRequest;
-  proxy?: Partial<ProxyConfig>;
-}
+import type { StartPinnedBody } from '../../../types/generated/StartPinnedBody';
+export type StartPinnedRequest = Pick<StartPinnedBody, 'model_id'> &
+  Partial<{
+    /** Per-model launch overrides, same camelCase shape as `/api/servers/start`. */
+    options: StartServerRequest;
+    proxy: ProxyConfig;
+  }>;
 
 /**
  * Proxy server status.

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -101,12 +101,12 @@ What is still written by hand falls into three groups, and each is deliberate:
 |------|----------|-----|
 | View-models | `ServerViewModel`, the chat types | No Rust counterpart. Assembled in the GUI from several responses. |
 | Request bodies needing sparseness | `SparseInferenceConfig`, `ServeConfig` | A form clears a control with `delete`, which does not compile against the required key ts-rs renders for an `Option<T>`. This is a client need and not a wire one: inside `InferenceConfig` an absent key and a `null` are the same value to serde, so neither spelling reaches the backend differently. Contrast `UpdateSettingsRequest`, whose fields carry `double_option` and whose generated form is therefore already optional — it needs no wrapper, only the two-field narrowing recorded below. |
-| Narrowings over a generated shape | `ParamProvenance.param`, `McpServer.server_type`, `SecondarySlotState` | Rust types the field as `String` or `&'static str`. The union is the more accurate claim, so it is intersected back on — `X & { field: Union }`, never `Omit<X, 'field'> & …`, which reduces a union of arms to the keys they share and so flattens it. (`Omit` is safe over a plain object type, which is why the row below uses it.) Each is a Rust-side `#[ts(type = …)]` away from being generated too. |
+| Narrowings over a generated shape | `ParamProvenance.param`, `McpServer.server_type` | Rust types the field as `String`. The union is the more accurate claim, so it is intersected back on — `X & { field: Union }`, never `Omit<X, 'field'> & …`, which reduces a union of arms to the keys they share and so flattens it. (`Omit` is safe over a plain object type, which is why the row below uses it.) Each is a Rust-side `#[ts(type = …)]` away from being generated too — the route `SecondarySlotStatus.state` and `CacheStatus.ram_state` already took. |
 | | `UpdateSettingsRequest` | A different narrowing: two fields typed `InferenceConfig`/`InferenceProfile[]` on the generated body take their sparse form instead, because a settings save carries the parameters the form touched rather than a complete config. The other 21 fields are the generated ones untouched. |
 
 Anything else hand-written under `types/` mirroring a wire shape is drift, not
-design. The events, SSE and proxy-dashboard surfaces are the remaining ones and
-have not been migrated yet.
+design. The REST surface, the SSE event bus, the download queue and the proxy
+dashboard have all been migrated; what is left is the list above.
 
 The `services/transport/` layer handles JSON serialization between these.
 

--- a/src/types/generated/DownloadEvent.ts
+++ b/src/types/generated/DownloadEvent.ts
@@ -26,8 +26,8 @@ import type { QueueRunSummary } from "./QueueRunSummary";
  * download that has just started has no meaningful rate yet. Renderers must
  * show a placeholder for the absent case rather than substituting `0`, and
  * must never compute a rate of their own from successive `downloaded` values;
- * the manager's `RateEstimator` is the only source. The mirrored TypeScript
- * declaration lives in `src/services/transport/types/events.ts`.
+ * the manager's `RateEstimator` is the only source. TypeScript reads this
+ * type through its generated binding; there is no mirror to keep in step.
  */
 export type DownloadEvent = { "type": "queue_snapshot", 
 /**

--- a/src/types/generated/SecondarySlotStatus.ts
+++ b/src/types/generated/SecondarySlotStatus.ts
@@ -12,9 +12,13 @@ export type SecondarySlotStatus = {
  * A `&'static str`, which ts-rs would render as a bare `string` — losing
  * the exhaustiveness the GUI's icon table and tone function are written
  * against. The override restates the closed set above, the same way
- * `gglib_proxy::dashboard::CacheSnapshot::ram_state` does; it is produced
- * by one exhaustive `match`, so a new arm there is the one other place
- * that must touch this line.
+ * `gglib_proxy::dashboard::CacheSnapshot::ram_state` does.
+ *
+ * Three places set it, and all three must stay inside that set:
+ * [`Self::default`] and [`Self::resident`] each write one literal, and
+ * [`Self::from_decision`] takes `SecondarySlotDecision::label` for every
+ * refusal. `label` also answers `"grant"`, which never reaches here —
+ * `from_decision` maps a grant to `"available"` before consulting it.
  */
 state: "resident" | "available" | "too_large" | "no_headroom" | "unknown_footprint" | "unknown_budget", 
 /**

--- a/src/types/generated/SecondarySlotStatus.ts
+++ b/src/types/generated/SecondarySlotStatus.ts
@@ -12,7 +12,7 @@ export type SecondarySlotStatus = {
  * A `&'static str`, which ts-rs would render as a bare `string` — losing
  * the exhaustiveness the GUI's icon table and tone function are written
  * against. The override restates the closed set above, the same way
- * `gglib_proxy::dashboard::CacheSnapshot::ram_state` does.
+ * `gglib_proxy::dashboard::CacheStatus::ram_state` does.
  *
  * Three places set it, and all three must stay inside that set:
  * [`Self::default`] and [`Self::resident`] each write one literal, and

--- a/src/types/generated/SecondarySlotStatus.ts
+++ b/src/types/generated/SecondarySlotStatus.ts
@@ -8,8 +8,15 @@ export type SecondarySlotStatus = {
  * Stable machine-readable label, for styling. One of `resident`,
  * `available`, `too_large`, `no_headroom`, `unknown_footprint`,
  * `unknown_budget`.
+ *
+ * A `&'static str`, which ts-rs would render as a bare `string` — losing
+ * the exhaustiveness the GUI's icon table and tone function are written
+ * against. The override restates the closed set above, the same way
+ * `gglib_proxy::dashboard::CacheSnapshot::ram_state` does; it is produced
+ * by one exhaustive `match`, so a new arm there is the one other place
+ * that must touch this line.
  */
-state: string, 
+state: "resident" | "available" | "too_large" | "no_headroom" | "unknown_footprint" | "unknown_budget", 
 /**
  * Ready-to-render explanation. Phrased for display rather than parsing —
  * consumers branch on [`Self::state`].

--- a/tests/ts/components/ProxyReasoningRows.test.tsx
+++ b/tests/ts/components/ProxyReasoningRows.test.tsx
@@ -8,21 +8,11 @@ import type {
   SamplingEffortSupport,
   SamplingReasoningReadback,
 } from '../../../src/services/transport/types/dashboard';
+import { reasoningReadback } from '../fixtures/dashboard';
 
-const BLIND =
-  'llama-server echoes neither reasoning control: reasoning_effort is a chat-template kwarg ' +
-  'consumed at render time, and task_params::to_json serialises no reasoning_budget_* field.';
-
-function reasoning(
+const reasoning = (
   overrides: Partial<SamplingReasoningReadback> = {},
-): SamplingReasoningReadback {
-  return {
-    effort_support: { state: 'not_yet_observed', reason: 'no /props read has completed yet.' },
-    latest: null,
-    wire_blind_reason: BLIND,
-    ...overrides,
-  };
-}
+): SamplingReasoningReadback => reasoningReadback(overrides);
 
 describe('ProxyReasoningRows', () => {
   // The collapse ADR 0007 decision 3 forbids, at the last layer that can make
@@ -32,7 +22,12 @@ describe('ProxyReasoningRows', () => {
     render(<ProxyReasoningRows reasoning={reasoning()} />);
 
     expect(screen.getByText(/support for reasoning_effort is unknown/i)).toBeInTheDocument();
-    expect(screen.getByText(/no \/props read has completed yet/)).toBeInTheDocument();
+    // The reason string the proxy actually sends — `EffortSupportState::of`
+    // in `audit_records.rs`. The old assertion matched a shortened version
+    // that came from the fixture rather than from the wire.
+    expect(
+      screen.getByText(/no \/props read has completed for the running model yet/),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/never reads reasoning_effort/i)).not.toBeInTheDocument();
   });
 

--- a/tests/ts/components/ProxySamplingPanel.test.tsx
+++ b/tests/ts/components/ProxySamplingPanel.test.tsx
@@ -3,18 +3,10 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ProxySamplingPanel, { formatValue } from '../../../src/components/ProxySamplingPanel';
 import type { SamplingAuditSnapshot } from '../../../src/services/transport/types/dashboard';
+import { samplingAudit } from '../fixtures/dashboard';
 
-function audit(overrides: Partial<SamplingAuditSnapshot> = {}): SamplingAuditSnapshot {
-  return {
-    state: { state: 'not_yet_observed' },
-    skipped_ambiguous: 0,
-    client_fields_rejected: 0,
-    client_fields_discarded: 0,
-    recent_divergences: [],
-    baseline: { state: 'not_yet_read' },
-    ...overrides,
-  };
-}
+const audit = (overrides: Partial<SamplingAuditSnapshot> = {}): SamplingAuditSnapshot =>
+  samplingAudit(overrides);
 
 describe('ProxySamplingPanel', () => {
   // The rule the whole Tier C contract rests on. A blind organ and a healthy
@@ -440,8 +432,17 @@ describe('ProxySamplingPanel', () => {
       expect(screen.queryByText(/gglib is overriding/i)).not.toBeInTheDocument();
     });
 
-    it('renders nothing at all on a proxy that predates the field', () => {
-      render(<ProxySamplingPanel audit={audit({ published: null })} />);
+    // `published` is unconditional on the wire, so the snapshot type no longer
+    // admits a missing one — but `PublishedRows` still guards, because the
+    // value arrives through an unchecked cast over parsed JSON and rendering
+    // `undefined.fields` would take the panel down. The cast here builds the
+    // malformed frame the guard is for.
+    it('renders nothing rather than throwing when the field is missing', () => {
+      render(
+        <ProxySamplingPanel
+          audit={audit({ published: undefined as unknown as SamplingAuditSnapshot['published'] })}
+        />,
+      );
       expect(screen.queryByText(/no request resolved yet/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/publishes no sampler defaults/i)).not.toBeInTheDocument();
     });

--- a/tests/ts/components/TrayPanel.test.tsx
+++ b/tests/ts/components/TrayPanel.test.tsx
@@ -11,6 +11,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { TrayPanel } from '../../../src/pages/TrayPanel';
 import type { DashboardSnapshot } from '../../../src/services/transport/types/dashboard';
+import { dashboardSnapshot } from '../fixtures/dashboard';
 
 const transport = vi.hoisted(() => ({
   startProxy: vi.fn().mockResolvedValue(undefined),
@@ -47,16 +48,8 @@ vi.mock('../../../src/hooks/useProxyDashboard', () => ({
   useProxyDashboard: () => dashboard.current,
 }));
 
-function snapshot(overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot {
-  return {
-    active_connections: [],
-    slots: [],
-    slots_available: false,
-    slots_status: 'Slot metrics unavailable.',
-    total_requests: 0,
-    ...overrides,
-  } as DashboardSnapshot;
-}
+const snapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot =>
+  dashboardSnapshot(overrides);
 
 describe('TrayPanel', () => {
   beforeEach(() => {

--- a/tests/ts/components/proxyShared.test.tsx
+++ b/tests/ts/components/proxyShared.test.tsx
@@ -21,21 +21,13 @@ import type {
   ActiveConnectionSnapshot,
   DashboardSnapshot,
 } from '../../../src/services/transport/types/dashboard';
-import { activeConnection, slotSnapshot } from '../fixtures/dashboard';
+import { activeConnection, dashboardSnapshot, slotSnapshot } from '../fixtures/dashboard';
 
 const connection = (overrides: Partial<ActiveConnectionSnapshot> = {}): ActiveConnectionSnapshot =>
   activeConnection({ id: 'c1', model_name: 'qwen3-coder', is_streaming: true, ...overrides });
 
-function snapshot(overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot {
-  return {
-    active_connections: [],
-    slots: [],
-    slots_available: false,
-    slots_status: 'Slot metrics unavailable.',
-    total_requests: 0,
-    ...overrides,
-  } as DashboardSnapshot;
-}
+const snapshot = (overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot =>
+  dashboardSnapshot(overrides);
 
 describe('ProxyStatusPill', () => {
   it('reads Running when the proxy is up', () => {
@@ -183,6 +175,11 @@ describe('InferenceSlotsSection', () => {
       <InferenceSlotsSection
         snapshot={snapshot({
           slots_available: true,
+          // `dashboard.rs` derives both from one match: `Available` gives
+          // `true` with no status line, and either unavailable arm gives
+          // `false` with one. Setting only the flag builds a frame the proxy
+          // cannot send.
+          slots_status: null,
           slots: [
             slotSnapshot({ id: 0, is_processing: true, n_ctx: 4096 }),
             slotSnapshot({ id: 1, is_processing: false, n_ctx: 4096 }),

--- a/tests/ts/components/proxyShared.test.tsx
+++ b/tests/ts/components/proxyShared.test.tsx
@@ -21,17 +21,10 @@ import type {
   ActiveConnectionSnapshot,
   DashboardSnapshot,
 } from '../../../src/services/transport/types/dashboard';
+import { activeConnection, slotSnapshot } from '../fixtures/dashboard';
 
-function connection(overrides: Partial<ActiveConnectionSnapshot> = {}): ActiveConnectionSnapshot {
-  return {
-    id: 'c1',
-    model_name: 'qwen3-coder',
-    started_at_secs: 0,
-    is_streaming: true,
-    phase: 'generating',
-    ...overrides,
-  };
-}
+const connection = (overrides: Partial<ActiveConnectionSnapshot> = {}): ActiveConnectionSnapshot =>
+  activeConnection({ id: 'c1', model_name: 'qwen3-coder', is_streaming: true, ...overrides });
 
 function snapshot(overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot {
   return {
@@ -191,8 +184,8 @@ describe('InferenceSlotsSection', () => {
         snapshot={snapshot({
           slots_available: true,
           slots: [
-            { id: 0, is_processing: true, n_ctx: 4096 },
-            { id: 1, is_processing: false, n_ctx: 4096 },
+            slotSnapshot({ id: 0, is_processing: true, n_ctx: 4096 }),
+            slotSnapshot({ id: 1, is_processing: false, n_ctx: 4096 }),
           ],
         })}
       />,

--- a/tests/ts/fixtures/README.md
+++ b/tests/ts/fixtures/README.md
@@ -16,6 +16,7 @@ endpoint produces, and passing.
 | `model.ts` | `GuiModel` | The eight fields the old mirror made optional are required; only the three MoE fields, which really do carry `skip_serializing_if`, are omitted. |
 | `explain.ts` | `SamplingExplanation` | `published` is an empty array rather than an absent key, and `defaultsOrigin` and `profile` are required nullables. `effortSuppressed` stays optional — it is the one field that genuinely skips. |
 | `mcp.ts` | `McpServerInfo` | The nested `{server, status, tools}` every server route answers with, not the bare row two mocks were returning. |
+| `dashboard.ts` | `SlotSnapshot`, `ActiveConnectionSnapshot`, `SamplingAuditSnapshot`, `DashboardSnapshot` | Every field of every frame, since nothing on the dashboard contract skips. The whole-snapshot builder replaces two tests that named five of sixteen fields behind a cast. Values are the ones the proxy can actually emit — `slots_status` is the poller's own default, not the GUI's fallback string. |
 
 ## Rules
 

--- a/tests/ts/fixtures/dashboard.ts
+++ b/tests/ts/fixtures/dashboard.ts
@@ -1,8 +1,10 @@
 /**
  * Proxy dashboard pieces, as the `/v1/proxy/status/stream` frame sends them.
  *
- * Nothing in `gglib-proxy` uses `skip_serializing_if`, so every field of every
- * snapshot is present on every frame and "not applicable" is a `null`. The
+ * Nothing on the dashboard contract uses `skip_serializing_if` — `gglib-proxy`
+ * uses it elsewhere, on `models.rs` and the MCP types, but on nothing the
+ * snapshot reaches — so every field of every snapshot is present on every
+ * frame and "not applicable" is a `null`. The
  * hand-written mirror these replace had thirty-two fields marked optional
  * that the proxy has never omitted, and the fixtures written against it were
  * naming three or four keys out of eleven.
@@ -12,6 +14,7 @@
  */
 import type {
   ActiveConnectionSnapshot,
+  DashboardSnapshot,
   SamplingAuditSnapshot,
   SlotSnapshot,
 } from '../../../src/services/transport/types/dashboard';
@@ -65,9 +68,20 @@ const AUDIT: SamplingAuditSnapshot = {
   published: { intents: 0, fields: [] },
   effort_suppressed: { requests: 0, latest: null },
   reasoning: {
-    effort_support: { state: 'not_yet_observed', reason: 'never launched' },
+    effort_support: {
+      state: 'not_yet_observed',
+      reason: 'no /props read has completed for the running model yet',
+    },
     latest: null,
-    wire_blind_reason: '',
+    // Carried on every readback, never empty: `WIRE_BLIND_REASON` in
+    // `audit_records.rs` is a fixed constant, and `ProxyReasoningRows`
+    // renders it as the body of a warning banner. An empty string here
+    // would let a test asserting on that banner pass against nothing.
+    wire_blind_reason:
+      'llama-server echoes neither reasoning control: reasoning_effort is a chat-template ' +
+      'kwarg consumed at render time, and task_params::to_json serialises no ' +
+      'reasoning_budget_* field (ADR 0007 finding 7a). These are gglib’s own record of ' +
+      'what it sent — no readback can confirm them.',
   },
   client_field_names: { fields: [], untracked: 0 },
 };
@@ -77,4 +91,60 @@ export function samplingAudit(
   overrides: Partial<SamplingAuditSnapshot> = {},
 ): SamplingAuditSnapshot {
   return { ...AUDIT, ...overrides };
+}
+
+const SNAPSHOT: DashboardSnapshot = {
+  active_connections: [],
+  slots_available: false,
+  slots: [],
+  slots_status: 'Slot metrics unavailable.',
+  recent_requests: [],
+  total_requests: 0,
+  dialect_residue_total: 0,
+  tool_repairs_attempted: 0,
+  tool_repairs_succeeded: 0,
+  upstream_health: {
+    consecutive_strikes: 0,
+    total_empty_responses: 0,
+    total_upstream_errors: 0,
+    total_first_byte_timeouts: 0,
+    total_client_aborts: 0,
+    total_recycles: 0,
+    total_recycle_failures: 0,
+  },
+  per_model_defects: {},
+  cache: null,
+  agent_usage: {
+    reporting_requests: 0,
+    unreported_requests: 0,
+    prompt_tokens: 0,
+    cached_tokens: 0,
+    last_prompt_tokens: null,
+    last_cached_tokens: null,
+  },
+  launch: null,
+  admission: {
+    slots: [],
+    queued: [],
+    total_queued: 0,
+    total_swaps: 0,
+    secondary_slot: { state: 'available', detail: 'No second model has been requested yet.' },
+  },
+  sampling_audit: AUDIT,
+};
+
+/**
+ * A whole frame from an idle proxy, with `overrides` applied.
+ *
+ * All sixteen fields, because that is what the proxy sends. The tests this
+ * serves used to build one by naming five and casting — which typechecks,
+ * leaves eleven fields `undefined` at runtime, and means a component reading
+ * any of them is tested against a frame that cannot arrive.
+ *
+ * `slots_available: false` pairs with the "unavailable" `slots_status` on
+ * purpose: `dashboard.rs` derives both from one `match`, so `true` alongside
+ * that message is a combination the proxy cannot produce.
+ */
+export function dashboardSnapshot(overrides: Partial<DashboardSnapshot> = {}): DashboardSnapshot {
+  return { ...SNAPSHOT, ...overrides };
 }

--- a/tests/ts/fixtures/dashboard.ts
+++ b/tests/ts/fixtures/dashboard.ts
@@ -1,0 +1,80 @@
+/**
+ * Proxy dashboard pieces, as the `/v1/proxy/status/stream` frame sends them.
+ *
+ * Nothing in `gglib-proxy` uses `skip_serializing_if`, so every field of every
+ * snapshot is present on every frame and "not applicable" is a `null`. The
+ * hand-written mirror these replace had thirty-two fields marked optional
+ * that the proxy has never omitted, and the fixtures written against it were
+ * naming three or four keys out of eleven.
+ *
+ * Builders rather than constants, because the interesting part of a dashboard
+ * test is always one or two fields and the rest is noise.
+ */
+import type {
+  ActiveConnectionSnapshot,
+  SamplingAuditSnapshot,
+  SlotSnapshot,
+} from '../../../src/services/transport/types/dashboard';
+
+const SLOT: SlotSnapshot = {
+  id: 0,
+  id_task: null,
+  n_ctx: null,
+  is_processing: false,
+  params: null,
+  n_past: null,
+  cache_tokens: null,
+  n_prompt_tokens: null,
+  n_prompt_tokens_processed: null,
+  n_prompt_tokens_cache: null,
+  next_token: null,
+};
+
+/** An idle slot holding nothing, with `overrides` applied. */
+export function slotSnapshot(overrides: Partial<SlotSnapshot> = {}): SlotSnapshot {
+  return { ...SLOT, ...overrides };
+}
+
+const CONNECTION: ActiveConnectionSnapshot = {
+  id: 'conn-1',
+  model_name: 'test-model',
+  started_at_secs: 0,
+  is_streaming: false,
+  num_ctx: null,
+  phase: 'queued',
+  prompt_processed: null,
+  prompt_total: null,
+  prompt_cached: null,
+  prompt_time_ms: null,
+};
+
+/** A queued connection that has not begun prefill. */
+export function activeConnection(
+  overrides: Partial<ActiveConnectionSnapshot> = {},
+): ActiveConnectionSnapshot {
+  return { ...CONNECTION, ...overrides };
+}
+
+const AUDIT: SamplingAuditSnapshot = {
+  state: { state: 'not_yet_observed' },
+  skipped_ambiguous: 0,
+  client_fields_rejected: 0,
+  client_fields_discarded: 0,
+  recent_divergences: [],
+  baseline: { state: 'not_yet_read' },
+  published: { intents: 0, fields: [] },
+  effort_suppressed: { requests: 0, latest: null },
+  reasoning: {
+    effort_support: { state: 'not_yet_observed', reason: 'never launched' },
+    latest: null,
+    wire_blind_reason: '',
+  },
+  client_field_names: { fields: [], untracked: 0 },
+};
+
+/** An audit that has seen nothing yet — the state a fresh proxy reports. */
+export function samplingAudit(
+  overrides: Partial<SamplingAuditSnapshot> = {},
+): SamplingAuditSnapshot {
+  return { ...AUDIT, ...overrides };
+}

--- a/tests/ts/fixtures/dashboard.ts
+++ b/tests/ts/fixtures/dashboard.ts
@@ -16,6 +16,7 @@ import type {
   ActiveConnectionSnapshot,
   DashboardSnapshot,
   SamplingAuditSnapshot,
+  SamplingReasoningReadback,
   SlotSnapshot,
 } from '../../../src/services/transport/types/dashboard';
 
@@ -58,6 +59,36 @@ export function activeConnection(
   return { ...CONNECTION, ...overrides };
 }
 
+const READBACK: SamplingReasoningReadback = {
+  effort_support: {
+    state: 'not_yet_observed',
+    reason: 'no /props read has completed for the running model yet',
+  },
+  latest: null,
+  // The whole of `WIRE_BLIND_REASON`, not a stand-in: `ProxyReasoningRows`
+  // renders it as the body of a warning banner, so a shortened copy lets a
+  // test assert on text the user never sees.
+  wire_blind_reason:
+    'llama-server echoes neither reasoning control: reasoning_effort is a chat-template kwarg ' +
+    'consumed at render time, and task_params::to_json serialises no reasoning_budget_* field ' +
+    "(ADR 0007 finding 7a). These are gglib's own record of what it sent — no readback can " +
+    'confirm them.',
+};
+
+/**
+ * A readback from a proxy that has not seen a request yet.
+ *
+ * `wire_blind_reason` is the whole of `WIRE_BLIND_REASON` from
+ * `audit_records.rs`, not a shortened stand-in: `ProxyReasoningRows` renders
+ * it as the body of a warning banner, so a truncated copy lets a test assert
+ * on text the user never sees.
+ */
+export function reasoningReadback(
+  overrides: Partial<SamplingReasoningReadback> = {},
+): SamplingReasoningReadback {
+  return { ...READBACK, ...overrides };
+}
+
 const AUDIT: SamplingAuditSnapshot = {
   state: { state: 'not_yet_observed' },
   skipped_ambiguous: 0,
@@ -67,22 +98,7 @@ const AUDIT: SamplingAuditSnapshot = {
   baseline: { state: 'not_yet_read' },
   published: { intents: 0, fields: [] },
   effort_suppressed: { requests: 0, latest: null },
-  reasoning: {
-    effort_support: {
-      state: 'not_yet_observed',
-      reason: 'no /props read has completed for the running model yet',
-    },
-    latest: null,
-    // Carried on every readback, never empty: `WIRE_BLIND_REASON` in
-    // `audit_records.rs` is a fixed constant, and `ProxyReasoningRows`
-    // renders it as the body of a warning banner. An empty string here
-    // would let a test asserting on that banner pass against nothing.
-    wire_blind_reason:
-      'llama-server echoes neither reasoning control: reasoning_effort is a chat-template ' +
-      'kwarg consumed at render time, and task_params::to_json serialises no ' +
-      'reasoning_budget_* field (ADR 0007 finding 7a). These are gglib’s own record of ' +
-      'what it sent — no readback can confirm them.',
-  },
+  reasoning: READBACK,
   client_field_names: { fields: [], untracked: 0 },
 };
 
@@ -97,7 +113,11 @@ const SNAPSHOT: DashboardSnapshot = {
   active_connections: [],
   slots_available: false,
   slots: [],
-  slots_status: 'Slot metrics unavailable.',
+  // The poller's own default. `dashboard.rs` can emit only `null`
+  // (slots available), the `--no-slots` line, or the poller's reason — the
+  // 'Slot metrics unavailable.' string is the GUI's `??` fallback in
+  // `ProxyMetricsGrid`, never something the proxy sends.
+  slots_status: 'no /slots poll has completed yet',
   recent_requests: [],
   total_requests: 0,
   dialect_residue_total: 0,

--- a/tests/ts/services/downloadQueue.test.ts
+++ b/tests/ts/services/downloadQueue.test.ts
@@ -1,0 +1,84 @@
+/**
+ * How a flat queue snapshot becomes `{current, pending, failed}`.
+ *
+ * The wire reports seven statuses. Two of them — `finalizing` and
+ * `registering` — are the tail of a download: the bytes are on disk and the
+ * queue is checksumming and writing the row. Both sides of the GUI used to
+ * treat them as *nothing*: they matched neither `current` nor `pending`, so
+ * the download card unmounted for the duration and came back when the next
+ * event arrived, which is the phase whose "Finalizing" and "Registering"
+ * labels were written to be shown.
+ *
+ * That it stayed on screen at all was a race — a `download_status_changed`
+ * event re-setting the active id before React committed the unmount.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { bucketQueue, isInFlight } from '../../../src/services/transport/downloadQueue';
+import type { DownloadQueueItem } from '../../../src/services/transport/types/downloads';
+import type { DownloadStatus } from '../../../src/types/generated/DownloadStatus';
+
+function item(status: DownloadStatus, id: string = status): DownloadQueueItem {
+  return { id, display_name: id, status, position: 0 };
+}
+
+describe('isInFlight', () => {
+  it.each(['downloading', 'finalizing', 'registering'] as const)(
+    'counts %s as work in progress',
+    (status) => {
+      expect(isInFlight(item(status))).toBe(true);
+    },
+  );
+
+  it.each(['queued', 'completed', 'failed', 'cancelled'] as const)(
+    'does not count %s',
+    (status) => {
+      expect(isInFlight(item(status))).toBe(false);
+    },
+  );
+});
+
+describe('bucketQueue', () => {
+  it('keeps a finalizing row as the current download', () => {
+    const { current } = bucketQueue([item('finalizing')]);
+
+    expect(current?.status).toBe('finalizing');
+  });
+
+  it('keeps a registering row as the current download', () => {
+    const { current } = bucketQueue([item('registering')]);
+
+    expect(current?.status).toBe('registering');
+  });
+
+  it('sorts the ordinary statuses into their buckets', () => {
+    const { current, pending, failed } = bucketQueue([
+      item('queued', 'a'),
+      item('downloading', 'b'),
+      item('queued', 'c'),
+      item('failed', 'd'),
+      item('completed', 'e'),
+    ]);
+
+    expect(current?.id).toBe('b');
+    expect(pending.map((i) => i.id)).toEqual(['a', 'c']);
+    expect(failed.map((i) => i.id)).toEqual(['d']);
+  });
+
+  /**
+   * `cancelled` is its own status on the wire and is not folded into `failed`.
+   * The SSE path used to map it across, which put a row the user cancelled on
+   * a list of things that went wrong — a list nothing renders, so the fold
+   * bought nothing and lost the distinction.
+   */
+  it('does not report a cancelled download as failed', () => {
+    const { failed } = bucketQueue([item('cancelled')]);
+
+    expect(failed).toEqual([]);
+  });
+
+  it('reports no current download when nothing is in flight', () => {
+    expect(bucketQueue([item('queued'), item('completed')]).current).toBeNull();
+  });
+});

--- a/tests/ts/services/downloadQueue.test.ts
+++ b/tests/ts/services/downloadQueue.test.ts
@@ -1,16 +1,18 @@
 /**
  * How a flat queue snapshot becomes `{current, pending, failed}`.
  *
- * The wire reports seven statuses. Two of them — `finalizing` and
- * `registering` — are the tail of a download: the bytes are on disk and the
- * queue is checksumming and writing the row. Both sides of the GUI used to
- * treat them as *nothing*: they matched neither `current` nor `pending`, so
- * the download card unmounted for the duration and came back when the next
- * event arrived, which is the phase whose "Finalizing" and "Registering"
- * labels were written to be shown.
+ * Two paths produce that shape — the SSE `queue_snapshot` frame and
+ * `GET /api/models/downloads/queue` — and they used to hold separate copies of
+ * the rules. The copies agreed, so this is not a regression test for a bug; it
+ * pins the rules now that there is one implementation to pin.
  *
- * That it stayed on screen at all was a race — a `download_status_changed`
- * event re-setting the active id before React committed the unmount.
+ * **Most of the statuses below cannot reach these functions.** A snapshot
+ * carries `downloading` on the single active row and `queued` on the rest —
+ * `gglib-download` hard-codes both — and failures live in a `recent_failures`
+ * list the wire type does not carry. The `finalizing`, `registering`,
+ * `completed`, `failed` and `cancelled` cases are here because
+ * `DownloadStatus` admits them and the predicates answer for them: they say
+ * what the code would do, not what the server does.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -24,8 +26,15 @@ function item(status: DownloadStatus, id: string = status): DownloadQueueItem {
 }
 
 describe('isInFlight', () => {
-  it.each(['downloading', 'finalizing', 'registering'] as const)(
-    'counts %s as work in progress',
+  it('counts the status a snapshot actually carries', () => {
+    expect(isInFlight(item('downloading'))).toBe(true);
+  });
+
+  // Unreachable today. Named so that if the queue ever reports its tail
+  // phases, the answer is already decided and visible rather than falling out
+  // of whichever predicate happens not to match.
+  it.each(['finalizing', 'registering'] as const)(
+    'would count %s as work in progress, not as nothing',
     (status) => {
       expect(isInFlight(item(status))).toBe(true);
     },
@@ -40,45 +49,36 @@ describe('isInFlight', () => {
 });
 
 describe('bucketQueue', () => {
-  it('keeps a finalizing row as the current download', () => {
-    const { current } = bucketQueue([item('finalizing')]);
-
-    expect(current?.status).toBe('finalizing');
-  });
-
-  it('keeps a registering row as the current download', () => {
-    const { current } = bucketQueue([item('registering')]);
-
-    expect(current?.status).toBe('registering');
-  });
-
-  it('sorts the ordinary statuses into their buckets', () => {
-    const { current, pending, failed } = bucketQueue([
+  it('sorts the two statuses a snapshot carries', () => {
+    const { current, pending } = bucketQueue([
       item('queued', 'a'),
       item('downloading', 'b'),
       item('queued', 'c'),
-      item('failed', 'd'),
-      item('completed', 'e'),
     ]);
 
     expect(current?.id).toBe('b');
     expect(pending.map((i) => i.id)).toEqual(['a', 'c']);
-    expect(failed.map((i) => i.id)).toEqual(['d']);
-  });
-
-  /**
-   * `cancelled` is its own status on the wire and is not folded into `failed`.
-   * The SSE path used to map it across, which put a row the user cancelled on
-   * a list of things that went wrong — a list nothing renders, so the fold
-   * bought nothing and lost the distinction.
-   */
-  it('does not report a cancelled download as failed', () => {
-    const { failed } = bucketQueue([item('cancelled')]);
-
-    expect(failed).toEqual([]);
   });
 
   it('reports no current download when nothing is in flight', () => {
-    expect(bucketQueue([item('queued'), item('completed')]).current).toBeNull();
+    expect(bucketQueue([item('queued')]).current).toBeNull();
+  });
+
+  /**
+   * `failed` is always empty: the queue keeps failures in `recent_failures`,
+   * which the snapshot does not carry, and nothing renders the bucket. This
+   * pins that a row which did somehow arrive `failed` is not mistaken for
+   * pending or current.
+   */
+  it('keeps a failed row out of the buckets that drive the UI', () => {
+    const { current, pending, failed } = bucketQueue([item('failed')]);
+
+    expect(current).toBeNull();
+    expect(pending).toEqual([]);
+    expect(failed).toHaveLength(1);
+  });
+
+  it('does not report a cancelled download as failed', () => {
+    expect(bucketQueue([item('cancelled')]).failed).toEqual([]);
   });
 });

--- a/tests/ts/services/eventCategory.test.ts
+++ b/tests/ts/services/eventCategory.test.ts
@@ -8,11 +8,47 @@
  * threw every one away.
  */
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, it, expect } from 'vitest';
 
 import { getEventCategory } from '../../../src/services/transport/events/category';
 
+/**
+ * Every `type` tag the generated `AppEvent` can carry.
+ *
+ * Read out of the binding rather than listed here, so a variant added in Rust
+ * arrives in this test on the next `make bindings` instead of whenever
+ * somebody remembers. That is the failure this file exists for: the model
+ * events were declared in Rust, mapped by `event_name()`, and silently
+ * discarded by the frontend for their whole existence.
+ */
+const WIRE_TAGS: string[] = (() => {
+  const binding = readFileSync(
+    resolve(import.meta.dirname, '../../../src/types/generated/AppEvent.ts'),
+    'utf8',
+  );
+  const tags = [...binding.matchAll(/"type": "([a-z_]+)"/g)].map((m) => m[1]);
+  if (tags.length === 0) throw new Error('found no tags in the AppEvent binding');
+  return [...new Set(tags)];
+})();
+
 describe('getEventCategory', () => {
+  /**
+   * The map's five categories against the union's arms. `AppEventMap` claims
+   * to cover `AppEvent`, but `getEventCategory` is ordinary runtime code and
+   * the compiler cannot check that claim — a new `server_*` arm widens the
+   * `Extract` slice with no type error while the router returns `null` for it
+   * and `validateEvent` drops the frame in silence.
+   */
+  it('claims every tag the wire union can carry', () => {
+    const unrouted = WIRE_TAGS.filter((tag) => getEventCategory(tag) === null);
+
+    expect(unrouted).toEqual([]);
+    expect(WIRE_TAGS.length).toBeGreaterThan(10); // extractor sanity check
+  });
+
   it('routes the three model lifecycle tags to the model category', () => {
     expect(getEventCategory('model_added')).toBe('model');
     expect(getEventCategory('model_updated')).toBe('model');

--- a/tests/ts/services/transport/slotTokens.test.ts
+++ b/tests/ts/services/transport/slotTokens.test.ts
@@ -12,7 +12,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { tokensInUse, type SlotSnapshot } from '../../../../src/services/transport/types/dashboard';
+import { tokensInUse } from '../../../../src/services/transport/slotTokens';
+import type { SlotSnapshot } from '../../../../src/services/transport/types/dashboard';
 
 function slot(overrides: Partial<SlotSnapshot>): SlotSnapshot {
   return { id: 0, is_processing: false, ...overrides };

--- a/tests/ts/services/transport/slotTokens.test.ts
+++ b/tests/ts/services/transport/slotTokens.test.ts
@@ -14,10 +14,9 @@
 import { describe, it, expect } from 'vitest';
 import { tokensInUse } from '../../../../src/services/transport/slotTokens';
 import type { SlotSnapshot } from '../../../../src/services/transport/types/dashboard';
+import { slotSnapshot } from '../../fixtures/dashboard';
 
-function slot(overrides: Partial<SlotSnapshot>): SlotSnapshot {
-  return { id: 0, is_processing: false, ...overrides };
-}
+const slot = (overrides: Partial<SlotSnapshot>): SlotSnapshot => slotSnapshot(overrides);
 
 describe('tokensInUse', () => {
   it('prefers n_past when present', () => {


### PR DESCRIPTION
Stacked on #873. The second half of the migration: events, SSE, the download queue and the proxy dashboard now import their wire types from `src/types/generated/` instead of keeping a second, hand-written copy.

`src/services/transport/types/dashboard.ts` goes from 559 lines to 163 — 559 to 523 when the one runtime function living among the declarations moved out, then 523 to 150 when the declarations became aliases, and back up to 163 as review corrections added an alias and some comments. No production code changed to make any of it happen.

## What the mirror had got wrong

**Thirty-two fields were out of step on optionality.** That figure comes from diffing every type against its binding rather than from counting — a script, because it is exactly the sort of number a person gets wrong. Nothing on the dashboard contract uses `skip_serializing_if`, so every field is on every frame and "not applicable" is a `null`. Walking the `DashboardSnapshot` binding graph reaches 38 types and finds no optional field anywhere in it. The `?` on those thirty-two described a proxy that has never existed, and a client that only ever *reads* the wire never finds out it is wrong about what is optional.

**Seven fields the proxy sends were not declared at all.** Four on `DashboardSnapshot` — `tool_repairs_attempted`, `tool_repairs_succeeded`, `upstream_health`, `per_model_defects` — plus `SlotSnapshot.params` (llama-server's own parsed sampler chain, the only place the dashboard can show what the *server* believes it was asked for), `ContextSnapshot.tool_repaired`, and `SamplingAuditSnapshot.effort_suppressed`, which ADR 0007 calls the one record nothing else in the system can reconstruct. The GUI had no way to render it.

## The closed unions

Two fields are `&'static str` in Rust, which ts-rs renders as a bare `string` — losing exhaustiveness the GUI depends on. Rather than narrow them back in TypeScript, both now carry a `#[ts(type = …)]` override on the Rust field, so the union is *generated*: `SecondarySlotStatus.state` joins `CacheStatus.ram_state`, which PR 4 had already done. The six variants are stated once instead of twice, and deleting an arm from the GUI's icon table still fails typecheck.

## The SSE bus

Four hand-written unions restating thirteen arms become `Extract`s over the generated `AppEvent`. All fourteen arms land in exactly one slice — no gaps, no overlaps, verified rather than assumed.

`AppEventMap` still names its five slices rather than collapsing to a bare `AppEvent`: a handler registered for `'proxy'` should not have to narrow against `server_started`.

**What `Extract` does not buy** is worth stating, because it is the failure this whole arc exists to close. A `server_*` arm added in Rust joins the slice with no TypeScript error while `getEventCategory` returns `null` for it and `validateEvent` drops the frame in silence — widening a union a consumer reads is not a type error. That is precisely how the model events spent their entire existence declared, mapped in Rust, and thrown away by the frontend. So the claim gets a test rather than a comment: `eventCategory.test.ts` reads the tags out of the generated binding and asserts the router claims every one, failing on the next `make bindings` after a new variant.

## A retraction

One commit here is a correction to another. An earlier draft of the download-queue commit claimed `finalizing` and `registering` were reaching the GUI and rendering as failures, with a symptom and a saving race. **None of it can happen.** `gglib-download` hard-codes the active row to `Downloading` and every pending row to `Queued`, and failed rows never enter `items` — they go to a `recent_failures` list the snapshot wire type does not carry. Two of seven statuses can arrive, and on those two the old status map was the identity, so the fallback it was aimed at never fired.

The migration notes asserted the defect; I built a module docblock, a test file and a commit message on top without checking the producer. The last three commits here are the correction, kept as commits rather than folded away — the first retracts the claim, the second fixes fixture values that could not come off the wire, and the third catches three more source comments that still asserted it after the retraction said they had been fixed.

Correcting the fixtures then exposed a test asserting on a support-reason string the proxy does not send. That is fixed too.

What is real in that commit: the generated `DownloadSummary`, `DownloadEvent`, `CompletionKind` and `CompletionDetail`; five `(item as any)` casts deleted, which existed only because the mirror was wrong about fields the wire sends; and one bucketing implementation where there were two copies that agreed. The predicates answer for all seven statuses and say plainly that five of them are defence against inputs nothing currently produces.

## Fixtures

`tests/ts/fixtures/dashboard.ts` builds slots, connections, audits and whole snapshots as the proxy sends them. The tests it replaces built a `DashboardSnapshot` by naming five of sixteen fields behind a cast — which typechecks, leaves eleven `undefined` at runtime, and means a component reading any of them was tested against a frame that cannot arrive. One paired `slots_available: true` with the "unavailable" status line, which `dashboard.rs` derives from a single `match` and so cannot emit together.

## Not in scope

`McpTool` and `DownloadQueueItem` stay hand-written; both are blocked on Rust-side shape questions rather than on this migration.

## Verification

`make pre-commit` · `cargo fmt --all -- --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test --workspace` · `npx tsc -b` · `npm run lint -- --max-warnings 0` · `npm run test:run` (944) · `make bindings-check`.

Both complexity ratchets were also run against **every commit** on the branch, not just the tip — this repo merges rather than squashes, so an intermediate commit that fails a gate is a bisection trap. All nine pass independently.

**One unrelated flaky test, flagged rather than hidden.** `gglib-core`'s `sampling_log_tests::a_surviving_level_is_still_reported_with_its_rung` failed once across roughly six full-workspace runs, panicking with `no layer outlives the subscriber` — a `tracing` global-subscriber lifetime error. It did not reproduce in ten further runs of that crate's suite, nor in a repeat full-workspace run, so I could not pin it down. The file is untouched by this branch (the only Rust changes here are one doc comment and one `cfg_attr`) and was last modified by #866. Pre-existing, and worth its own look.

Ratchet movements, all deliberate: `admission.rs` +16 (the override plus the comment naming which three constructors must stay inside the union). Three reductions recorded with it — `dashboard.ts` drops off the list entirely at 163, `index.ts` 867 → 555, `benchmark.ts` 539 → 538.
