### PR TITLE
fix(core,runtime,cli,downloads,frontend): label binary sizes as binary

### DIFF
--- a/crates/gglib-cli/src/handlers/model/verification.rs
+++ b/crates/gglib-cli/src/handlers/model/verification.rs
@@ -55,15 +55,15 @@ pub(crate) async fn execute_verify(
                     bytes_processed,
                     total_bytes,
                 } => {
-                    let mb_processed = *bytes_processed as f64 / 1024.0 / 1024.0;
-                    let mb_total = *total_bytes as f64 / 1024.0 / 1024.0;
+                    let mib_processed = *bytes_processed as f64 / 1024.0 / 1024.0;
+                    let mib_total = *total_bytes as f64 / 1024.0 / 1024.0;
                     println!(
-                        "  Shard {}/{}: Hashing... {}% ({:.1} MB / {:.1} MB)",
+                        "  Shard {}/{}: Hashing... {}% ({:.1} MiB / {:.1} MiB)",
                         progress.shard_index + 1,
                         progress.total_shards,
                         percent,
-                        mb_processed,
-                        mb_total
+                        mib_processed,
+                        mib_total
                     );
                 }
                 ShardProgress::Completed { health } => {

--- a/crates/gglib-cli/src/handlers/up/choose.rs
+++ b/crates/gglib-cli/src/handlers/up/choose.rs
@@ -112,7 +112,7 @@ async fn download_recommended(
 /// State the choice and the arithmetic behind it.
 ///
 /// The size and headroom are the part that earns trust: a bare model name is a
-/// guess, whereas "18.9 GB of 24.0 GB VRAM" is a claim the user can check.
+/// guess, whereas "18.9 GiB of 24.0 GiB VRAM" is a claim the user can check.
 fn print_recommendation(rec: &Recommendation) {
     let c = rec.candidate;
     println!();

--- a/crates/gglib-cli/src/handlers/up/mod.rs
+++ b/crates/gglib-cli/src/handlers/up/mod.rs
@@ -178,14 +178,14 @@ mod tests {
 
     #[test]
     fn a_note_renders_in_parentheses_after_the_value() {
-        let lines = render_row("VRAM", "24.0 GB", Some("nvidia-smi"), false);
-        assert_eq!(lines[0], "    VRAM      24.0 GB  (nvidia-smi)");
+        let lines = render_row("VRAM", "24.0 GiB", Some("nvidia-smi"), false);
+        assert_eq!(lines[0], "    VRAM      24.0 GiB  (nvidia-smi)");
     }
 
     #[test]
     fn a_row_without_a_note_stops_after_the_value() {
-        let lines = render_row("RAM", "64.0 GB", None, false);
-        assert_eq!(lines[0], "    RAM       64.0 GB");
+        let lines = render_row("RAM", "64.0 GiB", None, false);
+        assert_eq!(lines[0], "    RAM       64.0 GiB");
     }
 
     /// Values must form a column, as they do in the launch narration.
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn no_ansi_escapes_when_color_is_off() {
-        let lines = render_row("VRAM", "24.0 GB", Some("probe"), false);
+        let lines = render_row("VRAM", "24.0 GiB", Some("probe"), false);
         assert!(!lines[0].contains('\u{1b}'));
     }
 

--- a/crates/gglib-core/src/domain/launch_narration.rs
+++ b/crates/gglib-core/src/domain/launch_narration.rs
@@ -48,7 +48,7 @@ pub struct LaunchDecision {
     /// Stable because the GUI and the CLI dashboard both key styling off it;
     /// treat it as part of the wire contract rather than a display string.
     pub label: String,
-    /// Display-ready value, e.g. `32768` or `q8_0 -> 2.1 GB, f16 would be 4.2 GB`.
+    /// Display-ready value, e.g. `32768` or `q8_0 -> 2.1 GiB, f16 would be 4.2 GiB`.
     pub value: String,
     /// Where the value came from, rendered in parentheses by every consumer.
     ///
@@ -100,7 +100,7 @@ pub struct LaunchNarration {
     /// Quantization label (`Q4_K_M`), when the catalog recorded one.
     pub quantization: Option<String>,
     /// On-disk weight size in bytes, summed across shards. `0` when unknown —
-    /// rendered as absent rather than as "0 GB".
+    /// rendered as absent rather than as "0 GiB".
     #[cfg_attr(feature = "ts-bindings", ts(type = "number"))]
     pub weights_bytes: u64,
     /// The decisions, in the order they should be displayed.
@@ -129,10 +129,10 @@ impl LaunchNarration {
         self.decisions.push(decision);
     }
 
-    /// The identity line: `qwen3-30b-a3b · Q4_K_M · 17.2 GB`.
+    /// The identity line: `qwen3-30b-a3b · Q4_K_M · 17.2 GiB`.
     ///
     /// Unknown quantization and unknown size are dropped rather than rendered
-    /// as `unknown` or `0 GB` — a banner that pads itself with non-answers
+    /// as `unknown` or `0 GiB` — a banner that pads itself with non-answers
     /// reads as broken.
     #[must_use]
     pub fn headline(&self) -> String {
@@ -153,16 +153,17 @@ impl LaunchNarration {
     }
 }
 
-/// Format a byte count as GiB with one decimal, e.g. `17.2 GB`.
+/// Format a byte count as GiB with one decimal, e.g. `17.2 GiB`.
 ///
-/// Deliberately GiB-not-GB: it matches how every other memory figure in the
-/// launch path is computed, and a banner whose numbers disagree with the
-/// `--cache-ram` budget beside them is worse than no banner.
+/// GiB rather than GB, because the division is by 1024^3: it matches how every
+/// other memory figure in the launch path is computed, and a banner whose
+/// numbers disagree with the `--cache-ram` budget beside them is worse than no
+/// banner.
 #[must_use]
 pub fn format_gib(bytes: u64) -> String {
     #[allow(clippy::cast_precision_loss)]
     let gib = bytes as f64 / 1_073_741_824.0;
-    format!("{gib:.1} GB")
+    format!("{gib:.1} GiB")
 }
 
 /// Format a MiB count as GiB with one decimal, for the RAM cache budget.
@@ -170,7 +171,7 @@ pub fn format_gib(bytes: u64) -> String {
 pub fn format_mib_as_gib(mib: u64) -> String {
     #[allow(clippy::cast_precision_loss)]
     let gib = mib as f64 / 1024.0;
-    format!("{gib:.1} GB")
+    format!("{gib:.1} GiB")
 }
 
 #[cfg(test)]
@@ -180,7 +181,7 @@ mod tests {
     #[test]
     fn headline_joins_the_three_identity_parts() {
         let n = LaunchNarration::new("qwen3-30b-a3b", Some("Q4_K_M".to_string()), 18_476_297_420);
-        assert_eq!(n.headline(), "qwen3-30b-a3b \u{b7} Q4_K_M \u{b7} 17.2 GB");
+        assert_eq!(n.headline(), "qwen3-30b-a3b \u{b7} Q4_K_M \u{b7} 17.2 GiB");
     }
 
     /// Unknown quant and unknown size drop out rather than rendering as
@@ -194,7 +195,7 @@ mod tests {
     #[test]
     fn headline_keeps_size_when_only_quantization_is_unknown() {
         let n = LaunchNarration::new("mystery", None, 1_073_741_824);
-        assert_eq!(n.headline(), "mystery \u{b7} 1.0 GB");
+        assert_eq!(n.headline(), "mystery \u{b7} 1.0 GiB");
     }
 
     #[test]
@@ -210,6 +211,6 @@ mod tests {
 
     #[test]
     fn format_mib_as_gib_scales_by_1024() {
-        assert_eq!(format_mib_as_gib(6144), "6.0 GB");
+        assert_eq!(format_mib_as_gib(6144), "6.0 GiB");
     }
 }

--- a/crates/gglib-core/src/domain/recommendation.rs
+++ b/crates/gglib-core/src/domain/recommendation.rs
@@ -92,8 +92,8 @@ impl ModelCandidate {
 
 /// Which pool of memory the recommendation was sized against.
 ///
-/// Worth carrying rather than inferring at the print site: "24.0 GB VRAM" and
-/// "24.0 GB system RAM" lead to very different expectations, and the
+/// Worth carrying rather than inferring at the print site: "24.0 GiB VRAM" and
+/// "24.0 GiB system RAM" lead to very different expectations, and the
 /// [`SystemRam`](Self::SystemRam) case is frequently a *fallback* rather than a
 /// CPU-only machine — see [`recommend`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/gglib-download/src/cli_exec/api.rs
+++ b/crates/gglib-download/src/cli_exec/api.rs
@@ -65,8 +65,8 @@ pub async fn list_quantizations(
                                 String::new()
                             };
                             #[allow(clippy::cast_precision_loss)]
-                            let size_mb = quant.total_size as f64 / 1_048_576.0;
-                            println!("  {} ({:.1} MB){}", quant.name, size_mb, shard_info);
+                            let size_mib = quant.total_size as f64 / 1_048_576.0;
+                            println!("  {} ({:.1} MiB){}", quant.name, size_mib, shard_info);
                         }
 
                         println!("\nTo download a specific quantization, use:");
@@ -149,8 +149,8 @@ async fn fallback_file_search(
                         || "size unknown".to_string(),
                         |bytes| {
                             #[allow(clippy::cast_precision_loss)]
-                            let mb = bytes as f64 / 1_048_576.0;
-                            format!("{mb:.1} MB")
+                            let mib = bytes as f64 / 1_048_576.0;
+                            format!("{mib:.1} MiB")
                         },
                     );
                 println!("  ✓ {pattern} ({size_info})");

--- a/crates/gglib-integration-tests/tests/integration_huggingface.rs
+++ b/crates/gglib-integration-tests/tests/integration_huggingface.rs
@@ -199,24 +199,24 @@ async fn test_sharded_file_pattern_detection() {
 async fn test_file_size_parsing() {
     // Test handling of file sizes from HuggingFace API
     let size_test_cases = vec![
-        (1_048_576u64, "1.0 MB"),
-        (1_073_741_824u64, "1024.0 MB"),
-        (5_368_709_120u64, "5120.0 MB"),
-        (10_737_418_240u64, "10240.0 MB"),
-        (1_000_000u64, "1.0 MB"), // Approximately
+        (1_048_576u64, "1.0 MiB"),
+        (1_073_741_824u64, "1024.0 MiB"),
+        (5_368_709_120u64, "5120.0 MiB"),
+        (10_737_418_240u64, "10240.0 MiB"),
+        (1_000_000u64, "1.0 MiB"), // Approximately
     ];
 
     for (size_bytes, _expected_approx) in size_test_cases {
-        let size_mb = size_bytes as f64 / 1_048_576.0;
-        let formatted = format!("{size_mb:.1} MB");
+        let size_mib = size_bytes as f64 / 1_048_576.0;
+        let formatted = format!("{size_mib:.1} MiB");
 
         // Test that we can format sizes consistently
-        assert!(formatted.contains("MB"));
+        assert!(formatted.contains("MiB"));
         assert!(formatted.contains('.'));
 
         // For larger files, verify they're in the expected range
         if size_bytes > 1_073_741_824 {
-            assert!(size_mb > 1000.0, "Large files should show >1000 MB");
+            assert!(size_mib > 1000.0, "Large files should show >1000 MiB");
         }
     }
 }

--- a/crates/gglib-runtime/src/launch_narration.rs
+++ b/crates/gglib-runtime/src/launch_narration.rs
@@ -142,7 +142,7 @@ fn native_summary(flags: RuntimeFlags) -> String {
 /// The KV line, including what quantization actually bought.
 ///
 /// The `f16 would be N` comparison is the point: `q8_0` alone means nothing
-/// to a user, while "2.1 GB, and f16 would be 4.2" is the reason the default
+/// to a user, while "2.1 GiB, and f16 would be 4.2" is the reason the default
 /// exists. Omitted when the model's metadata didn't yield a per-token
 /// estimate, rather than shown against a fabricated one.
 fn kv_decision(inputs: &NarrationInputs<'_>, ctx: u64) -> LaunchDecision {
@@ -486,7 +486,7 @@ mod tests {
         let cache = n.decision("cache").unwrap();
         assert_eq!(
             cache.value,
-            "6.0 GB RAM of 31.0 GB free \u{b7} disk slots on"
+            "6.0 GiB RAM of 31.0 GiB free \u{b7} disk slots on"
         );
         assert_eq!(cache.source.as_deref(), Some("auto-sized"));
     }

--- a/crates/gglib-runtime/src/llama/args/cache_ram.rs
+++ b/crates/gglib-runtime/src/llama/args/cache_ram.rs
@@ -11,6 +11,7 @@
 //! footprint at the launch context size.
 
 use crate::system::is_truthy_flag;
+use gglib_core::domain::format_gib;
 use gglib_core::server_config::{
     CACHE_RAM_UNKNOWN_KV_ALLOWANCE_BYTES, CacheRamSetting, compute_auto_cache_ram_mb,
 };
@@ -153,11 +154,6 @@ fn resolve_cache_ram_inner(
     }
 }
 
-/// Format bytes as GiB with one decimal, for the human-facing breakdown.
-fn gib(bytes: u64) -> String {
-    format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-}
-
 impl CacheRamResolution {
     /// A one-line, human-readable explanation of an auto-sized budget.
     ///
@@ -177,19 +173,19 @@ impl CacheRamResolution {
         if mb == 0 {
             return Some(format!(
                 "auto-sized llama-server RAM cache: disabled — model {} + {} {} at {} ctx leave no room in {}",
-                gib(self.model_bytes),
+                format_gib(self.model_bytes),
                 kv_label,
-                gib(self.kv_bytes),
+                format_gib(self.kv_bytes),
                 self.context_size,
-                gib(self.total_ram_bytes),
+                format_gib(self.total_ram_bytes),
             ));
         }
         Some(format!(
             "auto-sized llama-server RAM cache: {mb} MiB (total {} − model {} − {} {} at {} ctx − headroom) — override with --cache-ram-mb, disable with GGLIB_DISABLE_CACHE_AUTOSIZE=1",
-            gib(self.total_ram_bytes),
-            gib(self.model_bytes),
+            format_gib(self.total_ram_bytes),
+            format_gib(self.model_bytes),
             kv_label,
-            gib(self.kv_bytes),
+            format_gib(self.kv_bytes),
             self.context_size,
         ))
     }

--- a/crates/gglib-runtime/src/proxy/banner.rs
+++ b/crates/gglib-runtime/src/proxy/banner.rs
@@ -111,7 +111,7 @@ mod tests {
         let lines = render_launch_narration(&narration(), false);
         assert_eq!(
             lines[1].trim(),
-            "qwen3-30b-a3b \u{b7} Q4_K_M \u{b7} 17.2 GB"
+            "qwen3-30b-a3b \u{b7} Q4_K_M \u{b7} 17.2 GiB"
         );
     }
 

--- a/scripts/rust-complexity-baseline.txt
+++ b/scripts/rust-complexity-baseline.txt
@@ -150,7 +150,7 @@ crates/gglib-proxy/tests/integration_proxy_pipeline.rs 645
 crates/gglib-proxy/tests/integration_slot_roundtrip.rs 615
 crates/gglib-runtime/src/command.rs 736
 crates/gglib-runtime/src/launch_narration.rs 695
-crates/gglib-runtime/src/llama/args/cache_ram.rs 344
+crates/gglib-runtime/src/llama/args/cache_ram.rs 340
 crates/gglib-runtime/src/llama/build/mod.rs 418
 crates/gglib-runtime/src/llama/detect/cuda.rs 304
 crates/gglib-runtime/src/llama/download/mod.rs 1313

--- a/src/components/ProxyLaunchPanel.tsx
+++ b/src/components/ProxyLaunchPanel.tsx
@@ -30,7 +30,7 @@ function formatWeights(bytes: number): string {
 }
 
 /**
- * The model identity line: `qwen3-30b-a3b · Q4_K_M · 17.2 GB`.
+ * The model identity line: `qwen3-30b-a3b · Q4_K_M · 17.2 GiB`.
  *
  * Unknown quantization and unknown size drop out rather than rendering as
  * filler, mirroring `LaunchNarration::headline` on the backend.

--- a/src/types/generated/LaunchDecision.ts
+++ b/src/types/generated/LaunchDecision.ts
@@ -17,7 +17,7 @@ export type LaunchDecision = {
  */
 label: string, 
 /**
- * Display-ready value, e.g. `32768` or `q8_0 -> 2.1 GB, f16 would be 4.2 GB`.
+ * Display-ready value, e.g. `32768` or `q8_0 -> 2.1 GiB, f16 would be 4.2 GiB`.
  */
 value: string, 
 /**

--- a/src/types/generated/LaunchNarration.ts
+++ b/src/types/generated/LaunchNarration.ts
@@ -21,7 +21,7 @@ model_name: string,
 quantization: string | null, 
 /**
  * On-disk weight size in bytes, summed across shards. `0` when unknown —
- * rendered as absent rather than as "0 GB".
+ * rendered as absent rather than as "0 GiB".
  */
 weights_bytes: number, 
 /**


### PR DESCRIPTION
`format_gib` divides a byte count by 1024^3 and labelled the result `GB`. Its
own doc contradicted itself inside one block — "Format a byte count as GiB with
one decimal, e.g. `17.2 GB`", then "Deliberately GiB-not-GB". The arithmetic was
settled; only the label drifted, which makes this a bug rather than a taste.

The GUI already disagreed with it: `ProxyLaunchPanel.tsx` renders the same
`weights_bytes` the CLI banner does, through a helper documented as "matching
the backend's `format_gib`" that returns `GiB`. One number, two surfaces, two
units.

Full reasoning is in the commit message.

### What changed

`format_gib` and `format_mib_as_gib`; the shard-hashing progress line in
`gglib model verify`; two size renderings behind
`gglib model download --list-quants`; and a size table in an integration test
that spelled one gibibyte `1024.0 MB`. `cache_ram.rs`'s private duplicate now
calls the shared helper.

### Verification

`make enforce`, `make boundaries`, `cargo fmt --check`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`make doc-check`, `cargo test --workspace`, `make bindings-check`,
`npm run typecheck` and `npm run test:run` all exit 0.

The `cache_ram.rs` consolidation was checked as behaviour-neutral rather than
assumed: a differential probe of the old private helper against `format_gib`
over ~6M inputs — the named edges plus a randomised sweep — found zero
mismatches, including on the sub-gibibyte path the existing tests do not reach.
That file's `explain_shows_the_arithmetic` test, asserting `128.0 GiB` and
`27.0 GiB` and green before this change, now guards the shared formatter's
label.

### Deliberately out of scope

`admission.rs::format_bytes` (renders `MiB` below a gibibyte — adopting it
changes `format_gib`'s output there, a behaviour change rather than a label
fix), `--cache-disk-gb`/`GGLIB_CACHE_DISK_GB` (a breaking rename across a flag,
an env var and a ts-rs field), and two llama.cpp release-asset sizes that divide
by 1000 under an `MB` label in a subsystem this commit does not otherwise touch.
