### PR TITLE
fix(runtime): test imports only a unix build uses

### DIFF
--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -354,7 +354,13 @@ impl ServerLogSinkPort for NoopLogSink {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Only the two `#[cfg(unix)]` tests below write an executable stub to
+    // disk, so on Windows these read as unused — the same reason
+    // `PermissionsExt` was already gated.
+    #[cfg(unix)]
     use std::fs;
+    #[cfg(unix)]
     use tempfile::TempDir;
 
     #[cfg(unix)]

--- a/crates/gglib-runtime/src/llama/validate.rs
+++ b/crates/gglib-runtime/src/llama/validate.rs
@@ -118,6 +118,9 @@ pub async fn handle_status() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // `tempdir` is used by the always-compiled tests; `fs` only by the
+    // `#[cfg(unix)]` one that sets a file's permission bits.
+    #[cfg(unix)]
     use std::fs;
     use tempfile::tempdir;
 

--- a/crates/gglib-runtime/src/process/shutdown/pid.rs
+++ b/crates/gglib-runtime/src/process/shutdown/pid.rs
@@ -117,13 +117,16 @@ async fn kill_pid_windows(_pid: u32) -> io::Result<()> {
     ))
 }
 
-#[cfg(test)]
+// Gated on `unix` as well as `test`: every test here drives a real signal at a
+// real PID, which `kill_pid` only implements on unix — on Windows it returns
+// `ErrorKind::Unsupported`. Gating the module rather than each test is what
+// keeps the imports from reading as unused there.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use tokio::process::Command;
 
     #[tokio::test]
-    #[cfg(unix)]
     async fn kill_pid_handles_already_gone() {
         // Use a PID that's very unlikely to exist
         let result = kill_pid(999999).await;
@@ -131,7 +134,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(unix)]
     async fn kill_pid_terminates_process() {
         // Spawn a long-running process
         let mut child = Command::new("sleep")


### PR DESCRIPTION
Second layer of the same Windows clippy failure. `-D warnings` stops at the first failing target, so clearing the `lib` errors in #880 let clippy reach `lib test` — where five imports read as unused because every consumer of them sits behind `#[cfg(unix)]`.

- **`command.rs`** — `std::fs` and `tempfile::TempDir` are used only by the two unix tests that write an executable stub to disk. Gated, the same way `PermissionsExt` beside them already was.
- **`llama/validate.rs`** — `std::fs` only by the unix test that sets permission bits. `tempdir` stays ungated; an always-compiled test uses it.
- **`process/shutdown/pid.rs`** — both tests drive a real signal at a real PID, which `kill_pid` implements on unix only (on Windows it returns `ErrorKind::Unsupported`). The module is now `#[cfg(all(test, unix))]`, and the per-test gates that made redundant are gone.

I scanned the rest of the workspace for the same shape rather than let CI find it one file per 16-minute round-trip. One other candidate turned up — `process/shutdown/child.rs` — and it is a **false positive**: its third test is not unix-gated and does use both imports, so gating them there would have broken the Windows build rather than fixed it.

**Verified on macOS:** `cargo clippy -p gglib-runtime --all-targets --all-features` and `cargo fmt --check` both clean.
**Not verified locally:** the Windows target. No Windows C cross-toolchain on this machine, so `zstd-sys` fails before clippy reaches any Rust.

Unblocks #878.