### PR TITLE
fix(core): the sampling-log tests asserted something tracing does not promise

### DIFF
--- a/crates/gglib-core/src/request_pipeline/sampling_log_tests.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling_log_tests.rs
@@ -50,13 +50,31 @@ impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
 }
 
 /// Run `f` with every event captured.
+///
+/// Reads the sink through the shared handle rather than taking it apart.
+/// `Arc::try_unwrap` was used here, on the assumption that `with_default`
+/// returning means the subscriber — and so the layer's clone of this `Arc` —
+/// has been dropped. That is not something `tracing` promises, and it is not
+/// true under concurrency: `tracing-core` registers every `Dispatch` for
+/// callsite-interest purposes, and another thread hitting a callsite for the
+/// first time can hold a strong reference to ours while we are asking.
+///
+/// Measured in a standalone reproduction of this exact shape — 32 threads,
+/// distinct callsites, 51,200 rounds — the sink was still shared on return
+/// 912 times, 1.8%. Every one of those would have been a panic here, which is
+/// what made this module fail about once in six full-workspace runs while
+/// passing hundreds of times in isolation.
+///
+/// Nothing needed exclusive ownership: `f` has finished and the layer records
+/// synchronously on this thread, so the events are all in by now and a clone
+/// of the vector is the whole requirement.
 fn capture(f: impl FnOnce()) -> Vec<(String, String)> {
     let sink: Captured = Arc::default();
     let subscriber = Registry::default().with(CaptureLayer(Arc::clone(&sink)));
     with_default(subscriber, f);
-    let out = Arc::try_unwrap(sink).expect("no layer outlives the subscriber");
-    out.into_inner()
+    sink.lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
 }
 
 /// The fields of the one event whose `message` is `name`.

--- a/crates/gglib-core/src/request_pipeline/sampling_log_tests.rs
+++ b/crates/gglib-core/src/request_pipeline/sampling_log_tests.rs
@@ -61,9 +61,11 @@ impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
 ///
 /// Measured in a standalone reproduction of this exact shape — 32 threads,
 /// distinct callsites, 51,200 rounds — the sink was still shared on return
-/// 912 times, 1.8%. Every one of those would have been a panic here, which is
-/// what made this module fail about once in six full-workspace runs while
-/// passing hundreds of times in isolation.
+/// 1,288 times, 2.5%. Every one of those would have been a panic here, which
+/// is what made this module fail about once in six full-workspace runs while
+/// passing hundreds of times in isolation. The same run measured the
+/// replacement: reading through the shared handle lost an event 0 times, and
+/// returned the full set on all 1,288 of the rounds that would have panicked.
 ///
 /// Nothing needed exclusive ownership: `f` has finished and the layer records
 /// synchronously on this thread, so the events are all in by now and a clone


### PR DESCRIPTION
`gglib-core`'s `sampling_log_tests` failed roughly one full-workspace run in six with

```
panicked at crates/gglib-core/src/request_pipeline/sampling_log_tests.rs:57:
no layer outlives the subscriber
```

**Branches from `main`, independent of the #869–#876 stack** — that stack never touches this file, so this can merge on its own.

## What was wrong

`capture()` ended with

```rust
let out = Arc::try_unwrap(sink).expect("no layer outlives the subscriber");
```

which looks like a tidy way to take the vector back and is really an assertion: that `with_default` returning means the subscriber — and with it the capture layer's clone of that `Arc` — has already been dropped.

`tracing` does not promise that. It promises the subscriber is no longer the thread's default. `tracing-core` registers every `Dispatch` so a callsite being hit for the first time can ask each one for its interest, and a thread doing that can hold a strong reference to *another* thread's subscriber while that thread is asking whether it holds the only one.

## Measured, not assumed

A standalone reproduction of this exact shape — 32 threads, a distinct callsite per round, 51,200 rounds:

```
rounds                                  51200
old assertion would have panicked        1288
replacement lost an event                   0
of the panicking rounds, read OK         1288
```

So the condition that panics occurs about 2.5% of the time under contention, and the replacement handles every instance of it.

That ratio explains the failure signature. The race needs other threads registering callsites at the moment this one tears down, which a lightly-loaded single-crate run rarely produces — the module passed **300 consecutive runs at `--test-threads=64`** while the full workspace failed one in six.

## The fix

Read the sink through the shared handle instead of taking it apart. Nothing needed exclusive ownership: by the time `with_default` returns, `f` has finished and the layer has recorded synchronously on this thread, so the events are all present and a clone of the vector is the whole requirement.

## Verification

After the change: 300 runs of the module at `--test-threads=64` and 40 runs of the full `gglib-core` test binary, no failures. `cargo fmt --check` and `clippy -D warnings` clean.

The stronger claim is that the expression which panicked no longer exists. The only `try_unwrap` left in the file is the sentence explaining why it went.
