### PR TITLE
chore(download,mcp,gui): delete re-exports nothing consumes, and re-arm the compiler

### DIFF
--- a/crates/gglib-app-services/src/lib.rs
+++ b/crates/gglib-app-services/src/lib.rs
@@ -34,17 +34,17 @@ pub mod types;
 pub use error::GuiError;
 
 // Domain ops + their Deps
-pub use benchmark::{BenchmarkDeps, BenchmarkOps};
-pub use downloads::{DownloadDeps, DownloadOps};
-pub use mcp::{McpDeps, McpOps};
+pub use benchmark::BenchmarkOps;
+pub use downloads::DownloadOps;
+pub use mcp::McpOps;
 pub use models::{ModelDeps, ModelOps};
-pub use proxy::{ProxyDeps, ProxyOps};
+pub use proxy::ProxyOps;
 pub use sampling_explain::{
     ParamProvenanceDto, ProvenanceKindDto, SamplingExplanationDto, SamplingLayerDto,
 };
-pub use servers::{ServerDeps, ServerOps};
+pub use servers::ServerOps;
 pub use service_graph::{AppServices, ServiceGraphParams, build_service_graph};
-pub use settings::{SettingsDeps, SettingsOps};
+pub use settings::SettingsOps;
 pub use setup::{GpuInfoDto, SetupDeps, SetupOps, SetupStatus};
 
 // Re-export commonly used types from gglib-core for convenience

--- a/crates/gglib-app-services/src/test_support.rs
+++ b/crates/gglib-app-services/src/test_support.rs
@@ -273,7 +273,7 @@ pub(crate) async fn test_core_and_proxy() -> (Arc<AppCore>, Arc<crate::ProxyOps>
             CacheRamSetting::Auto,
         ))));
 
-    let proxy = Arc::new(crate::ProxyOps::new(crate::ProxyDeps {
+    let proxy = Arc::new(crate::proxy::ProxyOps::new(crate::proxy::ProxyDeps {
         supervisor: Arc::new(ProxySupervisor::new()),
         model_repo: repos.models.clone(),
         mcp: Arc::new(McpService::new(repos.mcp_servers.clone())),

--- a/crates/gglib-download/src/lib.rs
+++ b/crates/gglib-download/src/lib.rs
@@ -22,15 +22,8 @@ mod resolver;
 // rather than a fixed tick and so needs its own emission rate limit.
 pub use progress::ProgressThrottle;
 
-// Re-export queue types needed by consumers
-pub use queue::ShardGroupId;
-
-// Re-export resolver for CLI usage
-pub use resolver::HfQuantizationResolver;
-
 // Quantization selection service
 mod quant_selector;
-pub use quant_selector::{QuantizationSelection, QuantizationSelector, SelectionError};
 
 // CLI execution module (list_quantizations + Python bridge helpers)
 pub mod cli_exec;
@@ -42,7 +35,4 @@ pub use cli_emitter::{CliDownloadEventEmitter, rate_suffix, total_bytes_key};
 // Public API - modular download manager
 mod manager;
 
-pub use manager::{
-    CompletedJob, DownloadDestination, DownloadJob, DownloadManagerDeps, DownloadManagerImpl,
-    ProgressUpdate, QueueAutoResult, WorkerDeps, build_download_manager,
-};
+pub use manager::{DownloadManagerDeps, build_download_manager};

--- a/crates/gglib-download/src/manager/mod.rs
+++ b/crates/gglib-download/src/manager/mod.rs
@@ -36,8 +36,8 @@ use crate::resolver::HfQuantizationResolver;
 
 use shard_group_tracker::{GroupMetadata, ShardGroupTracker};
 
-pub use paths::DownloadDestination;
-pub use worker::{CompletedJob, DownloadJob, ProgressUpdate, WorkerDeps};
+pub(crate) use paths::DownloadDestination;
+pub(crate) use worker::{CompletedJob, DownloadJob, ProgressUpdate, WorkerDeps};
 
 /// How often the progress bridge samples the worker and emits an event.
 ///
@@ -238,8 +238,8 @@ where
 
 /// Concrete implementation of the download manager.
 ///
-/// This struct is public but adapters should typically use
-/// `Arc<dyn DownloadManagerPort>` instead of depending on this type directly.
+/// Produced by [`build_download_manager`] and consumed as
+/// `Arc<dyn DownloadManagerPort>`; it is no longer nameable outside this crate.
 pub struct DownloadManagerImpl {
     /// Model registrar for completed downloads.
     model_registrar: Arc<dyn ModelRegistrarPort>,

--- a/crates/gglib-download/src/manager/paths.rs
+++ b/crates/gglib-download/src/manager/paths.rs
@@ -9,7 +9,7 @@ use gglib_core::download::{DownloadError, DownloadId};
 
 /// A planned download destination.
 #[derive(Debug, Clone)]
-pub struct DownloadDestination {
+pub(crate) struct DownloadDestination {
     /// The model directory where files will be stored.
     pub model_dir: PathBuf,
     /// The files to download (relative paths within the model dir).
@@ -24,7 +24,7 @@ impl DownloadDestination {
     /// * `models_directory` - Base directory for all models
     /// * `id` - Download ID used to derive the subdirectory name
     /// * `files` - List of files to download
-    pub fn plan(models_directory: &Path, id: &DownloadId, files: Vec<String>) -> Self {
+    pub(crate) fn plan(models_directory: &Path, id: &DownloadId, files: Vec<String>) -> Self {
         // Convert repo ID to a safe directory name (replace / with _)
         let dir_name = id.model_id().replace('/', "_");
         let model_dir = models_directory.join(dir_name);
@@ -33,7 +33,7 @@ impl DownloadDestination {
     }
 
     /// Ensure the model directory exists, creating it if necessary.
-    pub fn ensure_dir(&self) -> Result<(), DownloadError> {
+    pub(crate) fn ensure_dir(&self) -> Result<(), DownloadError> {
         if !self.model_dir.exists() {
             std::fs::create_dir_all(&self.model_dir)
                 .map_err(|e| DownloadError::io("create_dir", e.to_string()))?;
@@ -42,12 +42,12 @@ impl DownloadDestination {
     }
 
     /// Get the primary file path (first file in the list).
-    pub fn primary_path(&self) -> Option<PathBuf> {
+    pub(crate) fn primary_path(&self) -> Option<PathBuf> {
         self.files.first().map(|f| self.model_dir.join(f))
     }
 
     /// Get all file paths.
-    pub fn all_paths(&self) -> Vec<PathBuf> {
+    pub(crate) fn all_paths(&self) -> Vec<PathBuf> {
         self.files.iter().map(|f| self.model_dir.join(f)).collect()
     }
 }

--- a/crates/gglib-download/src/manager/worker.rs
+++ b/crates/gglib-download/src/manager/worker.rs
@@ -37,7 +37,7 @@ use super::paths::DownloadDestination;
 /// completion state the manager sequences. Progress and terminal events
 /// still flow exclusively through the watch channel and `finalize_job`.
 #[derive(Clone)]
-pub struct WorkerDeps {
+pub(crate) struct WorkerDeps {
     /// Configuration (models directory, HF token, etc.).
     pub config: DownloadManagerConfig,
     /// Event sink for [`DownloadEvent::DownloadNotice`] only.
@@ -48,7 +48,7 @@ pub struct WorkerDeps {
 ///
 /// This is a value type containing all information needed to execute
 /// a download, with no references back to the manager.
-pub struct DownloadJob {
+pub(crate) struct DownloadJob {
     /// The download ID.
     pub id: DownloadId,
     /// Planned destination (model directory + files).
@@ -70,7 +70,7 @@ pub struct DownloadJob {
 
 /// Progress update sent through the watch channel.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ProgressUpdate {
+pub(crate) struct ProgressUpdate {
     /// Bytes downloaded so far.
     pub downloaded: u64,
     /// Total bytes to download.
@@ -80,8 +80,11 @@ pub struct ProgressUpdate {
 }
 
 impl ProgressUpdate {
-    /// Create a new progress update with a sequence number.
-    pub const fn new(downloaded: u64, total: u64, seq: u64) -> Self {
+    /// Test-only: production seeds the watch channel with `default()` and moves
+    /// it forward with `send_modify`, never constructing one this way. Gated so
+    /// `dead_code` keeps telling the truth about production reach.
+    #[cfg(test)]
+    pub(crate) const fn new(downloaded: u64, total: u64, seq: u64) -> Self {
         Self {
             downloaded,
             total,
@@ -92,9 +95,7 @@ impl ProgressUpdate {
 
 /// Result of a successful download.
 #[derive(Debug, Clone)]
-pub struct CompletedJob {
-    /// The download ID.
-    pub id: DownloadId,
+pub(crate) struct CompletedJob {
     /// Path to the primary downloaded file.
     pub primary_path: PathBuf,
     /// All downloaded file paths.
@@ -184,7 +185,6 @@ pub(crate) async fn run_job(
     );
 
     Ok(CompletedJob {
-        id: job.id,
         primary_path,
         all_paths,
         repo_id,

--- a/crates/gglib-download/src/quant_selector.rs
+++ b/crates/gglib-download/src/quant_selector.rs
@@ -34,7 +34,7 @@ const DEFAULT_QUANT_PREFERENCE: &[&str] = &["Q5_K_M", "Q4_K_M", "Q5_K_S", "Q4_K_
 
 /// Result of quantization selection.
 #[derive(Debug, Clone)]
-pub struct QuantizationSelection {
+pub(crate) struct QuantizationSelection {
     /// The selected quantization.
     pub quantization: Quantization,
     /// Whether this was auto-selected (vs. explicitly requested).
@@ -115,13 +115,13 @@ impl From<SelectionError> for DownloadError {
 /// Quantization selection service.
 ///
 /// Uses a resolver to list available quantizations and applies selection rules.
-pub struct QuantizationSelector {
+pub(crate) struct QuantizationSelector {
     resolver: Arc<dyn QuantizationResolver>,
 }
 
 impl QuantizationSelector {
     /// Create a new selector with the given resolver.
-    pub fn new(resolver: Arc<dyn QuantizationResolver>) -> Self {
+    pub(crate) fn new(resolver: Arc<dyn QuantizationResolver>) -> Self {
         Self { resolver }
     }
 
@@ -141,7 +141,7 @@ impl QuantizationSelector {
     /// - `NoQuantizationsAvailable` if the repo has no GGUF files
     /// - `QuantizationNotFound` if the requested quant doesn't exist
     /// - `SelectionRequired` if multiple quants exist but none match defaults
-    pub async fn select(
+    pub(crate) async fn select(
         &self,
         repo_id: &str,
         requested: Option<&str>,

--- a/crates/gglib-download/src/queue/mod.rs
+++ b/crates/gglib-download/src/queue/mod.rs
@@ -8,7 +8,7 @@ use gglib_core::download::{
     CompletionKey, DownloadError, DownloadId, DownloadStatus, QueueSnapshot, ShardInfo,
 };
 
-pub use shard_group::ShardGroupId;
+pub(crate) use shard_group::ShardGroupId;
 pub(crate) use types::{FailedItem, QueuedItem};
 
 /// Saturating conversion from usize to u32 for queue positions.

--- a/crates/gglib-download/src/queue/shard_group.rs
+++ b/crates/gglib-download/src/queue/shard_group.rs
@@ -11,28 +11,33 @@ use gglib_core::download::DownloadId;
 /// (cancel all, fail all, retry all). The group ID contains the download ID
 /// plus a unique suffix to distinguish different download attempts.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ShardGroupId(String);
+pub(crate) struct ShardGroupId(String);
 
 impl ShardGroupId {
     /// Create a new shard group ID from a string.
-    pub fn new(id: impl Into<String>) -> Self {
+    pub(crate) fn new(id: impl Into<String>) -> Self {
         Self(id.into())
+    }
+
+    /// Get the inner string reference.
+    ///
+    /// Test-only: production reads this type through its [`fmt::Display`] impl.
+    /// Kept rather than deleted so the tests below need not hand-roll it, and
+    /// gated so `dead_code` keeps telling the truth about production reach.
+    #[cfg(test)]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
     }
 
     /// Generate a unique group ID for a download.
     ///
     /// Uses a simple counter-based approach instead of UUID to avoid
     /// the dependency on uuid crate in this module.
-    pub fn generate(download_id: &DownloadId) -> Self {
+    pub(crate) fn generate(download_id: &DownloadId) -> Self {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
         Self(format!("{download_id}:{seq}"))
-    }
-
-    /// Get the inner string reference.
-    pub fn as_str(&self) -> &str {
-        &self.0
     }
 }
 

--- a/crates/gglib-download/src/resolver/mod.rs
+++ b/crates/gglib-download/src/resolver/mod.rs
@@ -7,13 +7,13 @@ use gglib_core::download::{DownloadError, Quantization};
 use gglib_core::ports::{HfClientPort, QuantizationResolver, Resolution, ResolvedFile};
 
 /// Resolver that uses the `HuggingFace` client port.
-pub struct HfQuantizationResolver {
+pub(crate) struct HfQuantizationResolver {
     hf_client: Arc<dyn HfClientPort>,
 }
 
 impl HfQuantizationResolver {
     /// Create a new resolver with the given HF client.
-    pub fn new(hf_client: Arc<dyn HfClientPort>) -> Self {
+    pub(crate) fn new(hf_client: Arc<dyn HfClientPort>) -> Self {
         Self { hf_client }
     }
 }

--- a/crates/gglib-mcp/src/builtin/README.md
+++ b/crates/gglib-mcp/src/builtin/README.md
@@ -13,7 +13,7 @@ server process rather than through an external MCP child process.
 # Tool-name format
 
 Names are qualified with `"builtin:"` (e.g. `"builtin:get_current_time"`),
-matching the convention used by [`crate::McpToolExecutorAdapter`] where names
+matching the convention used by [`crate::tool_executor::McpToolExecutorAdapter`] where names
 are qualified with the numeric server id (e.g. `"3:read_file"`).
 [`crate::CombinedToolExecutor`] routes calls with the `"builtin:"` prefix here.
 

--- a/crates/gglib-mcp/src/lib.rs
+++ b/crates/gglib-mcp/src/lib.rs
@@ -27,11 +27,7 @@ pub use gglib_core::{
     McpEnvEntry, McpLifecycle, McpServer, McpServerConfig, McpServerStatus, McpServerType, McpTool,
     McpToolResult, NewMcpServer,
 };
-// Re-export DTOs from core ports
-pub use gglib_core::ports::{ResolutionAttempt, ResolutionStatus};
-
 // Re-export this crate's public types
 pub use builtin::BuiltinToolExecutorAdapter;
 pub use combined::CombinedToolExecutor;
 pub use service::{McpServerInfo, McpService};
-pub use tool_executor::McpToolExecutorAdapter;

--- a/crates/gglib-mcp/src/tool_executor.rs
+++ b/crates/gglib-mcp/src/tool_executor.rs
@@ -15,13 +15,20 @@
 //!
 //! # Wiring
 //!
-//! Entrypoint crates (`gglib-axum`, `gglib-cli`) construct this adapter at the
-//! composition root:
+//! This adapter is not constructed by the entrypoint crates. It is wrapped by
+//! [`crate::combined::CombinedToolExecutor`], which `gglib-runtime`'s
+//! `compose::compose_agent_loop_inner` builds:
 //!
 //! ```rust,ignore
-//! let executor: Arc<dyn ToolExecutorPort> =
-//!     Arc::new(McpToolExecutorAdapter::new(Arc::clone(&mcp_service)));
+//! let tool_executor: Arc<dyn ToolExecutorPort> = match sandbox_root {
+//!     Some(root) => Arc::new(CombinedToolExecutor::with_sandbox(mcp, root)),
+//!     None => Arc::new(CombinedToolExecutor::new(mcp)),
+//! };
 //! ```
+//!
+//! The previous version of this note named `gglib-axum` and `gglib-cli` as the
+//! constructing crates. Neither names this type; the crate-root re-export of it
+//! had no consumer to lose.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -50,13 +57,13 @@ use crate::service::McpService;
 /// (`"{server_id}:{bare_name}"`) to route the call directly.  No list scan
 /// is required; the server-id is encoded in the name itself.
 #[derive(Clone)]
-pub struct McpToolExecutorAdapter {
+pub(crate) struct McpToolExecutorAdapter {
     mcp: Arc<McpService>,
 }
 
 impl McpToolExecutorAdapter {
     /// Wrap an existing `McpService` handle.
-    pub const fn new(mcp: Arc<McpService>) -> Self {
+    pub(crate) const fn new(mcp: Arc<McpService>) -> Self {
         Self { mcp }
     }
 }

--- a/crates/gglib-runtime/src/compose.rs
+++ b/crates/gglib-runtime/src/compose.rs
@@ -5,8 +5,9 @@
 //!
 //! 1. `LlmCompletionAdapter::with_client(…)` — wrap `reqwest::Client` as an
 //!    [`LlmCompletionPort`].
-//! 2. `McpToolExecutorAdapter::new(…)` — wrap [`McpService`] as a
-//!    [`ToolExecutorPort`].
+//! 2. `CombinedToolExecutor::{new, with_sandbox}(…)` — wrap [`McpService`] as a
+//!    [`ToolExecutorPort`], routing qualified names to MCP and bare ones to the
+//!    built-ins.
 //! 3. `AgentLoop::build(llm, tool_executor, tool_filter)` — compose both
 //!    ports into an [`AgentLoopPort`], optionally filtering the tool set.
 //!


### PR DESCRIPTION
A `pub use` at a crate root is reachable, so `dead_code` never examines what it
exports.

Removed, each verified to have no consumer outside its defining crate:

- gglib-download: `ShardGroupId`, `HfQuantizationResolver`, `QuantizationSelection`,
  `QuantizationSelector`, `SelectionError`, and seven of the nine names in the
  `manager` block (`CompletedJob`, `DownloadDestination`, `DownloadJob`,
  `DownloadManagerImpl`, `ProgressUpdate`, `QueueAutoResult`, `WorkerDeps`).
- gglib-mcp: `ResolutionAttempt`, `ResolutionStatus`, `McpToolExecutorAdapter`.
- gglib-app-services: `BenchmarkDeps`, `DownloadDeps`, `McpDeps`, `ProxyDeps`,
  `ServerDeps`, `SettingsDeps`.

Kept, because they do have external consumers: `ProgressThrottle` (src-tauri's
llama installer), `DownloadManagerDeps` and `build_download_manager`
(gglib-bootstrap), `ModelDeps` and `SetupDeps` (gglib-cli). The download
`manager` block was a mixed line — deleting it wholesale would have taken two
live names with it.

`ResolutionAttempt` and `ResolutionStatus` are worth stating precisely, since a
reference count says otherwise: both types are used, but through
`gglib_core::ports::…` directly rather than through the gglib-mcp re-export,
which is what is removed here.

Closing those doors is the point. It turned a batch of items into
`unreachable_pub` errors, now narrowed to `pub(crate)`, and surfaced three that
`dead_code` could not previously reach. Two of the three are test-only rather
than dead (`ShardGroupId::as_str`, `ProgressUpdate::new`): a plain `cargo check`
reports them unused because it does not compile tests, and `--all-targets` shows
the tests that use them. Both are now `#[cfg(test)]`, so `dead_code` answers
about production reach. The third, `CompletedJob.id`, is removed: it was written
from `job.id` and never read, because every consumer already takes the
`QueuedItem` beside it and reads the identity there.

Three doc corrections the deletions forced:

- `gglib-mcp/src/builtin/README.md` linked `[crate::McpToolExecutorAdapter]`,
  which resolved through the re-export being removed. It now points at
  `crate::tool_executor::McpToolExecutorAdapter`.
- `tool_executor.rs`'s "# Wiring" section said entrypoint crates construct the
  adapter at the composition root. Neither names the type; `gglib-runtime`'s
  `compose::compose_agent_loop_inner` builds `CombinedToolExecutor`, which wraps
  it. `compose.rs`'s own numbered wiring list said the same thing about itself
  and is corrected in step.
- `DownloadManagerImpl`'s doc offered a choice between naming the type and using
  `Arc<dyn DownloadManagerPort>`; the re-export removal settles it.

Ratchet: manager/worker.rs is the only touched file on the baseline and lands
back at its recorded 316. tool_executor.rs and queue/shard_group.rs both stay
under the 300 budget and are unrecorded.