### PR TITLE
fix(runtime): three clippy errors only a Windows build could see

### DIFF
--- a/crates/gglib-runtime/src/llama/deps.rs
+++ b/crates/gglib-runtime/src/llama/deps.rs
@@ -140,7 +140,7 @@ pub fn check_disk_space(_required_mb: u64) -> Result<bool> {
     {
         // On Windows, you'd use GetDiskFreeSpaceEx
         // For now, assume enough space
-        return Ok(true);
+        Ok(true)
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/crates/gglib-runtime/src/llama/detect/vulkan/probe.rs
+++ b/crates/gglib-runtime/src/llama/detect/vulkan/probe.rs
@@ -130,7 +130,7 @@ fn check_vulkan_headers() -> bool {
     {
         if let Some(sdk) = vulkan_sdk_dir() {
             let include = sdk.join("Include");
-            if include.join(REL).exists() {
+            if header_exists_in(&[include.as_path()], REL) {
                 return true;
             }
         }
@@ -176,7 +176,9 @@ fn check_spirv_headers() -> bool {
     {
         if let Some(sdk) = vulkan_sdk_dir() {
             let include = sdk.join("Include");
-            if include.join(REL_PRIMARY).exists() || include.join(REL_ALTERNATE).exists() {
+            if header_exists_in(&[include.as_path()], REL_PRIMARY)
+                || header_exists_in(&[include.as_path()], REL_ALTERNATE)
+            {
                 return true;
             }
         }

--- a/crates/gglib-runtime/src/system/gpu.rs
+++ b/crates/gglib-runtime/src/system/gpu.rs
@@ -63,12 +63,11 @@ fn detect_nvidia_hardware() -> bool {
         if let Ok(output) = cmd("wmic")
             .args(["path", "win32_VideoController", "get", "name"])
             .output()
+            && output.status.success()
         {
-            if output.status.success() {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                if stdout.to_lowercase().contains("nvidia") {
-                    return true;
-                }
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.to_lowercase().contains("nvidia") {
+                return true;
             }
         }
     }


### PR DESCRIPTION
`clippy-cross-os` failed on `x86_64-pc-windows-msvc` the first time it ran — which was this stack wiring it into CI. macOS and Linux clippy were both green; all three errors are in code neither platform compiles.

- **`system/gpu.rs`** — the wmic probe nested `if let Ok(output)` inside `if output.status.success()`; collapsed into a let-chain, the shape `probe.rs` already uses.
- **`llama/deps.rs`** — the `#[cfg(windows)]` arm ended in `return Ok(true);` where it is the tail expression, unlike the `#[cfg(unix)]` arm above it.
- **`llama/detect/vulkan/probe.rs`** — `header_exists_in` was dead on Windows, both callers being inside `#[cfg(target_os = "linux")]` blocks. Rather than gate or `allow` it, the two Windows branches now call it: they were hand-rolling `include.join(REL).exists()`, which is exactly what the helper does and what its doc comment says it is for. Now used on both platforms it compiles for, duplication gone.

**Verified:** `cargo clippy -p gglib-runtime --all-targets --all-features` clean on macOS; `cargo fmt --check` clean.

**Not verified locally:** the Windows path itself. The target is installed but there is no Windows C cross-toolchain on this machine, so `zstd-sys` fails to build before reaching any of this code. CI is the check — which is the argument for having wired the job in.

Unblocks #878.