### PR TITLE
chore(deps): sync lockfile version with package.json 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gglib-gui",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gglib-gui",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@assistant-ui/react": "^0.11.48",


### PR DESCRIPTION
## What

Syncs the two root `version` fields in `package-lock.json` from `0.14.1` to `0.15.0`. That is the entire diff — no dependency tree changes.

## Why

`.github/workflows/bump-version.yml` does not write `package-lock.json`. Its version sync runs `scripts/sync_versions.py`, whose JSON work is a single `update_json('package.json', version)` (`scripts/sync_versions.py:111`); its lockfile steps run `cargo generate-lockfile` and `git add Cargo.lock` (`bump-version.yml:115-128`); and its verification step iterates `for file in package.json` (`bump-version.yml:137`). So #884 bumped `package.json` to `0.15.0` and left the lockfile at the value it has carried since #878.

`npm install` mirrors `package.json`'s version into the lock, and it runs from `make build-gui` (`Makefile:164`) and `make build-tauri` (`Makefile:476`), which `make setup` depends on. An ordinary build therefore leaves the file modified in the working tree, where `git add -A` would carry it into an unrelated commit.

`Cargo.lock` was checked and is in sync at `0.15.0`; `package-lock.json` was the file that had drifted.

## How this diff was produced

By running `npm install`, not by hand-editing. The result is 2 insertions and 2 deletions. A second `npm install` on top of it left the tree clean.

## Gates

`make enforce`, `make boundaries`, `npm run lint -- --max-warnings 0`, `npm run typecheck`, `npm run deadcode`, `npm run test:run` (946 passed), `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `make doc-check` — all pass.

## Labels

`chore(deps):` titles match `EXEMPT_TITLES` in `label-check.yml` (`:76` and `:331`), so neither the enrichment comment nor the required-label check fires on this PR. Labels are applied by hand, matching #793.

## Follow-up, not done here

#793 synced `0.13.0` the same way, and its body already recommended making version bumps update both files atomically. That was not done, and this is the recurrence. The durable fix belongs in `bump-version.yml`: an npm lockfile step beside `cargo generate-lockfile`, `package-lock.json` in "Stage lockfiles", and `package-lock.json` in the verification loop. Kept out of this PR because `bump-version.yml` is `workflow_dispatch`-only and cannot be exercised by PR CI, so the change would ship untested until the next release.
