### PR TITLE
chore(core,runtime): delete items with no reader, and gate the test-only ones

### DIFF
--- a/crates/gglib-core/src/download/completion.rs
+++ b/crates/gglib-core/src/download/completion.rs
@@ -156,14 +156,24 @@ impl AttemptCounts {
     }
 
     /// Total number of attempts across all kinds.
+    ///
+    /// Test-only: where production wants these summed it reads the three
+    /// fields directly — `gglib-download`'s `calculate_total_attempts` folds
+    /// them into `QueueRunSummary`'s own `total_attempts_*` fields. Gated so
+    /// `dead_code` keeps telling the truth about production reach.
+    #[cfg(test)]
     #[must_use]
-    pub const fn total(&self) -> u32 {
+    pub(crate) const fn total(&self) -> u32 {
         self.downloaded + self.failed + self.cancelled
     }
 
     /// Check if there were any retry attempts (more than one total attempt).
+    ///
+    /// Test-only, and gated for the same reason as [`Self::total`]: nothing in
+    /// production asks an `AttemptCounts` whether it retried.
+    #[cfg(test)]
     #[must_use]
-    pub const fn has_retries(&self) -> bool {
+    pub(crate) const fn has_retries(&self) -> bool {
         self.total() > 1
     }
 }
@@ -234,24 +244,10 @@ pub struct QueueRunSummary {
 }
 
 impl QueueRunSummary {
-    /// Total number of unique models across all result kinds.
-    #[must_use]
-    pub const fn total_unique_models(&self) -> u32 {
-        self.unique_models_downloaded + self.unique_models_failed + self.unique_models_cancelled
-    }
-
     /// Total number of attempts across all result kinds.
     #[must_use]
     pub const fn total_attempts(&self) -> u32 {
         self.total_attempts_downloaded + self.total_attempts_failed + self.total_attempts_cancelled
-    }
-
-    /// Check if any models had retry attempts.
-    #[must_use]
-    pub fn has_retries(&self) -> bool {
-        self.items
-            .iter()
-            .any(|item| item.attempt_counts.has_retries())
     }
 }
 
@@ -557,108 +553,5 @@ mod tests {
         };
 
         assert_eq!(summary.total_attempts(), 6);
-        assert_eq!(summary.total_unique_models(), 4);
-    }
-
-    #[test]
-    fn test_queue_run_summary_has_retries() {
-        // FALSE scenario: all items have exactly 1 attempt — no retries
-        let single_attempt_detail = CompletionDetail {
-            key: CompletionKey::HfFile {
-                repo_id: "model-a".to_string(),
-                revision: "main".to_string(),
-                filename_canon: "a.gguf".to_string(),
-                quantization: None,
-            },
-            display_name: "model-a".to_string(),
-            last_result: CompletionKind::Downloaded,
-            last_completed_at_ms: 1000,
-            download_ids: vec![DownloadId::from_model("model-a")],
-            attempt_counts: AttemptCounts::from_kind(CompletionKind::Downloaded),
-        };
-
-        let no_retry_summary = QueueRunSummary {
-            run_id: Uuid::nil(),
-            started_at_ms: 0,
-            completed_at_ms: 1000,
-            total_attempts_downloaded: 3,
-            total_attempts_failed: 0,
-            total_attempts_cancelled: 0,
-            unique_models_downloaded: 3,
-            unique_models_failed: 0,
-            unique_models_cancelled: 0,
-            items: vec![
-                single_attempt_detail.clone(),
-                single_attempt_detail.clone(),
-                single_attempt_detail.clone(),
-            ],
-            truncated: false,
-        };
-        assert!(
-            !no_retry_summary.has_retries(),
-            "should be false when all items have exactly 1 attempt"
-        );
-
-        // TRUE scenario: one item has 3 attempts (2 failures + 1 success)
-        let mut retried_counts = AttemptCounts::default();
-        retried_counts.increment(CompletionKind::Failed);
-        retried_counts.increment(CompletionKind::Failed);
-        retried_counts.increment(CompletionKind::Downloaded);
-
-        let retried_detail = CompletionDetail {
-            key: CompletionKey::HfFile {
-                repo_id: "model-b".to_string(),
-                revision: "main".to_string(),
-                filename_canon: "b.gguf".to_string(),
-                quantization: None,
-            },
-            display_name: "model-b".to_string(),
-            last_result: CompletionKind::Downloaded,
-            last_completed_at_ms: 2000,
-            download_ids: vec![
-                DownloadId::from_model("model-b"),
-                DownloadId::from_model("model-b"),
-                DownloadId::from_model("model-b"),
-            ],
-            attempt_counts: retried_counts,
-        };
-
-        let retry_summary = QueueRunSummary {
-            run_id: Uuid::nil(),
-            started_at_ms: 0,
-            completed_at_ms: 2000,
-            // 3 unique models downloaded, but 5 total attempts (one was retried)
-            total_attempts_downloaded: 4,
-            total_attempts_failed: 2,
-            total_attempts_cancelled: 0,
-            unique_models_downloaded: 3,
-            unique_models_failed: 0,
-            unique_models_cancelled: 0,
-            items: vec![
-                single_attempt_detail.clone(),
-                retried_detail.clone(),
-                single_attempt_detail,
-            ],
-            truncated: false,
-        };
-        assert!(
-            retry_summary.has_retries(),
-            "should be true when at least one item has >1 attempt"
-        );
-
-        // Verify unique-vs-attempts distinction: 3 unique models but 6 total attempts
-        assert_eq!(retry_summary.total_unique_models(), 3);
-        assert_eq!(retry_summary.total_attempts(), 6);
-        assert_ne!(
-            retry_summary.total_unique_models(),
-            retry_summary.total_attempts(),
-            "unique models should differ from total attempts when retries occurred"
-        );
-
-        // Verify the retried item specifically
-        assert_eq!(retried_detail.attempt_counts.failed, 2);
-        assert_eq!(retried_detail.attempt_counts.downloaded, 1);
-        assert_eq!(retried_detail.attempt_counts.total(), 3);
-        assert!(retried_detail.attempt_counts.has_retries());
     }
 }

--- a/crates/gglib-core/src/download/errors.rs
+++ b/crates/gglib-core/src/download/errors.rs
@@ -227,9 +227,6 @@ impl DownloadError {
     }
 }
 
-/// Convenience result type for download operations.
-pub type DownloadResult<T> = Result<T, DownloadError>;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gglib-core/src/download/events.rs
+++ b/crates/gglib-core/src/download/events.rs
@@ -381,14 +381,6 @@ impl DownloadEvent {
         Self::DownloadCancelled { id: id.into() }
     }
 
-    /// Create a status-changed event for non-terminal lifecycle transitions.
-    pub fn status_changed(id: impl Into<String>, status: DownloadStatus) -> Self {
-        Self::DownloadStatusChanged {
-            id: id.into(),
-            status,
-        }
-    }
-
     /// Create a queue run complete event.
     pub const fn queue_run_complete(summary: QueueRunSummary) -> Self {
         Self::QueueRunComplete { summary }

--- a/crates/gglib-core/src/download/mod.rs
+++ b/crates/gglib-core/src/download/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod types;
 pub use completion::{
     AttemptCounts, CompletionDetail, CompletionKey, CompletionKind, QueueRunSummary,
 };
-pub use errors::{DownloadError, DownloadResult};
+pub use errors::DownloadError;
 pub use events::{DownloadEvent, DownloadStatus, DownloadSummary};
 pub use format::{format_duration, format_rate};
 pub use queue::{FailedDownload, QueueSnapshot, QueuedDownload};

--- a/crates/gglib-core/src/paths/config.rs
+++ b/crates/gglib-core/src/paths/config.rs
@@ -11,7 +11,7 @@ use super::error::PathError;
 use super::platform::data_root;
 
 /// Location of the `.env` file that stores user overrides.
-pub fn env_file_path() -> Result<PathBuf, PathError> {
+fn env_file_path() -> Result<PathBuf, PathError> {
     Ok(data_root()?.join(".env"))
 }
 
@@ -19,7 +19,7 @@ pub fn env_file_path() -> Result<PathBuf, PathError> {
 ///
 /// If the key already exists, its value is updated.
 /// If the key doesn't exist, it is appended to the file.
-pub fn persist_env_value(key: &str, value: &str) -> Result<(), PathError> {
+fn persist_env_value(key: &str, value: &str) -> Result<(), PathError> {
     let env_path = env_file_path()?;
 
     let lines: Vec<String> = if env_path.exists() {

--- a/crates/gglib-core/src/paths/ensure.rs
+++ b/crates/gglib-core/src/paths/ensure.rs
@@ -54,7 +54,7 @@ pub fn ensure_directory(path: &Path, strategy: DirectoryCreationStrategy) -> Res
 }
 
 /// Verify a directory is writable by attempting to create a test file.
-pub fn verify_writable(path: &Path) -> Result<(), PathError> {
+fn verify_writable(path: &Path) -> Result<(), PathError> {
     let test_file = path.join(".gglib_write_test");
     let result = OpenOptions::new()
         .create(true)

--- a/crates/gglib-core/src/paths/mod.rs
+++ b/crates/gglib-core/src/paths/mod.rs
@@ -41,10 +41,10 @@ pub use models::{
 pub use pids::pids_dir;
 
 // Directory operations
-pub use ensure::{DirectoryCreationStrategy, ensure_directory, verify_writable};
+pub use ensure::{DirectoryCreationStrategy, ensure_directory};
 
 // Configuration persistence
-pub use config::{env_file_path, persist_env_value, persist_models_dir};
+pub use config::persist_models_dir;
 
 // Pure resolver for testing and CLI
 pub use resolver::ResolvedPaths;

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -104,15 +104,6 @@ impl ModelService {
         }
     }
 
-    /// Get a model by name.
-    pub async fn get_by_name(&self, name: &str) -> Result<Option<Model>, CoreError> {
-        match self.repo.get_by_name(name).await {
-            Ok(model) => Ok(Some(model)),
-            Err(RepositoryError::NotFound(_)) => Ok(None),
-            Err(e) => Err(CoreError::from(e)),
-        }
-    }
-
     /// Find a model by identifier — a numeric id, then an exact name (not an
     /// HF id, despite what this said for a long time). Errors if not found.
     pub async fn find_by_identifier(&self, identifier: &str) -> Result<Model, CoreError> {
@@ -1165,7 +1156,7 @@ mod tests {
         let created = service.add(new_model).await.unwrap();
         assert_eq!(created.name, "test-model");
 
-        let found = service.get_by_name("test-model").await.unwrap();
+        let found = service.get("test-model").await.unwrap();
         assert!(found.is_some());
         assert_eq!(found.unwrap().id, created.id);
     }

--- a/crates/gglib-runtime/src/process/admission/lease.rs
+++ b/crates/gglib-runtime/src/process/admission/lease.rs
@@ -28,7 +28,7 @@ use gglib_core::domain::{AdmissionSnapshot, SecondarySlotDecision};
 use gglib_core::ports::{AdmissionLease, AdmissionRelease};
 use tokio::sync::Notify;
 
-use super::state::{AdmissionDecision, QueueState, Resident, SLOT_COUNT, Ticket};
+use super::state::{AdmissionDecision, QueueState, Resident, Ticket};
 
 /// The admission queue: who is resident, who is waiting, and whose turn it is.
 ///
@@ -167,18 +167,6 @@ impl AdmissionQueue {
         let previous = self.lock().evict(slot);
         self.notify();
         previous
-    }
-
-    /// Empty every slot, returning what was there.
-    pub fn evict_all(&self) -> Vec<Resident> {
-        let evicted = {
-            let mut state = self.lock();
-            (0..SLOT_COUNT)
-                .filter_map(|slot| state.evict(slot))
-                .collect()
-        };
-        self.notify();
-        evicted
     }
 
     /// The primary slot's resident.

--- a/crates/gglib-runtime/src/process/core.rs
+++ b/crates/gglib-runtime/src/process/core.rs
@@ -99,14 +99,7 @@ impl GuiProcessCore {
             .unwrap()
             .as_secs();
 
-        let info = ServerInfo::new(
-            model_id,
-            config.model_name,
-            pid,
-            port,
-            now,
-            config.context_size,
-        );
+        let info = ServerInfo::new(model_id, config.model_name, pid, port, now);
         let running = RunningProcess::new(info, child);
         self.processes.insert(model_id, running);
 
@@ -157,58 +150,29 @@ impl GuiProcessCore {
         Ok(())
     }
 
-    /// Get information about a running process
-    pub fn get_info(&self, model_id: u32) -> Option<&ServerInfo> {
-        self.processes.get(&model_id).map(|p| &p.info)
-    }
-
     /// List all running processes
     pub fn list_all(&self) -> Vec<&ServerInfo> {
         debug!(process_count = %self.processes.len(), "GuiProcessCore: list_all called");
         self.processes.values().map(|p| &p.info).collect()
     }
 
-    /// Check if a model is running
-    pub fn is_running(&self, model_id: u32) -> bool {
+    /// Check if a model is running.
+    ///
+    /// Test-only: its production caller was `ProcessManager::is_serving`,
+    /// removed in this commit. Gated so `dead_code` keeps telling the truth
+    /// about production reach.
+    #[cfg(test)]
+    pub(crate) fn is_running(&self, model_id: u32) -> bool {
         self.processes.contains_key(&model_id)
     }
 
-    /// Get count of running processes
-    pub fn count(&self) -> usize {
+    /// Get count of running processes.
+    ///
+    /// Test-only, and already so before this commit — nothing outside the test
+    /// below calls it. Gated for the same reason as [`Self::is_running`].
+    #[cfg(test)]
+    pub(crate) fn count(&self) -> usize {
         self.processes.len()
-    }
-
-    /// Kill all running processes in parallel.
-    /// Errors are logged but do not abort the shutdown of other processes.
-    pub async fn kill_all(&mut self) {
-        let model_ids: Vec<u32> = self.processes.keys().copied().collect();
-
-        // Remove all from HashMap and collect RunningProcess structs
-        let mut processes_to_kill = Vec::new();
-        for model_id in &model_ids {
-            if let Some(running) = self.processes.remove(model_id) {
-                processes_to_kill.push((*model_id, running));
-            }
-        }
-
-        // Kill all in parallel
-        let kill_futures: Vec<_> = processes_to_kill.into_iter().map(|(model_id, running)| {
-            async move {
-                let pid = running.info.pid;
-                debug!(model_id = %model_id, pid = %pid, port = %running.info.port, "Stopping process");
-
-                // Use graceful shutdown with SIGTERM → SIGKILL
-                let _ = shutdown_child(running.child).await;
-
-                // Remove PID file
-                if let Err(e) = delete_pidfile(model_id as i64) {
-                    debug!("Failed to delete PID file: {}", e);
-                }
-            }
-        }).collect();
-
-        // Execute all kills in parallel - cannot fail (errors are logged inside)
-        futures_util::future::join_all(kill_futures).await;
     }
 
     /// Remove dead processes from tracking and clean PID files
@@ -244,8 +208,9 @@ impl GuiProcessCore {
     }
 }
 
-// Note: Drop is not async, so we can't use shutdown_child here.
-// Caller should explicitly call kill_all() before dropping if graceful shutdown is needed.
+// Note: Drop is not async, so the SIGTERM-then-SIGKILL sequence `kill` uses
+// cannot run here. This is a backstop that kills outright; anything wanting a
+// graceful stop has to go through `kill` before the core is dropped.
 impl Drop for GuiProcessCore {
     fn drop(&mut self) {
         // Best effort: just kill the child handles

--- a/crates/gglib-runtime/src/process/manager.rs
+++ b/crates/gglib-runtime/src/process/manager.rs
@@ -13,7 +13,6 @@
 //! sequence that mutates it.
 
 use super::core::GuiProcessCore;
-use super::types::ServerInfo;
 use anyhow::Result;
 use gglib_core::domain::AdmissionSnapshot;
 use gglib_core::ports::{
@@ -22,7 +21,6 @@ use gglib_core::ports::{
 use gglib_core::server_config::{CacheRamSetting, ServerConfigOptions};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::info;
 
 use crate::process::residency::ResidentSet;
 
@@ -156,51 +154,11 @@ impl ProcessManager {
         self.residency.stop_primary(&self.core).await
     }
 
-    /// Stop a running server by model ID
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the process could not be stopped.
-    pub async fn stop_server(&self, model_id: u32) -> Result<()> {
-        let mut core = self.core.write().await;
-        core.kill(model_id).await
-    }
-
-    /// Stop all running servers
-    ///
-    /// # Errors
-    ///
-    /// Never returns an error; individual failures are logged.
-    pub async fn stop_all(&self) -> Result<()> {
-        let mut core = self.core.write().await;
-        core.kill_all().await;
-        Ok(())
-    }
-
-    /// Check if a model is being served
-    pub async fn is_serving(&self, model_id: u32) -> bool {
-        let core = self.core.read().await;
-        core.is_running(model_id)
-    }
-
-    /// Get info for a running server
-    pub async fn get_server_info(&self, model_id: u32) -> Option<ServerInfo> {
-        let core = self.core.read().await;
-        core.get_info(model_id).cloned()
-    }
-
-    /// List all running servers
-    pub async fn list_servers(&self) -> Vec<ServerInfo> {
-        let core = self.core.read().await;
-        core.list_all().into_iter().cloned().collect()
-    }
-
     /// List running servers as [`ProcessHandle`]s.
     ///
-    /// The same processes [`Self::list_servers`] reports, projected onto the
-    /// port type so callers that already speak `ProcessHandle` — the GUI
-    /// server list and its health monitor — can consume a manager-backed
-    /// runtime without a second shape to handle.
+    /// The core's own records, projected onto the port type so callers that
+    /// already speak `ProcessHandle` can consume a manager-backed runtime
+    /// without a second shape to handle.
     pub async fn list_running(&self) -> Vec<ProcessHandle> {
         let core = self.core.read().await;
         core.list_all()
@@ -215,17 +173,6 @@ impl ProcessManager {
                 )
             })
             .collect()
-    }
-
-    /// Graceful shutdown
-    ///
-    /// # Errors
-    ///
-    /// Never returns an error; individual failures are logged.
-    pub async fn shutdown(&self) -> Result<()> {
-        info!("Shutting down process manager");
-        self.residency.forget_all();
-        self.stop_all().await
     }
 
     /// The single model this manager is pinned to, if any.
@@ -394,29 +341,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_is_serving() {
-        assert!(!manager().is_serving(1).await);
-    }
-
-    #[tokio::test]
-    async fn test_list_servers_empty() {
-        assert_eq!(manager().list_servers().await.len(), 0);
-    }
-
-    #[tokio::test]
     async fn list_running_is_empty_with_no_servers() {
         assert!(manager().list_running().await.is_empty());
-    }
-
-    /// Both listings project the same underlying process set, so they must
-    /// never disagree on how many servers are up.
-    #[tokio::test]
-    async fn list_running_agrees_with_list_servers() {
-        let manager = manager();
-        assert_eq!(
-            manager.list_running().await.len(),
-            manager.list_servers().await.len()
-        );
     }
 
     #[tokio::test]

--- a/crates/gglib-runtime/src/process/residency/mod.rs
+++ b/crates/gglib-runtime/src/process/residency/mod.rs
@@ -497,11 +497,6 @@ impl ResidentSet {
         }
         Ok(())
     }
-
-    /// Forget every resident, for shutdown.
-    pub(super) fn forget_all(&self) -> Vec<Resident> {
-        self.queue.evict_all()
-    }
 }
 
 /// Project a resident onto the routing type callers outside this crate speak.

--- a/crates/gglib-runtime/src/process/types.rs
+++ b/crates/gglib-runtime/src/process/types.rs
@@ -16,42 +16,18 @@ pub struct ServerInfo {
     pub port: u16,
     /// Unix timestamp when server was started
     pub started_at: u64,
-    /// Unix timestamp of last known activity
-    pub last_used: u64,
-    /// Whether the server is healthy (responding to requests)
-    pub healthy: bool,
-    /// Context size being used
-    pub context_size: Option<u64>,
 }
 
 impl ServerInfo {
     /// Create a new `ServerInfo`
-    pub fn new(
-        model_id: u32,
-        model_name: String,
-        pid: u32,
-        port: u16,
-        started_at: u64,
-        context_size: Option<u64>,
-    ) -> Self {
+    pub fn new(model_id: u32, model_name: String, pid: u32, port: u16, started_at: u64) -> Self {
         Self {
             model_id,
             model_name,
             pid,
             port,
             started_at,
-            last_used: started_at,
-            healthy: true,
-            context_size,
         }
-    }
-
-    /// Update the last used timestamp
-    pub fn touch(&mut self) {
-        self.last_used = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
     }
 }
 

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -14,7 +14,7 @@ crates/gglib-app-services/src/models.rs 576
 crates/gglib-app-services/src/proxy.rs 463
 crates/gglib-app-services/src/sampling_explain_tests.rs 757
 crates/gglib-app-services/src/sampling_explain.rs 454
-crates/gglib-app-services/src/servers.rs 965
+crates/gglib-app-services/src/servers.rs 959
 crates/gglib-app-services/src/settings.rs 404
 crates/gglib-app-services/src/setup.rs 351
 crates/gglib-app-services/src/types.rs 1055
@@ -58,8 +58,8 @@ crates/gglib-core/src/domain/query.rs 432
 crates/gglib-core/src/domain/recommendation.rs 381
 crates/gglib-core/src/domain/residency.rs 414
 crates/gglib-core/src/domain/runtime_capabilities.rs 408
-crates/gglib-core/src/download/completion.rs 664
-crates/gglib-core/src/download/events.rs 486
+crates/gglib-core/src/download/completion.rs 557
+crates/gglib-core/src/download/events.rs 478
 crates/gglib-core/src/download/queue.rs 548
 crates/gglib-core/src/download/rate.rs 378
 crates/gglib-core/src/download/types.rs 752
@@ -76,7 +76,7 @@ crates/gglib-core/src/request_pipeline/validate.rs 790
 crates/gglib-core/src/server_config.rs 627
 crates/gglib-core/src/services/model_import.rs 689
 crates/gglib-core/src/services/model_registrar.rs 336
-crates/gglib-core/src/services/model_service.rs 1508
+crates/gglib-core/src/services/model_service.rs 1499
 crates/gglib-core/src/services/model_verification.rs 806
 crates/gglib-core/src/settings_tests.rs 452
 crates/gglib-core/src/settings.rs 698
@@ -160,9 +160,9 @@ crates/gglib-runtime/src/ports_impl/llm_completion/retry/execute_tests.rs 342
 crates/gglib-runtime/src/ports_impl/llm_completion/shaping_tests.rs 358
 crates/gglib-runtime/src/process/admission/queue_tests.rs 973
 crates/gglib-runtime/src/process/admission/state.rs 736
-crates/gglib-runtime/src/process/manager.rs 441
+crates/gglib-runtime/src/process/manager.rs 367
 crates/gglib-runtime/src/process/residency/launch.rs 445
-crates/gglib-runtime/src/process/residency/mod.rs 523
+crates/gglib-runtime/src/process/residency/mod.rs 518
 crates/gglib-runtime/src/proxy/supervisor.rs 763
 crates/gglib-runtime/src/system/mod.rs 568
 crates/gglib-runtime/src/unified_server_config.rs 491


### PR DESCRIPTION
Third and last sweep of the kind #843–#853 and #889 began: items that are
`pub` behind a live `pub use`, so `dead_code` treats them as live roots and
never reports them. Gated on #889, which removed the re-exports that were
hiding the previous tranche.

Full reasoning is in the commit message. In short:

- **gglib-core** — `DownloadResult<T>`, `DownloadEvent::status_changed` (the
  constructor; the variant stays), `ModelService::get_by_name`,
  `QueueRunSummary::{has_retries, total_unique_models}`. `verify_writable`,
  `env_file_path` and `persist_env_value` are demoted to module-private rather
  than deleted — one caller each, in their own file.
- **gglib-runtime** — six `ProcessManager` methods, which stranded four more
  items the compiler could not report: `ResidentSet::forget_all`,
  `AdmissionQueue::evict_all`, `GuiProcessCore::{kill_all, get_info}`. Then
  `ServerInfo`'s `last_used`, `healthy` and `context_size`, all write-only, and
  `touch` with them.
- **Test-only, not dead** — `AttemptCounts::{total, has_retries}` and
  `GuiProcessCore::{is_running, count}` are `#[cfg(test)] pub(crate)` per #889's
  precedent, so `dead_code` keeps answering about production reach.

No behaviour change. `context_size` still reaches llama-server as `-c`; the
daemon shutdown path (`ServerOps::stop_all`) never touched the removed methods.

### Verification

`make enforce`, `make boundaries`, `make doc-check`, `cargo fmt --check`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`, the same
with default features, `cargo test --workspace`, `cargo test`, `cargo test --doc`
— all exit 0. 83 suites, 3229 passed, 0 failed.

That the chain terminates was checked mechanically rather than by grep: with the
`process`, `download`, `paths` and `services` modules made crate-private in a
throwaway worktree, `dead_code` can see behind the re-exports, and the warning
set at this HEAD is a strict subset of the one at `73fdcf38`.

Ratchet: completion.rs 664→557, events.rs 486→478, model_service.rs 1508→1499,
process/manager.rs 441→367, residency/mod.rs 523→518. The baseline also picks up
`gglib-app-services/src/servers.rs` 965→959, which was already stale on `main`
and is untouched here — re-recording it keeps the file reproducible from
`--update`.

### Noted, deliberately out of scope

- `GuiProcessCore`, `ServerInfo`, `RunningProcess` and `SLOT_COUNT` are exported
  from `gglib-runtime` with no consumer outside the crate. Narrowing those is
  #889's move applied to a crate it did not cover, and wants its own PR.
- `AdmissionQueue::slot_of` (with `QueueState::slot_of` and `SlotState::model`
  behind it), `AdmissionQueue::lease` (test-only) and `Resident::model_path`
  (written, never read) are the next list. All identical on `main`.
