### PR TITLE
fix(core,gui): drop the health flag that was always false

### DIFF
--- a/crates/gglib-app-services/src/servers.rs
+++ b/crates/gglib-app-services/src/servers.rs
@@ -246,7 +246,6 @@ impl ServerOps {
                     model_id: id.to_string(),
                     model_name: model.name.clone(),
                     port: 0, // No port on failure
-                    healthy: Some(false),
                 };
                 self.deps.server_events.error(&error_summary, &e);
                 map_runtime_error(&e)
@@ -259,7 +258,6 @@ impl ServerOps {
             model_id: id.to_string(),
             model_name: model.name.clone(),
             port: target.port,
-            healthy: Some(true), // Assume healthy on successful start
         };
         self.deps.server_events.started(&summary);
 
@@ -357,7 +355,6 @@ impl ServerOps {
             model_id: id.to_string(),
             model_name: model.name.clone(),
             port: running.port,
-            healthy: None, // Unknown during shutdown
         };
         self.deps.server_events.stopping(&summary);
 
@@ -431,7 +428,6 @@ impl ServerOps {
                         model_id: server.model_id.to_string(),
                         model_name: model.name,
                         port: server.port,
-                        healthy: None,
                     });
                 }
                 Ok(None) => {
@@ -440,7 +436,6 @@ impl ServerOps {
                         model_id: server.model_id.to_string(),
                         model_name: format!("Model {}", server.model_id),
                         port: server.port,
-                        healthy: None,
                     });
                 }
                 Err(_) => continue,
@@ -795,7 +790,6 @@ mod tests {
             model_id: "42".to_string(),
             model_name: "TestModel".to_string(),
             port: 8080,
-            healthy: Some(true),
         };
 
         recorder.started(&summary);

--- a/crates/gglib-core/src/events/server.rs
+++ b/crates/gglib-core/src/events/server.rs
@@ -21,8 +21,6 @@ pub struct ServerSummary {
     pub model_name: String,
     /// Port the server is listening on.
     pub port: u16,
-    /// Health status (None = unknown/pending).
-    pub healthy: Option<bool>,
 }
 
 /// Port for emitting server lifecycle events.
@@ -110,8 +108,6 @@ pub struct ServerSnapshotEntry {
     /// Unix timestamp (seconds) when started.
     #[cfg_attr(feature = "ts-bindings", ts(type = "number"))]
     pub started_at: u64,
-    /// Whether the server is healthy.
-    pub healthy: bool,
 }
 
 impl AppEvent {
@@ -181,7 +177,6 @@ impl AppEvent {
                 model_name: s.model_name.clone(),
                 port: s.port,
                 started_at,
-                healthy: s.healthy.unwrap_or(false),
             })
             .collect();
         Self::server_snapshot(entries)
@@ -198,7 +193,6 @@ mod tests {
             model_id: model_id.to_string(),
             model_name: name.to_string(),
             port,
-            healthy: Some(true),
         }
     }
 

--- a/src/services/serverEvents.normalize.ts
+++ b/src/services/serverEvents.normalize.ts
@@ -98,10 +98,11 @@ function normalizeSnapshot(data: Record<string, unknown>): ServerEvent | null {
  * A separate entry point rather than a snake_case fallback inside
  * [`normalizeServerEventFromAppEvent`], because this is not an `AppEvent` and
  * never was — it is a REST list the caller re-wrapped to look like one. The
- * two producers really do disagree: `ServerSnapshotEntry` is camelCase with a
- * `healthy` flag, `ServerInfo` is snake_case with a `pid`. Naming both paths
- * is what lets each read exactly the shape its own producer sends, instead of
- * one tolerant reader accepting either and documenting neither.
+ * two producers really do disagree: `ServerSnapshotEntry` is camelCase, while
+ * `ServerInfo` is snake_case and carries a `pid` the registry has no use for.
+ * Naming both paths is what lets each read exactly the shape its own producer
+ * sends, instead of one tolerant reader accepting either and documenting
+ * neither.
  *
  * Total, not `null`-returning: there is no whole-payload failure to report,
  * only individual entries — malformed, or with an id that will not coerce —

--- a/src/types/generated/ServerSnapshotEntry.ts
+++ b/src/types/generated/ServerSnapshotEntry.ts
@@ -19,8 +19,4 @@ port: number,
 /**
  * Unix timestamp (seconds) when started.
  */
-startedAt: number, 
-/**
- * Whether the server is healthy.
- */
-healthy: boolean, };
+startedAt: number, };

--- a/tests/ts/services/server/serverEvents.normalize.test.ts
+++ b/tests/ts/services/server/serverEvents.normalize.test.ts
@@ -26,7 +26,6 @@ describe('serverEvents.normalize', () => {
           modelName: 'M',
           port: MOCK_PROXY_PORT,
           startedAt: 1_700_000_000,
-          healthy: true,
         },
       ],
     });
@@ -136,10 +135,10 @@ describe('serverEvents.normalize', () => {
    * The hydration path, and the reason there are two entry points.
    *
    * `GET /api/servers` reports the same running servers as the SSE snapshot,
-   * in a different shape: snake_case keys, a `pid` the registry has no use
-   * for, and no `healthy`. It is the current schema, not a legacy one — this
-   * test used to claim otherwise while being the only cover for the branch
-   * that made startup hydration work.
+   * in a different shape: snake_case keys and a `pid` the registry has no use
+   * for. It is the current schema, not a legacy one — this test used to claim
+   * otherwise while being the only cover for the branch that made startup
+   * hydration work.
    */
   it('normalizes the REST server list, which is snake_case', () => {
     const evt = normalizeServerSnapshotFromList([


### PR DESCRIPTION
`ServerSnapshotEntry.healthy` was populated by one expression,
`healthy: s.healthy.unwrap_or(false)`, from a `ServerSummary.healthy` that the
producer of that slice sets to `None` at both of its push sites. Every
`server_snapshot` frame the daemon emitted therefore reported the fleet as
unhealthy.

It reached clients: `ServerSnapshotEntry` is ts-rs exported and declared
`healthy: boolean` — not optional — in the generated bindings. Nothing reads it,
which is why this was harmless. The frontend's `snapshotEntry` copies `modelId`,
`modelName`, `port` and `startedAt`.

A serialized field that cannot be true is worse than an absent one: it is a claim
the backend makes and cannot honour, and whoever wired the UI to it would inherit
a permanently-unhealthy fleet. Removed rather than fixed, per the decision taken
for this sweep; if snapshot health is wanted later it should come from the health
monitor `build_server_snapshot` already runs alongside.

`ServerSummary.healthy` goes with it. Its other assignments — `Some(true)` on a
successful start, `Some(false)` on an error, `None` during shutdown — fed the
`ServerEvents` start, stop and error methods. The implementations of those three
(the Axum adapter, the noop, the recording test double) use `model_id`,
`model_name` and `port`. The one reader of the field anywhere was
`from_server_snapshot`, above.

Bindings regenerated. Two comments described `healthy` as part of the snapshot
shape and are corrected: the header on `serverEvents.normalize.ts` and the
hydration test's doc comment. That test's fixture also carried a `healthy: true`
that no longer type-checks.