### PR TITLE
refactor(cli,core)!: one door for model identifier resolution

### DIFF
--- a/crates/gglib-cli/README.md
+++ b/crates/gglib-cli/README.md
@@ -118,10 +118,10 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `list` | List all models with metadata |
 | `inspect <id\|name>` | Show full details for a model (arch, quant, capabilities, inference defaults, GGUF metadata) |
 | `explain <id\|name> [--profile <name>]` | Show every resolved inference parameter and which layer of the sampling hierarchy supplied it |
-| `remove <id>` | Remove a model from the library |
-| `serve <id>` | Start llama-server for a model (respects per-model server_defaults from DB, overridable with `--ctx-size`) |
-| `chat <id>` | Start interactive llama-cli chat |
-| `chat <id> --continue <N>` | Resume a previous conversation by ID |
+| `remove <id\|name>` | Remove a model from the library |
+| `serve <id\|name>` | Start llama-server for a model (respects per-model server_defaults from DB, overridable with `--ctx-size`) |
+| `chat <id\|name>` | Start interactive llama-cli chat |
+| `chat <id\|name> --continue <N>` | Resume a previous conversation by ID |
 | `question <text>` | Ask a question (with optional piped context) |
 | `question <text>` | Ask a question; filesystem tools are on unless `--no-tools` |
 | `chat history` | List past conversations with message counts |
@@ -130,7 +130,7 @@ See the [Architecture Overview](../../README.md#architecture) for the complete d
 | `download <repo>` | Download a model from HuggingFace |
 | `search <query>` | Search HuggingFace Hub for models |
 | `config settings show` | Show current configuration |
-| `config default <id>` | Set/show/clear the default model |
+| `config default <id\|name>` | Set/show/clear the default model |
 | `config profile list` | List named sampling profiles |
 | `config profile show <name>` | Show one profile's parameters |
 | `config profile set <name> [flags]` | Create or update a profile (only the flags passed are set; `--unset <param>` clears one) |

--- a/crates/gglib-cli/src/handlers/model/inspect.rs
+++ b/crates/gglib-cli/src/handlers/model/inspect.rs
@@ -5,7 +5,7 @@
 //! inference defaults, and timestamps.
 //!
 //! This handler is intentionally thin:
-//! - Flexible identifier resolution via `AppCore::models().get()` (name **or** ID)
+//! - Flexible identifier resolution via [`resolver::resolve_model_identifier`] (name **or** ID)
 //! - Serving-status-aware DTO via `ModelOps::get_detail()` (same path as the Axum route)
 //! - `--json` → serialize `ModelDetailDto` to stdout
 //! - human mode → delegate to [`inspect_display::print_model_detail`]
@@ -14,6 +14,7 @@
 
 use anyhow::Result;
 
+use super::resolver;
 use crate::bootstrap::CliContext;
 use crate::presentation::inspect_display;
 
@@ -24,15 +25,8 @@ pub(crate) async fn execute(
     show_metadata: bool,
     json: bool,
 ) -> Result<()> {
-    // Step 1: resolve name-or-id via the flexible core service.
-    let model = match ctx.app.models().get(identifier).await? {
-        Some(m) => m,
-        None => {
-            eprintln!("No model found matching: '{identifier}'");
-            eprintln!("Use 'gglib model list' to see available models.");
-            return Ok(());
-        }
-    };
+    // Step 1: resolve name-or-id through the one door.
+    let model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
     // Step 2: fetch the full DTO via ModelOps so serving status is included.
     // This mirrors exactly what the Axum detail route does, ensuring CLI and

--- a/crates/gglib-cli/src/handlers/model/remove.rs
+++ b/crates/gglib-cli/src/handlers/model/remove.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 
+use super::resolver;
 use crate::bootstrap::CliContext;
 use crate::presentation::{ModelSummaryOpts, display_model_summary};
 use crate::utils::input;
@@ -33,14 +34,7 @@ use crate::utils::input;
 /// - Database removal operation fails
 pub(crate) async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> Result<()> {
     // First, try to find the model to show it to the user
-    let model = match ctx.app.models().get(identifier).await? {
-        Some(m) => m,
-        None => {
-            println!("No model found matching: '{identifier}'");
-            println!("Use 'gglib model list' to see available models.");
-            return Ok(());
-        }
-    };
+    let model = resolver::resolve_model_identifier(ctx, identifier).await?;
 
     if !force {
         display_model_summary(&model, ModelSummaryOpts::for_removal());
@@ -55,8 +49,11 @@ pub(crate) async fn execute(ctx: &CliContext, identifier: &str, force: bool) -> 
         }
     }
 
-    // Remove the model
-    let removed = ctx.app.models().remove(identifier).await?;
+    // Delete by the id resolved above rather than handing the raw identifier
+    // to a second lookup: the confirmation prompt sits between the two, so
+    // they can disagree, and the second one reports in core's vocabulary.
+    ctx.app.models().delete(model.id).await?;
+    let removed = &model;
 
     println!(
         "✓ Model '{}' (ID {}) successfully removed from database.",

--- a/crates/gglib-cli/src/handlers/model/resolver.rs
+++ b/crates/gglib-cli/src/handlers/model/resolver.rs
@@ -1,9 +1,9 @@
 //! Model identifier resolver.
 //!
-//! Provides a single entry-point for resolving a user-supplied identifier
-//! (either a numeric ID or a model name) to a [`Model`] record.  All model
-//! command handlers use this instead of calling `get_by_id` directly, giving
-//! every command consistent name-or-id resolution and error messaging.
+//! The one entry-point for resolving a user-supplied identifier (either a
+//! numeric ID or a model name) to a [`Model`] record. Every `gglib model`
+//! subcommand that takes an identifier goes through it, so all of them fail
+//! the same way: one message, on stderr, with a non-zero exit.
 //!
 //! [`Model`]: gglib_core::domain::Model
 

--- a/crates/gglib-cli/src/handlers/model/retag.rs
+++ b/crates/gglib-cli/src/handlers/model/retag.rs
@@ -11,6 +11,7 @@
 
 use anyhow::{Context, Result};
 
+use super::resolver;
 use crate::bootstrap::CliContext;
 
 /// Execute the retag command.
@@ -32,10 +33,7 @@ pub(crate) async fn execute(
             .map(|m| (m.id, m.name))
             .collect::<Vec<_>>()
     } else if let Some(id) = identifier {
-        let m = models
-            .find_by_identifier(&id)
-            .await
-            .context("failed to look up model")?;
+        let m = resolver::resolve_model_identifier(ctx, &id).await?;
         vec![(m.id, m.name)]
     } else {
         anyhow::bail!("specify a model identifier or pass --all");

--- a/crates/gglib-cli/src/handlers/model/update.rs
+++ b/crates/gglib-cli/src/handlers/model/update.rs
@@ -11,6 +11,7 @@ use gglib_core::{
     domain::{DefaultsOrigin, InferenceConfig, ReasoningEffort},
 };
 
+use super::resolver;
 use crate::bootstrap::CliContext;
 use crate::sampling_params::clear_param;
 
@@ -65,12 +66,7 @@ pub(crate) struct UpdateArgs {
 /// Returns `Result<()>` indicating the success or failure of the operation.
 pub(crate) async fn execute(ctx: &CliContext, args: UpdateArgs) -> Result<()> {
     // Get the existing model by name or ID
-    let existing_model = ctx
-        .app
-        .models()
-        .get(&args.identifier)
-        .await?
-        .ok_or_else(|| anyhow!("No model found matching: '{}'", args.identifier))?;
+    let existing_model = resolver::resolve_model_identifier(ctx, &args.identifier).await?;
 
     // Verify the file still exists
     if !existing_model.file_path.exists() && !args.force {

--- a/crates/gglib-cli/tests/model_identifier_failure.rs
+++ b/crates/gglib-cli/tests/model_identifier_failure.rs
@@ -1,0 +1,68 @@
+//! `gglib model <cmd> <identifier>` against an identifier that matches nothing.
+//!
+//! Every subcommand that takes an identifier resolves it through one door, so
+//! all of them fail the same way. Two of them used to exit 0 — `inspect` after
+//! printing to stderr, `remove` after printing to stdout — which made a missing
+//! model invisible to a script checking the exit code.
+//!
+//! Unlike `daemon_lifecycle`, these bind nothing: the lookup fails before any
+//! daemon or port is involved, so they run in CI rather than behind `--ignored`.
+
+use std::process::Command;
+
+/// Every `gglib model` subcommand that takes an identifier.
+///
+/// `retag` also accepts `--all`, and `check-updates` spells its identifier as a
+/// flag; both still route through the same resolver.
+const IDENTIFIER_SUBCOMMANDS: &[&[&str]] = &[
+    &["inspect", "__no_such_model__"],
+    &["inspect", "__no_such_model__", "--json"],
+    &["remove", "__no_such_model__", "--force"],
+    &["update", "__no_such_model__", "--name", "x", "--force"],
+    &["retag", "__no_such_model__"],
+    &["verify", "__no_such_model__"],
+    &["repair", "__no_such_model__"],
+    &["upgrade", "__no_such_model__"],
+    &["capabilities", "__no_such_model__"],
+    &["explain", "__no_such_model__"],
+    &["check-updates", "--identifier", "__no_such_model__"],
+];
+
+#[test]
+fn an_unknown_identifier_fails_the_same_way_everywhere() {
+    let dir = tempfile::tempdir().expect("temp data dir");
+
+    for args in IDENTIFIER_SUBCOMMANDS {
+        let out = Command::new(env!("CARGO_BIN_EXE_gglib"))
+            .arg("model")
+            .args(*args)
+            .env("GGLIB_DATA_DIR", dir.path())
+            .output()
+            .unwrap_or_else(|e| panic!("running `gglib model {}`: {e}", args.join(" ")));
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let label = args.join(" ");
+
+        // The hazard this guards: `Ok(())` here means `gglib model remove x`
+        // succeeds against a model that does not exist.
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "`gglib model {label}` must exit 1 for an unknown identifier\n\
+             stdout: {stdout}\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("No model found matching: '__no_such_model__'"),
+            "`gglib model {label}` must name the identifier on stderr, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("Use 'gglib model list'"),
+            "`gglib model {label}` must keep the hint, got: {stderr}"
+        );
+        assert!(
+            stdout.is_empty(),
+            "`gglib model {label}` must write nothing to stdout, got: {stdout}"
+        );
+    }
+}

--- a/crates/gglib-core/src/services/model_service.rs
+++ b/crates/gglib-core/src/services/model_service.rs
@@ -343,13 +343,6 @@ impl ModelService {
         self.repo.delete(id).await.map_err(CoreError::from)
     }
 
-    /// Remove a model by identifier. Returns the removed model.
-    pub async fn remove(&self, identifier: &str) -> Result<Model, CoreError> {
-        let model = self.find_by_identifier(identifier).await?;
-        self.repo.delete(model.id).await.map_err(CoreError::from)?;
-        Ok(model)
-    }
-
     // ─────────────────────────────────────────────────────────────────────────
     // Tag Operations
     // ─────────────────────────────────────────────────────────────────────────

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -30,7 +30,7 @@ crates/gglib-cli/src/handlers/config/llama_install.rs 341
 crates/gglib-cli/src/handlers/config/settings/profiles.rs 436
 crates/gglib-cli/src/handlers/config/settings/settings_display.rs 404
 crates/gglib-cli/src/handlers/model/download/interactive.rs 426
-crates/gglib-cli/src/handlers/model/update.rs 630
+crates/gglib-cli/src/handlers/model/update.rs 626
 crates/gglib-cli/src/handlers/proxy_dashboard/render_tests.rs 632
 crates/gglib-cli/src/handlers/proxy_dashboard/render.rs 447
 crates/gglib-cli/src/model_commands.rs 403
@@ -76,7 +76,7 @@ crates/gglib-core/src/request_pipeline/validate.rs 790
 crates/gglib-core/src/server_config.rs 627
 crates/gglib-core/src/services/model_import.rs 689
 crates/gglib-core/src/services/model_registrar.rs 336
-crates/gglib-core/src/services/model_service.rs 1499
+crates/gglib-core/src/services/model_service.rs 1492
 crates/gglib-core/src/services/model_verification.rs 806
 crates/gglib-core/src/settings_tests.rs 452
 crates/gglib-core/src/settings.rs 698


### PR DESCRIPTION
> **Breaking.** `gglib model inspect` and `gglib model remove` now exit 1 when
> the identifier matches no model — both previously exited 0 — and `remove`
> writes that failure to stderr rather than stdout. Details in the commit's
> `BREAKING CHANGE:` trailer.

`gglib model <cmd> <identifier>` had five places that resolved an identifier,
four ways of saying it matched nothing, and two ideas about what should happen
next. Two of the five exited 0, so `gglib model remove x >/dev/null` discarded
the only signal and still succeeded.

All four bypassing handlers — `inspect`, `remove`, `update`, `retag` — now call
`resolve_model_identifier`. Ten `gglib model` subcommands take an identifier and
every one now fails the same way: one message, on stderr, with the
`gglib model list` hint, exit 1.

Full reasoning is in the commit message.

### Verification

`make enforce`, `make boundaries`, `cargo fmt --check`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`make doc-check` and `cargo test --workspace` all exit 0.

`tests/model_identifier_failure.rs` drives the real binary against an isolated
`GGLIB_DATA_DIR` and pins all ten subcommands. It runs in CI rather than behind
`--ignored`, because unlike `daemon_lifecycle` the lookup fails before any daemon
or port is involved. It was checked against the previous behaviour before being
kept — it fails on `inspect` at the first assertion, `left: Some(0)`.

### Also in this diff

`ModelService::remove` is deleted. Switching `remove` to `delete(model.id)` left
it with no caller in the workspace, and it was itself a second door — identifier
to model to delete. Four `README.md` rows that described `<id>` where the handler
takes a name are corrected.

### Noted, out of scope

The remaining "not found" spellings live outside `gglib model` — `serve`,
`config default`, `up`, `agent_chat`, `benchmark`. Unifying those needs a
`CoreError::NotFound` variant so each surface can render its own hint, rather
than baking a CLI command name into the domain layer.
