### PR TITLE
fix(runtime): keep command.rs under the ratchet it was already over

### DIFF
--- a/crates/gglib-runtime/src/command.rs
+++ b/crates/gglib-runtime/src/command.rs
@@ -355,16 +355,9 @@ impl ServerLogSinkPort for NoopLogSink {
 mod tests {
     use super::*;
 
-    // Only the two `#[cfg(unix)]` tests below write an executable stub to
-    // disk, so on Windows these read as unused — the same reason
-    // `PermissionsExt` was already gated.
+    // Only the `#[cfg(unix)]` tests below write an executable stub to disk.
     #[cfg(unix)]
-    use std::fs;
-    #[cfg(unix)]
-    use tempfile::TempDir;
-
-    #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
+    use {std::fs, std::os::unix::fs::PermissionsExt, tempfile::TempDir};
 
     #[test]
     fn is_truthy_flag_recognises_on_values() {


### PR DESCRIPTION
The Rust file-size ratchet fails on **any** growth in a file already over the 300 LOC budget, and the `#[cfg(unix)]` gating in #881 took `command.rs` from 737 to 743.

Collapsed rather than recorded with `--update`. The three unix-only test imports — `std::fs`, `PermissionsExt` and `tempfile::TempDir` — are one concern, so they now share one gate and one `use`. That reads better than three separate attributes and puts the file at **736**, a line under where it started.

**My miss.** After the previous edit I ran `cargo clippy` and `cargo fmt` but not `make enforce`, and the ratchet is in neither. Verified this time: `make enforce` fully green, `cargo clippy -p gglib-runtime --all-targets --all-features` clean, `cargo fmt --check` clean, `check_boundaries.sh` clean.

Unblocks #878.