### PR TITLE
fix(ci): make the transport-branching guard capable of failing

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,9 +76,19 @@ Enforces "HTTP-first, OS-glue-only" Tauri command policy:
 
 ### `check_transport_branching.sh`
 
-Ensures platform-specific code (`isTauriApp`) never appears in client modules:
-- Frontend transport should be unified (HTTP for both web and Tauri)
-- Platform branching only allowed in designated platform layer files
+Three rules over `src/`:
+
+1. no `isTauriApp` inside `src/services/clients/`;
+2. a client module may import `transport/api/client` (the base-URL/auth
+   primitive) and `transport/types/*` (declarations), but not a transport
+   *domain* API — needing one means the module should not be a client;
+3. remaining `isTauriApp` uses carry a `TRANSPORT_EXCEPTION:` comment (warning
+   only).
+
+Rule 2 self-tests against known-bad and known-good fixtures before the real scan,
+and fails when zero client modules are scanned. Both guards exist because the
+rule it replaced could never fail: it grepped for four identifiers that had never
+existed as code, and an empty scan is indistinguishable from a clean one.
 
 ```bash
 ./scripts/check_transport_branching.sh

--- a/scripts/check_transport_branching.sh
+++ b/scripts/check_transport_branching.sh
@@ -8,7 +8,9 @@
 #
 # Exit codes:
 #   0 - All checks pass
-#   1 - Platform branching found in forbidden locations
+#   1 - Any of: platform branching in a client module (Rule 1); a client
+#       importing a transport domain API (Rule 2); the Rule 2 self-test failing;
+#       or zero client modules scanned
 
 set -euo pipefail
 
@@ -48,20 +50,96 @@ fi
 echo ""
 
 # ============================================================================
-# Rule 2: No direct transport imports in clients (except getTransport)
+# Rule 2: Clients reach the transport only through its low-level primitive
 # ============================================================================
-echo "📋 Rule 2: Clients import only getTransport, not transport implementations"
+#
+# What this rule is FOR. `src/services/clients/` holds the modules that own real
+# request logic of their own — hand-parsed streaming, or a server that is not the
+# app's own backend. They are allowed the low-level primitive (`transport/api/client`,
+# which supplies the base URL and auth headers) and they are allowed types. They
+# must not reach into a *domain* API module, because that is the layer whose job
+# they are deliberately doing themselves; an import from there means the client
+# should not have existed.
+#
+# The previous version of this rule grepped for `transport/tauri`,
+# `transport/http`, `TauriTransport` and `HttpTransport`. None of the four appears
+# anywhere in the tree, so the rule could not fail. It also did not describe the
+# directory it guarded: `clients/benchmark.ts` imports `transport/api/client`
+# directly, and neither client module imports `getTransport`.
+#
+# So the invariant is restated as the one that is actually true and actually worth
+# holding, and it self-tests against known-bad and known-good fixtures before
+# scanning anything real — a rule that has never been watched to fail is not a rule.
+echo "📋 Rule 2: Clients import only the transport's low-level client, not domain APIs"
+
+# A transport import is permitted from a client module iff it names either
+# `transport/api/client` (the primitive) or something under `transport/types/`
+# (declarations only — no runtime behaviour to bypass).
+transport_import_violations() {
+    # $1 = directory to scan
+    # Filter on the extracted specifier, not the whole line: an unrelated mention
+    # of an allowed path anywhere on a line must not suppress a real violation.
+    grep -rnE "(from|import|require)[[:space:]]*\(?[[:space:]]*['\"\`][^'\"\`]*transport(/|['\"\`])" "$1" \
+        --include='*.ts' --include='*.tsx' 2>/dev/null \
+    | while IFS= read -r hit; do
+        spec=$(printf '%s' "$hit" | sed -E "s/.*(from|import|require)[[:space:]]*\(?[[:space:]]*['\"\`]([^'\"\`]+)['\"\`].*/\2/")
+        case "$spec" in
+            */transport/api/client) continue ;;
+            */transport/types|*/transport/types/*) continue ;;
+        esac
+        printf '%s\n' "$hit"
+    done
+}
+
+# --- self-test: the detector must catch a domain import and clear the allowed ones
+SELFTEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$SELFTEST_DIR"' EXIT
+cat > "$SELFTEST_DIR/known_bad.ts" <<'EOF'
+import { listModels } from '../transport/api/models/local';
+import { getTransport } from '../transport';
+const { streamSse } = await import('../transport/api/sse');
+const { get } = await import(`../transport/api/models/local`);
+EOF
+cat > "$SELFTEST_DIR/known_good.ts" <<'EOF'
+import { get, getAuthenticatedFetchConfig } from '../transport/api/client';
+import type { DashboardSnapshot } from '../transport/types/dashboard';
+import type { Transport } from '../transport/types';
+import { appLogger } from '../platform';
+EOF
+SELFTEST_BAD=$(transport_import_violations "$SELFTEST_DIR" | grep -c "known_bad" || true)
+SELFTEST_GOOD=$(transport_import_violations "$SELFTEST_DIR" | grep -c "known_good" || true)
+rm -rf "$SELFTEST_DIR"; trap - EXIT
+
+if [ "$SELFTEST_BAD" -ne 4 ]; then
+    echo -e "${RED}❌ self-test: the detector missed a domain-API import (caught $SELFTEST_BAD/4)${NC}"
+    VIOLATIONS=$((VIOLATIONS + 1))
+elif [ "$SELFTEST_GOOD" -ne 0 ]; then
+    echo -e "${RED}❌ self-test: the detector flagged an allowed import (flagged $SELFTEST_GOOD)${NC}"
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    echo -e "  ${GREEN}✓${NC} self-test: domain imports caught, primitive and type imports cleared"
+fi
 
 if [ -d "$PROJECT_ROOT/src/services/clients" ]; then
-    # Look for imports of TauriTransport or HttpTransport directly
-    DIRECT_IMPORTS=$(grep -rn "import.*from.*transport/tauri\|import.*from.*transport/http\|TauriTransport\|HttpTransport" "$PROJECT_ROOT/src/services/clients" 2>/dev/null || true)
-    
-    if [ -n "$DIRECT_IMPORTS" ]; then
-        echo -e "${RED}❌ VIOLATION: Direct transport implementation imports found${NC}"
-        echo "$DIRECT_IMPORTS"
+    CLIENT_FILES=$(find "$PROJECT_ROOT/src/services/clients" -name '*.ts' -o -name '*.tsx' 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$CLIENT_FILES" -eq 0 ]; then
+        # Liveness guard. An empty scan is indistinguishable from a clean one, and
+        # that is precisely how the previous version of this rule stayed green.
+        echo -e "${RED}❌ no client modules were scanned — the rule cannot have passed${NC}"
         VIOLATIONS=$((VIOLATIONS + 1))
     else
-        echo -e "${GREEN}✓ No direct transport imports in client modules${NC}"
+        DIRECT_IMPORTS=$(transport_import_violations "$PROJECT_ROOT/src/services/clients")
+
+        if [ -n "$DIRECT_IMPORTS" ]; then
+            echo -e "${RED}❌ VIOLATION: client module imports a transport domain API${NC}"
+            echo "$DIRECT_IMPORTS"
+            echo "  Allowed: transport/api/client (the primitive) and transport/types/*."
+            echo "  A client needing a domain API should not be a client — move it out."
+            VIOLATIONS=$((VIOLATIONS + 1))
+        else
+            echo -e "${GREEN}✓ No domain-API imports in client modules${NC} ($CLIENT_FILES scanned)"
+        fi
     fi
 else
     echo -e "${YELLOW}⚠ src/services/clients/ does not exist yet${NC}"

--- a/src/services/transport/errors.ts
+++ b/src/services/transport/errors.ts
@@ -1,8 +1,14 @@
 /**
  * Transport error handling.
  * 
- * Both TauriTransport and HttpTransport throw only TransportError.
- * This ensures consistent error handling across platforms.
+ * `readData` below maps HTTP-status failures and body-decode failures to
+ * TransportError. Errors from other sources — a `fetch` rejection, a failed
+ * Tauri `invoke` — are rethrown unchanged by `api/client.ts`, so a caller can
+ * still receive a plain `Error`. Note `TransportErrorCode` declares `NETWORK`,
+ * which nothing in this directory constructs.
+ *
+ * This header previously described two classes, `TauriTransport` and
+ * `HttpTransport`. Neither appears anywhere in the tree.
  */
 
 import { appLogger } from '../platform';


### PR DESCRIPTION
Rule 2's banner said "Clients import only getTransport, not transport
implementations". Its grep looked for `transport/tauri`, `transport/http`,
`TauriTransport` and `HttpTransport`. None of the four appears anywhere in the
tree, so the rule could not fail.

It also did not describe the directory it guards: `clients/benchmark.ts` imports
`transport/api/client` directly, and neither client module imports
`getTransport`.

So the rule is restated as one that holds. A client module may use the low-level
primitive (`transport/api/client`, which supplies the base URL and auth headers)
and may import types, but must not reach into a domain API module — that is the
layer whose work these modules do themselves, so an import from there means the
module should not be a client. Both current clients satisfy it unchanged. It is
deliberately not written as "imports only getTransport", since neither client
does.

Three things borrowed from `check_param_source_exhaustive.sh`:

- A **self-test** against known-bad and known-good fixtures before the real scan.
  It caught four bugs in this rule while it was being written: a pattern
  requiring a trailing slash that missed `from '../transport'`, the same bug in
  the allow-list rejecting `from '../transport/types'`, a pattern that missed
  `await import(...)`, and one that missed a template-literal specifier.
- A **liveness guard** failing on a zero-file scan, since an empty scan and a
  clean one are indistinguishable.
- **Specifier-scoped filtering.** The allow-list matches the extracted import
  path rather than the whole line.

Mutation-verified against a static domain import and a dynamic
`await import(...)`: both are reported with file and line, exit 1; removing them
returns exit 0.

Also rewrites the header of `transport/errors.ts`, which described two classes
that do not appear in the tree. The replacement states where TransportError is
actually produced — `readData`, for HTTP-status and body-decode failures — and
that `api/client.ts` rethrows other errors unchanged, so a caller can still
receive a plain `Error`. `TransportErrorCode` declares a `NETWORK` variant that
nothing in that directory constructs.

`scripts/README.md` described only Rule 1, and the script's exit-code table
named only platform branching.