### PR TITLE
refactor(core,axum,proxy): one constant-time comparison, not two

### DIFF
--- a/crates/gglib-axum/src/access.rs
+++ b/crates/gglib-axum/src/access.rs
@@ -24,7 +24,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use gglib_core::access::{is_loopback_host, normalize_host};
+use gglib_core::access::{constant_time_eq, is_loopback_host, normalize_host};
 use gglib_core::{CorsConfig, ProxyAccessConfig};
 use serde_json::json;
 use tracing::warn;
@@ -159,28 +159,9 @@ pub(crate) async fn bearer_guard(
         .into_response()
 }
 
-/// Compare two byte strings without an early exit on the first difference,
-/// so response timing does not leak how many leading bytes of the token a
-/// caller guessed right. The length check leaks only the token's length,
-/// which is not the secret.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn constant_time_eq_agrees_with_equality() {
-        assert!(constant_time_eq(b"Bearer abc", b"Bearer abc"));
-        assert!(constant_time_eq(b"", b""));
-        assert!(!constant_time_eq(b"Bearer abc", b"Bearer abd"));
-        assert!(!constant_time_eq(b"Bearer abc", b"Bearer ab"));
-    }
 
     /// Loopback binds keep the proxy's strict policy: no IP-literal
     /// exemption, no foreign hostnames.

--- a/crates/gglib-core/src/access/mod.rs
+++ b/crates/gglib-core/src/access/mod.rs
@@ -27,6 +27,26 @@ pub enum ApiKeySource {
     None,
 }
 
+/// Compare two byte strings without an early exit on the first difference, so
+/// response timing does not leak how many leading bytes of a secret a caller
+/// guessed right.
+///
+/// The length check is a deliberate exception: it leaks only the secret's
+/// length, which is not the secret, and comparing unequal-length slices has no
+/// meaningful definition.
+///
+/// Lives here because both `gglib-axum` and `gglib-proxy` guard bearer tokens
+/// and each had a byte-identical private copy. `normalize_host`, which both
+/// guards also call, already lived here. A hardening change to one private copy
+/// would not have been reported against the other by any lint.
+#[must_use]
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
 /// Mint a bearer token for an endpoint that is about to be exposed off
 /// loopback.
 ///
@@ -137,6 +157,24 @@ impl ProxyAccessConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The proxy's superset of the two former private copies: it also covers the
+    /// empty-vs-nonempty case, which the axum copy did not.
+    #[test]
+    fn constant_time_eq_agrees_with_equality() {
+        assert!(constant_time_eq(b"Bearer abc", b"Bearer abc"));
+        assert!(constant_time_eq(b"", b""));
+        assert!(!constant_time_eq(b"Bearer abc", b"Bearer abd"));
+        assert!(!constant_time_eq(b"Bearer abc", b"Bearer ab"));
+        assert!(!constant_time_eq(b"", b"x"));
+    }
+
+    /// A prefix match must not pass — the failure mode a naive `starts_with`
+    /// would introduce.
+    #[test]
+    fn constant_time_eq_rejects_a_prefix() {
+        assert!(!constant_time_eq(b"Bearer secret", b"Bearer secret-extra"));
+    }
 
     #[test]
     fn no_api_key_means_no_expected_header() {

--- a/crates/gglib-proxy/src/access/mod.rs
+++ b/crates/gglib-proxy/src/access/mod.rs
@@ -9,6 +9,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use gglib_core::ProxyAccessConfig;
+use gglib_core::access::constant_time_eq;
 use tracing::warn;
 
 use crate::models::ErrorResponse;
@@ -99,43 +100,4 @@ pub(crate) async fn bearer_guard(
         )),
     )
         .into_response()
-}
-
-/// Compare two byte strings without an early exit on the first difference.
-///
-/// A `==` on the token would return as soon as two bytes differ, and the time
-/// that takes is a function of how many leading bytes the attacker guessed
-/// right — enough, over many requests, to recover the token one byte at a time.
-/// Folding every byte into a single accumulator makes the comparison take the
-/// same time whatever the input.
-///
-/// The length check is a deliberate exception: it leaks only the token's
-/// length, which is not the secret, and comparing unequal-length slices has no
-/// meaningful definition.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn constant_time_eq_agrees_with_equality() {
-        assert!(constant_time_eq(b"Bearer abc", b"Bearer abc"));
-        assert!(constant_time_eq(b"", b""));
-        assert!(!constant_time_eq(b"Bearer abc", b"Bearer abd"));
-        assert!(!constant_time_eq(b"Bearer abc", b"Bearer ab"));
-        assert!(!constant_time_eq(b"", b"x"));
-    }
-
-    /// A prefix match must not pass — the failure mode a naive `starts_with`
-    /// would introduce.
-    #[test]
-    fn constant_time_eq_rejects_a_prefix() {
-        assert!(!constant_time_eq(b"Bearer secret", b"Bearer secret-extra"));
-    }
 }


### PR DESCRIPTION
`gglib-axum` and `gglib-proxy` each carried a private `constant_time_eq` with a
byte-identical body, and each guards bearer tokens with it. This is the
authentication path: a hardening change to one copy would not have been reported
against the other by any lint, because neither is dead and neither is public.

`normalize_host`, which both guards also call, already lives in
`gglib_core::access`, so the comparison joins it there beside `generate_api_key`
and `ApiKeySource`. Adding to the existing `mod.rs` means no module-table churn.

The tests move with it, since a unit test for a core function has no business
living in a surface crate. The proxy's block was the larger of the two — it adds
an empty-versus-nonempty case to the four assertions axum had, plus a separate
prefix test guarding the failure mode a naive `starts_with` would introduce — so
that is the one kept, and axum's are dropped rather than merged.
`gglib-proxy`'s `access` test module is left empty by the move and goes with it;
the guards' own behaviour is covered by `integration_auth` and `daemon_access`.

The guards themselves are deliberately not merged. Axum answers with
`Json(json!({… "type": "HOST_NOT_ALLOWED"}))` while the proxy answers with
`Json(ErrorResponse::with_code(…, "host_not_allowed"))`, over different state
types and different error envelopes. Only the comparison was literally
duplicated, and only it moves.

Going `pub` and cross-crate can cost an inlining opportunity but cannot introduce
an early exit, so no timing property changes. `#[must_use]` only adds a lint, and
both call sites consume the bool in an `if`.