### PR TITLE
fix(ci): point the badge extractors at modules that exist, and let them publish

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -127,8 +127,15 @@ jobs:
             if [ -f "$TEST_FILE" ]; then
               # Count tests that start with the module name (e.g., "domain::" or "handlers::")
               # Look for lines like "test domain::model::tests::..." and count ok/FAILED
-              PASSED=$(grep -E "^test ${MODULE}::" "$TEST_FILE" | grep -c " \.\.\. ok$" || echo "0")
-              FAILED=$(grep -E "^test ${MODULE}::" "$TEST_FILE" | grep -c " \.\.\. FAILED$" || echo "0")
+              # `grep -c` PRINTS 0 and EXITS 1 when it matches nothing, so the old
+              # `|| echo "0"` appended a SECOND zero and made TOTAL="0\n0" — a bad
+              # math expression that aborted the function. Every module with no
+              # failing tests hit it, which is every passing module, which is why
+              # no per-module tests badge has ever been published.
+              PASSED=$(grep -E "^test ${MODULE}::" "$TEST_FILE" | grep -c " \.\.\. ok$" || true)
+              FAILED=$(grep -E "^test ${MODULE}::" "$TEST_FILE" | grep -c " \.\.\. FAILED$" || true)
+              PASSED=${PASSED:-0}
+              FAILED=${FAILED:-0}
               TOTAL=$((PASSED + FAILED))
               
               if [ "$TOTAL" -gt 0 ]; then
@@ -182,69 +189,21 @@ jobs:
           done
           
           # gglib-cli submodules (handlers subdirectories)
-          if [ -f "$CLI_TEST" ]; then
-            # handlers/download/* tests
-            PASSED=$(grep -E "^test handlers::download::" "$CLI_TEST" | grep -c " \.\.\. ok$" || echo "0")
-            FAILED=$(grep -E "^test handlers::download::" "$CLI_TEST" | grep -c " \.\.\. FAILED$" || echo "0")
-            TOTAL=$((PASSED + FAILED))
-            if [ "$TOTAL" -gt 0 ]; then
-              PCT=$((PASSED * 100 / TOTAL))
-              MSG="${PASSED}/${TOTAL}"
-              if [ "$PCT" -eq 100 ]; then COL="brightgreen";
-              elif [ "$PCT" -gt 90 ]; then COL="green";
-              elif [ "$PCT" -gt 80 ]; then COL="yellowgreen";
-              elif [ "$PCT" -gt 60 ]; then COL="yellow";
-              else COL="red"; fi
-              echo "{\"schemaVersion\":1,\"label\":\"tests\",\"message\":\"$MSG\",\"color\":\"$COL\"}" > "badges/gglib-cli-download-tests.json"
-              echo "  gglib-cli-download: $MSG"
-            else
-              echo "{\"schemaVersion\":1,\"label\":\"tests\",\"message\":\"0\",\"color\":\"lightgrey\"}" > "badges/gglib-cli-download-tests.json"
-            fi
-            
-            # handlers/check_deps/* tests
-            PASSED=$(grep -E "^test handlers::check_deps::" "$CLI_TEST" | grep -c " \.\.\. ok$" || echo "0")
-            FAILED=$(grep -E "^test handlers::check_deps::" "$CLI_TEST" | grep -c " \.\.\. FAILED$" || echo "0")
-            TOTAL=$((PASSED + FAILED))
-            if [ "$TOTAL" -gt 0 ]; then
-              PCT=$((PASSED * 100 / TOTAL))
-              MSG="${PASSED}/${TOTAL}"
-              if [ "$PCT" -eq 100 ]; then COL="brightgreen";
-              elif [ "$PCT" -gt 90 ]; then COL="green";
-              elif [ "$PCT" -gt 80 ]; then COL="yellowgreen";
-              elif [ "$PCT" -gt 60 ]; then COL="yellow";
-              else COL="red"; fi
-              echo "{\"schemaVersion\":1,\"label\":\"tests\",\"message\":\"$MSG\",\"color\":\"$COL\"}" > "badges/gglib-cli-check_deps-tests.json"
-              echo "  gglib-cli-check_deps: $MSG"
-            else
-              echo "{\"schemaVersion\":1,\"label\":\"tests\",\"message\":\"0\",\"color\":\"lightgrey\"}" > "badges/gglib-cli-check_deps-tests.json"
-            fi
-            
-            # handlers/check_deps/instructions/* tests
-            PASSED=$(grep -E "^test handlers::check_deps::instructions::" "$CLI_TEST" | grep -c " \.\.\. ok$" || echo "0")
-            FAILED=$(grep -E "^test handlers::check_deps::instructions::" "$CLI_TEST" | grep -c " \.\.\. FAILED$" || echo "0")
-            TOTAL=$((PASSED + FAILED))
-            if [ "$TOTAL" -gt 0 ]; then
-              PCT=$((PASSED * 100 / TOTAL))
-              MSG="${PASSED}/${TOTAL}"
-              if [ "$PCT" -eq 100 ]; then COL="brightgreen";
-              elif [ "$PCT" -gt 90 ]; then COL="green";
-              elif [ "$PCT" -gt 80 ]; then COL="yellowgreen";
-              elif [ "$PCT" -gt 60 ]; then COL="yellow";
-              else COL="red"; fi
-              echo "{\"schemaVersion\":1,\"label\":\"tests\",\"message\":\"$MSG\",\"color\":\"$COL\"}" > "badges/gglib-cli-instructions-tests.json"
-              echo "  gglib-cli-instructions: $MSG"
-            else
-              echo "{\"schemaVersion\":1,\"label\":\"tests\",\"message\":\"0\",\"color\":\"lightgrey\"}" > "badges/gglib-cli-instructions-tests.json"
-            fi
-          fi
-          
+          #
+          # These were three hand-inlined copies of extract_module_tests. All three
+          # named module paths that had moved — handlers/download became
+          # handlers/model/download, handlers/check_deps became
+          # handlers/config/check_deps — and because a miss writes a lightgrey "0"
+          # rather than failing, the READMEs advertised "0 tests" for modules that
+          # are tested. Copies are why exactly these three drifted and the twenty
+          # call sites beside them did not, so they are calls now.
+          extract_module_tests "$CLI_TEST" "handlers::model::download" "gglib-cli-download"
+          extract_module_tests "$CLI_TEST" "handlers::config::check_deps" "gglib-cli-check_deps"
+          extract_module_tests "$CLI_TEST" "handlers::config::check_deps::instructions" "gglib-cli-instructions"
+
           # gglib-axum modules
           AXUM_TEST="$(find artifacts -name 'rust-test-gglib-axum.txt' -type f 2>/dev/null | head -1)"
           extract_module_tests "$AXUM_TEST" "dto" "gglib-axum-dto"
-          
-          # gglib-tauri modules
-          TAURI_TEST="$(find artifacts -name 'rust-test-gglib-tauri.txt' -type f 2>/dev/null | head -1)"
-          extract_module_tests "$TAURI_TEST" "gui_backend" "gglib-tauri-gui_backend"
           
           # gglib-hf modules
           HF_TEST="$(find artifacts -name 'rust-test-gglib-hf.txt' -type f 2>/dev/null | head -1)"
@@ -264,7 +223,7 @@ jobs:
           
           # gglib-agent modules
           AGENT_TEST="$(find artifacts -name 'rust-test-gglib-agent.txt' -type f 2>/dev/null | head -1)"
-          for MODULE in agent_loop context_pruning fnv1a loop_detection stagnation stream_collector tool_execution util; do
+          for MODULE in agent_loop context_pruning stream_collector tool_execution util; do
             extract_module_tests "$AGENT_TEST" "$MODULE" "gglib-agent-$MODULE"
           done
           
@@ -525,17 +484,14 @@ jobs:
           done
           
           # gglib-cli submodules (handlers subdirectories)
-          extract_module_cov "$CLI_LCOV" "src/handlers/download/" "gglib-cli-download"
-          extract_module_cov "$CLI_LCOV" "src/handlers/check_deps/" "gglib-cli-check_deps"
-          extract_module_cov "$CLI_LCOV" "src/handlers/check_deps/instructions/" "gglib-cli-instructions"
+          extract_module_cov "$CLI_LCOV" "src/handlers/model/download/" "gglib-cli-download"
+          extract_module_cov "$CLI_LCOV" "src/handlers/config/check_deps/" "gglib-cli-check_deps"
+          extract_module_cov "$CLI_LCOV" "src/handlers/config/check_deps/instructions/" "gglib-cli-instructions"
           
           # gglib-axum modules
           AXUM_LCOV="$(find artifacts -name 'gglib-axum-lcov.info' -type f 2>/dev/null | head -1)"
           extract_module_cov "$AXUM_LCOV" "src/dto/" "gglib-axum-dto"
           
-          # gglib-tauri modules
-          TAURI_LCOV="$(find artifacts -name 'gglib-tauri-lcov.info' -type f 2>/dev/null | head -1)"
-          extract_module_cov "$TAURI_LCOV" "src/gui_backend/" "gglib-tauri-gui_backend"
           
           # gglib-hf modules
           HF_LCOV="$(find artifacts -name 'gglib-hf-lcov.info' -type f 2>/dev/null | head -1)"
@@ -557,11 +513,11 @@ jobs:
           
           # gglib-agent file modules
           AGENT_LCOV="$(find artifacts -name 'gglib-agent-lcov.info' -type f 2>/dev/null | head -1)"
-          for MODULE in agent_loop fnv1a stream_collector util; do
+          for MODULE in agent_loop stream_collector util; do
             extract_module_cov "$AGENT_LCOV" "src/$MODULE.rs" "gglib-agent-$MODULE"
           done
           # gglib-agent directory modules
-          for MODULE in context_pruning loop_detection stagnation tool_execution; do
+          for MODULE in context_pruning tool_execution; do
             extract_module_cov "$AGENT_LCOV" "src/$MODULE/" "gglib-agent-$MODULE"
           done
           
@@ -892,19 +848,6 @@ jobs:
             echo "  gglib-axum/dto: $LOC loc, $COMPLEXITY complexity"
           fi
           
-          # =============================================================================
-          # Per-module badges for gglib-tauri
-          # =============================================================================
-          if [ -d "crates/gglib-tauri/src/gui_backend" ]; then
-            SCC_DATA=$(scc "crates/gglib-tauri/src/gui_backend" --format json 2>/dev/null | jq '[.[] | select(.Name == "Rust")] | .[0] // {Code: 0, Complexity: 0}')
-            LOC=$(echo "$SCC_DATA" | jq '.Code // 0')
-            COMPLEXITY=$(echo "$SCC_DATA" | jq '.Complexity // 0')
-            LOC_COL=$(loc_color $LOC)
-            CX_COL=$(cx_color $COMPLEXITY)
-            echo "{\"schemaVersion\":1,\"label\":\"loc\",\"message\":\"$LOC\",\"color\":\"$LOC_COL\"}" > "badges/gglib-tauri-gui_backend-loc.json"
-            echo "{\"schemaVersion\":1,\"label\":\"complexity\",\"message\":\"$COMPLEXITY\",\"color\":\"$CX_COL\"}" > "badges/gglib-tauri-gui_backend-complexity.json"
-            echo "  gglib-tauri/gui_backend: $LOC loc, $COMPLEXITY complexity"
-          fi
           
           # =============================================================================
           # Per-module badges for gglib-hf

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,7 @@ This directory contains helper scripts for development, CI enforcement, and docu
 | [check_file_complexity.sh](#check_file_complexitysh) | TypeScript/CSS file-size ratchet | CI |
 | [check_rust_complexity.sh](#check_rust_complexitysh) | Rust file-size ratchet | CI |
 | [check_param_source_exhaustive.sh](#check_param_source_exhaustivesh) | No catch-all arm over `ParamSource` | CI |
-| [check_workflow_yaml.sh](#check_workflow_yamlsh) | No duplicate keys in workflow YAML | CI |
+| [check_workflow_yaml.sh](#check_workflow_yamlsh) | Workflow sanity: duplicate YAML keys, and badges.yml module paths | CI |
 | [check_transport_branching.sh](#check_transport_branchingsh) | Enforce transport layer unification | CI |
 | [check_settings_surfaces.sh](#check_settings_surfacessh) | Every `Settings` field is settable from somewhere | CI |
 | [check-deps.sh](#check-depssh) | Verify system dependencies | `make check-deps` |
@@ -115,6 +115,17 @@ adding a variant a silent behaviour change instead of a compile error.
 ```
 
 ### `check_workflow_yaml.sh`
+
+Two checks over `.github/workflows/`:
+
+1. no duplicate mapping keys;
+2. every module and coverage path named in `badges.yml` still resolves to a
+   directory or file under `crates/`.
+
+The second lives here rather than in `badges.yml` because the two jobs that
+extract test and coverage badges check out the `badges` branch, not the source,
+so they cannot see `crates/`. This script runs under `make enforce`, where the
+source is present.
 
 Fails on duplicate mapping keys in `.github/workflows/`. GitHub rejects such a
 file outright — the run is marked "failed because of a workflow file issue" and

--- a/scripts/check_workflow_yaml.sh
+++ b/scripts/check_workflow_yaml.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Validate .github/workflows/*.yml for duplicate mapping keys.
+# Also checks that every module and coverage path named in badges.yml still
+# resolves under crates/ — see the second section below for why it lives here.
 #
 # GitHub rejects a workflow file containing a duplicate key outright: the run is
 # marked "failed because of a workflow file issue" and NO jobs start. That makes
@@ -58,3 +60,87 @@ else
   exit 1
 end
 '
+
+# ---------------------------------------------------------------------------
+# badges.yml names module paths that must still exist in the tree
+# ---------------------------------------------------------------------------
+#
+# The two jobs that extract test and coverage badges check out the `badges`
+# branch, not the source, so they cannot see `crates/` and cannot notice when a
+# module they name has moved. Nor does it fail
+# when one has: a missed `extract_module_tests` writes a lightgrey "0" and a
+# missed `extract_module_cov` writes nothing at all. Six paths had rotted that
+# way while their coverage badges kept serving numbers from the last run that
+# did resolve.
+#
+# This runs where the source IS present, on every PR, so the next move fails here
+# instead of quietly freezing a badge.
+#
+# The crate is derived from the artifact each *_LCOV / *_TEST variable looks for
+# (gglib-cli-lcov.info -> crates/gglib-cli), so no path mapping has to be kept in
+# step by hand — the thing this check exists to prevent.
+echo ""
+echo "Checking badges.yml module paths resolve..."
+BADGES=".github/workflows/badges.yml"
+BADGE_PATH_FAILURES=0
+
+
+while IFS='|' read -r var relpath; do
+    [ -z "$var" ] && continue
+    case "$relpath" in *'$'*) continue ;; esac
+    crate=$(grep -oE "^ *${var}=\"\\\$\(find artifacts -name '[^']+'" "$BADGES" | head -1 | grep -oE "gglib-[a-z-]+" | head -1 | sed -E 's/-(lcov|tests)$//' || true)
+    if [ -z "$crate" ]; then
+        echo -e "\033[1;33m⚠\033[0m could not derive a crate for $var — skipping its paths"
+        continue
+    fi
+    if [ ! -d "crates/$crate/$relpath" ]; then
+        echo -e "\033[0;31m✗\033[0m badges.yml names crates/$crate/$relpath, which does not exist"
+        BADGE_PATH_FAILURES=$((BADGE_PATH_FAILURES + 1))
+    fi
+done < <(grep -oE 'extract_module_cov "\$[A-Z_]+" "[^"]+"' "$BADGES" \
+         | sed -E 's/extract_module_cov "\$([A-Z_]+)" "([^"]+)"/\1|\2/')
+
+# Module names reach extract_module_tests two ways: as a literal, or as $MODULE
+# from a `for MODULE in a b c` list just above the call. Expand the lists so both
+# are checked; a bare "$MODULE" on its own would otherwise be treated as a path.
+while IFS='|' read -r var modpath; do
+    [ -z "$var" ] && continue
+    crate=$(grep -oE "^ *${var}=\"\\\$\(find artifacts -name '[^']+'" "$BADGES" | head -1 | grep -oE "gglib-[a-z-]+" | head -1 | sed -E 's/-(lcov|tests)$//' || true)
+    if [ -z "$crate" ]; then
+        echo -e "\033[1;33m⚠\033[0m could not derive a crate for $var — skipping its paths"
+        continue
+    fi
+    dir="crates/$crate/src/$(printf '%s' "$modpath" | sed 's|::|/|g')"
+    if [ ! -d "$dir" ] && [ ! -f "$dir.rs" ]; then
+        echo -e "\033[0;31m✗\033[0m badges.yml names module $modpath in $crate, which is neither $dir nor $dir.rs"
+        BADGE_PATH_FAILURES=$((BADGE_PATH_FAILURES + 1))
+    fi
+done < <(awk '
+    /for MODULE in / {
+        line = $0
+        sub(/.*for MODULE in /, "", line)
+        sub(/;.*/, "", line)
+        list = line
+        next
+    }
+    /extract_module_tests "\$[A-Z_]+"/ {
+        match($0, /extract_module_tests "\$[A-Z_]+"/)
+        v = substr($0, RSTART, RLENGTH)
+        gsub(/extract_module_tests "\$|"/, "", v)
+        rest = $0
+        sub(/.*extract_module_tests "\$[A-Z_]+" "/, "", rest)
+        sub(/".*/, "", rest)
+        if (rest == "$MODULE") {
+            n = split(list, parts, /[ \t]+/)
+            for (i = 1; i <= n; i++) if (parts[i] != "") print v "|" parts[i]
+        } else if (rest !~ /\$/) {
+            print v "|" rest
+        }
+    }
+' "$BADGES")
+
+if [ "$BADGE_PATH_FAILURES" -gt 0 ]; then
+    echo -e "\033[0;31m$BADGE_PATH_FAILURES badge path(s) point at modules that have moved or gone\033[0m"
+    exit 1
+fi
+echo -e "\033[0;32m✓\033[0m every badges.yml module and coverage path resolves"


### PR DESCRIPTION
Seven module paths in `badges.yml` no longer resolved:

- `handlers/download/` is now `handlers/model/download/`
- `handlers/check_deps/` and its `instructions/` are now under `handlers/config/`
- `gglib-tauri/src/gui_backend/` was removed
- gglib-agent's `fnv1a`, `loop_detection` and `stagnation` moved to gglib-core

None of it failed a job. `extract_module_cov` writes nothing when its path
matches nothing, and the deploy step uses `keep_files: true`, so a badge already
on the `badges` branch keeps serving whatever it was last given —
`gglib-cli-check_deps-coverage.json` currently reads 8%. On the tests side no
per-module badge exists at all. So the three affected READMEs each show a stale
figure and a 404 rather than an error.

The three CLI paths are repointed rather than removed: their badge names are
referenced by live READMEs. The other four are removed — the code is gone and no
README references them.

**The tests side needed a bug fixed, not just a path corrected.**
`extract_module_tests` computed `PASSED=$(… | grep -c "… ok$" || echo "0")`. But
`grep -c` prints `0` and exits 1 when it matches nothing, so `|| echo "0"`
appended a second zero, making `TOTAL="0\n0"` — a bad math expression that aborts
the function. Any module with no failing tests hits it. Repointing the paths
alone would have published nothing. `|| true` plus a `${VAR:-0}` default is the
fix, since `grep -c` already prints the zero.

The three `handlers/*` extractions were hand-inlined copies of
`extract_module_tests` and are now calls to it — those copies are the ones that
drifted while the call sites beside them did not.

Adds a guard so the next move fails instead of freezing a badge. It lives in
`check_workflow_yaml.sh` because the two jobs that extract test and coverage
badges check out the `badges` branch, not the source, so they cannot see
`crates/`. `check_workflow_yaml.sh` runs under `make enforce`, where the source
is present. It derives each crate from the artifact its `*_LCOV`/`*_TEST`
variable looks for, so no path mapping has to be maintained by hand, and expands
`for MODULE in …` lists rather than treating `$MODULE` as a path. A variable it
cannot resolve produces a warning naming it, not a silent exit.

Mutation-verified three ways: a reverted coverage path and a misnamed module each
exit 1 naming the file; an unresolvable artifact name warns and continues.